### PR TITLE
feat: exclude cache dir from Time Machine and Spotlight on macOS

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -1062,7 +1062,10 @@ mod tests {
         exclude_from_indexing(dir.path());
         let sentinel = dir.path().join(".metadata_never_index");
         assert!(sentinel.exists());
-        assert!(sentinel.metadata().unwrap().len() == 0, "sentinel should be empty");
+        assert!(
+            sentinel.metadata().unwrap().len() == 0,
+            "sentinel should be empty"
+        );
         // Idempotent — second call doesn't fail or modify
         exclude_from_indexing(dir.path());
         assert!(sentinel.exists());


### PR DESCRIPTION
Automatically call `tmutil addexclusion` (no sudo) and create a
`.metadata_never_index` sentinel in the cache directory when the
store is opened, so reproducible build artifacts are skipped by
backups and indexing.
