### PR TITLE
Tighten daemon lifecycle defaults and migrate the macOS launchd label

### DIFF
--- a/docs/kache-docs/getting-started/configuration.mdx
+++ b/docs/kache-docs/getting-started/configuration.mdx
@@ -49,6 +49,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly |
 | `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd compression level (1–22) |
 | `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `16` | Max concurrent S3 operations |
+| `KACHE_DAEMON_IDLE_TIMEOUT` | `cache.daemon_idle_timeout_secs` | `600` | Idle daemon shutdown timeout in seconds (`0` disables auto-shutdown) |
 | `KACHE_DISABLED` | — | `0` | Disable caching entirely (pass-through to rustc) |
 | `KACHE_LOG` | — | `kache=warn` | Log level for stderr output |
 | `KACHE_LOG_FILE` | — | `kache=info` | Log level for the file log |

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -115,7 +115,7 @@ in {
               daemon_idle_timeout_secs = lib.mkOption {
                 type = lib.types.nullOr lib.types.ints.unsigned;
                 default = null;
-                description = "Daemon idle timeout in seconds. 0 = no timeout. Default: 3600.";
+                description = "Daemon idle timeout in seconds. 0 = no timeout. Default: 600.";
               };
 
               remote = lib.mkOption {
@@ -188,7 +188,7 @@ in {
     (lib.mkIf cfg.daemon.enable {
       launchd.user.agents.kache = {
         serviceConfig = {
-          Label = "com.zondax.kache";
+          Label = "ninja.kunobi.kache";
           ProgramArguments = [kacheExe "daemon" "run"];
           RunAtLoad = true;
           KeepAlive = {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@ use bytesize::ByteSize;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+pub const DEFAULT_DAEMON_IDLE_TIMEOUT_SECS: u64 = 10 * 60;
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub cache_dir: PathBuf,
@@ -17,7 +19,7 @@ pub struct Config {
     pub compression_level: i32,
     /// Max concurrent S3 operations (default 16).
     pub s3_concurrency: u32,
-    /// Daemon idle timeout in seconds (default 3600 = 1 hour). 0 = no timeout.
+    /// Daemon idle timeout in seconds (default 600 = 10 minutes). 0 = no timeout.
     pub daemon_idle_timeout_secs: u64,
 }
 
@@ -205,7 +207,7 @@ impl Config {
                     .and_then(|c| c.cache.as_ref())
                     .and_then(|c| c.daemon_idle_timeout_secs)
             })
-            .unwrap_or(3600);
+            .unwrap_or(DEFAULT_DAEMON_IDLE_TIMEOUT_SECS);
 
         let remote = Self::load_remote_config(&file_config);
 
@@ -535,7 +537,7 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
         assert_eq!(config.store_dir(), PathBuf::from("/tmp/kache/store"));
     }
@@ -553,7 +555,7 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
         assert_eq!(config.index_db_path(), PathBuf::from("/tmp/kache/index.db"));
     }
@@ -571,7 +573,7 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
         assert_eq!(
             config.event_log_path(),
@@ -592,7 +594,7 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
         assert_eq!(
             config.socket_path(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3051,7 +3051,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         }
     }
 

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -382,7 +382,7 @@ fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{blob_path, create_entry_pack_zstd, extract_entry_pack};
-    use crate::config::Config;
+    use crate::config::{Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS};
     use crate::store::{EntryMeta, Store};
 
     #[test]
@@ -399,7 +399,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
         let store = Store::open(&config).unwrap();
 
@@ -454,7 +454,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
         let restore_store = Store::open(&restore_config).unwrap();
         let restore_entry_dir = restore_store.entry_dir("key123");

--- a/src/remote_plan.rs
+++ b/src/remote_plan.rs
@@ -73,7 +73,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::{RemoteLayoutKind, RemotePlanner, RemoteWorkload};
-    use crate::config::Config;
+    use crate::config::{Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS};
 
     fn test_config() -> Config {
         Config {
@@ -87,7 +87,7 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         }
     }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -1450,7 +1450,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
 
         // Write build events
@@ -1616,7 +1616,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
 
         // Only write build events, no transfers
@@ -1642,7 +1642,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
 
         // Mostly misses — should trigger high miss share suggestion
@@ -1721,7 +1721,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
 
         let report = generate_report(&config, 24, 10).unwrap();

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 
-const LABEL: &str = "com.zondax.kache";
-const PLIST_NAME: &str = "com.zondax.kache.plist";
+const LABEL: &str = "ninja.kunobi.kache";
+const PLIST_NAME: &str = "ninja.kunobi.kache.plist";
+const LEGACY_LABEL: &str = "com.zondax.kache";
+const LEGACY_PLIST_NAME: &str = "com.zondax.kache.plist";
 const UNIT_NAME: &str = "kache.service";
 
 // ── Path helpers ─────────────────────────────────────────────────
@@ -12,6 +14,13 @@ fn plist_path() -> PathBuf {
         .unwrap_or_default()
         .join("Library/LaunchAgents")
         .join(PLIST_NAME)
+}
+
+fn legacy_plist_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join("Library/LaunchAgents")
+        .join(LEGACY_PLIST_NAME)
 }
 
 fn unit_path() -> PathBuf {
@@ -38,6 +47,18 @@ fn log_dir() -> PathBuf {
         .join("Library/Logs/kache")
 }
 
+fn stop_launchd_service(uid: u32, label: &str, plist: &std::path::Path) {
+    let bootout = std::process::Command::new("launchctl")
+        .args(["bootout", &format!("gui/{uid}/{label}")])
+        .output();
+
+    if !matches!(bootout, Ok(out) if out.status.success()) {
+        let _ = std::process::Command::new("launchctl")
+            .args(["unload", &plist.display().to_string()])
+            .output();
+    }
+}
+
 // ── Install ──────────────────────────────────────────────────────
 
 pub fn install() -> Result<()> {
@@ -59,14 +80,18 @@ pub fn install() -> Result<()> {
 
 fn install_launchd(exe: &std::path::Path) -> Result<()> {
     let plist = plist_path();
+    let legacy_plist = legacy_plist_path();
     let uid = unsafe { libc::getuid() };
 
     // If already installed, stop old service first
-    if plist.exists() {
+    if plist.exists() || legacy_plist.exists() {
         println!("Existing service found — upgrading in place...");
-        let _ = std::process::Command::new("launchctl")
-            .args(["bootout", &format!("gui/{uid}/{LABEL}")])
-            .output();
+        stop_launchd_service(uid, LABEL, &plist);
+        stop_launchd_service(uid, LEGACY_LABEL, &legacy_plist);
+    }
+
+    if legacy_plist.exists() {
+        std::fs::remove_file(&legacy_plist).context("removing legacy plist")?;
     }
 
     // Ensure directories exist
@@ -237,31 +262,34 @@ pub fn uninstall() -> Result<()> {
 
 fn uninstall_launchd() -> Result<()> {
     let plist = plist_path();
+    let legacy_plist = legacy_plist_path();
     let uid = unsafe { libc::getuid() };
+    let had_plist = plist.exists();
+    let had_legacy_plist = legacy_plist.exists();
 
-    if !plist.exists() {
+    if !had_plist && !had_legacy_plist {
         println!("Service is not installed (no plist found).");
         return Ok(());
     }
 
-    // Stop — try modern API first, fall back to legacy
-    let bootout = std::process::Command::new("launchctl")
-        .args(["bootout", &format!("gui/{uid}/{LABEL}")])
-        .output();
+    stop_launchd_service(uid, LABEL, &plist);
+    stop_launchd_service(uid, LEGACY_LABEL, &legacy_plist);
 
-    match bootout {
-        Ok(out) if out.status.success() => {}
-        _ => {
-            let _ = std::process::Command::new("launchctl")
-                .args(["unload", &plist.display().to_string()])
-                .output();
-        }
+    if had_plist {
+        std::fs::remove_file(&plist).context("removing plist")?;
     }
 
-    std::fs::remove_file(&plist).context("removing plist")?;
+    if had_legacy_plist {
+        std::fs::remove_file(&legacy_plist).context("removing legacy plist")?;
+    }
 
     println!("Service stopped and removed.");
-    println!("  removed: {}", plist.display());
+    if had_plist {
+        println!("  removed: {}", plist.display());
+    }
+    if had_legacy_plist {
+        println!("  removed: {}", legacy_plist.display());
+    }
     Ok(())
 }
 
@@ -293,6 +321,21 @@ fn uninstall_systemd() -> Result<()> {
 pub fn status() -> Result<()> {
     let config = crate::config::Config::load().ok();
     let service_path = service_file_path();
+    let installed_service_path = service_path
+        .as_ref()
+        .and_then(|path| path.exists().then(|| path.clone()))
+        .or_else(|| {
+            if cfg!(target_os = "macos") {
+                let legacy_path = legacy_plist_path();
+                legacy_path.exists().then_some(legacy_path)
+            } else {
+                None
+            }
+        });
+    let legacy_service_installed = installed_service_path
+        .as_ref()
+        .and_then(|path| path.file_name().and_then(|name| name.to_str()))
+        == Some(LEGACY_PLIST_NAME);
 
     // 0. Binary version (always shown)
     println!(
@@ -302,13 +345,13 @@ pub fn status() -> Result<()> {
     );
 
     // 1. Service file installed?
-    let installed = service_path.as_ref().map(|p| p.exists()).unwrap_or(false);
-
-    if installed {
-        println!(
-            "  Service:  \x1b[32minstalled\x1b[0m ({})",
-            service_path.as_ref().unwrap().display()
-        );
+    if let Some(ref path) = installed_service_path {
+        println!("  Service:  \x1b[32minstalled\x1b[0m ({})", path.display());
+        if legacy_service_installed {
+            println!(
+                "            \x1b[33mlegacy label detected — run `kache daemon install` to migrate to {LABEL}\x1b[0m"
+            );
+        }
     } else if service_path.is_some() {
         println!("  Service:  \x1b[33mnot installed\x1b[0m");
         println!("            run `kache daemon install` to set up");
@@ -371,7 +414,7 @@ pub fn status() -> Result<()> {
     }
 
     // 6. Exe path mismatch warning
-    if installed && let Some(ref path) = service_path {
+    if let Some(ref path) = installed_service_path {
         let current_exe = std::env::current_exe()
             .ok()
             .and_then(|p| p.canonicalize().ok());
@@ -494,7 +537,7 @@ mod tests {
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.zondax.kache</string>
+    <string>ninja.kunobi.kache</string>
     <key>ProgramArguments</key>
     <array>
         <string>/usr/local/bin/kache</string>
@@ -553,12 +596,12 @@ WantedBy=default.target
 
     #[test]
     fn test_label_constant() {
-        assert_eq!(LABEL, "com.zondax.kache");
+        assert_eq!(LABEL, "ninja.kunobi.kache");
     }
 
     #[test]
     fn test_plist_name_constant() {
-        assert_eq!(PLIST_NAME, "com.zondax.kache.plist");
+        assert_eq!(PLIST_NAME, "ninja.kunobi.kache.plist");
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -1210,7 +1210,7 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18,6 +18,11 @@ fn build_kache() {
     assert!(status.success(), "kache build failed");
 }
 
+fn isolated_config_path(cache_dir: &Path) -> PathBuf {
+    // Prevent tests from inheriting the developer's real ~/.config/kache/config.toml.
+    cache_dir.join("config.toml")
+}
+
 #[test]
 fn test_cli_help() {
     build_kache();
@@ -36,6 +41,7 @@ fn test_cli_list_empty() {
     Command::new(kache_binary())
         .arg("list")
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .assert()
         .success()
         .stdout(predicates::str::contains("No cached entries"));
@@ -49,6 +55,7 @@ fn test_cli_purge_empty() {
     Command::new(kache_binary())
         .arg("purge")
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .assert()
         .success()
         .stdout(predicates::str::contains("Cleared"));
@@ -69,6 +76,7 @@ fn test_disabled_passthrough() {
         .env("RUSTC_WRAPPER", kache_binary())
         .env("KACHE_DISABLED", "1")
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .env("CARGO_TARGET_DIR", target_dir.path())
         .status()
         .expect("failed to run cargo build with kache disabled");
@@ -93,6 +101,7 @@ fn test_wrapper_hello_world() {
         .current_dir(&test_project)
         .env("RUSTC_WRAPPER", kache_binary())
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .env("CARGO_TARGET_DIR", target_dir.path())
         .env("KACHE_LOG", "kache=debug")
         .status()
@@ -129,6 +138,7 @@ fn test_wrapper_hello_world() {
         .current_dir(&test_project)
         .env("RUSTC_WRAPPER", kache_binary())
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .env("CARGO_TARGET_DIR", target_dir.path())
         .env("KACHE_LOG", "kache=debug")
         .status()

--- a/tests/stale_artifact_test.rs
+++ b/tests/stale_artifact_test.rs
@@ -19,6 +19,11 @@ fn build_kache() {
     assert!(status.success(), "kache build failed");
 }
 
+fn isolated_config_path(cache_dir: &Path) -> PathBuf {
+    // Prevent tests from inheriting the developer's real ~/.config/kache/config.toml.
+    cache_dir.join("config.toml")
+}
+
 /// Recursively copies a directory.
 fn copy_dir(src: &Path, dst: &Path) {
     std::fs::create_dir_all(dst).unwrap();
@@ -55,6 +60,7 @@ fn build_and_run(
         .current_dir(project)
         .env("RUSTC_WRAPPER", kache_binary())
         .env("KACHE_CACHE_DIR", cache_dir)
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
         .env("CARGO_TARGET_DIR", target_dir)
         .env("CARGO_INCREMENTAL", "0")
         .env("KACHE_LOG", "kache=debug");
@@ -461,6 +467,7 @@ fn stale_concurrent_builds_safe() {
         .current_dir(project.path())
         .env("RUSTC_WRAPPER", &kache)
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .env("CARGO_TARGET_DIR", target1.path())
         .env("CARGO_INCREMENTAL", "0")
         .spawn()
@@ -471,6 +478,7 @@ fn stale_concurrent_builds_safe() {
         .current_dir(project.path())
         .env("RUSTC_WRAPPER", &kache)
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .env("CARGO_TARGET_DIR", target2.path())
         .env("CARGO_INCREMENTAL", "0")
         .spawn()


### PR DESCRIPTION
## Summary
- lower the default daemon idle timeout from 1 hour to 10 minutes and use a shared constant for the runtime default and test fixtures
- rename the macOS launchd service from `com.zondax.kache` to `ninja.kunobi.kache`, with legacy install/status/uninstall handling so upgrades clean up old plists
- isolate integration tests from the developer's real kache config via `KACHE_CONFIG` so temp test caches do not inherit personal remote daemon settings

## Testing
- cargo test
