### PR TITLE
fix: test_resolve_config_path_prefers_kache_config missing arg

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -704,7 +704,7 @@ mod tests {
 
     #[test]
     fn test_resolve_config_path_prefers_kache_config() {
-        let path = resolve_config_path_from(Some(PathBuf::from("/tmp/managed/config.toml")));
+        let path = resolve_config_path_from(Some(PathBuf::from("/tmp/managed/config.toml")), None);
         assert_eq!(path, PathBuf::from("/tmp/managed/config.toml"));
     }
 


### PR DESCRIPTION
## Summary
- Commit d2f291c changed `resolve_config_path_from` to take 2 args (`kache_config`, `current_dir`), but this unit test still passed only 1.
- Result: `cargo test --bin kache` failed to compile on every build since d2f291c landed, which in turn broke CI for the following commit.

## Test plan
- [x] `cargo test --bin kache test_resolve_config_path_prefers_kache_config` passes locally.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)