### PR TITLE
fix(daemon): auto-recover stale state in restart, detect legacy cruft in doctor

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1800,6 +1800,87 @@ pub fn doctor(
         });
     }
 
+    // 10. Lingering kache daemon processes — if the socket isn't reachable
+    //     but `kache daemon run` processes exist, something got stuck.
+    //     `kache daemon restart` now force-recovers this automatically.
+    if let Some(ref cfg) = config {
+        let reachable = crate::daemon::send_stats_request(cfg, false, None, None).is_ok();
+        let pids = crate::daemon::find_daemon_pids();
+        if !reachable && !pids.is_empty() {
+            let pids_str = pids
+                .iter()
+                .map(|p| p.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            checks.push(Check {
+                label: "Daemon processes",
+                pass: false,
+                detail: format!(
+                    "{} zombie daemon(s) (pid {pids_str}), socket unreachable",
+                    pids.len()
+                ),
+                fix: Some(
+                    "kache daemon restart  (auto-kills lingering processes + cleans stale files)"
+                        .into(),
+                ),
+            });
+        }
+    }
+
+    // 11. Stale lock files — when no daemon is running, leftover lock files
+    //     are legacy cruft from an unclean shutdown. Harmless but worth
+    //     surfacing so users know `daemon restart` will tidy them up.
+    if let Some(ref cfg) = config {
+        let sock = cfg.socket_path();
+        let mut stale_files = Vec::new();
+        for ext in ["lock", "run.lock"] {
+            let p = sock.with_extension(ext);
+            if p.exists() {
+                stale_files.push(p);
+            }
+        }
+        if !stale_files.is_empty()
+            && crate::daemon::find_daemon_pids().is_empty()
+            && crate::daemon::send_stats_request(cfg, false, None, None).is_err()
+        {
+            checks.push(Check {
+                label: "Stale locks",
+                pass: false,
+                detail: format!(
+                    "{} legacy lock file(s) from a previous daemon",
+                    stale_files.len()
+                ),
+                fix: Some("kache daemon restart  (removes stale files and starts fresh)".into()),
+            });
+        }
+    }
+
+    // 12. Service plist exe mismatch (macOS/Linux) — if the registered
+    //     service points to a binary that no longer exists or differs from
+    //     the current `kache`, the daemon will relaunch the wrong binary.
+    if let Some(service_path) = crate::service::service_file_path()
+        && service_path.exists()
+    {
+        let current_exe = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.canonicalize().ok());
+        let installed_exe = crate::service::parse_exe_from_service_file(&service_path);
+        if let (Some(current), Some(installed)) = (current_exe, installed_exe)
+            && current != installed
+        {
+            checks.push(Check {
+                label: "Service exe",
+                pass: false,
+                detail: format!(
+                    "plist points to {} but current exe is {}",
+                    installed.display(),
+                    current.display()
+                ),
+                fix: Some("kache daemon install  (re-registers against current binary)".into()),
+            });
+        }
+    }
+
     // Print
     let version = crate::VERSION;
     let rustc_version = std::process::Command::new("rustc")

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2850,47 +2850,108 @@ pub fn send_shutdown_request(config: &Config) -> Result<()> {
     }
 }
 
+/// Find PIDs of running `kache daemon run` processes via pgrep.
+///
+/// Returns only PIDs that are still alive at the moment of the check — stale
+/// pgrep output is filtered out with a `kill -0` probe.
+pub fn find_daemon_pids() -> Vec<u32> {
+    let output = match std::process::Command::new("pgrep")
+        .args(["-f", "kache daemon run"])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+    let own_pid = std::process::id();
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|l| l.trim().parse::<u32>().ok())
+        .filter(|&pid| pid != own_pid && process_is_alive(pid))
+        .collect()
+}
+
+/// Nuclear recovery: kill any lingering `kache daemon run` processes, then
+/// wipe stale coordination files (socket, lock files, state json).
+///
+/// Used as the fallback when a regular restart can't produce a reachable
+/// daemon — typically because a zombie process still holds the run lock or
+/// stale lockfiles survived an unclean shutdown.
+pub fn force_recover(config: &Config) -> Result<()> {
+    let socket_path = config.socket_path();
+    let pids = find_daemon_pids();
+
+    if !pids.is_empty() {
+        tracing::info!(?pids, "killing lingering kache daemon processes");
+        for &pid in &pids {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGTERM);
+            }
+        }
+        // Give the SIGTERM a moment to land.
+        std::thread::sleep(Duration::from_millis(500));
+        for &pid in &pids {
+            if process_is_alive(pid) {
+                tracing::warn!(pid, "SIGTERM did not land, escalating to SIGKILL");
+                unsafe {
+                    libc::kill(pid as i32, libc::SIGKILL);
+                }
+            }
+        }
+        // Allow the OS a moment to reap zombies and release flocks.
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    // Remove stale coordination files. Once processes are gone, OS has
+    // released their flocks; wiping these files starts the next daemon
+    // with a clean slate.
+    let _ = std::fs::remove_file(&socket_path);
+    let _ = std::fs::remove_file(daemon_state_path(&socket_path));
+    let _ = std::fs::remove_file(socket_path.with_extension("lock"));
+    let _ = std::fs::remove_file(socket_path.with_extension("run.lock"));
+
+    Ok(())
+}
+
 /// Explicit daemon restart for `kache daemon restart` and init recovery.
 ///
-/// Prefers the platform service manager (launchd/systemd) when a service is
-/// installed, since it owns the daemon process and knows how to bring it back
-/// cleanly. Falls back to manual stop+start otherwise.
+/// Three-tier recovery strategy:
+/// 1. Prefer the platform service manager (launchd/systemd) when installed —
+///    it owns the daemon lifecycle and `kickstart -k` cleans its own state.
+/// 2. If that doesn't yield a reachable daemon, do `force_recover` — kill
+///    lingering manually-spawned daemons and wipe stale coordination files
+///    (covers the case where a process is alive outside the service manager's
+///    knowledge).
+/// 3. Finally, spawn a fresh daemon via `start_daemon_background`.
 ///
 /// Returns `Ok(true)` if the daemon is reachable after restart.
 pub fn restart(config: &Config) -> Result<bool> {
     let socket_path = config.socket_path();
 
-    // Prefer the service manager when available — it's the authoritative owner.
+    // Tier 1: service manager
     match crate::service::kickstart() {
         Ok(true) => {
             eprintln!("restarting daemon via service manager...");
-            // After kickstart, give the daemon a few seconds to publish its socket.
             if wait_for_socket_until(&socket_path, None, Duration::from_secs(10))? {
                 eprintln!("daemon restarted");
                 return Ok(true);
             }
             tracing::warn!(
-                "service kickstart completed but socket not ready; falling through to manual restart"
+                "service kickstart completed but socket not ready; attempting nuclear recovery"
             );
         }
         Ok(false) => {
             // No service installed — fall through to manual path.
         }
         Err(e) => {
-            tracing::warn!("service kickstart failed: {e:#} — falling back to manual restart");
+            tracing::warn!("service kickstart failed: {e:#}; attempting nuclear recovery");
         }
     }
 
-    // Manual path: stop existing daemon (best-effort), wipe stale files,
-    // then re-spawn a fresh daemon via the standard startup coordinator.
+    // Tier 2: best-effort graceful shutdown then force cleanup
     let _ = send_shutdown_request(config);
+    force_recover(config)?;
 
-    // Wipe stale coordination files. Safe because any live process that held
-    // a flock on these files already had its fd closed when it exited; a new
-    // file at the same path starts with a clean flock state.
-    let _ = std::fs::remove_file(&socket_path);
-    let _ = std::fs::remove_file(daemon_state_path(&socket_path));
-
+    // Tier 3: fresh spawn
     match start_daemon_background()? {
         true => {
             eprintln!("daemon restarted");

--- a/src/service.rs
+++ b/src/service.rs
@@ -481,7 +481,7 @@ pub fn status() -> Result<()> {
 }
 
 /// Extract the executable path from a service file.
-fn parse_exe_from_service_file(path: &std::path::Path) -> Option<PathBuf> {
+pub(crate) fn parse_exe_from_service_file(path: &std::path::Path) -> Option<PathBuf> {
     let content = std::fs::read_to_string(path).ok()?;
 
     if cfg!(target_os = "macos") {


### PR DESCRIPTION
## Summary
Eliminates the "daemon offline, user has to \`rm\` files by hand" class of bugs. \`kache init\` and \`kache daemon restart\` now unstick any install automatically; \`kache doctor\` surfaces the specific legacy state that caused it.

## Changes

### \`daemon::force_recover()\` (new, pub)
- \`pgrep -f "kache daemon run"\` → SIGTERM → 500ms → SIGKILL survivors
- Wipes \`.sock\`, \`.sock.lock\`, \`.sock.run.lock\`, \`.state.json\`
- Used as fallback tier in \`restart()\`

### \`daemon::restart()\` now has three tiers
1. **Service manager kickstart** (launchctl / systemctl) — authoritative owner, clean
2. **\`force_recover\`** — covers the edge case where a manually-spawned daemon (e.g., from a previous \`start_daemon_background\`) lives outside the service manager's knowledge and still holds the run lock
3. **Fresh spawn** via \`start_daemon_background\`

### \`kache doctor\` adds three checks
- **Daemon processes**: zombie \`kache daemon run\` PIDs when the socket is unreachable
- **Stale locks**: leftover \`.lock\` / \`.run.lock\` from an unclean shutdown
- **Service exe**: plist/unit points to a binary path that differs from the current \`kache\` (happens after \`just install\` without re-registering the service)

All three auto-fix with a single \`kache daemon restart\`.

## Test plan
- [x] \`cargo test --bin kache\` — 336/336 passing
- [x] \`cargo clippy --all-targets\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] Manual: reproduce stuck state (kill daemon mid-run, leave lock behind) and confirm \`kache daemon restart\` recovers without manual \`rm\`

## Why now
User hit the exact sequence this PR addresses: \`kache init\` succeeded visually ("daemon started") but \`kache doctor\` immediately reported "daemon not reachable" because the spawned daemon died on a stale run.lock. The fix makes recovery a zero-effort operation.