### PR TITLE
Switch remote cache runtime to v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ tarpaulin-report.json
 
 # Plans
 docs/plans/
+docs/planning/*
+!docs/planning/.gitignore
 
 # Git worktrees
 .worktrees/

--- a/docs/design/v3-foundations.md
+++ b/docs/design/v3-foundations.md
@@ -1,0 +1,154 @@
+# V3 foundations
+
+This document describes the `v3` remote cache format that is implemented on this
+branch and the rollout assumptions behind it.
+
+## Summary
+
+- `v3` is now the active remote entry format in runtime code.
+- Local storage stays content-addressed.
+- Remote storage is pack-first.
+- `v1` and `v2` are no longer active remote entry transport paths.
+- This is a hard remote cutover: new code uses `prefix/v3/...` and does not read
+  older remote entry objects.
+
+## Design
+
+`v3` deliberately splits local and remote concerns:
+
+- local store:
+  - blobs stay content-addressed
+  - restores keep the existing local fast path
+  - repeated hits after the first remote import stay cheap
+- remote store:
+  - one small manifest object per entry
+  - one packed `tar.zst` object per entry
+  - low request fan-out for cold object-store restores
+
+This keeps the remote path simple and transport-efficient while preserving the
+existing local CAS model.
+
+## Runtime shape
+
+The runtime now routes normal remote work through a planner and layout boundary:
+
+- [remote_plan.rs](/Users/lenij/zondax/kache/src/remote_plan.rs)
+- [remote_layout.rs](/Users/lenij/zondax/kache/src/remote_layout.rs)
+
+The following workloads use that path:
+
+- restore checks
+- prefetch downloads
+- sync pull
+- sync push
+- background upload
+- key discovery
+
+The main call sites are in:
+
+- [daemon.rs](/Users/lenij/zondax/kache/src/daemon.rs)
+- [cli.rs](/Users/lenij/zondax/kache/src/cli.rs)
+
+The local import seam for downloaded entries is in:
+
+- [store.rs](/Users/lenij/zondax/kache/src/store.rs)
+
+## Remote layout
+
+`v3` stores remote entry data under a dedicated namespace:
+
+- manifests:
+  - `{prefix}/v3/manifests/{crate_name}/{cache_key}.json`
+- packs:
+  - `{prefix}/v3/packs/{crate_name}/{cache_key}.tar.zst`
+
+The manifest records:
+
+- schema version
+- cache key
+- crate name
+- pack object key
+- compressed bytes
+- uncompressed bytes
+- file count
+
+The pack contains:
+
+- `meta.json`
+- one entry for each cached output file
+
+Downloaded packs are extracted into an entry directory and then imported back
+into the local CAS.
+
+## What changed relative to older formats
+
+Old remote entry transport had two undesirable properties:
+
+- request fan-out for cold CI
+- restore work that mirrored internal blob structure too closely
+
+`v3` removes that from the hot remote path:
+
+- no per-entry remote blob fan-out
+- no `v2` manifest-plus-blobs restore path
+- no `v1` tar fallback in normal runtime
+
+The code may still contain compatibility comments and reporting for historical
+transfer data, but active remote entry traffic is `v3`.
+
+## Daemon startup fix
+
+This branch also includes a daemon startup reliability fix needed for normal
+`v3` use.
+
+The autostart path now:
+
+- treats `daemon.run.lock` as "startup already in progress"
+- waits instead of spawning losing daemon children
+- cleans up a starter child that misses the socket timeout
+
+That avoids the noisy:
+
+- `daemon exited before socket became ready`
+- `could not reach or start daemon, skipping upload`
+
+pattern that was showing up in wrapper builds.
+
+## Rollout implications
+
+This is a deliberate hard cutover for remote entry storage.
+
+That means:
+
+- the remote cache will warm from scratch under `v3/`
+- old `v1` and `v2` remote entry objects are not read by this runtime
+- a separate backfill or migration job would be optional future work, not part
+  of correctness
+
+Local store migration is still supported for older on-disk entry layouts through
+the existing blob migration and import code.
+
+## Verification
+
+The branch was verified with:
+
+- `env -u RUSTC_WRAPPER CARGO_TARGET_DIR=/tmp/kache-target cargo check`
+- `env -u RUSTC_WRAPPER CARGO_TARGET_DIR=/tmp/kache-target cargo test -- --nocapture`
+
+Results:
+
+- 297 unit tests passed
+- 5 integration tests passed
+- 11 stale-artifact tests passed
+
+## Remaining work after merge
+
+The remaining tasks are operational, not architectural:
+
+- commit and release the branch
+- cut over users to the new binary
+- accept the cold remote cache event
+- optionally clean old daemon processes on developer machines
+
+The next architectural step after `v3` is still a future planner or coordinator
+layer, but that is not required for `v3` to be usable now.

--- a/docs/planning/.gitignore
+++ b/docs/planning/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2040,6 +2040,7 @@ async fn sync_inner(
     let client = crate::remote::create_s3_client(remote)
         .await
         .context("connecting to S3 — check credentials and endpoint")?;
+    let planner = crate::remote_plan::RemotePlanner::new(config);
 
     // For pull: if we have Cargo.lock crate names and --all is not set,
     // use filtered listing (only crate-prefixed keys) for efficiency.
@@ -2049,19 +2050,20 @@ async fn sync_inner(
             && !crates.is_empty()
         {
             eprint!("Listing S3 keys for {} crates...", crates.len());
-            let keys = crate::remote::list_keys_for_crates(
-                &client,
-                &remote.bucket,
-                &remote.prefix,
-                crates,
-            )
-            .await
-            .context("listing S3 keys for workspace crates")?;
+            let keys = planner
+                .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
+                .layout(&client, remote)
+                .list_keys_for_crates(crates)
+                .await
+                .context("listing S3 keys for workspace crates")?;
             eprintln!(" {} keys", keys.len());
             keys
         } else {
             eprint!("Listing S3 keys...");
-            let keys = crate::remote::list_keys(&client, &remote.bucket, &remote.prefix)
+            let keys = planner
+                .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
+                .layout(&client, remote)
+                .list_keys()
                 .await
                 .context("listing S3 keys")?;
             eprintln!(" {} keys", keys.len());
@@ -2070,7 +2072,10 @@ async fn sync_inner(
     } else {
         // push-only mode: still need to list S3 keys to know what's already uploaded
         eprint!("Listing S3 keys...");
-        let keys = crate::remote::list_keys(&client, &remote.bucket, &remote.prefix)
+        let keys = planner
+            .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
+            .layout(&client, remote)
+            .list_keys()
             .await
             .context("listing S3 keys")?;
         eprintln!(" {} keys", keys.len());
@@ -2161,9 +2166,9 @@ async fn sync_inner(
             }
 
             let client = client.clone();
-            let bucket = remote.bucket.clone();
-            let prefix = remote.prefix.clone();
+            let remote_cfg = remote.clone();
             let cfg = config.clone();
+            let download_plan = planner.plan(crate::remote_plan::RemoteWorkload::SyncPull);
             let ok_ref = &ok;
             let fail_ref = &fail;
 
@@ -2178,39 +2183,16 @@ async fn sync_inner(
                 }
 
                 let blobs_dir = cfg.store_dir().join("blobs");
-                // Try v2 blob format first, fall back to v1 tar format
-                let result = match crate::remote::download_entry_v2(
-                    &client,
-                    &bucket,
-                    &prefix,
-                    &key,
-                    &crate_name,
-                    &entry_dir,
-                    &blobs_dir,
-                )
-                .await
-                {
-                    Ok(Some(bytes)) => Ok(bytes),
-                    Ok(None) => {
-                        // No v2 manifest — fall back to v1 tar format
-                        crate::remote::download_with_client(
-                            &client,
-                            &bucket,
-                            &prefix,
-                            &key,
-                            &entry_dir,
-                            &crate_name,
-                        )
-                        .await
-                    }
-                    Err(e) => Err(e),
-                };
+                let result = download_plan
+                    .layout(&client, &remote_cfg)
+                    .download_entry(&key, &crate_name, &entry_dir, &blobs_dir)
+                    .await;
                 match result {
                     Ok(_bytes) => {
                         // Import into index — opens a fresh Store (cheap with WAL).
                         // INSERT OR REPLACE is idempotent if daemon also imported.
                         if let Ok(s) = Store::open(&cfg)
-                            && let Err(e) = s.import_downloaded_entry(&key)
+                            && let Err(e) = s.import_restored_entry(&key)
                         {
                             eprintln!("\n  warn: import {}...: {e}", &key[..16.min(key.len())]);
                         }
@@ -2266,9 +2248,9 @@ async fn sync_inner(
             }
 
             let client = client.clone();
-            let bucket = remote.bucket.clone();
-            let prefix = remote.prefix.clone();
+            let remote_cfg = remote.clone();
             let cfg = config.clone();
+            let upload_plan = planner.plan(crate::remote_plan::RemoteWorkload::SyncPush);
             let ok_ref = &ok;
             let fail_ref = &fail;
 
@@ -2281,17 +2263,16 @@ async fn sync_inner(
                 }
 
                 let blobs_dir = cfg.store_dir().join("blobs");
-                match crate::remote::upload_entry_v2(
-                    &client,
-                    &bucket,
-                    &prefix,
-                    &key,
-                    &crate_name,
-                    &entry_dir,
-                    &blobs_dir,
-                    cfg.compression_level,
-                )
-                .await
+                match upload_plan
+                    .layout(&client, &remote_cfg)
+                    .upload_entry(
+                        &key,
+                        &crate_name,
+                        &entry_dir,
+                        &blobs_dir,
+                        cfg.compression_level,
+                    )
+                    .await
                 {
                     Ok(_bytes) => {
                         ok_ref.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -2334,7 +2315,7 @@ async fn sync_inner(
 /// then uploads to `{prefix}/_manifests/{manifest_key}.json`.
 ///
 /// When `namespace` is provided and Cargo.lock exists, also computes and uploads
-/// content-addressed shards to `{prefix}/_manifests/v2/{namespace}/shards/{hash}.json`.
+/// content-addressed shards to `{prefix}/_manifests/v3/{namespace}/shards/{hash}.json`.
 pub fn save_manifest(
     config: &Config,
     manifest_key: Option<&str>,
@@ -2393,7 +2374,7 @@ pub fn save_manifest(
         .unwrap_or_else(default_manifest_key);
 
     let manifest = crate::remote::BuildManifest {
-        version: 0, // v1 legacy format
+        version: 3,
         created: chrono::Utc::now().to_rfc3339(),
         manifest_key: key.clone(),
         entries: entries.clone(),
@@ -2407,11 +2388,11 @@ pub fn save_manifest(
     rt.block_on(async {
         let client = crate::remote::create_s3_client(remote).await?;
 
-        // Always upload the v1 legacy manifest
+        // Always upload the monolithic build manifest
         crate::remote::upload_manifest(&client, &remote.bucket, &remote.prefix, &key, &manifest)
             .await?;
 
-        // Upload v2 shards if namespace is provided and Cargo.lock exists
+        // Upload sharded build-manifest indexes if namespace is provided and Cargo.lock exists
         if let Some(ns) = namespace {
             let lock_path = std::path::Path::new("Cargo.lock");
             if lock_path.exists() {
@@ -2477,7 +2458,7 @@ async fn upload_shards(
         }
 
         let shard = crate::remote::Shard {
-            version: 2,
+            version: 3,
             entries: shard_entries,
         };
         uploads.push((shard_hash.clone(), shard));

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -305,6 +305,8 @@ pub enum TransferDirection {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TransferEvent {
+    #[serde(default = "default_transfer_schema")]
+    pub schema: u32,
     pub crate_name: String,
     pub direction: TransferDirection,
     #[serde(default)]
@@ -346,6 +348,10 @@ pub struct TransferEvent {
     pub blobs_total: u32,
     pub ok: bool,
     pub timestamp: u64,
+}
+
+const fn default_transfer_schema() -> u32 {
+    1
 }
 
 pub(crate) struct TransferCounters {
@@ -738,24 +744,12 @@ impl Daemon {
                 return Response::err(format!("S3 client init failed: {e:#}"));
             }
         };
+        let plan = crate::remote_plan::RemotePlanner::new(&self.config)
+            .plan(crate::remote_plan::RemoteWorkload::BackgroundUpload);
+        let layout = plan.layout(client, remote);
 
-        // Check if already in S3 (v2 manifest or v1 tar)
-        let already_exists = crate::remote::exists_v2(
-            client,
-            &remote.bucket,
-            &remote.prefix,
-            &job.key,
-            &job.crate_name,
-        )
-        .await
-        .unwrap_or(false)
-            || crate::remote::exists_with_client(
-                client,
-                &remote.bucket,
-                &remote.prefix,
-                &job.key,
-                &job.crate_name,
-            )
+        let already_exists = layout
+            .exists_entry(&job.key, &job.crate_name)
             .await
             .unwrap_or(false);
 
@@ -784,17 +778,15 @@ impl Daemon {
         let entry_dir = PathBuf::from(&job.entry_dir);
         let blobs_dir = self.config.store_dir().join("blobs");
         let start = Instant::now();
-        match crate::remote::upload_entry_v2(
-            client,
-            &remote.bucket,
-            &remote.prefix,
-            &job.key,
-            &job.crate_name,
-            &entry_dir,
-            &blobs_dir,
-            self.config.compression_level,
-        )
-        .await
+        match layout
+            .upload_entry(
+                &job.key,
+                &job.crate_name,
+                &entry_dir,
+                &blobs_dir,
+                self.config.compression_level,
+            )
+            .await
         {
             Ok(ul) => {
                 let elapsed_ms = start.elapsed().as_millis() as u64;
@@ -803,22 +795,23 @@ impl Daemon {
                     .fetch_add(1, Ordering::Relaxed);
                 self.transfer_counters
                     .bytes_uploaded
-                    .fetch_add(ul.compressed_bytes, Ordering::Relaxed);
+                    .fetch_add(ul.transfer.compressed_bytes, Ordering::Relaxed);
                 self.push_transfer_event(TransferEvent {
+                    schema: default_transfer_schema(),
                     crate_name: job.crate_name.clone(),
                     direction: TransferDirection::Upload,
-                    format: "v2".to_string(),
-                    compressed_bytes: ul.compressed_bytes,
+                    format: ul.format.to_string(),
+                    compressed_bytes: ul.transfer.compressed_bytes,
                     elapsed_ms,
-                    network_ms: ul.network_ms,
+                    network_ms: ul.transfer.network_ms,
                     request_ms: 0,
                     body_ms: 0,
                     request_count: 0,
                     original_bytes: 0,
                     decompress_ms: 0,
                     disk_io_ms: 0,
-                    compression_ms: ul.compression_ms,
-                    head_checks_ms: ul.head_checks_ms,
+                    compression_ms: ul.transfer.compression_ms,
+                    head_checks_ms: ul.transfer.head_checks_ms,
                     blobs_skipped: 0,
                     blobs_total: 0,
                     ok: true,
@@ -839,9 +832,10 @@ impl Daemon {
                     .uploads_failed
                     .fetch_add(1, Ordering::Relaxed);
                 self.push_transfer_event(TransferEvent {
+                    schema: default_transfer_schema(),
                     crate_name: job.crate_name.clone(),
                     direction: TransferDirection::Upload,
-                    format: "v2".to_string(),
+                    format: plan.transfer_format().to_string(),
                     compressed_bytes: 0,
                     elapsed_ms,
                     network_ms: 0,
@@ -905,6 +899,9 @@ impl Daemon {
         };
 
         let cn = &req.crate_name;
+        let plan = crate::remote_plan::RemotePlanner::new(&self.config)
+            .plan(crate::remote_plan::RemoteWorkload::RestoreCheck);
+        let layout = plan.layout(client, remote);
 
         // Check key cache first (no semaphore needed for in-memory lookup)
         match self.key_cache.check(&req.key).await {
@@ -923,15 +920,7 @@ impl Daemon {
                 let Ok(_permit) = self.s3_semaphore.acquire().await else {
                     return Response::err("S3 semaphore closed");
                 };
-                match crate::remote::exists_with_client(
-                    client,
-                    &remote.bucket,
-                    &remote.prefix,
-                    &req.key,
-                    cn,
-                )
-                .await
-                {
+                match layout.exists_entry(&req.key, cn).await {
                     Ok(false) => return Response::found(false),
                     Ok(true) => {
                         self.key_cache
@@ -950,15 +939,7 @@ impl Daemon {
                 let Ok(_permit) = self.s3_semaphore.acquire().await else {
                     return Response::err("S3 semaphore closed");
                 };
-                match crate::remote::exists_with_client(
-                    client,
-                    &remote.bucket,
-                    &remote.prefix,
-                    &req.key,
-                    cn,
-                )
-                .await
-                {
+                match layout.exists_entry(&req.key, cn).await {
                     Ok(false) => return Response::found(false),
                     Ok(true) => {
                         self.key_cache
@@ -1000,42 +981,11 @@ impl Daemon {
             return Response::err("S3 semaphore closed");
         };
 
-        // Download to local store — try v2 (blob-based) first, then fall back to v1 (tar)
+        // Download to local store using the current remote layout.
         let entry_dir = PathBuf::from(&req.entry_dir);
         let blobs_dir = self.config.store_dir().join("blobs");
         let start = Instant::now();
-
-        // Try v2 download first
-        let download_result = match crate::remote::download_entry_v2(
-            client,
-            &remote.bucket,
-            &remote.prefix,
-            &req.key,
-            cn,
-            &entry_dir,
-            &blobs_dir,
-        )
-        .await
-        {
-            Ok(Some(dl)) => Ok(dl),
-            Ok(None) => {
-                // No v2 manifest — fall back to v1 tar format
-                tracing::debug!(
-                    "no v2 manifest for {}, falling back to v1",
-                    &req.key[..req.key.len().min(16)]
-                );
-                crate::remote::download_with_client(
-                    client,
-                    &remote.bucket,
-                    &remote.prefix,
-                    &req.key,
-                    &entry_dir,
-                    cn,
-                )
-                .await
-            }
-            Err(e) => Err(e),
-        };
+        let download_result = layout.download_entry(&req.key, cn, &entry_dir, &blobs_dir).await;
 
         let result = match download_result {
             Ok(dl) => {
@@ -1047,6 +997,7 @@ impl Daemon {
                     .bytes_downloaded
                     .fetch_add(dl.compressed_bytes, Ordering::Relaxed);
                 self.push_transfer_event(TransferEvent {
+                    schema: default_transfer_schema(),
                     crate_name: cn.to_string(),
                     direction: TransferDirection::Download,
                     format: dl.format.to_string(),
@@ -1071,7 +1022,7 @@ impl Daemon {
                 });
                 // Commit to SQLite so store.get() can find it
                 if let Ok(store) = Store::open(&self.config)
-                    && let Err(e) = store.import_downloaded_entry(&req.key)
+                    && let Err(e) = store.import_restored_entry(&req.key)
                 {
                     tracing::warn!("failed to import downloaded entry {}: {e}", &req.key);
                 }
@@ -1083,9 +1034,10 @@ impl Daemon {
                     .downloads_failed
                     .fetch_add(1, Ordering::Relaxed);
                 self.push_transfer_event(TransferEvent {
+                    schema: default_transfer_schema(),
                     crate_name: cn.to_string(),
                     direction: TransferDirection::Download,
-                    format: String::new(),
+                    format: plan.transfer_format().to_string(),
                     compressed_bytes: 0,
                     elapsed_ms,
                     network_ms: 0,
@@ -1164,7 +1116,11 @@ impl Daemon {
         if req.keys.is_empty()
             && let Ok(client) = self.get_s3_client().await
             && let Ok(s3_keys) =
-                crate::remote::list_keys(client, &remote.bucket, &remote.prefix).await
+                crate::remote_plan::RemotePlanner::new(&self.config)
+                    .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
+                    .layout(client, remote)
+                    .list_keys()
+                    .await
         {
             for (key, crate_name) in s3_keys {
                 let entry_dir = store.entry_dir(&key);
@@ -1192,6 +1148,9 @@ impl Daemon {
         let daemon = Arc::clone(self);
         let bucket = remote.bucket.clone();
         let prefix = remote.prefix.clone();
+        let remote_endpoint = remote.endpoint.clone();
+        let remote_region = remote.region.clone();
+        let remote_profile = remote.profile.clone();
         let cancel_rx = self.prefetch_cancel.subscribe();
         tokio::spawn(async move {
             let mut in_flight = futures::stream::FuturesUnordered::new();
@@ -1222,6 +1181,11 @@ impl Daemon {
                 let d = daemon.clone();
                 let b = bucket.clone();
                 let p = prefix.clone();
+                let endpoint = remote_endpoint.clone();
+                let region = remote_region.clone();
+                let profile = remote_profile.clone();
+                let download_plan = crate::remote_plan::RemotePlanner::new(&d.config)
+                    .plan(crate::remote_plan::RemoteWorkload::Prefetch);
                 in_flight.push(tokio::spawn(async move {
                     let Ok(_permit) = sem.acquire().await else {
                         tracing::warn!("prefetch: semaphore closed for {}", key);
@@ -1237,33 +1201,17 @@ impl Daemon {
                     };
                     let blobs_dir = d.config.store_dir().join("blobs");
                     let start = Instant::now();
-
-                    // Try v2 (blob-based) first, fall back to v1 (tar)
-                    let download_result = match crate::remote::download_entry_v2(
-                        client,
-                        &b,
-                        &p,
-                        &key,
-                        &crate_name,
-                        &entry_dir,
-                        &blobs_dir,
-                    )
-                    .await
-                    {
-                        Ok(Some(dl)) => Ok(dl),
-                        Ok(None) => {
-                            crate::remote::download_with_client(
-                                client,
-                                &b,
-                                &p,
-                                &key,
-                                &entry_dir,
-                                &crate_name,
-                            )
-                            .await
-                        }
-                        Err(e) => Err(e),
+                    let remote_cfg = crate::config::RemoteConfig {
+                        bucket: b,
+                        endpoint,
+                        region,
+                        prefix: p,
+                        profile,
                     };
+                    let download_result = download_plan
+                        .layout(client, &remote_cfg)
+                        .download_entry(&key, &crate_name, &entry_dir, &blobs_dir)
+                        .await;
 
                     match download_result {
                         Ok(dl) => {
@@ -1275,6 +1223,7 @@ impl Daemon {
                                 .bytes_downloaded
                                 .fetch_add(dl.compressed_bytes, Ordering::Relaxed);
                             d.push_transfer_event(TransferEvent {
+                                schema: default_transfer_schema(),
                                 crate_name: crate_name.clone(),
                                 direction: TransferDirection::Download,
                                 format: dl.format.to_string(),
@@ -1298,7 +1247,7 @@ impl Daemon {
                                     .as_secs(),
                             });
                             if let Ok(store) = Store::open(&d.config)
-                                && let Err(e) = store.import_downloaded_entry(&key)
+                                && let Err(e) = store.import_restored_entry(&key)
                             {
                                 tracing::warn!("prefetch import failed for {}: {e}", key);
                             }
@@ -1311,9 +1260,10 @@ impl Daemon {
                                 .downloads_failed
                                 .fetch_add(1, Ordering::Relaxed);
                             d.push_transfer_event(TransferEvent {
+                                schema: default_transfer_schema(),
                                 crate_name: crate_name.clone(),
                                 direction: TransferDirection::Download,
-                                format: String::new(),
+                                format: download_plan.transfer_format().to_string(),
                                 compressed_bytes: 0,
                                 elapsed_ms,
                                 network_ms: 0,
@@ -1912,7 +1862,11 @@ async fn populate_key_cache(daemon: &Daemon) -> Result<usize> {
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("no remote configured"))?;
 
-    let keys = crate::remote::list_keys(client, &remote.bucket, &remote.prefix).await?;
+    let keys = crate::remote_plan::RemotePlanner::new(&daemon.config)
+        .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
+        .layout(client, remote)
+        .list_keys()
+        .await?;
     let count = keys.len();
     daemon.key_cache.populate(keys).await;
     Ok(count)
@@ -1923,7 +1877,7 @@ async fn populate_key_cache(daemon: &Daemon) -> Result<usize> {
 ///
 /// If `KACHE_NAMESPACE` is set and Cargo.lock is available, uses shard-based prefetch:
 /// computes shard hashes from Cargo.lock deps, downloads matching shards in parallel,
-/// and collects cache keys from them. Otherwise falls back to the v1 monolithic manifest.
+/// and collects cache keys from them. Otherwise falls back to the monolithic build manifest.
 async fn manifest_prefetch(daemon: &Arc<Daemon>) {
     let Some(remote) = &daemon.config.remote else {
         return;
@@ -1956,16 +1910,19 @@ async fn manifest_prefetch(daemon: &Arc<Daemon>) {
                     return;
                 }
                 Err(e) => {
-                    tracing::warn!("shard prefetch failed, falling back to v1 manifest: {e}");
+                    tracing::warn!(
+                        "shard prefetch failed, falling back to monolithic build manifest: {e}"
+                    );
                 }
             }
         } else {
-            tracing::info!("KACHE_NAMESPACE set but no Cargo.lock found, falling back to v1");
+            tracing::info!(
+                "KACHE_NAMESPACE set but no Cargo.lock found, falling back to monolithic build manifest"
+            );
         }
     }
 
-    // v1 legacy manifest fallback
-    legacy_manifest_prefetch(daemon, client, remote).await;
+    monolithic_manifest_prefetch(daemon, client, remote).await;
 }
 
 /// Shard-based prefetch: compute shard hashes from Cargo.lock, download matching shards
@@ -2041,8 +1998,8 @@ async fn shard_prefetch(
     Ok(count)
 }
 
-/// Legacy v1 manifest prefetch: download monolithic manifest, filter by compile cost.
-async fn legacy_manifest_prefetch(
+/// Monolithic build-manifest prefetch: download the manifest and filter by compile cost.
+async fn monolithic_manifest_prefetch(
     daemon: &Arc<Daemon>,
     client: &aws_sdk_s3::Client,
     remote: &crate::config::RemoteConfig,
@@ -2706,6 +2663,14 @@ pub fn start_daemon_background() -> Result<bool> {
         // Fall through to spawn a new daemon below.
     }
 
+    if daemon_run_lock_is_held(&socket_path)? {
+        tracing::debug!(
+            socket = %socket_path.display(),
+            "daemon run lock already held, waiting for socket"
+        );
+        return wait_for_socket(&socket_path, None);
+    }
+
     let exe = std::env::current_exe().context("getting current executable path")?;
     tracing::info!("auto-starting daemon");
 
@@ -2740,6 +2705,27 @@ pub fn start_daemon_background() -> Result<bool> {
     Ok(ready)
 }
 
+fn daemon_run_lock_is_held(socket_path: &Path) -> Result<bool> {
+    let run_lock_path = socket_path.with_extension("run.lock");
+    let run_lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&run_lock_path)
+        .context("opening daemon run lock probe file")?;
+
+    use std::os::unix::io::AsRawFd;
+    let got_lock =
+        unsafe { libc::flock(run_lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0;
+
+    if got_lock {
+        unsafe { libc::flock(run_lock_file.as_raw_fd(), libc::LOCK_UN) };
+        Ok(false)
+    } else {
+        Ok(true)
+    }
+}
+
 fn wait_for_socket(socket_path: &Path, child: Option<&mut std::process::Child>) -> Result<bool> {
     wait_for_socket_until(socket_path, child, DAEMON_START_TIMEOUT)
 }
@@ -2756,9 +2742,20 @@ fn wait_for_socket_until(
             return Ok(true);
         }
 
-        if let Some(child) = child.as_deref_mut()
-            && let Some(status) = child.try_wait().context("checking daemon process status")?
+        if let Some(child_proc) = child.as_deref_mut()
+            && let Some(status) = child_proc
+                .try_wait()
+                .context("checking daemon process status")?
         {
+            if status.success() {
+                tracing::debug!(
+                    socket = %socket_path.display(),
+                    ?status,
+                    "daemon starter exited cleanly before socket became ready, continuing to wait"
+                );
+                child = None;
+                continue;
+            }
             tracing::warn!(
                 socket = %socket_path.display(),
                 ?status,
@@ -2768,6 +2765,25 @@ fn wait_for_socket_until(
         }
 
         std::thread::sleep(DAEMON_START_POLL_INTERVAL);
+    }
+
+    if socket_path.exists() && std::os::unix::net::UnixStream::connect(socket_path).is_ok() {
+        return Ok(true);
+    }
+
+    if let Some(child) = child.as_deref_mut()
+        && child
+            .try_wait()
+            .context("checking daemon process status after timeout")?
+            .is_none()
+    {
+        tracing::warn!(
+            socket = %socket_path.display(),
+            timeout_ms = timeout.as_millis(),
+            "daemon did not start within timeout, terminating starter process"
+        );
+        let _ = child.kill();
+        let _ = child.wait();
     }
 
     tracing::warn!(
@@ -2846,6 +2862,48 @@ mod tests {
         let ready = wait_for_socket_until(&socket_path, None, Duration::from_millis(150)).unwrap();
 
         assert!(!ready);
+    }
+
+    #[test]
+    fn test_wait_for_socket_until_ignores_clean_child_exit_if_socket_appears() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("daemon.sock");
+        let socket_path_bg = socket_path.clone();
+
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(150));
+            let _listener = std::os::unix::net::UnixListener::bind(socket_path_bg).unwrap();
+            std::thread::sleep(Duration::from_millis(200));
+        });
+
+        let mut child = std::process::Command::new("sh")
+            .args(["-c", "exit 0"])
+            .spawn()
+            .unwrap();
+
+        let ready =
+            wait_for_socket_until(&socket_path, Some(&mut child), Duration::from_secs(1)).unwrap();
+
+        handle.join().unwrap();
+        assert!(ready);
+    }
+
+    #[test]
+    fn test_wait_for_socket_until_kills_stuck_child_after_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("missing.sock");
+        let mut child = std::process::Command::new("sh")
+            .args(["-c", "sleep 30"])
+            .spawn()
+            .unwrap();
+
+        let ready =
+            wait_for_socket_until(&socket_path, Some(&mut child), Duration::from_millis(150))
+                .unwrap();
+
+        assert!(!ready);
+        let status = child.try_wait().unwrap();
+        assert!(status.is_some());
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -985,7 +985,9 @@ impl Daemon {
         let entry_dir = PathBuf::from(&req.entry_dir);
         let blobs_dir = self.config.store_dir().join("blobs");
         let start = Instant::now();
-        let download_result = layout.download_entry(&req.key, cn, &entry_dir, &blobs_dir).await;
+        let download_result = layout
+            .download_entry(&req.key, cn, &entry_dir, &blobs_dir)
+            .await;
 
         let result = match download_result {
             Ok(dl) => {
@@ -1115,12 +1117,11 @@ impl Daemon {
         // If empty keys were sent, fetch all S3 keys missing locally
         if req.keys.is_empty()
             && let Ok(client) = self.get_s3_client().await
-            && let Ok(s3_keys) =
-                crate::remote_plan::RemotePlanner::new(&self.config)
-                    .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
-                    .layout(client, remote)
-                    .list_keys()
-                    .await
+            && let Ok(s3_keys) = crate::remote_plan::RemotePlanner::new(&self.config)
+                .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
+                .layout(client, remote)
+                .list_keys()
+                .await
         {
             for (key, crate_name) in s3_keys {
                 let entry_dir = store.entry_dir(&key);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -17,6 +17,8 @@ const KEY_CACHE_REFRESH_SECS: u64 = 60;
 const STALENESS_THRESHOLD: Duration = Duration::from_secs(55);
 const DAEMON_START_TIMEOUT: Duration = Duration::from_secs(8);
 const DAEMON_START_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const DAEMON_COORD_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
+const DAEMON_COORD_STALE_AFTER: Duration = Duration::from_secs(15);
 const VERSION: &str = crate::VERSION;
 
 /// Compute a "build epoch" from the executable's mtime.
@@ -30,6 +32,177 @@ pub fn build_epoch() -> u64 {
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_secs())
         .unwrap_or(0)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum DaemonPhase {
+    Starting,
+    Ready,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct DaemonCoordState {
+    pid: u32,
+    build_epoch: u64,
+    phase: DaemonPhase,
+    updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+struct DaemonCoordFile {
+    path: PathBuf,
+    pid: u32,
+    build_epoch: u64,
+}
+
+impl DaemonCoordFile {
+    fn for_socket(socket_path: &Path) -> Self {
+        Self {
+            path: daemon_state_path(socket_path),
+            pid: std::process::id(),
+            build_epoch: build_epoch(),
+        }
+    }
+
+    fn write_phase(&self, phase: DaemonPhase) -> Result<()> {
+        let state = DaemonCoordState {
+            pid: self.pid,
+            build_epoch: self.build_epoch,
+            phase,
+            updated_at_ms: now_millis(),
+        };
+        write_json_atomically(&self.path, &state)
+    }
+}
+
+struct DaemonCoordGuard {
+    path: PathBuf,
+}
+
+impl DaemonCoordGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl Drop for DaemonCoordGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn daemon_state_path(socket_path: &Path) -> PathBuf {
+    socket_path.with_extension("state.json")
+}
+
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn write_json_atomically<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("state file has no parent directory"))?;
+    std::fs::create_dir_all(parent)?;
+
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("state file has no file name"))?
+        .to_string_lossy();
+    let tmp_path = parent.join(format!("{file_name}.{}.tmp", std::process::id()));
+    let json = serde_json::to_vec(value)?;
+    std::fs::write(&tmp_path, json)?;
+    std::fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+fn read_daemon_state(socket_path: &Path) -> Option<DaemonCoordState> {
+    let path = daemon_state_path(socket_path);
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn daemon_state_is_recent(state: &DaemonCoordState) -> bool {
+    let age_ms = now_millis().saturating_sub(state.updated_at_ms);
+    age_ms <= DAEMON_COORD_STALE_AFTER.as_millis() as u64
+}
+
+fn process_is_alive(pid: u32) -> bool {
+    let rc = unsafe { libc::kill(pid as i32, 0) };
+    rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+fn wait_for_run_lock_release(socket_path: &Path, timeout: Duration) -> Result<bool> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if !daemon_run_lock_is_held(socket_path)? {
+            return Ok(true);
+        }
+        if Instant::now() >= deadline {
+            return Ok(false);
+        }
+        std::thread::sleep(DAEMON_START_POLL_INTERVAL);
+    }
+}
+
+fn terminate_daemon_pid(pid: u32, socket_path: &Path) -> Result<bool> {
+    unsafe {
+        libc::kill(pid as i32, libc::SIGTERM);
+    }
+
+    if wait_for_run_lock_release(socket_path, Duration::from_secs(1))? {
+        return Ok(true);
+    }
+
+    unsafe {
+        libc::kill(pid as i32, libc::SIGKILL);
+    }
+
+    wait_for_run_lock_release(socket_path, Duration::from_secs(1))
+}
+
+fn recover_unhealthy_daemon(socket_path: &Path, reason: &str) -> Result<bool> {
+    let run_lock_held = daemon_run_lock_is_held(socket_path)?;
+    if let Some(state) = read_daemon_state(socket_path) {
+        let state_recent = daemon_state_is_recent(&state);
+        if run_lock_held && process_is_alive(state.pid) {
+            tracing::warn!(
+                socket = %socket_path.display(),
+                pid = state.pid,
+                ?state.phase,
+                heartbeat_fresh = state_recent,
+                reason,
+                "terminating unhealthy daemon coordinator"
+            );
+            if !terminate_daemon_pid(state.pid, socket_path)? {
+                tracing::warn!(
+                    socket = %socket_path.display(),
+                    pid = state.pid,
+                    heartbeat_fresh = state_recent,
+                    reason,
+                    "daemon process did not release run lock during recovery"
+                );
+                return Ok(false);
+            }
+        }
+    }
+
+    if daemon_run_lock_is_held(socket_path)? {
+        tracing::warn!(
+            socket = %socket_path.display(),
+            reason,
+            "daemon run lock still held and no recoverable coordinator state was found"
+        );
+        return Ok(false);
+    }
+
+    let _ = std::fs::remove_file(socket_path);
+    let _ = std::fs::remove_file(daemon_state_path(socket_path));
+    Ok(true)
 }
 
 // ── Protocol types ───────────────────────────────────────────────
@@ -1547,15 +1720,20 @@ pub fn run_server(config: &Config) -> Result<()> {
 
     // Hold lock_file (and thus the flock) for the daemon's entire lifetime.
     let _lock = lock_file;
+    let coord = DaemonCoordFile::for_socket(&socket_path);
+    coord
+        .write_phase(DaemonPhase::Starting)
+        .context("writing daemon coordinator state")?;
+    let _coord_guard = DaemonCoordGuard::new(coord.path.clone());
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
 
-    rt.block_on(server_main(config))
+    rt.block_on(server_main(config, coord))
 }
 
-async fn server_main(config: &Config) -> Result<()> {
+async fn server_main(config: &Config, coord: DaemonCoordFile) -> Result<()> {
     let socket_path = config.socket_path();
     std::fs::create_dir_all(socket_path.parent().unwrap())?;
 
@@ -1579,6 +1757,9 @@ async fn server_main(config: &Config) -> Result<()> {
     }
 
     let listener = UnixListener::bind(&socket_path).context("binding Unix socket")?;
+    coord
+        .write_phase(DaemonPhase::Ready)
+        .context("publishing daemon ready state")?;
     tracing::info!("daemon listening on {}", socket_path.display());
 
     // Exclude cache dir from Time Machine / Spotlight (once, not per-crate).
@@ -1748,6 +1929,18 @@ async fn server_main(config: &Config) -> Result<()> {
 
     // Shutdown flag: set by Shutdown request or OS signal
     let shutdown_flag = Arc::new(AtomicBool::new(false));
+    let heartbeat_coord = coord.clone();
+    let heartbeat_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(DAEMON_COORD_HEARTBEAT_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            if let Err(e) = heartbeat_coord.write_phase(DaemonPhase::Ready) {
+                tracing::debug!("daemon coordinator heartbeat failed: {e}");
+            }
+        }
+    });
 
     // Accept connections until shutdown signal
     let shutdown = shutdown_signal();
@@ -1827,6 +2020,7 @@ async fn server_main(config: &Config) -> Result<()> {
     if let Some(h) = manifest_handle {
         h.abort();
     }
+    heartbeat_handle.abort();
 
     // Graceful shutdown: drop the daemon's sender to close the unbounded buffer,
     // which will cause the enqueue task to exit, closing the worker channel,
@@ -2583,127 +2777,140 @@ pub fn start_daemon_background() -> Result<bool> {
     let socket_path = config.socket_path();
     let lock_path = socket_path.with_extension("lock");
 
-    std::fs::create_dir_all(socket_path.parent().unwrap())?;
+    for attempt in 0..2 {
+        std::fs::create_dir_all(socket_path.parent().unwrap())?;
 
-    let lock_file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(false)
-        .open(&lock_path)
-        .context("opening daemon lock file")?;
+        let lock_file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)
+            .context("opening daemon lock file")?;
 
-    use std::os::unix::io::AsRawFd;
-    let got_lock =
-        unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0;
+        use std::os::unix::io::AsRawFd;
+        let got_lock =
+            unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0;
 
-    if !got_lock {
-        // Another process is already starting the daemon — just wait for the socket.
-        tracing::debug!("daemon start already in progress, waiting for socket");
-        return wait_for_socket(&socket_path, None);
-    }
+        if !got_lock {
+            tracing::debug!("daemon start already in progress, waiting for socket");
+            if wait_for_socket(&socket_path, None)? {
+                return Ok(true);
+            }
+            if attempt == 0 {
+                tracing::warn!(
+                    socket = %socket_path.display(),
+                    "daemon starter timed out without publishing a ready socket, retrying coordination"
+                );
+                std::thread::sleep(DAEMON_START_POLL_INTERVAL);
+                continue;
+            }
+            return Ok(false);
+        }
 
-    // We hold the lock. Check if daemon is already running.
-    if socket_path.exists() && std::os::unix::net::UnixStream::connect(&socket_path).is_ok() {
-        // Probe whether the running daemon is stale (older binary epoch).
-        let my_epoch = build_epoch();
-        let is_stale = my_epoch > 0
-            && send_request_with_timeout(
-                &socket_path,
-                &Request::Stats(StatsRequest {
-                    include_entries: false,
-                    sort_by: None,
-                    event_hours: None,
-                    client_epoch: my_epoch,
-                }),
-                Duration::from_secs(2),
-            )
-            .ok()
-            .and_then(|s| serde_json::from_str::<Response>(&s).ok())
-            .and_then(|r| r.stats)
-            .map(|s| s.build_epoch > 0 && my_epoch > s.build_epoch)
-            .unwrap_or(false);
+        // We hold the lock. Check if daemon is already running.
+        if socket_path.exists() && std::os::unix::net::UnixStream::connect(&socket_path).is_ok() {
+            let my_epoch = build_epoch();
+            let is_stale = my_epoch > 0
+                && send_request_with_timeout(
+                    &socket_path,
+                    &Request::Stats(StatsRequest {
+                        include_entries: false,
+                        sort_by: None,
+                        event_hours: None,
+                        client_epoch: my_epoch,
+                    }),
+                    Duration::from_secs(2),
+                )
+                .ok()
+                .and_then(|s| serde_json::from_str::<Response>(&s).ok())
+                .and_then(|r| r.stats)
+                .map(|s| s.build_epoch > 0 && my_epoch > s.build_epoch)
+                .unwrap_or(false);
 
-        if !is_stale {
-            tracing::debug!("daemon already running");
+            if !is_stale {
+                tracing::debug!("daemon already running");
+                return Ok(true);
+            }
+
+            tracing::info!("stale daemon detected, requesting shutdown before restart");
+            let _ =
+                send_request_with_timeout(&socket_path, &Request::Shutdown, Duration::from_secs(2));
+
+            if !wait_for_run_lock_release(&socket_path, Duration::from_secs(5))? {
+                tracing::warn!(
+                    socket = %socket_path.display(),
+                    "stale daemon did not exit within timeout, attempting bounded recovery"
+                );
+                if attempt == 0
+                    && recover_unhealthy_daemon(
+                        &socket_path,
+                        "stale daemon did not exit after shutdown request",
+                    )?
+                {
+                    continue;
+                }
+                return Ok(false);
+            }
+        }
+
+        if daemon_run_lock_is_held(&socket_path)? {
+            tracing::debug!(
+                socket = %socket_path.display(),
+                "daemon run lock already held, waiting for socket"
+            );
+            if wait_for_socket(&socket_path, None)? {
+                return Ok(true);
+            }
+            if attempt == 0
+                && recover_unhealthy_daemon(
+                    &socket_path,
+                    "daemon run lock held but no ready socket became reachable",
+                )?
+            {
+                continue;
+            }
+            return Ok(false);
+        }
+
+        let exe = std::env::current_exe().context("getting current executable path")?;
+        tracing::info!("auto-starting daemon");
+
+        let log_path = socket_path.with_extension("log");
+        if std::fs::metadata(&log_path).is_ok_and(|m| m.len() > 2 * 1024 * 1024) {
+            let _ = std::fs::write(&log_path, b"--- log rotated ---\n");
+        }
+        let stderr_target = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .map(std::process::Stdio::from)
+            .unwrap_or_else(|_| std::process::Stdio::null());
+
+        let mut child = std::process::Command::new(exe)
+            .args(["daemon", "run"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(stderr_target)
+            .spawn()
+            .context("spawning daemon process")?;
+
+        let ready = wait_for_socket(&socket_path, Some(&mut child))?;
+        if ready {
+            tracing::info!("daemon started successfully");
             return Ok(true);
         }
-
-        // Stale daemon detected — the stats request already triggered its
-        // shutdown_flag (via client_epoch check).  Send an explicit Shutdown
-        // as well, then wait for the run lock to be released.
-        tracing::info!("stale daemon detected, requesting shutdown before restart");
-        let _ = send_request_with_timeout(&socket_path, &Request::Shutdown, Duration::from_secs(2));
-
-        let run_lock_path = socket_path.with_extension("run.lock");
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            // Try to acquire the run lock — if we get it the old daemon has exited.
-            let run_lock_file = std::fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(false)
-                .open(&run_lock_path);
-            if let Ok(f) = run_lock_file {
-                let probe =
-                    unsafe { libc::flock(f.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0;
-                if probe {
-                    // Old daemon exited.  Drop this probe lock immediately —
-                    // the new daemon's run_server() will acquire its own.
-                    unsafe { libc::flock(f.as_raw_fd(), libc::LOCK_UN) };
-                    break;
-                }
-            }
-            if std::time::Instant::now() >= deadline {
-                tracing::warn!("stale daemon did not exit within timeout, proceeding anyway");
-                // Remove stale socket so the new daemon can bind.
-                let _ = std::fs::remove_file(&socket_path);
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(100));
+        if attempt == 0
+            && recover_unhealthy_daemon(
+                &socket_path,
+                "daemon starter failed to publish a ready socket before timeout",
+            )?
+        {
+            continue;
         }
-        // Fall through to spawn a new daemon below.
+        return Ok(false);
     }
 
-    if daemon_run_lock_is_held(&socket_path)? {
-        tracing::debug!(
-            socket = %socket_path.display(),
-            "daemon run lock already held, waiting for socket"
-        );
-        return wait_for_socket(&socket_path, None);
-    }
-
-    let exe = std::env::current_exe().context("getting current executable path")?;
-    tracing::info!("auto-starting daemon");
-
-    // Redirect daemon stderr to a log file so panics/crashes are diagnosable.
-    // Append instead of truncating so previous daemon sessions are preserved.
-    // Simple rotation: if the file exceeds 2 MB, truncate before appending.
-    let log_path = socket_path.with_extension("log");
-    if std::fs::metadata(&log_path).is_ok_and(|m| m.len() > 2 * 1024 * 1024) {
-        let _ = std::fs::write(&log_path, b"--- log rotated ---\n");
-    }
-    let stderr_target = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_path)
-        .map(std::process::Stdio::from)
-        .unwrap_or_else(|_| std::process::Stdio::null());
-
-    let mut child = std::process::Command::new(exe)
-        .args(["daemon", "run"])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(stderr_target)
-        .spawn()
-        .context("spawning daemon process")?;
-
-    // Lock is released on drop (when this function returns),
-    // allowing other waiters to proceed once the socket is ready.
-    let ready = wait_for_socket(&socket_path, Some(&mut child))?;
-    if ready {
-        tracing::info!("daemon started successfully");
-    }
-    Ok(ready)
+    Ok(false)
 }
 
 fn daemon_run_lock_is_held(socket_path: &Path) -> Result<bool> {
@@ -2800,6 +3007,30 @@ fn wait_for_socket_until(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc;
+
+    fn hold_run_lock_for_test(
+        socket_path: &Path,
+        hold_for: Duration,
+    ) -> std::thread::JoinHandle<()> {
+        let run_lock_path = socket_path.with_extension("run.lock");
+        let (tx, rx) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(&run_lock_path)
+                .unwrap();
+            use std::os::unix::io::AsRawFd;
+            assert_eq!(unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) }, 0);
+            tx.send(()).unwrap();
+            std::thread::sleep(hold_for);
+            unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+        });
+        rx.recv().unwrap();
+        handle
+    }
 
     /// Helper: create a Config pointing at a tempdir.
     fn test_config(dir: &Path) -> Config {
@@ -2905,6 +3136,121 @@ mod tests {
         assert!(!ready);
         let status = child.try_wait().unwrap();
         assert!(status.is_some());
+    }
+
+    #[test]
+    fn test_daemon_coord_state_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("daemon.sock");
+        let coord = DaemonCoordFile::for_socket(&socket_path);
+
+        coord.write_phase(DaemonPhase::Starting).unwrap();
+        let state = read_daemon_state(&socket_path).unwrap();
+        assert_eq!(state.pid, std::process::id());
+        assert_eq!(state.build_epoch, build_epoch());
+        assert_eq!(state.phase, DaemonPhase::Starting);
+        assert!(daemon_state_is_recent(&state));
+    }
+
+    #[test]
+    fn test_recover_unhealthy_daemon_cleans_stale_socket_and_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("daemon.sock");
+        std::fs::write(&socket_path, b"stale").unwrap();
+
+        let state = DaemonCoordState {
+            pid: u32::MAX,
+            build_epoch: build_epoch(),
+            phase: DaemonPhase::Starting,
+            updated_at_ms: now_millis(),
+        };
+        write_json_atomically(&daemon_state_path(&socket_path), &state).unwrap();
+
+        assert!(recover_unhealthy_daemon(&socket_path, "test").unwrap());
+        assert!(!socket_path.exists());
+        assert!(read_daemon_state(&socket_path).is_none());
+    }
+
+    #[test]
+    fn test_recover_unhealthy_daemon_terminates_recent_recorded_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("daemon.sock");
+        std::fs::write(&socket_path, b"stale").unwrap();
+        let run_lock_handle = hold_run_lock_for_test(&socket_path, Duration::from_millis(150));
+
+        let mut child = std::process::Command::new("sh")
+            .args(["-c", "sleep 30"])
+            .spawn()
+            .unwrap();
+
+        let state = DaemonCoordState {
+            pid: child.id(),
+            build_epoch: build_epoch(),
+            phase: DaemonPhase::Ready,
+            updated_at_ms: now_millis(),
+        };
+        write_json_atomically(&daemon_state_path(&socket_path), &state).unwrap();
+
+        assert!(recover_unhealthy_daemon(&socket_path, "test").unwrap());
+        run_lock_handle.join().unwrap();
+        assert_ne!(child.wait().unwrap().code(), Some(0));
+        assert!(!socket_path.exists());
+        assert!(read_daemon_state(&socket_path).is_none());
+    }
+
+    #[test]
+    fn test_recover_unhealthy_daemon_terminates_stale_recorded_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("daemon.sock");
+        std::fs::write(&socket_path, b"stale").unwrap();
+        let run_lock_handle = hold_run_lock_for_test(&socket_path, Duration::from_millis(150));
+
+        let mut child = std::process::Command::new("sh")
+            .args(["-c", "sleep 30"])
+            .spawn()
+            .unwrap();
+
+        let state = DaemonCoordState {
+            pid: child.id(),
+            build_epoch: build_epoch(),
+            phase: DaemonPhase::Ready,
+            updated_at_ms: now_millis()
+                .saturating_sub(DAEMON_COORD_STALE_AFTER.as_millis() as u64 + 1),
+        };
+        write_json_atomically(&daemon_state_path(&socket_path), &state).unwrap();
+
+        assert!(recover_unhealthy_daemon(&socket_path, "test").unwrap());
+        run_lock_handle.join().unwrap();
+        assert_ne!(child.wait().unwrap().code(), Some(0));
+        assert!(!socket_path.exists());
+        assert!(read_daemon_state(&socket_path).is_none());
+    }
+
+    #[test]
+    fn test_recover_unhealthy_daemon_does_not_kill_pid_without_run_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("daemon.sock");
+        std::fs::write(&socket_path, b"stale").unwrap();
+
+        let mut child = std::process::Command::new("sh")
+            .args(["-c", "sleep 30"])
+            .spawn()
+            .unwrap();
+
+        let state = DaemonCoordState {
+            pid: child.id(),
+            build_epoch: build_epoch(),
+            phase: DaemonPhase::Ready,
+            updated_at_ms: now_millis(),
+        };
+        write_json_atomically(&daemon_state_path(&socket_path), &state).unwrap();
+
+        assert!(recover_unhealthy_daemon(&socket_path, "test").unwrap());
+        assert!(child.try_wait().unwrap().is_none());
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(!socket_path.exists());
+        assert!(read_daemon_state(&socket_path).is_none());
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2950,7 +2950,7 @@ fn wait_for_socket_until(
             return Ok(true);
         }
 
-        if let Some(child_proc) = child.as_deref_mut()
+        if let Some(child_proc) = child.as_mut()
             && let Some(status) = child_proc
                 .try_wait()
                 .context("checking daemon process status")?
@@ -2979,7 +2979,7 @@ fn wait_for_socket_until(
         return Ok(true);
     }
 
-    if let Some(child) = child.as_deref_mut()
+    if let Some(child) = child.as_mut()
         && child
             .try_wait()
             .context("checking daemon process status after timeout")?

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ mod daemon;
 mod events;
 mod link;
 mod remote;
+mod remote_layout;
+mod remote_plan;
 mod report;
 mod service;
 mod shards;
@@ -130,7 +132,7 @@ enum Commands {
         #[arg(long)]
         manifest_key: Option<String>,
         /// Shard namespace: target/rustc_hash/profile. If set and Cargo.lock exists,
-        /// uploads content-addressed shards alongside the legacy manifest.
+        /// uploads content-addressed shards alongside the monolithic build manifest.
         #[arg(long)]
         namespace: Option<String>,
     },

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,10 +1,7 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
 
 use crate::config::RemoteConfig;
-use crate::store::EntryMeta;
 
 /// Result of a download operation with timing breakdown.
 pub struct DownloadResult {
@@ -42,698 +39,14 @@ pub struct UploadResult {
     pub network_ms: u64,
 }
 
-// ── S3 operations (take a pre-created client) ────────────────────
-
-/// Download a cached entry from S3 using an existing client.
-/// Uses streaming decompression to avoid buffering the full decompressed data in memory.
-/// Key format: `{prefix}/{crate_name}/{cache_key}.tar.zst`
-pub async fn download_with_client(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
-    prefix: &str,
-    cache_key: &str,
-    dest_dir: &Path,
-    crate_name: &str,
-) -> Result<DownloadResult> {
-    let object_key = s3_object_key(prefix, cache_key, crate_name);
-
-    tracing::debug!("downloading s3://{}/{}", bucket, object_key);
-
-    // Time only the network portion (S3 GET + body collection)
-    let request_start = std::time::Instant::now();
-    let resp = client
-        .get_object()
-        .bucket(bucket)
-        .key(&object_key)
-        .send()
-        .await
-        .context("downloading from S3")?;
-    let request_ms = request_start.elapsed().as_millis() as u64;
-
-    let body_start = std::time::Instant::now();
-    let body = resp
-        .body
-        .collect()
-        .await
-        .context("reading S3 response body")?;
-    let body_ms = body_start.elapsed().as_millis() as u64;
-    let compressed = body.into_bytes();
-    let network_ms = request_ms + body_ms;
-    let compressed_len = compressed.len();
-
-    // Streaming: zstd decoder wraps compressed bytes, tar reads from decoder
-    let decompress_start = std::time::Instant::now();
-    let decoder = zstd::stream::Decoder::new(std::io::Cursor::new(&compressed))
-        .context("creating zstd decoder")?;
-    let original_bytes = extract_tar_streaming(decoder, dest_dir)?;
-    let decompress_ms = decompress_start.elapsed().as_millis() as u64;
-
-    tracing::info!(
-        "downloaded {} ({} bytes compressed)",
-        cache_key,
-        compressed_len
-    );
-    Ok(DownloadResult {
-        format: "v1",
-        compressed_bytes: compressed_len as u64,
-        original_bytes,
-        network_ms,
-        request_ms,
-        body_ms,
-        request_count: 1,
-        decompress_ms,
-        disk_io_ms: 0,
-        blobs_skipped: 0,
-        blobs_total: 0,
-    })
-}
-
-/// Check if a cached entry exists in S3 using an existing client.
-/// Key format: `{prefix}/{crate_name}/{cache_key}.tar.zst`
-pub async fn exists_with_client(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
-    prefix: &str,
-    cache_key: &str,
-    crate_name: &str,
-) -> Result<bool> {
-    let object_key = s3_object_key(prefix, cache_key, crate_name);
-
-    match client
-        .head_object()
-        .bucket(bucket)
-        .key(&object_key)
-        .send()
-        .await
-    {
-        Ok(_) => Ok(true),
-        Err(e) => {
-            let err = e.into_service_error();
-            if err.is_not_found() {
-                Ok(false)
-            } else {
-                Err(anyhow::anyhow!("S3 head_object error: {err}"))
-            }
-        }
-    }
-}
-
-/// Upload a cached entry to S3 using an existing client (v1 tar format).
-/// Uses streaming compression: tar data is piped through zstd encoder.
-/// Key format: `{prefix}/{crate_name}/{cache_key}.tar.zst`
-///
-/// Kept for v1 compatibility; new uploads use `upload_entry_v2`.
-#[allow(dead_code)]
-pub async fn upload_with_client(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
-    prefix: &str,
-    cache_key: &str,
-    entry_dir: &Path,
-    compression_level: i32,
-    crate_name: &str,
-) -> Result<u64> {
-    let object_key = s3_object_key(prefix, cache_key, crate_name);
-
-    // Stream tar directly through zstd (single buffer, no intermediate Vec)
-    let compressed = create_tar_zstd(entry_dir, compression_level)?;
-
-    let compressed_len = compressed.len() as u64;
-
-    tracing::debug!(
-        "uploading s3://{}/{} ({} bytes compressed)",
-        bucket,
-        object_key,
-        compressed_len
-    );
-
-    client
-        .put_object()
-        .bucket(bucket)
-        .key(&object_key)
-        .body(compressed.into())
-        .send()
-        .await
-        .context("uploading to S3")?;
-
-    tracing::info!("uploaded {} to S3", cache_key);
-    Ok(compressed_len)
-}
-
-/// List all cache keys from S3 (paginated).
-/// Returns a map of cache_key → crate_name.
-/// Checks both v1 (`{prefix}/{crate_name}/{cache_key}.tar.zst`) and
-/// v2 (`{prefix}/manifests/{crate_name}/{cache_key}.json`) formats.
-pub async fn list_keys(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
-    prefix: &str,
-) -> Result<HashMap<String, String>> {
-    let mut keys = HashMap::new();
-
-    // ── v1 keys: {prefix}/{crate_name}/{cache_key}.tar.zst ──
-    let mut continuation_token: Option<String> = None;
-    let s3_prefix = format!("{prefix}/");
-
-    loop {
-        let mut req = client.list_objects_v2().bucket(bucket).prefix(&s3_prefix);
-
-        if let Some(token) = &continuation_token {
-            req = req.continuation_token(token);
-        }
-
-        let resp = req.send().await.context("listing S3 objects (v1)")?;
-
-        for obj in resp.contents() {
-            if let Some(key) = obj.key()
-                && let Some(stripped) = key.strip_prefix(&s3_prefix)
-                && let Some(without_ext) = stripped.strip_suffix(".tar.zst")
-            {
-                // Format: "{crate_name}/{cache_key}"
-                if let Some((crate_name, hash)) = without_ext.rsplit_once('/') {
-                    keys.insert(hash.to_string(), crate_name.to_string());
-                }
-            }
-        }
-
-        if resp.is_truncated == Some(true) {
-            continuation_token = resp.next_continuation_token().map(|s| s.to_string());
-        } else {
-            break;
-        }
-    }
-
-    // ── v2 keys: {prefix}/manifests/{crate_name}/{cache_key}.json ──
-    let manifests_prefix = format!("{prefix}/manifests/");
-    continuation_token = None;
-
-    loop {
-        let mut req = client
-            .list_objects_v2()
-            .bucket(bucket)
-            .prefix(&manifests_prefix);
-
-        if let Some(token) = &continuation_token {
-            req = req.continuation_token(token);
-        }
-
-        let resp = req.send().await.context("listing S3 objects (v2)")?;
-
-        for obj in resp.contents() {
-            if let Some(key) = obj.key()
-                && let Some(stripped) = key.strip_prefix(&manifests_prefix)
-                && let Some(without_ext) = stripped.strip_suffix(".json")
-            {
-                // Format: "{crate_name}/{cache_key}"
-                if let Some((crate_name, cache_key)) = without_ext.rsplit_once('/') {
-                    keys.entry(cache_key.to_string())
-                        .or_insert_with(|| crate_name.to_string());
-                }
-            }
-        }
-
-        if resp.is_truncated == Some(true) {
-            continuation_token = resp.next_continuation_token().map(|s| s.to_string());
-        } else {
-            break;
-        }
-    }
-
-    Ok(keys)
-}
-
-/// List S3 cache keys filtered to specific crate names.
-/// Uses per-crate prefix listing for efficiency — only queries S3 for matching crates.
-/// Checks both v1 and v2 formats. Returns a map of cache_key → crate_name.
-pub async fn list_keys_for_crates(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
-    prefix: &str,
-    crate_names: &HashSet<String>,
-) -> Result<HashMap<String, String>> {
-    let mut keys = HashMap::new();
-
-    for crate_name in crate_names {
-        // ── v1: {prefix}/{crate_name}/{cache_key}.tar.zst ──
-        let crate_prefix = format!("{prefix}/{crate_name}/");
-        let mut continuation_token: Option<String> = None;
-
-        loop {
-            let mut req = client
-                .list_objects_v2()
-                .bucket(bucket)
-                .prefix(&crate_prefix);
-
-            if let Some(token) = &continuation_token {
-                req = req.continuation_token(token);
-            }
-
-            let resp = req
-                .send()
-                .await
-                .with_context(|| format!("listing S3 objects for crate {crate_name} (v1)"))?;
-
-            for obj in resp.contents() {
-                if let Some(key) = obj.key()
-                    && let Some(stripped) = key.strip_prefix(&crate_prefix)
-                    && let Some(cache_key) = stripped.strip_suffix(".tar.zst")
-                {
-                    keys.insert(cache_key.to_string(), crate_name.clone());
-                }
-            }
-
-            if resp.is_truncated == Some(true) {
-                continuation_token = resp.next_continuation_token().map(|s| s.to_string());
-            } else {
-                break;
-            }
-        }
-
-        // ── v2: {prefix}/manifests/{crate_name}/{cache_key}.json ──
-        let manifest_prefix = format!("{prefix}/manifests/{crate_name}/");
-        continuation_token = None;
-
-        loop {
-            let mut req = client
-                .list_objects_v2()
-                .bucket(bucket)
-                .prefix(&manifest_prefix);
-
-            if let Some(token) = &continuation_token {
-                req = req.continuation_token(token);
-            }
-
-            let resp = req
-                .send()
-                .await
-                .with_context(|| format!("listing S3 objects for crate {crate_name} (v2)"))?;
-
-            for obj in resp.contents() {
-                if let Some(key) = obj.key()
-                    && let Some(stripped) = key.strip_prefix(&manifest_prefix)
-                    && let Some(cache_key) = stripped.strip_suffix(".json")
-                {
-                    keys.entry(cache_key.to_string())
-                        .or_insert_with(|| crate_name.clone());
-                }
-            }
-
-            if resp.is_truncated == Some(true) {
-                continuation_token = resp.next_continuation_token().map(|s| s.to_string());
-            } else {
-                break;
-            }
-        }
-    }
-
-    Ok(keys)
-}
-
-/// Build the S3 object key for a cache entry (v1 format).
-/// Format: `{prefix}/{crate_name}/{cache_key}.tar.zst`
-fn s3_object_key(prefix: &str, cache_key: &str, crate_name: &str) -> String {
-    format!("{prefix}/{crate_name}/{cache_key}.tar.zst")
-}
-
-/// S3 key for a content-addressed blob (v2 format).
-/// Format: `{prefix}/blobs/{hash[0..2]}/{hash}.zst`
-pub fn s3_blob_key(prefix: &str, hash: &str) -> String {
-    format!("{prefix}/blobs/{}/{hash}.zst", &hash[..2])
-}
-
-/// S3 key for a cache entry manifest (v2 format).
-/// Format: `{prefix}/manifests/{crate_name}/{cache_key}.json`
-pub fn s3_manifest_key(prefix: &str, cache_key: &str, crate_name: &str) -> String {
-    format!("{prefix}/manifests/{crate_name}/{cache_key}.json")
-}
-
-// ── V2 blob-based S3 operations ─────────────────────────────────
-
-/// Resolve the local blob path from the blobs directory.
-fn local_blob_path(blobs_dir: &Path, hash: &str) -> PathBuf {
-    blobs_dir.join(&hash[..2]).join(hash)
-}
-
-/// Upload a cache entry using the v2 blob-based format.
-///
-/// For each file in the entry's manifest:
-///   - HEAD-check if the blob already exists on S3
-///   - If not, read from local blob store, zstd-compress, and upload
-///
-/// Finally, upload the manifest (meta.json) to the manifests prefix.
-/// Returns the total compressed bytes uploaded.
-pub async fn upload_entry_v2(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
-    prefix: &str,
-    cache_key: &str,
-    crate_name: &str,
-    entry_dir: &Path,
-    blobs_dir: &Path,
-    compression_level: i32,
-) -> Result<UploadResult> {
-    // Read meta.json to get the list of files/blobs
-    let meta_path = entry_dir.join("meta.json");
-    let meta_content =
-        std::fs::read_to_string(&meta_path).context("reading meta.json for v2 upload")?;
-    let meta: EntryMeta =
-        serde_json::from_str(&meta_content).context("parsing meta.json for v2 upload")?;
-
-    let mut total_bytes: u64 = 0;
-    let mut total_compression_ms: u64 = 0;
-    let mut total_head_checks_ms: u64 = 0;
-    let mut total_network_ms: u64 = 0;
-
-    // Upload each blob that doesn't already exist on S3
-    for cached_file in &meta.files {
-        let blob_key = s3_blob_key(prefix, &cached_file.hash);
-
-        // HEAD check — skip if already uploaded
-        let head_start = std::time::Instant::now();
-        let exists = match client
-            .head_object()
-            .bucket(bucket)
-            .key(&blob_key)
-            .send()
-            .await
-        {
-            Ok(_) => true,
-            Err(e) => {
-                let err = e.into_service_error();
-                if err.is_not_found() {
-                    false
-                } else {
-                    return Err(anyhow::anyhow!("S3 HEAD blob error: {err}"));
-                }
-            }
-        };
-        total_head_checks_ms += head_start.elapsed().as_millis() as u64;
-
-        if exists {
-            tracing::debug!("blob {} already on S3, skipping", &cached_file.hash[..16]);
-            continue;
-        }
-
-        // Read the blob from local store
-        let blob_path = local_blob_path(blobs_dir, &cached_file.hash);
-        let blob_data = std::fs::read(&blob_path)
-            .with_context(|| format!("reading blob {} for upload", blob_path.display()))?;
-
-        // Compress with zstd
-        let compress_start = std::time::Instant::now();
-        let compressed = zstd::encode_all(std::io::Cursor::new(&blob_data), compression_level)
-            .context("zstd-compressing blob for upload")?;
-        total_compression_ms += compress_start.elapsed().as_millis() as u64;
-        let compressed_len = compressed.len() as u64;
-
-        tracing::debug!(
-            "uploading blob s3://{}/{} ({} bytes compressed)",
-            bucket,
-            blob_key,
-            compressed_len
-        );
-
-        let put_start = std::time::Instant::now();
-        client
-            .put_object()
-            .bucket(bucket)
-            .key(&blob_key)
-            .body(compressed.into())
-            .send()
-            .await
-            .with_context(|| format!("uploading blob {} to S3", &cached_file.hash[..16]))?;
-        total_network_ms += put_start.elapsed().as_millis() as u64;
-
-        total_bytes += compressed_len;
-    }
-
-    // Upload manifest (meta.json as JSON)
-    let manifest_key = s3_manifest_key(prefix, cache_key, crate_name);
-    let manifest_body = meta_content.into_bytes();
-    let manifest_len = manifest_body.len() as u64;
-
-    tracing::debug!(
-        "uploading manifest s3://{}/{} ({} bytes)",
-        bucket,
-        manifest_key,
-        manifest_len
-    );
-
-    let put_start = std::time::Instant::now();
-    client
-        .put_object()
-        .bucket(bucket)
-        .key(&manifest_key)
-        .body(manifest_body.into())
-        .content_type("application/json")
-        .send()
-        .await
-        .context("uploading v2 manifest to S3")?;
-    total_network_ms += put_start.elapsed().as_millis() as u64;
-
-    total_bytes += manifest_len;
-
-    tracing::info!(
-        "uploaded {} (v2, {} blobs, {} bytes compressed)",
-        cache_key.get(..16).unwrap_or(cache_key),
-        meta.files.len(),
-        total_bytes
-    );
-
-    Ok(UploadResult {
-        compressed_bytes: total_bytes,
-        compression_ms: total_compression_ms,
-        head_checks_ms: total_head_checks_ms,
-        network_ms: total_network_ms,
-    })
-}
-
-/// Download a cache entry using the v2 blob-based format.
-///
-/// 1. Fetch manifest from S3. If 404, return `Ok(None)` (caller should try v1).
-/// 2. For each file in manifest: download blob if not in local store, decompress, write.
-/// 3. Write meta.json to entry_dir.
-///
-/// Returns `Ok(Some(DownloadResult))` on success, `Ok(None)` if no v2 manifest found.
-pub async fn download_entry_v2(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
-    prefix: &str,
-    cache_key: &str,
-    crate_name: &str,
-    entry_dir: &Path,
-    blobs_dir: &Path,
-) -> Result<Option<DownloadResult>> {
-    let manifest_key = s3_manifest_key(prefix, cache_key, crate_name);
-
-    // Time only network I/O (S3 GET + body collection), not decompression/disk
-    let manifest_request_start = std::time::Instant::now();
-
-    // Try to fetch the v2 manifest
-    let manifest_resp = match client
-        .get_object()
-        .bucket(bucket)
-        .key(&manifest_key)
-        .send()
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => {
-            let debug = format!("{e:?}");
-            let err = e.into_service_error();
-            if err.is_no_such_key() {
-                return Ok(None); // No v2 manifest — caller should try v1
-            }
-            return Err(anyhow::anyhow!(
-                "S3 get manifest s3://{bucket}/{manifest_key} failed: {err} [{debug}]"
-            ));
-        }
-    };
-    let manifest_request_ms = manifest_request_start.elapsed().as_millis() as u64;
-    let manifest_body_start = std::time::Instant::now();
-    let manifest_body = manifest_resp
-        .body
-        .collect()
-        .await
-        .context("reading v2 manifest response body")?;
-    let manifest_body_ms = manifest_body_start.elapsed().as_millis() as u64;
-    let manifest_bytes = manifest_body.into_bytes();
-    let mut request_ms = manifest_request_ms;
-    let mut body_ms = manifest_body_ms;
-    let mut network_ms = manifest_request_ms + manifest_body_ms;
-    let mut request_count = 1u32;
-
-    let meta: EntryMeta =
-        serde_json::from_slice(&manifest_bytes).context("parsing v2 manifest JSON")?;
-
-    let blobs_total = meta.files.len() as u32;
-    let mut blobs_skipped = 0u32;
-    let mut total_bytes: u64 = manifest_bytes.len() as u64;
-    let mut total_original: u64 = 0;
-    let mut total_decompress_ms: u64 = 0;
-    let mut total_disk_io_ms: u64 = 0;
-
-    // Download each blob that isn't already in the local store
-    for cached_file in &meta.files {
-        total_original += cached_file.size;
-        let blob_path = local_blob_path(blobs_dir, &cached_file.hash);
-
-        if blob_path.is_file() {
-            blobs_skipped += 1;
-            tracing::debug!(
-                "blob {} already local, skipping download",
-                &cached_file.hash[..16]
-            );
-            continue;
-        }
-
-        let blob_key = s3_blob_key(prefix, &cached_file.hash);
-
-        // Time only the network portion of each blob download
-        let blob_request_start = std::time::Instant::now();
-        let resp = client
-            .get_object()
-            .bucket(bucket)
-            .key(&blob_key)
-            .send()
-            .await
-            .with_context(|| format!("downloading blob {}", &cached_file.hash[..16]))?;
-        request_ms += blob_request_start.elapsed().as_millis() as u64;
-        request_count += 1;
-
-        let blob_body_start = std::time::Instant::now();
-        let body = resp
-            .body
-            .collect()
-            .await
-            .context("reading blob response body")?;
-        body_ms += blob_body_start.elapsed().as_millis() as u64;
-        let compressed = body.into_bytes();
-        network_ms = request_ms + body_ms;
-        total_bytes += compressed.len() as u64;
-
-        // Decompress — timed separately from network
-        let decompress_start = std::time::Instant::now();
-        let decompressed = zstd::decode_all(std::io::Cursor::new(&compressed))
-            .with_context(|| format!("decompressing blob {}", &cached_file.hash[..16]))?;
-        total_decompress_ms += decompress_start.elapsed().as_millis() as u64;
-
-        // Write to local blob store (atomic: write temp then rename)
-        let disk_start = std::time::Instant::now();
-        let shard_dir = blob_path.parent().unwrap();
-        std::fs::create_dir_all(shard_dir).context("creating blob shard dir")?;
-
-        let tmp_path = shard_dir.join(format!(".tmp_{}", &cached_file.hash));
-        std::fs::write(&tmp_path, &decompressed).context("writing blob temp file")?;
-
-        // Make read-only
-        {
-            let mut perms = std::fs::metadata(&tmp_path)?.permissions();
-            perms.set_readonly(true);
-            std::fs::set_permissions(&tmp_path, perms)?;
-        }
-
-        // Atomic rename (ignore AlreadyExists race — another download beat us)
-        if let Err(e) = std::fs::rename(&tmp_path, &blob_path) {
-            // If the blob appeared between our check and rename, that's fine
-            if blob_path.is_file() {
-                let _ = std::fs::remove_file(&tmp_path);
-            } else {
-                return Err(e).context("renaming blob into store");
-            }
-        }
-        total_disk_io_ms += disk_start.elapsed().as_millis() as u64;
-
-        tracing::debug!(
-            "downloaded blob {} ({} bytes compressed)",
-            &cached_file.hash[..16],
-            compressed.len()
-        );
-    }
-
-    // Write meta.json to entry dir
-    let meta_disk_start = std::time::Instant::now();
-    std::fs::create_dir_all(entry_dir).context("creating entry dir for v2 download")?;
-    std::fs::write(entry_dir.join("meta.json"), &manifest_bytes)
-        .context("writing meta.json from v2 manifest")?;
-    total_disk_io_ms += meta_disk_start.elapsed().as_millis() as u64;
-
-    // Also write the artifact files as symlinks/copies from blob store into entry dir
-    // so that import_downloaded_entry can find them (it expects files in entry_dir)
-    let link_disk_start = std::time::Instant::now();
-    for cached_file in &meta.files {
-        let blob_path = local_blob_path(blobs_dir, &cached_file.hash);
-        let dest_path = entry_dir.join(&cached_file.name);
-        // Hard-link or copy the blob so import_downloaded_entry can move it
-        if !dest_path.exists() {
-            // Copy rather than hardlink — import_downloaded_entry will move/delete these
-            std::fs::copy(&blob_path, &dest_path)
-                .with_context(|| format!("copying blob to entry dir for {}", cached_file.name))?;
-            // Make writable so import_downloaded_entry can process it
-            let mut perms = std::fs::metadata(&dest_path)?.permissions();
-            perms.set_readonly(false);
-            std::fs::set_permissions(&dest_path, perms)?;
-        }
-    }
-    total_disk_io_ms += link_disk_start.elapsed().as_millis() as u64;
-
-    tracing::info!(
-        "downloaded {} (v2, {} blobs, {} bytes compressed)",
-        cache_key.get(..16).unwrap_or(cache_key),
-        meta.files.len(),
-        total_bytes
-    );
-
-    Ok(Some(DownloadResult {
-        format: "v2",
-        compressed_bytes: total_bytes,
-        original_bytes: total_original,
-        network_ms,
-        request_ms,
-        body_ms,
-        request_count,
-        decompress_ms: total_decompress_ms,
-        disk_io_ms: total_disk_io_ms,
-        blobs_skipped,
-        blobs_total,
-    }))
-}
-
-/// Check if a v2 manifest exists for a cache key on S3.
-pub async fn exists_v2(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
-    prefix: &str,
-    cache_key: &str,
-    crate_name: &str,
-) -> Result<bool> {
-    let key = s3_manifest_key(prefix, cache_key, crate_name);
-
-    match client.head_object().bucket(bucket).key(&key).send().await {
-        Ok(_) => Ok(true),
-        Err(e) => {
-            let err = e.into_service_error();
-            if err.is_not_found() {
-                Ok(false)
-            } else {
-                Err(anyhow::anyhow!("S3 head_object error (v2 manifest): {err}"))
-            }
-        }
-    }
-}
-
-// ── Client construction ──────────────────────────────────────────
-
 pub async fn create_s3_client(remote: &RemoteConfig) -> Result<aws_sdk_s3::Client> {
     let mut config_builder = aws_config::defaults(aws_config::BehaviorVersion::latest())
         .region(aws_config::Region::new(remote.region.clone()));
 
-    // Apply AWS profile if configured (credentials from ~/.aws/credentials [profile])
     if let Some(profile) = &remote.profile {
         config_builder = config_builder.profile_name(profile);
     }
 
-    // Check for kache-specific credentials (overrides profile)
     let has_access = std::env::var("KACHE_S3_ACCESS_KEY").ok();
     let has_secret = std::env::var("KACHE_S3_SECRET_KEY").ok();
     match (&has_access, &has_secret) {
@@ -761,8 +74,7 @@ pub async fn create_s3_client(remote: &RemoteConfig) -> Result<aws_sdk_s3::Clien
     }
 
     let sdk_config = config_builder.load().await;
-
-    let mut s3_config = aws_sdk_s3::config::Builder::from(&sdk_config).force_path_style(true); // Required for Ceph/MinIO
+    let mut s3_config = aws_sdk_s3::config::Builder::from(&sdk_config).force_path_style(true);
 
     if let Some(endpoint) = &remote.endpoint {
         s3_config = s3_config.endpoint_url(endpoint);
@@ -771,106 +83,8 @@ pub async fn create_s3_client(remote: &RemoteConfig) -> Result<aws_sdk_s3::Clien
     Ok(aws_sdk_s3::Client::from_conf(s3_config.build()))
 }
 
-// ── Internal helpers ─────────────────────────────────────────────
-
-/// Create a tar+zstd archive from a directory in a single pass (no intermediate tar buffer).
-#[allow(dead_code)]
-fn create_tar_zstd(dir: &Path, compression_level: i32) -> Result<Vec<u8>> {
-    let encoder = zstd::stream::Encoder::new(Vec::new(), compression_level)
-        .context("creating zstd encoder")?;
-    let mut archive = tar::Builder::new(encoder);
-
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let name = entry.file_name();
-
-        if path.is_file() {
-            archive
-                .append_path_with_name(&path, &name)
-                .with_context(|| format!("adding {} to tar", path.display()))?;
-        }
-    }
-
-    let encoder = archive.into_inner().context("finishing tar archive")?;
-    encoder.finish().context("finishing zstd compression")
-}
-
-/// Extract a tar archive from a reader into a directory, with security checks.
-/// Works with any `Read` source — enables streaming decompression.
-/// Uses atomic extraction: writes to a temp dir, then renames on success.
-/// Extract a tar archive to a directory. Returns total bytes extracted.
-fn extract_tar_streaming<R: std::io::Read>(reader: R, dest_dir: &Path) -> Result<u64> {
-    // Atomic extraction: extract into a sibling temp directory, rename on success
-    let parent = dest_dir.parent().unwrap_or(Path::new("/tmp"));
-    std::fs::create_dir_all(parent)?;
-    let tmp_dir = tempfile::tempdir_in(parent).context("creating temp dir for extraction")?;
-
-    let mut archive = tar::Archive::new(reader);
-    let mut total_bytes = 0u64;
-
-    for entry in archive.entries()? {
-        let mut entry = entry?;
-        total_bytes += entry.size();
-        let path = entry.path()?.to_path_buf();
-
-        // Security: reject absolute paths, path traversal, and symlinks
-        if path.is_absolute() {
-            bail!("tar entry contains absolute path: {}", path.display());
-        }
-        if path
-            .components()
-            .any(|c| c == std::path::Component::ParentDir)
-        {
-            bail!("tar entry contains path traversal: {}", path.display());
-        }
-        if entry.header().entry_type().is_symlink() || entry.header().entry_type().is_hard_link() {
-            bail!(
-                "tar entry contains link (rejected for security): {}",
-                path.display()
-            );
-        }
-
-        let dest = tmp_dir.path().join(&path);
-        entry.unpack(&dest)?;
-    }
-
-    // Atomic swap: if dest already exists (race), remove it first
-    if dest_dir.exists() {
-        std::fs::remove_dir_all(dest_dir).context("removing existing dest dir")?;
-    }
-
-    // Persist the temp dir (prevent cleanup on drop) and rename
-    let tmp_path = tmp_dir.keep();
-    std::fs::rename(&tmp_path, dest_dir).or_else(|_| {
-        // rename fails across filesystems — fall back to copy + remove
-        copy_dir_all(&tmp_path, dest_dir).and_then(|()| {
-            std::fs::remove_dir_all(&tmp_path).context("removing temp dir after copy")
-        })
-    })?;
-
-    Ok(total_bytes)
-}
-
-/// Recursively copy a directory (fallback when rename crosses filesystems).
-fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let dest = dst.join(entry.file_name());
-        if entry.path().is_dir() {
-            copy_dir_all(&entry.path(), &dest)?;
-        } else {
-            std::fs::copy(entry.path(), &dest)?;
-        }
-    }
-    Ok(())
-}
-
-// ── Build Manifest ───────────────────────────────────────────────
-
 const MANIFEST_PREFIX: &str = "_manifests";
-pub const MANIFEST_VERSION: &str = "v2";
+pub const MANIFEST_VERSION: &str = "v3";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManifestEntry {
@@ -882,7 +96,7 @@ pub struct ManifestEntry {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BuildManifest {
-    /// 0 = legacy (v1), 2 = sharded (v2)
+    /// 3 = current build-manifest schema used alongside the v3 remote entry layout.
     #[serde(default)]
     pub version: u32,
     pub created: String,
@@ -890,24 +104,18 @@ pub struct BuildManifest {
     pub entries: Vec<ManifestEntry>,
 }
 
-// ── Sharded Manifest (v2) ────────────────────────────────────────
-
-/// A single entry in a manifest shard — just the cache key and crate name.
-/// No compile times (those are noisy and would destabilize shard hashes).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ShardEntry {
     pub cache_key: String,
     pub crate_name: String,
 }
 
-/// A content-addressed shard of the manifest.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Shard {
     pub version: u32,
     pub entries: Vec<ShardEntry>,
 }
 
-/// Download a build manifest from S3.
 pub async fn download_manifest(
     client: &aws_sdk_s3::Client,
     bucket: &str,
@@ -934,7 +142,6 @@ pub async fn download_manifest(
     serde_json::from_slice(&bytes).context("parsing manifest JSON")
 }
 
-/// Upload a build manifest to S3.
 pub async fn upload_manifest(
     client: &aws_sdk_s3::Client,
     bucket: &str,
@@ -958,15 +165,11 @@ pub async fn upload_manifest(
     Ok(())
 }
 
-// ── Shard S3 operations ──────────────────────────────────────────
-
-/// Build the S3 object key for a shard file.
-/// Format: `{prefix}/_manifests/v2/{namespace}/shards/{shard_hash}.json`
+/// Format: `{prefix}/_manifests/v3/{namespace}/shards/{shard_hash}.json`
 pub fn shard_object_key(prefix: &str, namespace: &str, shard_hash: &str) -> String {
     format!("{prefix}/{MANIFEST_PREFIX}/{MANIFEST_VERSION}/{namespace}/shards/{shard_hash}.json")
 }
 
-/// Download a single shard from S3. Returns `Ok(None)` on 404 (shard not found).
 pub async fn download_shard(
     client: &aws_sdk_s3::Client,
     bucket: &str,
@@ -1004,7 +207,6 @@ pub async fn download_shard(
     }
 }
 
-/// Upload a single shard to S3.
 pub async fn upload_shard(
     client: &aws_sdk_s3::Client,
     bucket: &str,
@@ -1034,139 +236,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_tar_zstd_roundtrip() {
-        let dir = tempfile::tempdir().unwrap();
-        let src_dir = dir.path().join("source");
-        std::fs::create_dir_all(&src_dir).unwrap();
-        std::fs::write(src_dir.join("file1.rlib"), b"rlib data").unwrap();
-        std::fs::write(src_dir.join("meta.json"), b"{}").unwrap();
-
-        let compressed = create_tar_zstd(&src_dir, 3).unwrap();
-        assert!(!compressed.is_empty());
-
-        let decoder = zstd::stream::Decoder::new(std::io::Cursor::new(&compressed)).unwrap();
-        let dest_dir = dir.path().join("dest");
-        extract_tar_streaming(decoder, &dest_dir).unwrap();
-
-        assert_eq!(
-            std::fs::read_to_string(dest_dir.join("file1.rlib")).unwrap(),
-            "rlib data"
-        );
-        assert_eq!(
-            std::fs::read_to_string(dest_dir.join("meta.json")).unwrap(),
-            "{}"
-        );
-    }
-
-    #[test]
-    fn test_streaming_zstd_roundtrip() {
-        let dir = tempfile::tempdir().unwrap();
-        let src_dir = dir.path().join("source");
-        std::fs::create_dir_all(&src_dir).unwrap();
-        std::fs::write(src_dir.join("data.rlib"), b"streaming test data").unwrap();
-
-        let compressed = create_tar_zstd(&src_dir, 3).unwrap();
-
-        // Decompress: zstd decoder → tar extract (streaming)
-        let decoder = zstd::stream::Decoder::new(std::io::Cursor::new(&compressed)).unwrap();
-        let dest_dir = dir.path().join("dest");
-        extract_tar_streaming(decoder, &dest_dir).unwrap();
-
-        assert_eq!(
-            std::fs::read_to_string(dest_dir.join("data.rlib")).unwrap(),
-            "streaming test data"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_tar_zstd_keeps_readonly_source_permissions() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = tempfile::tempdir().unwrap();
-        let src_dir = dir.path().join("source");
-        std::fs::create_dir_all(&src_dir).unwrap();
-        let path = src_dir.join("readonly.rlib");
-        std::fs::write(&path, b"readonly data").unwrap();
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o444)).unwrap();
-
-        let compressed = create_tar_zstd(&src_dir, 3).unwrap();
-
-        assert!(!compressed.is_empty());
-        assert!(
-            std::fs::metadata(&path).unwrap().permissions().readonly(),
-            "archiving must not flip source permissions on shared cache files"
-        );
-    }
-
-    /// Build a raw tar archive with a crafted filename (bypasses tar crate validation).
-    fn build_raw_tar(filename: &[u8], body: &[u8]) -> Vec<u8> {
-        // Tar header is 512 bytes: name[0..100], mode[100..108], ..., size[124..136], checksum[148..156]
-        let mut header = [0u8; 512];
-
-        // Name field (first 100 bytes)
-        let name_len = filename.len().min(100);
-        header[..name_len].copy_from_slice(&filename[..name_len]);
-
-        // Mode: 0000644
-        header[100..107].copy_from_slice(b"0000644");
-        header[107] = 0;
-
-        // Size in octal (11 chars + null)
-        let size_str = format!("{:011o}", body.len());
-        header[124..135].copy_from_slice(size_str.as_bytes());
-        header[135] = 0;
-
-        // Type flag: '0' = regular file
-        header[156] = b'0';
-
-        // Compute checksum (sum of all bytes, treating checksum field as spaces)
-        header[148..156].fill(b' ');
-        let cksum: u32 = header.iter().map(|&b| b as u32).sum();
-        let cksum_str = format!("{:06o}\0 ", cksum);
-        header[148..156].copy_from_slice(cksum_str.as_bytes());
-
-        let mut tar_data = Vec::new();
-        tar_data.extend_from_slice(&header);
-        tar_data.extend_from_slice(body);
-        // Pad to 512-byte boundary
-        let padding = (512 - (body.len() % 512)) % 512;
-        tar_data.extend(std::iter::repeat_n(0u8, padding));
-        // End-of-archive: two 512-byte zero blocks
-        tar_data.extend(std::iter::repeat_n(0u8, 1024));
-        tar_data
-    }
-
-    #[test]
-    fn test_extract_rejects_absolute_path() {
-        let tar_data = build_raw_tar(b"/etc/passwd", b"evil");
-        let dir = tempfile::tempdir().unwrap();
-        let dest = dir.path().join("out");
-        let result = extract_tar_streaming(std::io::Cursor::new(&tar_data), &dest);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("absolute path"));
-    }
-
-    #[test]
-    fn test_extract_rejects_path_traversal() {
-        let tar_data = build_raw_tar(b"../escape.txt", b"evil");
-        let dir = tempfile::tempdir().unwrap();
-        let dest = dir.path().join("out");
-        let result = extract_tar_streaming(std::io::Cursor::new(&tar_data), &dest);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("path traversal"));
-    }
-
-    #[test]
-    fn test_s3_object_key() {
-        let key = s3_object_key("artifacts", "abc123", "serde");
-        assert_eq!(key, "artifacts/serde/abc123.tar.zst");
-    }
-
-    #[test]
     fn test_manifest_serde_roundtrip() {
         let manifest = BuildManifest {
-            version: 2,
+            version: 3,
             created: "2025-01-01T00:00:00Z".to_string(),
             manifest_key: "x86_64-unknown-linux-gnu".to_string(),
             entries: vec![
@@ -1186,7 +258,7 @@ mod tests {
         };
         let json = serde_json::to_string(&manifest).unwrap();
         let parsed: BuildManifest = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.version, 2);
+        assert_eq!(parsed.version, 3);
         assert_eq!(parsed.entries.len(), 2);
         assert_eq!(parsed.entries[0].crate_name, "serde");
         assert_eq!(parsed.entries[0].compile_time_ms, 5000);
@@ -1195,16 +267,15 @@ mod tests {
 
     #[test]
     fn test_manifest_legacy_no_version_field() {
-        // Simulate a v1 manifest that has no "version" field
         let json = r#"{"created":"2025-01-01T00:00:00Z","manifest_key":"test","entries":[]}"#;
         let parsed: BuildManifest = serde_json::from_str(json).unwrap();
-        assert_eq!(parsed.version, 0); // default = legacy
+        assert_eq!(parsed.version, 0);
     }
 
     #[test]
     fn test_manifest_empty_entries() {
         let manifest = BuildManifest {
-            version: 0,
+            version: 3,
             created: "2025-01-01T00:00:00Z".to_string(),
             manifest_key: "test".to_string(),
             entries: vec![],
@@ -1217,7 +288,7 @@ mod tests {
     #[test]
     fn test_shard_serde_roundtrip() {
         let shard = Shard {
-            version: 2,
+            version: 3,
             entries: vec![
                 ShardEntry {
                     cache_key: "abc123".to_string(),
@@ -1231,7 +302,7 @@ mod tests {
         };
         let json = serde_json::to_string(&shard).unwrap();
         let parsed: Shard = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.version, 2);
+        assert_eq!(parsed.version, 3);
         assert_eq!(parsed.entries.len(), 2);
         assert_eq!(parsed.entries[0].crate_name, "serde");
     }
@@ -1241,39 +312,7 @@ mod tests {
         let key = shard_object_key("artifacts", "x86_64-linux/abc123/release", "deadbeef");
         assert_eq!(
             key,
-            "artifacts/_manifests/v2/x86_64-linux/abc123/release/shards/deadbeef.json"
+            "artifacts/_manifests/v3/x86_64-linux/abc123/release/shards/deadbeef.json"
         );
-    }
-
-    #[test]
-    fn test_s3_blob_key() {
-        let key = s3_blob_key(
-            "cache",
-            "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-        );
-        assert_eq!(
-            key,
-            "cache/blobs/ab/abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890.zst"
-        );
-
-        // Different prefix
-        let key2 = s3_blob_key("my/prefix", "ff0011223344");
-        assert_eq!(key2, "my/prefix/blobs/ff/ff0011223344.zst");
-    }
-
-    #[test]
-    fn test_s3_manifest_key() {
-        let key = s3_manifest_key("cache", "abc123hash", "serde");
-        assert_eq!(key, "cache/manifests/serde/abc123hash.json");
-
-        let key2 = s3_manifest_key("my/prefix", "deadbeef", "tokio-runtime");
-        assert_eq!(key2, "my/prefix/manifests/tokio-runtime/deadbeef.json");
-    }
-
-    #[test]
-    fn test_local_blob_path() {
-        let blobs = Path::new("/store/blobs");
-        let path = local_blob_path(blobs, "abcdef1234");
-        assert_eq!(path, PathBuf::from("/store/blobs/ab/abcdef1234"));
     }
 }

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -1,0 +1,516 @@
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use crate::config::RemoteConfig;
+use crate::remote::{DownloadResult, UploadResult};
+use crate::store::EntryMeta;
+
+const V3_ROOT: &str = "v3";
+const V3_MANIFESTS: &str = "manifests";
+const V3_PACKS: &str = "packs";
+const V3_MANIFEST_VERSION: u32 = 3;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct V3Manifest {
+    version: u32,
+    cache_key: String,
+    crate_name: String,
+    pack_key: String,
+    pack_bytes: u64,
+    original_bytes: u64,
+    file_count: usize,
+}
+
+/// Remote cache layout for the `v3` pack-first format.
+///
+/// `v3` stores:
+/// - a small manifest object for listing/existence checks
+/// - one packed tar.zst object per entry for restore/upload
+///
+/// The local store stays content-addressed; remote transport is optimized for
+/// cold object-store restores with low request fan-out.
+pub struct RemoteLayout<'a> {
+    client: &'a aws_sdk_s3::Client,
+    remote: &'a RemoteConfig,
+}
+
+pub struct RemoteUploadResult {
+    pub format: &'static str,
+    pub transfer: UploadResult,
+}
+
+impl<'a> RemoteLayout<'a> {
+    pub fn new(client: &'a aws_sdk_s3::Client, remote: &'a RemoteConfig) -> Self {
+        Self { client, remote }
+    }
+
+    pub async fn exists_entry(&self, cache_key: &str, crate_name: &str) -> Result<bool> {
+        let object_key = v3_manifest_key(&self.remote.prefix, cache_key, crate_name);
+        match self
+            .client
+            .head_object()
+            .bucket(&self.remote.bucket)
+            .key(&object_key)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(e) => {
+                let err = e.into_service_error();
+                if err.is_not_found() {
+                    Ok(false)
+                } else {
+                    Err(anyhow::anyhow!("S3 head_object error: {err}"))
+                }
+            }
+        }
+    }
+
+    pub async fn download_entry(
+        &self,
+        cache_key: &str,
+        crate_name: &str,
+        entry_dir: &Path,
+        _blobs_dir: &Path,
+    ) -> Result<DownloadResult> {
+        let object_key = v3_pack_key(&self.remote.prefix, cache_key, crate_name);
+
+        tracing::debug!("downloading v3 pack s3://{}/{}", self.remote.bucket, object_key);
+
+        let request_start = std::time::Instant::now();
+        let resp = self
+            .client
+            .get_object()
+            .bucket(&self.remote.bucket)
+            .key(&object_key)
+            .send()
+            .await
+            .context("downloading v3 pack from S3")?;
+        let request_ms = request_start.elapsed().as_millis() as u64;
+
+        let body_start = std::time::Instant::now();
+        let body = resp
+            .body
+            .collect()
+            .await
+            .context("reading v3 pack response body")?;
+        let body_ms = body_start.elapsed().as_millis() as u64;
+        let compressed = body.into_bytes();
+        let compressed_len = compressed.len() as u64;
+
+        let decompress_start = std::time::Instant::now();
+        let decoder = zstd::stream::Decoder::new(std::io::Cursor::new(&compressed))
+            .context("creating v3 zstd decoder")?;
+        let original_bytes = extract_entry_pack(decoder, entry_dir)?;
+        let decompress_ms = decompress_start.elapsed().as_millis() as u64;
+
+        Ok(DownloadResult {
+            format: "v3",
+            compressed_bytes: compressed_len,
+            original_bytes,
+            network_ms: request_ms + body_ms,
+            request_ms,
+            body_ms,
+            request_count: 1,
+            decompress_ms,
+            disk_io_ms: 0,
+            blobs_skipped: 0,
+            blobs_total: 0,
+        })
+    }
+
+    pub async fn upload_entry(
+        &self,
+        cache_key: &str,
+        crate_name: &str,
+        entry_dir: &Path,
+        blobs_dir: &Path,
+        compression_level: i32,
+    ) -> Result<RemoteUploadResult> {
+        let meta_path = entry_dir.join("meta.json");
+        let meta_content = std::fs::read_to_string(&meta_path).context("reading meta.json")?;
+        let meta: EntryMeta = serde_json::from_str(&meta_content).context("parsing meta.json")?;
+
+        let compression_start = std::time::Instant::now();
+        let packed = create_entry_pack_zstd(entry_dir, blobs_dir, &meta, compression_level)?;
+        let compression_ms = compression_start.elapsed().as_millis() as u64;
+        let pack_bytes = packed.len() as u64;
+        let original_bytes = meta.files.iter().map(|f| f.size).sum::<u64>() + meta_content.len() as u64;
+
+        let pack_key = v3_pack_key(&self.remote.prefix, cache_key, crate_name);
+        let put_pack_start = std::time::Instant::now();
+        self.client
+            .put_object()
+            .bucket(&self.remote.bucket)
+            .key(&pack_key)
+            .body(packed.into())
+            .send()
+            .await
+            .context("uploading v3 pack to S3")?;
+        let mut network_ms = put_pack_start.elapsed().as_millis() as u64;
+
+        let manifest = V3Manifest {
+            version: V3_MANIFEST_VERSION,
+            cache_key: cache_key.to_string(),
+            crate_name: crate_name.to_string(),
+            pack_key: pack_key.clone(),
+            pack_bytes,
+            original_bytes,
+            file_count: meta.files.len(),
+        };
+        let manifest_body = serde_json::to_vec(&manifest).context("serializing v3 manifest")?;
+        let manifest_len = manifest_body.len() as u64;
+        let manifest_key = v3_manifest_key(&self.remote.prefix, cache_key, crate_name);
+
+        let put_manifest_start = std::time::Instant::now();
+        self.client
+            .put_object()
+            .bucket(&self.remote.bucket)
+            .key(&manifest_key)
+            .body(manifest_body.into())
+            .content_type("application/json")
+            .send()
+            .await
+            .context("uploading v3 manifest to S3")?;
+        network_ms += put_manifest_start.elapsed().as_millis() as u64;
+
+        Ok(RemoteUploadResult {
+            format: "v3",
+            transfer: UploadResult {
+                compressed_bytes: pack_bytes + manifest_len,
+                compression_ms,
+                head_checks_ms: 0,
+                network_ms,
+            },
+        })
+    }
+
+    pub async fn list_keys(&self) -> Result<HashMap<String, String>> {
+        let mut keys = HashMap::new();
+        let mut continuation_token: Option<String> = None;
+        let manifest_prefix = format!("{}/{V3_ROOT}/{V3_MANIFESTS}/", self.remote.prefix);
+
+        loop {
+            let mut req = self
+                .client
+                .list_objects_v2()
+                .bucket(&self.remote.bucket)
+                .prefix(&manifest_prefix);
+
+            if let Some(token) = &continuation_token {
+                req = req.continuation_token(token);
+            }
+
+            let resp = req.send().await.context("listing v3 manifests")?;
+
+            for obj in resp.contents() {
+                if let Some(key) = obj.key()
+                    && let Some(stripped) = key.strip_prefix(&manifest_prefix)
+                    && let Some(without_ext) = stripped.strip_suffix(".json")
+                    && let Some((crate_name, cache_key)) = without_ext.rsplit_once('/')
+                {
+                    keys.insert(cache_key.to_string(), crate_name.to_string());
+                }
+            }
+
+            if resp.is_truncated == Some(true) {
+                continuation_token = resp.next_continuation_token().map(|s| s.to_string());
+            } else {
+                break;
+            }
+        }
+
+        Ok(keys)
+    }
+
+    pub async fn list_keys_for_crates(
+        &self,
+        crate_names: &HashSet<String>,
+    ) -> Result<HashMap<String, String>> {
+        let mut keys = HashMap::new();
+
+        for crate_name in crate_names {
+            let mut continuation_token: Option<String> = None;
+            let manifest_prefix =
+                format!("{}/{V3_ROOT}/{V3_MANIFESTS}/{crate_name}/", self.remote.prefix);
+
+            loop {
+                let mut req = self
+                    .client
+                    .list_objects_v2()
+                    .bucket(&self.remote.bucket)
+                    .prefix(&manifest_prefix);
+
+                if let Some(token) = &continuation_token {
+                    req = req.continuation_token(token);
+                }
+
+                let resp = req
+                    .send()
+                    .await
+                    .with_context(|| format!("listing v3 manifests for crate {crate_name}"))?;
+
+                for obj in resp.contents() {
+                    if let Some(key) = obj.key()
+                        && let Some(stripped) = key.strip_prefix(&manifest_prefix)
+                        && let Some(cache_key) = stripped.strip_suffix(".json")
+                    {
+                        keys.insert(cache_key.to_string(), crate_name.clone());
+                    }
+                }
+
+                if resp.is_truncated == Some(true) {
+                    continuation_token = resp.next_continuation_token().map(|s| s.to_string());
+                } else {
+                    break;
+                }
+            }
+        }
+
+        Ok(keys)
+    }
+}
+
+fn v3_manifest_key(prefix: &str, cache_key: &str, crate_name: &str) -> String {
+    format!("{prefix}/{V3_ROOT}/{V3_MANIFESTS}/{crate_name}/{cache_key}.json")
+}
+
+fn v3_pack_key(prefix: &str, cache_key: &str, crate_name: &str) -> String {
+    format!("{prefix}/{V3_ROOT}/{V3_PACKS}/{crate_name}/{cache_key}.tar.zst")
+}
+
+fn create_entry_pack_zstd(
+    entry_dir: &Path,
+    blobs_dir: &Path,
+    meta: &EntryMeta,
+    compression_level: i32,
+) -> Result<Vec<u8>> {
+    let encoder = zstd::stream::Encoder::new(Vec::new(), compression_level)
+        .context("creating zstd encoder")?;
+    let mut archive = tar::Builder::new(encoder);
+
+    let meta_path = entry_dir.join("meta.json");
+    archive
+        .append_path_with_name(&meta_path, "meta.json")
+        .with_context(|| format!("adding {} to v3 pack", meta_path.display()))?;
+
+    for cached_file in &meta.files {
+        let path = blob_path(blobs_dir, &cached_file.hash);
+        archive
+            .append_path_with_name(&path, &cached_file.name)
+            .with_context(|| format!("adding {} to v3 pack", path.display()))?;
+    }
+
+    let encoder = archive.into_inner().context("finishing v3 tar archive")?;
+    encoder.finish().context("finishing v3 zstd compression")
+}
+
+fn blob_path(blobs_dir: &Path, hash: &str) -> PathBuf {
+    blobs_dir.join(&hash[..2]).join(hash)
+}
+
+fn extract_entry_pack<R: std::io::Read>(reader: R, dest_dir: &Path) -> Result<u64> {
+    let parent = dest_dir.parent().unwrap_or(Path::new("/tmp"));
+    std::fs::create_dir_all(parent)?;
+    let tmp_dir = tempfile::tempdir_in(parent).context("creating temp dir for v3 extraction")?;
+
+    let mut archive = tar::Archive::new(reader);
+    let mut total_bytes = 0u64;
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        total_bytes += entry.size();
+        let path = entry.path()?.to_path_buf();
+
+        if path.is_absolute() {
+            bail!("tar entry contains absolute path: {}", path.display());
+        }
+        if path
+            .components()
+            .any(|c| c == std::path::Component::ParentDir)
+        {
+            bail!("tar entry contains path traversal: {}", path.display());
+        }
+        if entry.header().entry_type().is_symlink() || entry.header().entry_type().is_hard_link() {
+            bail!(
+                "tar entry contains link (rejected for security): {}",
+                path.display()
+            );
+        }
+
+        let dest = tmp_dir.path().join(&path);
+        entry.unpack(&dest)?;
+    }
+
+    if dest_dir.exists() {
+        std::fs::remove_dir_all(dest_dir).context("removing existing extracted v3 entry dir")?;
+    }
+
+    let tmp_path = tmp_dir.keep();
+    std::fs::rename(&tmp_path, dest_dir).or_else(|_| {
+        copy_dir_all(&tmp_path, dest_dir).and_then(|()| {
+            std::fs::remove_dir_all(&tmp_path).context("removing temp dir after v3 copy")
+        })
+    })?;
+
+    Ok(total_bytes)
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let dest = dst.join(entry.file_name());
+        if entry.path().is_dir() {
+            copy_dir_all(&entry.path(), &dest)?;
+        } else {
+            std::fs::copy(entry.path(), &dest)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{blob_path, create_entry_pack_zstd, extract_entry_pack};
+    use crate::config::Config;
+    use crate::store::{EntryMeta, Store};
+
+    #[test]
+    fn v3_pack_roundtrip_restores_meta_and_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = Config {
+            cache_dir: tmp.path().join("cache"),
+            max_size: 1024 * 1024,
+            remote: None,
+            disabled: false,
+            cache_executables: false,
+            clean_incremental: true,
+            event_log_max_size: 1024 * 1024,
+            event_log_keep_lines: 1000,
+            compression_level: 3,
+            s3_concurrency: 16,
+            daemon_idle_timeout_secs: 3600,
+        };
+        let store = Store::open(&config).unwrap();
+
+        let source_dir = tmp.path().join("source");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source_file = source_dir.join("libfoo.rlib");
+        std::fs::write(&source_file, b"hello world").unwrap();
+
+        store
+            .put(
+                "key123",
+                "foo",
+                &["lib".to_string()],
+                &[],
+                "x86_64-unknown-linux-gnu",
+                "debug",
+                &[(source_file, "libfoo.rlib".to_string())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        let entry_dir = store.entry_dir("key123");
+        let meta: crate::store::EntryMeta = serde_json::from_slice(
+            &std::fs::read(entry_dir.join("meta.json")).unwrap(),
+        )
+        .unwrap();
+
+        let packed = create_entry_pack_zstd(&entry_dir, &store.blobs_dir(), &meta, 3).unwrap();
+
+        let restored = tmp.path().join("restored");
+        let decoder = zstd::stream::Decoder::new(std::io::Cursor::new(&packed)).unwrap();
+        let original_bytes = extract_entry_pack(decoder, &restored).unwrap();
+
+        assert!(original_bytes >= 11);
+        assert_eq!(
+            std::fs::read(restored.join("libfoo.rlib")).unwrap(),
+            b"hello world"
+        );
+        let restored_meta: EntryMeta =
+            serde_json::from_slice(&std::fs::read(restored.join("meta.json")).unwrap()).unwrap();
+        assert_eq!(restored_meta.cache_key, "key123");
+        assert_eq!(restored_meta.files.len(), 1);
+
+        let restore_cache_dir = tmp.path().join("restore-cache");
+        let restore_config = Config {
+            cache_dir: restore_cache_dir,
+            max_size: 1024 * 1024,
+            remote: None,
+            disabled: false,
+            cache_executables: false,
+            clean_incremental: true,
+            event_log_max_size: 1024 * 1024,
+            event_log_keep_lines: 1000,
+            compression_level: 3,
+            s3_concurrency: 16,
+            daemon_idle_timeout_secs: 3600,
+        };
+        let restore_store = Store::open(&restore_config).unwrap();
+        let restore_entry_dir = restore_store.entry_dir("key123");
+        if let Some(parent) = restore_entry_dir.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::rename(&restored, &restore_entry_dir).unwrap();
+
+        restore_store.import_restored_entry("key123").unwrap();
+        let restored_entry = restore_store.get("key123").unwrap().unwrap();
+        assert_eq!(restored_entry.cache_key, "key123");
+        assert_eq!(restored_entry.files.len(), 1);
+        assert_eq!(restored_entry.files[0].name, "libfoo.rlib");
+
+        let blob = blob_path(&restore_store.blobs_dir(), &restored_entry.files[0].hash);
+        assert_eq!(std::fs::read(blob).unwrap(), b"hello world");
+        assert!(restore_entry_dir.join("meta.json").exists());
+        assert!(!restore_entry_dir.join("libfoo.rlib").exists());
+    }
+
+    fn build_raw_tar(filename: &[u8], body: &[u8]) -> Vec<u8> {
+        let mut header = [0u8; 512];
+        let name_len = filename.len().min(100);
+        header[..name_len].copy_from_slice(&filename[..name_len]);
+        header[100..107].copy_from_slice(b"0000644");
+        header[107] = 0;
+        let size_str = format!("{:011o}", body.len());
+        header[124..135].copy_from_slice(size_str.as_bytes());
+        header[135] = 0;
+        header[156] = b'0';
+        header[148..156].fill(b' ');
+        let checksum: u32 = header.iter().map(|&b| b as u32).sum();
+        let checksum_str = format!("{:06o}\0 ", checksum);
+        header[148..156].copy_from_slice(checksum_str.as_bytes());
+
+        let mut tar_data = Vec::new();
+        tar_data.extend_from_slice(&header);
+        tar_data.extend_from_slice(body);
+        let padding = (512 - (body.len() % 512)) % 512;
+        tar_data.extend(std::iter::repeat_n(0u8, padding));
+        tar_data.extend(std::iter::repeat_n(0u8, 1024));
+        tar_data
+    }
+
+    #[test]
+    fn v3_extract_rejects_absolute_path() {
+        let tar_data = build_raw_tar(b"/etc/passwd", b"evil");
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out");
+        let result = extract_entry_pack(std::io::Cursor::new(&tar_data), &dest);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("absolute path"));
+    }
+
+    #[test]
+    fn v3_extract_rejects_path_traversal() {
+        let tar_data = build_raw_tar(b"../escape.txt", b"evil");
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out");
+        let result = extract_entry_pack(std::io::Cursor::new(&tar_data), &dest);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("path traversal"));
+    }
+}

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -77,7 +77,11 @@ impl<'a> RemoteLayout<'a> {
     ) -> Result<DownloadResult> {
         let object_key = v3_pack_key(&self.remote.prefix, cache_key, crate_name);
 
-        tracing::debug!("downloading v3 pack s3://{}/{}", self.remote.bucket, object_key);
+        tracing::debug!(
+            "downloading v3 pack s3://{}/{}",
+            self.remote.bucket,
+            object_key
+        );
 
         let request_start = std::time::Instant::now();
         let resp = self
@@ -137,7 +141,8 @@ impl<'a> RemoteLayout<'a> {
         let packed = create_entry_pack_zstd(entry_dir, blobs_dir, &meta, compression_level)?;
         let compression_ms = compression_start.elapsed().as_millis() as u64;
         let pack_bytes = packed.len() as u64;
-        let original_bytes = meta.files.iter().map(|f| f.size).sum::<u64>() + meta_content.len() as u64;
+        let original_bytes =
+            meta.files.iter().map(|f| f.size).sum::<u64>() + meta_content.len() as u64;
 
         let pack_key = v3_pack_key(&self.remote.prefix, cache_key, crate_name);
         let put_pack_start = std::time::Instant::now();
@@ -233,8 +238,10 @@ impl<'a> RemoteLayout<'a> {
 
         for crate_name in crate_names {
             let mut continuation_token: Option<String> = None;
-            let manifest_prefix =
-                format!("{}/{V3_ROOT}/{V3_MANIFESTS}/{crate_name}/", self.remote.prefix);
+            let manifest_prefix = format!(
+                "{}/{V3_ROOT}/{V3_MANIFESTS}/{crate_name}/",
+                self.remote.prefix
+            );
 
             loop {
                 let mut req = self
@@ -416,10 +423,8 @@ mod tests {
             .unwrap();
 
         let entry_dir = store.entry_dir("key123");
-        let meta: crate::store::EntryMeta = serde_json::from_slice(
-            &std::fs::read(entry_dir.join("meta.json")).unwrap(),
-        )
-        .unwrap();
+        let meta: crate::store::EntryMeta =
+            serde_json::from_slice(&std::fs::read(entry_dir.join("meta.json")).unwrap()).unwrap();
 
         let packed = create_entry_pack_zstd(&entry_dir, &store.blobs_dir(), &meta, 3).unwrap();
 

--- a/src/remote_plan.rs
+++ b/src/remote_plan.rs
@@ -1,0 +1,110 @@
+use crate::config::{Config, RemoteConfig};
+use crate::remote_layout::RemoteLayout;
+
+/// The kind of remote workload being planned.
+///
+/// `v3` should eventually tune remote behavior differently for cold restores,
+/// background prefetch, and uploads. Today all workloads use the same pack-first
+/// layout, but callers no longer decide that directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteWorkload {
+    RestoreCheck,
+    Prefetch,
+    SyncPull,
+    SyncPush,
+    BackgroundUpload,
+    KeyDiscovery,
+}
+
+/// Remote object layout selected for an operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteLayoutKind {
+    V3,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemotePlan {
+    pub workload: RemoteWorkload,
+    pub layout: RemoteLayoutKind,
+}
+
+impl RemotePlan {
+    pub fn layout<'a>(
+        &self,
+        client: &'a aws_sdk_s3::Client,
+        remote: &'a RemoteConfig,
+    ) -> RemoteLayout<'a> {
+        match self.layout {
+            RemoteLayoutKind::V3 => RemoteLayout::new(client, remote),
+        }
+    }
+
+    pub fn transfer_format(&self) -> &'static str {
+        match self.layout {
+            RemoteLayoutKind::V3 => "v3",
+        }
+    }
+}
+
+/// Chooses the remote plan for each workload.
+///
+/// For now this routes every workload through the same `v3` pack-first layout.
+/// The goal is to keep one place where local-optimized and remote-optimized
+/// behavior can diverge later without rewriting call sites again.
+pub struct RemotePlanner<'a> {
+    _config: &'a Config,
+}
+
+impl<'a> RemotePlanner<'a> {
+    pub fn new(config: &'a Config) -> Self {
+        Self { _config: config }
+    }
+
+    pub fn plan(&self, workload: RemoteWorkload) -> RemotePlan {
+        RemotePlan {
+            workload,
+            layout: RemoteLayoutKind::V3,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{RemoteLayoutKind, RemotePlanner, RemoteWorkload};
+    use crate::config::Config;
+
+    fn test_config() -> Config {
+        Config {
+            cache_dir: PathBuf::from("/tmp/kache-test"),
+            max_size: 1024,
+            remote: None,
+            disabled: false,
+            cache_executables: false,
+            clean_incremental: true,
+            event_log_max_size: 1024,
+            event_log_keep_lines: 100,
+            compression_level: 3,
+            s3_concurrency: 16,
+            daemon_idle_timeout_secs: 3600,
+        }
+    }
+
+    #[test]
+    fn default_plans_use_v3_layout() {
+        let config = test_config();
+        let planner = RemotePlanner::new(&config);
+
+        for workload in [
+            RemoteWorkload::RestoreCheck,
+            RemoteWorkload::Prefetch,
+            RemoteWorkload::SyncPull,
+            RemoteWorkload::SyncPush,
+            RemoteWorkload::BackgroundUpload,
+            RemoteWorkload::KeyDiscovery,
+        ] {
+            assert_eq!(planner.plan(workload).layout, RemoteLayoutKind::V3);
+        }
+    }
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -1503,11 +1503,46 @@ mod tests {
 
         // Write transfer events
         let transfers = vec![
-            test_transfer("serde", TransferDirection::Download, "v3", 500_000, 150, true),
-            test_transfer("tokio", TransferDirection::Download, "v3", 1_000_000, 300, true),
-            test_transfer("regex", TransferDirection::Download, "v3", 200_000, 80, true),
-            test_transfer("my_lib", TransferDirection::Upload, "v3", 2_000_000, 500, true),
-            test_transfer("my_app", TransferDirection::Upload, "v3", 3_000_000, 700, true),
+            test_transfer(
+                "serde",
+                TransferDirection::Download,
+                "v3",
+                500_000,
+                150,
+                true,
+            ),
+            test_transfer(
+                "tokio",
+                TransferDirection::Download,
+                "v3",
+                1_000_000,
+                300,
+                true,
+            ),
+            test_transfer(
+                "regex",
+                TransferDirection::Download,
+                "v3",
+                200_000,
+                80,
+                true,
+            ),
+            test_transfer(
+                "my_lib",
+                TransferDirection::Upload,
+                "v3",
+                2_000_000,
+                500,
+                true,
+            ),
+            test_transfer(
+                "my_app",
+                TransferDirection::Upload,
+                "v3",
+                3_000_000,
+                700,
+                true,
+            ),
             test_transfer("fail_dl", TransferDirection::Download, "v3", 0, 50, false),
         ];
         for t in &transfers {

--- a/src/report.rs
+++ b/src/report.rs
@@ -140,6 +140,8 @@ pub struct NetworkAnalysis {
     #[serde(default)]
     pub v2_downloads: usize,
     #[serde(default)]
+    pub v3_downloads: usize,
+    #[serde(default)]
     pub unknown_format_downloads: usize,
     pub slowest_downloads: Vec<TransferDetail>,
 }
@@ -440,6 +442,7 @@ fn build_network_analysis(transfers: &[TransferEvent], top: usize) -> NetworkAna
     let mut blobs_total = 0u32;
     let mut v1_downloads = 0usize;
     let mut v2_downloads = 0usize;
+    let mut v3_downloads = 0usize;
     let mut unknown_format_downloads = 0usize;
 
     for t in transfers {
@@ -474,6 +477,7 @@ fn build_network_analysis(transfers: &[TransferEvent], top: usize) -> NetworkAna
                     match t.format.as_str() {
                         "v1" => v1_downloads += 1,
                         "v2" => v2_downloads += 1,
+                        "v3" => v3_downloads += 1,
                         _ => unknown_format_downloads += 1,
                     }
                     total_download_ms += t.elapsed_ms;
@@ -590,6 +594,7 @@ fn build_network_analysis(transfers: &[TransferEvent], top: usize) -> NetworkAna
         blobs_total,
         v1_downloads,
         v2_downloads,
+        v3_downloads,
         unknown_format_downloads,
         slowest_downloads: download_details.into_iter().take(top).collect(),
     }
@@ -664,7 +669,7 @@ fn generate_suggestions(
         }
         if net.downloads_ok > 0 && net.total_get_requests > net.downloads_ok as u32 * 3 {
             suggestions.push(format!(
-                "Downloads fan out to {:.1} GETs per cache hit — check v2 blob granularity or prefer packed downloads on CI",
+                "Downloads fan out to {:.1} GETs per cache hit — check remote layout granularity or prefer pack-first downloads on CI",
                 net.total_get_requests as f64 / net.downloads_ok as f64
             ));
         }
@@ -1044,10 +1049,14 @@ pub fn format_github(report: &BuildReport) -> String {
             "| Download time | avg {:.0}ms · p95 {}ms |",
             net.avg_download_ms, net.p95_download_ms
         ));
-        if net.v1_downloads > 0 || net.v2_downloads > 0 || net.unknown_format_downloads > 0 {
+        if net.v1_downloads > 0
+            || net.v2_downloads > 0
+            || net.v3_downloads > 0
+            || net.unknown_format_downloads > 0
+        {
             lines.push(format!(
-                "| Download format | v1 {} · v2 {} · unknown {} |",
-                net.v1_downloads, net.v2_downloads, net.unknown_format_downloads
+                "| Download format | v1 {} · v2 {} · v3 {} · unknown {} |",
+                net.v1_downloads, net.v2_downloads, net.v3_downloads, net.unknown_format_downloads
             ));
         }
         if net.total_get_requests > 0 {
@@ -1401,14 +1410,16 @@ mod tests {
     fn test_transfer(
         crate_name: &str,
         direction: TransferDirection,
+        format: &str,
         compressed_bytes: u64,
         elapsed_ms: u64,
         ok: bool,
     ) -> TransferEvent {
         TransferEvent {
+            schema: 1,
             crate_name: crate_name.to_string(),
             direction,
-            format: "v2".to_string(),
+            format: format.to_string(),
             compressed_bytes,
             elapsed_ms,
             network_ms: elapsed_ms / 2, // simulate network = half of total
@@ -1492,12 +1503,12 @@ mod tests {
 
         // Write transfer events
         let transfers = vec![
-            test_transfer("serde", TransferDirection::Download, 500_000, 150, true),
-            test_transfer("tokio", TransferDirection::Download, 1_000_000, 300, true),
-            test_transfer("regex", TransferDirection::Download, 200_000, 80, true),
-            test_transfer("my_lib", TransferDirection::Upload, 2_000_000, 500, true),
-            test_transfer("my_app", TransferDirection::Upload, 3_000_000, 700, true),
-            test_transfer("fail_dl", TransferDirection::Download, 0, 50, false),
+            test_transfer("serde", TransferDirection::Download, "v3", 500_000, 150, true),
+            test_transfer("tokio", TransferDirection::Download, "v3", 1_000_000, 300, true),
+            test_transfer("regex", TransferDirection::Download, "v3", 200_000, 80, true),
+            test_transfer("my_lib", TransferDirection::Upload, "v3", 2_000_000, 500, true),
+            test_transfer("my_app", TransferDirection::Upload, "v3", 3_000_000, 700, true),
+            test_transfer("fail_dl", TransferDirection::Download, "v3", 0, 50, false),
         ];
         for t in &transfers {
             events::log_transfer(&config.transfer_log_path(), t).unwrap();
@@ -1520,6 +1531,10 @@ mod tests {
         assert_eq!(report.summary.errors, 1);
         assert!(report.summary.hit_rate_pct > 0.0);
         assert!(report.summary.time_saved_ms > 0);
+        let network = report.network.as_ref().unwrap();
+        assert_eq!(network.v3_downloads, 3);
+        assert_eq!(network.v2_downloads, 0);
+        assert_eq!(network.total_get_requests, 12);
     }
 
     #[test]
@@ -1639,6 +1654,9 @@ mod tests {
         assert!(gh.contains("<summary><strong>Timing & Prefetch</strong>"));
         assert!(gh.contains("Download format"));
         assert!(gh.contains("GET fan-out"));
+        assert!(gh.contains("v3 3"));
+        assert!(gh.contains("request"));
+        assert!(gh.contains("body"));
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -567,6 +567,14 @@ impl Store {
         Ok(())
     }
 
+    /// Import a restored entry into the local store.
+    ///
+    /// This is the format-agnostic seam future remote layouts should call.
+    /// Today it is equivalent to `import_downloaded_entry()`.
+    pub fn import_restored_entry(&self, cache_key: &str) -> Result<()> {
+        self.import_downloaded_entry(cache_key)
+    }
+
     /// Look up cache keys for the given crate names (most recent per crate).
     pub fn keys_for_crates(
         &self,


### PR DESCRIPTION
## Summary
- switch remote cache runtime paths to the new v3 planner and pack-first layout
- add the local import seam, v3 tests, and updated reporting/design docs
- fix daemon autostart races so normal wrapper use does not spam startup warnings

## Verification
- env -u RUSTC_WRAPPER CARGO_TARGET_DIR=/tmp/kache-target cargo check
- env -u RUSTC_WRAPPER CARGO_TARGET_DIR=/tmp/kache-target cargo test -- --nocapture