### PR TITLE
perf(remote): tune S3 HTTP pool idle timeout to 300s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,6 +3222,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "aws-smithy-http-client",
  "blake3",
  "bytesize",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ resolver = "3"
 blake3 = "1"
 aws-sdk-s3 = "1"
 aws-config = "1"
+aws-smithy-http-client = { version = "1", features = ["rustls-ring"] }
 kache-core = { path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Environment variables take highest priority, then config file, then defaults.
 | `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly |
 | `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd compression level (1-22) |
 | `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `8` | Max concurrent S3 operations |
+| `KACHE_S3_POOL_IDLE_SECS` | `cache.s3_pool_idle_secs` | `300` | How long an idle S3 connection is kept in the HTTP pool. Higher values reuse warm TLS sessions across build phases; lower this if you sit behind a load balancer that drops idle connections aggressively |
 | `KACHE_DISABLED` | — | `0` | Disable caching entirely |
 | `KACHE_LOG` | — | `kache=warn` | Log level |
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2138,7 +2138,7 @@ async fn sync_inner(
     pull_all: bool,
     lock_crates: Option<&std::collections::HashSet<String>>,
 ) -> Result<()> {
-    let client = crate::remote::create_s3_client(remote)
+    let client = crate::remote::create_s3_client(remote, config.s3_pool_idle_secs)
         .await
         .context("connecting to S3 — check credentials and endpoint")?;
     let planner = crate::remote_plan::RemotePlanner::new(config);
@@ -2486,8 +2486,9 @@ pub fn save_manifest(
         .build()
         .context("building tokio runtime")?;
 
+    let pool_idle_secs = config.s3_pool_idle_secs;
     rt.block_on(async {
-        let client = crate::remote::create_s3_client(remote).await?;
+        let client = crate::remote::create_s3_client(remote, pool_idle_secs).await?;
 
         // Always upload the monolithic build manifest
         crate::remote::upload_manifest(&client, &remote.bucket, &remote.prefix, &key, &manifest)

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 pub const DEFAULT_DAEMON_IDLE_TIMEOUT_SECS: u64 = 10 * 60;
 pub const DEFAULT_PLANNER_TIMEOUT_MS: u64 = 750;
+pub const DEFAULT_S3_POOL_IDLE_SECS: u64 = 300;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -22,6 +23,13 @@ pub struct Config {
     pub s3_concurrency: u32,
     /// Daemon idle timeout in seconds (default 600 = 10 minutes). 0 = no timeout.
     pub daemon_idle_timeout_secs: u64,
+    /// How long an idle TCP/TLS connection is kept in the S3 client's pool, in
+    /// seconds (default 300). Tuned higher than hyper's 90s default so that
+    /// gaps between S3 bursts (e.g. between prefetch and post-build sync)
+    /// reuse warm TLS sessions instead of re-handshaking. Set lower if you sit
+    /// behind a load balancer with an aggressive idle timeout that may drop
+    /// connections silently.
+    pub s3_pool_idle_secs: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -60,6 +68,7 @@ pub(crate) struct CacheFileConfig {
     pub(crate) compression_level: Option<i32>,
     pub(crate) s3_concurrency: Option<u32>,
     pub(crate) daemon_idle_timeout_secs: Option<u64>,
+    pub(crate) s3_pool_idle_secs: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
@@ -228,6 +237,18 @@ impl Config {
             })
             .unwrap_or(DEFAULT_DAEMON_IDLE_TIMEOUT_SECS);
 
+        let s3_pool_idle_secs = std::env::var("KACHE_S3_POOL_IDLE_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .or_else(|| {
+                file_config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.cache.as_ref())
+                    .and_then(|c| c.s3_pool_idle_secs)
+            })
+            .unwrap_or(DEFAULT_S3_POOL_IDLE_SECS);
+
         let remote = Self::load_remote_config(&file_config);
 
         Ok(Config {
@@ -242,6 +263,7 @@ impl Config {
             compression_level,
             s3_concurrency,
             daemon_idle_timeout_secs,
+            s3_pool_idle_secs,
         })
     }
 
@@ -562,6 +584,7 @@ mod tests {
                 compression_level: Some(3),
                 s3_concurrency: Some(8),
                 daemon_idle_timeout_secs: None,
+                s3_pool_idle_secs: None,
                 remote: Some(RemoteFileConfig {
                     _type: Some("s3".to_string()),
                     bucket: Some("my-bucket".to_string()),
@@ -631,6 +654,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
         assert_eq!(config.store_dir(), PathBuf::from("/tmp/kache/store"));
     }
@@ -649,6 +673,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
         assert_eq!(config.index_db_path(), PathBuf::from("/tmp/kache/index.db"));
     }
@@ -667,6 +692,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
         assert_eq!(
             config.event_log_path(),
@@ -688,6 +714,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
         assert_eq!(
             config.socket_path(),
@@ -772,6 +799,7 @@ mod tests {
                 compression_level: Some(5),
                 s3_concurrency: None,
                 daemon_idle_timeout_secs: None,
+                s3_pool_idle_secs: None,
                 remote: None,
             }),
         };

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -404,6 +404,7 @@ fn fields_to_file_config(fields: &[FormField]) -> FileConfig {
             s3_concurrency: get("s3_concurrency").and_then(|s| s.parse::<u32>().ok()),
             daemon_idle_timeout_secs: get("daemon_idle_timeout_secs")
                 .and_then(|s| s.parse::<u64>().ok()),
+            s3_pool_idle_secs: get("s3_pool_idle_secs").and_then(|s| s.parse::<u64>().ok()),
             remote,
         }),
     }
@@ -1048,6 +1049,7 @@ mod tests {
                 compression_level: Some(3),
                 s3_concurrency: Some(8),
                 daemon_idle_timeout_secs: None,
+                s3_pool_idle_secs: None,
                 remote: Some(RemoteFileConfig {
                     _type: Some("s3".to_string()),
                     bucket: Some("test-bucket".to_string()),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -875,7 +875,7 @@ impl Daemon {
                     .remote
                     .as_ref()
                     .ok_or_else(|| anyhow::anyhow!("no remote configured"))?;
-                crate::remote::create_s3_client(remote).await
+                crate::remote::create_s3_client(remote, self.config.s3_pool_idle_secs).await
             })
             .await
     }
@@ -3371,6 +3371,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         }
     }
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,5 +1,10 @@
 use anyhow::{Context, Result};
+use aws_smithy_http_client::{
+    Builder as SmithyHttpClientBuilder,
+    tls::{self, rustls_provider::CryptoMode},
+};
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 use crate::config::RemoteConfig;
 
@@ -39,7 +44,10 @@ pub struct UploadResult {
     pub network_ms: u64,
 }
 
-pub async fn create_s3_client(remote: &RemoteConfig) -> Result<aws_sdk_s3::Client> {
+pub async fn create_s3_client(
+    remote: &RemoteConfig,
+    pool_idle_secs: u64,
+) -> Result<aws_sdk_s3::Client> {
     let mut config_builder = aws_config::defaults(aws_config::BehaviorVersion::latest())
         .region(aws_config::Region::new(remote.region.clone()));
 
@@ -75,6 +83,13 @@ pub async fn create_s3_client(remote: &RemoteConfig) -> Result<aws_sdk_s3::Clien
 
     let sdk_config = config_builder.load().await;
     let mut s3_config = aws_sdk_s3::config::Builder::from(&sdk_config).force_path_style(true);
+
+    let http_client = SmithyHttpClientBuilder::new()
+        .tls_provider(tls::Provider::Rustls(CryptoMode::Ring))
+        .pool_idle_timeout(Duration::from_secs(pool_idle_secs))
+        .build_https();
+    s3_config = s3_config.http_client(http_client);
+    tracing::debug!(pool_idle_secs, "S3 HTTP client configured");
 
     if let Some(endpoint) = &remote.endpoint {
         s3_config = s3_config.endpoint_url(endpoint);

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -419,7 +419,7 @@ fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{blob_path, create_entry_pack_zstd, extract_entry_pack};
-    use crate::config::{Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS};
+    use crate::config::{Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS, DEFAULT_S3_POOL_IDLE_SECS};
     use crate::store::{EntryMeta, Store};
     use aws_sdk_s3::error::ErrorMetadata;
     use aws_sdk_s3::operation::head_object::HeadObjectError;
@@ -439,6 +439,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
         let store = Store::open(&config).unwrap();
 
@@ -494,6 +495,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
         let restore_store = Store::open(&restore_config).unwrap();
         let restore_entry_dir = restore_store.entry_dir("key123");

--- a/src/remote_plan.rs
+++ b/src/remote_plan.rs
@@ -73,7 +73,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::{RemoteLayoutKind, RemotePlanner, RemoteWorkload};
-    use crate::config::{Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS};
+    use crate::config::{Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS, DEFAULT_S3_POOL_IDLE_SECS};
 
     fn test_config() -> Config {
         Config {
@@ -88,6 +88,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         }
     }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -1451,6 +1451,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         };
 
         // Write build events
@@ -1617,6 +1618,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         };
 
         // Only write build events, no transfers
@@ -1643,6 +1645,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         };
 
         // Mostly misses — should trigger high miss share suggestion
@@ -1722,6 +1725,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         };
 
         let report = generate_report(&config, 24, 10).unwrap();

--- a/src/store.rs
+++ b/src/store.rs
@@ -1211,6 +1211,7 @@ mod tests {
             compression_level: 3,
             s3_concurrency: 16,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         }
     }
 


### PR DESCRIPTION
## Summary

- Default hyper-util's pool idle timeout (90s) is too short for kache's bursty S3 workload — gaps between prefetch and post-build sync routinely exceed it, forcing TLS re-handshakes that compound with concurrency=16 (≈18ms × N at start of each burst).
- Plugs in a custom `aws-smithy-http-client` with `pool_idle_timeout=300s` by default, configurable via `KACHE_S3_POOL_IDLE_SECS` / `cache.s3_pool_idle_secs`.
- The SDK's standard retry policy already covers stale-pool-entry RSTs, so users behind LBs with aggressive idle timeouts can lower this knob without dropping safety.

## Context

Investigating S3 latency in CI ([example](https://github.com/Zondax/kunobi-frontend/actions/runs/24981622352/job/73144944168)), found:
- HTTP endpoint to RGW: ~1-2ms
- HTTPS to same backend: ~18-24ms — TLS handshake dominates
- RGW does not negotiate HTTP/2 (ALPN fail → HTTP/1.1), so multiplexing is not an option
- Daemon creates a single S3 client and reuses it (✓), but hyper-util's 90s default pool idle was evicting connections during compile gaps

## What's NOT in this PR

- TCP keepalive — `aws-smithy-http-client::Builder` doesn't expose `SO_KEEPALIVE`. If telemetry shows excessive reuse failures behind hostile LBs, a follow-up can implement `HttpClient` directly with full hyper-util control.
- Connection open/reuse counters — same reason; would need a custom `HttpClient` impl.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --bins` (336 passed)
- [ ] CI integration tests (worktree-local cargo workspace conflict — run on actual CI)
- [ ] Validate in real CI: confirm fewer TLS handshakes during a long build (look for fewer SYNs to s3.* in `tcpdump`, or set `KACHE_LOG=hyper_util=debug` and grep for "reuse idle connection")