### PR TITLE
refactor: tighten config ownership and reduce daemon/TUI overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ S3 layout: `{prefix}/{crate_name}/{cache_key}.tar.zst` — organized by crate fo
 
 Configure via the TUI editor (`kache config`), environment variables, or the config file directly.
 
-Config file: `~/.config/kache/config.toml` (respects `XDG_CONFIG_HOME`).
+Config file: `~/.config/kache/config.toml` (respects `XDG_CONFIG_HOME`, overridden by `KACHE_CONFIG`).
 
 Environment variables take highest priority, then config file, then defaults.
 
@@ -81,6 +81,7 @@ Environment variables take highest priority, then config file, then defaults.
 |---|---|---|---|
 | `KACHE_CACHE_DIR` | `cache.local_store` | `~/.cache/kache` | Local store directory |
 | `KACHE_MAX_SIZE` | `cache.local_max_size` | `50GB` | Max store size |
+| `KACHE_CONFIG` | — | XDG config path | Explicit config file path |
 | `KACHE_S3_BUCKET` | `cache.remote.bucket` | — | S3 bucket for remote cache |
 | `KACHE_S3_ENDPOINT` | `cache.remote.endpoint` | — | Custom S3 endpoint (required for Ceph/MinIO/R2) |
 | `KACHE_S3_REGION` | `cache.remote.region` | `us-east-1` | AWS region |
@@ -89,7 +90,7 @@ Environment variables take highest priority, then config file, then defaults.
 | `KACHE_S3_ACCESS_KEY` | — | — | Explicit S3 access key (overrides profile) |
 | `KACHE_S3_SECRET_KEY` | — | — | Explicit S3 secret key (overrides profile) |
 | `KACHE_CACHE_EXECUTABLES` | `cache.cache_executables` | `false` | Cache bin/dylib/cdylib outputs |
-| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean incremental dirs during GC |
+| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly |
 | `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd compression level (1-22) |
 | `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `8` | Max concurrent S3 operations |
 | `KACHE_DISABLED` | — | `0` | Disable caching entirely |

--- a/docs/kache-docs/commands/reference.mdx
+++ b/docs/kache-docs/commands/reference.mdx
@@ -89,7 +89,7 @@ kache gc --max-age 30d    # remove anything unused for 30 days
 kache gc --max-age 7d     # aggressive cleanup before a release build
 ```
 
-If `clean_incremental` is enabled (the default), GC also removes incremental compilation directories from known `target/` locations.
+If `clean_incremental` is enabled (the default), GC removes tracked incremental compilation directories that previous wrapper invocations registered. Active wrapper invocations also remove the current build's incremental dir eagerly.
 
 ---
 

--- a/docs/kache-docs/getting-started/configuration.mdx
+++ b/docs/kache-docs/getting-started/configuration.mdx
@@ -8,7 +8,7 @@ description: Config file, environment variables, and the TUI editor.
 kache reads configuration from three places, in order of priority:
 
 1. **Environment variables** — always win, useful for CI overrides
-2. **Config file** — `~/.config/kache/config.toml` (respects `XDG_CONFIG_HOME`)
+2. **Config file** — `~/.config/kache/config.toml` (respects `XDG_CONFIG_HOME`, overridden by `KACHE_CONFIG`)
 3. **Defaults** — sensible values that work without any configuration
 
 ## Config file
@@ -37,6 +37,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 |---|---|---|---|
 | `KACHE_CACHE_DIR` | `cache.local_store` | `~/.cache/kache` | Local cache directory |
 | `KACHE_MAX_SIZE` | `cache.local_max_size` | `50GiB` | Maximum local store size |
+| `KACHE_CONFIG` | — | XDG config path | Explicit config file path |
 | `KACHE_S3_BUCKET` | `cache.remote.bucket` | — | S3 bucket name |
 | `KACHE_S3_ENDPOINT` | `cache.remote.endpoint` | — | S3 endpoint URL (required for Ceph, MinIO, R2) |
 | `KACHE_S3_REGION` | `cache.remote.region` | `us-east-1` | AWS region |
@@ -45,7 +46,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_S3_ACCESS_KEY` | — | — | Explicit S3 access key |
 | `KACHE_S3_SECRET_KEY` | — | — | Explicit S3 secret key |
 | `KACHE_CACHE_EXECUTABLES` | `cache.cache_executables` | `false` | Cache bin/dylib/cdylib/proc-macro outputs |
-| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Remove incremental dirs during GC |
+| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly |
 | `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd compression level (1–22) |
 | `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `16` | Max concurrent S3 operations |
 | `KACHE_DISABLED` | — | `0` | Disable caching entirely (pass-through to rustc) |

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -17,7 +17,6 @@
   stripNulls = lib.filterAttrsRecursive (_: v: v != null);
 
   configFile = tomlFormat.generate "kache-config" (stripNulls cfg.settings);
-
   kacheExe = lib.getExe cfg.package;
 
   # Check which platform options exist rather than querying pkgs,
@@ -28,7 +27,12 @@ in {
   options.services.kache = {
     enable = lib.mkEnableOption "kache, a Rust build cache";
 
-    package = lib.mkPackageOption pkgs "kache" {};
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./package.nix {};
+      defaultText = lib.literalExpression "pkgs.callPackage ./package.nix {}";
+      description = "kache package to install and run.";
+    };
 
     rustcWrapper = lib.mkOption {
       type = lib.types.bool;
@@ -93,7 +97,7 @@ in {
               clean_incremental = lib.mkOption {
                 type = lib.types.nullOr lib.types.bool;
                 default = null;
-                description = "Auto-clean incremental compilation dirs during GC.";
+                description = "Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly.";
               };
 
               compression_level = lib.mkOption {
@@ -171,6 +175,7 @@ in {
     {
       environment.systemPackages = [cfg.package];
       environment.etc."kache/config.toml".source = configFile;
+      environment.variables.KACHE_CONFIG = "${configFile}";
     }
 
     # Set RUSTC_WRAPPER system-wide
@@ -213,7 +218,7 @@ in {
         };
         environment = {
           KACHE_LOG = cfg.daemon.logLevel;
-          KACHE_CONFIG = configFile;
+          KACHE_CONFIG = "${configFile}";
         };
       };
     })

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,9 +225,10 @@ impl Config {
     }
 
     /// Load the raw file config without applying env overrides or defaults.
+    /// The config path still honors `KACHE_CONFIG`.
     /// Returns `(config, file_existed)`.
     pub(crate) fn load_raw_file_config() -> (FileConfig, bool) {
-        Self::load_raw_file_config_from(&config_file_path())
+        Self::load_raw_file_config_from(&resolve_config_path())
     }
 
     /// Load a raw FileConfig from an explicit path.
@@ -245,9 +246,10 @@ impl Config {
         }
     }
 
-    /// Serialize and write a FileConfig to the config file path.
+    /// Serialize and write a FileConfig to the active config path.
+    /// The config path still honors `KACHE_CONFIG`.
     pub(crate) fn save_file_config(config: &FileConfig) -> Result<()> {
-        Self::save_file_config_to(config, &config_file_path())
+        Self::save_file_config_to(config, &resolve_config_path())
     }
 
     /// Serialize and write a FileConfig to an explicit path.
@@ -364,8 +366,12 @@ pub(crate) fn default_cache_dir() -> PathBuf {
 /// Resolve the config file path to actually load from.
 /// Priority: `KACHE_CONFIG` env var > XDG user config.
 pub(crate) fn resolve_config_path() -> PathBuf {
-    if let Ok(p) = std::env::var("KACHE_CONFIG") {
-        return PathBuf::from(p);
+    resolve_config_path_from(std::env::var_os("KACHE_CONFIG").map(PathBuf::from))
+}
+
+fn resolve_config_path_from(kache_config: Option<PathBuf>) -> PathBuf {
+    if let Some(p) = kache_config {
+        return p;
     }
     config_file_path()
 }
@@ -398,6 +404,36 @@ pub(crate) fn parse_size(s: &str) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, OnceLock};
+
+    fn config_path_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    struct TestEnvGuard {
+        previous: Option<OsString>,
+    }
+
+    impl Drop for TestEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.previous.as_ref() {
+                    Some(value) => std::env::set_var("KACHE_CONFIG", value),
+                    None => std::env::remove_var("KACHE_CONFIG"),
+                }
+            }
+        }
+    }
+
+    fn set_kache_config_for_test(path: &std::path::Path) -> TestEnvGuard {
+        let previous = std::env::var_os("KACHE_CONFIG");
+        unsafe {
+            std::env::set_var("KACHE_CONFIG", path);
+        }
+        TestEnvGuard { previous }
+    }
 
     #[test]
     fn test_default_cache_dir() {
@@ -569,6 +605,38 @@ mod tests {
         let path = config_file_path();
         assert!(path.to_string_lossy().contains("kache"));
         assert!(path.to_string_lossy().ends_with("config.toml"));
+    }
+
+    #[test]
+    fn test_resolve_config_path_prefers_kache_config() {
+        let path = resolve_config_path_from(Some(PathBuf::from("/tmp/managed/config.toml")));
+        assert_eq!(path, PathBuf::from("/tmp/managed/config.toml"));
+    }
+
+    #[test]
+    fn test_load_and_save_raw_file_config_use_resolved_path() {
+        let _guard = config_path_lock();
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("managed/config.toml");
+        let _env_guard = set_kache_config_for_test(&config_path);
+
+        let config = FileConfig {
+            cache: Some(CacheFileConfig {
+                local_store: Some("/tmp/managed-cache".to_string()),
+                ..Default::default()
+            }),
+        };
+
+        Config::save_file_config(&config).unwrap();
+        assert!(config_path.exists());
+
+        let (loaded, existed) = Config::load_raw_file_config();
+        assert!(existed);
+        assert_eq!(
+            loaded.cache.as_ref().and_then(|c| c.local_store.as_deref()),
+            Some("/tmp/managed-cache")
+        );
     }
 
     #[test]

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -11,8 +11,8 @@ use std::ops::Range;
 use std::time::Duration;
 
 use crate::config::{
-    CacheFileConfig, Config, EnvOverrides, FileConfig, RemoteFileConfig, config_file_path,
-    default_cache_dir, parse_size,
+    CacheFileConfig, Config, EnvOverrides, FileConfig, RemoteFileConfig, default_cache_dir,
+    parse_size, resolve_config_path,
 };
 
 // ── Field definitions ─────────────────────────────────────────────────────
@@ -882,7 +882,7 @@ fn draw_form(f: &mut ratatui::Frame, area: Rect, state: &mut EditorState) {
 }
 
 fn draw_footer(f: &mut ratatui::Frame, path_area: Rect, keys_area: Rect, state: &EditorState) {
-    let path = config_file_path();
+    let path = resolve_config_path();
     let path_str = path.to_string_lossy();
 
     let mut path_spans = vec![Span::styled(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2,8 +2,8 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
@@ -652,6 +652,7 @@ impl S3KeyCache {
 
 pub(crate) struct Daemon {
     config: Config,
+    store: OnceLock<Mutex<Store>>,
     s3_client: tokio::sync::OnceCell<aws_sdk_s3::Client>,
     key_cache: Arc<S3KeyCache>,
     s3_semaphore: Arc<tokio::sync::Semaphore>,
@@ -683,6 +684,7 @@ impl Daemon {
         let (warming_tx, _) = tokio::sync::watch::channel(false);
         let (prefetch_cancel, _) = tokio::sync::watch::channel(false);
         Self {
+            store: OnceLock::new(),
             s3_semaphore: Arc::new(tokio::sync::Semaphore::new(permits)),
             s3_client: tokio::sync::OnceCell::new(),
             key_cache: Arc::new(S3KeyCache::new()),
@@ -700,6 +702,31 @@ impl Daemon {
             recent_transfers: std::sync::Mutex::new(std::collections::VecDeque::new()),
             config,
         }
+    }
+
+    fn store_lock(&self) -> Result<&Mutex<Store>> {
+        if let Some(store) = self.store.get() {
+            return Ok(store);
+        }
+
+        let store = Store::open(&self.config)?;
+        let _ = self.store.set(Mutex::new(store));
+
+        self.store
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("daemon store failed to initialize"))
+    }
+
+    fn with_store<T>(&self, f: impl FnOnce(&Store) -> Result<T>) -> Result<T> {
+        let guard = self
+            .store_lock()?
+            .lock()
+            .map_err(|_| anyhow::anyhow!("daemon store mutex poisoned"))?;
+        f(&guard)
+    }
+
+    fn entry_dir_for(&self, cache_key: &str) -> PathBuf {
+        self.config.store_dir().join(cache_key)
     }
 
     /// Wait for the manifest prefetch to complete (or timeout).
@@ -772,33 +799,33 @@ impl Daemon {
 
     /// Handle a stats request — reads store and event log.
     pub fn handle_stats(&self, req: &StatsRequest) -> Response {
-        let store = match Store::open(&self.config) {
-            Ok(s) => s,
+        let (total_size, entry_count, entries) = match self.with_store(|store| {
+            let total_size = store.total_size().unwrap_or(0);
+            let entry_count = store.entry_count().unwrap_or(0);
+            let entries = if req.include_entries {
+                let sort = req.sort_by.as_deref().unwrap_or("size");
+                store.list_entries(sort).ok().map(|list| {
+                    list.into_iter()
+                        .map(|e| StatsEntry {
+                            cache_key: e.cache_key,
+                            crate_name: e.crate_name,
+                            crate_type: e.crate_type,
+                            profile: e.profile,
+                            size: e.size,
+                            hit_count: e.hit_count,
+                            created_at: e.created_at,
+                            last_accessed: e.last_accessed,
+                            content_hash: e.content_hash,
+                        })
+                        .collect()
+                })
+            } else {
+                None
+            };
+            Ok((total_size, entry_count, entries))
+        }) {
+            Ok(values) => values,
             Err(e) => return Response::err(format!("store open failed: {e}")),
-        };
-
-        let total_size = store.total_size().unwrap_or(0);
-        let entry_count = store.entry_count().unwrap_or(0);
-
-        let entries = if req.include_entries {
-            let sort = req.sort_by.as_deref().unwrap_or("size");
-            store.list_entries(sort).ok().map(|list| {
-                list.into_iter()
-                    .map(|e| StatsEntry {
-                        cache_key: e.cache_key,
-                        crate_name: e.crate_name,
-                        crate_type: e.crate_type,
-                        profile: e.profile,
-                        size: e.size,
-                        hit_count: e.hit_count,
-                        created_at: e.created_at,
-                        last_accessed: e.last_accessed,
-                        content_hash: e.content_hash,
-                    })
-                    .collect()
-            })
-        } else {
-            None
         };
 
         let hours = req.event_hours.unwrap_or(24);
@@ -1196,9 +1223,7 @@ impl Daemon {
                         .as_secs(),
                 });
                 // Commit to SQLite so store.get() can find it
-                if let Ok(store) = Store::open(&self.config)
-                    && let Err(e) = store.import_restored_entry(&req.key)
-                {
+                if let Err(e) = self.with_store(|store| store.import_restored_entry(&req.key)) {
                     tracing::warn!("failed to import downloaded entry {}: {e}", &req.key);
                 }
                 Response::found(true)
@@ -1264,16 +1289,11 @@ impl Daemon {
             return Response::err("S3 client init failed");
         }
 
-        let store = match Store::open(&self.config) {
-            Ok(s) => s,
-            Err(e) => return Response::err(format!("store open failed: {e}")),
-        };
-
         // Filter to keys that need downloading: (cache_key, crate_name, entry_dir)
         let mut keys_to_fetch: Vec<(String, String, PathBuf)> = Vec::new();
         let downloading_guard = self.downloading.read().await;
         for (key, crate_name) in &req.keys {
-            let entry_dir = store.entry_dir(key);
+            let entry_dir = self.entry_dir_for(key);
             if entry_dir.exists() {
                 continue;
             }
@@ -1297,7 +1317,7 @@ impl Daemon {
                 .await
         {
             for (key, crate_name) in s3_keys {
-                let entry_dir = store.entry_dir(&key);
+                let entry_dir = self.entry_dir_for(&key);
                 if !entry_dir.exists() {
                     keys_to_fetch.push((key, crate_name, entry_dir));
                 }
@@ -1420,8 +1440,7 @@ impl Daemon {
                                     .unwrap_or_default()
                                     .as_secs(),
                             });
-                            if let Ok(store) = Store::open(&d.config)
-                                && let Err(e) = store.import_restored_entry(&key)
+                            if let Err(e) = d.with_store(|store| store.import_restored_entry(&key))
                             {
                                 tracing::warn!("prefetch import failed for {}: {e}", key);
                             }
@@ -1485,13 +1504,8 @@ impl Daemon {
             return Response::err("no remote configured");
         };
 
-        let store = match Store::open(&self.config) {
-            Ok(s) => s,
-            Err(e) => return Response::err(format!("store open failed: {e}")),
-        };
-
         // 1. Try local SQLite first (has exact keys from previous builds)
-        let entries = match store.keys_for_crates(&req.crate_names) {
+        let entries = match self.with_store(|store| store.keys_for_crates(&req.crate_names)) {
             Ok(e) => e,
             Err(e) => return Response::err(format!("key lookup failed: {e}")),
         };
@@ -1515,7 +1529,7 @@ impl Daemon {
             for name in &unresolved {
                 let s3_keys = self.key_cache.keys_for_crate(name).await;
                 for key in s3_keys {
-                    let entry_dir = store.entry_dir(&key);
+                    let entry_dir = self.entry_dir_for(&key);
                     extra_entries.push((key, (*name).clone(), entry_dir));
                 }
             }
@@ -1570,52 +1584,58 @@ impl Daemon {
 
     /// After a successful upload, check if store exceeds max_size → LRU eviction.
     fn maybe_evict_after_upload(&self) {
-        if let Ok(store) = Store::open(&self.config)
-            && let Ok(size) = store.total_size()
-            && size > self.config.max_size
-        {
-            tracing::info!(
-                "store size {} > max {}, running LRU eviction",
-                size,
-                self.config.max_size
-            );
-            let _ = store.evict();
-        }
+        let _ = self.with_store(|store| {
+            let size = store.total_size()?;
+            if size > self.config.max_size {
+                tracing::info!(
+                    "store size {} > max {}, running LRU eviction",
+                    size,
+                    self.config.max_size
+                );
+                let _ = store.evict();
+            }
+            Ok(())
+        });
     }
 
     /// Core GC logic: evict entries, clean stale tool-version caches, and clean registered incremental dirs.
     /// Returns aggregated GcStats and persists them to `gc_stats.json` in the cache dir.
     pub fn run_gc(&self, max_age_hours: Option<u64>) -> Result<crate::store::GcStats> {
         let start = Instant::now();
-        let store = Store::open(&self.config)?;
+        let (dedup_stats, evict_stats, incremental_cleaned) = self.with_store(|store| {
+            // Backfill content_hash for legacy entries
+            let backfilled = store.backfill_content_hashes().unwrap_or(0);
+            if backfilled > 0 {
+                tracing::info!("backfilled {backfilled} content hashes");
+            }
 
-        // Backfill content_hash for legacy entries
-        let backfilled = store.backfill_content_hashes().unwrap_or(0);
-        if backfilled > 0 {
-            tracing::info!("backfilled {backfilled} content hashes");
-        }
+            // Evict duplicate entries (same content, different cache keys)
+            let dedup_stats = store.evict_duplicate_entries().unwrap_or_default();
+            if dedup_stats.entries_evicted > 0 {
+                tracing::info!("evicted {} duplicate entries", dedup_stats.entries_evicted);
+            }
 
-        // Evict duplicate entries (same content, different cache keys)
-        let dedup_stats = store.evict_duplicate_entries().unwrap_or_default();
-        if dedup_stats.entries_evicted > 0 {
-            tracing::info!("evicted {} duplicate entries", dedup_stats.entries_evicted);
-        }
+            let evict_stats = if let Some(hours) = max_age_hours {
+                store.evict_older_than(hours)?
+            } else {
+                store.evict()?
+            };
 
-        let evict_stats = if let Some(hours) = max_age_hours {
-            store.evict_older_than(hours)?
-        } else {
-            store.evict()?
-        };
+            let incremental_cleaned = if self.config.clean_incremental {
+                store.clean_registered_incremental_dirs().unwrap_or(0)
+            } else {
+                0
+            };
+
+            Ok((dedup_stats, evict_stats, incremental_cleaned))
+        })?;
 
         // Clean up stale tool-version cache files (rustc-ver-*.txt, linker-ver-*.txt).
         // Each toolchain update leaves behind orphaned files keyed by the old binary mtime.
         Self::clean_tool_version_caches(&self.config.cache_dir);
 
-        if self.config.clean_incremental
-            && let Ok(cleaned) = store.clean_registered_incremental_dirs()
-            && cleaned > 0
-        {
-            tracing::info!("cleaned {cleaned} registered incremental dirs");
+        if incremental_cleaned > 0 {
+            tracing::info!("cleaned {incremental_cleaned} registered incremental dirs");
         }
 
         // Aggregate stats
@@ -3870,6 +3890,18 @@ mod tests {
         assert_eq!(stats.entries.unwrap().len(), 0);
         assert_eq!(stats.events.local_hits, 0);
         assert_eq!(stats.events.misses, 0);
+    }
+
+    #[test]
+    fn test_daemon_reuses_store_handle() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let daemon = Daemon::new(config);
+
+        let first = daemon.store_lock().unwrap() as *const _;
+        let second = daemon.store_lock().unwrap() as *const _;
+
+        assert_eq!(first, second);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1583,7 +1583,7 @@ impl Daemon {
         }
     }
 
-    /// Core GC logic: evict entries, clean stale tool-version caches, optionally clean incremental dirs.
+    /// Core GC logic: evict entries, clean stale tool-version caches, and clean registered incremental dirs.
     /// Returns aggregated GcStats and persists them to `gc_stats.json` in the cache dir.
     pub fn run_gc(&self, max_age_hours: Option<u64>) -> Result<crate::store::GcStats> {
         let start = Instant::now();
@@ -1610,6 +1610,13 @@ impl Daemon {
         // Clean up stale tool-version cache files (rustc-ver-*.txt, linker-ver-*.txt).
         // Each toolchain update leaves behind orphaned files keyed by the old binary mtime.
         Self::clean_tool_version_caches(&self.config.cache_dir);
+
+        if self.config.clean_incremental
+            && let Ok(cleaned) = store.clean_registered_incremental_dirs()
+            && cleaned > 0
+        {
+            tracing::info!("cleaned {cleaned} registered incremental dirs");
+        }
 
         // Aggregate stats
         let stats = crate::store::GcStats {
@@ -3531,6 +3538,32 @@ mod tests {
 
         let stats = daemon.run_gc(None).unwrap();
         assert_eq!(stats.entries_evicted, 0);
+    }
+
+    #[test]
+    fn test_run_gc_cleans_registered_incremental_dirs_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.clean_incremental = true;
+        let incremental_dir = dir.path().join("workspace/target/debug/incremental");
+        std::fs::create_dir_all(&incremental_dir).unwrap();
+        std::fs::write(incremental_dir.join("junk"), b"tmp").unwrap();
+
+        let store = Store::open(&config).unwrap();
+        store.remember_incremental_dir(&incremental_dir).unwrap();
+        drop(store);
+
+        let daemon = Daemon::new(config.clone());
+        let stats = daemon.run_gc(None).unwrap();
+        assert_eq!(stats.entries_evicted, 0);
+        assert!(!incremental_dir.exists());
+
+        std::fs::create_dir_all(&incremental_dir).unwrap();
+        std::fs::write(incremental_dir.join("junk"), b"tmp2").unwrap();
+
+        let stats = daemon.run_gc(None).unwrap();
+        assert_eq!(stats.entries_evicted, 0);
+        assert!(incremental_dir.exists());
     }
 
     // ── Socket integration tests ─────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,24 +218,48 @@ pub(crate) fn diagnostic_log_path() -> PathBuf {
 
 const MAX_LOG_BYTES: u64 = 5 * 1024 * 1024; // 5 MB
 
-fn init_logging(is_wrapper: bool) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogMode {
+    Wrapper,
+    Cli,
+    TerminalUi,
+}
+
+fn detect_log_mode(env_args: &[String]) -> LogMode {
+    if env_args.len() >= 2 && args::looks_like_rustc(&env_args[1]) {
+        return LogMode::Wrapper;
+    }
+
+    match env_args.get(1).map(String::as_str) {
+        None | Some("monitor" | "config") => LogMode::TerminalUi,
+        _ => LogMode::Cli,
+    }
+}
+
+fn init_logging(mode: LogMode) {
     use std::sync::Mutex;
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::{EnvFilter, fmt};
 
-    // Stderr layer: controlled by KACHE_LOG env var, default warn.
-    // This is what appears in build output (wrapper) or gets captured by launchd (daemon).
-    let stderr_filter =
-        EnvFilter::try_from_env("KACHE_LOG").unwrap_or_else(|_| "kache=warn".parse().unwrap());
-    let stderr_layer = fmt::layer()
-        .with_writer(std::io::stderr)
-        .with_filter(stderr_filter);
+    // Interactive TUIs own the terminal, so background logs must not write to stderr
+    // while the alternate screen is active. File logging remains enabled for diagnostics.
+    let stderr_layer = if mode == LogMode::TerminalUi {
+        None
+    } else {
+        let stderr_filter =
+            EnvFilter::try_from_env("KACHE_LOG").unwrap_or_else(|_| "kache=warn".parse().unwrap());
+        Some(
+            fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_filter(stderr_filter),
+        )
+    };
 
     // File layer: persistent log at info level (overridable via KACHE_LOG_FILE).
     // Skipped in wrapper mode to avoid 2 extra syscalls (stat + open) per crate —
     // the daemon already captures all important events.  CLI/daemon mode gets
     // the file layer for diagnostics.
-    let file_layer = if is_wrapper {
+    let file_layer = if mode == LogMode::Wrapper {
         None
     } else {
         (|| -> Option<_> {
@@ -273,11 +297,12 @@ fn init_logging(is_wrapper: bool) {
 
 fn main() -> Result<()> {
     let env_args: Vec<String> = std::env::args().collect();
+    let log_mode = detect_log_mode(&env_args);
 
     // Detect RUSTC_WRAPPER mode: cargo passes the rustc path as arg[1]
     // In this mode: argv[0]=kache, argv[1]=rustc, argv[2..]=rustc args
-    let is_wrapper = env_args.len() >= 2 && args::looks_like_rustc(&env_args[1]);
-    init_logging(is_wrapper);
+    let is_wrapper = log_mode == LogMode::Wrapper;
+    init_logging(log_mode);
 
     if is_wrapper {
         return run_wrapper_mode(&env_args[1..]);
@@ -439,5 +464,26 @@ mod tests {
         assert_eq!(parse_duration_hours("1h"), Some(1));
         assert_eq!(parse_duration_hours("48"), Some(48));
         assert_eq!(parse_duration_hours("invalid"), None);
+    }
+
+    #[test]
+    fn test_detect_log_mode() {
+        assert_eq!(detect_log_mode(&["kache".into()]), LogMode::TerminalUi);
+        assert_eq!(
+            detect_log_mode(&["kache".into(), "monitor".into()]),
+            LogMode::TerminalUi
+        );
+        assert_eq!(
+            detect_log_mode(&["kache".into(), "config".into()]),
+            LogMode::TerminalUi
+        );
+        assert_eq!(
+            detect_log_mode(&["kache".into(), "stats".into()]),
+            LogMode::Cli
+        );
+        assert_eq!(
+            detect_log_mode(&["kache".into(), "rustc".into(), "--crate-name".into()]),
+            LogMode::Wrapper
+        );
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1318,7 +1318,9 @@ mod tests {
 
         let count_before: i64 = store
             .db
-            .query_row("SELECT COUNT(*) FROM incremental_dirs", [], |row| row.get(0))
+            .query_row("SELECT COUNT(*) FROM incremental_dirs", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert_eq!(count_before, 2);
 
@@ -1328,7 +1330,9 @@ mod tests {
 
         let count_after: i64 = store
             .db
-            .query_row("SELECT COUNT(*) FROM incremental_dirs", [], |row| row.get(0))
+            .query_row("SELECT COUNT(*) FROM incremental_dirs", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert_eq!(count_after, 0);
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -145,6 +145,13 @@ fn initialize_db(db: &Connection) -> rusqlite::Result<()> {
         );",
     )?;
 
+    db.execute_batch(
+        "CREATE TABLE IF NOT EXISTS incremental_dirs (
+            path      TEXT PRIMARY KEY,
+            last_seen TEXT NOT NULL DEFAULT (datetime('now'))
+        );",
+    )?;
+
     Ok(())
 }
 
@@ -653,6 +660,70 @@ impl Store {
         Ok(count as usize)
     }
 
+    /// Remember an incremental compilation directory seen by the wrapper.
+    pub fn remember_incremental_dir(&self, path: &Path) -> Result<()> {
+        let path = path.to_string_lossy().into_owned();
+        self.db.execute(
+            "INSERT OR REPLACE INTO incremental_dirs (path, last_seen) VALUES (?1, datetime('now'))",
+            params![path],
+        )?;
+        Ok(())
+    }
+
+    /// Remove registered incremental directories and prune stale registry rows.
+    pub fn clean_registered_incremental_dirs(&self) -> Result<usize> {
+        let paths: Vec<String> = {
+            let mut stmt = self
+                .db
+                .prepare("SELECT path FROM incremental_dirs ORDER BY last_seen ASC")?;
+            stmt.query_map([], |row| row.get(0))?
+                .collect::<Result<Vec<_>, _>>()?
+        };
+
+        let mut cleaned = 0;
+        for path_str in paths {
+            let path = PathBuf::from(&path_str);
+            if !path.exists() {
+                self.db.execute(
+                    "DELETE FROM incremental_dirs WHERE path = ?1",
+                    params![path_str],
+                )?;
+                continue;
+            }
+
+            if !path.is_dir() {
+                tracing::warn!(
+                    "registered incremental path is not a directory, pruning: {}",
+                    path.display()
+                );
+                self.db.execute(
+                    "DELETE FROM incremental_dirs WHERE path = ?1",
+                    params![path_str],
+                )?;
+                continue;
+            }
+
+            match fs::remove_dir_all(&path) {
+                Ok(()) => {
+                    self.db.execute(
+                        "DELETE FROM incremental_dirs WHERE path = ?1",
+                        params![path_str],
+                    )?;
+                    cleaned += 1;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "failed to remove registered incremental dir {}: {}",
+                        path.display(),
+                        e
+                    );
+                }
+            }
+        }
+
+        Ok(cleaned)
+    }
+
     /// Weighted eviction: remove entries with lowest priority score until under the size limit.
     /// Prefers evicting large, old, rarely-accessed entries.
     /// Evicts down to 90% of max_size to create headroom and avoid boundary thrashing.
@@ -876,6 +947,7 @@ impl Store {
         }
         self.db.execute("DELETE FROM entries", [])?;
         self.db.execute("DELETE FROM blobs", [])?;
+        self.db.execute("DELETE FROM incremental_dirs", [])?;
         Ok(())
     }
 
@@ -1226,6 +1298,39 @@ mod tests {
         let stats = store.evict().unwrap();
         assert!(stats.entries_evicted > 0);
         assert!(!store.contains("key1"));
+    }
+
+    #[test]
+    fn test_incremental_dir_registry_deduplicates_and_cleans() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let incremental_dir = dir.path().join("target/debug/incremental");
+        std::fs::create_dir_all(&incremental_dir).unwrap();
+        std::fs::write(incremental_dir.join("junk"), b"tmp").unwrap();
+
+        store.remember_incremental_dir(&incremental_dir).unwrap();
+        store.remember_incremental_dir(&incremental_dir).unwrap();
+        store
+            .remember_incremental_dir(&dir.path().join("missing/incremental"))
+            .unwrap();
+
+        let count_before: i64 = store
+            .db
+            .query_row("SELECT COUNT(*) FROM incremental_dirs", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count_before, 2);
+
+        let cleaned = store.clean_registered_incremental_dirs().unwrap();
+        assert_eq!(cleaned, 1);
+        assert!(!incremental_dir.exists());
+
+        let count_after: i64 = store
+            .db
+            .query_row("SELECT COUNT(*) FROM incremental_dirs", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count_after, 0);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -26,6 +26,10 @@ enum Tab {
     Transfer,
 }
 
+fn tab_needs_entries(tab: Tab) -> bool {
+    matches!(tab, Tab::Store)
+}
+
 // ── Sort mode (shared between tabs) ────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy)]
@@ -134,6 +138,7 @@ struct AppState {
     rustc_version_slot: Arc<Mutex<Option<String>>>,
     stats_result_slot: Arc<Mutex<Option<StatsSnapshot>>>,
     stats_fetch_in_flight: bool,
+    stats_fetch_requested_entries: bool,
 
     should_quit: bool,
     rustc_version: String,
@@ -218,6 +223,7 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
         rustc_version_slot: Arc::clone(&rustc_version_slot),
         stats_result_slot: Arc::clone(&stats_result_slot),
         stats_fetch_in_flight: false,
+        stats_fetch_requested_entries: false,
         should_quit: false,
         rustc_version: "\u{2026}".to_string(), // placeholder until background thread completes
         service_installed,
@@ -240,6 +246,15 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
         if let Ok(mut slot) = state.stats_result_slot.lock()
             && let Some(new_snap) = slot.take()
         {
+            let previous_entries = if state.stats_fetch_requested_entries {
+                Vec::new()
+            } else {
+                std::mem::take(&mut state.stats_snapshot.entries)
+            };
+            let mut new_snap = new_snap;
+            if !state.stats_fetch_requested_entries {
+                new_snap.entries = previous_entries;
+            }
             let old_up = state.stats_snapshot.bytes_uploaded;
             let old_down = state.stats_snapshot.bytes_downloaded;
             let interval = SNAPSHOT_REFRESH_INTERVAL.as_secs_f64();
@@ -261,9 +276,11 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
             state.last_stats_fetch = Instant::now();
             let cfg = state.config.clone();
             let sort = state.sort_mode.label().to_string();
+            let include_entries = tab_needs_entries(state.active_tab);
+            state.stats_fetch_requested_entries = include_entries;
             let slot = Arc::clone(&state.stats_result_slot);
             std::thread::spawn(move || {
-                let snap = fetch_stats(&cfg, true, &sort);
+                let snap = fetch_stats(&cfg, include_entries, &sort);
                 if let Ok(mut s) = slot.lock() {
                     *s = Some(snap);
                 }
@@ -373,14 +390,20 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
             state.active_tab = Tab::Projects;
             state.last_project_refresh = Instant::now() - PROJECT_REFRESH_INTERVAL;
         }
-        KeyCode::Char('3') => state.active_tab = Tab::Store,
+        KeyCode::Char('3') => {
+            state.active_tab = Tab::Store;
+            state.last_stats_fetch = Instant::now() - SNAPSHOT_REFRESH_INTERVAL;
+        }
         KeyCode::Char('4') => state.active_tab = Tab::Transfer,
         KeyCode::BackTab | KeyCode::Tab => match state.active_tab {
             Tab::Build => {
                 state.active_tab = Tab::Projects;
                 state.last_project_refresh = Instant::now() - PROJECT_REFRESH_INTERVAL;
             }
-            Tab::Projects => state.active_tab = Tab::Store,
+            Tab::Projects => {
+                state.active_tab = Tab::Store;
+                state.last_stats_fetch = Instant::now() - SNAPSHOT_REFRESH_INTERVAL;
+            }
             Tab::Store => state.active_tab = Tab::Transfer,
             Tab::Transfer => state.active_tab = Tab::Build,
         },
@@ -407,6 +430,7 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
         // Store tab
         KeyCode::Char('s') if state.active_tab == Tab::Store => {
             state.sort_mode = state.sort_mode.next();
+            state.last_stats_fetch = Instant::now() - SNAPSHOT_REFRESH_INTERVAL;
         }
         KeyCode::Char('f') if state.active_tab == Tab::Store => {
             state.filter_active = true;
@@ -416,6 +440,19 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
             state.last_project_refresh = Instant::now() - PROJECT_REFRESH_INTERVAL;
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tab_needs_entries_only_for_store() {
+        assert!(!tab_needs_entries(Tab::Build));
+        assert!(!tab_needs_entries(Tab::Projects));
+        assert!(tab_needs_entries(Tab::Store));
+        assert!(!tab_needs_entries(Tab::Transfer));
     }
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -66,6 +66,29 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     // Parse the rustc arguments (wrapper_args[0] is the rustc path)
     let args = RustcArgs::parse(wrapper_args).context("parsing rustc arguments")?;
+    let store = if args.is_primary || (config.clean_incremental && args.incremental.is_some()) {
+        match Store::open(config) {
+            Ok(store) => Some(store),
+            Err(e) => {
+                tracing::warn!("failed to open store: {}", e);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    if config.clean_incremental
+        && let Some(incr_dir) = &args.incremental
+        && let Some(store) = &store
+        && let Err(e) = store.remember_incremental_dir(incr_dir)
+    {
+        tracing::warn!(
+            "failed to register incremental dir {}: {}",
+            incr_dir.display(),
+            e
+        );
+    }
 
     // If this isn't a primary compilation (no source file), just pass through to rustc
     if !args.is_primary {
@@ -107,13 +130,9 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     tracing::debug!("cache key for {}: {}", crate_name, &cache_key[..16]);
 
-    // Open the store
-    let store = match Store::open(config) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!("failed to open store: {}", e);
-            return passthrough(&args);
-        }
+    let store = match store {
+        Some(store) => store,
+        None => return passthrough(&args),
     };
 
     // 1. Check local store


### PR DESCRIPTION
## Summary

This follow-up started as a Nix/module fix, then expanded into a small architecture cleanup for configuration ownership and long-lived daemon/TUI overhead.

- make `services.kache` self-contained by defaulting the package from the module itself instead of requiring the overlay to be applied separately
- export `KACHE_CONFIG` globally so wrapper-mode builds and the daemon share one generated config path
- make raw config load/save and the config TUI honor the resolved config path so editing and runtime use the same authority
- restore coherent `clean_incremental` behavior with a SQLite-backed registry of tracked incremental dirs instead of walking from daemon `cwd`
- keep tracing logs out of alternate-screen terminal UIs while preserving file logging
- let the daemon reuse a persistent `Store` handle instead of reopening SQLite on each request path
- avoid fetching and serializing full store entry lists in the monitor unless the Store tab is active

## Architecture Notes

The main design change is tightening ownership boundaries:

- the module now owns package/config wiring instead of depending on external overlay or per-process drift
- the daemon now behaves like a long-lived process with reused store state instead of a stateless SQLite client
- the monitor now requests heavy entry data only when the active view needs it

## Testing

- `cargo fmt`
- `cargo test`