### PR TITLE
feat: kache daemon restart, wire into init recovery

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3349,22 +3349,37 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
     // service::install() on macOS/Linux also starts the daemon, so skip the
     // manual start if we just installed it.
     let config = crate::config::Config::load().ok();
-    let daemon_running = config
-        .as_ref()
-        .is_some_and(|c| crate::daemon::send_stats_request(c, false, None, None).is_ok());
+    let is_daemon_reachable = |cfg: &Option<crate::config::Config>| {
+        cfg.as_ref()
+            .is_some_and(|c| crate::daemon::send_stats_request(c, false, None, None).is_ok())
+    };
 
-    if daemon_running {
+    if is_daemon_reachable(&config) {
         println!("  \x1b[32m✓\x1b[0m daemon is running");
     } else if service_action_taken {
         // Service install typically starts the daemon. Give it a moment and re-check.
         std::thread::sleep(std::time::Duration::from_millis(500));
-        let ok = config
-            .as_ref()
-            .is_some_and(|c| crate::daemon::send_stats_request(c, false, None, None).is_ok());
-        if ok {
+        if is_daemon_reachable(&config) {
             println!("  \x1b[32m✓\x1b[0m daemon started by service");
         } else {
             println!("  \x1b[33m→\x1b[0m daemon not reachable yet — it may take a few seconds");
+        }
+    } else if service_installed {
+        // Service is installed (from a previous run) but daemon isn't reachable.
+        // Prefer `launchctl kickstart` / `systemctl restart` over a manual spawn
+        // so the service manager clears any stale state (lockfiles, half-dead
+        // processes) and owns the new process.
+        println!("  \x1b[33m→\x1b[0m restart daemon via service manager (daemon offline)");
+        if !check
+            && prompt_yes_no("Restart daemon?", true, yes)?
+            && let Some(ref cfg) = config
+        {
+            match crate::daemon::restart(cfg)? {
+                true => println!("    \x1b[32m✓\x1b[0m daemon restarted"),
+                false => {
+                    println!("    \x1b[31m✗\x1b[0m daemon did not restart — see `kache doctor`");
+                }
+            }
         }
     } else {
         println!("  \x1b[33m→\x1b[0m start daemon in background");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2850,6 +2850,59 @@ pub fn send_shutdown_request(config: &Config) -> Result<()> {
     }
 }
 
+/// Explicit daemon restart for `kache daemon restart` and init recovery.
+///
+/// Prefers the platform service manager (launchd/systemd) when a service is
+/// installed, since it owns the daemon process and knows how to bring it back
+/// cleanly. Falls back to manual stop+start otherwise.
+///
+/// Returns `Ok(true)` if the daemon is reachable after restart.
+pub fn restart(config: &Config) -> Result<bool> {
+    let socket_path = config.socket_path();
+
+    // Prefer the service manager when available — it's the authoritative owner.
+    match crate::service::kickstart() {
+        Ok(true) => {
+            eprintln!("restarting daemon via service manager...");
+            // After kickstart, give the daemon a few seconds to publish its socket.
+            if wait_for_socket_until(&socket_path, None, Duration::from_secs(10))? {
+                eprintln!("daemon restarted");
+                return Ok(true);
+            }
+            tracing::warn!(
+                "service kickstart completed but socket not ready; falling through to manual restart"
+            );
+        }
+        Ok(false) => {
+            // No service installed — fall through to manual path.
+        }
+        Err(e) => {
+            tracing::warn!("service kickstart failed: {e:#} — falling back to manual restart");
+        }
+    }
+
+    // Manual path: stop existing daemon (best-effort), wipe stale files,
+    // then re-spawn a fresh daemon via the standard startup coordinator.
+    let _ = send_shutdown_request(config);
+
+    // Wipe stale coordination files. Safe because any live process that held
+    // a flock on these files already had its fd closed when it exited; a new
+    // file at the same path starts with a clean flock state.
+    let _ = std::fs::remove_file(&socket_path);
+    let _ = std::fs::remove_file(daemon_state_path(&socket_path));
+
+    match start_daemon_background()? {
+        true => {
+            eprintln!("daemon restarted");
+            Ok(true)
+        }
+        false => {
+            eprintln!("daemon did not start within timeout");
+            Ok(false)
+        }
+    }
+}
+
 /// Best-effort restart for stale-daemon detection from stats polling.
 /// This path is intentionally outside build hot paths, so a short bounded wait
 /// is acceptable to keep monitor/status output current.

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,8 @@ enum DaemonCommands {
     Start,
     /// Stop a running daemon
     Stop,
+    /// Restart daemon (via launchd/systemd if installed, else manual stop+start)
+    Restart,
     /// Install daemon as a system service (launchd/systemd)
     Install,
     /// Remove the daemon service
@@ -407,6 +409,12 @@ fn main() -> Result<()> {
         Some(Commands::Daemon {
             command: Some(DaemonCommands::Stop),
         }) => daemon::send_shutdown_request(&config),
+        Some(Commands::Daemon {
+            command: Some(DaemonCommands::Restart),
+        }) => match daemon::restart(&config)? {
+            true => Ok(()),
+            false => std::process::exit(1),
+        },
         Some(Commands::Daemon {
             command: Some(DaemonCommands::Install),
         }) => service::install(),

--- a/src/service.rs
+++ b/src/service.rs
@@ -248,6 +248,51 @@ WantedBy=default.target
     Ok(())
 }
 
+// ── Kickstart ────────────────────────────────────────────────────
+
+/// Force-restart the installed service. Used by `kache daemon restart` and by
+/// `kache init` recovery when the service file is present but the daemon isn't
+/// reachable (e.g. after idle-timeout shutdown left stale lockfiles, or launchd
+/// hasn't re-spawned on its own).
+///
+/// Returns `Ok(false)` if no service is installed on this platform.
+pub fn kickstart() -> Result<bool> {
+    if cfg!(target_os = "macos") {
+        let plist = plist_path();
+        if !plist.exists() {
+            return Ok(false);
+        }
+        let uid = unsafe { libc::getuid() };
+        let target = format!("gui/{uid}/{LABEL}");
+        // `kickstart -k` stops the service if running and starts it again.
+        let out = std::process::Command::new("launchctl")
+            .args(["kickstart", "-k", &target])
+            .output()
+            .context("running launchctl kickstart")?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            anyhow::bail!("launchctl kickstart {target} failed: {stderr}");
+        }
+        Ok(true)
+    } else if cfg!(target_os = "linux") {
+        let unit = unit_path();
+        if !unit.exists() {
+            return Ok(false);
+        }
+        let out = std::process::Command::new("systemctl")
+            .args(["--user", "restart", UNIT_NAME])
+            .output()
+            .context("running systemctl --user restart")?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            anyhow::bail!("systemctl --user restart {UNIT_NAME} failed: {stderr}");
+        }
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
 // ── Uninstall ────────────────────────────────────────────────────
 
 pub fn uninstall() -> Result<()> {


### PR DESCRIPTION
## Summary
- Adds `kache daemon restart`: prefers `launchctl kickstart -k` / `systemctl --user restart` when a service is installed, falls back to manual stop + stale-file cleanup + spawn.
- Updates `kache init` step 3: when the service is installed but the daemon isn't reachable, it now restarts via the service manager instead of spawning a manual daemon that would race with the existing (possibly stuck) launchd/systemd registration.

## Context
Real-world footgun: after idle-timeout shutdown, launchd leaves the service registered with exit code 0 but no live process. Subsequent `start_daemon_background()` attempts spawn a kache daemon that exits with \"another daemon holds the run lock\" — because the flock is either held by a zombie or the lockfile state is stale. `launchctl kickstart -k` clears this cleanly because it owns the process.

## Test plan
- [x] `cargo check`, `cargo clippy --all-targets`, `cargo fmt --check` pass locally.
- [x] `cargo test --bin kache cli::tests` passes (25/25).
- [x] `./target/debug/kache daemon --help` shows new `restart` subcommand.
- [ ] Manual: on macOS, run `kache init` against a state with installed plist + offline daemon → confirm it kicks the service and daemon becomes reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)