### PR TITLE
perf(service): swap surrealdb storage from kv-rocksdb to kv-surrealkv

### DIFF
--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4", features = ["derive", "env"] }
 kache-core = { path = "../kache-core", default-features = false, features = ["planning"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-surrealdb = { version = "3.0.5", features = ["kv-rocksdb"] }
+surrealdb = { version = "3.0.5", features = ["kv-surrealkv"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/crates/kache-service/src/state.rs
+++ b/crates/kache-service/src/state.rs
@@ -7,7 +7,7 @@ use kache_core::{PlannerDataSource, PrefetchCandidate};
 use serde::{Deserialize, Serialize};
 use surrealdb::{
     Surreal,
-    engine::local::{Db, RocksDb},
+    engine::local::{Db, SurrealKv},
 };
 
 pub const DEFAULT_DB_PATH: &str = "/var/lib/kache/planner.db";
@@ -43,7 +43,7 @@ impl SurrealPlannerRepository {
                 .with_context(|| format!("creating planner db directory {}", parent.display()))?;
         }
 
-        let db = Surreal::new::<RocksDb>(path.to_path_buf())
+        let db = Surreal::new::<SurrealKv>(path.to_path_buf())
             .await
             .with_context(|| format!("opening embedded planner db at {}", path.display()))?;
         db.use_ns(PLANNER_NAMESPACE)


### PR DESCRIPTION
## Summary
Swap the SurrealDB storage backend from \`kv-rocksdb\` to \`kv-surrealkv\`. Two tokens change: one feature flag in \`Cargo.toml\` and one engine type in \`state.rs\`.

## Why
\`kv-rocksdb\` pulls in the C++ RocksDB build (~4-5 min cold) which dominates CI time on every cache miss. \`kv-surrealkv\` is SurrealDB's native Rust KV engine, shipping the **same SurrealQL feature surface** — tables, indexes, \`RELATE\`, graph traversal, transactions. This is a storage swap, not a capability cut.

Keeps the door open for the graph-heavy planner logic this service was explicitly designed around, while removing the heaviest single dep from the tree.

## Dep tree impact
Before: \`surrealdb → … → rocksdb → librocksdb-sys (C++ compile)\`
After: \`surrealdb → … → surrealkv v0.21 (pure Rust)\`

## Test plan
- [x] \`cargo check -p kache-service\` — clean
- [x] \`cargo test -p kache-service\` — 7/7 passing, including the two state.rs tests that actually exercise the DB
- [x] \`cargo clippy -p kache-service --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] CI on this PR shows meaningful build time reduction

## Migration note
No data migration in-repo (v0.0.0, no production deployments yet that I'm aware of). If any dev has an existing \`planner.db\` from kv-rocksdb, they'll need to re-seed.