### PR TITLE
feat: content-addressable dedup for local and S3 blob store

### DIFF
--- a/docs/plans/2026-03-04-content-addressable-dedup-design.md
+++ b/docs/plans/2026-03-04-content-addressable-dedup-design.md
@@ -1,0 +1,177 @@
+# Content-Addressable Dedup for Kache
+
+## Problem
+
+The kache local store accumulates many entries for the same crate with different cache keys (due to dependency artifact hash churn, feature permutations, `-C metadata` changes, etc.). Analysis of a real store shows:
+
+- **8,337 entries, 50.4 GB** total
+- **24,733 unique file hashes** across 40,332 artifact files
+- **11.5 GB (22.7%)** is pure content duplication — identical bytes stored under different cache keys
+- Worst offenders: `kunobi_lib` (1.55 GB wasted), `aws_sdk_s3` (902 MB), `futures_util` (2.5x duplication ratio)
+
+## Design
+
+### Core idea
+
+Replace per-entry artifact storage with a **content-addressed blob store**. Entry directories contain only `meta.json`; artifact bytes live in a shared blob store keyed by blake3 content hash (already computed and stored in `CachedFile.hash`).
+
+### Local blob store layout
+
+```
+~/Library/Caches/kache/
+├── index.db                  # gains `blobs` table
+├── store/
+│   ├── blobs/                # content-addressed blob store
+│   │   └── ab/               # 2-char hex prefix sharding
+│   │       └── abcdef1234…   # canonical artifact, read-only (0444)
+│   └── <cache_key>/          # entry directories (metadata only)
+│       └── meta.json         # unchanged format
+```
+
+- **2-char prefix sharding** prevents any single directory from having 24k+ entries.
+- Blob files are read-only (0444), consistent with current artifact protection.
+- `meta.json` format is **unchanged** — `CachedFile { name, size, hash }` already contains everything needed to resolve blobs.
+
+### SQLite schema addition
+
+```sql
+CREATE TABLE blobs (
+    hash     TEXT PRIMARY KEY,   -- blake3 hex (64 chars)
+    size     INTEGER NOT NULL,   -- file size in bytes
+    refcount INTEGER NOT NULL DEFAULT 1
+);
+```
+
+Refcount tracks how many cache entries reference each blob. Blob file is deleted only when refcount reaches 0.
+
+### Modified operations
+
+#### `put()` — writing a new cache entry
+
+```
+For each artifact file:
+  1. hash = blake3(source_file)   # already computed for CachedFile
+  2. blob_path = store/blobs/{hash[0..2]}/{hash}
+  3. IF blob exists (refcount > 0):
+       UPDATE blobs SET refcount = refcount + 1
+     ELSE:
+       copy(source, blob_path), chmod 0444
+       INSERT INTO blobs (hash, size, refcount) VALUES (?, ?, 1)
+  4. Build CachedFile { name, size, hash } as before
+Write meta.json to entry dir (no artifact files in entry dir).
+INSERT INTO entries as before.
+```
+
+Blob creation uses `O_CREAT|O_EXCL` for atomicity when two processes race to create the same blob.
+
+#### `get()` / `restore_from_cache()` — cache hit
+
+```
+1. Read meta.json from entry dir
+2. For each CachedFile:
+     blob_path = store/blobs/{hash[0..2]}/{hash}
+     link_to_target(blob_path, cargo_target/filename, strategy)
+       # hardlink → reflink → copy (existing fallback chain in link.rs)
+3. Update last_accessed / hit_count in SQLite
+```
+
+If any blob is missing, treat as corrupted entry → `remove_entry()`.
+
+#### `remove_entry()` — eviction / deletion
+
+```
+For each CachedFile in meta.json:
+  UPDATE blobs SET refcount = refcount - 1 WHERE hash = ?
+  IF refcount = 0:
+    DELETE FROM blobs WHERE hash = ?
+    unlink(blob_path)
+remove_dir_all(entry_dir)   # only meta.json remains
+DELETE FROM entries WHERE cache_key = ?
+```
+
+#### `evict()` — size tracking
+
+`entries.size` remains **logical size** (sum of all referenced file sizes, regardless of sharing). This is what the user sees and what LRU decisions should be based on. Actual disk savings happen transparently.
+
+A new `kache stats` display shows: `Logical: 46.9 GB | Physical: ~36 GB | Dedup savings: 23%`
+
+### Remote (S3) dedup
+
+#### New S3 layout
+
+```
+<prefix>/
+├── blobs/
+│   └── ab/
+│       └── abcdef1234…5678.zst    # individually compressed blob
+├── manifests/
+│   └── <crate_name>/
+│       └── <cache_key>.json       # EntryMeta (metadata only, no artifact bytes)
+```
+
+#### Upload flow
+
+1. For each `CachedFile`: HEAD check if `blobs/{hash[0..2]}/{hash}.zst` exists on S3 (use in-memory S3KeyCache)
+2. Upload only missing blobs (zstd-compressed individually)
+3. Upload manifest (meta.json content)
+
+#### Download flow
+
+1. Fetch manifest → parse `EntryMeta`
+2. For each `CachedFile`: check if blob exists in local blob store
+3. Download only missing blobs from S3
+4. Insert into local blob store, update refcounts
+5. Write meta.json to entry dir, commit in SQLite
+
+#### Backward compatibility
+
+- Download: check for old `{prefix}/{crate_name}/{cache_key}.tar.zst` format; if found, download and extract as before, then optionally dedup locally
+- Upload: always use new format (blobs + manifests)
+- Old-format S3 entries remain readable until evicted; can be batch-upgraded via `kache dedup --remote`
+
+### Migration of existing local stores
+
+`kache dedup` CLI command (also runnable as daemon background task on startup):
+
+```
+For each store/<cache_key>/meta.json:
+  For each CachedFile:
+    blob_path = blobs/{hash[0..2]}/{hash}
+    entry_file = <cache_key>/{filename}
+    IF blob doesn't exist:
+      rename(entry_file, blob_path)    # instant (same filesystem)
+      INSERT INTO blobs (hash, size, refcount) VALUES (?, ?, 1)
+    ELSE:
+      unlink(entry_file)              # blob already has the content
+      UPDATE blobs SET refcount = refcount + 1
+  # entry dir now contains only meta.json
+Report: "Migrated N entries, saved X GB"
+```
+
+- **Non-destructive**: if interrupted, entries with remaining artifact files still work in the new code (get() can fall back to reading from entry dir if blob is missing)
+- **Resumable**: skips entries that are already migrated (no artifact files in entry dir)
+- No cache key version bump needed — keys and meta.json format are unchanged
+
+### Concurrency safety
+
+- Blob file creation: `O_CREAT|O_EXCL` (atomic, same pattern as existing `KeyLock`)
+- Refcount updates: SQLite transactions (serialized by WAL + busy_timeout)
+- Per-key `KeyLock`: prevents two processes from writing the same cache entry simultaneously (unchanged)
+- Migration: safe to run concurrently with normal cache operations — worst case, a blob gets created by both migration and a put(), one wins via O_EXCL
+
+### Version detection
+
+Add `store/.version` file containing `2` (current: no file = v1). Future format breaks can detect and handle version mismatches.
+
+## Non-goals
+
+- Compression of local blobs (filesystem-level compression like APFS handles this better)
+- Deduplication across different rustc versions (keys already differentiate)
+- Block-level deduplication (filesystem concern, not application concern)
+
+## Testing strategy
+
+- Unit tests: blob store operations (put, get, remove, refcount lifecycle)
+- Integration tests: migration of a synthetic store, concurrent put/get with shared blobs
+- Property tests: refcount invariant (sum of entry references = blob refcount)
+- Edge cases: interrupted migration, corrupted blob, eviction with shared blobs, cross-process races

--- a/docs/plans/2026-03-04-content-addressable-dedup-plan.md
+++ b/docs/plans/2026-03-04-content-addressable-dedup-plan.md
@@ -1,0 +1,1460 @@
+# Content-Addressable Dedup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace per-entry artifact storage with a content-addressed blob store, deduplicating identical files across cache entries both locally and on S3.
+
+**Architecture:** A `store/blobs/{hash[0..2]}/{hash}` directory tree holds one canonical copy per unique file. Entry directories (`store/<cache_key>/`) shrink to only `meta.json`. A new `blobs` SQLite table tracks refcounts. `restore_from_cache()` links directly from blobs to cargo target dirs. S3 uploads individual blobs + manifests instead of per-entry tars.
+
+**Tech Stack:** Rust, rusqlite, blake3 (already in use), aws-sdk-s3, zstd, clap
+
+**Design doc:** `docs/plans/2026-03-04-content-addressable-dedup-design.md`
+
+---
+
+### Task 1: Add blob store helpers to Store
+
+**Files:**
+- Modify: `src/store.rs:52-55` (Store struct)
+- Modify: `src/store.rs:69-104` (Store::open)
+- Test: `src/store.rs` (mod tests)
+
+**Step 1: Write failing tests for blob path resolution and blob table creation**
+
+```rust
+// Add to existing mod tests in src/store.rs
+
+#[test]
+fn test_blob_path_sharding() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    let hash = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+    let path = store.blob_path(hash);
+    assert!(path.to_string_lossy().contains("blobs/ab/"));
+    assert!(path.to_string_lossy().ends_with(hash));
+}
+
+#[test]
+fn test_blobs_table_created() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    // Table should exist — query it
+    let count: i64 = store
+        .db
+        .query_row("SELECT COUNT(*) FROM blobs", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 0);
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib store::tests::test_blob_path_sharding -- --nocapture`
+Expected: FAIL — `blob_path` method doesn't exist
+
+**Step 3: Implement blob_path() and blobs table creation**
+
+Add to `Store`:
+
+```rust
+/// Resolve the filesystem path for a content-addressed blob.
+/// Layout: store/blobs/{first 2 hex chars}/{full hash}
+pub fn blob_path(&self, hash: &str) -> PathBuf {
+    let prefix = &hash[..2];
+    self.config.store_dir().join("blobs").join(prefix).join(hash)
+}
+
+/// Directory containing all blobs.
+pub fn blobs_dir(&self) -> PathBuf {
+    self.config.store_dir().join("blobs")
+}
+```
+
+In `Store::open()`, after the existing `CREATE TABLE entries` and migrations, add:
+
+```rust
+db.execute_batch(
+    "CREATE TABLE IF NOT EXISTS blobs (
+        hash     TEXT PRIMARY KEY,
+        size     INTEGER NOT NULL,
+        refcount INTEGER NOT NULL DEFAULT 1
+    );",
+)
+.context("creating blobs table")?;
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib store::tests::test_blob_path_sharding store::tests::test_blobs_table_created -- --nocapture`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/store.rs
+git commit -m "feat(store): add blob store helpers and blobs table"
+```
+
+---
+
+### Task 2: Implement blob-aware `put()`
+
+**Files:**
+- Modify: `src/store.rs:216-283` (Store::put)
+- Test: `src/store.rs` (mod tests)
+
+**Step 1: Write failing tests for blob-aware put**
+
+```rust
+#[test]
+fn test_put_creates_blob() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    let output = dir.path().join("lib.rlib");
+    fs::write(&output, b"rlib content").unwrap();
+    store
+        .put("k1", "mycrate", &["lib".into()], &[], "", "dev",
+             &[(output, "lib.rlib".into())], "", "")
+        .unwrap();
+
+    // Blob should exist
+    let meta = store.get("k1").unwrap().unwrap();
+    let blob = store.blob_path(&meta.files[0].hash);
+    assert!(blob.exists(), "blob file should exist at {}", blob.display());
+
+    // Entry dir should only have meta.json (no artifact files)
+    let entry_dir = store.entry_dir("k1");
+    let files: Vec<_> = fs::read_dir(&entry_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    assert_eq!(files, vec!["meta.json"], "entry dir should only contain meta.json");
+}
+
+#[test]
+fn test_put_deduplicates_identical_content() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    let output = dir.path().join("lib.rlib");
+    fs::write(&output, b"same content").unwrap();
+    store
+        .put("k1", "crate_a", &["lib".into()], &[], "", "dev",
+             &[(output.clone(), "lib.rlib".into())], "", "")
+        .unwrap();
+
+    // Put again with same content but different cache key
+    fs::write(&output, b"same content").unwrap();
+    store
+        .put("k2", "crate_a", &["lib".into()], &[], "", "dev",
+             &[(output, "lib.rlib".into())], "", "")
+        .unwrap();
+
+    // Both entries should reference the same blob
+    let meta1 = store.get("k1").unwrap().unwrap();
+    let meta2 = store.get("k2").unwrap().unwrap();
+    assert_eq!(meta1.files[0].hash, meta2.files[0].hash);
+
+    // Refcount should be 2
+    let refcount: i64 = store.db.query_row(
+        "SELECT refcount FROM blobs WHERE hash = ?1",
+        params![meta1.files[0].hash],
+        |row| row.get(0),
+    ).unwrap();
+    assert_eq!(refcount, 2);
+}
+
+#[test]
+fn test_put_blob_is_readonly() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    let output = dir.path().join("lib.rlib");
+    fs::write(&output, b"content").unwrap();
+    store
+        .put("k1", "c", &["lib".into()], &[], "", "dev",
+             &[(output, "lib.rlib".into())], "", "")
+        .unwrap();
+
+    let meta = store.get("k1").unwrap().unwrap();
+    let blob = store.blob_path(&meta.files[0].hash);
+    let perms = fs::metadata(&blob).unwrap().permissions();
+    assert!(perms.readonly(), "blob should be read-only");
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib store::tests::test_put_creates_blob -- --nocapture`
+Expected: FAIL — entry dir still contains artifact files (old put behavior)
+
+**Step 3: Rewrite `put()` to use blob store**
+
+Replace the current `put()` body. Key changes:
+- Hash the source file first (before copying)
+- Check if blob exists; if yes, increment refcount; if no, copy to blob path
+- Use `O_CREAT|O_EXCL` via `OpenOptions::new().create_new(true)` for atomic blob creation
+- Do NOT write artifact files into entry dir — only `meta.json`
+- Use `fs::create_dir_all` for the blob shard dir (`blobs/ab/`)
+
+```rust
+pub fn put(
+    &self,
+    cache_key: &str,
+    crate_name: &str,
+    crate_types: &[String],
+    features: &[String],
+    target: &str,
+    profile: &str,
+    output_files: &[(PathBuf, String)],
+    stdout: &str,
+    stderr: &str,
+) -> Result<()> {
+    let entry_dir = self.entry_dir(cache_key);
+    fs::create_dir_all(&entry_dir).context("creating entry directory")?;
+
+    let mut cached_files = Vec::new();
+    let mut total_size = 0u64;
+
+    for (source_path, store_name) in output_files {
+        let hash = crate::cache_key::hash_file(source_path)?;
+        let size = fs::metadata(source_path)?.len();
+        total_size += size;
+
+        let blob = self.blob_path(&hash);
+
+        // Check if blob already exists in DB
+        let existing: Option<i64> = self
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![hash],
+                |row| row.get(0),
+            )
+            .ok();
+
+        if existing.is_some() {
+            // Blob exists — increment refcount
+            self.db.execute(
+                "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                params![hash],
+            )?;
+        } else {
+            // New blob — copy to blob store
+            let blob_dir = blob.parent().unwrap();
+            fs::create_dir_all(blob_dir)?;
+
+            // Atomic create: copy to temp then rename, or use create_new
+            let temp_blob = blob.with_extension("tmp");
+            fs::copy(source_path, &temp_blob)
+                .with_context(|| format!("copying {} to blob store", source_path.display()))?;
+
+            // Make read-only
+            let meta = fs::metadata(&temp_blob)?;
+            let mut perms = meta.permissions();
+            perms.set_readonly(true);
+            fs::set_permissions(&temp_blob, perms)?;
+
+            // Atomic move into place (if another process raced us, rename fails on some platforms;
+            // on POSIX rename replaces atomically which is fine — same content)
+            match fs::rename(&temp_blob, &blob) {
+                Ok(()) => {}
+                Err(_) if blob.exists() => {
+                    // Another process created it first — that's fine, remove our temp
+                    let _ = fs::remove_file(&temp_blob);
+                }
+                Err(e) => return Err(e.into()),
+            }
+
+            self.db.execute(
+                "INSERT OR IGNORE INTO blobs (hash, size, refcount) VALUES (?1, ?2, 1)",
+                params![hash, size as i64],
+            )?;
+            // If INSERT OR IGNORE didn't insert (race), increment instead
+            if self.db.changes() == 0 {
+                self.db.execute(
+                    "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                    params![hash],
+                )?;
+            }
+        }
+
+        cached_files.push(CachedFile {
+            name: store_name.clone(),
+            size,
+            hash,
+        });
+    }
+
+    // Write metadata only — no artifact files in entry dir
+    let meta = EntryMeta {
+        cache_key: cache_key.to_string(),
+        crate_name: crate_name.to_string(),
+        crate_types: crate_types.to_vec(),
+        files: cached_files,
+        stdout: stdout.to_string(),
+        stderr: stderr.to_string(),
+        features: features.to_vec(),
+        target: target.to_string(),
+        profile: profile.to_string(),
+    };
+    let meta_json =
+        serde_json::to_string_pretty(&meta).context("serializing entry metadata")?;
+    fs::write(entry_dir.join("meta.json"), meta_json)?;
+
+    let crate_type_str = crate_types.join(",");
+    let num_features = features.len() as i64;
+    self.db.execute(
+        "INSERT OR REPLACE INTO entries (cache_key, crate_name, crate_type, profile, num_features, size, committed) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)",
+        params![cache_key, crate_name, crate_type_str, profile, num_features, total_size as i64],
+    )?;
+
+    Ok(())
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib store::tests -- --nocapture`
+Expected: PASS (all new tests + existing tests — existing `test_store_put_and_get` may need updating since `cached_file_path` now returns entry_dir paths that don't have artifacts)
+
+**Step 5: Fix existing tests that assume artifacts in entry dir**
+
+The existing `test_store_put_and_get` calls `store.get()` which internally checks files exist at `entry_dir.join(name)`. This must be updated — see Task 3.
+
+**Step 6: Commit**
+
+```bash
+git add src/store.rs
+git commit -m "feat(store): blob-aware put() with content dedup and refcounting"
+```
+
+---
+
+### Task 3: Update `get()` and `contains()` to resolve blobs
+
+**Files:**
+- Modify: `src/store.rs:107-157` (contains, get)
+- Test: `src/store.rs` (mod tests)
+
+**Step 1: Write failing test for blob-aware get**
+
+```rust
+#[test]
+fn test_get_verifies_blobs_not_entry_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    let output = dir.path().join("lib.rlib");
+    fs::write(&output, b"content").unwrap();
+    store
+        .put("k1", "c", &["lib".into()], &[], "", "dev",
+             &[(output, "lib.rlib".into())], "", "")
+        .unwrap();
+
+    // Entry dir should NOT have lib.rlib — only meta.json
+    assert!(!store.entry_dir("k1").join("lib.rlib").exists());
+
+    // get() should still succeed (resolving via blob store)
+    let meta = store.get("k1").unwrap();
+    assert!(meta.is_some());
+}
+
+#[test]
+fn test_get_evicts_when_blob_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    let output = dir.path().join("lib.rlib");
+    fs::write(&output, b"content").unwrap();
+    store
+        .put("k1", "c", &["lib".into()], &[], "", "dev",
+             &[(output, "lib.rlib".into())], "", "")
+        .unwrap();
+
+    // Delete the blob to simulate corruption
+    let meta = store.get("k1").unwrap().unwrap();
+    let blob = store.blob_path(&meta.files[0].hash);
+    let mut perms = fs::metadata(&blob).unwrap().permissions();
+    perms.set_readonly(false);
+    fs::set_permissions(&blob, perms).unwrap();
+    fs::remove_file(&blob).unwrap();
+
+    // get() should detect missing blob and evict
+    let result = store.get("k1").unwrap();
+    assert!(result.is_none());
+    assert!(!store.contains("k1"));
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib store::tests::test_get_verifies_blobs_not_entry_files -- --nocapture`
+Expected: FAIL — current `get()` checks `entry_dir.join(name)` which no longer has artifacts
+
+**Step 3: Update `get()` to verify blobs instead of entry dir files**
+
+```rust
+pub fn get(&self, cache_key: &str) -> Result<Option<EntryMeta>> {
+    if !self.contains(cache_key) {
+        return Ok(None);
+    }
+
+    let entry_dir = self.entry_dir(cache_key);
+    let meta_path = entry_dir.join("meta.json");
+    let content = fs::read_to_string(&meta_path).context("reading entry meta.json")?;
+    let meta: EntryMeta = serde_json::from_str(&content).context("parsing entry meta.json")?;
+
+    // Verify all blobs exist (not entry dir files)
+    for cached_file in &meta.files {
+        let blob = self.blob_path(&cached_file.hash);
+        if !blob.is_file() {
+            tracing::warn!(
+                "cache entry {} missing blob {} for file {}, evicting",
+                cache_key.get(..16).unwrap_or(cache_key),
+                &cached_file.hash[..16],
+                cached_file.name
+            );
+            let _ = self.remove_entry(cache_key);
+            return Ok(None);
+        }
+    }
+
+    // Update access time and hit count
+    self.db.execute(
+        "UPDATE entries SET last_accessed = datetime('now'), hit_count = hit_count + 1 WHERE cache_key = ?1",
+        params![cache_key],
+    )?;
+
+    Ok(Some(meta))
+}
+```
+
+**Step 4: Run all store tests**
+
+Run: `cargo test --lib store::tests -- --nocapture`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/store.rs
+git commit -m "feat(store): get() verifies blobs instead of entry dir files"
+```
+
+---
+
+### Task 4: Update `remove_entry()` with refcount decrement
+
+**Files:**
+- Modify: `src/store.rs:432-453` (remove_entry)
+- Test: `src/store.rs` (mod tests)
+
+**Step 1: Write failing tests for refcount-aware removal**
+
+```rust
+#[test]
+fn test_remove_entry_decrements_refcount() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    let output = dir.path().join("lib.rlib");
+    fs::write(&output, b"shared content").unwrap();
+    store.put("k1", "c", &["lib".into()], &[], "", "dev",
+             &[(output.clone(), "lib.rlib".into())], "", "").unwrap();
+    fs::write(&output, b"shared content").unwrap();
+    store.put("k2", "c", &["lib".into()], &[], "", "dev",
+             &[(output, "lib.rlib".into())], "", "").unwrap();
+
+    let meta = store.get("k1").unwrap().unwrap();
+    let hash = &meta.files[0].hash;
+    let blob = store.blob_path(hash);
+
+    // Remove first entry — blob should still exist (refcount 1)
+    store.remove_entry("k1").unwrap();
+    assert!(blob.exists(), "blob should survive when refcount > 0");
+
+    let refcount: i64 = store.db.query_row(
+        "SELECT refcount FROM blobs WHERE hash = ?1",
+        params![hash],
+        |row| row.get(0),
+    ).unwrap();
+    assert_eq!(refcount, 1);
+
+    // Remove second entry — blob should be deleted (refcount 0)
+    store.remove_entry("k2").unwrap();
+    assert!(!blob.exists(), "blob should be deleted when refcount = 0");
+
+    let count: i64 = store.db.query_row(
+        "SELECT COUNT(*) FROM blobs WHERE hash = ?1",
+        params![hash],
+        |row| row.get(0),
+    ).unwrap();
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn test_remove_entry_nonexistent_still_safe() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    // Should not error
+    store.remove_entry("nonexistent").unwrap();
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib store::tests::test_remove_entry_decrements_refcount -- --nocapture`
+Expected: FAIL — current `remove_entry` doesn't touch blobs table
+
+**Step 3: Rewrite `remove_entry()`**
+
+```rust
+pub fn remove_entry(&self, cache_key: &str) -> Result<()> {
+    let entry_dir = self.entry_dir(cache_key);
+
+    // Decrement blob refcounts based on meta.json
+    let meta_path = entry_dir.join("meta.json");
+    if meta_path.exists() {
+        if let Ok(content) = fs::read_to_string(&meta_path) {
+            if let Ok(meta) = serde_json::from_str::<EntryMeta>(&content) {
+                for cached_file in &meta.files {
+                    self.decrement_blob_refcount(&cached_file.hash)?;
+                }
+            }
+        }
+    }
+
+    // Remove entry directory (just meta.json in new format, may have artifacts in legacy format)
+    if entry_dir.exists() {
+        if let Ok(entries) = fs::read_dir(&entry_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if let Ok(meta) = fs::metadata(&path) {
+                    let mut perms = meta.permissions();
+                    perms.set_readonly(false);
+                    let _ = fs::set_permissions(&path, perms);
+                }
+            }
+        }
+        fs::remove_dir_all(&entry_dir)?;
+    }
+
+    self.db.execute(
+        "DELETE FROM entries WHERE cache_key = ?1",
+        params![cache_key],
+    )?;
+
+    Ok(())
+}
+
+/// Decrement a blob's refcount. Deletes blob file when refcount reaches 0.
+fn decrement_blob_refcount(&self, hash: &str) -> Result<()> {
+    self.db.execute(
+        "UPDATE blobs SET refcount = refcount - 1 WHERE hash = ?1",
+        params![hash],
+    )?;
+
+    let refcount: Option<i64> = self
+        .db
+        .query_row(
+            "SELECT refcount FROM blobs WHERE hash = ?1",
+            params![hash],
+            |row| row.get(0),
+        )
+        .ok();
+
+    if refcount == Some(0) {
+        let blob = self.blob_path(hash);
+        if blob.exists() {
+            let mut perms = fs::metadata(&blob)?.permissions();
+            perms.set_readonly(false);
+            fs::set_permissions(&blob, perms)?;
+            fs::remove_file(&blob)?;
+        }
+        self.db
+            .execute("DELETE FROM blobs WHERE hash = ?1", params![hash])?;
+    }
+
+    Ok(())
+}
+```
+
+**Step 4: Run all store tests**
+
+Run: `cargo test --lib store::tests -- --nocapture`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/store.rs
+git commit -m "feat(store): refcount-aware remove_entry with blob cleanup"
+```
+
+---
+
+### Task 5: Update `clear()` to also clear blobs
+
+**Files:**
+- Modify: `src/store.rs:456-477` (clear)
+- Test: `src/store.rs` (mod tests)
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_clear_removes_blobs_too() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    let output = dir.path().join("lib.rlib");
+    fs::write(&output, b"content").unwrap();
+    store.put("k1", "c", &["lib".into()], &[], "", "dev",
+             &[(output, "lib.rlib".into())], "", "").unwrap();
+
+    store.clear().unwrap();
+
+    // Blobs dir should be empty or gone
+    let blobs_dir = store.blobs_dir();
+    if blobs_dir.exists() {
+        let count = fs::read_dir(&blobs_dir).unwrap().count();
+        assert_eq!(count, 0, "blobs dir should be empty after clear");
+    }
+
+    // Blobs table should be empty
+    let count: i64 = store.db.query_row(
+        "SELECT COUNT(*) FROM blobs", [], |row| row.get(0),
+    ).unwrap();
+    assert_eq!(count, 0);
+}
+```
+
+**Step 2: Run test to verify failure, then implement**
+
+Update `clear()` to also remove `blobs/` directory and truncate `blobs` table:
+
+```rust
+pub fn clear(&self) -> Result<()> {
+    let store_dir = self.config.store_dir();
+    if store_dir.exists() {
+        // Make everything writable first, then remove all dirs
+        for entry in fs::read_dir(&store_dir)?.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                // Recursively make writable
+                fn make_writable_recursive(dir: &Path) {
+                    if let Ok(entries) = fs::read_dir(dir) {
+                        for file in entries.flatten() {
+                            let fp = file.path();
+                            if fp.is_dir() {
+                                make_writable_recursive(&fp);
+                            } else if let Ok(meta) = fs::metadata(&fp) {
+                                let mut perms = meta.permissions();
+                                perms.set_readonly(false);
+                                let _ = fs::set_permissions(&fp, perms);
+                            }
+                        }
+                    }
+                }
+                make_writable_recursive(&path);
+                let _ = fs::remove_dir_all(&path);
+            }
+        }
+    }
+    self.db.execute("DELETE FROM entries", [])?;
+    self.db.execute("DELETE FROM blobs", [])?;
+    Ok(())
+}
+```
+
+**Step 3: Run tests, commit**
+
+Run: `cargo test --lib store::tests -- --nocapture`
+
+```bash
+git add src/store.rs
+git commit -m "feat(store): clear() also removes blobs dir and table"
+```
+
+---
+
+### Task 6: Update `restore_from_cache()` to link from blobs
+
+**Files:**
+- Modify: `src/wrapper.rs:318-387` (restore_from_cache)
+- Modify: `src/store.rs` (add `pub fn blob_path` if not already pub)
+- Test: `src/store.rs` or integration test
+
+**Step 1: Write failing test**
+
+Add an integration-style test that exercises the full put → get → restore flow using blobs. This test should be in `src/store.rs` since we need to verify blob resolution works:
+
+```rust
+#[test]
+fn test_cached_file_path_resolves_to_blob() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    let output = dir.path().join("lib.rlib");
+    fs::write(&output, b"rlib bytes").unwrap();
+    store.put("k1", "c", &["lib".into()], &[], "", "dev",
+             &[(output, "lib.rlib".into())], "", "").unwrap();
+
+    let meta = store.get("k1").unwrap().unwrap();
+    // cached_file_path should now resolve to blob, not entry dir
+    let path = store.cached_file_path("k1", &meta.files[0].name);
+    // For backward compat, the actual restore should use blob_path
+    let blob = store.blob_path(&meta.files[0].hash);
+    assert!(blob.exists());
+    assert_eq!(fs::read(&blob).unwrap(), b"rlib bytes");
+}
+```
+
+**Step 2: Update `restore_from_cache()` in wrapper.rs**
+
+Change the store_path resolution from `store.cached_file_path(cache_key, name)` to `store.blob_path(hash)`:
+
+```rust
+fn restore_from_cache(
+    _config: &Config,
+    store: &Store,
+    args: &RustcArgs,
+    meta: &crate::store::EntryMeta,
+) -> Result<()> {
+    let output_dir = if let Some(output) = &args.output {
+        output.parent().unwrap_or(Path::new(".")).to_path_buf()
+    } else if let Some(dir) = &args.out_dir {
+        dir.clone()
+    } else {
+        anyhow::bail!("no output path (-o) or output directory (--out-dir) in args");
+    };
+
+    let strategy = if args.is_executable_output() {
+        LinkStrategy::Copy
+    } else {
+        LinkStrategy::Hardlink
+    };
+
+    for cached_file in &meta.files {
+        // Resolve from blob store (content-addressed)
+        let store_path = store.blob_path(&cached_file.hash);
+
+        if !store_path.exists() {
+            anyhow::bail!(
+                "blob missing for {} (hash {}): {}",
+                meta.cache_key,
+                &cached_file.hash[..16],
+                cached_file.name
+            );
+        }
+
+        let target_path = if let Some(output) = &args.output {
+            if cached_file.name == output.file_name().unwrap_or_default().to_string_lossy() {
+                output.clone()
+            } else {
+                output_dir.join(&cached_file.name)
+            }
+        } else {
+            output_dir.join(&cached_file.name)
+        };
+
+        link::link_to_target(&store_path, &target_path, strategy).with_context(|| {
+            format!("linking {} -> {}", store_path.display(), target_path.display())
+        })?;
+
+        link::touch_mtime(&target_path)?;
+
+        if cached_file.name.ends_with(".d")
+            && let Ok(pwd) = std::env::current_dir()
+        {
+            let _ = link::rewrite_depinfo(&target_path, &pwd, DepInfoMode::Expand);
+        }
+
+        if args.is_executable_output() && !cached_file.name.ends_with(".d") {
+            compile::codesign_adhoc(&target_path)?;
+        }
+    }
+
+    Ok(())
+}
+```
+
+**Step 3: Run full test suite**
+
+Run: `cargo test -- --nocapture`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add src/wrapper.rs src/store.rs
+git commit -m "feat(wrapper): restore_from_cache links from blob store"
+```
+
+---
+
+### Task 7: Update `import_downloaded_entry()` to populate blob store
+
+**Files:**
+- Modify: `src/store.rs:285-316` (import_downloaded_entry)
+- Test: `src/store.rs` (mod tests)
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_import_downloaded_entry_creates_blobs() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    // Simulate a downloaded entry (old tar format: files in entry dir)
+    let entry_dir = config.store_dir().join("dl_key");
+    fs::create_dir_all(&entry_dir).unwrap();
+    fs::write(entry_dir.join("lib.rlib"), b"artifact data").unwrap();
+
+    let hash = crate::cache_key::hash_file(&entry_dir.join("lib.rlib")).unwrap();
+    let meta = EntryMeta {
+        cache_key: "dl_key".to_string(),
+        crate_name: "dl_crate".to_string(),
+        crate_types: vec!["lib".to_string()],
+        files: vec![CachedFile {
+            name: "lib.rlib".to_string(),
+            size: 13,
+            hash: hash.clone(),
+        }],
+        stdout: String::new(), stderr: String::new(),
+        features: vec![], target: String::new(), profile: "dev".to_string(),
+    };
+    fs::write(
+        entry_dir.join("meta.json"),
+        serde_json::to_string_pretty(&meta).unwrap(),
+    ).unwrap();
+
+    store.import_downloaded_entry("dl_key").unwrap();
+
+    // Blob should exist
+    let blob = store.blob_path(&hash);
+    assert!(blob.exists(), "blob should be created from downloaded artifact");
+
+    // Entry dir should only have meta.json
+    let entry_files: Vec<_> = fs::read_dir(&entry_dir).unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    assert_eq!(entry_files, vec!["meta.json"]);
+}
+```
+
+**Step 2: Run test to verify failure**
+
+**Step 3: Update `import_downloaded_entry()` to move artifacts into blob store**
+
+```rust
+pub fn import_downloaded_entry(&self, cache_key: &str) -> Result<()> {
+    let entry_dir = self.entry_dir(cache_key);
+    let meta_path = entry_dir.join("meta.json");
+    let content = fs::read_to_string(&meta_path).context("reading downloaded meta.json")?;
+    let meta: EntryMeta =
+        serde_json::from_str(&content).context("parsing downloaded meta.json")?;
+
+    for cached_file in &meta.files {
+        let file_path = entry_dir.join(&cached_file.name);
+        if !file_path.is_file() {
+            anyhow::bail!(
+                "downloaded entry {} missing file: {}",
+                cache_key.get(..16).unwrap_or(cache_key),
+                cached_file.name
+            );
+        }
+
+        // Move artifact into blob store
+        let blob = self.blob_path(&cached_file.hash);
+        let existing: Option<i64> = self
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![cached_file.hash],
+                |row| row.get(0),
+            )
+            .ok();
+
+        if existing.is_some() {
+            // Blob already exists — just delete the downloaded file
+            let _ = fs::remove_file(&file_path);
+            self.db.execute(
+                "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                params![cached_file.hash],
+            )?;
+        } else {
+            // Move into blob store
+            let blob_dir = blob.parent().unwrap();
+            fs::create_dir_all(blob_dir)?;
+
+            // Make read-only before moving
+            let meta = fs::metadata(&file_path)?;
+            let mut perms = meta.permissions();
+            perms.set_readonly(true);
+            fs::set_permissions(&file_path, perms)?;
+
+            fs::rename(&file_path, &blob)?;
+
+            self.db.execute(
+                "INSERT OR IGNORE INTO blobs (hash, size, refcount) VALUES (?1, ?2, 1)",
+                params![cached_file.hash, cached_file.size as i64],
+            )?;
+            if self.db.changes() == 0 {
+                self.db.execute(
+                    "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                    params![cached_file.hash],
+                )?;
+            }
+        }
+    }
+
+    let total_size: u64 = meta.files.iter().map(|f| f.size).sum();
+    let crate_type_str = meta.crate_types.join(",");
+    let num_features = meta.features.len() as i64;
+    self.db.execute(
+        "INSERT OR REPLACE INTO entries (cache_key, crate_name, crate_type, profile, num_features, size, committed) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)",
+        params![cache_key, meta.crate_name, crate_type_str, meta.profile, num_features, total_size as i64],
+    )?;
+
+    Ok(())
+}
+```
+
+**Step 4: Run tests, commit**
+
+Run: `cargo test --lib store::tests -- --nocapture`
+
+```bash
+git add src/store.rs
+git commit -m "feat(store): import_downloaded_entry moves artifacts into blob store"
+```
+
+---
+
+### Task 8: Add `kache dedup` CLI command for migrating existing stores
+
+**Files:**
+- Modify: `src/main.rs:48-151` (Commands enum)
+- Modify: `src/store.rs` (add `migrate_to_blobs` method)
+- Test: `src/store.rs` (mod tests)
+
+**Step 1: Write failing test for migration**
+
+```rust
+#[test]
+fn test_migrate_to_blobs() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    // Simulate old-format entries: artifacts in entry dir (bypass new put)
+    let entry_dir = config.store_dir().join("old_key");
+    fs::create_dir_all(&entry_dir).unwrap();
+    let content = b"old format artifact";
+    fs::write(entry_dir.join("lib.rlib"), content).unwrap();
+
+    let hash = crate::cache_key::hash_file(&entry_dir.join("lib.rlib")).unwrap();
+    let meta = EntryMeta {
+        cache_key: "old_key".to_string(),
+        crate_name: "old_crate".to_string(),
+        crate_types: vec!["lib".to_string()],
+        files: vec![CachedFile {
+            name: "lib.rlib".to_string(),
+            size: content.len() as u64,
+            hash: hash.clone(),
+        }],
+        stdout: String::new(), stderr: String::new(),
+        features: vec![], target: String::new(), profile: "dev".to_string(),
+    };
+    fs::write(
+        entry_dir.join("meta.json"),
+        serde_json::to_string_pretty(&meta).unwrap(),
+    ).unwrap();
+    store.db.execute(
+        "INSERT INTO entries (cache_key, crate_name, size, committed) VALUES ('old_key', 'old_crate', ?1, 1)",
+        params![content.len() as i64],
+    ).unwrap();
+
+    // Run migration
+    let stats = store.migrate_to_blobs(|_, _| {}).unwrap();
+    assert_eq!(stats.entries_migrated, 1);
+    assert_eq!(stats.blobs_created, 1);
+
+    // Blob should exist
+    let blob = store.blob_path(&hash);
+    assert!(blob.exists());
+
+    // Entry dir should only have meta.json
+    let files: Vec<_> = fs::read_dir(&entry_dir).unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    assert_eq!(files, vec!["meta.json"]);
+
+    // get() should work
+    assert!(store.get("old_key").unwrap().is_some());
+}
+
+#[test]
+fn test_migrate_deduplicates_shared_content() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_config(dir.path());
+    let store = Store::open(&config).unwrap();
+
+    let content = b"shared artifact bytes";
+    let hash = {
+        let tmp = dir.path().join("tmp");
+        fs::write(&tmp, content).unwrap();
+        crate::cache_key::hash_file(&tmp).unwrap()
+    };
+
+    // Create two old-format entries with identical content
+    for key in &["old1", "old2"] {
+        let entry_dir = config.store_dir().join(key);
+        fs::create_dir_all(&entry_dir).unwrap();
+        fs::write(entry_dir.join("lib.rlib"), content).unwrap();
+
+        let meta = EntryMeta {
+            cache_key: key.to_string(),
+            crate_name: "shared_crate".to_string(),
+            crate_types: vec!["lib".to_string()],
+            files: vec![CachedFile {
+                name: "lib.rlib".to_string(),
+                size: content.len() as u64,
+                hash: hash.clone(),
+            }],
+            stdout: String::new(), stderr: String::new(),
+            features: vec![], target: String::new(), profile: "dev".to_string(),
+        };
+        fs::write(
+            entry_dir.join("meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        ).unwrap();
+        store.db.execute(
+            &format!("INSERT INTO entries (cache_key, crate_name, size, committed) VALUES ('{key}', 'shared_crate', {}, 1)", content.len()),
+            [],
+        ).unwrap();
+    }
+
+    let stats = store.migrate_to_blobs(|_, _| {}).unwrap();
+    assert_eq!(stats.entries_migrated, 2);
+    assert_eq!(stats.blobs_created, 1); // only one unique blob
+
+    // Refcount should be 2
+    let refcount: i64 = store.db.query_row(
+        "SELECT refcount FROM blobs WHERE hash = ?1",
+        params![hash],
+        |row| row.get(0),
+    ).unwrap();
+    assert_eq!(refcount, 2);
+}
+```
+
+**Step 2: Run tests to verify failure**
+
+**Step 3: Implement `migrate_to_blobs()` on Store**
+
+```rust
+#[derive(Debug, Default)]
+pub struct MigrationStats {
+    pub entries_scanned: usize,
+    pub entries_migrated: usize,
+    pub entries_skipped: usize,
+    pub blobs_created: usize,
+    pub blobs_reused: usize,
+    pub bytes_saved: u64,
+}
+
+/// Migrate existing entries from per-entry artifact storage to blob store.
+/// Callback receives (entries_processed, total_entries) for progress reporting.
+pub fn migrate_to_blobs(
+    &self,
+    progress: impl Fn(usize, usize),
+) -> Result<MigrationStats> {
+    let store_dir = self.config.store_dir();
+    let mut stats = MigrationStats::default();
+
+    // Collect all entry dirs that have artifact files (not just meta.json)
+    let mut entry_dirs = Vec::new();
+    if let Ok(entries) = fs::read_dir(&store_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() && path.file_name().map_or(false, |n| n != "blobs") {
+                let meta_path = path.join("meta.json");
+                if meta_path.exists() {
+                    // Check if there are non-meta.json files (needs migration)
+                    let has_artifacts = fs::read_dir(&path)
+                        .into_iter()
+                        .flatten()
+                        .flatten()
+                        .any(|e| e.file_name() != "meta.json");
+                    if has_artifacts {
+                        entry_dirs.push(path);
+                    }
+                }
+            }
+        }
+    }
+
+    let total = entry_dirs.len();
+
+    for (i, entry_dir) in entry_dirs.iter().enumerate() {
+        progress(i, total);
+        stats.entries_scanned += 1;
+
+        let meta_path = entry_dir.join("meta.json");
+        let content = match fs::read_to_string(&meta_path) {
+            Ok(c) => c,
+            Err(_) => { stats.entries_skipped += 1; continue; }
+        };
+        let meta: EntryMeta = match serde_json::from_str(&content) {
+            Ok(m) => m,
+            Err(_) => { stats.entries_skipped += 1; continue; }
+        };
+
+        let mut migrated_any = false;
+        for cached_file in &meta.files {
+            let artifact_path = entry_dir.join(&cached_file.name);
+            if !artifact_path.exists() {
+                continue; // Already migrated or missing
+            }
+
+            let blob = self.blob_path(&cached_file.hash);
+            let existing: Option<i64> = self
+                .db
+                .query_row(
+                    "SELECT refcount FROM blobs WHERE hash = ?1",
+                    params![cached_file.hash],
+                    |row| row.get(0),
+                )
+                .ok();
+
+            if existing.is_some() {
+                // Blob already exists — delete the artifact, increment refcount
+                // Make writable to delete
+                if let Ok(m) = fs::metadata(&artifact_path) {
+                    let mut perms = m.permissions();
+                    perms.set_readonly(false);
+                    let _ = fs::set_permissions(&artifact_path, perms);
+                }
+                fs::remove_file(&artifact_path)?;
+                self.db.execute(
+                    "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                    params![cached_file.hash],
+                )?;
+                stats.blobs_reused += 1;
+                stats.bytes_saved += cached_file.size;
+            } else {
+                // New blob — rename artifact into blob store
+                let blob_dir = blob.parent().unwrap();
+                fs::create_dir_all(blob_dir)?;
+
+                // Ensure read-only
+                if let Ok(m) = fs::metadata(&artifact_path) {
+                    let mut perms = m.permissions();
+                    if !perms.readonly() {
+                        perms.set_readonly(true);
+                        fs::set_permissions(&artifact_path, perms)?;
+                    }
+                }
+
+                fs::rename(&artifact_path, &blob)?;
+                self.db.execute(
+                    "INSERT OR IGNORE INTO blobs (hash, size, refcount) VALUES (?1, ?2, 1)",
+                    params![cached_file.hash, cached_file.size as i64],
+                )?;
+                if self.db.changes() == 0 {
+                    self.db.execute(
+                        "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                        params![cached_file.hash],
+                    )?;
+                    stats.blobs_reused += 1;
+                } else {
+                    stats.blobs_created += 1;
+                }
+            }
+
+            migrated_any = true;
+        }
+
+        if migrated_any {
+            stats.entries_migrated += 1;
+        } else {
+            stats.entries_skipped += 1;
+        }
+    }
+
+    progress(total, total);
+    Ok(stats)
+}
+```
+
+**Step 4: Add CLI command in `src/main.rs`**
+
+Add `Dedup` variant to `Commands` enum:
+
+```rust
+/// Deduplicate cached artifacts using content-addressed blob store
+Dedup {
+    /// Preview what would be deduplicated without making changes
+    #[arg(long)]
+    dry_run: bool,
+},
+```
+
+Add handler in the match block (wherever other commands are handled):
+
+```rust
+Commands::Dedup { dry_run } => {
+    let config = config::Config::load()?;
+    let store = store::Store::open(&config)?;
+
+    if dry_run {
+        eprintln!("Dry run — scanning for deduplication opportunities...");
+        // TODO: implement dry-run stats
+    } else {
+        eprintln!("Migrating existing cache to content-addressed blob store...");
+        let stats = store.migrate_to_blobs(|done, total| {
+            if total > 0 {
+                eprint!("\r  [{}/{}] entries processed", done, total);
+            }
+        })?;
+        eprintln!();
+        eprintln!("Migration complete:");
+        eprintln!("  Entries migrated: {}", stats.entries_migrated);
+        eprintln!("  Entries skipped:  {}", stats.entries_skipped);
+        eprintln!("  Blobs created:    {}", stats.blobs_created);
+        eprintln!("  Blobs reused:     {}", stats.blobs_reused);
+        eprintln!(
+            "  Space saved:      {:.1} MiB",
+            stats.bytes_saved as f64 / 1_048_576.0
+        );
+    }
+}
+```
+
+**Step 5: Run tests, commit**
+
+Run: `cargo test -- --nocapture`
+
+```bash
+git add src/store.rs src/main.rs
+git commit -m "feat: kache dedup command to migrate existing stores to blob store"
+```
+
+---
+
+### Task 9: Add dedup stats to `kache stats` and TUI
+
+**Files:**
+- Modify: `src/store.rs` (add `blob_stats()` method)
+- Modify: `src/cli.rs` or wherever stats are rendered
+- Modify: `src/tui.rs` (Store tab)
+
+**Step 1: Add `blob_stats()` to Store**
+
+```rust
+#[derive(Debug, Default)]
+pub struct BlobStats {
+    pub total_blobs: usize,
+    pub total_blob_size: u64,
+    pub total_logical_size: u64,
+    pub savings: u64,
+}
+
+pub fn blob_stats(&self) -> Result<BlobStats> {
+    let total_blobs: i64 = self.db.query_row(
+        "SELECT COUNT(*) FROM blobs", [], |row| row.get(0),
+    )?;
+    let total_blob_size: i64 = self.db.query_row(
+        "SELECT COALESCE(SUM(size), 0) FROM blobs", [], |row| row.get(0),
+    )?;
+    let total_logical_size: i64 = self.db.query_row(
+        "SELECT COALESCE(SUM(size), 0) FROM entries", [], |row| row.get(0),
+    )?;
+    Ok(BlobStats {
+        total_blobs: total_blobs as usize,
+        total_blob_size: total_blob_size as u64,
+        total_logical_size: total_logical_size as u64,
+        savings: (total_logical_size as u64).saturating_sub(total_blob_size as u64),
+    })
+}
+```
+
+**Step 2: Integrate into stats display and TUI**
+
+Find where stats are displayed (likely in CLI handler for `Commands::Stats` and in `tui.rs` Store tab) and add dedup lines:
+
+```
+  Logical size:  46.9 GiB
+  Physical size: 36.2 GiB (blobs)
+  Dedup savings: 10.7 GiB (22.8%)
+```
+
+**Step 3: Run tests, commit**
+
+```bash
+git add src/store.rs src/cli.rs src/tui.rs
+git commit -m "feat: show dedup savings in kache stats and TUI"
+```
+
+---
+
+### Task 10: Update S3 upload to use blob-based format
+
+**Files:**
+- Modify: `src/remote.rs` (add blob upload/download, keep old format for backward compat)
+- Modify: `src/daemon.rs` (update upload/download handlers)
+- Test: `src/remote.rs` (mod tests)
+
+**Step 1: Add S3 blob key helpers**
+
+```rust
+/// S3 key for a content-addressed blob.
+fn s3_blob_key(prefix: &str, hash: &str) -> String {
+    format!("{prefix}/blobs/{}/{hash}.zst", &hash[..2])
+}
+
+/// S3 key for a cache entry manifest.
+fn s3_manifest_key(prefix: &str, cache_key: &str, crate_name: &str) -> String {
+    format!("{prefix}/manifests/{crate_name}/{cache_key}.json")
+}
+```
+
+**Step 2: Implement `upload_entry_v2()`**
+
+New upload function that:
+1. For each `CachedFile` in meta: HEAD check `s3_blob_key`, upload blob if missing (zstd compressed individually)
+2. Upload manifest (meta.json content without artifact bytes)
+
+**Step 3: Implement `download_entry_v2()`**
+
+New download function that:
+1. Try fetching manifest first (`s3_manifest_key`)
+2. If found: download missing blobs, populate local blob store
+3. If not found: fall back to old `download_with_client()` (tar format)
+
+**Step 4: Update daemon to use v2 for uploads, v2-with-fallback for downloads**
+
+**Step 5: Run tests, commit**
+
+```bash
+git add src/remote.rs src/daemon.rs
+git commit -m "feat(remote): S3 blob-based upload/download with tar fallback"
+```
+
+---
+
+### Task 11: Update S3 sync command for blob format
+
+**Files:**
+- Modify: `src/main.rs` or `src/cli.rs` (sync command handler)
+- Modify: `src/remote.rs` (sync logic)
+
+**Step 1: Update sync to use manifest-based listing**
+
+The `kache sync` command currently lists S3 objects matching `{prefix}/{crate_name}/`. Update to also check `{prefix}/manifests/{crate_name}/` for v2 entries.
+
+**Step 2: Update sync download to use v2 format with fallback**
+
+**Step 3: Run tests, commit**
+
+```bash
+git add src/remote.rs src/main.rs
+git commit -m "feat(sync): support blob-based S3 format with tar fallback"
+```
+
+---
+
+### Task 12: Full integration test suite
+
+**Files:**
+- Create: `tests/dedup_integration.rs` (or add to existing integration tests)
+
+**Step 1: Write comprehensive integration tests**
+
+```rust
+// Test: full lifecycle — put, get, restore, evict, migrate
+// Test: concurrent put with same content (refcount correctness)
+// Test: eviction with shared blobs (last entry eviction deletes blob)
+// Test: migration of mixed old/new format store
+// Test: import_downloaded_entry into blob store
+// Test: clear() removes everything including blobs
+```
+
+**Step 2: Run full test suite**
+
+Run: `make test`
+
+**Step 3: Commit**
+
+```bash
+git add tests/dedup_integration.rs
+git commit -m "test: comprehensive dedup integration tests"
+```
+
+---
+
+### Task 13: Final cleanup and make check/lint
+
+**Files:**
+- All modified files
+
+**Step 1: Run full CI checks**
+
+```bash
+make check
+make lint
+make test
+```
+
+**Step 2: Fix any warnings or clippy issues**
+
+**Step 3: Commit**
+
+```bash
+git commit -m "chore: fix clippy warnings from dedup changes"
+```
+
+---
+
+## Implementation Order & Dependencies
+
+```
+Task 1 (blob helpers + table)
+  └─► Task 2 (blob-aware put)
+       └─► Task 3 (blob-aware get)
+            └─► Task 4 (refcount-aware remove)
+                 └─► Task 5 (clear with blobs)
+                      └─► Task 6 (restore from blobs)
+                           └─► Task 7 (import downloaded → blobs)
+                                └─► Task 8 (migration CLI)
+                                     └─► Task 9 (stats/TUI)
+Task 10 (S3 blob upload) — can start after Task 7
+Task 11 (S3 sync) — after Task 10
+Task 12 (integration tests) — after Task 8
+Task 13 (cleanup) — final
+```
+
+Tasks 10-11 (S3) can be developed in parallel with Tasks 8-9 (local migration/stats) since they touch different files.

--- a/docs/plans/2026-03-04-content-addressable-dedup-plan.md
+++ b/docs/plans/2026-03-04-content-addressable-dedup-plan.md
@@ -952,23 +952,23 @@ git commit -m "feat(store): import_downloaded_entry moves artifacts into blob st
 
 ---
 
-### Task 8: Add `kache dedup` CLI command for migrating existing stores
+### Task 8: Lazy migration on access + background bulk migration
 
 **Files:**
-- Modify: `src/main.rs:48-151` (Commands enum)
-- Modify: `src/store.rs` (add `migrate_to_blobs` method)
+- Modify: `src/store.rs` (add `migrate_entry_to_blobs`, `migrate_to_blobs`, update `get()`)
+- Modify: `src/daemon.rs` (spawn background migration task on startup)
 - Test: `src/store.rs` (mod tests)
 
-**Step 1: Write failing test for migration**
+**Step 1: Write failing tests for lazy migration**
 
 ```rust
 #[test]
-fn test_migrate_to_blobs() {
+fn test_get_lazily_migrates_legacy_entry() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_config(dir.path());
     let store = Store::open(&config).unwrap();
 
-    // Simulate old-format entries: artifacts in entry dir (bypass new put)
+    // Simulate a legacy entry: artifacts in entry dir, no blobs
     let entry_dir = config.store_dir().join("old_key");
     fs::create_dir_all(&entry_dir).unwrap();
     let content = b"old format artifact";
@@ -996,28 +996,24 @@ fn test_migrate_to_blobs() {
         params![content.len() as i64],
     ).unwrap();
 
-    // Run migration
-    let stats = store.migrate_to_blobs(|_, _| {}).unwrap();
-    assert_eq!(stats.entries_migrated, 1);
-    assert_eq!(stats.blobs_created, 1);
+    // get() should transparently migrate the entry
+    let result = store.get("old_key").unwrap();
+    assert!(result.is_some());
 
-    // Blob should exist
+    // Blob should now exist
     let blob = store.blob_path(&hash);
-    assert!(blob.exists());
+    assert!(blob.exists(), "get() should have migrated artifact to blob store");
 
     // Entry dir should only have meta.json
     let files: Vec<_> = fs::read_dir(&entry_dir).unwrap()
         .filter_map(|e| e.ok())
-        .map(|e| e.file_name().to_string_lossy().to_string())
-        .collect();
-    assert_eq!(files, vec!["meta.json"]);
-
-    // get() should work
-    assert!(store.get("old_key").unwrap().is_some());
+        .filter(|e| e.file_name() != "meta.json")
+        .count();
+    assert_eq!(files, 0, "artifact should have been moved out of entry dir");
 }
 
 #[test]
-fn test_migrate_deduplicates_shared_content() {
+fn test_migrate_to_blobs_bulk() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_config(dir.path());
     let store = Store::open(&config).unwrap();
@@ -1029,7 +1025,7 @@ fn test_migrate_deduplicates_shared_content() {
         crate::cache_key::hash_file(&tmp).unwrap()
     };
 
-    // Create two old-format entries with identical content
+    // Create two legacy entries with identical content
     for key in &["old1", "old2"] {
         let entry_dir = config.store_dir().join(key);
         fs::create_dir_all(&entry_dir).unwrap();
@@ -1073,7 +1069,127 @@ fn test_migrate_deduplicates_shared_content() {
 
 **Step 2: Run tests to verify failure**
 
-**Step 3: Implement `migrate_to_blobs()` on Store**
+Run: `cargo test --lib store::tests::test_get_lazily_migrates_legacy_entry -- --nocapture`
+Expected: FAIL — get() doesn't know about lazy migration yet
+
+**Step 3: Implement `migrate_entry_to_blobs()` (single entry) and update `get()`**
+
+Add a private helper that migrates one entry's artifacts into the blob store:
+
+```rust
+/// Migrate a single legacy entry's artifacts into the blob store.
+/// Called lazily on get() when artifacts are found in the entry dir instead of blobs.
+fn migrate_entry_to_blobs(&self, meta: &EntryMeta) -> Result<()> {
+    let entry_dir = self.entry_dir(&meta.cache_key);
+
+    for cached_file in &meta.files {
+        let artifact_path = entry_dir.join(&cached_file.name);
+        if !artifact_path.exists() {
+            continue; // Already migrated or missing
+        }
+
+        let blob = self.blob_path(&cached_file.hash);
+
+        let existing: Option<i64> = self
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![cached_file.hash],
+                |row| row.get(0),
+            )
+            .ok();
+
+        if existing.is_some() {
+            // Blob already exists — delete the artifact, increment refcount
+            if let Ok(m) = fs::metadata(&artifact_path) {
+                let mut perms = m.permissions();
+                perms.set_readonly(false);
+                let _ = fs::set_permissions(&artifact_path, perms);
+            }
+            fs::remove_file(&artifact_path)?;
+            self.db.execute(
+                "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                params![cached_file.hash],
+            )?;
+        } else {
+            // New blob — rename artifact into blob store
+            let blob_dir = blob.parent().unwrap();
+            fs::create_dir_all(blob_dir)?;
+
+            if let Ok(m) = fs::metadata(&artifact_path) {
+                let mut perms = m.permissions();
+                if !perms.readonly() {
+                    perms.set_readonly(true);
+                    fs::set_permissions(&artifact_path, perms)?;
+                }
+            }
+
+            fs::rename(&artifact_path, &blob)?;
+            self.db.execute(
+                "INSERT OR IGNORE INTO blobs (hash, size, refcount) VALUES (?1, ?2, 1)",
+                params![cached_file.hash, cached_file.size as i64],
+            )?;
+            if self.db.changes() == 0 {
+                self.db.execute(
+                    "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                    params![cached_file.hash],
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+```
+
+Update `get()` — after parsing meta, before verifying blobs, check for legacy artifacts:
+
+```rust
+pub fn get(&self, cache_key: &str) -> Result<Option<EntryMeta>> {
+    if !self.contains(cache_key) {
+        return Ok(None);
+    }
+
+    let entry_dir = self.entry_dir(cache_key);
+    let meta_path = entry_dir.join("meta.json");
+    let content = fs::read_to_string(&meta_path).context("reading entry meta.json")?;
+    let meta: EntryMeta = serde_json::from_str(&content).context("parsing entry meta.json")?;
+
+    // Lazy migration: if artifacts are in entry dir (legacy format), migrate them
+    let needs_migration = meta.files.iter().any(|f| entry_dir.join(&f.name).exists());
+    if needs_migration {
+        if let Err(e) = self.migrate_entry_to_blobs(&meta) {
+            tracing::warn!("lazy migration failed for {}: {e}", &cache_key[..16]);
+        }
+    }
+
+    // Verify all blobs exist
+    for cached_file in &meta.files {
+        let blob = self.blob_path(&cached_file.hash);
+        if !blob.is_file() {
+            tracing::warn!(
+                "cache entry {} missing blob {} for file {}, evicting",
+                cache_key.get(..16).unwrap_or(cache_key),
+                &cached_file.hash[..16],
+                cached_file.name
+            );
+            let _ = self.remove_entry(cache_key);
+            return Ok(None);
+        }
+    }
+
+    self.db.execute(
+        "UPDATE entries SET last_accessed = datetime('now'), hit_count = hit_count + 1 WHERE cache_key = ?1",
+        params![cache_key],
+    )?;
+
+    Ok(Some(meta))
+}
+```
+
+**Step 4: Implement `migrate_to_blobs()` (bulk, for background daemon use)**
+
+Same `migrate_to_blobs()` as before — walks all entry dirs and calls `migrate_entry_to_blobs()`:
 
 ```rust
 #[derive(Debug, Default)]
@@ -1086,181 +1202,46 @@ pub struct MigrationStats {
     pub bytes_saved: u64,
 }
 
-/// Migrate existing entries from per-entry artifact storage to blob store.
-/// Callback receives (entries_processed, total_entries) for progress reporting.
 pub fn migrate_to_blobs(
     &self,
     progress: impl Fn(usize, usize),
 ) -> Result<MigrationStats> {
-    let store_dir = self.config.store_dir();
-    let mut stats = MigrationStats::default();
-
-    // Collect all entry dirs that have artifact files (not just meta.json)
-    let mut entry_dirs = Vec::new();
-    if let Ok(entries) = fs::read_dir(&store_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() && path.file_name().map_or(false, |n| n != "blobs") {
-                let meta_path = path.join("meta.json");
-                if meta_path.exists() {
-                    // Check if there are non-meta.json files (needs migration)
-                    let has_artifacts = fs::read_dir(&path)
-                        .into_iter()
-                        .flatten()
-                        .flatten()
-                        .any(|e| e.file_name() != "meta.json");
-                    if has_artifacts {
-                        entry_dirs.push(path);
-                    }
-                }
-            }
-        }
-    }
-
-    let total = entry_dirs.len();
-
-    for (i, entry_dir) in entry_dirs.iter().enumerate() {
-        progress(i, total);
-        stats.entries_scanned += 1;
-
-        let meta_path = entry_dir.join("meta.json");
-        let content = match fs::read_to_string(&meta_path) {
-            Ok(c) => c,
-            Err(_) => { stats.entries_skipped += 1; continue; }
-        };
-        let meta: EntryMeta = match serde_json::from_str(&content) {
-            Ok(m) => m,
-            Err(_) => { stats.entries_skipped += 1; continue; }
-        };
-
-        let mut migrated_any = false;
-        for cached_file in &meta.files {
-            let artifact_path = entry_dir.join(&cached_file.name);
-            if !artifact_path.exists() {
-                continue; // Already migrated or missing
-            }
-
-            let blob = self.blob_path(&cached_file.hash);
-            let existing: Option<i64> = self
-                .db
-                .query_row(
-                    "SELECT refcount FROM blobs WHERE hash = ?1",
-                    params![cached_file.hash],
-                    |row| row.get(0),
-                )
-                .ok();
-
-            if existing.is_some() {
-                // Blob already exists — delete the artifact, increment refcount
-                // Make writable to delete
-                if let Ok(m) = fs::metadata(&artifact_path) {
-                    let mut perms = m.permissions();
-                    perms.set_readonly(false);
-                    let _ = fs::set_permissions(&artifact_path, perms);
-                }
-                fs::remove_file(&artifact_path)?;
-                self.db.execute(
-                    "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
-                    params![cached_file.hash],
-                )?;
-                stats.blobs_reused += 1;
-                stats.bytes_saved += cached_file.size;
-            } else {
-                // New blob — rename artifact into blob store
-                let blob_dir = blob.parent().unwrap();
-                fs::create_dir_all(blob_dir)?;
-
-                // Ensure read-only
-                if let Ok(m) = fs::metadata(&artifact_path) {
-                    let mut perms = m.permissions();
-                    if !perms.readonly() {
-                        perms.set_readonly(true);
-                        fs::set_permissions(&artifact_path, perms)?;
-                    }
-                }
-
-                fs::rename(&artifact_path, &blob)?;
-                self.db.execute(
-                    "INSERT OR IGNORE INTO blobs (hash, size, refcount) VALUES (?1, ?2, 1)",
-                    params![cached_file.hash, cached_file.size as i64],
-                )?;
-                if self.db.changes() == 0 {
-                    self.db.execute(
-                        "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
-                        params![cached_file.hash],
-                    )?;
-                    stats.blobs_reused += 1;
-                } else {
-                    stats.blobs_created += 1;
-                }
-            }
-
-            migrated_any = true;
-        }
-
-        if migrated_any {
-            stats.entries_migrated += 1;
-        } else {
-            stats.entries_skipped += 1;
-        }
-    }
-
-    progress(total, total);
-    Ok(stats)
+    // ... (same implementation as before, walks store dir, calls migrate_entry_to_blobs)
 }
 ```
 
-**Step 4: Add CLI command in `src/main.rs`**
+**Step 5: Add background migration to daemon startup**
 
-Add `Dedup` variant to `Commands` enum:
-
-```rust
-/// Deduplicate cached artifacts using content-addressed blob store
-Dedup {
-    /// Preview what would be deduplicated without making changes
-    #[arg(long)]
-    dry_run: bool,
-},
-```
-
-Add handler in the match block (wherever other commands are handled):
+In `src/daemon.rs`, after the daemon server starts, spawn a non-blocking tokio task:
 
 ```rust
-Commands::Dedup { dry_run } => {
-    let config = config::Config::load()?;
-    let store = store::Store::open(&config)?;
-
-    if dry_run {
-        eprintln!("Dry run — scanning for deduplication opportunities...");
-        // TODO: implement dry-run stats
-    } else {
-        eprintln!("Migrating existing cache to content-addressed blob store...");
-        let stats = store.migrate_to_blobs(|done, total| {
-            if total > 0 {
-                eprint!("\r  [{}/{}] entries processed", done, total);
+// In daemon server setup, after listener is bound:
+tokio::spawn(async move {
+    let config = config.clone();
+    tokio::task::spawn_blocking(move || {
+        if let Ok(store) = Store::open(&config) {
+            let stats = store.migrate_to_blobs(|_, _| {});
+            if let Ok(stats) = stats {
+                if stats.entries_migrated > 0 {
+                    tracing::info!(
+                        "background migration: migrated {} entries, saved {:.1} MiB",
+                        stats.entries_migrated,
+                        stats.bytes_saved as f64 / 1_048_576.0
+                    );
+                }
             }
-        })?;
-        eprintln!();
-        eprintln!("Migration complete:");
-        eprintln!("  Entries migrated: {}", stats.entries_migrated);
-        eprintln!("  Entries skipped:  {}", stats.entries_skipped);
-        eprintln!("  Blobs created:    {}", stats.blobs_created);
-        eprintln!("  Blobs reused:     {}", stats.blobs_reused);
-        eprintln!(
-            "  Space saved:      {:.1} MiB",
-            stats.bytes_saved as f64 / 1_048_576.0
-        );
-    }
-}
+        }
+    }).await
+});
 ```
 
-**Step 5: Run tests, commit**
+**Step 6: Run tests, commit**
 
 Run: `cargo test -- --nocapture`
 
 ```bash
-git add src/store.rs src/main.rs
-git commit -m "feat: kache dedup command to migrate existing stores to blob store"
+git add src/store.rs src/daemon.rs
+git commit -m "feat(store): lazy migration on get() + background bulk migration on daemon startup"
 ```
 
 ---
@@ -1449,7 +1430,7 @@ Task 1 (blob helpers + table)
                  └─► Task 5 (clear with blobs)
                       └─► Task 6 (restore from blobs)
                            └─► Task 7 (import downloaded → blobs)
-                                └─► Task 8 (migration CLI)
+                                └─► Task 8 (lazy + background migration)
                                      └─► Task 9 (stats/TUI)
 Task 10 (S3 blob upload) — can start after Task 7
 Task 11 (S3 sync) — after Task 10
@@ -1458,3 +1439,8 @@ Task 13 (cleanup) — final
 ```
 
 Tasks 10-11 (S3) can be developed in parallel with Tasks 8-9 (local migration/stats) since they touch different files.
+
+**Migration strategy (no CLI command needed):**
+- **Lazy**: `get()` detects legacy artifacts in entry dir and migrates them on the fly (near-instant per entry)
+- **Background**: Daemon spawns a non-blocking migration task on startup to catch remaining entries
+- Together these ensure all entries are migrated without any user action or startup delay

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1788,16 +1788,35 @@ async fn sync_inner(
                     return;
                 }
 
-                match crate::remote::download_with_client(
+                let blobs_dir = cfg.store_dir().join("blobs");
+                // Try v2 blob format first, fall back to v1 tar format
+                let result = match crate::remote::download_entry_v2(
                     &client,
                     &bucket,
                     &prefix,
                     &key,
-                    &entry_dir,
                     &crate_name,
+                    &entry_dir,
+                    &blobs_dir,
                 )
                 .await
                 {
+                    Ok(Some(bytes)) => Ok(bytes),
+                    Ok(None) => {
+                        // No v2 manifest — fall back to v1 tar format
+                        crate::remote::download_with_client(
+                            &client,
+                            &bucket,
+                            &prefix,
+                            &key,
+                            &entry_dir,
+                            &crate_name,
+                        )
+                        .await
+                    }
+                    Err(e) => Err(e),
+                };
+                match result {
                     Ok(_bytes) => {
                         // Import into index — opens a fresh Store (cheap with WAL).
                         // INSERT OR REPLACE is idempotent if daemon also imported.
@@ -1872,14 +1891,16 @@ async fn sync_inner(
                     return;
                 }
 
-                match crate::remote::upload_with_client(
+                let blobs_dir = cfg.store_dir().join("blobs");
+                match crate::remote::upload_entry_v2(
                     &client,
                     &bucket,
                     &prefix,
                     &key,
-                    &entry_dir,
-                    cfg.compression_level,
                     &crate_name,
+                    &entry_dir,
+                    &blobs_dir,
+                    cfg.compression_level,
                 )
                 .await
                 {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -196,6 +196,23 @@ pub fn stats(config: &Config, hours: Option<u64>) -> Result<()> {
         store_pct,
     );
 
+    // Content dedup stats
+    let store = Store::open(config)?;
+    let blob_stats = store.blob_stats()?;
+    if blob_stats.total_blobs > 0 {
+        let savings_pct = if blob_stats.total_logical_size > 0 {
+            blob_stats.savings as f64 / blob_stats.total_logical_size as f64 * 100.0
+        } else {
+            0.0
+        };
+        println!(
+            "Dedup:      {} unique blobs, {} physical, {:.1}% savings",
+            blob_stats.total_blobs,
+            ByteSize(blob_stats.total_blob_size),
+            savings_pct,
+        );
+    }
+
     // Hit rate
     let es = &snap.event_stats;
     let total = es.local_hits + es.prefetch_hits + es.remote_hits + es.misses;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,6 @@ use crate::store::Store;
 
 /// Cached store + event stats, refreshed periodically.
 /// Used by both the TUI monitor and `kache stats` CLI.
-#[allow(dead_code)]
 pub(crate) struct StatsSnapshot {
     pub total_size: u64,
     pub max_size: u64,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1509,14 +1509,13 @@ async fn server_main(config: &Config) -> Result<()> {
         })
         .await;
 
-        if let Ok(Ok(stats)) = result {
-            if stats.entries_migrated > 0 {
+        if let Ok(Ok(stats)) = result
+            && stats.entries_migrated > 0 {
                 tracing::info!(
                     "background migration: migrated {} entries",
                     stats.entries_migrated,
                 );
             }
-        }
     });
 
     // Shutdown flag: set by Shutdown request or OS signal

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -684,8 +684,8 @@ impl Daemon {
             }
         };
 
-        // Check if already in S3 (another runner may have uploaded it)
-        if let Ok(exists) = crate::remote::exists_with_client(
+        // Check if already in S3 (v2 manifest or v1 tar)
+        let already_exists = crate::remote::exists_v2(
             client,
             &remote.bucket,
             &remote.prefix,
@@ -693,8 +693,18 @@ impl Daemon {
             &job.crate_name,
         )
         .await
-            && exists
-        {
+        .unwrap_or(false)
+            || crate::remote::exists_with_client(
+                client,
+                &remote.bucket,
+                &remote.prefix,
+                &job.key,
+                &job.crate_name,
+            )
+            .await
+            .unwrap_or(false);
+
+        if already_exists {
             self.key_cache
                 .insert(job.key.clone(), Some(&job.crate_name))
                 .await;
@@ -717,15 +727,17 @@ impl Daemon {
         );
 
         let entry_dir = PathBuf::from(&job.entry_dir);
+        let blobs_dir = self.config.store_dir().join("blobs");
         let start = Instant::now();
-        match crate::remote::upload_with_client(
+        match crate::remote::upload_entry_v2(
             client,
             &remote.bucket,
             &remote.prefix,
             &job.key,
-            &entry_dir,
-            self.config.compression_level,
             &job.crate_name,
+            &entry_dir,
+            &blobs_dir,
+            self.config.compression_level,
         )
         .await
         {
@@ -909,19 +921,44 @@ impl Daemon {
             return Response::err("S3 semaphore closed");
         };
 
-        // Download to local store
+        // Download to local store — try v2 (blob-based) first, then fall back to v1 (tar)
         let entry_dir = PathBuf::from(&req.entry_dir);
+        let blobs_dir = self.config.store_dir().join("blobs");
         let start = Instant::now();
-        let result = match crate::remote::download_with_client(
+
+        // Try v2 download first
+        let download_result = match crate::remote::download_entry_v2(
             client,
             &remote.bucket,
             &remote.prefix,
             &req.key,
-            &entry_dir,
             cn,
+            &entry_dir,
+            &blobs_dir,
         )
         .await
         {
+            Ok(Some(bytes)) => Ok(bytes),
+            Ok(None) => {
+                // No v2 manifest — fall back to v1 tar format
+                tracing::debug!(
+                    "no v2 manifest for {}, falling back to v1",
+                    &req.key[..req.key.len().min(16)]
+                );
+                crate::remote::download_with_client(
+                    client,
+                    &remote.bucket,
+                    &remote.prefix,
+                    &req.key,
+                    &entry_dir,
+                    cn,
+                )
+                .await
+            }
+            Err(e) => Err(e),
+        };
+
+        let result = match download_result {
             Ok(bytes) => {
                 let elapsed_ms = start.elapsed().as_millis() as u64;
                 self.transfer_counters
@@ -1095,17 +1132,37 @@ impl Daemon {
                             return;
                         }
                     };
+                    let blobs_dir = d.config.store_dir().join("blobs");
                     let start = Instant::now();
-                    match crate::remote::download_with_client(
+
+                    // Try v2 (blob-based) first, fall back to v1 (tar)
+                    let download_result = match crate::remote::download_entry_v2(
                         client,
                         &b,
                         &p,
                         &key,
-                        &entry_dir,
                         &crate_name,
+                        &entry_dir,
+                        &blobs_dir,
                     )
                     .await
                     {
+                        Ok(Some(bytes)) => Ok(bytes),
+                        Ok(None) => {
+                            crate::remote::download_with_client(
+                                client,
+                                &b,
+                                &p,
+                                &key,
+                                &entry_dir,
+                                &crate_name,
+                            )
+                            .await
+                        }
+                        Err(e) => Err(e),
+                    };
+
+                    match download_result {
                         Ok(bytes) => {
                             let elapsed_ms = start.elapsed().as_millis() as u64;
                             d.transfer_counters
@@ -1510,12 +1567,13 @@ async fn server_main(config: &Config) -> Result<()> {
         .await;
 
         if let Ok(Ok(stats)) = result
-            && stats.entries_migrated > 0 {
-                tracing::info!(
-                    "background migration: migrated {} entries",
-                    stats.entries_migrated,
-                );
-            }
+            && stats.entries_migrated > 0
+        {
+            tracing::info!(
+                "background migration: migrated {} entries",
+                stats.entries_migrated,
+            );
+        }
     });
 
     // Shutdown flag: set by Shutdown request or OS signal

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -422,7 +422,6 @@ impl S3KeyCache {
 
 // ── Daemon (the "lib" — all business logic, no I/O) ─────────────
 
-#[allow(dead_code)]
 pub(crate) struct Daemon {
     config: Config,
     s3_client: tokio::sync::OnceCell<aws_sdk_s3::Client>,
@@ -501,7 +500,6 @@ impl Daemon {
     }
 
     /// Set the upload buffer sender (called during server setup).
-    #[allow(dead_code)]
     pub fn set_upload_tx(&mut self, tx: tokio::sync::mpsc::UnboundedSender<UploadJob>) {
         self.upload_tx = Some(tx);
     }
@@ -665,7 +663,6 @@ impl Daemon {
     }
 
     /// Execute an upload directly (used by upload queue workers).
-    #[allow(dead_code)]
     pub async fn do_upload(&self, job: &UploadJob) -> Response {
         let key_short = &job.key[..job.key.len().min(16)];
         let Some(remote) = &self.config.remote else {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1497,6 +1497,28 @@ async fn server_main(config: &Config) -> Result<()> {
         None
     };
 
+    // Background blob migration: lazily migrate legacy entries on startup
+    let migration_config = config.clone();
+    tokio::spawn(async move {
+        let result = tokio::task::spawn_blocking(move || {
+            if let Ok(store) = Store::open(&migration_config) {
+                store.migrate_to_blobs(|_, _| {})
+            } else {
+                Err(anyhow::anyhow!("failed to open store for migration"))
+            }
+        })
+        .await;
+
+        if let Ok(Ok(stats)) = result {
+            if stats.entries_migrated > 0 {
+                tracing::info!(
+                    "background migration: migrated {} entries",
+                    stats.entries_migrated,
+                );
+            }
+        }
+    });
+
     // Shutdown flag: set by Shutdown request or OS signal
     let shutdown_flag = Arc::new(AtomicBool::new(false));
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,9 +1,10 @@
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::config::RemoteConfig;
+use crate::store::EntryMeta;
 
 // ── S3 operations (take a pre-created client) ────────────────────
 
@@ -122,13 +123,16 @@ pub async fn upload_with_client(
 
 /// List all cache keys from S3 (paginated).
 /// Returns a map of cache_key → crate_name.
-/// Key format: `{prefix}/{crate_name}/{cache_key}.tar.zst`
+/// Checks both v1 (`{prefix}/{crate_name}/{cache_key}.tar.zst`) and
+/// v2 (`{prefix}/manifests/{crate_name}/{cache_key}.json`) formats.
 pub async fn list_keys(
     client: &aws_sdk_s3::Client,
     bucket: &str,
     prefix: &str,
 ) -> Result<HashMap<String, String>> {
     let mut keys = HashMap::new();
+
+    // ── v1 keys: {prefix}/{crate_name}/{cache_key}.tar.zst ──
     let mut continuation_token: Option<String> = None;
     let s3_prefix = format!("{prefix}/");
 
@@ -139,7 +143,7 @@ pub async fn list_keys(
             req = req.continuation_token(token);
         }
 
-        let resp = req.send().await.context("listing S3 objects")?;
+        let resp = req.send().await.context("listing S3 objects (v1)")?;
 
         for obj in resp.contents() {
             if let Some(key) = obj.key()
@@ -160,12 +164,48 @@ pub async fn list_keys(
         }
     }
 
+    // ── v2 keys: {prefix}/manifests/{crate_name}/{cache_key}.json ──
+    let manifests_prefix = format!("{prefix}/manifests/");
+    continuation_token = None;
+
+    loop {
+        let mut req = client
+            .list_objects_v2()
+            .bucket(bucket)
+            .prefix(&manifests_prefix);
+
+        if let Some(token) = &continuation_token {
+            req = req.continuation_token(token);
+        }
+
+        let resp = req.send().await.context("listing S3 objects (v2)")?;
+
+        for obj in resp.contents() {
+            if let Some(key) = obj.key()
+                && let Some(stripped) = key.strip_prefix(&manifests_prefix)
+                && let Some(without_ext) = stripped.strip_suffix(".json")
+            {
+                // Format: "{crate_name}/{cache_key}"
+                if let Some((crate_name, cache_key)) = without_ext.rsplit_once('/') {
+                    keys.entry(cache_key.to_string())
+                        .or_insert_with(|| crate_name.to_string());
+                }
+            }
+        }
+
+        if resp.is_truncated == Some(true) {
+            continuation_token = resp.next_continuation_token().map(|s| s.to_string());
+        } else {
+            break;
+        }
+    }
+
     Ok(keys)
 }
 
 /// List S3 cache keys filtered to specific crate names.
 /// Uses per-crate prefix listing for efficiency — only queries S3 for matching crates.
-/// Returns a map of cache_key → crate_name.
+/// Checks both v1 and v2 formats. Returns a map of cache_key → crate_name.
 pub async fn list_keys_for_crates(
     client: &aws_sdk_s3::Client,
     bucket: &str,
@@ -175,6 +215,7 @@ pub async fn list_keys_for_crates(
     let mut keys = HashMap::new();
 
     for crate_name in crate_names {
+        // ── v1: {prefix}/{crate_name}/{cache_key}.tar.zst ──
         let crate_prefix = format!("{prefix}/{crate_name}/");
         let mut continuation_token: Option<String> = None;
 
@@ -191,7 +232,7 @@ pub async fn list_keys_for_crates(
             let resp = req
                 .send()
                 .await
-                .with_context(|| format!("listing S3 objects for crate {crate_name}"))?;
+                .with_context(|| format!("listing S3 objects for crate {crate_name} (v1)"))?;
 
             for obj in resp.contents() {
                 if let Some(key) = obj.key()
@@ -208,15 +249,356 @@ pub async fn list_keys_for_crates(
                 break;
             }
         }
+
+        // ── v2: {prefix}/manifests/{crate_name}/{cache_key}.json ──
+        let manifest_prefix = format!("{prefix}/manifests/{crate_name}/");
+        continuation_token = None;
+
+        loop {
+            let mut req = client
+                .list_objects_v2()
+                .bucket(bucket)
+                .prefix(&manifest_prefix);
+
+            if let Some(token) = &continuation_token {
+                req = req.continuation_token(token);
+            }
+
+            let resp = req
+                .send()
+                .await
+                .with_context(|| format!("listing S3 objects for crate {crate_name} (v2)"))?;
+
+            for obj in resp.contents() {
+                if let Some(key) = obj.key()
+                    && let Some(stripped) = key.strip_prefix(&manifest_prefix)
+                    && let Some(cache_key) = stripped.strip_suffix(".json")
+                {
+                    keys.entry(cache_key.to_string())
+                        .or_insert_with(|| crate_name.clone());
+                }
+            }
+
+            if resp.is_truncated == Some(true) {
+                continuation_token = resp.next_continuation_token().map(|s| s.to_string());
+            } else {
+                break;
+            }
+        }
     }
 
     Ok(keys)
 }
 
-/// Build the S3 object key for a cache entry.
+/// Build the S3 object key for a cache entry (v1 format).
 /// Format: `{prefix}/{crate_name}/{cache_key}.tar.zst`
 fn s3_object_key(prefix: &str, cache_key: &str, crate_name: &str) -> String {
     format!("{prefix}/{crate_name}/{cache_key}.tar.zst")
+}
+
+/// S3 key for a content-addressed blob (v2 format).
+/// Format: `{prefix}/blobs/{hash[0..2]}/{hash}.zst`
+pub fn s3_blob_key(prefix: &str, hash: &str) -> String {
+    format!("{prefix}/blobs/{}/{hash}.zst", &hash[..2])
+}
+
+/// S3 key for a cache entry manifest (v2 format).
+/// Format: `{prefix}/manifests/{crate_name}/{cache_key}.json`
+pub fn s3_manifest_key(prefix: &str, cache_key: &str, crate_name: &str) -> String {
+    format!("{prefix}/manifests/{crate_name}/{cache_key}.json")
+}
+
+// ── V2 blob-based S3 operations ─────────────────────────────────
+
+/// Resolve the local blob path from the blobs directory.
+fn local_blob_path(blobs_dir: &Path, hash: &str) -> PathBuf {
+    blobs_dir.join(&hash[..2]).join(hash)
+}
+
+/// Upload a cache entry using the v2 blob-based format.
+///
+/// For each file in the entry's manifest:
+///   - HEAD-check if the blob already exists on S3
+///   - If not, read from local blob store, zstd-compress, and upload
+///
+/// Finally, upload the manifest (meta.json) to the manifests prefix.
+/// Returns the total compressed bytes uploaded.
+pub async fn upload_entry_v2(
+    client: &aws_sdk_s3::Client,
+    bucket: &str,
+    prefix: &str,
+    cache_key: &str,
+    crate_name: &str,
+    entry_dir: &Path,
+    blobs_dir: &Path,
+    compression_level: i32,
+) -> Result<u64> {
+    // Read meta.json to get the list of files/blobs
+    let meta_path = entry_dir.join("meta.json");
+    let meta_content =
+        std::fs::read_to_string(&meta_path).context("reading meta.json for v2 upload")?;
+    let meta: EntryMeta =
+        serde_json::from_str(&meta_content).context("parsing meta.json for v2 upload")?;
+
+    let mut total_bytes: u64 = 0;
+
+    // Upload each blob that doesn't already exist on S3
+    for cached_file in &meta.files {
+        let blob_key = s3_blob_key(prefix, &cached_file.hash);
+
+        // HEAD check — skip if already uploaded
+        let exists = match client
+            .head_object()
+            .bucket(bucket)
+            .key(&blob_key)
+            .send()
+            .await
+        {
+            Ok(_) => true,
+            Err(e) => {
+                let err = e.into_service_error();
+                if err.is_not_found() {
+                    false
+                } else {
+                    return Err(anyhow::anyhow!("S3 HEAD blob error: {err}"));
+                }
+            }
+        };
+
+        if exists {
+            tracing::debug!("blob {} already on S3, skipping", &cached_file.hash[..16]);
+            continue;
+        }
+
+        // Read the blob from local store
+        let blob_path = local_blob_path(blobs_dir, &cached_file.hash);
+        let blob_data = std::fs::read(&blob_path)
+            .with_context(|| format!("reading blob {} for upload", blob_path.display()))?;
+
+        // Compress with zstd
+        let compressed = zstd::encode_all(std::io::Cursor::new(&blob_data), compression_level)
+            .context("zstd-compressing blob for upload")?;
+        let compressed_len = compressed.len() as u64;
+
+        tracing::debug!(
+            "uploading blob s3://{}/{} ({} bytes compressed)",
+            bucket,
+            blob_key,
+            compressed_len
+        );
+
+        client
+            .put_object()
+            .bucket(bucket)
+            .key(&blob_key)
+            .body(compressed.into())
+            .send()
+            .await
+            .with_context(|| format!("uploading blob {} to S3", &cached_file.hash[..16]))?;
+
+        total_bytes += compressed_len;
+    }
+
+    // Upload manifest (meta.json as JSON)
+    let manifest_key = s3_manifest_key(prefix, cache_key, crate_name);
+    let manifest_body = meta_content.into_bytes();
+    let manifest_len = manifest_body.len() as u64;
+
+    tracing::debug!(
+        "uploading manifest s3://{}/{} ({} bytes)",
+        bucket,
+        manifest_key,
+        manifest_len
+    );
+
+    client
+        .put_object()
+        .bucket(bucket)
+        .key(&manifest_key)
+        .body(manifest_body.into())
+        .content_type("application/json")
+        .send()
+        .await
+        .context("uploading v2 manifest to S3")?;
+
+    total_bytes += manifest_len;
+
+    tracing::info!(
+        "uploaded {} (v2, {} blobs, {} bytes compressed)",
+        cache_key.get(..16).unwrap_or(cache_key),
+        meta.files.len(),
+        total_bytes
+    );
+
+    Ok(total_bytes)
+}
+
+/// Download a cache entry using the v2 blob-based format.
+///
+/// 1. Fetch manifest from S3. If 404, return `Ok(None)` (caller should try v1).
+/// 2. For each file in manifest: download blob if not in local store, decompress, write.
+/// 3. Write meta.json to entry_dir.
+///
+/// Returns `Ok(Some(compressed_bytes))` on success, `Ok(None)` if no v2 manifest found.
+pub async fn download_entry_v2(
+    client: &aws_sdk_s3::Client,
+    bucket: &str,
+    prefix: &str,
+    cache_key: &str,
+    crate_name: &str,
+    entry_dir: &Path,
+    blobs_dir: &Path,
+) -> Result<Option<u64>> {
+    let manifest_key = s3_manifest_key(prefix, cache_key, crate_name);
+
+    // Try to fetch the v2 manifest
+    let manifest_bytes = match client
+        .get_object()
+        .bucket(bucket)
+        .key(&manifest_key)
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            let body = resp
+                .body
+                .collect()
+                .await
+                .context("reading v2 manifest response body")?;
+            body.into_bytes()
+        }
+        Err(e) => {
+            let err = e.into_service_error();
+            if err.is_no_such_key() {
+                return Ok(None); // No v2 manifest — caller should try v1
+            }
+            return Err(anyhow::anyhow!("S3 get manifest error: {err}"));
+        }
+    };
+
+    let meta: EntryMeta =
+        serde_json::from_slice(&manifest_bytes).context("parsing v2 manifest JSON")?;
+
+    let mut total_bytes: u64 = manifest_bytes.len() as u64;
+
+    // Download each blob that isn't already in the local store
+    for cached_file in &meta.files {
+        let blob_path = local_blob_path(blobs_dir, &cached_file.hash);
+
+        if blob_path.is_file() {
+            tracing::debug!(
+                "blob {} already local, skipping download",
+                &cached_file.hash[..16]
+            );
+            continue;
+        }
+
+        let blob_key = s3_blob_key(prefix, &cached_file.hash);
+
+        let resp = client
+            .get_object()
+            .bucket(bucket)
+            .key(&blob_key)
+            .send()
+            .await
+            .with_context(|| format!("downloading blob {}", &cached_file.hash[..16]))?;
+
+        let body = resp
+            .body
+            .collect()
+            .await
+            .context("reading blob response body")?;
+        let compressed = body.into_bytes();
+        total_bytes += compressed.len() as u64;
+
+        // Decompress
+        let decompressed = zstd::decode_all(std::io::Cursor::new(&compressed))
+            .with_context(|| format!("decompressing blob {}", &cached_file.hash[..16]))?;
+
+        // Write to local blob store (atomic: write temp then rename)
+        let shard_dir = blob_path.parent().unwrap();
+        std::fs::create_dir_all(shard_dir).context("creating blob shard dir")?;
+
+        let tmp_path = shard_dir.join(format!(".tmp_{}", &cached_file.hash));
+        std::fs::write(&tmp_path, &decompressed).context("writing blob temp file")?;
+
+        // Make read-only
+        {
+            let mut perms = std::fs::metadata(&tmp_path)?.permissions();
+            perms.set_readonly(true);
+            std::fs::set_permissions(&tmp_path, perms)?;
+        }
+
+        // Atomic rename (ignore AlreadyExists race — another download beat us)
+        if let Err(e) = std::fs::rename(&tmp_path, &blob_path) {
+            // If the blob appeared between our check and rename, that's fine
+            if blob_path.is_file() {
+                let _ = std::fs::remove_file(&tmp_path);
+            } else {
+                return Err(e).context("renaming blob into store");
+            }
+        }
+
+        tracing::debug!(
+            "downloaded blob {} ({} bytes compressed)",
+            &cached_file.hash[..16],
+            compressed.len()
+        );
+    }
+
+    // Write meta.json to entry dir
+    std::fs::create_dir_all(entry_dir).context("creating entry dir for v2 download")?;
+    std::fs::write(entry_dir.join("meta.json"), &manifest_bytes)
+        .context("writing meta.json from v2 manifest")?;
+
+    // Also write the artifact files as symlinks/copies from blob store into entry dir
+    // so that import_downloaded_entry can find them (it expects files in entry_dir)
+    for cached_file in &meta.files {
+        let blob_path = local_blob_path(blobs_dir, &cached_file.hash);
+        let dest_path = entry_dir.join(&cached_file.name);
+        // Hard-link or copy the blob so import_downloaded_entry can move it
+        if !dest_path.exists() {
+            // Copy rather than hardlink — import_downloaded_entry will move/delete these
+            std::fs::copy(&blob_path, &dest_path)
+                .with_context(|| format!("copying blob to entry dir for {}", cached_file.name))?;
+            // Make writable so import_downloaded_entry can process it
+            let mut perms = std::fs::metadata(&dest_path)?.permissions();
+            perms.set_readonly(false);
+            std::fs::set_permissions(&dest_path, perms)?;
+        }
+    }
+
+    tracing::info!(
+        "downloaded {} (v2, {} blobs, {} bytes compressed)",
+        cache_key.get(..16).unwrap_or(cache_key),
+        meta.files.len(),
+        total_bytes
+    );
+
+    Ok(Some(total_bytes))
+}
+
+/// Check if a v2 manifest exists for a cache key on S3.
+pub async fn exists_v2(
+    client: &aws_sdk_s3::Client,
+    bucket: &str,
+    prefix: &str,
+    cache_key: &str,
+    crate_name: &str,
+) -> Result<bool> {
+    let key = s3_manifest_key(prefix, cache_key, crate_name);
+
+    match client.head_object().bucket(bucket).key(&key).send().await {
+        Ok(_) => Ok(true),
+        Err(e) => {
+            let err = e.into_service_error();
+            if err.is_not_found() {
+                Ok(false)
+            } else {
+                Err(anyhow::anyhow!("S3 head_object error (v2 manifest): {err}"))
+            }
+        }
+    }
 }
 
 // ── Client construction ──────────────────────────────────────────
@@ -753,5 +1135,37 @@ mod tests {
             key,
             "artifacts/_manifests/v2/x86_64-linux/abc123/release/shards/deadbeef.json"
         );
+    }
+
+    #[test]
+    fn test_s3_blob_key() {
+        let key = s3_blob_key(
+            "cache",
+            "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        );
+        assert_eq!(
+            key,
+            "cache/blobs/ab/abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890.zst"
+        );
+
+        // Different prefix
+        let key2 = s3_blob_key("my/prefix", "ff0011223344");
+        assert_eq!(key2, "my/prefix/blobs/ff/ff0011223344.zst");
+    }
+
+    #[test]
+    fn test_s3_manifest_key() {
+        let key = s3_manifest_key("cache", "abc123hash", "serde");
+        assert_eq!(key, "cache/manifests/serde/abc123hash.json");
+
+        let key2 = s3_manifest_key("my/prefix", "deadbeef", "tokio-runtime");
+        assert_eq!(key2, "my/prefix/manifests/tokio-runtime/deadbeef.json");
+    }
+
+    #[test]
+    fn test_local_blob_path() {
+        let blobs = Path::new("/store/blobs");
+        let path = local_blob_path(blobs, "abcdef1234");
+        assert_eq!(path, PathBuf::from("/store/blobs/ab/abcdef1234"));
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -783,7 +783,6 @@ fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
 // ── Build Manifest ───────────────────────────────────────────────
 
 const MANIFEST_PREFIX: &str = "_manifests";
-#[allow(dead_code)]
 pub const MANIFEST_VERSION: &str = "v2";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -815,7 +814,6 @@ pub struct ShardEntry {
 }
 
 /// A content-addressed shard of the manifest.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Shard {
     pub version: u32,
@@ -877,13 +875,11 @@ pub async fn upload_manifest(
 
 /// Build the S3 object key for a shard file.
 /// Format: `{prefix}/_manifests/v2/{namespace}/shards/{shard_hash}.json`
-#[allow(dead_code)]
 pub fn shard_object_key(prefix: &str, namespace: &str, shard_hash: &str) -> String {
     format!("{prefix}/{MANIFEST_PREFIX}/{MANIFEST_VERSION}/{namespace}/shards/{shard_hash}.json")
 }
 
 /// Download a single shard from S3. Returns `Ok(None)` on 404 (shard not found).
-#[allow(dead_code)]
 pub async fn download_shard(
     client: &aws_sdk_s3::Client,
     bucket: &str,
@@ -922,7 +918,6 @@ pub async fn download_shard(
 }
 
 /// Upload a single shard to S3.
-#[allow(dead_code)]
 pub async fn upload_shard(
     client: &aws_sdk_s3::Client,
     bucket: &str,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -82,9 +82,12 @@ pub async fn exists_with_client(
     }
 }
 
-/// Upload a cached entry to S3 using an existing client.
+/// Upload a cached entry to S3 using an existing client (v1 tar format).
 /// Uses streaming compression: tar data is piped through zstd encoder.
 /// Key format: `{prefix}/{crate_name}/{cache_key}.tar.zst`
+///
+/// Kept for v1 compatibility; new uploads use `upload_entry_v2`.
+#[allow(dead_code)]
 pub async fn upload_with_client(
     client: &aws_sdk_s3::Client,
     bucket: &str,
@@ -653,6 +656,7 @@ pub async fn create_s3_client(remote: &RemoteConfig) -> Result<aws_sdk_s3::Clien
 // ── Internal helpers ─────────────────────────────────────────────
 
 /// Guard that restores read-only permission on drop (exception safety).
+#[allow(dead_code)]
 struct ReadonlyGuard {
     path: std::path::PathBuf,
     restore: bool,
@@ -671,6 +675,7 @@ impl Drop for ReadonlyGuard {
 }
 
 /// Create a tar+zstd archive from a directory in a single pass (no intermediate tar buffer).
+#[allow(dead_code)]
 fn create_tar_zstd(dir: &Path, compression_level: i32) -> Result<Vec<u8>> {
     let encoder = zstd::stream::Encoder::new(Vec::new(), compression_level)
         .context("creating zstd encoder")?;

--- a/src/shards.rs
+++ b/src/shards.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use std::path::Path;
 
-#[allow(dead_code)]
 pub const NUM_SHARDS: usize = 64;
 
 /// A computed set of shards for a dependency graph.
@@ -18,7 +17,6 @@ pub struct ShardSet {
 /// Sharding is deterministic: `blake3(crate_name) % NUM_SHARDS` assigns the bucket,
 /// then the shard content hash is `blake3("name1@v1|name2@v2|...")` over sorted entries.
 /// This gives insertion stability -- adding one crate only invalidates one shard.
-#[allow(dead_code)]
 pub fn compute_shards(namespace: &str, deps: &[(String, String)]) -> ShardSet {
     let mut buckets: BTreeMap<usize, Vec<(String, String)>> = BTreeMap::new();
     for (name, version) in deps {
@@ -49,14 +47,12 @@ pub fn compute_shards(namespace: &str, deps: &[(String, String)]) -> ShardSet {
     }
 }
 
-#[allow(dead_code)]
 #[derive(serde::Deserialize)]
 struct LockFile {
     #[serde(default)]
     package: Vec<LockPackage>,
 }
 
-#[allow(dead_code)]
 #[derive(serde::Deserialize)]
 struct LockPackage {
     name: String,
@@ -67,7 +63,6 @@ struct LockPackage {
 ///
 /// Handles Cargo.lock versions 3 and 4. Uses serde deserialization
 /// to tolerate extra fields (source, checksum, dependencies).
-#[allow(dead_code)]
 pub fn parse_cargo_lock(path: &Path) -> Result<Vec<(String, String)>> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("reading Cargo.lock at {}", path.display()))?;

--- a/src/store.rs
+++ b/src/store.rs
@@ -142,6 +142,17 @@ impl Store {
         let content = fs::read_to_string(&meta_path).context("reading entry meta.json")?;
         let meta: EntryMeta = serde_json::from_str(&content).context("parsing entry meta.json")?;
 
+        // Lazy migration: if legacy artifacts still live in the entry dir, migrate them
+        let needs_migration = meta.files.iter().any(|f| entry_dir.join(&f.name).exists());
+        if needs_migration {
+            if let Err(e) = self.migrate_entry_to_blobs(&meta) {
+                tracing::warn!(
+                    "lazy migration failed for {}: {e}",
+                    &cache_key[..16.min(cache_key.len())]
+                );
+            }
+        }
+
         // Verify all cached blobs still exist on disk and match expected size
         for cached_file in &meta.files {
             let blob = self.blob_path(&cached_file.hash);
@@ -689,6 +700,121 @@ impl Store {
         Ok(entries)
     }
 
+    /// Migrate a single legacy entry's artifacts into the blob store.
+    fn migrate_entry_to_blobs(&self, meta: &EntryMeta) -> Result<()> {
+        let entry_dir = self.entry_dir(&meta.cache_key);
+        for cached_file in &meta.files {
+            let artifact_path = entry_dir.join(&cached_file.name);
+            if !artifact_path.exists() {
+                continue; // Already migrated
+            }
+            let blob = self.blob_path(&cached_file.hash);
+            let blob_dir = blob.parent().unwrap();
+            fs::create_dir_all(blob_dir)?;
+
+            // Check if blob already exists
+            let existing: Option<i64> = self
+                .db
+                .query_row(
+                    "SELECT refcount FROM blobs WHERE hash = ?1",
+                    params![cached_file.hash],
+                    |row| row.get(0),
+                )
+                .ok();
+
+            if existing.is_some() {
+                // Blob exists — delete artifact, bump refcount
+                if let Ok(m) = fs::metadata(&artifact_path) {
+                    let mut perms = m.permissions();
+                    perms.set_readonly(false);
+                    let _ = fs::set_permissions(&artifact_path, perms);
+                }
+                fs::remove_file(&artifact_path)?;
+                self.db.execute(
+                    "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                    params![cached_file.hash],
+                )?;
+            } else {
+                // New blob — rename artifact into blob store
+                if let Ok(m) = fs::metadata(&artifact_path) {
+                    let mut perms = m.permissions();
+                    if !perms.readonly() {
+                        perms.set_readonly(true);
+                        fs::set_permissions(&artifact_path, perms)?;
+                    }
+                }
+                fs::rename(&artifact_path, &blob)?;
+                self.db.execute(
+                    "INSERT OR IGNORE INTO blobs (hash, size, refcount) VALUES (?1, ?2, 1)",
+                    params![cached_file.hash, cached_file.size as i64],
+                )?;
+                if self.db.changes() == 0 {
+                    self.db.execute(
+                        "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                        params![cached_file.hash],
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Bulk-migrate all legacy entries' artifacts into the blob store.
+    pub fn migrate_to_blobs(&self, progress: impl Fn(usize, usize)) -> Result<MigrationStats> {
+        let store_dir = self.config.store_dir();
+        let mut stats = MigrationStats::default();
+
+        let mut entry_dirs = Vec::new();
+        if let Ok(entries) = fs::read_dir(&store_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() && path.file_name().map_or(false, |n| n != "blobs") {
+                    let meta_path = path.join("meta.json");
+                    if meta_path.exists() {
+                        let has_artifacts = fs::read_dir(&path)
+                            .into_iter()
+                            .flatten()
+                            .flatten()
+                            .any(|e| e.file_name() != "meta.json");
+                        if has_artifacts {
+                            entry_dirs.push(path);
+                        }
+                    }
+                }
+            }
+        }
+
+        let total = entry_dirs.len();
+        for (i, entry_dir) in entry_dirs.iter().enumerate() {
+            progress(i, total);
+            stats.entries_scanned += 1;
+
+            let meta_path = entry_dir.join("meta.json");
+            let content = match fs::read_to_string(&meta_path) {
+                Ok(c) => c,
+                Err(_) => {
+                    stats.entries_skipped += 1;
+                    continue;
+                }
+            };
+            let meta: EntryMeta = match serde_json::from_str(&content) {
+                Ok(m) => m,
+                Err(_) => {
+                    stats.entries_skipped += 1;
+                    continue;
+                }
+            };
+
+            match self.migrate_entry_to_blobs(&meta) {
+                Ok(()) => stats.entries_migrated += 1,
+                Err(_) => stats.entries_skipped += 1,
+            }
+        }
+
+        progress(total, total);
+        Ok(stats)
+    }
+
     fn is_lock_stale(&self, lock_path: &Path) -> Result<bool> {
         let content = fs::read_to_string(lock_path).unwrap_or_default();
         if let Ok(pid) = content.trim().parse::<u32>() {
@@ -710,6 +836,18 @@ impl Store {
             Ok(true) // Can't parse PID, consider stale
         }
     }
+}
+
+/// Statistics from a blob migration run.
+#[derive(Debug, Default)]
+#[allow(dead_code)] // fields used by later dedup tasks
+pub struct MigrationStats {
+    pub entries_scanned: usize,
+    pub entries_migrated: usize,
+    pub entries_skipped: usize,
+    pub blobs_created: usize,
+    pub blobs_reused: usize,
+    pub bytes_saved: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -1933,5 +2071,127 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM blobs", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_get_lazily_migrates_legacy_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        // Simulate a legacy entry: artifacts in entry dir, no blobs
+        let entry_dir = config.store_dir().join("old_key");
+        fs::create_dir_all(&entry_dir).unwrap();
+        let content = b"old format artifact";
+        fs::write(entry_dir.join("lib.rlib"), content).unwrap();
+
+        let hash = crate::cache_key::hash_file(&entry_dir.join("lib.rlib")).unwrap();
+        let meta = EntryMeta {
+            cache_key: "old_key".to_string(),
+            crate_name: "old_crate".to_string(),
+            crate_types: vec!["lib".to_string()],
+            files: vec![CachedFile {
+                name: "lib.rlib".to_string(),
+                size: content.len() as u64,
+                hash: hash.clone(),
+            }],
+            stdout: String::new(),
+            stderr: String::new(),
+            features: vec![],
+            target: String::new(),
+            profile: "dev".to_string(),
+        };
+        fs::write(
+            entry_dir.join("meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+        store
+            .db
+            .execute(
+                "INSERT INTO entries (cache_key, crate_name, size, committed) VALUES ('old_key', 'old_crate', ?1, 1)",
+                params![content.len() as i64],
+            )
+            .unwrap();
+
+        // get() should transparently migrate the entry
+        let result = store.get("old_key").unwrap();
+        assert!(result.is_some());
+
+        // Blob should now exist
+        let blob = store.blob_path(&hash);
+        assert!(
+            blob.exists(),
+            "get() should have migrated artifact to blob store"
+        );
+
+        // Artifact should be gone from entry dir
+        assert!(!entry_dir.join("lib.rlib").exists());
+    }
+
+    #[test]
+    fn test_migrate_to_blobs_bulk() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let content = b"shared artifact bytes";
+        let hash = {
+            let tmp = dir.path().join("tmp");
+            fs::write(&tmp, content).unwrap();
+            crate::cache_key::hash_file(&tmp).unwrap()
+        };
+
+        // Create two legacy entries with identical content
+        for key in &["old1", "old2"] {
+            let entry_dir = config.store_dir().join(key);
+            fs::create_dir_all(&entry_dir).unwrap();
+            fs::write(entry_dir.join("lib.rlib"), content).unwrap();
+
+            let meta = EntryMeta {
+                cache_key: key.to_string(),
+                crate_name: "shared_crate".to_string(),
+                crate_types: vec!["lib".to_string()],
+                files: vec![CachedFile {
+                    name: "lib.rlib".to_string(),
+                    size: content.len() as u64,
+                    hash: hash.clone(),
+                }],
+                stdout: String::new(),
+                stderr: String::new(),
+                features: vec![],
+                target: String::new(),
+                profile: "dev".to_string(),
+            };
+            fs::write(
+                entry_dir.join("meta.json"),
+                serde_json::to_string_pretty(&meta).unwrap(),
+            )
+            .unwrap();
+            store
+                .db
+                .execute(
+                    &format!(
+                        "INSERT INTO entries (cache_key, crate_name, size, committed) VALUES ('{key}', 'shared_crate', {}, 1)",
+                        content.len()
+                    ),
+                    [],
+                )
+                .unwrap();
+        }
+
+        let stats = store.migrate_to_blobs(|_, _| {}).unwrap();
+        assert_eq!(stats.entries_migrated, 2);
+
+        // Refcount should be 2
+        let refcount: i64 = store
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(refcount, 2);
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -509,8 +509,21 @@ impl Store {
     /// Remove a single cache entry (files + DB record).
     pub fn remove_entry(&self, cache_key: &str) -> Result<()> {
         let entry_dir = self.entry_dir(cache_key);
+
+        // Decrement blob refcounts based on meta.json
+        let meta_path = entry_dir.join("meta.json");
+        if meta_path.exists() {
+            if let Ok(content) = fs::read_to_string(&meta_path) {
+                if let Ok(meta) = serde_json::from_str::<EntryMeta>(&content) {
+                    for cached_file in &meta.files {
+                        self.decrement_blob_refcount(&cached_file.hash)?;
+                    }
+                }
+            }
+        }
+
+        // Remove entry directory (just meta.json in new format, may have artifacts in legacy)
         if entry_dir.exists() {
-            // Need to make files writable before removing (they're read-only)
             if let Ok(entries) = fs::read_dir(&entry_dir) {
                 for entry in entries.flatten() {
                     let path = entry.path();
@@ -523,10 +536,43 @@ impl Store {
             }
             fs::remove_dir_all(&entry_dir)?;
         }
+
         self.db.execute(
             "DELETE FROM entries WHERE cache_key = ?1",
             params![cache_key],
         )?;
+
+        Ok(())
+    }
+
+    /// Decrement a blob's refcount. Deletes blob file when refcount reaches 0.
+    fn decrement_blob_refcount(&self, hash: &str) -> Result<()> {
+        self.db.execute(
+            "UPDATE blobs SET refcount = refcount - 1 WHERE hash = ?1",
+            params![hash],
+        )?;
+
+        let refcount: Option<i64> = self
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![hash],
+                |row| row.get(0),
+            )
+            .ok();
+
+        if refcount == Some(0) {
+            let blob = self.blob_path(hash);
+            if blob.exists() {
+                let mut perms = fs::metadata(&blob)?.permissions();
+                perms.set_readonly(false);
+                fs::set_permissions(&blob, perms)?;
+                fs::remove_file(&blob)?;
+            }
+            self.db
+                .execute("DELETE FROM blobs WHERE hash = ?1", params![hash])?;
+        }
+
         Ok(())
     }
 
@@ -1641,5 +1687,77 @@ mod tests {
         let blob = store.blob_path(&meta.files[0].hash);
         let perms = fs::metadata(&blob).unwrap().permissions();
         assert!(perms.readonly(), "blob should be read-only");
+    }
+
+    #[test]
+    fn test_remove_entry_decrements_refcount() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let output = dir.path().join("lib.rlib");
+        fs::write(&output, b"shared content").unwrap();
+        store
+            .put(
+                "k1",
+                "c",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output.clone(), "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+        fs::write(&output, b"shared content").unwrap();
+        store
+            .put(
+                "k2",
+                "c",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // Get the hash from meta.json
+        let meta_content =
+            fs::read_to_string(store.entry_dir("k1").join("meta.json")).unwrap();
+        let meta: EntryMeta = serde_json::from_str(&meta_content).unwrap();
+        let hash = meta.files[0].hash.clone();
+        let blob = store.blob_path(&hash);
+
+        // Remove first entry — blob should still exist (refcount 1)
+        store.remove_entry("k1").unwrap();
+        assert!(blob.exists(), "blob should survive when refcount > 0");
+
+        let refcount: i64 = store
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![&hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(refcount, 1);
+
+        // Remove second entry — blob should be deleted (refcount 0)
+        store.remove_entry("k2").unwrap();
+        assert!(!blob.exists(), "blob should be deleted when refcount = 0");
+
+        let count: i64 = store
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM blobs WHERE hash = ?1",
+                params![&hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -580,24 +580,34 @@ impl Store {
     pub fn clear(&self) -> Result<()> {
         let store_dir = self.config.store_dir();
         if store_dir.exists() {
-            // Make everything writable first
+            // Make everything writable recursively, then remove all subdirs
             for entry in fs::read_dir(&store_dir)?.flatten() {
                 let path = entry.path();
                 if path.is_dir() {
-                    for file in fs::read_dir(&path).into_iter().flatten().flatten() {
-                        let fp = file.path();
-                        if let Ok(meta) = fs::metadata(&fp) {
-                            let mut perms = meta.permissions();
-                            perms.set_readonly(false);
-                            let _ = fs::set_permissions(&fp, perms);
-                        }
-                    }
+                    Self::make_writable_recursive(&path);
                     let _ = fs::remove_dir_all(&path);
                 }
             }
         }
         self.db.execute("DELETE FROM entries", [])?;
+        self.db.execute("DELETE FROM blobs", [])?;
         Ok(())
+    }
+
+    /// Recursively make all files in a directory writable so they can be deleted.
+    fn make_writable_recursive(dir: &Path) {
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    Self::make_writable_recursive(&path);
+                } else if let Ok(meta) = fs::metadata(&path) {
+                    let mut perms = meta.permissions();
+                    perms.set_readonly(false);
+                    let _ = fs::set_permissions(&path, perms);
+                }
+            }
+        }
     }
 
     /// List all entries for display.
@@ -1757,6 +1767,51 @@ mod tests {
                 params![&hash],
                 |row| row.get(0),
             )
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_clear_removes_blobs_too() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let output = dir.path().join("lib.rlib");
+        fs::write(&output, b"content").unwrap();
+        store
+            .put(
+                "k1",
+                "c",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        store.clear().unwrap();
+
+        // Blobs dir should be empty or gone
+        let blobs_dir = store.blobs_dir();
+        if blobs_dir.exists() {
+            let has_files = fs::read_dir(&blobs_dir)
+                .unwrap()
+                .flatten()
+                .any(|e| e.path().is_dir());
+            assert!(
+                !has_files,
+                "blobs dir should have no shard subdirs after clear"
+            );
+        }
+
+        // Blobs table should be empty
+        let count: i64 = store
+            .db
+            .query_row("SELECT COUNT(*) FROM blobs", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 0);
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -167,7 +167,7 @@ impl Store {
 
             // Size validation: catches truncated/corrupt artifacts (e.g. LLVM
             // "truncated or malformed object") without the cost of re-hashing.
-            if let Ok(file_meta) = fs::metadata(&file_path)
+            if let Ok(file_meta) = fs::metadata(&blob)
                 && file_meta.len() != cached_file.size
             {
                 tracing::warn!(
@@ -1502,12 +1502,15 @@ mod tests {
             .unwrap();
         assert!(store.contains("corrupt_key"));
 
-        // Simulate corruption: truncate the artifact to a different size
-        let artifact = store.cached_file_path("corrupt_key", "lib.rlib");
-        let mut perms = std::fs::metadata(&artifact).unwrap().permissions();
+        // Simulate corruption: truncate the blob to a different size
+        let meta_content =
+            std::fs::read_to_string(store.entry_dir("corrupt_key").join("meta.json")).unwrap();
+        let meta: EntryMeta = serde_json::from_str(&meta_content).unwrap();
+        let blob = store.blob_path(&meta.files[0].hash);
+        let mut perms = std::fs::metadata(&blob).unwrap().permissions();
         perms.set_readonly(false);
-        std::fs::set_permissions(&artifact, perms).unwrap();
-        std::fs::write(&artifact, b"short").unwrap();
+        std::fs::set_permissions(&blob, perms).unwrap();
+        std::fs::write(&blob, b"short").unwrap();
 
         // get() should detect the size mismatch, evict, and return None
         let result = store.get("corrupt_key").unwrap();

--- a/src/store.rs
+++ b/src/store.rs
@@ -142,13 +142,14 @@ impl Store {
         let content = fs::read_to_string(&meta_path).context("reading entry meta.json")?;
         let meta: EntryMeta = serde_json::from_str(&content).context("parsing entry meta.json")?;
 
-        // Verify all cached files still exist on disk and match expected size
+        // Verify all cached blobs still exist on disk and match expected size
         for cached_file in &meta.files {
-            let file_path = entry_dir.join(&cached_file.name);
-            if !file_path.is_file() {
+            let blob = self.blob_path(&cached_file.hash);
+            if !blob.is_file() {
                 tracing::warn!(
-                    "cache entry {} missing file {}, evicting",
+                    "cache entry {} missing blob {} for file {}, evicting",
                     cache_key.get(..16).unwrap_or(cache_key),
+                    &cached_file.hash[..16],
                     cached_file.name
                 );
                 let _ = self.remove_entry(cache_key);
@@ -1109,13 +1110,16 @@ mod tests {
             .unwrap();
         assert!(store.contains("damaged_key"));
 
-        // Simulate corruption: delete the artifact file from the store
-        let artifact = store.cached_file_path("damaged_key", "lib.rlib");
+        // Simulate corruption: delete the blob file from the store
+        let meta_content =
+            std::fs::read_to_string(store.entry_dir("damaged_key").join("meta.json")).unwrap();
+        let meta: EntryMeta = serde_json::from_str(&meta_content).unwrap();
+        let blob = store.blob_path(&meta.files[0].hash);
         // Make writable so we can delete
-        let mut perms = std::fs::metadata(&artifact).unwrap().permissions();
+        let mut perms = std::fs::metadata(&blob).unwrap().permissions();
         perms.set_readonly(false);
-        std::fs::set_permissions(&artifact, perms).unwrap();
-        std::fs::remove_file(&artifact).unwrap();
+        std::fs::set_permissions(&blob, perms).unwrap();
+        std::fs::remove_file(&blob).unwrap();
 
         // get() should detect the missing file, evict, and return None
         let result = store.get("damaged_key").unwrap();
@@ -1536,6 +1540,76 @@ mod tests {
             )
             .unwrap();
         assert_eq!(refcount, 2);
+    }
+
+    #[test]
+    fn test_get_verifies_blobs_not_entry_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let output = dir.path().join("lib.rlib");
+        fs::write(&output, b"content").unwrap();
+        store
+            .put(
+                "k1",
+                "c",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // Entry dir should NOT have lib.rlib — only meta.json
+        assert!(!store.entry_dir("k1").join("lib.rlib").exists());
+
+        // get() should still succeed (resolving via blob store)
+        let meta = store.get("k1").unwrap();
+        assert!(meta.is_some());
+    }
+
+    #[test]
+    fn test_get_evicts_when_blob_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let output = dir.path().join("lib.rlib");
+        fs::write(&output, b"content").unwrap();
+        store
+            .put(
+                "k1",
+                "c",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // Read meta to get the hash
+        let meta_content =
+            fs::read_to_string(store.entry_dir("k1").join("meta.json")).unwrap();
+        let meta: EntryMeta = serde_json::from_str(&meta_content).unwrap();
+        let blob = store.blob_path(&meta.files[0].hash);
+
+        // Delete the blob to simulate corruption
+        let mut perms = fs::metadata(&blob).unwrap().permissions();
+        perms.set_readonly(false);
+        fs::set_permissions(&blob, perms).unwrap();
+        fs::remove_file(&blob).unwrap();
+
+        // get() should detect missing blob and evict
+        let result = store.get("k1").unwrap();
+        assert!(result.is_none());
+        assert!(!store.contains("k1"));
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -479,7 +479,7 @@ impl Store {
     }
 
     /// Directory containing all blobs.
-    #[allow(dead_code)] // used by later dedup tasks
+    #[allow(dead_code)] // used in tests
     pub fn blobs_dir(&self) -> PathBuf {
         self.config.store_dir().join("blobs")
     }
@@ -872,7 +872,7 @@ pub struct BlobStats {
 
 /// Statistics from a blob migration run.
 #[derive(Debug, Default)]
-#[allow(dead_code)] // fields used by later dedup tasks
+#[allow(dead_code)]
 pub struct MigrationStats {
     pub entries_scanned: usize,
     pub entries_migrated: usize,

--- a/src/store.rs
+++ b/src/store.rs
@@ -144,13 +144,12 @@ impl Store {
 
         // Lazy migration: if legacy artifacts still live in the entry dir, migrate them
         let needs_migration = meta.files.iter().any(|f| entry_dir.join(&f.name).exists());
-        if needs_migration
-            && let Err(e) = self.migrate_entry_to_blobs(&meta) {
-                tracing::warn!(
-                    "lazy migration failed for {}: {e}",
-                    &cache_key[..16.min(cache_key.len())]
-                );
-            }
+        if needs_migration && let Err(e) = self.migrate_entry_to_blobs(&meta) {
+            tracing::warn!(
+                "lazy migration failed for {}: {e}",
+                &cache_key[..16.min(cache_key.len())]
+            );
+        }
 
         // Verify all cached blobs still exist on disk and match expected size
         for cached_file in &meta.files {
@@ -575,11 +574,12 @@ impl Store {
         let meta_path = entry_dir.join("meta.json");
         if meta_path.exists()
             && let Ok(content) = fs::read_to_string(&meta_path)
-                && let Ok(meta) = serde_json::from_str::<EntryMeta>(&content) {
-                    for cached_file in &meta.files {
-                        self.decrement_blob_refcount(&cached_file.hash)?;
-                    }
-                }
+            && let Ok(meta) = serde_json::from_str::<EntryMeta>(&content)
+        {
+            for cached_file in &meta.files {
+                self.decrement_blob_refcount(&cached_file.hash)?;
+            }
+        }
 
         // Remove entry directory (just meta.json in new format, may have artifacts in legacy)
         if entry_dir.exists() {

--- a/src/store.rs
+++ b/src/store.rs
@@ -97,6 +97,15 @@ impl Store {
             "ALTER TABLE entries ADD COLUMN num_features INTEGER NOT NULL DEFAULT 0",
         );
 
+        db.execute_batch(
+            "CREATE TABLE IF NOT EXISTS blobs (
+                hash     TEXT PRIMARY KEY,
+                size     INTEGER NOT NULL,
+                refcount INTEGER NOT NULL DEFAULT 1
+            );",
+        )
+        .context("creating blobs table")?;
+
         Ok(Store {
             config: config.clone(),
             db,
@@ -375,6 +384,20 @@ impl Store {
             results.push((key, cn, entry_dir));
         }
         Ok(results)
+    }
+
+    /// Resolve the filesystem path for a content-addressed blob.
+    /// Layout: store/blobs/{first 2 hex chars}/{full hash}
+    #[allow(dead_code)] // used by later dedup tasks
+    pub fn blob_path(&self, hash: &str) -> PathBuf {
+        let prefix = &hash[..2];
+        self.config.store_dir().join("blobs").join(prefix).join(hash)
+    }
+
+    /// Directory containing all blobs.
+    #[allow(dead_code)] // used by later dedup tasks
+    pub fn blobs_dir(&self) -> PathBuf {
+        self.config.store_dir().join("blobs")
     }
 
     /// Get the directory for a cache entry.
@@ -1345,6 +1368,32 @@ mod tests {
         exclude_from_indexing(dir.path());
         // Should not overwrite — guard checks exists()
         assert_eq!(fs::read(&sentinel).unwrap(), b"existing");
+    }
+
+    #[test]
+    fn test_blob_path_sharding() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let hash = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+        let path = store.blob_path(hash);
+        assert!(path.to_string_lossy().contains("blobs/ab/"));
+        assert!(path.to_string_lossy().ends_with(hash));
+    }
+
+    #[test]
+    fn test_blobs_table_created() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        // Table should exist — query it
+        let count: i64 = store
+            .db
+            .query_row("SELECT COUNT(*) FROM blobs", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -238,6 +238,11 @@ impl Store {
     }
 
     /// Store compilation outputs under the cache key.
+    ///
+    /// Artifact files are stored in the content-addressed blob store
+    /// (`store/blobs/{hash[0..2]}/{hash}`). The entry directory only
+    /// contains `meta.json`. Identical content is deduplicated via
+    /// reference counting in the `blobs` table.
     pub fn put(
         &self,
         cache_key: &str,
@@ -257,25 +262,45 @@ impl Store {
         let mut total_size = 0u64;
 
         for (source_path, store_name) in output_files {
-            let dest = entry_dir.join(store_name);
-
-            // Copy the file into the store
-            fs::copy(source_path, &dest)
-                .with_context(|| format!("copying {} to store", source_path.display()))?;
-
-            let metadata = fs::metadata(&dest)?;
-            let size = metadata.len();
+            // 1. Hash the source file BEFORE copying
+            let hash = crate::cache_key::hash_file(source_path)?;
+            let size = fs::metadata(source_path)?.len();
             if size == 0 {
                 anyhow::bail!("refusing to cache zero-byte artifact: {}", store_name);
             }
             total_size += size;
 
-            // Make it read-only to prevent accidental modification through hardlinks
-            let mut perms = metadata.permissions();
-            perms.set_readonly(true);
-            fs::set_permissions(&dest, perms)?;
+            // 2. Compute blob path
+            let blob = self.blob_path(&hash);
 
-            let hash = crate::cache_key::hash_file(&dest)?;
+            // 3. Try to insert into blobs table (INSERT OR IGNORE for race safety)
+            self.db.execute(
+                "INSERT OR IGNORE INTO blobs (hash, size, refcount) VALUES (?1, ?2, 1)",
+                params![hash, size as i64],
+            )?;
+
+            if self.db.changes() == 0 {
+                // 4. Blob already exists — bump refcount
+                self.db.execute(
+                    "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                    params![hash],
+                )?;
+            } else {
+                // 5. New blob — copy source to blob path atomically
+                fs::create_dir_all(blob.parent().unwrap())
+                    .context("creating blob shard directory")?;
+                let tmp = blob.with_extension("tmp");
+                fs::copy(source_path, &tmp).with_context(|| {
+                    format!("copying {} to blob store", source_path.display())
+                })?;
+                fs::rename(&tmp, &blob).context("atomic rename of blob")?;
+
+                // Make blob read-only to prevent accidental modification
+                let mut perms = fs::metadata(&blob)?.permissions();
+                perms.set_readonly(true);
+                fs::set_permissions(&blob, perms)?;
+            }
+
             cached_files.push(CachedFile {
                 name: store_name.clone(),
                 size,
@@ -283,7 +308,7 @@ impl Store {
             });
         }
 
-        // Write metadata
+        // Write metadata (only meta.json in the entry directory)
         let meta = EntryMeta {
             cache_key: cache_key.to_string(),
             crate_name: crate_name.to_string(),
@@ -388,7 +413,6 @@ impl Store {
 
     /// Resolve the filesystem path for a content-addressed blob.
     /// Layout: store/blobs/{first 2 hex chars}/{full hash}
-    #[allow(dead_code)] // used by later dedup tasks
     pub fn blob_path(&self, hash: &str) -> PathBuf {
         let prefix = &hash[..2];
         self.config.store_dir().join("blobs").join(prefix).join(hash)
@@ -1403,5 +1427,145 @@ mod tests {
         assert!(!dir.exists());
         // Should not panic — both operations fail silently
         exclude_from_indexing(&dir);
+    }
+
+    #[test]
+    fn test_put_creates_blob() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let output = dir.path().join("lib.rlib");
+        fs::write(&output, b"rlib content").unwrap();
+        store
+            .put(
+                "k1",
+                "mycrate",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // Blob should exist
+        let meta_path = store.entry_dir("k1").join("meta.json");
+        let content = fs::read_to_string(&meta_path).unwrap();
+        let meta: EntryMeta = serde_json::from_str(&content).unwrap();
+        let blob = store.blob_path(&meta.files[0].hash);
+        assert!(
+            blob.exists(),
+            "blob file should exist at {}",
+            blob.display()
+        );
+
+        // Entry dir should only have meta.json (no artifact files)
+        let entry_dir = store.entry_dir("k1");
+        let mut files: Vec<_> = fs::read_dir(&entry_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        files.sort();
+        assert_eq!(
+            files,
+            vec!["meta.json"],
+            "entry dir should only contain meta.json"
+        );
+    }
+
+    #[test]
+    fn test_put_deduplicates_identical_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let output = dir.path().join("lib.rlib");
+        fs::write(&output, b"same content").unwrap();
+        store
+            .put(
+                "k1",
+                "crate_a",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output.clone(), "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // Put again with same content but different cache key
+        fs::write(&output, b"same content").unwrap();
+        store
+            .put(
+                "k2",
+                "crate_a",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // Both entries should reference the same blob hash
+        let m1: EntryMeta = serde_json::from_str(
+            &fs::read_to_string(store.entry_dir("k1").join("meta.json")).unwrap(),
+        )
+        .unwrap();
+        let m2: EntryMeta = serde_json::from_str(
+            &fs::read_to_string(store.entry_dir("k2").join("meta.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(m1.files[0].hash, m2.files[0].hash);
+
+        // Refcount should be 2
+        let refcount: i64 = store
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![m1.files[0].hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(refcount, 2);
+    }
+
+    #[test]
+    fn test_put_blob_is_readonly() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let output = dir.path().join("lib.rlib");
+        fs::write(&output, b"content").unwrap();
+        store
+            .put(
+                "k1",
+                "c",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        let meta: EntryMeta = serde_json::from_str(
+            &fs::read_to_string(store.entry_dir("k1").join("meta.json")).unwrap(),
+        )
+        .unwrap();
+        let blob = store.blob_path(&meta.files[0].hash);
+        let perms = fs::metadata(&blob).unwrap().permissions();
+        assert!(perms.readonly(), "blob should be read-only");
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -2272,4 +2272,517 @@ mod tests {
         assert!(stats.total_logical_size > stats.total_blob_size); // dedup savings
         assert!(stats.savings > 0);
     }
+
+    // =========================================================================
+    // Comprehensive dedup integration tests
+    // =========================================================================
+
+    /// Helper: create a temp file with given content and return its path.
+    fn write_temp_file(dir: &Path, name: &str, content: &[u8]) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, content).unwrap();
+        path
+    }
+
+    /// Helper: read meta.json for a cache key and return the EntryMeta.
+    fn read_meta(store: &Store, cache_key: &str) -> EntryMeta {
+        let meta_path = store.entry_dir(cache_key).join("meta.json");
+        let content = fs::read_to_string(&meta_path).unwrap();
+        serde_json::from_str(&content).unwrap()
+    }
+
+    /// Helper: query refcount for a blob hash, returns None if blob doesn't exist in DB.
+    fn blob_refcount(store: &Store, hash: &str) -> Option<i64> {
+        store
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![hash],
+                |row| row.get(0),
+            )
+            .ok()
+    }
+
+    /// Helper: count rows in blobs table.
+    fn blob_table_count(store: &Store) -> i64 {
+        store
+            .db
+            .query_row("SELECT COUNT(*) FROM blobs", [], |row| row.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn test_full_dedup_lifecycle() {
+        // Put two entries with some shared and some unique files.
+        // Verify blobs exist and refcounts are correct.
+        // Remove one entry — shared blobs still exist (refcount decremented).
+        // Remove second entry — all blobs are deleted (refcount 0).
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        // Shared content between entries 1 and 2
+        let shared = write_temp_file(dir.path(), "shared.rlib", b"shared artifact data");
+        // Unique content for entry 1
+        let unique1 = write_temp_file(dir.path(), "unique1.rlib", b"unique to entry 1");
+        // Unique content for entry 2
+        let unique2 = write_temp_file(dir.path(), "unique2.rlib", b"unique to entry 2");
+
+        // Put entry 1: shared + unique1
+        store
+            .put(
+                "entry1",
+                "crate_a",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[
+                    (shared.clone(), "shared.rlib".into()),
+                    (unique1, "unique1.rlib".into()),
+                ],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // Re-create shared file (put() reads from source path, content must exist)
+        fs::write(&shared, b"shared artifact data").unwrap();
+
+        // Put entry 2: shared + unique2
+        store
+            .put(
+                "entry2",
+                "crate_b",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[
+                    (shared, "shared.rlib".into()),
+                    (unique2, "unique2.rlib".into()),
+                ],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // Read metadata to get hashes
+        let meta1 = read_meta(&store, "entry1");
+        let meta2 = read_meta(&store, "entry2");
+        let shared_hash = &meta1
+            .files
+            .iter()
+            .find(|f| f.name == "shared.rlib")
+            .unwrap()
+            .hash;
+        let unique1_hash = &meta1
+            .files
+            .iter()
+            .find(|f| f.name == "unique1.rlib")
+            .unwrap()
+            .hash;
+        let unique2_hash = &meta2
+            .files
+            .iter()
+            .find(|f| f.name == "unique2.rlib")
+            .unwrap()
+            .hash;
+
+        // Shared blob should have the same hash in both entries
+        let shared_hash2 = &meta2
+            .files
+            .iter()
+            .find(|f| f.name == "shared.rlib")
+            .unwrap()
+            .hash;
+        assert_eq!(shared_hash, shared_hash2);
+
+        // Verify refcounts: shared=2, unique1=1, unique2=1
+        assert_eq!(blob_refcount(&store, shared_hash), Some(2));
+        assert_eq!(blob_refcount(&store, unique1_hash), Some(1));
+        assert_eq!(blob_refcount(&store, unique2_hash), Some(1));
+
+        // All blob files should exist on disk
+        assert!(store.blob_path(shared_hash).exists());
+        assert!(store.blob_path(unique1_hash).exists());
+        assert!(store.blob_path(unique2_hash).exists());
+
+        // Remove entry 1 — shared blob should still exist, unique1 blob should be gone
+        store.remove_entry("entry1").unwrap();
+        assert_eq!(blob_refcount(&store, shared_hash), Some(1));
+        assert!(store.blob_path(shared_hash).exists());
+        assert!(!store.blob_path(unique1_hash).exists());
+        assert_eq!(blob_refcount(&store, unique1_hash), None);
+
+        // Remove entry 2 — everything should be gone
+        store.remove_entry("entry2").unwrap();
+        assert!(!store.blob_path(shared_hash).exists());
+        assert!(!store.blob_path(unique2_hash).exists());
+        assert_eq!(blob_refcount(&store, shared_hash), None);
+        assert_eq!(blob_refcount(&store, unique2_hash), None);
+        assert_eq!(blob_table_count(&store), 0);
+    }
+
+    #[test]
+    fn test_put_get_restore_cycle() {
+        // Put an entry with multiple files, get it, verify metadata,
+        // verify blob files exist and are read-only,
+        // verify entry dir only contains meta.json.
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let file_a = write_temp_file(dir.path(), "a.rlib", b"rlib artifact content");
+        let file_b = write_temp_file(dir.path(), "b.dylib", b"dylib artifact content");
+        let file_c = write_temp_file(dir.path(), "c.rmeta", b"rmeta artifact content");
+
+        store
+            .put(
+                "multi_key",
+                "multi_crate",
+                &["lib".into(), "dylib".into()],
+                &["serde".into(), "tokio".into()],
+                "aarch64-apple-darwin",
+                "release",
+                &[
+                    (file_a, "a.rlib".into()),
+                    (file_b, "b.dylib".into()),
+                    (file_c, "c.rmeta".into()),
+                ],
+                "some stdout",
+                "some stderr",
+            )
+            .unwrap();
+
+        // Get the entry and verify metadata
+        let meta = store.get("multi_key").unwrap().unwrap();
+        assert_eq!(meta.crate_name, "multi_crate");
+        assert_eq!(meta.crate_types, vec!["lib", "dylib"]);
+        assert_eq!(meta.features, vec!["serde", "tokio"]);
+        assert_eq!(meta.target, "aarch64-apple-darwin");
+        assert_eq!(meta.profile, "release");
+        assert_eq!(meta.stdout, "some stdout");
+        assert_eq!(meta.stderr, "some stderr");
+        assert_eq!(meta.files.len(), 3);
+
+        // Verify blob files exist and are read-only
+        for cached_file in &meta.files {
+            let blob = store.blob_path(&cached_file.hash);
+            assert!(blob.exists(), "blob for {} should exist", cached_file.name);
+            let perms = fs::metadata(&blob).unwrap().permissions();
+            assert!(
+                perms.readonly(),
+                "blob for {} should be read-only",
+                cached_file.name
+            );
+        }
+
+        // Verify entry dir only contains meta.json
+        let entry_dir = store.entry_dir("multi_key");
+        let mut files: Vec<String> = fs::read_dir(&entry_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        files.sort();
+        assert_eq!(files, vec!["meta.json"]);
+    }
+
+    #[test]
+    fn test_clear_removes_all_blobs_and_tables() {
+        // Put a few entries, call clear(), verify blobs directory and tables are empty.
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        // Create 3 entries with different content
+        for i in 0..3 {
+            let file = write_temp_file(
+                dir.path(),
+                &format!("f{i}.rlib"),
+                format!("content {i}").as_bytes(),
+            );
+            store
+                .put(
+                    &format!("key{i}"),
+                    &format!("crate{i}"),
+                    &["lib".into()],
+                    &[],
+                    "",
+                    "dev",
+                    &[(file, format!("lib{i}.rlib"))],
+                    "",
+                    "",
+                )
+                .unwrap();
+        }
+
+        assert_eq!(store.entry_count().unwrap(), 3);
+        assert!(blob_table_count(&store) >= 3);
+
+        store.clear().unwrap();
+
+        // Entries table should be empty
+        assert_eq!(store.entry_count().unwrap(), 0);
+
+        // Blobs table should be empty
+        assert_eq!(blob_table_count(&store), 0);
+
+        // Blobs directory should be empty or removed
+        let blobs_dir = store.blobs_dir();
+        if blobs_dir.exists() {
+            let any_content = fs::read_dir(&blobs_dir).unwrap().flatten().any(|_| true);
+            assert!(!any_content, "blobs dir should be empty after clear");
+        }
+    }
+
+    #[test]
+    fn test_migration_of_legacy_entry() {
+        // Create a "legacy" entry by manually writing files to an entry dir
+        // (meta.json + artifact files, without blob store).
+        // Call migrate_entry_to_blobs() directly.
+        // Verify artifacts moved to blob store, entry dir only has meta.json.
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let entry_dir = config.store_dir().join("legacy_key");
+        fs::create_dir_all(&entry_dir).unwrap();
+
+        // Create two legacy artifact files
+        let content_a = b"legacy artifact A";
+        let content_b = b"legacy artifact B";
+        fs::write(entry_dir.join("a.rlib"), content_a).unwrap();
+        fs::write(entry_dir.join("b.dylib"), content_b).unwrap();
+
+        let hash_a = crate::cache_key::hash_file(&entry_dir.join("a.rlib")).unwrap();
+        let hash_b = crate::cache_key::hash_file(&entry_dir.join("b.dylib")).unwrap();
+
+        let meta = EntryMeta {
+            cache_key: "legacy_key".to_string(),
+            crate_name: "legacy_crate".to_string(),
+            crate_types: vec!["lib".to_string()],
+            files: vec![
+                CachedFile {
+                    name: "a.rlib".to_string(),
+                    size: content_a.len() as u64,
+                    hash: hash_a.clone(),
+                },
+                CachedFile {
+                    name: "b.dylib".to_string(),
+                    size: content_b.len() as u64,
+                    hash: hash_b.clone(),
+                },
+            ],
+            stdout: String::new(),
+            stderr: String::new(),
+            features: vec![],
+            target: String::new(),
+            profile: "dev".to_string(),
+        };
+        fs::write(
+            entry_dir.join("meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+
+        // Register in DB as committed
+        store
+            .db
+            .execute(
+                "INSERT INTO entries (cache_key, crate_name, size, committed) VALUES ('legacy_key', 'legacy_crate', ?1, 1)",
+                params![(content_a.len() + content_b.len()) as i64],
+            )
+            .unwrap();
+
+        // Call migrate_entry_to_blobs directly
+        store.migrate_entry_to_blobs(&meta).unwrap();
+
+        // Artifacts should be gone from entry dir
+        assert!(
+            !entry_dir.join("a.rlib").exists(),
+            "a.rlib should be moved to blob store"
+        );
+        assert!(
+            !entry_dir.join("b.dylib").exists(),
+            "b.dylib should be moved to blob store"
+        );
+
+        // meta.json should remain
+        assert!(entry_dir.join("meta.json").exists());
+
+        // Blobs should exist and be read-only
+        let blob_a = store.blob_path(&hash_a);
+        let blob_b = store.blob_path(&hash_b);
+        assert!(blob_a.exists(), "blob for a.rlib should exist");
+        assert!(blob_b.exists(), "blob for b.dylib should exist");
+        assert!(fs::metadata(&blob_a).unwrap().permissions().readonly());
+        assert!(fs::metadata(&blob_b).unwrap().permissions().readonly());
+
+        // Refcounts should be 1
+        assert_eq!(blob_refcount(&store, &hash_a), Some(1));
+        assert_eq!(blob_refcount(&store, &hash_b), Some(1));
+
+        // Entry dir should only have meta.json
+        let files: Vec<String> = fs::read_dir(&entry_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(files, vec!["meta.json"]);
+    }
+
+    #[test]
+    fn test_eviction_with_shared_blobs() {
+        // Put 3 entries where entries 1 and 2 share blobs, entry 3 is unique.
+        // Remove entry 1 → shared blobs persist with refcount decremented.
+        // Remove entry 2 → shared blobs deleted.
+        // Entry 3's blobs should be unaffected throughout.
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let shared_content = b"shared between 1 and 2";
+        let unique3_content = b"unique to entry 3 only";
+
+        // Entry 1: shared blob
+        let f = write_temp_file(dir.path(), "shared.rlib", shared_content);
+        store
+            .put(
+                "e1",
+                "c1",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(f, "shared.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // Entry 2: same shared blob
+        let f = write_temp_file(dir.path(), "shared.rlib", shared_content);
+        store
+            .put(
+                "e2",
+                "c2",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(f, "shared.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // Entry 3: unique blob
+        let f = write_temp_file(dir.path(), "unique3.rlib", unique3_content);
+        store
+            .put(
+                "e3",
+                "c3",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(f, "unique3.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        let meta1 = read_meta(&store, "e1");
+        let meta3 = read_meta(&store, "e3");
+        let shared_hash = &meta1.files[0].hash;
+        let unique3_hash = &meta3.files[0].hash;
+
+        assert_eq!(blob_refcount(&store, shared_hash), Some(2));
+        assert_eq!(blob_refcount(&store, unique3_hash), Some(1));
+
+        // Remove entry 1 — shared blob persists
+        store.remove_entry("e1").unwrap();
+        assert_eq!(blob_refcount(&store, shared_hash), Some(1));
+        assert!(store.blob_path(shared_hash).exists());
+        // Entry 3 unaffected
+        assert!(store.blob_path(unique3_hash).exists());
+        assert_eq!(blob_refcount(&store, unique3_hash), Some(1));
+
+        // Remove entry 2 — shared blob now deleted
+        store.remove_entry("e2").unwrap();
+        assert!(!store.blob_path(shared_hash).exists());
+        assert_eq!(blob_refcount(&store, shared_hash), None);
+        // Entry 3 still unaffected
+        assert!(store.blob_path(unique3_hash).exists());
+        assert_eq!(blob_refcount(&store, unique3_hash), Some(1));
+
+        // Verify entry 3 can still be retrieved
+        let meta = store.get("e3").unwrap();
+        assert!(meta.is_some());
+    }
+
+    #[test]
+    fn test_blob_stats_with_known_overlap() {
+        // Put entries with known content overlap.
+        // Verify logical vs physical size, savings percentage.
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let shared_content = b"AAAA"; // 4 bytes, shared by entries 1 and 2
+        let unique_content = b"BBBBBBBB"; // 8 bytes, only in entry 1
+
+        // Entry 1: shared (4 bytes) + unique (8 bytes) = 12 bytes logical
+        let f_shared = write_temp_file(dir.path(), "shared.rlib", shared_content);
+        let f_unique = write_temp_file(dir.path(), "unique.rlib", unique_content);
+        store
+            .put(
+                "stats1",
+                "c1",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[
+                    (f_shared, "shared.rlib".into()),
+                    (f_unique, "unique.rlib".into()),
+                ],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // Entry 2: shared (4 bytes) = 4 bytes logical
+        let f_shared = write_temp_file(dir.path(), "shared.rlib", shared_content);
+        store
+            .put(
+                "stats2",
+                "c2",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(f_shared, "shared.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // Total logical size from entries table = 12 + 4 = 16 bytes
+        // Total physical blob size = 4 (shared) + 8 (unique) = 12 bytes
+        // Savings = 16 - 12 = 4 bytes
+        let stats = store.blob_stats().unwrap();
+        assert_eq!(stats.total_blobs, 2, "should have 2 unique blobs");
+        assert_eq!(
+            stats.total_blob_size, 12,
+            "physical size should be 12 bytes"
+        );
+        assert_eq!(
+            stats.total_logical_size, 16,
+            "logical size should be 16 bytes"
+        );
+        assert_eq!(stats.savings, 4, "savings should be 4 bytes");
+    }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -144,14 +144,13 @@ impl Store {
 
         // Lazy migration: if legacy artifacts still live in the entry dir, migrate them
         let needs_migration = meta.files.iter().any(|f| entry_dir.join(&f.name).exists());
-        if needs_migration {
-            if let Err(e) = self.migrate_entry_to_blobs(&meta) {
+        if needs_migration
+            && let Err(e) = self.migrate_entry_to_blobs(&meta) {
                 tracing::warn!(
                     "lazy migration failed for {}: {e}",
                     &cache_key[..16.min(cache_key.len())]
                 );
             }
-        }
 
         // Verify all cached blobs still exist on disk and match expected size
         for cached_file in &meta.files {
@@ -302,9 +301,8 @@ impl Store {
                 fs::create_dir_all(blob.parent().unwrap())
                     .context("creating blob shard directory")?;
                 let tmp = blob.with_extension("tmp");
-                fs::copy(source_path, &tmp).with_context(|| {
-                    format!("copying {} to blob store", source_path.display())
-                })?;
+                fs::copy(source_path, &tmp)
+                    .with_context(|| format!("copying {} to blob store", source_path.display()))?;
                 fs::rename(&tmp, &blob).context("atomic rename of blob")?;
 
                 // Make blob read-only to prevent accidental modification
@@ -474,7 +472,11 @@ impl Store {
     /// Layout: store/blobs/{first 2 hex chars}/{full hash}
     pub fn blob_path(&self, hash: &str) -> PathBuf {
         let prefix = &hash[..2];
-        self.config.store_dir().join("blobs").join(prefix).join(hash)
+        self.config
+            .store_dir()
+            .join("blobs")
+            .join(prefix)
+            .join(hash)
     }
 
     /// Directory containing all blobs.
@@ -571,15 +573,13 @@ impl Store {
 
         // Decrement blob refcounts based on meta.json
         let meta_path = entry_dir.join("meta.json");
-        if meta_path.exists() {
-            if let Ok(content) = fs::read_to_string(&meta_path) {
-                if let Ok(meta) = serde_json::from_str::<EntryMeta>(&content) {
+        if meta_path.exists()
+            && let Ok(content) = fs::read_to_string(&meta_path)
+                && let Ok(meta) = serde_json::from_str::<EntryMeta>(&content) {
                     for cached_file in &meta.files {
                         self.decrement_blob_refcount(&cached_file.hash)?;
                     }
                 }
-            }
-        }
 
         // Remove entry directory (just meta.json in new format, may have artifacts in legacy)
         if entry_dir.exists() {
@@ -768,7 +768,7 @@ impl Store {
         if let Ok(entries) = fs::read_dir(&store_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.is_dir() && path.file_name().map_or(false, |n| n != "blobs") {
+                if path.is_dir() && path.file_name().is_some_and(|n| n != "blobs") {
                     let meta_path = path.join("meta.json");
                     if meta_path.exists() {
                         let has_artifacts = fs::read_dir(&path)
@@ -836,6 +836,38 @@ impl Store {
             Ok(true) // Can't parse PID, consider stale
         }
     }
+
+    /// Return content-dedup statistics: unique blobs, physical vs logical size.
+    pub fn blob_stats(&self) -> Result<BlobStats> {
+        let total_blobs: i64 = self
+            .db
+            .query_row("SELECT COUNT(*) FROM blobs", [], |row| row.get(0))?;
+        let total_blob_size: i64 =
+            self.db
+                .query_row("SELECT COALESCE(SUM(size), 0) FROM blobs", [], |row| {
+                    row.get(0)
+                })?;
+        let total_logical_size: i64 =
+            self.db
+                .query_row("SELECT COALESCE(SUM(size), 0) FROM entries", [], |row| {
+                    row.get(0)
+                })?;
+        Ok(BlobStats {
+            total_blobs: total_blobs as usize,
+            total_blob_size: total_blob_size as u64,
+            total_logical_size: total_logical_size as u64,
+            savings: (total_logical_size as u64).saturating_sub(total_blob_size as u64),
+        })
+    }
+}
+
+/// Content-dedup statistics.
+#[derive(Debug, Default)]
+pub struct BlobStats {
+    pub total_blobs: usize,
+    pub total_blob_size: u64,
+    pub total_logical_size: u64,
+    pub savings: u64,
 }
 
 /// Statistics from a blob migration run.
@@ -1908,8 +1940,7 @@ mod tests {
             .unwrap();
 
         // Read meta to get the hash
-        let meta_content =
-            fs::read_to_string(store.entry_dir("k1").join("meta.json")).unwrap();
+        let meta_content = fs::read_to_string(store.entry_dir("k1").join("meta.json")).unwrap();
         let meta: EntryMeta = serde_json::from_str(&meta_content).unwrap();
         let blob = store.blob_path(&meta.files[0].hash);
 
@@ -1993,8 +2024,7 @@ mod tests {
             .unwrap();
 
         // Get the hash from meta.json
-        let meta_content =
-            fs::read_to_string(store.entry_dir("k1").join("meta.json")).unwrap();
+        let meta_content = fs::read_to_string(store.entry_dir("k1").join("meta.json")).unwrap();
         let meta: EntryMeta = serde_json::from_str(&meta_content).unwrap();
         let hash = meta.files[0].hash.clone();
         let blob = store.blob_path(&hash);
@@ -2193,5 +2223,53 @@ mod tests {
             )
             .unwrap();
         assert_eq!(refcount, 2);
+    }
+
+    #[test]
+    fn test_blob_stats() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        // Empty store
+        let stats = store.blob_stats().unwrap();
+        assert_eq!(stats.total_blobs, 0);
+        assert_eq!(stats.savings, 0);
+
+        // Add two entries with same content
+        let output = dir.path().join("lib.rlib");
+        fs::write(&output, b"shared content!").unwrap();
+        store
+            .put(
+                "k1",
+                "c",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output.clone(), "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+        fs::write(&output, b"shared content!").unwrap();
+        store
+            .put(
+                "k2",
+                "c",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        let stats = store.blob_stats().unwrap();
+        assert_eq!(stats.total_blobs, 1); // one unique blob
+        assert!(stats.total_logical_size > stats.total_blob_size); // dedup savings
+        assert!(stats.savings > 0);
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -430,7 +430,8 @@ impl Store {
         self.config.store_dir().join(cache_key)
     }
 
-    /// Get the full path to a cached file.
+    /// Get the full path to a cached file (legacy entry-based layout).
+    #[allow(dead_code)]
     pub fn cached_file_path(&self, cache_key: &str, filename: &str) -> PathBuf {
         self.entry_dir(cache_key).join(filename)
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -337,7 +337,12 @@ impl Store {
     }
 
     /// Import a remotely downloaded entry into the database.
-    /// Reads meta.json from the entry directory and marks it committed.
+    ///
+    /// Downloaded entries arrive as tar archives extracted into the entry
+    /// directory (old format: artifact files alongside meta.json). This
+    /// method moves the artifact files into the content-addressed blob
+    /// store and records them in the `blobs` table, leaving only
+    /// `meta.json` in the entry directory.
     pub fn import_downloaded_entry(&self, cache_key: &str) -> Result<()> {
         let entry_dir = self.entry_dir(cache_key);
         let meta_path = entry_dir.join("meta.json");
@@ -365,6 +370,48 @@ impl Store {
                     cached_file.size,
                     file_meta.len(),
                 );
+            }
+        }
+
+        // Move artifact files into the content-addressed blob store
+        for cached_file in &meta.files {
+            let file_path = entry_dir.join(&cached_file.name);
+            let hash = &cached_file.hash;
+            let blob = self.blob_path(hash);
+
+            // INSERT OR IGNORE for race safety (same pattern as put())
+            self.db.execute(
+                "INSERT OR IGNORE INTO blobs (hash, size, refcount) VALUES (?1, ?2, 1)",
+                params![hash, cached_file.size as i64],
+            )?;
+
+            if self.db.changes() == 0 {
+                // Blob already exists — bump refcount, delete the downloaded copy
+                self.db.execute(
+                    "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                    params![hash],
+                )?;
+                fs::remove_file(&file_path).with_context(|| {
+                    format!(
+                        "removing deduplicated downloaded artifact {}",
+                        file_path.display()
+                    )
+                })?;
+            } else {
+                // New blob — move the downloaded file into the blob store
+                fs::create_dir_all(blob.parent().unwrap())
+                    .context("creating blob shard directory")?;
+                fs::rename(&file_path, &blob).with_context(|| {
+                    format!(
+                        "moving downloaded artifact {} to blob store",
+                        file_path.display()
+                    )
+                })?;
+
+                // Make blob read-only to prevent accidental modification
+                let mut perms = fs::metadata(&blob)?.permissions();
+                perms.set_readonly(true);
+                fs::set_permissions(&blob, perms)?;
             }
         }
 
@@ -1141,6 +1188,77 @@ mod tests {
             "expected 'missing file' error, got: {err}"
         );
         assert!(!store.contains("incomplete_key"));
+    }
+
+    #[test]
+    fn test_import_downloaded_entry_creates_blobs() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        // Simulate a downloaded entry (old tar format: files in entry dir)
+        let entry_dir = config.store_dir().join("dl_key");
+        fs::create_dir_all(&entry_dir).unwrap();
+        fs::write(entry_dir.join("lib.rlib"), b"artifact data").unwrap();
+
+        let hash = crate::cache_key::hash_file(&entry_dir.join("lib.rlib")).unwrap();
+        let meta = EntryMeta {
+            cache_key: "dl_key".to_string(),
+            crate_name: "dl_crate".to_string(),
+            crate_types: vec!["lib".to_string()],
+            files: vec![CachedFile {
+                name: "lib.rlib".to_string(),
+                size: 13,
+                hash: hash.clone(),
+            }],
+            stdout: String::new(),
+            stderr: String::new(),
+            features: vec![],
+            target: String::new(),
+            profile: "dev".to_string(),
+        };
+        fs::write(
+            entry_dir.join("meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+
+        store.import_downloaded_entry("dl_key").unwrap();
+
+        // Blob should exist
+        let blob = store.blob_path(&hash);
+        assert!(
+            blob.exists(),
+            "blob should be created from downloaded artifact"
+        );
+
+        // Entry dir artifact should be gone (only meta.json remains)
+        assert!(
+            !entry_dir.join("lib.rlib").exists(),
+            "artifact should have been moved to blob store"
+        );
+        assert!(
+            entry_dir.join("meta.json").exists(),
+            "meta.json should remain"
+        );
+
+        // Blob should be read-only
+        let perms = fs::metadata(&blob).unwrap().permissions();
+        assert!(perms.readonly(), "imported blob should be read-only");
+
+        // Refcount should be 1 in the blobs table
+        let refcount: i64 = store
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![&hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(refcount, 1);
+
+        // Entry should be committed
+        assert!(store.contains("dl_key"));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -722,8 +722,30 @@ fn draw_store_tab(frame: &mut Frame, state: &AppState, area: Rect) {
 }
 
 fn draw_store_table(frame: &mut Frame, state: &AppState, area: Rect) {
+    let dedup_info = if let Ok(store) = crate::store::Store::open(&state.config) {
+        if let Ok(bs) = store.blob_stats() {
+            if bs.total_blobs > 0 {
+                let pct = if bs.total_logical_size > 0 {
+                    bs.savings as f64 / bs.total_logical_size as f64 * 100.0
+                } else {
+                    0.0
+                };
+                format!(
+                    " | dedup: {} physical, {:.1}% saved",
+                    ByteSize(bs.total_blob_size),
+                    pct,
+                )
+            } else {
+                String::new()
+            }
+        } else {
+            String::new()
+        }
+    } else {
+        String::new()
+    };
     let title = format!(
-        " Cached Crates — {} entries, {} (sort: {}) ",
+        " Cached Crates — {} entries, {} (sort: {}){dedup_info} ",
         state.stats_snapshot.entry_count,
         ByteSize(state.stats_snapshot.total_size),
         state.sort_mode.label()

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -337,12 +337,14 @@ fn restore_from_cache(
     };
 
     for cached_file in &meta.files {
-        let store_path = store.cached_file_path(&meta.cache_key, &cached_file.name);
+        // Resolve from blob store (content-addressed)
+        let store_path = store.blob_path(&cached_file.hash);
 
         if !store_path.exists() {
             anyhow::bail!(
-                "store file missing for {}: {}",
+                "blob missing for {} (hash {}): {}",
                 meta.cache_key,
+                &cached_file.hash[..16],
                 cached_file.name
             );
         }

--- a/tests/stale_artifact_test.rs
+++ b/tests/stale_artifact_test.rs
@@ -400,22 +400,21 @@ fn stale_recovers_from_corrupted_artifact() {
     );
     assert_eq!(out1, "v1.helper-v1.default.debug.plain");
 
-    // Corrupt: delete an rlib from the store
-    let store_dir = cache_dir.path().join("store");
+    // Corrupt: delete a blob from the content-addressed store
+    let blobs_dir = cache_dir.path().join("store").join("blobs");
     let mut deleted = false;
-    for entry in std::fs::read_dir(&store_dir).unwrap() {
-        let entry = entry.unwrap();
-        if entry.file_type().unwrap().is_dir() {
-            for file in std::fs::read_dir(entry.path()).unwrap() {
-                let file = file.unwrap();
-                let name = file.file_name();
-                if name.to_string_lossy().ends_with(".rlib") {
-                    // rlib files in the store are read-only; make writable before deleting
-                    let mut perms = std::fs::metadata(file.path()).unwrap().permissions();
+    for prefix_entry in std::fs::read_dir(&blobs_dir).unwrap() {
+        let prefix_entry = prefix_entry.unwrap();
+        if prefix_entry.file_type().unwrap().is_dir() {
+            for blob in std::fs::read_dir(prefix_entry.path()).unwrap() {
+                let blob = blob.unwrap();
+                if blob.file_type().unwrap().is_file() {
+                    // blob files in the store are read-only; make writable before deleting
+                    let mut perms = std::fs::metadata(blob.path()).unwrap().permissions();
                     #[allow(clippy::permissions_set_readonly_false)]
                     perms.set_readonly(false);
-                    std::fs::set_permissions(file.path(), perms).unwrap();
-                    std::fs::remove_file(file.path()).unwrap();
+                    std::fs::set_permissions(blob.path(), perms).unwrap();
+                    std::fs::remove_file(blob.path()).unwrap();
                     deleted = true;
                     break;
                 }
@@ -427,7 +426,7 @@ fn stale_recovers_from_corrupted_artifact() {
     }
     assert!(
         deleted,
-        "should have found and deleted an rlib in the store"
+        "should have found and deleted a blob in the store"
     );
 
     // Clean and rebuild — kache should detect the missing file and recompile

--- a/tests/stale_artifact_test.rs
+++ b/tests/stale_artifact_test.rs
@@ -424,10 +424,7 @@ fn stale_recovers_from_corrupted_artifact() {
             }
         }
     }
-    assert!(
-        deleted,
-        "should have found and deleted a blob in the store"
-    );
+    assert!(deleted, "should have found and deleted a blob in the store");
 
     // Clean and rebuild — kache should detect the missing file and recompile
     let _ = std::process::Command::new("cargo")


### PR DESCRIPTION
## Summary

Replace per-entry artifact storage with a **content-addressed blob store**, deduplicating identical files across cache entries both locally and on S3.

Analysis of a real store showed **11.5 GB (22.7%) wasted** on identical content stored under different cache keys. This PR eliminates that waste transparently.

### Key changes:
- **Local blob store**: Artifacts stored at `store/blobs/{hash[0..2]}/{hash}` with SQLite refcount tracking. Entry directories shrink to only `meta.json`.
- **S3 blob format (v2)**: Individual blob uploads + manifest JSON, replacing monolithic tar.zst per entry. Backward-compatible fallback to v1 tar format on download.
- **Automatic migration**: Lazy migration on `get()` for legacy entries + non-blocking background bulk migration on daemon startup. Crash-safe, resumable, no downtime.
- **Stats**: CLI (`kache stats`) and TUI show physical vs logical size and dedup savings percentage.
- **6 new integration tests** covering full lifecycle, migration, eviction with shared blobs, and stats.

### Design doc
`docs/plans/2026-03-04-content-addressable-dedup-design.md`

## Test plan
- [x] 287 tests pass (271 unit + 5 integration + 11 stale artifact)
- [x] `make check` clean (fmt + clippy + tests)
- [x] Full dedup lifecycle: put → get → restore → evict → migrate
- [x] Concurrent put with same content (refcount correctness)
- [x] Eviction with shared blobs (last entry eviction deletes blob)
- [x] Migration of legacy entries (files moved to blob store)
- [x] Clear removes all blobs and table entries
- [x] Blob stats report correct logical/physical sizes