### PR TITLE
feat: remote health circuit breaker and S3 error diagnostics

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+target
+.DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
           env: "false"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: azure/setup-helm@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy

--- a/.github/workflows/service-image.yml
+++ b/.github/workflows/service-image.yml
@@ -1,0 +1,45 @@
+name: Service Image
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release:
+    name: Build Service Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive release metadata
+        id: meta
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "build_version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Push service image
+        env:
+          REGISTRY: ghcr.io/${{ github.repository_owner }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          IMAGE_TAG: ${{ steps.meta.outputs.image_tag }}
+          BUILD_VERSION: ${{ steps.meta.outputs.build_version }}
+          BUILD_COMMIT: ${{ github.sha }}
+          BUILD_DATE: ${{ steps.meta.outputs.build_date }}
+        run: docker buildx bake -f docker-bake.hcl release

--- a/.github/workflows/service-image.yml
+++ b/.github/workflows/service-image.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: jdx/mise-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
@@ -42,4 +46,4 @@ jobs:
           BUILD_VERSION: ${{ steps.meta.outputs.build_version }}
           BUILD_COMMIT: ${{ github.sha }}
           BUILD_DATE: ${{ steps.meta.outputs.build_date }}
-        run: docker buildx bake -f docker-bake.hcl release
+        run: just image-service-release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,12 +2039,14 @@ name = "kache-service"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "clap",
  "http-body-util",
  "kache-core",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tower",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +584,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,7 +990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -938,7 +1001,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1139,7 +1202,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1204,7 +1267,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1395,8 +1458,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1406,9 +1471,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1431,7 +1498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1628,6 +1695,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1666,6 +1734,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1870,6 +1939,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,6 +1995,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "async-trait",
  "aws-config",
  "aws-sdk-s3",
  "blake3",
@@ -1926,9 +2006,11 @@ dependencies = [
  "dirs",
  "filetime",
  "futures",
+ "kache-core",
  "libc",
  "predicates",
  "ratatui",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1939,6 +2021,34 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zstd",
+]
+
+[[package]]
+name = "kache-core"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "kache-service"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "http-body-util",
+ "kache-core",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2050,6 +2160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2183,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -2098,6 +2220,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -2348,7 +2476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2423,6 +2551,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2472,6 +2609,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "socket2 0.6.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,7 +2684,27 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2502,6 +2714,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2654,6 +2875,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,6 +2963,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2745,6 +3010,7 @@ checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.9",
  "subtle",
@@ -2769,6 +3035,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2918,12 +3185,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3001,7 +3291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3135,6 +3425,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -3333,6 +3632,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3437,6 +3751,30 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3459,6 +3797,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3704,6 +4043,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3767,6 +4120,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4215,6 +4597,26 @@ dependencies = [
  "quote",
  "syn 2.0.116",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,21 @@ license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"
 rust-version = "1.93"
 
+[workspace]
+members = ["crates/kache-core", "crates/kache-service"]
+exclude = [
+    "test-projects/hello-world",
+    "test-projects/multi-dep",
+    "test-projects/stale-check",
+]
+resolver = "3"
+
 [dependencies]
 blake3 = "1"
 aws-sdk-s3 = "1"
 aws-config = "1"
+kache-core = { path = "crates/kache-core", default-features = false, features = ["planning"] }
+async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -31,6 +42,7 @@ tar = "0.4"
 futures = "0.3"
 libc = "0.2"
 tempfile = "3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Justfile
+++ b/Justfile
@@ -10,13 +10,13 @@ check: fmt-check lint test
 
 # Mirror the repo CI verification flow.
 [group('dev')]
-ci: fmt-check lint coverage
+ci: fmt-check lint image-service-print helm-lint coverage
 
 # Auto-fix formatting and clippy warnings.
 [group('dev')]
 fix:
-  cargo fmt
-  cargo clippy --fix --allow-dirty --allow-staged -- -D warnings
+  cargo fmt --all
+  cargo clippy --fix --allow-dirty --allow-staged --workspace --all-targets -- -D warnings
 
 # Install kache to ~/.cargo/bin and register the daemon service.
 [group('dev')]
@@ -29,25 +29,50 @@ install:
 build:
   cargo build --release
 
-# Run all tests.
+# Build the remote service binary.
+[group('build')]
+build-service:
+  cargo build --release -p kache-service
+
+# Build the service container image locally.
+[group('docker')]
+image-service:
+  docker buildx bake -f docker-bake.hcl service
+
+# Print the resolved service image bake plan.
+[group('docker')]
+image-service-print:
+  docker buildx bake -f docker-bake.hcl --print service
+
+# Build and push the release service image.
+[group('docker')]
+image-service-release:
+  docker buildx bake -f docker-bake.hcl release
+
+# Run the full workspace test suite.
 [group('dev')]
 test:
-  cargo test
+  cargo test --workspace
 
 # Run clippy with deny warnings.
 [group('dev')]
 lint:
-  cargo clippy -- -D warnings
+  cargo clippy --workspace --all-targets -- -D warnings
 
-# Format code.
+# Format the workspace.
 [group('dev')]
 fmt:
-  cargo fmt
+  cargo fmt --all
 
 # Check formatting without changing files.
 [group('dev')]
 fmt-check:
-  cargo fmt -- --check
+  cargo fmt --all -- --check
+
+# Lint the deployable Helm chart.
+[group('deploy')]
+helm-lint:
+  helm lint charts/kache-service
 
 # Run tarpaulin coverage and emit JSON.
 [group('coverage')]

--- a/README.md
+++ b/README.md
@@ -139,9 +139,10 @@ The repo now also contains an experimental remote service shell in [`crates/kach
 Useful commands:
 
 ```sh
+just build-service
+just image-service
+just image-service-release
 cargo run -p kache-service
-docker buildx bake -f docker-bake.hcl service
-docker buildx bake -f docker-bake.hcl release
 helm upgrade --install kache-service ./charts/kache-service
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,3 +131,18 @@ profile = "ceph"
 - **Cache keys**: Deterministic blake3 hash of rustc version, crate name, source, dependencies, and normalized flags — portable across machines
 
 Incremental compilation is automatically disabled when kache wraps rustc (`CARGO_INCREMENTAL=0`), since kache's artifact caching subsumes it and avoids APFS-related corruption on macOS.
+
+## Remote service
+
+The repo now also contains an experimental remote service shell in [`crates/kache-service`](crates/kache-service). It currently exposes planner endpoints and intentionally returns `use_fallback`, which makes the remote control-plane deployable without changing build correctness while the real planner kernel stays shared in `kache-core`.
+
+Useful commands:
+
+```sh
+cargo run -p kache-service
+docker buildx bake -f docker-bake.hcl service
+docker buildx bake -f docker-bake.hcl release
+helm upgrade --install kache-service ./charts/kache-service
+```
+
+The chart in [`charts/kache-service`](charts/kache-service) is intentionally small: one `Deployment`, one `Service`, security defaults, health probes, and optional bearer-token wiring through an existing `Secret`. It does not bundle ingress, databases, or cluster-level policy.

--- a/charts/kache-service/Chart.yaml
+++ b/charts/kache-service/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: kache-service
+description: Advisory remote planner service for kache
+type: application
+version: 0.0.0
+appVersion: "0.0.0"
+keywords:
+  - rust
+  - cache
+  - ci
+  - planner
+home: https://github.com/kunobi-ninja/kache
+sources:
+  - https://github.com/kunobi-ninja/kache
+maintainers:
+  - name: Zondax
+    url: https://zondax.ch

--- a/charts/kache-service/templates/NOTES.txt
+++ b/charts/kache-service/templates/NOTES.txt
@@ -1,0 +1,8 @@
+1. Get the planner service URL by running:
+  kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kache-service.fullname" . }}
+
+2. Point kache clients at the planner:
+  KACHE_PLANNER_ENDPOINT=http://{{ include "kache-service.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+3. If bearer auth is enabled, make sure clients also set:
+  KACHE_PLANNER_TOKEN=<matching token>

--- a/charts/kache-service/templates/_helpers.tpl
+++ b/charts/kache-service/templates/_helpers.tpl
@@ -1,0 +1,55 @@
+{{/*
+Chart name, truncated to 63 chars.
+*/}}
+{{- define "kache-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name, truncated to 63 chars.
+*/}}
+{{- define "kache-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label value: name-version
+*/}}
+{{- define "kache-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Standard labels applied to every resource.
+*/}}
+{{- define "kache-service.labels" -}}
+helm.sh/chart: {{ include "kache-service.chart" . }}
+{{ include "kache-service.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels used by Deployment and Service.
+*/}}
+{{- define "kache-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kache-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Planner image reference.
+*/}}
+{{- define "kache-service.image" -}}
+{{- $tag := .Values.image.tag | default "latest" -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}

--- a/charts/kache-service/templates/deployment.yaml
+++ b/charts/kache-service/templates/deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kache-service.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kache-service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kache-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kache-service.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: planner
+          image: {{ include "kache-service.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: KACHE_PLANNER_BIND
+              value: "0.0.0.0:{{ .Values.service.port }}"
+            - name: KACHE_PLANNER_NAME
+              value: {{ .Values.planner.name | quote }}
+            - name: KACHE_LOG
+              value: {{ .Values.logLevel | quote }}
+            {{- if .Values.auth.existingSecret }}
+            - name: KACHE_PLANNER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingSecret | quote }}
+                  key: {{ .Values.auth.existingSecretKey | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kache-service/templates/service.yaml
+++ b/charts/kache-service/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kache-service.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kache-service.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "kache-service.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/kache-service/values.schema.json
+++ b/charts/kache-service/values.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      },
+      "required": ["repository", "pullPolicy"]
+    },
+    "imagePullSecrets": {
+      "type": "array"
+    },
+    "planner": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["name"]
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        },
+        "existingSecretKey": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["existingSecret", "existingSecretKey"]
+    },
+    "logLevel": {
+      "type": "string",
+      "minLength": 1
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "annotations": {
+          "type": "object"
+        }
+      },
+      "required": ["type", "port", "annotations"]
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "containerSecurityContext": {
+      "type": "object"
+    },
+    "resources": {
+      "type": "object"
+    },
+    "extraEnv": {
+      "type": "array"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "replicaCount",
+    "image",
+    "imagePullSecrets",
+    "planner",
+    "auth",
+    "logLevel",
+    "service",
+    "podAnnotations",
+    "podLabels",
+    "podSecurityContext",
+    "containerSecurityContext",
+    "resources",
+    "extraEnv",
+    "nodeSelector",
+    "tolerations",
+    "affinity"
+  ]
+}

--- a/charts/kache-service/values.yaml
+++ b/charts/kache-service/values.yaml
@@ -1,0 +1,56 @@
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/kunobi-ninja/kache-service
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+planner:
+  name: planner
+
+auth:
+  existingSecret: ""
+  existingSecretKey: token
+
+logLevel: "kache_service=info"
+
+service:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 128Mi
+
+extraEnv: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "kache-core"
+version = "0.0.0"
+edition = "2024"
+license = "Apache-2.0"
+repository = "https://github.com/kunobi-ninja/kache"
+rust-version = "1.93"
+
+[features]
+default = ["planning"]
+planning = ["dep:anyhow", "dep:async-trait"]
+
+[dependencies]
+anyhow = { version = "1", optional = true }
+async-trait = { version = "0.1", optional = true }
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/kache-core/src/lib.rs
+++ b/crates/kache-core/src/lib.rs
@@ -1,0 +1,282 @@
+#[cfg(feature = "planning")]
+use std::collections::HashSet;
+
+#[cfg(feature = "planning")]
+use anyhow::Result;
+#[cfg(feature = "planning")]
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct BuildIntent {
+    #[serde(default)]
+    pub crate_names: Vec<String>,
+    #[serde(default)]
+    pub namespace: Option<String>,
+    #[serde(default)]
+    pub cargo_lock_deps: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrefetchCandidate {
+    pub cache_key: String,
+    pub crate_name: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PrefetchDisposition {
+    Execute,
+    UseFallback,
+    DoNothing,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrefetchPlan {
+    #[serde(default)]
+    pub plan_id: Option<String>,
+    #[serde(default)]
+    pub planner: Option<String>,
+    pub disposition: PrefetchDisposition,
+    #[serde(default)]
+    pub candidates: Vec<PrefetchCandidate>,
+}
+
+#[cfg(feature = "planning")]
+#[async_trait]
+pub trait PlannerDataSource {
+    async fn shard_candidates(
+        &self,
+        namespace: &str,
+        deps: &[(String, String)],
+    ) -> Result<Vec<PrefetchCandidate>>;
+
+    async fn history_candidates(&self, crate_names: &[String]) -> Result<Vec<PrefetchCandidate>>;
+
+    async fn key_cache_keys_for_crate(&self, crate_name: &str) -> Result<Vec<String>>;
+}
+
+#[cfg(feature = "planning")]
+pub async fn build_prefetch_plan<T>(
+    source: &T,
+    intent: &BuildIntent,
+    planner_name: &str,
+) -> Result<PrefetchPlan>
+where
+    T: PlannerDataSource + Sync,
+{
+    if let Some(namespace) = intent.namespace.as_deref()
+        && !intent.cargo_lock_deps.is_empty()
+    {
+        match source
+            .shard_candidates(namespace, &intent.cargo_lock_deps)
+            .await
+        {
+            Ok(candidates) if !candidates.is_empty() => {
+                return Ok(execute_plan(planner_name, candidates));
+            }
+            Ok(_) | Err(_) => {}
+        }
+    }
+
+    let mut seen = HashSet::new();
+    let mut resolved_crates = HashSet::new();
+    let mut candidates = Vec::new();
+
+    for candidate in source.history_candidates(&intent.crate_names).await? {
+        resolved_crates.insert(candidate.crate_name.clone());
+        if seen.insert(candidate.cache_key.clone()) {
+            candidates.push(candidate);
+        }
+    }
+
+    for crate_name in intent
+        .crate_names
+        .iter()
+        .filter(|name| !resolved_crates.contains(*name))
+    {
+        for cache_key in source.key_cache_keys_for_crate(crate_name).await? {
+            if seen.insert(cache_key.clone()) {
+                candidates.push(PrefetchCandidate {
+                    cache_key,
+                    crate_name: crate_name.clone(),
+                });
+            }
+        }
+    }
+
+    Ok(execute_plan(planner_name, candidates))
+}
+
+#[cfg(feature = "planning")]
+fn execute_plan(planner_name: &str, candidates: Vec<PrefetchCandidate>) -> PrefetchPlan {
+    let planner = planner_name.trim();
+    PrefetchPlan {
+        plan_id: None,
+        planner: Some(if planner.is_empty() {
+            "planner".to_string()
+        } else {
+            planner.to_string()
+        }),
+        disposition: PrefetchDisposition::Execute,
+        candidates,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "planning")]
+    use std::collections::HashMap;
+
+    #[cfg(feature = "planning")]
+    use anyhow::anyhow;
+
+    #[cfg(feature = "planning")]
+    #[derive(Default)]
+    struct FakePlannerDataSource {
+        shard_candidates: Vec<PrefetchCandidate>,
+        shard_error: bool,
+        history_candidates: Vec<PrefetchCandidate>,
+        key_cache: HashMap<String, Vec<String>>,
+    }
+
+    #[cfg(feature = "planning")]
+    #[async_trait]
+    impl PlannerDataSource for FakePlannerDataSource {
+        async fn shard_candidates(
+            &self,
+            _namespace: &str,
+            _deps: &[(String, String)],
+        ) -> Result<Vec<PrefetchCandidate>> {
+            if self.shard_error {
+                Err(anyhow!("shard lookup failed"))
+            } else {
+                Ok(self.shard_candidates.clone())
+            }
+        }
+
+        async fn history_candidates(
+            &self,
+            _crate_names: &[String],
+        ) -> Result<Vec<PrefetchCandidate>> {
+            Ok(self.history_candidates.clone())
+        }
+
+        async fn key_cache_keys_for_crate(&self, crate_name: &str) -> Result<Vec<String>> {
+            Ok(self.key_cache.get(crate_name).cloned().unwrap_or_default())
+        }
+    }
+
+    #[test]
+    fn test_build_intent_serde_roundtrip() {
+        let intent = BuildIntent {
+            crate_names: vec!["serde".into(), "tokio".into()],
+            namespace: Some("x86_64/hash/release".into()),
+            cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+        };
+
+        let json = serde_json::to_string(&intent).unwrap();
+        let parsed: BuildIntent = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, intent);
+    }
+
+    #[test]
+    fn test_prefetch_plan_serde_roundtrip() {
+        let plan = PrefetchPlan {
+            plan_id: Some("plan-1".into()),
+            planner: Some("local".into()),
+            disposition: PrefetchDisposition::Execute,
+            candidates: vec![PrefetchCandidate {
+                cache_key: "abc".into(),
+                crate_name: "serde".into(),
+            }],
+        };
+
+        let json = serde_json::to_string(&plan).unwrap();
+        let parsed: PrefetchPlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, plan);
+    }
+
+    #[test]
+    fn test_prefetch_plan_missing_disposition_is_rejected() {
+        let err = serde_json::from_str::<PrefetchPlan>(
+            r#"{"planner":"legacy","candidates":[{"cache_key":"abc","crate_name":"serde"}]}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("missing field"));
+    }
+
+    #[test]
+    fn test_prefetch_plan_do_nothing_roundtrip() {
+        let plan = PrefetchPlan {
+            plan_id: Some("plan-2".into()),
+            planner: Some("remote".into()),
+            disposition: PrefetchDisposition::DoNothing,
+            candidates: vec![],
+        };
+
+        let json = serde_json::to_string(&plan).unwrap();
+        let parsed: PrefetchPlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, plan);
+    }
+
+    #[cfg(feature = "planning")]
+    #[tokio::test]
+    async fn test_build_prefetch_plan_prefers_shard_candidates() {
+        let source = FakePlannerDataSource {
+            shard_candidates: vec![PrefetchCandidate {
+                cache_key: "from-shard".into(),
+                crate_name: "serde".into(),
+            }],
+            ..Default::default()
+        };
+        let intent = BuildIntent {
+            crate_names: vec!["serde".into()],
+            namespace: Some("linux/hash/release".into()),
+            cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+        };
+
+        let plan = build_prefetch_plan(&source, &intent, "fallback")
+            .await
+            .unwrap();
+
+        assert_eq!(plan.disposition, PrefetchDisposition::Execute);
+        assert_eq!(plan.planner.as_deref(), Some("fallback"));
+        assert_eq!(plan.candidates.len(), 1);
+        assert_eq!(plan.candidates[0].cache_key, "from-shard");
+    }
+
+    #[cfg(feature = "planning")]
+    #[tokio::test]
+    async fn test_build_prefetch_plan_falls_back_to_history_and_key_cache() {
+        let mut source = FakePlannerDataSource {
+            shard_error: true,
+            history_candidates: vec![PrefetchCandidate {
+                cache_key: "history-key".into(),
+                crate_name: "serde".into(),
+            }],
+            ..Default::default()
+        };
+        source.key_cache.insert(
+            "tokio".into(),
+            vec!["tokio-key".into(), "history-key".into()],
+        );
+
+        let intent = BuildIntent {
+            crate_names: vec!["serde".into(), "tokio".into()],
+            namespace: Some("linux/hash/debug".into()),
+            cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+        };
+
+        let plan = build_prefetch_plan(&source, &intent, "fallback")
+            .await
+            .unwrap();
+
+        assert_eq!(plan.disposition, PrefetchDisposition::Execute);
+        assert_eq!(plan.candidates.len(), 2);
+        assert_eq!(plan.candidates[0].cache_key, "history-key");
+        assert_eq!(plan.candidates[1].cache_key, "tokio-key");
+    }
+}

--- a/crates/kache-core/src/lib.rs
+++ b/crates/kache-core/src/lib.rs
@@ -63,7 +63,7 @@ pub async fn build_prefetch_plan<T>(
     planner_name: &str,
 ) -> Result<PrefetchPlan>
 where
-    T: PlannerDataSource + Sync,
+    T: PlannerDataSource + Sync + ?Sized,
 {
     if let Some(namespace) = intent.namespace.as_deref()
         && !intent.cargo_lock_deps.is_empty()

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -9,15 +9,17 @@ rust-version = "1.93"
 
 [dependencies]
 anyhow = "1"
+async-trait = "0.1"
 axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
-kache-core = { path = "../kache-core", default-features = false }
+kache-core = { path = "../kache-core", default-features = false, features = ["planning"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [dev-dependencies]
 http-body-util = "0.1"
-serde_json = "1"
+tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "kache-service"
+version = "0.0.0"
+edition = "2024"
+description = "Remote service shell for kache planner endpoints"
+license = "Apache-2.0"
+repository = "https://github.com/kunobi-ninja/kache"
+rust-version = "1.93"
+
+[dependencies]
+anyhow = "1"
+axum = "0.8"
+clap = { version = "4", features = ["derive", "env"] }
+kache-core = { path = "../kache-core", default-features = false }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
+[dev-dependencies]
+http-body-util = "0.1"
+serde_json = "1"
+tower = { version = "0.5", features = ["util"] }

--- a/crates/kache-service/src/lib.rs
+++ b/crates/kache-service/src/lib.rs
@@ -1,0 +1,267 @@
+use anyhow::{Context, Result};
+use axum::{
+    Json, Router,
+    extract::State,
+    http::{HeaderMap, StatusCode, header},
+    routing::{get, post},
+};
+use kache_core::{BuildIntent, PrefetchDisposition, PrefetchPlan};
+use serde::{Deserialize, Serialize};
+use std::{
+    net::SocketAddr,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+pub const VERSION: &str = {
+    const RAW: &str = match option_env!("KACHE_VERSION") {
+        Some(v) => v,
+        None => env!("CARGO_PKG_VERSION"),
+    };
+    let bytes = RAW.as_bytes();
+    if bytes.len() > 1 && bytes[0] == b'v' {
+        // SAFETY: removing a leading ASCII 'v' preserves UTF-8 validity.
+        unsafe { core::str::from_utf8_unchecked(bytes.split_at(1).1) }
+    } else {
+        RAW
+    }
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannerConfig {
+    pub bind: SocketAddr,
+    pub token: Option<String>,
+    pub planner_name: String,
+}
+
+#[derive(Debug, Clone)]
+struct AppState {
+    token: Option<String>,
+    planner_name: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct HealthResponse {
+    status: String,
+    planner: String,
+    version: String,
+}
+
+pub fn app(config: PlannerConfig) -> Router {
+    let state = AppState {
+        token: normalize_optional(config.token),
+        planner_name: normalize_name(config.planner_name),
+    };
+
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/readyz", get(healthz))
+        .route("/v1/prefetch-plan", post(prefetch_plan))
+        .route("/v2/prefetch-plan", post(prefetch_plan))
+        .with_state(state)
+}
+
+pub async fn serve(config: PlannerConfig) -> Result<()> {
+    let bind = config.bind;
+    let listener = tokio::net::TcpListener::bind(bind)
+        .await
+        .with_context(|| format!("binding planner listener on {bind}"))?;
+    let local_addr = listener
+        .local_addr()
+        .context("reading planner local address")?;
+
+    tracing::info!(bind = %local_addr, planner = %config.planner_name, "planner listening");
+
+    axum::serve(listener, app(config))
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .context("running planner server")
+}
+
+fn normalize_optional(value: Option<String>) -> Option<String> {
+    value
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn normalize_name(value: String) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        "planner".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+async fn healthz(State(state): State<AppState>) -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "ok".to_string(),
+        planner: state.planner_name,
+        version: VERSION.to_string(),
+    })
+}
+
+async fn prefetch_plan(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(intent): Json<BuildIntent>,
+) -> Result<Json<PrefetchPlan>, StatusCode> {
+    authorize(&headers, state.token.as_deref())?;
+
+    tracing::info!(
+        planner = %state.planner_name,
+        crate_count = intent.crate_names.len(),
+        lock_dep_count = intent.cargo_lock_deps.len(),
+        has_namespace = intent.namespace.is_some(),
+        "planner request: delegating to local fallback"
+    );
+
+    Ok(Json(PrefetchPlan {
+        plan_id: Some(next_plan_id()),
+        planner: Some(state.planner_name),
+        disposition: PrefetchDisposition::UseFallback,
+        candidates: vec![],
+    }))
+}
+
+fn authorize(headers: &HeaderMap, expected_token: Option<&str>) -> Result<(), StatusCode> {
+    let Some(expected_token) = expected_token else {
+        return Ok(());
+    };
+
+    let token = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "));
+
+    match token {
+        Some(token) if token == expected_token => Ok(()),
+        _ => Err(StatusCode::UNAUTHORIZED),
+    }
+}
+
+fn next_plan_id() -> String {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    format!("fallback-{millis}")
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("installing ctrl+c handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("installing terminate handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use http_body_util::BodyExt;
+    use tower::util::ServiceExt;
+
+    fn test_app(token: Option<&str>) -> Router {
+        app(PlannerConfig {
+            bind: "127.0.0.1:8080".parse().unwrap(),
+            token: token.map(str::to_string),
+            planner_name: "planner".to_string(),
+        })
+    }
+
+    #[tokio::test]
+    async fn health_endpoint_returns_service_metadata() {
+        let response = test_app(None)
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let parsed: HealthResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            parsed,
+            HealthResponse {
+                status: "ok".to_string(),
+                planner: "planner".to_string(),
+                version: VERSION.to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn prefetch_plan_requires_bearer_token_when_configured() {
+        let response = test_app(Some("secret-token"))
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/v2/prefetch-plan")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&BuildIntent::default()).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn prefetch_plan_returns_use_fallback_when_authorized() {
+        let response = test_app(Some("secret-token"))
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/v2/prefetch-plan")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::AUTHORIZATION, "Bearer secret-token")
+                    .body(Body::from(
+                        serde_json::to_vec(&BuildIntent {
+                            crate_names: vec!["serde".to_string()],
+                            namespace: Some("linux/hash/debug".to_string()),
+                            cargo_lock_deps: vec![("serde".to_string(), "1.0.0".to_string())],
+                        })
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let plan: PrefetchPlan = serde_json::from_slice(&body).unwrap();
+        assert_eq!(plan.disposition, PrefetchDisposition::UseFallback);
+        assert!(plan.candidates.is_empty());
+        assert_eq!(plan.planner.as_deref(), Some("planner"));
+        assert!(
+            plan.plan_id
+                .as_deref()
+                .is_some_and(|id| id.starts_with("fallback-"))
+        );
+    }
+}

--- a/crates/kache-service/src/lib.rs
+++ b/crates/kache-service/src/lib.rs
@@ -5,12 +5,22 @@ use axum::{
     http::{HeaderMap, StatusCode, header},
     routing::{get, post},
 };
-use kache_core::{BuildIntent, PrefetchDisposition, PrefetchPlan};
+use kache_core::{
+    BuildIntent, PlannerDataSource, PrefetchDisposition, PrefetchPlan, build_prefetch_plan,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     net::SocketAddr,
+    path::{Path, PathBuf},
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
+
+mod state;
+
+pub use state::{FilePlannerRepository, NamespaceState, PlannerStateFile};
+
+type SharedPlannerDataSource = Arc<dyn PlannerDataSource + Send + Sync>;
 
 pub const VERSION: &str = {
     const RAW: &str = match option_env!("KACHE_VERSION") {
@@ -31,12 +41,14 @@ pub struct PlannerConfig {
     pub bind: SocketAddr,
     pub token: Option<String>,
     pub planner_name: String,
+    pub state_file: Option<PathBuf>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct AppState {
     token: Option<String>,
     planner_name: String,
+    repository: Option<SharedPlannerDataSource>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -46,10 +58,16 @@ struct HealthResponse {
     version: String,
 }
 
-pub fn app(config: PlannerConfig) -> Router {
+pub fn app(config: PlannerConfig) -> Result<Router> {
+    let repository = load_repository(config.state_file.as_deref())?;
+    Ok(app_with_repository(config, repository))
+}
+
+fn app_with_repository(config: PlannerConfig, repository: Option<SharedPlannerDataSource>) -> Router {
     let state = AppState {
         token: normalize_optional(config.token),
         planner_name: normalize_name(config.planner_name),
+        repository,
     };
 
     Router::new()
@@ -62,6 +80,9 @@ pub fn app(config: PlannerConfig) -> Router {
 
 pub async fn serve(config: PlannerConfig) -> Result<()> {
     let bind = config.bind;
+    let planner_name = normalize_name(config.planner_name.clone());
+    let app = app(config)?;
+
     let listener = tokio::net::TcpListener::bind(bind)
         .await
         .with_context(|| format!("binding planner listener on {bind}"))?;
@@ -69,12 +90,21 @@ pub async fn serve(config: PlannerConfig) -> Result<()> {
         .local_addr()
         .context("reading planner local address")?;
 
-    tracing::info!(bind = %local_addr, planner = %config.planner_name, "planner listening");
+    tracing::info!(bind = %local_addr, planner = %planner_name, "planner listening");
 
-    axum::serve(listener, app(config))
+    axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
         .await
         .context("running planner server")
+}
+
+fn load_repository(state_file: Option<&Path>) -> Result<Option<SharedPlannerDataSource>> {
+    let Some(state_file) = state_file else {
+        return Ok(None);
+    };
+
+    let repository = FilePlannerRepository::load(state_file)?;
+    Ok(Some(Arc::new(repository)))
 }
 
 fn normalize_optional(value: Option<String>) -> Option<String> {
@@ -95,7 +125,7 @@ fn normalize_name(value: String) -> String {
 async fn healthz(State(state): State<AppState>) -> Json<HealthResponse> {
     Json(HealthResponse {
         status: "ok".to_string(),
-        planner: state.planner_name,
+        planner: state.planner_name.clone(),
         version: VERSION.to_string(),
     })
 }
@@ -107,20 +137,52 @@ async fn prefetch_plan(
 ) -> Result<Json<PrefetchPlan>, StatusCode> {
     authorize(&headers, state.token.as_deref())?;
 
+    let Some(repository) = state.repository.as_ref() else {
+        tracing::info!(
+            planner = %state.planner_name,
+            crate_count = intent.crate_names.len(),
+            lock_dep_count = intent.cargo_lock_deps.len(),
+            has_namespace = intent.namespace.is_some(),
+            "planner request: no service-side state configured, requesting fallback"
+        );
+        return Ok(Json(fallback_plan(&state.planner_name)));
+    };
+
+    let mut plan = match build_prefetch_plan(repository.as_ref(), &intent, &state.planner_name).await
+    {
+        Ok(plan) => plan,
+        Err(error) => {
+            tracing::warn!(
+                planner = %state.planner_name,
+                %error,
+                "planner request: planning failed, requesting fallback"
+            );
+            return Ok(Json(fallback_plan(&state.planner_name)));
+        }
+    };
+
+    if plan.candidates.is_empty() {
+        tracing::info!(
+            planner = %state.planner_name,
+            crate_count = intent.crate_names.len(),
+            lock_dep_count = intent.cargo_lock_deps.len(),
+            has_namespace = intent.namespace.is_some(),
+            "planner request: no candidates resolved from service state, requesting fallback"
+        );
+        return Ok(Json(fallback_plan(&state.planner_name)));
+    }
+
     tracing::info!(
         planner = %state.planner_name,
         crate_count = intent.crate_names.len(),
         lock_dep_count = intent.cargo_lock_deps.len(),
         has_namespace = intent.namespace.is_some(),
-        "planner request: delegating to local fallback"
+        candidate_count = plan.candidates.len(),
+        "planner request: returning execute plan from service state"
     );
 
-    Ok(Json(PrefetchPlan {
-        plan_id: Some(next_plan_id()),
-        planner: Some(state.planner_name),
-        disposition: PrefetchDisposition::UseFallback,
-        candidates: vec![],
-    }))
+    plan.plan_id.get_or_insert_with(next_plan_id);
+    Ok(Json(plan))
 }
 
 fn authorize(headers: &HeaderMap, expected_token: Option<&str>) -> Result<(), StatusCode> {
@@ -144,7 +206,16 @@ fn next_plan_id() -> String {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis();
-    format!("fallback-{millis}")
+    format!("plan-{millis}")
+}
+
+fn fallback_plan(planner_name: &str) -> PrefetchPlan {
+    PrefetchPlan {
+        plan_id: Some(next_plan_id()),
+        planner: Some(planner_name.to_string()),
+        disposition: PrefetchDisposition::UseFallback,
+        candidates: vec![],
+    }
 }
 
 async fn shutdown_signal() {
@@ -176,19 +247,25 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use http_body_util::BodyExt;
+    use kache_core::PrefetchCandidate;
+    use std::collections::HashMap;
     use tower::util::ServiceExt;
 
-    fn test_app(token: Option<&str>) -> Router {
-        app(PlannerConfig {
-            bind: "127.0.0.1:8080".parse().unwrap(),
-            token: token.map(str::to_string),
-            planner_name: "planner".to_string(),
-        })
+    fn test_app(token: Option<&str>, repository: Option<SharedPlannerDataSource>) -> Router {
+        app_with_repository(
+            PlannerConfig {
+                bind: "127.0.0.1:8080".parse().unwrap(),
+                token: token.map(str::to_string),
+                planner_name: "planner".to_string(),
+                state_file: None,
+            },
+            repository,
+        )
     }
 
     #[tokio::test]
     async fn health_endpoint_returns_service_metadata() {
-        let response = test_app(None)
+        let response = test_app(None, None)
             .oneshot(
                 axum::http::Request::builder()
                     .uri("/healthz")
@@ -213,7 +290,7 @@ mod tests {
 
     #[tokio::test]
     async fn prefetch_plan_requires_bearer_token_when_configured() {
-        let response = test_app(Some("secret-token"))
+        let response = test_app(Some("secret-token"), None)
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
@@ -232,7 +309,7 @@ mod tests {
 
     #[tokio::test]
     async fn prefetch_plan_returns_use_fallback_when_authorized() {
-        let response = test_app(Some("secret-token"))
+        let response = test_app(Some("secret-token"), None)
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
@@ -258,10 +335,79 @@ mod tests {
         assert_eq!(plan.disposition, PrefetchDisposition::UseFallback);
         assert!(plan.candidates.is_empty());
         assert_eq!(plan.planner.as_deref(), Some("planner"));
-        assert!(
-            plan.plan_id
-                .as_deref()
-                .is_some_and(|id| id.starts_with("fallback-"))
-        );
+        assert!(plan.plan_id.as_deref().is_some_and(|id| id.starts_with("plan-")));
+    }
+
+    #[tokio::test]
+    async fn prefetch_plan_returns_execute_when_repository_has_candidates() {
+        let repository = FilePlannerRepository::from_state(PlannerStateFile {
+            namespaces: HashMap::new(),
+            history: HashMap::from([(
+                "serde".to_string(),
+                vec![PrefetchCandidate {
+                    cache_key: "serde-key".to_string(),
+                    crate_name: "serde".to_string(),
+                }],
+            )]),
+            key_cache: HashMap::new(),
+        });
+
+        let response = test_app(None, Some(Arc::new(repository)))
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/v2/prefetch-plan")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&BuildIntent {
+                            crate_names: vec!["serde".to_string()],
+                            namespace: None,
+                            cargo_lock_deps: vec![],
+                        })
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let plan: PrefetchPlan = serde_json::from_slice(&body).unwrap();
+        assert_eq!(plan.disposition, PrefetchDisposition::Execute);
+        assert_eq!(plan.candidates.len(), 1);
+        assert_eq!(plan.candidates[0].cache_key, "serde-key");
+        assert_eq!(plan.planner.as_deref(), Some("planner"));
+        assert!(plan.plan_id.as_deref().is_some_and(|id| id.starts_with("plan-")));
+    }
+
+    #[tokio::test]
+    async fn prefetch_plan_returns_use_fallback_when_repository_has_no_candidates() {
+        let repository = FilePlannerRepository::default();
+
+        let response = test_app(None, Some(Arc::new(repository)))
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/v2/prefetch-plan")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&BuildIntent {
+                            crate_names: vec!["serde".to_string()],
+                            namespace: None,
+                            cargo_lock_deps: vec![],
+                        })
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let plan: PrefetchPlan = serde_json::from_slice(&body).unwrap();
+        assert_eq!(plan.disposition, PrefetchDisposition::UseFallback);
+        assert!(plan.candidates.is_empty());
     }
 }

--- a/crates/kache-service/src/lib.rs
+++ b/crates/kache-service/src/lib.rs
@@ -63,7 +63,10 @@ pub fn app(config: PlannerConfig) -> Result<Router> {
     Ok(app_with_repository(config, repository))
 }
 
-fn app_with_repository(config: PlannerConfig, repository: Option<SharedPlannerDataSource>) -> Router {
+fn app_with_repository(
+    config: PlannerConfig,
+    repository: Option<SharedPlannerDataSource>,
+) -> Router {
     let state = AppState {
         token: normalize_optional(config.token),
         planner_name: normalize_name(config.planner_name),
@@ -148,18 +151,18 @@ async fn prefetch_plan(
         return Ok(Json(fallback_plan(&state.planner_name)));
     };
 
-    let mut plan = match build_prefetch_plan(repository.as_ref(), &intent, &state.planner_name).await
-    {
-        Ok(plan) => plan,
-        Err(error) => {
-            tracing::warn!(
-                planner = %state.planner_name,
-                %error,
-                "planner request: planning failed, requesting fallback"
-            );
-            return Ok(Json(fallback_plan(&state.planner_name)));
-        }
-    };
+    let mut plan =
+        match build_prefetch_plan(repository.as_ref(), &intent, &state.planner_name).await {
+            Ok(plan) => plan,
+            Err(error) => {
+                tracing::warn!(
+                    planner = %state.planner_name,
+                    %error,
+                    "planner request: planning failed, requesting fallback"
+                );
+                return Ok(Json(fallback_plan(&state.planner_name)));
+            }
+        };
 
     if plan.candidates.is_empty() {
         tracing::info!(
@@ -335,7 +338,11 @@ mod tests {
         assert_eq!(plan.disposition, PrefetchDisposition::UseFallback);
         assert!(plan.candidates.is_empty());
         assert_eq!(plan.planner.as_deref(), Some("planner"));
-        assert!(plan.plan_id.as_deref().is_some_and(|id| id.starts_with("plan-")));
+        assert!(
+            plan.plan_id
+                .as_deref()
+                .is_some_and(|id| id.starts_with("plan-"))
+        );
     }
 
     #[tokio::test]
@@ -378,7 +385,11 @@ mod tests {
         assert_eq!(plan.candidates.len(), 1);
         assert_eq!(plan.candidates[0].cache_key, "serde-key");
         assert_eq!(plan.planner.as_deref(), Some("planner"));
-        assert!(plan.plan_id.as_deref().is_some_and(|id| id.starts_with("plan-")));
+        assert!(
+            plan.plan_id
+                .as_deref()
+                .is_some_and(|id| id.starts_with("plan-"))
+        );
     }
 
     #[tokio::test]

--- a/crates/kache-service/src/main.rs
+++ b/crates/kache-service/src/main.rs
@@ -1,0 +1,42 @@
+use anyhow::Result;
+use clap::Parser;
+use kache_service::{PlannerConfig, VERSION};
+use std::net::SocketAddr;
+
+#[derive(Debug, Parser)]
+#[command(name = "kache-service", version = VERSION, about = "Remote service shell for kache planner endpoints")]
+struct Cli {
+    /// Bind address for the planner HTTP service
+    #[arg(long, env = "KACHE_PLANNER_BIND", default_value = "0.0.0.0:8080")]
+    bind: SocketAddr,
+
+    /// Bearer token required for planner requests
+    #[arg(long, env = "KACHE_PLANNER_TOKEN")]
+    token: Option<String>,
+
+    /// Planner name reported in responses
+    #[arg(long, env = "KACHE_PLANNER_NAME", default_value = "planner")]
+    planner_name: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    init_logging();
+    let cli = Cli::parse();
+
+    kache_service::serve(PlannerConfig {
+        bind: cli.bind,
+        token: cli.token,
+        planner_name: cli.planner_name,
+    })
+    .await
+}
+
+fn init_logging() {
+    use tracing_subscriber::{EnvFilter, fmt};
+
+    let filter = EnvFilter::try_from_env("KACHE_LOG")
+        .unwrap_or_else(|_| "kache_service=info".parse().unwrap());
+
+    fmt().with_env_filter(filter).init();
+}

--- a/crates/kache-service/src/main.rs
+++ b/crates/kache-service/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use kache_service::{PlannerConfig, VERSION};
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::PathBuf};
 
 #[derive(Debug, Parser)]
 #[command(name = "kache-service", version = VERSION, about = "Remote service shell for kache planner endpoints")]
@@ -17,6 +17,10 @@ struct Cli {
     /// Planner name reported in responses
     #[arg(long, env = "KACHE_PLANNER_NAME", default_value = "planner")]
     planner_name: String,
+
+    /// Optional JSON file that seeds service-side planner state
+    #[arg(long, env = "KACHE_PLANNER_STATE_FILE")]
+    state_file: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -28,6 +32,7 @@ async fn main() -> Result<()> {
         bind: cli.bind,
         token: cli.token,
         planner_name: cli.planner_name,
+        state_file: cli.state_file,
     })
     .await
 }

--- a/crates/kache-service/src/state.rs
+++ b/crates/kache-service/src/state.rs
@@ -1,0 +1,185 @@
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use kache_core::{PlannerDataSource, PrefetchCandidate};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlannerStateFile {
+    #[serde(default)]
+    pub namespaces: HashMap<String, NamespaceState>,
+    #[serde(default)]
+    pub history: HashMap<String, Vec<PrefetchCandidate>>,
+    #[serde(default)]
+    pub key_cache: HashMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NamespaceState {
+    #[serde(default)]
+    pub deps: HashMap<String, Vec<PrefetchCandidate>>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FilePlannerRepository {
+    namespaces: HashMap<String, NamespaceState>,
+    history: HashMap<String, Vec<PrefetchCandidate>>,
+    key_cache: HashMap<String, Vec<String>>,
+}
+
+impl FilePlannerRepository {
+    pub fn load(path: &Path) -> Result<Self> {
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("reading planner state from {}", path.display()))?;
+        let state: PlannerStateFile = serde_json::from_slice(&bytes)
+            .with_context(|| format!("parsing planner state from {}", path.display()))?;
+        Ok(Self::from_state(state))
+    }
+
+    pub fn from_state(state: PlannerStateFile) -> Self {
+        Self {
+            namespaces: state.namespaces,
+            history: state.history,
+            key_cache: state.key_cache,
+        }
+    }
+}
+
+#[async_trait]
+impl PlannerDataSource for FilePlannerRepository {
+    async fn shard_candidates(
+        &self,
+        namespace: &str,
+        deps: &[(String, String)],
+    ) -> Result<Vec<PrefetchCandidate>> {
+        let Some(namespace_state) = self.namespaces.get(namespace) else {
+            return Ok(Vec::new());
+        };
+
+        let mut seen = HashSet::new();
+        let mut candidates = Vec::new();
+
+        for (name, version) in deps {
+            if let Some(entries) = namespace_state.deps.get(&dep_key(name, version)) {
+                for candidate in entries {
+                    if seen.insert(candidate.cache_key.clone()) {
+                        candidates.push(candidate.clone());
+                    }
+                }
+            }
+        }
+
+        Ok(candidates)
+    }
+
+    async fn history_candidates(&self, crate_names: &[String]) -> Result<Vec<PrefetchCandidate>> {
+        let mut seen = HashSet::new();
+        let mut candidates = Vec::new();
+
+        for crate_name in crate_names {
+            if let Some(entries) = self.history.get(crate_name) {
+                for candidate in entries {
+                    if seen.insert(candidate.cache_key.clone()) {
+                        candidates.push(candidate.clone());
+                    }
+                }
+            }
+        }
+
+        Ok(candidates)
+    }
+
+    async fn key_cache_keys_for_crate(&self, crate_name: &str) -> Result<Vec<String>> {
+        Ok(self.key_cache.get(crate_name).cloned().unwrap_or_default())
+    }
+}
+
+fn dep_key(name: &str, version: &str) -> String {
+    format!("{name}@{version}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn repository_resolves_namespace_candidates_from_dep_index() {
+        let repo = FilePlannerRepository::from_state(PlannerStateFile {
+            namespaces: HashMap::from([(
+                "linux/hash/debug".to_string(),
+                NamespaceState {
+                    deps: HashMap::from([
+                        (
+                            "serde@1.0.0".to_string(),
+                            vec![PrefetchCandidate {
+                                cache_key: "serde-key".to_string(),
+                                crate_name: "serde".to_string(),
+                            }],
+                        ),
+                        (
+                            "tokio@1.0.0".to_string(),
+                            vec![
+                                PrefetchCandidate {
+                                    cache_key: "tokio-key".to_string(),
+                                    crate_name: "tokio".to_string(),
+                                },
+                                PrefetchCandidate {
+                                    cache_key: "serde-key".to_string(),
+                                    crate_name: "serde".to_string(),
+                                },
+                            ],
+                        ),
+                    ]),
+                },
+            )]),
+            history: HashMap::new(),
+            key_cache: HashMap::new(),
+        });
+
+        let candidates = repo
+            .shard_candidates(
+                "linux/hash/debug",
+                &[
+                    ("serde".to_string(), "1.0.0".to_string()),
+                    ("tokio".to_string(), "1.0.0".to_string()),
+                ],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].cache_key, "serde-key");
+        assert_eq!(candidates[1].cache_key, "tokio-key");
+    }
+
+    #[test]
+    fn repository_loads_json_state_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("planner-state.json");
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&PlannerStateFile {
+                namespaces: HashMap::new(),
+                history: HashMap::from([(
+                    "serde".to_string(),
+                    vec![PrefetchCandidate {
+                        cache_key: "serde-key".to_string(),
+                        crate_name: "serde".to_string(),
+                    }],
+                )]),
+                key_cache: HashMap::from([(
+                    "tokio".to_string(),
+                    vec!["tokio-key".to_string()],
+                )]),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let repo = FilePlannerRepository::load(&path).unwrap();
+        assert_eq!(repo.history.get("serde").unwrap().len(), 1);
+        assert_eq!(repo.key_cache.get("tokio").unwrap(), &["tokio-key"]);
+    }
+}

--- a/crates/kache-service/src/state.rs
+++ b/crates/kache-service/src/state.rs
@@ -169,10 +169,7 @@ mod tests {
                         crate_name: "serde".to_string(),
                     }],
                 )]),
-                key_cache: HashMap::from([(
-                    "tokio".to_string(),
-                    vec!["tokio-key".to_string()],
-                )]),
+                key_cache: HashMap::from([("tokio".to_string(), vec!["tokio-key".to_string()])]),
             })
             .unwrap(),
         )

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,70 @@
+# Docker Bake configuration for kache service
+# Build:     docker buildx bake -f docker-bake.hcl
+# Dry run:   docker buildx bake -f docker-bake.hcl --print
+# Push:      docker buildx bake -f docker-bake.hcl release
+
+variable "REGISTRY" {
+  default = "ghcr.io/kunobi-ninja"
+}
+
+variable "IMAGE_TAG" {
+  default = "dev"
+}
+
+variable "VERSION" {
+  default = "0.0.0"
+}
+
+variable "BUILD_VERSION" {
+  default = "dev"
+}
+
+variable "BUILD_COMMIT" {
+  default = "unknown"
+}
+
+variable "BUILD_DATE" {
+  default = "unknown"
+}
+
+variable "PLATFORM" {
+  default = "linux/amd64"
+}
+
+function "tags" {
+  params = [name]
+  result = compact([
+    "${REGISTRY}/${name}:latest",
+    "${REGISTRY}/${name}:${IMAGE_TAG}",
+    notequal(VERSION, "0.0.0") ? "${REGISTRY}/${name}:v${VERSION}" : "",
+    notequal(VERSION, "0.0.0") ? "${REGISTRY}/${name}:v${split(".", VERSION)[0]}.${split(".", VERSION)[1]}" : "",
+    notequal(VERSION, "0.0.0") ? "${REGISTRY}/${name}:v${split(".", VERSION)[0]}" : "",
+  ])
+}
+
+group "default" {
+  targets = ["service"]
+}
+
+group "release" {
+  targets = ["service-release"]
+}
+
+target "service" {
+  dockerfile = "docker/service.Dockerfile"
+  context    = "."
+  platforms  = [PLATFORM]
+  tags       = tags("kache-service")
+  args = {
+    BUILD_VERSION = BUILD_VERSION
+    BUILD_COMMIT  = BUILD_COMMIT
+    BUILD_DATE    = BUILD_DATE
+  }
+  output = ["type=docker"]
+}
+
+target "service-release" {
+  inherits  = ["service"]
+  platforms = ["linux/amd64", "linux/arm64"]
+  output    = ["type=registry"]
+}

--- a/docker/service.Dockerfile
+++ b/docker/service.Dockerfile
@@ -1,0 +1,24 @@
+FROM rust:1.93-bookworm AS builder
+
+WORKDIR /app
+COPY . .
+RUN cargo build --release -p kache-service
+
+FROM gcr.io/distroless/cc-debian12
+
+ARG BUILD_VERSION=dev
+ARG BUILD_COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+LABEL org.opencontainers.image.title="kache-service"
+LABEL org.opencontainers.image.description="Remote service shell for kache planner endpoints"
+LABEL org.opencontainers.image.version="${BUILD_VERSION}"
+LABEL org.opencontainers.image.revision="${BUILD_COMMIT}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.source="https://github.com/kunobi-ninja/kache"
+
+COPY --from=builder /app/target/release/kache-service /kache-service
+
+EXPOSE 8080
+
+ENTRYPOINT ["/kache-service"]

--- a/src/build_intent.rs
+++ b/src/build_intent.rs
@@ -1,0 +1,205 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::Path;
+
+use kache_core::BuildIntent;
+
+pub fn discover() -> Option<BuildIntent> {
+    let crate_names = discover_crate_names_bfs()?;
+    if crate_names.is_empty() {
+        return None;
+    }
+
+    let namespace = std::env::var("KACHE_NAMESPACE")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    let cargo_lock_deps = namespace
+        .as_ref()
+        .and_then(|_| load_cargo_lock_deps(Path::new("Cargo.lock")))
+        .unwrap_or_default();
+
+    Some(BuildIntent {
+        crate_names,
+        namespace,
+        cargo_lock_deps,
+    })
+}
+
+pub fn into_build_started_request(
+    intent: BuildIntent,
+    client_epoch: u64,
+) -> crate::daemon::BuildStartedRequest {
+    crate::daemon::BuildStartedRequest {
+        intent,
+        client_epoch,
+    }
+}
+
+fn load_cargo_lock_deps(lock_path: &Path) -> Option<Vec<(String, String)>> {
+    crate::shards::parse_cargo_lock(lock_path)
+        .map_err(|err| {
+            tracing::debug!(
+                "build intent: failed to parse {} for shard prefetch: {}",
+                lock_path.display(),
+                err
+            );
+            err
+        })
+        .ok()
+}
+
+fn discover_crate_names_bfs() -> Option<Vec<String>> {
+    let output = std::process::Command::new("cargo")
+        .args(["metadata", "--format-version", "1"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    parse_metadata_crate_names_bfs(&output.stdout)
+}
+
+fn parse_metadata_crate_names_bfs(metadata_json: &[u8]) -> Option<Vec<String>> {
+    let value: serde_json::Value = serde_json::from_slice(metadata_json).ok()?;
+
+    let packages = value.get("packages")?.as_array()?;
+    let mut id_to_name: HashMap<String, String> = HashMap::new();
+    for pkg in packages {
+        if let (Some(id), Some(name)) = (
+            pkg.get("id").and_then(|v| v.as_str()),
+            pkg.get("name").and_then(|v| v.as_str()),
+        ) {
+            id_to_name.insert(id.to_string(), name.to_string());
+        }
+    }
+
+    let nodes = value.get("resolve")?.get("nodes")?.as_array()?;
+    let mut dep_count: HashMap<String, usize> = HashMap::new();
+    let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
+
+    for node in nodes {
+        let Some(id) = node.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let id = id.to_string();
+        let deps = node
+            .get("deps")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|d| d.get("pkg").and_then(|v| v.as_str()).map(String::from))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        dep_count.insert(id.clone(), deps.len());
+
+        for dep_id in deps {
+            dep_count.entry(dep_id.clone()).or_insert(0);
+            dependents.entry(dep_id).or_default().push(id.clone());
+        }
+    }
+
+    for reverse_edges in dependents.values_mut() {
+        reverse_edges.sort();
+    }
+
+    let mut zero_deps: Vec<String> = dep_count
+        .iter()
+        .filter(|&(_, &count)| count == 0)
+        .map(|(id, _)| id.clone())
+        .collect();
+    zero_deps.sort();
+    let mut queue: VecDeque<String> = zero_deps.into();
+
+    let mut seen = HashSet::new();
+    let mut ordered_names = Vec::new();
+
+    while let Some(id) = queue.pop_front() {
+        if let Some(name) = id_to_name.get(&id)
+            && seen.insert(name.clone())
+        {
+            ordered_names.push(name.clone());
+        }
+        if let Some(reverse_edges) = dependents.get(&id) {
+            for dependent in reverse_edges {
+                if let Some(count) = dep_count.get_mut(dependent) {
+                    *count = count.saturating_sub(1);
+                    if *count == 0 {
+                        queue.push_back(dependent.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    Some(ordered_names)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_metadata_crate_names_bfs_orders_leaves_first() {
+        let metadata = r#"{
+          "packages": [
+            {"id": "serde 1.0.0 (registry)", "name": "serde"},
+            {"id": "tokio 1.0.0 (registry)", "name": "tokio"},
+            {"id": "app 0.1.0 (path)", "name": "app"}
+          ],
+          "resolve": {
+            "nodes": [
+              {"id": "app 0.1.0 (path)", "deps": [
+                {"pkg": "serde 1.0.0 (registry)"},
+                {"pkg": "tokio 1.0.0 (registry)"}
+              ]},
+              {"id": "serde 1.0.0 (registry)", "deps": []},
+              {"id": "tokio 1.0.0 (registry)", "deps": []}
+            ]
+          }
+        }"#;
+
+        let names = parse_metadata_crate_names_bfs(metadata.as_bytes()).unwrap();
+        assert_eq!(names, vec!["serde", "tokio", "app"]);
+    }
+
+    #[test]
+    fn test_parse_metadata_crate_names_bfs_deduplicates_names() {
+        let metadata = r#"{
+          "packages": [
+            {"id": "serde 1.0.0 (registry)", "name": "serde"},
+            {"id": "serde 1.0.1 (registry)", "name": "serde"}
+          ],
+          "resolve": {
+            "nodes": [
+              {"id": "serde 1.0.0 (registry)", "deps": []},
+              {"id": "serde 1.0.1 (registry)", "deps": []}
+            ]
+          }
+        }"#;
+
+        let names = parse_metadata_crate_names_bfs(metadata.as_bytes()).unwrap();
+        assert_eq!(names, vec!["serde"]);
+    }
+
+    #[test]
+    fn test_build_intent_into_request_preserves_shard_context() {
+        let intent = BuildIntent {
+            crate_names: vec!["serde".into(), "tokio".into()],
+            namespace: Some("x86_64/hash/release".into()),
+            cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+        };
+
+        let req = into_build_started_request(intent, 42);
+        assert_eq!(req.intent.crate_names, vec!["serde", "tokio"]);
+        assert_eq!(req.intent.namespace.as_deref(), Some("x86_64/hash/release"));
+        assert_eq!(req.intent.cargo_lock_deps.len(), 1);
+        assert_eq!(req.client_epoch, 42);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 pub const DEFAULT_DAEMON_IDLE_TIMEOUT_SECS: u64 = 10 * 60;
+pub const DEFAULT_PLANNER_TIMEOUT_MS: u64 = 750;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -21,6 +22,13 @@ pub struct Config {
     pub s3_concurrency: u32,
     /// Daemon idle timeout in seconds (default 600 = 10 minutes). 0 = no timeout.
     pub daemon_idle_timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannerConfig {
+    pub endpoint: String,
+    pub timeout_ms: u64,
+    pub token: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +52,7 @@ pub(crate) struct CacheFileConfig {
     pub(crate) local_store: Option<String>,
     pub(crate) local_max_size: Option<String>,
     pub(crate) remote: Option<RemoteFileConfig>,
+    pub(crate) planner: Option<PlannerFileConfig>,
     pub(crate) cache_executables: Option<bool>,
     pub(crate) clean_incremental: Option<bool>,
     pub(crate) event_log_max_size: Option<String>,
@@ -67,6 +76,16 @@ pub(crate) struct RemoteFileConfig {
     pub(crate) prefix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) profile: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+pub(crate) struct PlannerFileConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) timeout_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) token: Option<String>,
 }
 
 /// Tracks which config fields have active env var overrides.
@@ -338,6 +357,55 @@ impl Config {
         })
     }
 
+    pub fn load_planner_config() -> Option<PlannerConfig> {
+        let file_config = Self::load_file_config();
+
+        let endpoint = std::env::var("KACHE_PLANNER_ENDPOINT")
+            .ok()
+            .or_else(|| {
+                file_config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.cache.as_ref())
+                    .and_then(|c| c.planner.as_ref())
+                    .and_then(|c| c.endpoint.clone())
+            })
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())?;
+
+        let timeout_ms = std::env::var("KACHE_PLANNER_TIMEOUT_MS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .or_else(|| {
+                file_config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.cache.as_ref())
+                    .and_then(|c| c.planner.as_ref())
+                    .and_then(|c| c.timeout_ms)
+            })
+            .unwrap_or(DEFAULT_PLANNER_TIMEOUT_MS);
+
+        let token = std::env::var("KACHE_PLANNER_TOKEN")
+            .ok()
+            .or_else(|| {
+                file_config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.cache.as_ref())
+                    .and_then(|c| c.planner.as_ref())
+                    .and_then(|c| c.token.clone())
+            })
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        Some(PlannerConfig {
+            endpoint,
+            timeout_ms,
+            token,
+        })
+    }
+
     pub fn store_dir(&self) -> PathBuf {
         self.cache_dir.join("store")
     }
@@ -462,6 +530,7 @@ mod tests {
             cache: Some(CacheFileConfig {
                 local_store: Some("~/my/cache".to_string()),
                 local_max_size: Some("50GiB".to_string()),
+                planner: None,
                 cache_executables: Some(true),
                 clean_incremental: Some(false),
                 event_log_max_size: Some("10MiB".to_string()),
@@ -671,6 +740,7 @@ mod tests {
             cache: Some(CacheFileConfig {
                 local_store: Some("/tmp/my-cache".to_string()),
                 local_max_size: Some("10GiB".to_string()),
+                planner: None,
                 cache_executables: Some(true),
                 clean_incremental: None,
                 event_log_max_size: None,
@@ -708,6 +778,7 @@ mod tests {
     fn test_remote_file_config_with_profile() {
         let config = FileConfig {
             cache: Some(CacheFileConfig {
+                planner: None,
                 remote: Some(RemoteFileConfig {
                     _type: Some("s3".to_string()),
                     bucket: Some("mybucket".to_string()),
@@ -733,5 +804,91 @@ mod tests {
                 .as_deref(),
             Some("ceph")
         );
+    }
+
+    #[test]
+    fn test_load_planner_config_from_file() {
+        let _guard = config_path_lock();
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("kache/config.toml");
+        let _env_guard = set_kache_config_for_test(&config_path);
+
+        let config = FileConfig {
+            cache: Some(CacheFileConfig {
+                planner: Some(PlannerFileConfig {
+                    endpoint: Some("https://planner.example.com".to_string()),
+                    timeout_ms: Some(1200),
+                    token: Some("secret".to_string()),
+                }),
+                ..Default::default()
+            }),
+        };
+
+        Config::save_file_config_to(&config, &config_path).unwrap();
+
+        let loaded = Config::load_planner_config().unwrap();
+        assert_eq!(loaded.endpoint, "https://planner.example.com");
+        assert_eq!(loaded.timeout_ms, 1200);
+        assert_eq!(loaded.token.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn test_load_planner_config_env_overrides_file() {
+        let _guard = config_path_lock();
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("kache/config.toml");
+        let _env_guard = set_kache_config_for_test(&config_path);
+
+        let config = FileConfig {
+            cache: Some(CacheFileConfig {
+                planner: Some(PlannerFileConfig {
+                    endpoint: Some("https://planner.example.com".to_string()),
+                    timeout_ms: Some(1200),
+                    token: Some("secret".to_string()),
+                }),
+                ..Default::default()
+            }),
+        };
+
+        Config::save_file_config_to(&config, &config_path).unwrap();
+
+        struct ScopedVar {
+            key: &'static str,
+            previous: Option<OsString>,
+        }
+
+        impl ScopedVar {
+            fn set(key: &'static str, value: &str) -> Self {
+                let previous = std::env::var_os(key);
+                unsafe {
+                    std::env::set_var(key, value);
+                }
+                Self { key, previous }
+            }
+        }
+
+        impl Drop for ScopedVar {
+            fn drop(&mut self) {
+                match &self.previous {
+                    Some(value) => unsafe {
+                        std::env::set_var(self.key, value);
+                    },
+                    None => unsafe {
+                        std::env::remove_var(self.key);
+                    },
+                }
+            }
+        }
+
+        let _endpoint = ScopedVar::set("KACHE_PLANNER_ENDPOINT", "https://env.example.com");
+        let _timeout = ScopedVar::set("KACHE_PLANNER_TIMEOUT_MS", "400");
+        let _token = ScopedVar::set("KACHE_PLANNER_TOKEN", "env-token");
+
+        let loaded = Config::load_planner_config().unwrap();
+        assert_eq!(loaded.endpoint, "https://env.example.com");
+        assert_eq!(loaded.timeout_ms, 400);
+        assert_eq!(loaded.token.as_deref(), Some("env-token"));
     }
 }

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -395,6 +395,7 @@ fn fields_to_file_config(fields: &[FormField]) -> FileConfig {
         cache: Some(CacheFileConfig {
             local_store: get("cache_dir"),
             local_max_size: get("max_size"),
+            planner: None,
             cache_executables: get_bool("cache_executables"),
             clean_incremental: get_bool("clean_incremental"),
             event_log_max_size: get("event_log_max_size"),
@@ -1047,6 +1048,7 @@ mod tests {
             cache: Some(CacheFileConfig {
                 local_store: Some("~/cache".to_string()),
                 local_max_size: Some("50GiB".to_string()),
+                planner: None,
                 cache_executables: Some(true),
                 clean_incremental: Some(false),
                 event_log_max_size: Some("10MiB".to_string()),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1238,7 +1238,6 @@ impl Daemon {
             Ok(c) => c,
             Err(e) => return Response::err(format!("S3 client init failed: {e}")),
         };
-
         let plan = crate::remote_plan::RemotePlanner::new(&self.config)
             .plan(crate::remote_plan::RemoteWorkload::RestoreCheck);
         let layout = plan.layout(client, remote);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use kache_core::{PrefetchDisposition, PrefetchPlan};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -336,17 +337,22 @@ pub struct PrefetchRequest {
     pub keys: Vec<(String, String)>,
 }
 
+impl PrefetchRequest {
+    pub fn from_plan(plan: PrefetchPlan) -> Self {
+        Self {
+            keys: plan
+                .candidates
+                .into_iter()
+                .map(|candidate| (candidate.cache_key, candidate.crate_name))
+                .collect(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BuildStartedRequest {
-    pub crate_names: Vec<String>,
-    /// Shard namespace (target/rustc_hash/profile). If set alongside cargo_lock_deps,
-    /// enables shard-based prefetch instead of key-cache lookup.
     #[serde(default)]
-    pub namespace: Option<String>,
-    /// Sorted (name, version) pairs from Cargo.lock. Enables shard-based prefetch
-    /// when the daemon receives a BuildStarted message.
-    #[serde(default)]
-    pub cargo_lock_deps: Vec<(String, String)>,
+    pub intent: kache_core::BuildIntent,
     /// Client binary mtime — lets the daemon detect when it's running stale code.
     #[serde(default)]
     pub client_epoch: u64,
@@ -790,7 +796,7 @@ impl Daemon {
             .ok_or_else(|| anyhow::anyhow!("daemon store failed to initialize"))
     }
 
-    fn with_store<T>(&self, f: impl FnOnce(&Store) -> Result<T>) -> Result<T> {
+    pub(crate) fn with_store<T>(&self, f: impl FnOnce(&Store) -> Result<T>) -> Result<T> {
         let guard = self
             .store_lock()?
             .lock()
@@ -798,8 +804,16 @@ impl Daemon {
         f(&guard)
     }
 
-    fn entry_dir_for(&self, cache_key: &str) -> PathBuf {
+    pub(crate) fn entry_dir_for(&self, cache_key: &str) -> PathBuf {
         self.config.store_dir().join(cache_key)
+    }
+
+    pub(crate) fn remote_config(&self) -> Option<&crate::config::RemoteConfig> {
+        self.config.remote.as_ref()
+    }
+
+    pub(crate) async fn key_cache_keys_for_crate(&self, crate_name: &str) -> Vec<String> {
+        self.key_cache.keys_for_crate(crate_name).await
     }
 
     /// Wait for the manifest prefetch to complete (or timeout).
@@ -839,7 +853,7 @@ impl Daemon {
     }
 
     /// Lazy-init the S3 client (requires remote config).
-    async fn get_s3_client(&self) -> Result<&aws_sdk_s3::Client> {
+    pub(crate) async fn get_s3_client(&self) -> Result<&aws_sdk_s3::Client> {
         self.s3_client
             .get_or_try_init(|| async {
                 let remote = self
@@ -1401,9 +1415,9 @@ impl Daemon {
             if downloading_guard.contains(key) {
                 continue;
             }
-            if let Some(false) = self.key_cache.check(key).await {
-                continue;
-            }
+            // Explicit prefetch candidates are treated as authoritative. Negative
+            // key-cache knowledge is only used during discovery paths, not to veto
+            // planner- or caller-supplied keys here.
             keys_to_fetch.push((key.clone(), crate_name.clone(), entry_dir));
         }
         drop(downloading_guard);
@@ -1594,92 +1608,90 @@ impl Daemon {
         Response::ok()
     }
 
-    /// Handle a build-started hint: resolve crate names to cache keys and prefetch
-    /// those that exist in S3 but are missing locally.
-    ///
-    /// Resolution order:
-    /// 1. Local SQLite store (has exact key→crate mapping from previous builds)
-    /// 2. S3 key cache reverse index (works on cold CI runners with empty local store)
+    /// Handle a build-started hint by asking the advisory remote planner first,
+    /// then falling back to the in-process planner that matches the daemon's
+    /// current shard/history/key-cache heuristics.
     pub async fn handle_build_started(self: &Arc<Self>, req: &BuildStartedRequest) -> Response {
         let Some(_remote) = &self.config.remote else {
             return Response::err("no remote configured");
         };
 
-        // 1. Try local SQLite first (has exact keys from previous builds)
-        let entries = match self.with_store(|store| store.keys_for_crates(&req.crate_names)) {
-            Ok(e) => e,
-            Err(e) => return Response::err(format!("key lookup failed: {e}")),
-        };
-
-        // Track which crate names were resolved via SQLite
-        let mut resolved_crates: HashSet<String> = HashSet::new();
-        for (_, crate_name, _) in &entries {
-            resolved_crates.insert(crate_name.clone());
-        }
-
-        // 2. For crates not in local SQLite, fall back to S3 key cache.
-        // This is the critical path for cold CI runners where the local store is empty.
-        let mut extra_entries = Vec::new();
-        let unresolved: Vec<&String> = req
-            .crate_names
-            .iter()
-            .filter(|n| !resolved_crates.contains(*n))
-            .collect();
-
-        if !unresolved.is_empty() {
-            for name in &unresolved {
-                let s3_keys = self.key_cache.keys_for_crate(name).await;
-                for key in s3_keys {
-                    let entry_dir = self.entry_dir_for(&key);
-                    extra_entries.push((key, (*name).clone(), entry_dir));
+        match crate::planner_client::resolve_prefetch_plan(&req.intent).await {
+            Ok(Some(plan)) => {
+                let plan_id = plan.plan_id.clone();
+                let planner = plan.planner.clone();
+                match plan.disposition {
+                    PrefetchDisposition::Execute if plan.candidates.is_empty() => {
+                        tracing::warn!(
+                            plan_id = ?plan_id,
+                            planner = ?planner,
+                            "build-started: planner returned execute with no candidates, falling back to local planning"
+                        );
+                    }
+                    PrefetchDisposition::Execute => {
+                        let prefetch_req = PrefetchRequest::from_plan(plan);
+                        let resp = self.handle_prefetch(&prefetch_req).await;
+                        if resp.ok {
+                            tracing::info!(
+                                plan_id = ?plan_id,
+                                planner = ?planner,
+                                candidate_count = prefetch_req.keys.len(),
+                                "build-started: using advisory planner plan"
+                            );
+                            return resp;
+                        }
+                        tracing::warn!(
+                            plan_id = ?plan_id,
+                            planner = ?planner,
+                            "build-started: planner plan execution failed, falling back to local planning"
+                        );
+                    }
+                    PrefetchDisposition::UseFallback => {
+                        tracing::debug!(
+                            plan_id = ?plan_id,
+                            planner = ?planner,
+                            "build-started: planner requested fallback to local planning"
+                        );
+                    }
+                    PrefetchDisposition::DoNothing => {
+                        tracing::info!(
+                            plan_id = ?plan_id,
+                            planner = ?planner,
+                            "build-started: planner explicitly requested no prefetch"
+                        );
+                        return Response::ok();
+                    }
                 }
             }
-            if !extra_entries.is_empty() {
-                tracing::info!(
-                    "build-started: resolved {} extra keys from S3 key cache \
-                     ({} crates had no local history)",
-                    extra_entries.len(),
-                    unresolved.len()
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(
+                    "build-started: planner lookup failed, falling back to local planning: {e}"
                 );
             }
         }
 
-        // Merge both sources and filter to keys missing locally
-        let all_entries = entries.into_iter().chain(extra_entries);
-        let mut keys_to_prefetch = Vec::new();
-        let downloading_guard = self.downloading.read().await;
-        for (key, crate_name, entry_dir) in all_entries {
-            if entry_dir.exists() {
-                continue;
-            }
-            if downloading_guard.contains(&key) {
-                continue;
-            }
-            match self.key_cache.check(&key).await {
-                Some(false) => continue,
-                Some(true) | None => keys_to_prefetch.push((key, crate_name)),
-            }
-        }
-        drop(downloading_guard);
+        let fallback_plan =
+            match crate::fallback_planner::build_prefetch_plan(self, &req.intent).await {
+                Ok(plan) => plan,
+                Err(e) => return Response::err(format!("fallback planning failed: {e}")),
+            };
 
-        if keys_to_prefetch.is_empty() {
+        if fallback_plan.candidates.is_empty() {
             tracing::debug!(
                 "build-started: nothing to prefetch ({} crate names checked)",
-                req.crate_names.len()
+                req.intent.crate_names.len()
             );
             return Response::ok();
         }
 
         tracing::info!(
-            "build-started: prefetching {} keys for {} crates",
-            keys_to_prefetch.len(),
-            req.crate_names.len()
+            "build-started: using fallback planner with {} candidates for {} crates",
+            fallback_plan.candidates.len(),
+            req.intent.crate_names.len()
         );
 
-        // Delegate to the existing prefetch machinery
-        let prefetch_req = PrefetchRequest {
-            keys: keys_to_prefetch,
-        };
+        let prefetch_req = PrefetchRequest::from_plan(fallback_plan);
         self.handle_prefetch(&prefetch_req).await
     }
 
@@ -2238,7 +2250,18 @@ async fn shard_prefetch(
     lock_path: &std::path::Path,
 ) -> anyhow::Result<usize> {
     let deps = crate::shards::parse_cargo_lock(lock_path)?;
-    let shard_set = crate::shards::compute_shards(namespace, &deps);
+    shard_prefetch_for_deps(daemon, client, bucket, prefix, namespace, &deps).await
+}
+
+async fn shard_prefetch_for_deps(
+    daemon: &Arc<Daemon>,
+    client: &aws_sdk_s3::Client,
+    bucket: &str,
+    prefix: &str,
+    namespace: &str,
+    deps: &[(String, String)],
+) -> anyhow::Result<usize> {
+    let shard_set = crate::shards::compute_shards(namespace, deps);
 
     tracing::info!(
         "shard prefetch: {} deps -> {} shards for namespace '{namespace}'",
@@ -2700,19 +2723,15 @@ pub fn send_prefetch(config: &Config, keys: &[(String, String)]) -> Result<()> {
 /// detect when it's running stale code and self-restart. This replaces the
 /// previous stats-request-based version check, avoiding an extra round-trip
 /// that was prone to timeouts during daemon startup.
-pub fn send_build_started(config: &Config, crate_names: &[String]) {
+pub fn send_build_started(config: &Config, req: BuildStartedRequest) {
     let socket_path = config.socket_path();
+    let crate_count = req.intent.crate_names.len();
 
-    let req = Request::BuildStarted(BuildStartedRequest {
-        crate_names: crate_names.to_vec(),
-        namespace: None,
-        cargo_lock_deps: vec![],
-        client_epoch: build_epoch(),
-    });
+    let req = Request::BuildStarted(req);
 
     match send_request_fire_and_forget(&socket_path, &req) {
         Ok(()) => {
-            tracing::debug!("build-started hint sent for {} crates", crate_names.len());
+            tracing::debug!("build-started hint sent for {} crates", crate_count);
         }
         Err(e) => {
             tracing::debug!("build-started hint: daemon unreachable ({e}), skipping");
@@ -4187,6 +4206,22 @@ mod tests {
     }
 
     #[test]
+    fn test_prefetch_request_from_plan() {
+        let plan = PrefetchPlan {
+            plan_id: Some("plan-1".into()),
+            planner: Some("fallback".into()),
+            disposition: PrefetchDisposition::Execute,
+            candidates: vec![kache_core::PrefetchCandidate {
+                cache_key: "abc123".into(),
+                crate_name: "serde".into(),
+            }],
+        };
+
+        let req = PrefetchRequest::from_plan(plan);
+        assert_eq!(req.keys, vec![("abc123".into(), "serde".into())]);
+    }
+
+    #[test]
     fn test_batch_response_serde() {
         let batch = BatchResponse {
             ok: true,
@@ -4527,9 +4562,11 @@ mod tests {
     #[test]
     fn test_build_started_request_serde() {
         let req = Request::BuildStarted(BuildStartedRequest {
-            crate_names: vec!["serde".into(), "tokio".into(), "anyhow".into()],
-            namespace: None,
-            cargo_lock_deps: vec![],
+            intent: kache_core::BuildIntent {
+                crate_names: vec!["serde".into(), "tokio".into(), "anyhow".into()],
+                namespace: Some("x86_64/hash/release".into()),
+                cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+            },
             client_epoch: 0,
         });
         let json = serde_json::to_string(&req).unwrap();
@@ -4539,14 +4576,13 @@ mod tests {
         assert!(json.contains("\"build_started\""));
         assert!(json.contains("\"serde\""));
         assert!(json.contains("\"tokio\""));
+        assert!(json.contains("x86_64/hash/release"));
     }
 
     #[test]
     fn test_build_started_request_empty_serde() {
         let req = Request::BuildStarted(BuildStartedRequest {
-            crate_names: vec![],
-            namespace: None,
-            cargo_lock_deps: vec![],
+            intent: kache_core::BuildIntent::default(),
             client_epoch: 0,
         });
         let json = serde_json::to_string(&req).unwrap();
@@ -4561,9 +4597,10 @@ mod tests {
         let daemon = Arc::new(Daemon::new(config));
 
         let req = BuildStartedRequest {
-            crate_names: vec!["mycrate".into()],
-            namespace: None,
-            cargo_lock_deps: vec![],
+            intent: kache_core::BuildIntent {
+                crate_names: vec!["mycrate".into()],
+                ..Default::default()
+            },
             client_epoch: 0,
         };
         let resp = daemon.handle_build_started(&req).await;
@@ -4583,9 +4620,10 @@ mod tests {
         let daemon = Daemon::new(config);
 
         let req = Request::BuildStarted(BuildStartedRequest {
-            crate_names: vec!["c".into()],
-            namespace: None,
-            cargo_lock_deps: vec![],
+            intent: kache_core::BuildIntent {
+                crate_names: vec!["c".into()],
+                ..Default::default()
+            },
             client_epoch: 0,
         });
         let resp = daemon.handle_request_sync(&req);

--- a/src/fallback_planner.rs
+++ b/src/fallback_planner.rs
@@ -1,0 +1,105 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::future::join_all;
+use kache_core::{
+    BuildIntent, PlannerDataSource, PrefetchCandidate, PrefetchPlan,
+    build_prefetch_plan as build_core_prefetch_plan,
+};
+
+use crate::daemon::Daemon;
+
+pub async fn build_prefetch_plan(
+    daemon: &Arc<Daemon>,
+    intent: &BuildIntent,
+) -> Result<PrefetchPlan> {
+    build_core_prefetch_plan(&LocalPlannerSource { daemon }, intent, "fallback").await
+}
+
+struct LocalPlannerSource<'a> {
+    daemon: &'a Arc<Daemon>,
+}
+
+#[async_trait]
+impl PlannerDataSource for LocalPlannerSource<'_> {
+    async fn shard_candidates(
+        &self,
+        namespace: &str,
+        deps: &[(String, String)],
+    ) -> Result<Vec<PrefetchCandidate>> {
+        let remote = self
+            .daemon
+            .remote_config()
+            .ok_or_else(|| anyhow::anyhow!("no remote configured"))?;
+        let client = self.daemon.get_s3_client().await?;
+        let shard_set = crate::shards::compute_shards(namespace, deps);
+
+        tracing::info!(
+            "fallback planner: {} deps -> {} shards for namespace '{namespace}'",
+            deps.len(),
+            shard_set.shards.len()
+        );
+
+        let shard_fetches = shard_set.shards.iter().map(|(hash, _entries)| {
+            crate::remote::download_shard(client, &remote.bucket, &remote.prefix, namespace, hash)
+        });
+        let shard_results = join_all(shard_fetches).await;
+
+        let mut shards_matched = 0usize;
+        let mut candidates = Vec::new();
+        let mut seen = HashSet::new();
+
+        for result in shard_results {
+            match result {
+                Ok(Some(shard)) => {
+                    shards_matched += 1;
+                    for entry in shard.entries {
+                        if seen.insert(entry.cache_key.clone()) {
+                            candidates.push(PrefetchCandidate {
+                                cache_key: entry.cache_key,
+                                crate_name: entry.crate_name,
+                            });
+                        }
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => tracing::warn!("fallback planner: shard download error: {e}"),
+            }
+        }
+
+        tracing::info!(
+            "fallback planner: {shards_matched}/{} shards matched, {} candidates resolved",
+            shard_set.shards.len(),
+            candidates.len()
+        );
+
+        Ok(candidates)
+    }
+
+    async fn history_candidates(&self, crate_names: &[String]) -> Result<Vec<PrefetchCandidate>> {
+        let entries = self
+            .daemon
+            .with_store(|store| store.keys_for_crates(crate_names))?;
+        Ok(entries
+            .into_iter()
+            .map(|(cache_key, crate_name, _entry_dir)| PrefetchCandidate {
+                cache_key,
+                crate_name,
+            })
+            .collect())
+    }
+
+    async fn key_cache_keys_for_crate(&self, crate_name: &str) -> Result<Vec<String>> {
+        let keys = self.daemon.key_cache_keys_for_crate(crate_name).await;
+        if !keys.is_empty() {
+            tracing::info!(
+                "fallback planner: resolved {} extra candidates from S3 key cache for crate '{}'",
+                keys.len(),
+                crate_name
+            );
+        }
+        Ok(keys)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 compile_error!("kache does not support Windows. Supported platforms are macOS and Linux.");
 
 mod args;
+mod build_intent;
 mod cache_key;
 mod cli;
 mod compile;
@@ -9,7 +10,9 @@ mod config;
 mod config_tui;
 mod daemon;
 mod events;
+mod fallback_planner;
 mod link;
+mod planner_client;
 mod remote;
 mod remote_layout;
 mod remote_plan;

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,13 +245,20 @@ fn init_logging(mode: LogMode) {
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::{EnvFilter, fmt};
 
-    // Interactive TUIs own the terminal, so background logs must not write to stderr
-    // while the alternate screen is active. File logging remains enabled for diagnostics.
+    // Wrapper mode: cargo captures RUSTC_WRAPPER stderr and caches it as compiler
+    // diagnostics, replaying stale warnings on every subsequent build.  Default to
+    // silent; users can still opt in via KACHE_LOG for one-off debugging.
+    // TUI mode: owns the terminal, stderr must stay silent.
     let stderr_layer = if mode == LogMode::TerminalUi {
         None
     } else {
-        let stderr_filter =
-            EnvFilter::try_from_env("KACHE_LOG").unwrap_or_else(|_| "kache=warn".parse().unwrap());
+        let default_filter = if mode == LogMode::Wrapper {
+            "off"
+        } else {
+            "kache=warn"
+        };
+        let stderr_filter = EnvFilter::try_from_env("KACHE_LOG")
+            .unwrap_or_else(|_| default_filter.parse().unwrap());
         Some(
             fmt::layer()
                 .with_writer(std::io::stderr)

--- a/src/planner_client.rs
+++ b/src/planner_client.rs
@@ -1,0 +1,219 @@
+use anyhow::{Context, Result};
+use std::time::Duration;
+
+#[cfg(test)]
+use std::borrow::Cow;
+
+use crate::config::PlannerConfig;
+use kache_core::{BuildIntent, PrefetchPlan};
+
+const PREFETCH_PLAN_PATH_V1: &str = "/v1/prefetch-plan";
+const PREFETCH_PLAN_PATH_V2: &str = "/v2/prefetch-plan";
+
+pub async fn resolve_prefetch_plan(req: &BuildIntent) -> Result<Option<PrefetchPlan>> {
+    let Some(config) = crate::config::Config::load_planner_config() else {
+        return Ok(None);
+    };
+
+    let plan = resolve_prefetch_plan_with_config(&config, req).await?;
+    Ok(Some(plan))
+}
+
+pub async fn resolve_prefetch_plan_with_config(
+    config: &PlannerConfig,
+    req: &BuildIntent,
+) -> Result<PrefetchPlan> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(config.timeout_ms))
+        .build()
+        .context("building planner client")?;
+
+    let mut request = client.post(prefetch_plan_url(&config.endpoint)).json(req);
+    if let Some(token) = config.token.as_deref() {
+        request = request.bearer_auth(token);
+    }
+
+    let response = request
+        .send()
+        .await
+        .context("requesting advisory prefetch plan")?
+        .error_for_status()
+        .context("planner returned an error status")?;
+
+    response
+        .json::<PrefetchPlan>()
+        .await
+        .context("decoding planner prefetch plan")
+}
+
+fn prefetch_plan_url(endpoint: &str) -> String {
+    let trimmed = endpoint.trim_end_matches('/');
+    if trimmed.ends_with(PREFETCH_PLAN_PATH_V1) || trimmed.ends_with(PREFETCH_PLAN_PATH_V2) {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}{PREFETCH_PLAN_PATH_V2}")
+    }
+}
+
+#[cfg(test)]
+fn expected_prefetch_plan_path(endpoint: &str) -> Cow<'static, str> {
+    if endpoint
+        .trim_end_matches('/')
+        .ends_with(PREFETCH_PLAN_PATH_V1)
+    {
+        Cow::Borrowed(PREFETCH_PLAN_PATH_V1)
+    } else {
+        Cow::Borrowed(PREFETCH_PLAN_PATH_V2)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kache_core::{PrefetchCandidate, PrefetchDisposition};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    async fn spawn_response_server(
+        body: String,
+        expected_auth: Option<&str>,
+        status_line: &str,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let expected_auth = expected_auth.map(str::to_string);
+        let status = status_line.to_string();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 4096];
+            let n = socket.read(&mut buf).await.unwrap();
+            let request = String::from_utf8_lossy(&buf[..n]);
+            assert!(request.starts_with(&format!(
+                "POST {} HTTP/1.1",
+                expected_prefetch_plan_path(&format!("http://{addr}"))
+            )));
+
+            match expected_auth {
+                Some(token) => assert!(
+                    request.contains(&format!("authorization: Bearer {token}"))
+                        || request.contains(&format!("Authorization: Bearer {token}"))
+                ),
+                None => assert!(
+                    !request.contains("authorization: Bearer")
+                        && !request.contains("Authorization: Bearer")
+                ),
+            }
+
+            let response = format!(
+                "{status}\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn test_prefetch_plan_url_appends_path_once() {
+        assert_eq!(
+            prefetch_plan_url("https://planner.example.com"),
+            "https://planner.example.com/v2/prefetch-plan"
+        );
+        assert_eq!(
+            prefetch_plan_url("https://planner.example.com/v2/prefetch-plan"),
+            "https://planner.example.com/v2/prefetch-plan"
+        );
+        assert_eq!(
+            prefetch_plan_url("https://planner.example.com/v1/prefetch-plan"),
+            "https://planner.example.com/v1/prefetch-plan"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_prefetch_plan_with_config() {
+        let body = serde_json::to_string(&PrefetchPlan {
+            plan_id: Some("plan-1".into()),
+            planner: Some("test".into()),
+            disposition: PrefetchDisposition::Execute,
+            candidates: vec![PrefetchCandidate {
+                cache_key: "abc".into(),
+                crate_name: "serde".into(),
+            }],
+        })
+        .unwrap();
+        let endpoint = spawn_response_server(body, Some("token-123"), "HTTP/1.1 200 OK").await;
+        let config = PlannerConfig {
+            endpoint,
+            timeout_ms: 1000,
+            token: Some("token-123".into()),
+        };
+        let req = BuildIntent {
+            crate_names: vec!["serde".into()],
+            namespace: Some("ns".into()),
+            cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+        };
+
+        let plan = resolve_prefetch_plan_with_config(&config, &req)
+            .await
+            .unwrap();
+        assert_eq!(plan.plan_id.as_deref(), Some("plan-1"));
+        assert_eq!(plan.candidates.len(), 1);
+        assert_eq!(plan.candidates[0].cache_key, "abc");
+        assert_eq!(plan.disposition, PrefetchDisposition::Execute);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_prefetch_plan_with_config_errors_on_bad_status() {
+        let endpoint = spawn_response_server(
+            "{\"error\":\"nope\"}".to_string(),
+            None,
+            "HTTP/1.1 503 Service Unavailable",
+        )
+        .await;
+        let config = PlannerConfig {
+            endpoint,
+            timeout_ms: 1000,
+            token: None,
+        };
+        let req = BuildIntent {
+            crate_names: vec!["serde".into()],
+            namespace: None,
+            cargo_lock_deps: vec![],
+        };
+
+        let err = resolve_prefetch_plan_with_config(&config, &req)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("error status"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_prefetch_plan_with_do_nothing_disposition() {
+        let body = serde_json::to_string(&PrefetchPlan {
+            plan_id: Some("plan-2".into()),
+            planner: Some("test".into()),
+            disposition: PrefetchDisposition::DoNothing,
+            candidates: vec![],
+        })
+        .unwrap();
+        let endpoint = spawn_response_server(body, None, "HTTP/1.1 200 OK").await;
+        let config = PlannerConfig {
+            endpoint,
+            timeout_ms: 1000,
+            token: None,
+        };
+        let req = BuildIntent {
+            crate_names: vec!["serde".into()],
+            namespace: None,
+            cargo_lock_deps: vec![],
+        };
+
+        let plan = resolve_prefetch_plan_with_config(&config, &req)
+            .await
+            .unwrap();
+        assert_eq!(plan.disposition, PrefetchDisposition::DoNothing);
+        assert!(plan.candidates.is_empty());
+    }
+}

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result, bail};
 use aws_sdk_s3::error::ProvideErrorMetadata;
 use aws_sdk_s3::operation::head_object::HeadObjectError;
-use aws_sdk_s3::operation::{RequestId, RequestIdExt};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -61,6 +60,7 @@ impl<'a> RemoteLayout<'a> {
         {
             Ok(_) => Ok(true),
             Err(e) => {
+                let http_status = e.raw_response().map(|r| r.status().as_u16());
                 let err = e.into_service_error();
                 if is_missing_head_object(&err) {
                     Ok(false)
@@ -69,7 +69,7 @@ impl<'a> RemoteLayout<'a> {
                         "S3 head_object error for s3://{}/{}: {}",
                         self.remote.bucket,
                         object_key,
-                        describe_head_object_error(&err)
+                        describe_head_object_error(&err, http_status)
                     ))
                 }
             }
@@ -304,21 +304,22 @@ fn is_missing_head_object(err: &HeadObjectError) -> bool {
         )
 }
 
-fn describe_head_object_error(err: &HeadObjectError) -> String {
+fn describe_head_object_error(err: &HeadObjectError, http_status: Option<u16>) -> String {
     let mut details = Vec::new();
-    details.push(err.to_string());
 
+    if let Some(status) = http_status {
+        details.push(format!("HTTP {status}"));
+    }
     if let Some(code) = err.code() {
         details.push(format!("code={code}"));
     }
     if let Some(message) = err.message() {
         details.push(format!("message={message}"));
     }
-    if let Some(request_id) = err.meta().request_id() {
-        details.push(format!("request_id={request_id}"));
-    }
-    if let Some(extended_request_id) = err.meta().extended_request_id() {
-        details.push(format!("extended_request_id={extended_request_id}"));
+
+    // Fallback: if no structured info, include Display output
+    if details.is_empty() || (http_status.is_none() && err.code().is_none()) {
+        details.push(err.to_string());
     }
 
     details.join(", ")

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -443,19 +443,6 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_tab_needs_entries_only_for_store() {
-        assert!(!tab_needs_entries(Tab::Build));
-        assert!(!tab_needs_entries(Tab::Projects));
-        assert!(tab_needs_entries(Tab::Store));
-        assert!(!tab_needs_entries(Tab::Transfer));
-    }
-}
-
 // ── Drawing ────────────────────────────────────────────────────────────────
 
 fn draw_ui(frame: &mut Frame, state: &AppState) {
@@ -1490,4 +1477,17 @@ fn draw_transfer_help(frame: &mut Frame, area: Rect) {
     let help = "  q: quit  ↑↓: scroll  Tab: next  1/2/3/4: tabs";
     let paragraph = Paragraph::new(help).style(Style::default().fg(Color::DarkGray));
     frame.render_widget(paragraph, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tab_needs_entries_only_for_store() {
+        assert!(!tab_needs_entries(Tab::Build));
+        assert!(!tab_needs_entries(Tab::Projects));
+        assert!(tab_needs_entries(Tab::Store));
+        assert!(!tab_needs_entries(Tab::Transfer));
+    }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -582,17 +582,28 @@ fn maybe_trigger_prefetch(config: &Config) {
     // Gather ALL dependency crate names in compilation order (leaves first).
     // This gives the daemon a comprehensive prefetch list that works even on
     // cold CI runners where the local SQLite store is empty.
-    let crate_names = match get_all_crate_names_bfs() {
-        Some(names) if !names.is_empty() => names,
+    let build_intent = match crate::build_intent::discover() {
+        Some(intent) => intent,
         _ => return,
     };
 
+    let shard_prefetch_enabled =
+        build_intent.namespace.is_some() && !build_intent.cargo_lock_deps.is_empty();
+
     tracing::info!(
-        "build session detected, sending prefetch hint for {} crates",
-        crate_names.len()
+        "build session detected, sending prefetch hint for {} crates (shard context: {})",
+        build_intent.crate_names.len(),
+        if shard_prefetch_enabled {
+            "available"
+        } else {
+            "fallback"
+        }
     );
 
-    crate::daemon::send_build_started(config, &crate_names);
+    crate::daemon::send_build_started(
+        config,
+        crate::build_intent::into_build_started_request(build_intent, crate::daemon::build_epoch()),
+    );
 
     // Write current epoch AFTER the prefetch succeeds so a failed/hung attempt
     // (e.g. cargo metadata hangs on a git dep) doesn't block retries for the
@@ -624,100 +635,6 @@ fn write_marker_timestamp(marker: &std::path::Path) {
         .unwrap_or_default()
         .as_secs();
     let _ = std::fs::write(marker, now.to_string());
-}
-
-/// Run `cargo metadata` to get ALL dependency crate names in BFS compilation
-/// order (leaves first — crates with no dependencies are compiled first by cargo).
-///
-/// Uses the resolve graph from cargo metadata to topologically sort packages,
-/// so the daemon prefetches crates in the order they'll be needed.
-/// Takes ~200–500ms depending on project size (runs once per build session).
-fn get_all_crate_names_bfs() -> Option<Vec<String>> {
-    let output = std::process::Command::new("cargo")
-        .args(["metadata", "--format-version", "1"])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let value: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
-
-    // Build package_id → name map
-    let packages = value.get("packages")?.as_array()?;
-    let mut id_to_name: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
-    for pkg in packages {
-        if let (Some(id), Some(name)) = (
-            pkg.get("id").and_then(|v| v.as_str()),
-            pkg.get("name").and_then(|v| v.as_str()),
-        ) {
-            id_to_name.insert(id.to_string(), name.to_string());
-        }
-    }
-
-    // Parse the dependency graph from resolve.nodes
-    let nodes = value.get("resolve")?.get("nodes")?.as_array()?;
-    let mut dep_count: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    let mut dependents: std::collections::HashMap<String, Vec<String>> =
-        std::collections::HashMap::new();
-
-    for node in nodes {
-        let Some(id) = node.get("id").and_then(|v| v.as_str()) else {
-            continue; // skip malformed nodes rather than aborting all prefetch
-        };
-        let id = id.to_string();
-        let deps = node
-            .get("deps")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|d| d.get("pkg").and_then(|v| v.as_str()).map(String::from))
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
-
-        dep_count.insert(id.clone(), deps.len());
-
-        // Record reverse edges: for each dependency, note that `id` depends on it
-        for dep_id in deps {
-            dep_count.entry(dep_id.clone()).or_insert(0);
-            dependents.entry(dep_id).or_default().push(id.clone());
-        }
-    }
-
-    // Kahn's algorithm: BFS from leaves (packages with 0 dependencies)
-    let mut queue: std::collections::VecDeque<String> = dep_count
-        .iter()
-        .filter(|&(_, &count)| count == 0)
-        .map(|(id, _)| id.clone())
-        .collect();
-
-    let mut seen = std::collections::HashSet::new();
-    let mut ordered_names = Vec::new();
-
-    while let Some(id) = queue.pop_front() {
-        if let Some(name) = id_to_name.get(&id)
-            && seen.insert(name.clone())
-        {
-            ordered_names.push(name.clone());
-        }
-        if let Some(deps) = dependents.get(&id) {
-            for dep_id in deps {
-                if let Some(count) = dep_count.get_mut(dep_id) {
-                    *count = count.saturating_sub(1);
-                    if *count == 0 {
-                        queue.push_back(dep_id.clone());
-                    }
-                }
-            }
-        }
-    }
-
-    Some(ordered_names)
 }
 
 /// Remove the incremental compilation directory for this crate.


### PR DESCRIPTION
## Summary

- **Daemon RemoteHealth circuit breaker**: Suppresses repetitive S3 HEAD probe warnings after 3 consecutive failures, entering a 45s degradation window where probes are skipped and logged at debug level. Recovers automatically on next success.
- **Improved S3 error messages**: Captures HTTP status code from the raw SDK response *before* `into_service_error()` strips it, so Ceph/MinIO errors now show `HTTP 403` instead of `unhandled error`.
- **Warming grace period**: Remote checks now wait up to 750ms for manifest prefetch to complete before falling through to HEAD probes.
- **Makefile → Justfile migration**: Build tasks moved to Justfile; CI workflows updated accordingly.
- **kache-service planner updates**: Updated planner integration in service crate.

## Test plan

- [ ] Verify `cargo test head_object` passes (unit tests for HEAD error classification)
- [ ] Verify `cargo test remote_health` passes (circuit breaker unit tests)  
- [ ] Verify `cargo test warming` passes (warming barrier tests)
- [ ] Manual: run daemon against unreachable S3 → confirm only 1 warn + circuit breaker activation instead of per-crate spam
- [ ] Manual: confirm error message includes HTTP status code (e.g. `HTTP 403`)