### PR TITLE
Merge dev into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 
 tarpaulin-report.json
 
+# Nix
+/result
+
 # Plans
 docs/plans/
 docs/planning/*

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ S3 layout: `{prefix}/{crate_name}/{cache_key}.tar.zst` — organized by crate fo
 
 Configure via the TUI editor (`kache config`), environment variables, or the config file directly.
 
-Config file: `~/.config/kache/config.toml` (respects `XDG_CONFIG_HOME`).
+Config file: `~/.config/kache/config.toml` (respects `XDG_CONFIG_HOME`, overridden by `KACHE_CONFIG`).
 
 Environment variables take highest priority, then config file, then defaults.
 
@@ -81,6 +81,7 @@ Environment variables take highest priority, then config file, then defaults.
 |---|---|---|---|
 | `KACHE_CACHE_DIR` | `cache.local_store` | `~/.cache/kache` | Local store directory |
 | `KACHE_MAX_SIZE` | `cache.local_max_size` | `50GB` | Max store size |
+| `KACHE_CONFIG` | — | XDG config path | Explicit config file path |
 | `KACHE_S3_BUCKET` | `cache.remote.bucket` | — | S3 bucket for remote cache |
 | `KACHE_S3_ENDPOINT` | `cache.remote.endpoint` | — | Custom S3 endpoint (required for Ceph/MinIO/R2) |
 | `KACHE_S3_REGION` | `cache.remote.region` | `us-east-1` | AWS region |
@@ -89,7 +90,7 @@ Environment variables take highest priority, then config file, then defaults.
 | `KACHE_S3_ACCESS_KEY` | — | — | Explicit S3 access key (overrides profile) |
 | `KACHE_S3_SECRET_KEY` | — | — | Explicit S3 secret key (overrides profile) |
 | `KACHE_CACHE_EXECUTABLES` | `cache.cache_executables` | `false` | Cache bin/dylib/cdylib outputs |
-| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean incremental dirs during GC |
+| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly |
 | `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd compression level (1-22) |
 | `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `8` | Max concurrent S3 operations |
 | `KACHE_DISABLED` | — | `0` | Disable caching entirely |

--- a/docs/kache-docs/commands/reference.mdx
+++ b/docs/kache-docs/commands/reference.mdx
@@ -89,7 +89,7 @@ kache gc --max-age 30d    # remove anything unused for 30 days
 kache gc --max-age 7d     # aggressive cleanup before a release build
 ```
 
-If `clean_incremental` is enabled (the default), GC also removes incremental compilation directories from known `target/` locations.
+If `clean_incremental` is enabled (the default), GC removes tracked incremental compilation directories that previous wrapper invocations registered. Active wrapper invocations also remove the current build's incremental dir eagerly.
 
 ---
 

--- a/docs/kache-docs/getting-started/configuration.mdx
+++ b/docs/kache-docs/getting-started/configuration.mdx
@@ -8,7 +8,7 @@ description: Config file, environment variables, and the TUI editor.
 kache reads configuration from three places, in order of priority:
 
 1. **Environment variables** — always win, useful for CI overrides
-2. **Config file** — `~/.config/kache/config.toml` (respects `XDG_CONFIG_HOME`)
+2. **Config file** — `~/.config/kache/config.toml` (respects `XDG_CONFIG_HOME`, overridden by `KACHE_CONFIG`)
 3. **Defaults** — sensible values that work without any configuration
 
 ## Config file
@@ -37,6 +37,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 |---|---|---|---|
 | `KACHE_CACHE_DIR` | `cache.local_store` | `~/.cache/kache` | Local cache directory |
 | `KACHE_MAX_SIZE` | `cache.local_max_size` | `50GiB` | Maximum local store size |
+| `KACHE_CONFIG` | — | XDG config path | Explicit config file path |
 | `KACHE_S3_BUCKET` | `cache.remote.bucket` | — | S3 bucket name |
 | `KACHE_S3_ENDPOINT` | `cache.remote.endpoint` | — | S3 endpoint URL (required for Ceph, MinIO, R2) |
 | `KACHE_S3_REGION` | `cache.remote.region` | `us-east-1` | AWS region |
@@ -45,7 +46,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_S3_ACCESS_KEY` | — | — | Explicit S3 access key |
 | `KACHE_S3_SECRET_KEY` | — | — | Explicit S3 secret key |
 | `KACHE_CACHE_EXECUTABLES` | `cache.cache_executables` | `false` | Cache bin/dylib/cdylib/proc-macro outputs |
-| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Remove incremental dirs during GC |
+| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly |
 | `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd compression level (1–22) |
 | `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `16` | Max concurrent S3 operations |
 | `KACHE_DISABLED` | — | `0` | Disable caching entirely (pass-through to rustc) |

--- a/docs/kache-docs/getting-started/configuration.mdx
+++ b/docs/kache-docs/getting-started/configuration.mdx
@@ -49,6 +49,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly |
 | `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd compression level (1–22) |
 | `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `16` | Max concurrent S3 operations |
+| `KACHE_DAEMON_IDLE_TIMEOUT` | `cache.daemon_idle_timeout_secs` | `600` | Idle daemon shutdown timeout in seconds (`0` disables auto-shutdown) |
 | `KACHE_DISABLED` | — | `0` | Disable caching entirely (pass-through to rustc) |
 | `KACHE_LOG` | — | `kache=warn` | Log level for stderr output |
 | `KACHE_LOG_FILE` | — | `kache=info` | Log level for the file log |

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773597492,
+        "narHash": "sha256-hQ284SkIeNaeyud+LS0WVLX+WL2rxcVZLFEaK0e03zg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a07d4ce6bee67d7c838a8a5796e75dff9caa21ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "kache - Zero-copy, content-addressed Rust build cache";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    {
+      nixosModules = {
+        kache = import ./nix/module.nix;
+        default = self.nixosModules.kache;
+      };
+
+      # The same module works for nix-darwin (launchd vs systemd is handled internally).
+      darwinModules = {
+        kache = import ./nix/module.nix;
+        default = self.darwinModules.kache;
+      };
+
+      overlays.default = _final: prev: {
+        kache = prev.callPackage ./nix/package.nix {};
+      };
+    }
+    // flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [self.overlays.default];
+      };
+    in {
+      packages = {
+        kache = pkgs.kache;
+        default = pkgs.kache;
+      };
+    });
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -17,7 +17,6 @@
   stripNulls = lib.filterAttrsRecursive (_: v: v != null);
 
   configFile = tomlFormat.generate "kache-config" (stripNulls cfg.settings);
-
   kacheExe = lib.getExe cfg.package;
 
   # Check which platform options exist rather than querying pkgs,
@@ -28,7 +27,12 @@ in {
   options.services.kache = {
     enable = lib.mkEnableOption "kache, a Rust build cache";
 
-    package = lib.mkPackageOption pkgs "kache" {};
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./package.nix {};
+      defaultText = lib.literalExpression "pkgs.callPackage ./package.nix {}";
+      description = "kache package to install and run.";
+    };
 
     rustcWrapper = lib.mkOption {
       type = lib.types.bool;
@@ -93,7 +97,7 @@ in {
               clean_incremental = lib.mkOption {
                 type = lib.types.nullOr lib.types.bool;
                 default = null;
-                description = "Auto-clean incremental compilation dirs during GC.";
+                description = "Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly.";
               };
 
               compression_level = lib.mkOption {
@@ -171,6 +175,7 @@ in {
     {
       environment.systemPackages = [cfg.package];
       environment.etc."kache/config.toml".source = configFile;
+      environment.variables.KACHE_CONFIG = "${configFile}";
     }
 
     # Set RUSTC_WRAPPER system-wide
@@ -213,7 +218,7 @@ in {
         };
         environment = {
           KACHE_LOG = cfg.daemon.logLevel;
-          KACHE_CONFIG = configFile;
+          KACHE_CONFIG = "${configFile}";
         };
       };
     })

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,221 @@
+# NixOS and nix-darwin module for kache.
+# Works on both platforms - uses launchd on macOS, systemd on Linux.
+{
+  config,
+  lib,
+  options,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.kache;
+  tomlFormat = pkgs.formats.toml {};
+
+  # Settings maps directly to config.toml. Freeform type allows arbitrary
+  # keys so the module doesn't break when kache adds new config options.
+  # Recursively strip null values - TOML has no null representation,
+  # and the typed options use null as "use kache's built-in default".
+  stripNulls = lib.filterAttrsRecursive (_: v: v != null);
+
+  configFile = tomlFormat.generate "kache-config" (stripNulls cfg.settings);
+
+  kacheExe = lib.getExe cfg.package;
+
+  # Check which platform options exist rather than querying pkgs,
+  # which would create a circular dependency with lib.optionals.
+  hasLaunchd = options ? launchd;
+  hasSystemd = options ? systemd;
+in {
+  options.services.kache = {
+    enable = lib.mkEnableOption "kache, a Rust build cache";
+
+    package = lib.mkPackageOption pkgs "kache" {};
+
+    rustcWrapper = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Set `RUSTC_WRAPPER` system-wide so all Rust builds use the cache.
+      '';
+    };
+
+    daemon = {
+      enable = lib.mkEnableOption "the kache background daemon";
+
+      logLevel = lib.mkOption {
+        type = lib.types.str;
+        default = "kache=info";
+        description = "Log level for the daemon (`KACHE_LOG` value).";
+      };
+    };
+
+    settings = lib.mkOption {
+      description = ''
+        Configuration written to `config.toml`.
+
+        The typed options below cover known fields for documentation and
+        validation. Any additional keys are passed through as-is, so the
+        module stays usable when kache adds new config options.
+
+        See <https://github.com/kunobi-ninja/kache#configuration> for
+        the full reference.
+      '';
+      default = {};
+      type = lib.types.submodule {
+        freeformType = tomlFormat.type;
+
+        options.cache = lib.mkOption {
+          description = "Cache settings.";
+          default = {};
+          type = lib.types.submodule {
+            freeformType = tomlFormat.type;
+
+            options = {
+              local_store = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = "Local cache store directory. Default: `~/.cache/kache`.";
+                example = "~/.cache/kache";
+              };
+
+              local_max_size = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = "Maximum local store size. Default: `50GB`.";
+                example = "50GB";
+              };
+
+              cache_executables = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = null;
+                description = "Whether to cache bin/dylib/cdylib outputs.";
+              };
+
+              clean_incremental = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = null;
+                description = "Auto-clean incremental compilation dirs during GC.";
+              };
+
+              compression_level = lib.mkOption {
+                type = lib.types.nullOr (lib.types.ints.between 1 22);
+                default = null;
+                description = "Zstd compression level (1-22). Default: 3.";
+              };
+
+              s3_concurrency = lib.mkOption {
+                type = lib.types.nullOr lib.types.ints.positive;
+                default = null;
+                description = "Max concurrent S3 operations. Default: 16.";
+              };
+
+              daemon_idle_timeout_secs = lib.mkOption {
+                type = lib.types.nullOr lib.types.ints.unsigned;
+                default = null;
+                description = "Daemon idle timeout in seconds. 0 = no timeout. Default: 3600.";
+              };
+
+              remote = lib.mkOption {
+                description = "S3 remote cache settings.";
+                default = {};
+                type = lib.types.submodule {
+                  freeformType = tomlFormat.type;
+
+                  options = {
+                    type = lib.mkOption {
+                      type = lib.types.nullOr lib.types.str;
+                      default = null;
+                      description = "Remote type. Currently only `s3`.";
+                    };
+
+                    bucket = lib.mkOption {
+                      type = lib.types.nullOr lib.types.str;
+                      default = null;
+                      description = "S3 bucket for remote cache.";
+                    };
+
+                    endpoint = lib.mkOption {
+                      type = lib.types.nullOr lib.types.str;
+                      default = null;
+                      description = "Custom S3 endpoint (for Ceph/MinIO/R2).";
+                    };
+
+                    region = lib.mkOption {
+                      type = lib.types.nullOr lib.types.str;
+                      default = null;
+                      description = "AWS region. Default: `us-east-1`.";
+                    };
+
+                    prefix = lib.mkOption {
+                      type = lib.types.nullOr lib.types.str;
+                      default = null;
+                      description = "S3 key prefix for artifacts. Default: `artifacts`.";
+                    };
+
+                    profile = lib.mkOption {
+                      type = lib.types.nullOr lib.types.str;
+                      default = null;
+                      description = "AWS profile name for credential lookup.";
+                    };
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge ([
+    # Install the package and config
+    {
+      environment.systemPackages = [cfg.package];
+      environment.etc."kache/config.toml".source = configFile;
+    }
+
+    # Set RUSTC_WRAPPER system-wide
+    (lib.mkIf cfg.rustcWrapper {
+      environment.variables.RUSTC_WRAPPER = kacheExe;
+    })
+  ]
+  # macOS: launchd user agent
+  ++ lib.optionals hasLaunchd [
+    (lib.mkIf cfg.daemon.enable {
+      launchd.user.agents.kache = {
+        serviceConfig = {
+          Label = "com.zondax.kache";
+          ProgramArguments = [kacheExe "daemon" "run"];
+          RunAtLoad = true;
+          KeepAlive = {
+            SuccessfulExit = false;
+          };
+          EnvironmentVariables = {
+            KACHE_LOG = cfg.daemon.logLevel;
+            KACHE_CONFIG = "${configFile}";
+          };
+          ThrottleInterval = 5;
+        };
+      };
+    })
+  ]
+  # Linux: systemd user service
+  ++ lib.optionals hasSystemd [
+    (lib.mkIf cfg.daemon.enable {
+      systemd.user.services.kache = {
+        description = "kache build cache daemon";
+        after = ["default.target"];
+        wantedBy = ["default.target"];
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${kacheExe} daemon run";
+          Restart = "on-failure";
+          RestartSec = "5s";
+        };
+        environment = {
+          KACHE_LOG = cfg.daemon.logLevel;
+          KACHE_CONFIG = configFile;
+        };
+      };
+    })
+  ]));
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -115,7 +115,7 @@ in {
               daemon_idle_timeout_secs = lib.mkOption {
                 type = lib.types.nullOr lib.types.ints.unsigned;
                 default = null;
-                description = "Daemon idle timeout in seconds. 0 = no timeout. Default: 3600.";
+                description = "Daemon idle timeout in seconds. 0 = no timeout. Default: 600.";
               };
 
               remote = lib.mkOption {
@@ -188,7 +188,7 @@ in {
     (lib.mkIf cfg.daemon.enable {
       launchd.user.agents.kache = {
         serviceConfig = {
-          Label = "com.zondax.kache";
+          Label = "ninja.kunobi.kache";
           ProgramArguments = [kacheExe "daemon" "run"];
           RunAtLoad = true;
           KeepAlive = {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  apple-sdk_15,
+  stdenv,
+}:
+rustPlatform.buildRustPackage {
+  pname = "kache";
+  version = "0-unstable";
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../src
+    ];
+  };
+
+  cargoHash = "sha256-sKGGDkVAt9vn8t5O0b419/REE89M5hrwyZ8erld7mcc=";
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk_15
+  ];
+
+  # The tmutil xattr test shells out to /usr/bin/tmutil which isn't in the sandbox.
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "--skip=store::tests::test_exclude_from_indexing_sets_tmutil_xattr"
+  ];
+
+  # Avoid bootstrapping loop: don't let kache wrap itself during build
+  env.RUSTC_WRAPPER = "";
+
+  meta = {
+    description = "Zero-copy, content-addressed Rust build cache";
+    homepage = "https://github.com/kunobi-ninja/kache";
+    license = lib.licenses.asl20;
+    mainProgram = "kache";
+  };
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1586,22 +1586,45 @@ pub fn doctor(
     });
 
     // 2. RUSTC_WRAPPER
-    let (wrapper_pass, wrapper_detail, wrapper_fix) = match std::env::var("RUSTC_WRAPPER") {
-        Ok(v) if v.contains("kache") => (true, "kache".into(), None),
-        Ok(v) if v.contains("sccache") => (
+    let (wrapper_pass, wrapper_detail, wrapper_fix) = match crate::wrapper_config::resolve_wrapper_setting() {
+        Some(crate::wrapper_config::WrapperSetting::Environment { value }) if value.contains("kache") => {
+            (true, "kache via env".into(), None)
+        }
+        Some(crate::wrapper_config::WrapperSetting::Environment { value })
+            if value.contains("sccache") =>
+        {
+            (
+                false,
+                format!("sccache ({value})"),
+                Some("export RUSTC_WRAPPER=kache".into()),
+            )
+        }
+        Some(crate::wrapper_config::WrapperSetting::Environment { value }) => (
             false,
-            format!("sccache ({v})"),
+            format!("{value} (not kache)"),
             Some("export RUSTC_WRAPPER=kache".into()),
         ),
-        Ok(v) => (
+        Some(crate::wrapper_config::WrapperSetting::CargoConfig { value, path })
+            if value.contains("kache") =>
+        {
+            (
+                true,
+                format!("kache via {}", crate::wrapper_config::display_path(&path)),
+                None,
+            )
+        }
+        Some(crate::wrapper_config::WrapperSetting::CargoConfig { value, path }) => (
             false,
-            format!("{v} (not kache)"),
-            Some("export RUSTC_WRAPPER=kache".into()),
+            format!("{value} in {}", crate::wrapper_config::display_path(&path)),
+            Some(format!(
+                "replace `rustc-wrapper = \"{value}\"` with `rustc-wrapper = \"kache\"` in {}",
+                path.display()
+            )),
         ),
-        Err(_) => (
+        None => (
             false,
             "not set".into(),
-            Some("add `export RUSTC_WRAPPER=kache` to ~/.zshrc".into()),
+            Some("set `build.rustc-wrapper = \"kache\"` in ~/.cargo/config.toml or export RUSTC_WRAPPER=kache".into()),
         ),
     };
     checks.push(Check {
@@ -1612,24 +1635,23 @@ pub fn doctor(
     });
 
     // 3. Cargo config
-    let mut cargo_pass = true;
-    let mut cargo_detail = "no conflicts".to_string();
-    let mut cargo_fix = None;
-    for name in ["config.toml", "config"] {
-        let cargo_config = home.join(".cargo").join(name);
-        if let Ok(content) = std::fs::read_to_string(&cargo_config) {
-            if content.contains("sccache") {
-                cargo_pass = false;
-                cargo_detail = format!("sccache in {}", cargo_config.display());
-                cargo_fix = Some(format!(
-                    "replace `rustc-wrapper = \"sccache\"` with `rustc-wrapper = \"kache\"` in {}",
-                    cargo_config.display()
-                ));
-            } else if content.contains("kache") {
-                cargo_detail = format!("kache in {}", cargo_config.display());
-            }
-        }
-    }
+    let (cargo_pass, cargo_detail, cargo_fix) = match crate::wrapper_config::cargo_wrapper_setting()
+    {
+        Some((value, path)) if value.contains("kache") => (
+            true,
+            format!("kache in {}", crate::wrapper_config::display_path(&path)),
+            None,
+        ),
+        Some((value, path)) => (
+            false,
+            format!("{value} in {}", crate::wrapper_config::display_path(&path)),
+            Some(format!(
+                "replace `rustc-wrapper = \"{value}\"` with `rustc-wrapper = \"kache\"` in {}",
+                path.display()
+            )),
+        ),
+        None => (true, "not set".to_string(), None),
+    };
     checks.push(Check {
         label: "Cargo config",
         pass: cargo_pass,

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,9 +225,10 @@ impl Config {
     }
 
     /// Load the raw file config without applying env overrides or defaults.
+    /// The config path still honors `KACHE_CONFIG`.
     /// Returns `(config, file_existed)`.
     pub(crate) fn load_raw_file_config() -> (FileConfig, bool) {
-        Self::load_raw_file_config_from(&config_file_path())
+        Self::load_raw_file_config_from(&resolve_config_path())
     }
 
     /// Load a raw FileConfig from an explicit path.
@@ -245,9 +246,10 @@ impl Config {
         }
     }
 
-    /// Serialize and write a FileConfig to the config file path.
+    /// Serialize and write a FileConfig to the active config path.
+    /// The config path still honors `KACHE_CONFIG`.
     pub(crate) fn save_file_config(config: &FileConfig) -> Result<()> {
-        Self::save_file_config_to(config, &config_file_path())
+        Self::save_file_config_to(config, &resolve_config_path())
     }
 
     /// Serialize and write a FileConfig to an explicit path.
@@ -364,8 +366,12 @@ pub(crate) fn default_cache_dir() -> PathBuf {
 /// Resolve the config file path to actually load from.
 /// Priority: `KACHE_CONFIG` env var > XDG user config.
 pub(crate) fn resolve_config_path() -> PathBuf {
-    if let Ok(p) = std::env::var("KACHE_CONFIG") {
-        return PathBuf::from(p);
+    resolve_config_path_from(std::env::var_os("KACHE_CONFIG").map(PathBuf::from))
+}
+
+fn resolve_config_path_from(kache_config: Option<PathBuf>) -> PathBuf {
+    if let Some(p) = kache_config {
+        return p;
     }
     config_file_path()
 }
@@ -398,6 +404,36 @@ pub(crate) fn parse_size(s: &str) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, OnceLock};
+
+    fn config_path_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    struct TestEnvGuard {
+        previous: Option<OsString>,
+    }
+
+    impl Drop for TestEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.previous.as_ref() {
+                    Some(value) => std::env::set_var("KACHE_CONFIG", value),
+                    None => std::env::remove_var("KACHE_CONFIG"),
+                }
+            }
+        }
+    }
+
+    fn set_kache_config_for_test(path: &std::path::Path) -> TestEnvGuard {
+        let previous = std::env::var_os("KACHE_CONFIG");
+        unsafe {
+            std::env::set_var("KACHE_CONFIG", path);
+        }
+        TestEnvGuard { previous }
+    }
 
     #[test]
     fn test_default_cache_dir() {
@@ -569,6 +605,38 @@ mod tests {
         let path = config_file_path();
         assert!(path.to_string_lossy().contains("kache"));
         assert!(path.to_string_lossy().ends_with("config.toml"));
+    }
+
+    #[test]
+    fn test_resolve_config_path_prefers_kache_config() {
+        let path = resolve_config_path_from(Some(PathBuf::from("/tmp/managed/config.toml")));
+        assert_eq!(path, PathBuf::from("/tmp/managed/config.toml"));
+    }
+
+    #[test]
+    fn test_load_and_save_raw_file_config_use_resolved_path() {
+        let _guard = config_path_lock();
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("managed/config.toml");
+        let _env_guard = set_kache_config_for_test(&config_path);
+
+        let config = FileConfig {
+            cache: Some(CacheFileConfig {
+                local_store: Some("/tmp/managed-cache".to_string()),
+                ..Default::default()
+            }),
+        };
+
+        Config::save_file_config(&config).unwrap();
+        assert!(config_path.exists());
+
+        let (loaded, existed) = Config::load_raw_file_config();
+        assert!(existed);
+        assert_eq!(
+            loaded.cache.as_ref().and_then(|c| c.local_store.as_deref()),
+            Some("/tmp/managed-cache")
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -261,7 +261,7 @@ impl Config {
     }
 
     fn load_file_config() -> Result<FileConfig> {
-        let config_path = config_file_path();
+        let config_path = resolve_config_path();
         if !config_path.exists() {
             return Ok(FileConfig::default());
         }
@@ -359,6 +359,15 @@ pub(crate) fn default_cache_dir() -> PathBuf {
     dirs::cache_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
         .join("kache")
+}
+
+/// Resolve the config file path to actually load from.
+/// Priority: `KACHE_CONFIG` env var > XDG user config.
+pub(crate) fn resolve_config_path() -> PathBuf {
+    if let Ok(p) = std::env::var("KACHE_CONFIG") {
+        return PathBuf::from(p);
+    }
+    config_file_path()
 }
 
 pub(crate) fn config_file_path() -> PathBuf {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@ use bytesize::ByteSize;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+pub const DEFAULT_DAEMON_IDLE_TIMEOUT_SECS: u64 = 10 * 60;
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub cache_dir: PathBuf,
@@ -17,7 +19,7 @@ pub struct Config {
     pub compression_level: i32,
     /// Max concurrent S3 operations (default 16).
     pub s3_concurrency: u32,
-    /// Daemon idle timeout in seconds (default 3600 = 1 hour). 0 = no timeout.
+    /// Daemon idle timeout in seconds (default 600 = 10 minutes). 0 = no timeout.
     pub daemon_idle_timeout_secs: u64,
 }
 
@@ -205,7 +207,7 @@ impl Config {
                     .and_then(|c| c.cache.as_ref())
                     .and_then(|c| c.daemon_idle_timeout_secs)
             })
-            .unwrap_or(3600);
+            .unwrap_or(DEFAULT_DAEMON_IDLE_TIMEOUT_SECS);
 
         let remote = Self::load_remote_config(&file_config);
 
@@ -535,7 +537,7 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
         assert_eq!(config.store_dir(), PathBuf::from("/tmp/kache/store"));
     }
@@ -553,7 +555,7 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
         assert_eq!(config.index_db_path(), PathBuf::from("/tmp/kache/index.db"));
     }
@@ -571,7 +573,7 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
         assert_eq!(
             config.event_log_path(),
@@ -592,7 +594,7 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
         assert_eq!(
             config.socket_path(),

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -11,8 +11,8 @@ use std::ops::Range;
 use std::time::Duration;
 
 use crate::config::{
-    CacheFileConfig, Config, EnvOverrides, FileConfig, RemoteFileConfig, config_file_path,
-    default_cache_dir, parse_size,
+    CacheFileConfig, Config, EnvOverrides, FileConfig, RemoteFileConfig, default_cache_dir,
+    parse_size, resolve_config_path,
 };
 
 // ── Field definitions ─────────────────────────────────────────────────────
@@ -882,7 +882,7 @@ fn draw_form(f: &mut ratatui::Frame, area: Rect, state: &mut EditorState) {
 }
 
 fn draw_footer(f: &mut ratatui::Frame, path_area: Rect, keys_area: Rect, state: &EditorState) {
-    let path = config_file_path();
+    let path = resolve_config_path();
     let path_str = path.to_string_lossy();
 
     let mut path_spans = vec![Span::styled(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2,8 +2,8 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
@@ -652,6 +652,7 @@ impl S3KeyCache {
 
 pub(crate) struct Daemon {
     config: Config,
+    store: OnceLock<Mutex<Store>>,
     s3_client: tokio::sync::OnceCell<aws_sdk_s3::Client>,
     key_cache: Arc<S3KeyCache>,
     s3_semaphore: Arc<tokio::sync::Semaphore>,
@@ -683,6 +684,7 @@ impl Daemon {
         let (warming_tx, _) = tokio::sync::watch::channel(false);
         let (prefetch_cancel, _) = tokio::sync::watch::channel(false);
         Self {
+            store: OnceLock::new(),
             s3_semaphore: Arc::new(tokio::sync::Semaphore::new(permits)),
             s3_client: tokio::sync::OnceCell::new(),
             key_cache: Arc::new(S3KeyCache::new()),
@@ -700,6 +702,31 @@ impl Daemon {
             recent_transfers: std::sync::Mutex::new(std::collections::VecDeque::new()),
             config,
         }
+    }
+
+    fn store_lock(&self) -> Result<&Mutex<Store>> {
+        if let Some(store) = self.store.get() {
+            return Ok(store);
+        }
+
+        let store = Store::open(&self.config)?;
+        let _ = self.store.set(Mutex::new(store));
+
+        self.store
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("daemon store failed to initialize"))
+    }
+
+    fn with_store<T>(&self, f: impl FnOnce(&Store) -> Result<T>) -> Result<T> {
+        let guard = self
+            .store_lock()?
+            .lock()
+            .map_err(|_| anyhow::anyhow!("daemon store mutex poisoned"))?;
+        f(&guard)
+    }
+
+    fn entry_dir_for(&self, cache_key: &str) -> PathBuf {
+        self.config.store_dir().join(cache_key)
     }
 
     /// Wait for the manifest prefetch to complete (or timeout).
@@ -772,33 +799,33 @@ impl Daemon {
 
     /// Handle a stats request — reads store and event log.
     pub fn handle_stats(&self, req: &StatsRequest) -> Response {
-        let store = match Store::open(&self.config) {
-            Ok(s) => s,
+        let (total_size, entry_count, entries) = match self.with_store(|store| {
+            let total_size = store.total_size().unwrap_or(0);
+            let entry_count = store.entry_count().unwrap_or(0);
+            let entries = if req.include_entries {
+                let sort = req.sort_by.as_deref().unwrap_or("size");
+                store.list_entries(sort).ok().map(|list| {
+                    list.into_iter()
+                        .map(|e| StatsEntry {
+                            cache_key: e.cache_key,
+                            crate_name: e.crate_name,
+                            crate_type: e.crate_type,
+                            profile: e.profile,
+                            size: e.size,
+                            hit_count: e.hit_count,
+                            created_at: e.created_at,
+                            last_accessed: e.last_accessed,
+                            content_hash: e.content_hash,
+                        })
+                        .collect()
+                })
+            } else {
+                None
+            };
+            Ok((total_size, entry_count, entries))
+        }) {
+            Ok(values) => values,
             Err(e) => return Response::err(format!("store open failed: {e}")),
-        };
-
-        let total_size = store.total_size().unwrap_or(0);
-        let entry_count = store.entry_count().unwrap_or(0);
-
-        let entries = if req.include_entries {
-            let sort = req.sort_by.as_deref().unwrap_or("size");
-            store.list_entries(sort).ok().map(|list| {
-                list.into_iter()
-                    .map(|e| StatsEntry {
-                        cache_key: e.cache_key,
-                        crate_name: e.crate_name,
-                        crate_type: e.crate_type,
-                        profile: e.profile,
-                        size: e.size,
-                        hit_count: e.hit_count,
-                        created_at: e.created_at,
-                        last_accessed: e.last_accessed,
-                        content_hash: e.content_hash,
-                    })
-                    .collect()
-            })
-        } else {
-            None
         };
 
         let hours = req.event_hours.unwrap_or(24);
@@ -1196,9 +1223,7 @@ impl Daemon {
                         .as_secs(),
                 });
                 // Commit to SQLite so store.get() can find it
-                if let Ok(store) = Store::open(&self.config)
-                    && let Err(e) = store.import_restored_entry(&req.key)
-                {
+                if let Err(e) = self.with_store(|store| store.import_restored_entry(&req.key)) {
                     tracing::warn!("failed to import downloaded entry {}: {e}", &req.key);
                 }
                 Response::found(true)
@@ -1264,16 +1289,11 @@ impl Daemon {
             return Response::err("S3 client init failed");
         }
 
-        let store = match Store::open(&self.config) {
-            Ok(s) => s,
-            Err(e) => return Response::err(format!("store open failed: {e}")),
-        };
-
         // Filter to keys that need downloading: (cache_key, crate_name, entry_dir)
         let mut keys_to_fetch: Vec<(String, String, PathBuf)> = Vec::new();
         let downloading_guard = self.downloading.read().await;
         for (key, crate_name) in &req.keys {
-            let entry_dir = store.entry_dir(key);
+            let entry_dir = self.entry_dir_for(key);
             if entry_dir.exists() {
                 continue;
             }
@@ -1297,7 +1317,7 @@ impl Daemon {
                 .await
         {
             for (key, crate_name) in s3_keys {
-                let entry_dir = store.entry_dir(&key);
+                let entry_dir = self.entry_dir_for(&key);
                 if !entry_dir.exists() {
                     keys_to_fetch.push((key, crate_name, entry_dir));
                 }
@@ -1420,8 +1440,7 @@ impl Daemon {
                                     .unwrap_or_default()
                                     .as_secs(),
                             });
-                            if let Ok(store) = Store::open(&d.config)
-                                && let Err(e) = store.import_restored_entry(&key)
+                            if let Err(e) = d.with_store(|store| store.import_restored_entry(&key))
                             {
                                 tracing::warn!("prefetch import failed for {}: {e}", key);
                             }
@@ -1485,13 +1504,8 @@ impl Daemon {
             return Response::err("no remote configured");
         };
 
-        let store = match Store::open(&self.config) {
-            Ok(s) => s,
-            Err(e) => return Response::err(format!("store open failed: {e}")),
-        };
-
         // 1. Try local SQLite first (has exact keys from previous builds)
-        let entries = match store.keys_for_crates(&req.crate_names) {
+        let entries = match self.with_store(|store| store.keys_for_crates(&req.crate_names)) {
             Ok(e) => e,
             Err(e) => return Response::err(format!("key lookup failed: {e}")),
         };
@@ -1515,7 +1529,7 @@ impl Daemon {
             for name in &unresolved {
                 let s3_keys = self.key_cache.keys_for_crate(name).await;
                 for key in s3_keys {
-                    let entry_dir = store.entry_dir(&key);
+                    let entry_dir = self.entry_dir_for(&key);
                     extra_entries.push((key, (*name).clone(), entry_dir));
                 }
             }
@@ -1570,46 +1584,59 @@ impl Daemon {
 
     /// After a successful upload, check if store exceeds max_size → LRU eviction.
     fn maybe_evict_after_upload(&self) {
-        if let Ok(store) = Store::open(&self.config)
-            && let Ok(size) = store.total_size()
-            && size > self.config.max_size
-        {
-            tracing::info!(
-                "store size {} > max {}, running LRU eviction",
-                size,
-                self.config.max_size
-            );
-            let _ = store.evict();
-        }
+        let _ = self.with_store(|store| {
+            let size = store.total_size()?;
+            if size > self.config.max_size {
+                tracing::info!(
+                    "store size {} > max {}, running LRU eviction",
+                    size,
+                    self.config.max_size
+                );
+                let _ = store.evict();
+            }
+            Ok(())
+        });
     }
 
-    /// Core GC logic: evict entries, clean stale tool-version caches, optionally clean incremental dirs.
+    /// Core GC logic: evict entries, clean stale tool-version caches, and clean registered incremental dirs.
     /// Returns aggregated GcStats and persists them to `gc_stats.json` in the cache dir.
     pub fn run_gc(&self, max_age_hours: Option<u64>) -> Result<crate::store::GcStats> {
         let start = Instant::now();
-        let store = Store::open(&self.config)?;
+        let (dedup_stats, evict_stats, incremental_cleaned) = self.with_store(|store| {
+            // Backfill content_hash for legacy entries
+            let backfilled = store.backfill_content_hashes().unwrap_or(0);
+            if backfilled > 0 {
+                tracing::info!("backfilled {backfilled} content hashes");
+            }
 
-        // Backfill content_hash for legacy entries
-        let backfilled = store.backfill_content_hashes().unwrap_or(0);
-        if backfilled > 0 {
-            tracing::info!("backfilled {backfilled} content hashes");
-        }
+            // Evict duplicate entries (same content, different cache keys)
+            let dedup_stats = store.evict_duplicate_entries().unwrap_or_default();
+            if dedup_stats.entries_evicted > 0 {
+                tracing::info!("evicted {} duplicate entries", dedup_stats.entries_evicted);
+            }
 
-        // Evict duplicate entries (same content, different cache keys)
-        let dedup_stats = store.evict_duplicate_entries().unwrap_or_default();
-        if dedup_stats.entries_evicted > 0 {
-            tracing::info!("evicted {} duplicate entries", dedup_stats.entries_evicted);
-        }
+            let evict_stats = if let Some(hours) = max_age_hours {
+                store.evict_older_than(hours)?
+            } else {
+                store.evict()?
+            };
 
-        let evict_stats = if let Some(hours) = max_age_hours {
-            store.evict_older_than(hours)?
-        } else {
-            store.evict()?
-        };
+            let incremental_cleaned = if self.config.clean_incremental {
+                store.clean_registered_incremental_dirs().unwrap_or(0)
+            } else {
+                0
+            };
+
+            Ok((dedup_stats, evict_stats, incremental_cleaned))
+        })?;
 
         // Clean up stale tool-version cache files (rustc-ver-*.txt, linker-ver-*.txt).
         // Each toolchain update leaves behind orphaned files keyed by the old binary mtime.
         Self::clean_tool_version_caches(&self.config.cache_dir);
+
+        if incremental_cleaned > 0 {
+            tracing::info!("cleaned {incremental_cleaned} registered incremental dirs");
+        }
 
         // Aggregate stats
         let stats = crate::store::GcStats {
@@ -3533,6 +3560,32 @@ mod tests {
         assert_eq!(stats.entries_evicted, 0);
     }
 
+    #[test]
+    fn test_run_gc_cleans_registered_incremental_dirs_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.clean_incremental = true;
+        let incremental_dir = dir.path().join("workspace/target/debug/incremental");
+        std::fs::create_dir_all(&incremental_dir).unwrap();
+        std::fs::write(incremental_dir.join("junk"), b"tmp").unwrap();
+
+        let store = Store::open(&config).unwrap();
+        store.remember_incremental_dir(&incremental_dir).unwrap();
+        drop(store);
+
+        let daemon = Daemon::new(config.clone());
+        let stats = daemon.run_gc(None).unwrap();
+        assert_eq!(stats.entries_evicted, 0);
+        assert!(!incremental_dir.exists());
+
+        std::fs::create_dir_all(&incremental_dir).unwrap();
+        std::fs::write(incremental_dir.join("junk"), b"tmp2").unwrap();
+
+        let stats = daemon.run_gc(None).unwrap();
+        assert_eq!(stats.entries_evicted, 0);
+        assert!(incremental_dir.exists());
+    }
+
     // ── Socket integration tests ─────────────────────────────────
 
     #[tokio::test]
@@ -3837,6 +3890,18 @@ mod tests {
         assert_eq!(stats.entries.unwrap().len(), 0);
         assert_eq!(stats.events.local_hits, 0);
         assert_eq!(stats.events.misses, 0);
+    }
+
+    #[test]
+    fn test_daemon_reuses_store_handle() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let daemon = Daemon::new(config);
+
+        let first = daemon.store_lock().unwrap() as *const _;
+        let second = daemon.store_lock().unwrap() as *const _;
+
+        assert_eq!(first, second);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1611,27 +1611,6 @@ impl Daemon {
         // Each toolchain update leaves behind orphaned files keyed by the old binary mtime.
         Self::clean_tool_version_caches(&self.config.cache_dir);
 
-        if self.config.clean_incremental
-            && let Ok(root) = std::env::current_dir()
-        {
-            let mut targets = Vec::new();
-            crate::cli::find_target_dirs(&root, &mut targets);
-
-            for t in &targets {
-                for profile in &t.profiles {
-                    let incr_dir = t.path.join(profile).join("incremental");
-                    let Ok(dirs) = std::fs::read_dir(&incr_dir) else {
-                        continue;
-                    };
-                    for entry in dirs.flatten() {
-                        if entry.path().is_dir() {
-                            let _ = std::fs::remove_dir_all(entry.path());
-                        }
-                    }
-                }
-            }
-        }
-
         // Aggregate stats
         let stats = crate::store::GcStats {
             entries_evicted: dedup_stats.entries_evicted + evict_stats.entries_evicted,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3051,7 +3051,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,24 +218,48 @@ pub(crate) fn diagnostic_log_path() -> PathBuf {
 
 const MAX_LOG_BYTES: u64 = 5 * 1024 * 1024; // 5 MB
 
-fn init_logging(is_wrapper: bool) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogMode {
+    Wrapper,
+    Cli,
+    TerminalUi,
+}
+
+fn detect_log_mode(env_args: &[String]) -> LogMode {
+    if env_args.len() >= 2 && args::looks_like_rustc(&env_args[1]) {
+        return LogMode::Wrapper;
+    }
+
+    match env_args.get(1).map(String::as_str) {
+        None | Some("monitor" | "config") => LogMode::TerminalUi,
+        _ => LogMode::Cli,
+    }
+}
+
+fn init_logging(mode: LogMode) {
     use std::sync::Mutex;
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::{EnvFilter, fmt};
 
-    // Stderr layer: controlled by KACHE_LOG env var, default warn.
-    // This is what appears in build output (wrapper) or gets captured by launchd (daemon).
-    let stderr_filter =
-        EnvFilter::try_from_env("KACHE_LOG").unwrap_or_else(|_| "kache=warn".parse().unwrap());
-    let stderr_layer = fmt::layer()
-        .with_writer(std::io::stderr)
-        .with_filter(stderr_filter);
+    // Interactive TUIs own the terminal, so background logs must not write to stderr
+    // while the alternate screen is active. File logging remains enabled for diagnostics.
+    let stderr_layer = if mode == LogMode::TerminalUi {
+        None
+    } else {
+        let stderr_filter =
+            EnvFilter::try_from_env("KACHE_LOG").unwrap_or_else(|_| "kache=warn".parse().unwrap());
+        Some(
+            fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_filter(stderr_filter),
+        )
+    };
 
     // File layer: persistent log at info level (overridable via KACHE_LOG_FILE).
     // Skipped in wrapper mode to avoid 2 extra syscalls (stat + open) per crate —
     // the daemon already captures all important events.  CLI/daemon mode gets
     // the file layer for diagnostics.
-    let file_layer = if is_wrapper {
+    let file_layer = if mode == LogMode::Wrapper {
         None
     } else {
         (|| -> Option<_> {
@@ -273,11 +297,12 @@ fn init_logging(is_wrapper: bool) {
 
 fn main() -> Result<()> {
     let env_args: Vec<String> = std::env::args().collect();
+    let log_mode = detect_log_mode(&env_args);
 
     // Detect RUSTC_WRAPPER mode: cargo passes the rustc path as arg[1]
     // In this mode: argv[0]=kache, argv[1]=rustc, argv[2..]=rustc args
-    let is_wrapper = env_args.len() >= 2 && args::looks_like_rustc(&env_args[1]);
-    init_logging(is_wrapper);
+    let is_wrapper = log_mode == LogMode::Wrapper;
+    init_logging(log_mode);
 
     if is_wrapper {
         return run_wrapper_mode(&env_args[1..]);
@@ -439,5 +464,26 @@ mod tests {
         assert_eq!(parse_duration_hours("1h"), Some(1));
         assert_eq!(parse_duration_hours("48"), Some(48));
         assert_eq!(parse_duration_hours("invalid"), None);
+    }
+
+    #[test]
+    fn test_detect_log_mode() {
+        assert_eq!(detect_log_mode(&["kache".into()]), LogMode::TerminalUi);
+        assert_eq!(
+            detect_log_mode(&["kache".into(), "monitor".into()]),
+            LogMode::TerminalUi
+        );
+        assert_eq!(
+            detect_log_mode(&["kache".into(), "config".into()]),
+            LogMode::TerminalUi
+        );
+        assert_eq!(
+            detect_log_mode(&["kache".into(), "stats".into()]),
+            LogMode::Cli
+        );
+        assert_eq!(
+            detect_log_mode(&["kache".into(), "rustc".into(), "--crate-name".into()]),
+            LogMode::Wrapper
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod shards;
 mod store;
 mod tui;
 mod wrapper;
+mod wrapper_config;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -382,7 +382,7 @@ fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{blob_path, create_entry_pack_zstd, extract_entry_pack};
-    use crate::config::Config;
+    use crate::config::{Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS};
     use crate::store::{EntryMeta, Store};
 
     #[test]
@@ -399,7 +399,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
         let store = Store::open(&config).unwrap();
 
@@ -454,7 +454,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
         let restore_store = Store::open(&restore_config).unwrap();
         let restore_entry_dir = restore_store.entry_dir("key123");

--- a/src/remote_plan.rs
+++ b/src/remote_plan.rs
@@ -73,7 +73,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::{RemoteLayoutKind, RemotePlanner, RemoteWorkload};
-    use crate::config::Config;
+    use crate::config::{Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS};
 
     fn test_config() -> Config {
         Config {
@@ -87,7 +87,7 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         }
     }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -1450,7 +1450,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
 
         // Write build events
@@ -1616,7 +1616,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
 
         // Only write build events, no transfers
@@ -1642,7 +1642,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
 
         // Mostly misses — should trigger high miss share suggestion
@@ -1721,7 +1721,7 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         };
 
         let report = generate_report(&config, 24, 10).unwrap();

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 
-const LABEL: &str = "com.zondax.kache";
-const PLIST_NAME: &str = "com.zondax.kache.plist";
+const LABEL: &str = "ninja.kunobi.kache";
+const PLIST_NAME: &str = "ninja.kunobi.kache.plist";
+const LEGACY_LABEL: &str = "com.zondax.kache";
+const LEGACY_PLIST_NAME: &str = "com.zondax.kache.plist";
 const UNIT_NAME: &str = "kache.service";
 
 // ── Path helpers ─────────────────────────────────────────────────
@@ -12,6 +14,13 @@ fn plist_path() -> PathBuf {
         .unwrap_or_default()
         .join("Library/LaunchAgents")
         .join(PLIST_NAME)
+}
+
+fn legacy_plist_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join("Library/LaunchAgents")
+        .join(LEGACY_PLIST_NAME)
 }
 
 fn unit_path() -> PathBuf {
@@ -38,6 +47,18 @@ fn log_dir() -> PathBuf {
         .join("Library/Logs/kache")
 }
 
+fn stop_launchd_service(uid: u32, label: &str, plist: &std::path::Path) {
+    let bootout = std::process::Command::new("launchctl")
+        .args(["bootout", &format!("gui/{uid}/{label}")])
+        .output();
+
+    if !matches!(bootout, Ok(out) if out.status.success()) {
+        let _ = std::process::Command::new("launchctl")
+            .args(["unload", &plist.display().to_string()])
+            .output();
+    }
+}
+
 // ── Install ──────────────────────────────────────────────────────
 
 pub fn install() -> Result<()> {
@@ -59,14 +80,18 @@ pub fn install() -> Result<()> {
 
 fn install_launchd(exe: &std::path::Path) -> Result<()> {
     let plist = plist_path();
+    let legacy_plist = legacy_plist_path();
     let uid = unsafe { libc::getuid() };
 
     // If already installed, stop old service first
-    if plist.exists() {
+    if plist.exists() || legacy_plist.exists() {
         println!("Existing service found — upgrading in place...");
-        let _ = std::process::Command::new("launchctl")
-            .args(["bootout", &format!("gui/{uid}/{LABEL}")])
-            .output();
+        stop_launchd_service(uid, LABEL, &plist);
+        stop_launchd_service(uid, LEGACY_LABEL, &legacy_plist);
+    }
+
+    if legacy_plist.exists() {
+        std::fs::remove_file(&legacy_plist).context("removing legacy plist")?;
     }
 
     // Ensure directories exist
@@ -237,31 +262,34 @@ pub fn uninstall() -> Result<()> {
 
 fn uninstall_launchd() -> Result<()> {
     let plist = plist_path();
+    let legacy_plist = legacy_plist_path();
     let uid = unsafe { libc::getuid() };
+    let had_plist = plist.exists();
+    let had_legacy_plist = legacy_plist.exists();
 
-    if !plist.exists() {
+    if !had_plist && !had_legacy_plist {
         println!("Service is not installed (no plist found).");
         return Ok(());
     }
 
-    // Stop — try modern API first, fall back to legacy
-    let bootout = std::process::Command::new("launchctl")
-        .args(["bootout", &format!("gui/{uid}/{LABEL}")])
-        .output();
+    stop_launchd_service(uid, LABEL, &plist);
+    stop_launchd_service(uid, LEGACY_LABEL, &legacy_plist);
 
-    match bootout {
-        Ok(out) if out.status.success() => {}
-        _ => {
-            let _ = std::process::Command::new("launchctl")
-                .args(["unload", &plist.display().to_string()])
-                .output();
-        }
+    if had_plist {
+        std::fs::remove_file(&plist).context("removing plist")?;
     }
 
-    std::fs::remove_file(&plist).context("removing plist")?;
+    if had_legacy_plist {
+        std::fs::remove_file(&legacy_plist).context("removing legacy plist")?;
+    }
 
     println!("Service stopped and removed.");
-    println!("  removed: {}", plist.display());
+    if had_plist {
+        println!("  removed: {}", plist.display());
+    }
+    if had_legacy_plist {
+        println!("  removed: {}", legacy_plist.display());
+    }
     Ok(())
 }
 
@@ -293,6 +321,21 @@ fn uninstall_systemd() -> Result<()> {
 pub fn status() -> Result<()> {
     let config = crate::config::Config::load().ok();
     let service_path = service_file_path();
+    let installed_service_path = service_path
+        .as_ref()
+        .and_then(|path| path.exists().then(|| path.clone()))
+        .or_else(|| {
+            if cfg!(target_os = "macos") {
+                let legacy_path = legacy_plist_path();
+                legacy_path.exists().then_some(legacy_path)
+            } else {
+                None
+            }
+        });
+    let legacy_service_installed = installed_service_path
+        .as_ref()
+        .and_then(|path| path.file_name().and_then(|name| name.to_str()))
+        == Some(LEGACY_PLIST_NAME);
 
     // 0. Binary version (always shown)
     println!(
@@ -302,13 +345,13 @@ pub fn status() -> Result<()> {
     );
 
     // 1. Service file installed?
-    let installed = service_path.as_ref().map(|p| p.exists()).unwrap_or(false);
-
-    if installed {
-        println!(
-            "  Service:  \x1b[32minstalled\x1b[0m ({})",
-            service_path.as_ref().unwrap().display()
-        );
+    if let Some(ref path) = installed_service_path {
+        println!("  Service:  \x1b[32minstalled\x1b[0m ({})", path.display());
+        if legacy_service_installed {
+            println!(
+                "            \x1b[33mlegacy label detected — run `kache daemon install` to migrate to {LABEL}\x1b[0m"
+            );
+        }
     } else if service_path.is_some() {
         println!("  Service:  \x1b[33mnot installed\x1b[0m");
         println!("            run `kache daemon install` to set up");
@@ -371,7 +414,7 @@ pub fn status() -> Result<()> {
     }
 
     // 6. Exe path mismatch warning
-    if installed && let Some(ref path) = service_path {
+    if let Some(ref path) = installed_service_path {
         let current_exe = std::env::current_exe()
             .ok()
             .and_then(|p| p.canonicalize().ok());
@@ -494,7 +537,7 @@ mod tests {
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.zondax.kache</string>
+    <string>ninja.kunobi.kache</string>
     <key>ProgramArguments</key>
     <array>
         <string>/usr/local/bin/kache</string>
@@ -553,12 +596,12 @@ WantedBy=default.target
 
     #[test]
     fn test_label_constant() {
-        assert_eq!(LABEL, "com.zondax.kache");
+        assert_eq!(LABEL, "ninja.kunobi.kache");
     }
 
     #[test]
     fn test_plist_name_constant() {
-        assert_eq!(PLIST_NAME, "com.zondax.kache.plist");
+        assert_eq!(PLIST_NAME, "ninja.kunobi.kache.plist");
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -145,6 +145,13 @@ fn initialize_db(db: &Connection) -> rusqlite::Result<()> {
         );",
     )?;
 
+    db.execute_batch(
+        "CREATE TABLE IF NOT EXISTS incremental_dirs (
+            path      TEXT PRIMARY KEY,
+            last_seen TEXT NOT NULL DEFAULT (datetime('now'))
+        );",
+    )?;
+
     Ok(())
 }
 
@@ -653,6 +660,70 @@ impl Store {
         Ok(count as usize)
     }
 
+    /// Remember an incremental compilation directory seen by the wrapper.
+    pub fn remember_incremental_dir(&self, path: &Path) -> Result<()> {
+        let path = path.to_string_lossy().into_owned();
+        self.db.execute(
+            "INSERT OR REPLACE INTO incremental_dirs (path, last_seen) VALUES (?1, datetime('now'))",
+            params![path],
+        )?;
+        Ok(())
+    }
+
+    /// Remove registered incremental directories and prune stale registry rows.
+    pub fn clean_registered_incremental_dirs(&self) -> Result<usize> {
+        let paths: Vec<String> = {
+            let mut stmt = self
+                .db
+                .prepare("SELECT path FROM incremental_dirs ORDER BY last_seen ASC")?;
+            stmt.query_map([], |row| row.get(0))?
+                .collect::<Result<Vec<_>, _>>()?
+        };
+
+        let mut cleaned = 0;
+        for path_str in paths {
+            let path = PathBuf::from(&path_str);
+            if !path.exists() {
+                self.db.execute(
+                    "DELETE FROM incremental_dirs WHERE path = ?1",
+                    params![path_str],
+                )?;
+                continue;
+            }
+
+            if !path.is_dir() {
+                tracing::warn!(
+                    "registered incremental path is not a directory, pruning: {}",
+                    path.display()
+                );
+                self.db.execute(
+                    "DELETE FROM incremental_dirs WHERE path = ?1",
+                    params![path_str],
+                )?;
+                continue;
+            }
+
+            match fs::remove_dir_all(&path) {
+                Ok(()) => {
+                    self.db.execute(
+                        "DELETE FROM incremental_dirs WHERE path = ?1",
+                        params![path_str],
+                    )?;
+                    cleaned += 1;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "failed to remove registered incremental dir {}: {}",
+                        path.display(),
+                        e
+                    );
+                }
+            }
+        }
+
+        Ok(cleaned)
+    }
+
     /// Weighted eviction: remove entries with lowest priority score until under the size limit.
     /// Prefers evicting large, old, rarely-accessed entries.
     /// Evicts down to 90% of max_size to create headroom and avoid boundary thrashing.
@@ -876,6 +947,7 @@ impl Store {
         }
         self.db.execute("DELETE FROM entries", [])?;
         self.db.execute("DELETE FROM blobs", [])?;
+        self.db.execute("DELETE FROM incremental_dirs", [])?;
         Ok(())
     }
 
@@ -1226,6 +1298,43 @@ mod tests {
         let stats = store.evict().unwrap();
         assert!(stats.entries_evicted > 0);
         assert!(!store.contains("key1"));
+    }
+
+    #[test]
+    fn test_incremental_dir_registry_deduplicates_and_cleans() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let incremental_dir = dir.path().join("target/debug/incremental");
+        std::fs::create_dir_all(&incremental_dir).unwrap();
+        std::fs::write(incremental_dir.join("junk"), b"tmp").unwrap();
+
+        store.remember_incremental_dir(&incremental_dir).unwrap();
+        store.remember_incremental_dir(&incremental_dir).unwrap();
+        store
+            .remember_incremental_dir(&dir.path().join("missing/incremental"))
+            .unwrap();
+
+        let count_before: i64 = store
+            .db
+            .query_row("SELECT COUNT(*) FROM incremental_dirs", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count_before, 2);
+
+        let cleaned = store.clean_registered_incremental_dirs().unwrap();
+        assert_eq!(cleaned, 1);
+        assert!(!incremental_dir.exists());
+
+        let count_after: i64 = store
+            .db
+            .query_row("SELECT COUNT(*) FROM incremental_dirs", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count_after, 0);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -1210,7 +1210,7 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
-            daemon_idle_timeout_secs: 3600,
+            daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -26,6 +26,10 @@ enum Tab {
     Transfer,
 }
 
+fn tab_needs_entries(tab: Tab) -> bool {
+    matches!(tab, Tab::Store)
+}
+
 // ── Sort mode (shared between tabs) ────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy)]
@@ -134,6 +138,7 @@ struct AppState {
     rustc_version_slot: Arc<Mutex<Option<String>>>,
     stats_result_slot: Arc<Mutex<Option<StatsSnapshot>>>,
     stats_fetch_in_flight: bool,
+    stats_fetch_requested_entries: bool,
 
     should_quit: bool,
     rustc_version: String,
@@ -218,6 +223,7 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
         rustc_version_slot: Arc::clone(&rustc_version_slot),
         stats_result_slot: Arc::clone(&stats_result_slot),
         stats_fetch_in_flight: false,
+        stats_fetch_requested_entries: false,
         should_quit: false,
         rustc_version: "\u{2026}".to_string(), // placeholder until background thread completes
         service_installed,
@@ -240,6 +246,15 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
         if let Ok(mut slot) = state.stats_result_slot.lock()
             && let Some(new_snap) = slot.take()
         {
+            let previous_entries = if state.stats_fetch_requested_entries {
+                Vec::new()
+            } else {
+                std::mem::take(&mut state.stats_snapshot.entries)
+            };
+            let mut new_snap = new_snap;
+            if !state.stats_fetch_requested_entries {
+                new_snap.entries = previous_entries;
+            }
             let old_up = state.stats_snapshot.bytes_uploaded;
             let old_down = state.stats_snapshot.bytes_downloaded;
             let interval = SNAPSHOT_REFRESH_INTERVAL.as_secs_f64();
@@ -261,9 +276,11 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
             state.last_stats_fetch = Instant::now();
             let cfg = state.config.clone();
             let sort = state.sort_mode.label().to_string();
+            let include_entries = tab_needs_entries(state.active_tab);
+            state.stats_fetch_requested_entries = include_entries;
             let slot = Arc::clone(&state.stats_result_slot);
             std::thread::spawn(move || {
-                let snap = fetch_stats(&cfg, true, &sort);
+                let snap = fetch_stats(&cfg, include_entries, &sort);
                 if let Ok(mut s) = slot.lock() {
                     *s = Some(snap);
                 }
@@ -373,14 +390,20 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
             state.active_tab = Tab::Projects;
             state.last_project_refresh = Instant::now() - PROJECT_REFRESH_INTERVAL;
         }
-        KeyCode::Char('3') => state.active_tab = Tab::Store,
+        KeyCode::Char('3') => {
+            state.active_tab = Tab::Store;
+            state.last_stats_fetch = Instant::now() - SNAPSHOT_REFRESH_INTERVAL;
+        }
         KeyCode::Char('4') => state.active_tab = Tab::Transfer,
         KeyCode::BackTab | KeyCode::Tab => match state.active_tab {
             Tab::Build => {
                 state.active_tab = Tab::Projects;
                 state.last_project_refresh = Instant::now() - PROJECT_REFRESH_INTERVAL;
             }
-            Tab::Projects => state.active_tab = Tab::Store,
+            Tab::Projects => {
+                state.active_tab = Tab::Store;
+                state.last_stats_fetch = Instant::now() - SNAPSHOT_REFRESH_INTERVAL;
+            }
             Tab::Store => state.active_tab = Tab::Transfer,
             Tab::Transfer => state.active_tab = Tab::Build,
         },
@@ -407,6 +430,7 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
         // Store tab
         KeyCode::Char('s') if state.active_tab == Tab::Store => {
             state.sort_mode = state.sort_mode.next();
+            state.last_stats_fetch = Instant::now() - SNAPSHOT_REFRESH_INTERVAL;
         }
         KeyCode::Char('f') if state.active_tab == Tab::Store => {
             state.filter_active = true;
@@ -416,6 +440,19 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
             state.last_project_refresh = Instant::now() - PROJECT_REFRESH_INTERVAL;
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tab_needs_entries_only_for_store() {
+        assert!(!tab_needs_entries(Tab::Build));
+        assert!(!tab_needs_entries(Tab::Projects));
+        assert!(tab_needs_entries(Tab::Store));
+        assert!(!tab_needs_entries(Tab::Transfer));
     }
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -555,11 +555,7 @@ fn draw_stats_bar(frame: &mut Frame, state: &AppState, area: Rect) {
         "not configured"
     };
 
-    let wrapper_status = match std::env::var("RUSTC_WRAPPER") {
-        Ok(v) if v.contains("kache") => "RUSTC_WRAPPER=kache ✓".to_string(),
-        Ok(v) => format!("RUSTC_WRAPPER={v} (not kache!)"),
-        Err(_) => "RUSTC_WRAPPER not set ✗".to_string(),
-    };
+    let wrapper_status = crate::wrapper_config::wrapper_status_line();
 
     let kache_version = crate::VERSION;
 
@@ -1013,11 +1009,7 @@ fn draw_projects_overview(frame: &mut Frame, state: &AppState, area: Rect) {
         "n/a".to_string()
     };
 
-    let wrapper_status = match std::env::var("RUSTC_WRAPPER") {
-        Ok(v) if v.contains("kache") => "RUSTC_WRAPPER=kache ✓".to_string(),
-        Ok(v) => format!("RUSTC_WRAPPER={v} (not kache!)"),
-        Err(_) => "RUSTC_WRAPPER not set ✗".to_string(),
-    };
+    let wrapper_status = crate::wrapper_config::wrapper_status_line();
 
     let remote_status = if let Some(remote) = &state.config.remote {
         format!("S3: {}", remote.bucket)

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -66,6 +66,29 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     // Parse the rustc arguments (wrapper_args[0] is the rustc path)
     let args = RustcArgs::parse(wrapper_args).context("parsing rustc arguments")?;
+    let store = if args.is_primary || (config.clean_incremental && args.incremental.is_some()) {
+        match Store::open(config) {
+            Ok(store) => Some(store),
+            Err(e) => {
+                tracing::warn!("failed to open store: {}", e);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    if config.clean_incremental
+        && let Some(incr_dir) = &args.incremental
+        && let Some(store) = &store
+        && let Err(e) = store.remember_incremental_dir(incr_dir)
+    {
+        tracing::warn!(
+            "failed to register incremental dir {}: {}",
+            incr_dir.display(),
+            e
+        );
+    }
 
     // If this isn't a primary compilation (no source file), just pass through to rustc
     if !args.is_primary {
@@ -107,13 +130,9 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     tracing::debug!("cache key for {}: {}", crate_name, &cache_key[..16]);
 
-    // Open the store
-    let store = match Store::open(config) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!("failed to open store: {}", e);
-            return passthrough(&args);
-        }
+    let store = match store {
+        Some(store) => store,
+        None => return passthrough(&args),
     };
 
     // 1. Check local store

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -156,6 +156,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             if !meta.stderr.is_empty() {
                 eprint!("{}", meta.stderr);
             }
+            clean_incremental_dir(config, &args);
             return Ok(0);
         }
     }
@@ -211,6 +212,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                     if !meta.stderr.is_empty() {
                         eprint!("{}", meta.stderr);
                     }
+                    clean_incremental_dir(config, &args);
                     return Ok(0);
                 }
             }
@@ -246,6 +248,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                         restore_ms,
                         0,
                     );
+                    clean_incremental_dir(config, &args);
                     return Ok(0);
                 }
             }
@@ -337,18 +340,8 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         }
     }
 
-    // 7. Clean incremental dir — with kache caching, incremental compilation is redundant
-    if config.clean_incremental
-        && let Some(incr_dir) = &args.incremental
-        && incr_dir.is_dir()
-        && let Err(e) = std::fs::remove_dir_all(incr_dir)
-    {
-        tracing::debug!(
-            "failed to clean incremental dir {}: {}",
-            incr_dir.display(),
-            e
-        );
-    }
+    // 7. Clean incremental dir, as with kache's caching, incremental compilation is redundant
+    clean_incremental_dir(config, &args);
 
     let elapsed = start.elapsed().as_millis() as u64;
     let size: u64 = result
@@ -706,4 +699,20 @@ fn get_all_crate_names_bfs() -> Option<Vec<String>> {
     }
 
     Some(ordered_names)
+}
+
+/// Remove the incremental compilation directory for this crate.
+/// With kache caching, incremental compilation is redundant and the dirs waste disk space.
+fn clean_incremental_dir(config: &Config, args: &RustcArgs) {
+    if config.clean_incremental
+        && let Some(incr_dir) = &args.incremental
+        && incr_dir.is_dir()
+        && let Err(e) = std::fs::remove_dir_all(incr_dir)
+    {
+        tracing::debug!(
+            "failed to clean incremental dir {}: {}",
+            incr_dir.display(),
+            e
+        );
+    }
 }

--- a/src/wrapper_config.rs
+++ b/src/wrapper_config.rs
@@ -1,0 +1,246 @@
+use serde::Deserialize;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+const CARGO_CONFIG_NAMES: [&str; 2] = ["config.toml", "config"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum WrapperSetting {
+    Environment { value: String },
+    CargoConfig { value: String, path: PathBuf },
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoConfigFile {
+    build: Option<CargoBuildConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoBuildConfig {
+    #[serde(rename = "rustc-wrapper")]
+    rustc_wrapper: Option<String>,
+}
+
+pub(crate) fn resolve_wrapper_setting() -> Option<WrapperSetting> {
+    resolve_wrapper_setting_from(
+        std::env::var_os("RUSTC_WRAPPER"),
+        std::env::current_dir().ok().as_deref(),
+        std::env::var_os("CARGO_HOME").map(PathBuf::from),
+        dirs::home_dir(),
+    )
+}
+
+pub(crate) fn cargo_wrapper_setting() -> Option<(String, PathBuf)> {
+    cargo_wrapper_setting_from(
+        std::env::current_dir().ok().as_deref(),
+        std::env::var_os("CARGO_HOME").map(PathBuf::from),
+        dirs::home_dir(),
+    )
+}
+
+pub(crate) fn wrapper_status_line() -> String {
+    match resolve_wrapper_setting() {
+        Some(WrapperSetting::Environment { value }) if value.contains("kache") => {
+            "RUSTC_WRAPPER=kache ✓".to_string()
+        }
+        Some(WrapperSetting::Environment { value }) => {
+            format!("RUSTC_WRAPPER={value} (not kache!)")
+        }
+        Some(WrapperSetting::CargoConfig { value, path }) if value.contains("kache") => {
+            format!("rustc-wrapper=kache via {} ✓", display_path(&path))
+        }
+        Some(WrapperSetting::CargoConfig { value, path }) => {
+            format!(
+                "rustc-wrapper={value} in {} (not kache!)",
+                display_path(&path)
+            )
+        }
+        None => "rustc-wrapper not configured ✗".to_string(),
+    }
+}
+
+pub(crate) fn display_path(path: &Path) -> String {
+    if let Some(home) = dirs::home_dir()
+        && let Ok(stripped) = path.strip_prefix(&home)
+    {
+        return format!("~/{}", stripped.display());
+    }
+    path.display().to_string()
+}
+
+fn resolve_wrapper_setting_from(
+    rustc_wrapper_env: Option<OsString>,
+    current_dir: Option<&Path>,
+    cargo_home: Option<PathBuf>,
+    home: Option<PathBuf>,
+) -> Option<WrapperSetting> {
+    if let Some(value) = rustc_wrapper_env {
+        return Some(WrapperSetting::Environment {
+            value: value.to_string_lossy().into_owned(),
+        });
+    }
+
+    cargo_wrapper_setting_from(current_dir, cargo_home, home)
+        .map(|(value, path)| WrapperSetting::CargoConfig { value, path })
+}
+
+fn cargo_wrapper_setting_from(
+    current_dir: Option<&Path>,
+    cargo_home: Option<PathBuf>,
+    home: Option<PathBuf>,
+) -> Option<(String, PathBuf)> {
+    let mut resolved = None;
+    for path in cargo_config_candidates(current_dir, cargo_home, home) {
+        if let Some(value) = read_rustc_wrapper_from_config(&path) {
+            resolved = Some((value, path));
+        }
+    }
+    resolved
+}
+
+fn cargo_config_candidates(
+    current_dir: Option<&Path>,
+    cargo_home: Option<PathBuf>,
+    home: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(cargo_home) = cargo_home.or_else(|| home.clone().map(|home| home.join(".cargo"))) {
+        push_config_candidates(&cargo_home, &mut candidates);
+    }
+
+    if let Some(current_dir) = current_dir {
+        let mut ancestors: Vec<&Path> = current_dir.ancestors().collect();
+        ancestors.reverse();
+        for ancestor in ancestors {
+            push_config_candidates(&ancestor.join(".cargo"), &mut candidates);
+        }
+    }
+
+    candidates
+}
+
+fn push_config_candidates(config_dir: &Path, candidates: &mut Vec<PathBuf>) {
+    for name in CARGO_CONFIG_NAMES {
+        let path = config_dir.join(name);
+        if path.exists() && !candidates.iter().any(|candidate| candidate == &path) {
+            candidates.push(path);
+        }
+    }
+}
+
+fn read_rustc_wrapper_from_config(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let parsed: CargoConfigFile = toml::from_str(&content).ok()?;
+    parsed.build?.rustc_wrapper
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_wrapper_takes_precedence_over_cargo_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let cargo_home = dir.path().join(".cargo");
+        std::fs::create_dir_all(&cargo_home).unwrap();
+        std::fs::write(
+            cargo_home.join("config.toml"),
+            "[build]\nrustc-wrapper = \"kache\"\n",
+        )
+        .unwrap();
+
+        let setting = resolve_wrapper_setting_from(
+            Some(OsString::from("sccache")),
+            Some(dir.path()),
+            Some(cargo_home),
+            Some(dir.path().to_path_buf()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            setting,
+            WrapperSetting::Environment {
+                value: "sccache".into()
+            }
+        );
+    }
+
+    #[test]
+    fn cargo_config_falls_back_to_home_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let cargo_home = dir.path().join(".cargo");
+        std::fs::create_dir_all(&cargo_home).unwrap();
+        std::fs::write(
+            cargo_home.join("config.toml"),
+            "[build]\nrustc-wrapper = \"kache\"\n",
+        )
+        .unwrap();
+
+        let setting = resolve_wrapper_setting_from(
+            None,
+            Some(dir.path()),
+            Some(cargo_home.clone()),
+            Some(dir.path().to_path_buf()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            setting,
+            WrapperSetting::CargoConfig {
+                value: "kache".into(),
+                path: cargo_home.join("config.toml"),
+            }
+        );
+    }
+
+    #[test]
+    fn nearest_project_cargo_config_overrides_home_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let project = dir.path().join("workspace/project");
+        std::fs::create_dir_all(home.join(".cargo")).unwrap();
+        std::fs::create_dir_all(project.join(".cargo")).unwrap();
+        std::fs::write(
+            home.join(".cargo/config.toml"),
+            "[build]\nrustc-wrapper = \"sccache\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            project.join(".cargo/config.toml"),
+            "[build]\nrustc-wrapper = \"kache\"\n",
+        )
+        .unwrap();
+
+        let setting = cargo_wrapper_setting_from(None, None, Some(home.clone()));
+        assert_eq!(
+            setting,
+            Some(("sccache".into(), home.join(".cargo/config.toml")))
+        );
+
+        let setting = cargo_wrapper_setting_from(Some(&project), None, Some(home));
+        assert_eq!(
+            setting,
+            Some(("kache".into(), project.join(".cargo/config.toml")))
+        );
+    }
+
+    #[test]
+    fn status_line_reports_cargo_config_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let cargo_home = dir.path().join(".cargo");
+        std::fs::create_dir_all(&cargo_home).unwrap();
+        let config_path = cargo_home.join("config.toml");
+        std::fs::write(&config_path, "[build]\nrustc-wrapper = \"kache\"\n").unwrap();
+
+        let setting = cargo_wrapper_setting_from(
+            Some(dir.path()),
+            Some(cargo_home),
+            Some(dir.path().to_path_buf()),
+        )
+        .unwrap();
+
+        assert_eq!(setting.0, "kache");
+        assert!(display_path(&config_path).ends_with(".cargo/config.toml"));
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18,6 +18,11 @@ fn build_kache() {
     assert!(status.success(), "kache build failed");
 }
 
+fn isolated_config_path(cache_dir: &Path) -> PathBuf {
+    // Prevent tests from inheriting the developer's real ~/.config/kache/config.toml.
+    cache_dir.join("config.toml")
+}
+
 #[test]
 fn test_cli_help() {
     build_kache();
@@ -36,6 +41,7 @@ fn test_cli_list_empty() {
     Command::new(kache_binary())
         .arg("list")
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .assert()
         .success()
         .stdout(predicates::str::contains("No cached entries"));
@@ -49,6 +55,7 @@ fn test_cli_purge_empty() {
     Command::new(kache_binary())
         .arg("purge")
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .assert()
         .success()
         .stdout(predicates::str::contains("Cleared"));
@@ -69,6 +76,7 @@ fn test_disabled_passthrough() {
         .env("RUSTC_WRAPPER", kache_binary())
         .env("KACHE_DISABLED", "1")
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .env("CARGO_TARGET_DIR", target_dir.path())
         .status()
         .expect("failed to run cargo build with kache disabled");
@@ -93,6 +101,7 @@ fn test_wrapper_hello_world() {
         .current_dir(&test_project)
         .env("RUSTC_WRAPPER", kache_binary())
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .env("CARGO_TARGET_DIR", target_dir.path())
         .env("KACHE_LOG", "kache=debug")
         .status()
@@ -129,6 +138,7 @@ fn test_wrapper_hello_world() {
         .current_dir(&test_project)
         .env("RUSTC_WRAPPER", kache_binary())
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .env("CARGO_TARGET_DIR", target_dir.path())
         .env("KACHE_LOG", "kache=debug")
         .status()

--- a/tests/stale_artifact_test.rs
+++ b/tests/stale_artifact_test.rs
@@ -19,6 +19,11 @@ fn build_kache() {
     assert!(status.success(), "kache build failed");
 }
 
+fn isolated_config_path(cache_dir: &Path) -> PathBuf {
+    // Prevent tests from inheriting the developer's real ~/.config/kache/config.toml.
+    cache_dir.join("config.toml")
+}
+
 /// Recursively copies a directory.
 fn copy_dir(src: &Path, dst: &Path) {
     std::fs::create_dir_all(dst).unwrap();
@@ -55,6 +60,7 @@ fn build_and_run(
         .current_dir(project)
         .env("RUSTC_WRAPPER", kache_binary())
         .env("KACHE_CACHE_DIR", cache_dir)
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
         .env("CARGO_TARGET_DIR", target_dir)
         .env("CARGO_INCREMENTAL", "0")
         .env("KACHE_LOG", "kache=debug");
@@ -461,6 +467,7 @@ fn stale_concurrent_builds_safe() {
         .current_dir(project.path())
         .env("RUSTC_WRAPPER", &kache)
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .env("CARGO_TARGET_DIR", target1.path())
         .env("CARGO_INCREMENTAL", "0")
         .spawn()
@@ -471,6 +478,7 @@ fn stale_concurrent_builds_safe() {
         .current_dir(project.path())
         .env("RUSTC_WRAPPER", &kache)
         .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
         .env("CARGO_TARGET_DIR", target2.path())
         .env("CARGO_INCREMENTAL", "0")
         .spawn()


### PR DESCRIPTION
## Summary
- bring the current dev line to main, including the recent daemon lifecycle hardening and wrapper-status fixes
- include the config/TUI ownership cleanup from #16 and the nix/home-manager support from #14
- ship the macOS launchd label migration to `ninja.kunobi.kache`, the 10-minute daemon idle default, and correct wrapper detection when Cargo is configured via `rustc-wrapper`

## Included PRs
- #18 Fix wrapper status detection from Cargo config
- #17 Tighten daemon lifecycle defaults and migrate the macOS launchd label
- #16 refactor: tighten config ownership and reduce daemon/TUI overhead
- #14 feat(nix): flake and hm module
