### PR TITLE
add kunobi auth and ha support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -834,7 +840,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a0f5948f30df5f43ac29d310b7476793be97c50787e6ef4a63d960a0d0be827"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "blowfish",
  "getrandom 0.3.4",
  "subtle",
@@ -1629,6 +1635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1732,6 +1739,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,6 +1773,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "earcutr"
@@ -2413,7 +2432,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2432,7 +2451,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2533,7 +2552,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http 1.4.0",
@@ -2794,11 +2813,13 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
+ "log",
  "rustls 0.23.39",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2820,7 +2841,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -3021,6 +3042,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -3069,6 +3101,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c00403deb17c3221a1fe4fb571b9ed0370b3dcd116553c77fa294a3d918699"
 
 [[package]]
+name = "interprocess"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3089,6 +3134,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3122,6 +3176,30 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jni"
@@ -3190,13 +3268,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633a7320c4bb672863a3782e89b9094ad70285e097ff6832cddd0ec615beadfa"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hmac 0.12.1",
@@ -3211,6 +3317,18 @@ dependencies = [
  "sha2 0.10.9",
  "signature 2.2.0",
  "simple_asn1",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b326f5219dd55872a72c1b6ddd1b830b8334996c667449c29391d657d78d5e"
+dependencies = [
+ "base64 0.22.1",
+ "jiff",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3235,7 +3353,7 @@ dependencies = [
  "libc",
  "predicates",
  "ratatui",
- "reqwest",
+ "reqwest 0.13.2",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3268,7 +3386,11 @@ dependencies = [
  "axum",
  "clap",
  "http-body-util",
+ "k8s-openapi",
  "kache-core",
+ "kube",
+ "kunobi-auth",
+ "kunobi-ha",
  "serde",
  "serde_json",
  "surrealdb",
@@ -3288,6 +3410,111 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kube"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc5a6a69da2975ed9925d56b5dcfc9cc739b66f37add06785b7c9f6d1e88741"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+]
+
+[[package]]
+name = "kube-client"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcaf2d1f1a91e1805d4cd82e8333c022767ae8ffd65909bbef6802733a7dd40"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "either",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
+ "hyper-timeout",
+ "hyper-util",
+ "jiff",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rustls 0.23.39",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f126d2db7a8b532ec1d839ece2a71e2485dc3bbca6cc3c3f929becaa810e719e"
+dependencies = [
+ "derive_more",
+ "form_urlencoded",
+ "http 1.4.0",
+ "jiff",
+ "k8s-openapi",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kunobi-auth"
+version = "0.2.0"
+source = "git+https://github.com/kunobi-ninja/kunobi-auth.git?tag=v0.3.0#17bc3045e90031cc93ae54fa860ac495267a52d2"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "http 1.4.0",
+ "jsonwebtoken 9.3.1",
+ "oauth2",
+ "openidconnect",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "ssh-agent-client-rs",
+ "ssh-encoding",
+ "ssh-key",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "kunobi-ha"
+version = "0.3.0"
+source = "git+https://github.com/kunobi-ninja/kunobi-ha.git?branch=main#bf310052ef1d34cabf6bd948cd11778666d11878"
+dependencies = [
+ "chrono",
+ "k8s-openapi",
+ "kube",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3586,7 +3813,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6e54a8b65764f71827a90ca1d56965ec0c67f069f996477bd493402a901d1f"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.13.0",
  "ndarray",
  "noisy_float",
@@ -3768,6 +3995,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http 1.4.0",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3825,6 +4072,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openidconnect"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac 0.12.1",
+ "http 1.4.0",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256 0.13.2",
+ "p384",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2 0.10.9",
+ "subtle",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3835,6 +4113,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -3883,6 +4170,20 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct 0.2.0",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "rand_core 0.6.4",
  "sha2 0.10.9",
 ]
 
@@ -3966,7 +4267,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -4653,6 +4954,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc4a4ea2a66a41a1152c4b3d86e8954dc087bdf33af35446e6e176db4e73c8c"
 
 [[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4679,6 +4986,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4733,11 +5060,49 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.39",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4913,6 +5278,7 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -5228,6 +5594,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5290,6 +5680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5343,6 +5742,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5387,6 +5796,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5405,6 +5823,50 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -5645,6 +6107,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssh-agent-client-rs"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e17f8c47c06666b1cffb0116555450c7ee46c4004701981208dd6f79850747"
+dependencies = [
+ "bytes",
+ "interprocess",
+ "signature 2.2.0",
+ "ssh-encoding",
+ "ssh-key",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "cipher",
+ "ssh-encoding",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
+dependencies = [
+ "ed25519-dalek",
+ "num-bigint-dig",
+ "p256 0.13.2",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1 0.7.3",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5748,10 +6267,10 @@ dependencies = [
  "chrono",
  "futures",
  "getrandom 0.3.4",
- "indexmap",
+ "indexmap 2.14.0",
  "js-sys",
  "path-clean",
- "reqwest",
+ "reqwest 0.13.2",
  "ring",
  "rustls 0.23.39",
  "rustls-pki-types",
@@ -5789,7 +6308,7 @@ dependencies = [
  "async-channel",
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bcrypt",
  "blake3",
  "bytes",
@@ -5811,7 +6330,7 @@ dependencies = [
  "http 1.4.0",
  "humantime",
  "ipnet",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "lexicmp",
  "md-5 0.10.6",
  "mime",
@@ -6084,7 +6603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.11.1",
  "fancy-regex",
  "filedescriptor",
@@ -6098,7 +6617,7 @@ dependencies = [
  "nix",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf 0.11.3",
@@ -6339,7 +6858,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -6363,7 +6882,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -6392,7 +6911,7 @@ checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2 0.4.13",
  "http 1.4.0",
@@ -6432,7 +6951,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -6449,16 +6968,19 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "base64 0.22.1",
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
+ "mime",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6643,6 +7165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6664,6 +7192,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6867,7 +7396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6893,7 +7422,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -7011,7 +7540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -7040,6 +7569,12 @@ dependencies = [
  "serde",
  "wezterm-dynamic",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -7485,7 +8020,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -7516,7 +8051,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -7535,7 +8070,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ kache doctor
 
 `kache init` is idempotent — re-run it any time to repair configuration. If you prefer to configure things by hand, just export `RUSTC_WRAPPER=kache` or add it to `~/.cargo/config.toml` under `[build]`.
 
+## Why local kache is fast
+
+kache is useful even before remote cache is configured:
+
+- Local hits are restored with hardlinks into `target/`, so artifact bytes are not copied.
+- The store is content-addressed by blake3 hash, so identical artifact blobs are stored once and linked many times.
+- Misses compile normally, then kache records the outputs for future builds.
+- The daemon is optional for local caching. If it is not running, local hits and misses still work; remote checks, uploads, and prefetching degrade gracefully.
+- Incremental compilation is disabled while kache wraps rustc, because artifact caching replaces that path and avoids APFS-related corruption on macOS.
+
 ## Development
 
 ```sh
@@ -77,72 +87,18 @@ The repo uses `just` as its single task runner. `mise.toml` pins the local Rust 
 
 Durations use human-friendly format: `7d`, `24h`, `30m`.
 
-### Sync
+## Remote cache and configuration
 
-`kache sync` works directly against S3 (no daemon required). By default, it filters pulls to crates found in the current workspace's `Cargo.lock`:
+`kache sync` can pull from and push to S3-compatible storage directly, without the daemon. Pulls are filtered by the current workspace's `Cargo.lock` by default. See [Sync](docs/kache-docs/remote-cache/sync.mdx) for the full command behavior and S3 layout.
 
-```sh
-kache sync              # pull missing deps + push local artifacts
-kache sync --pull       # download only
-kache sync --push       # upload only
-kache sync --all        # pull all artifacts (ignore Cargo.lock filter)
-kache sync --dry-run    # preview what would transfer
-```
-
-S3 layout: `{prefix}/{crate_name}/{cache_key}.tar.zst` — organized by crate for efficient filtered listing.
-
-## Configuration
-
-Configure via the TUI editor (`kache config`), environment variables, or the config file directly.
-
-Config file priority: `KACHE_CONFIG` env var > nearest project-local `.kache.toml` (walks up from the current directory) > user config at `~/.config/kache/config.toml` (respects `XDG_CONFIG_HOME`).
-
-Environment variables take highest priority, then config file, then defaults.
-
-| Variable | Config key | Default | Description |
-|---|---|---|---|
-| `KACHE_CACHE_DIR` | `cache.local_store` | `~/Library/Caches/kache` (macOS), `~/.cache/kache` (Linux) | Local store directory |
-| `KACHE_MAX_SIZE` | `cache.local_max_size` | `50GB` | Max store size |
-| `KACHE_CONFIG` | — | XDG config path | Explicit config file path |
-| `KACHE_S3_BUCKET` | `cache.remote.bucket` | — | S3 bucket for remote cache |
-| `KACHE_S3_ENDPOINT` | `cache.remote.endpoint` | — | Custom S3 endpoint (required for Ceph/MinIO/R2) |
-| `KACHE_S3_REGION` | `cache.remote.region` | `us-east-1` | AWS region |
-| `KACHE_S3_PREFIX` | `cache.remote.prefix` | `artifacts` | S3 key prefix for all artifacts |
-| `KACHE_S3_PROFILE` | `cache.remote.profile` | — | AWS profile name for credentials (e.g. `ceph`) |
-| `KACHE_S3_ACCESS_KEY` | — | — | Explicit S3 access key (overrides profile) |
-| `KACHE_S3_SECRET_KEY` | — | — | Explicit S3 secret key (overrides profile) |
-| `KACHE_CACHE_EXECUTABLES` | `cache.cache_executables` | `false` | Cache bin/dylib/cdylib outputs |
-| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly |
-| `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd compression level (1-22) |
-| `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `8` | Max concurrent S3 operations |
-| `KACHE_S3_POOL_IDLE_SECS` | `cache.s3_pool_idle_secs` | `300` | How long an idle S3 connection is kept in the HTTP pool. Higher values reuse warm TLS sessions across build phases; lower this if you sit behind a load balancer that drops idle connections aggressively |
-| `KACHE_DISABLED` | — | `0` | Disable caching entirely |
-| `KACHE_LOG` | — | `kache=warn` | Log level |
-
-### Credential resolution order
-
-1. `KACHE_S3_ACCESS_KEY` + `KACHE_S3_SECRET_KEY` (explicit override)
-2. AWS profile from config (`profile` field or `KACHE_S3_PROFILE`)
-3. AWS default chain (`AWS_ACCESS_KEY_ID`, `~/.aws/credentials [default]`, IAM roles)
-
-### Example config (Ceph)
-
-```toml
-[cache.remote]
-type = "s3"
-bucket = "build-cache"
-endpoint = "https://s3.example.com"
-profile = "ceph"
-```
+Configuration is available through `kache config`, environment variables, or config files. Environment variables win over config files, and project-local `.kache.toml` files are supported. See [Configuration](docs/kache-docs/getting-started/configuration.mdx) for the full reference.
 
 ## Architecture
 
 - **Wrapper**: `RUSTC_WRAPPER` intercepts rustc calls, computes blake3 cache keys, restores hits via hardlinks
 - **Daemon**: Background process handles async S3 uploads, remote checks, and prefetch. Auto-restarts when binary is updated
-- **Store**: SQLite index + content-addressed directories under `{cache_dir}/store/`
+- **Store**: SQLite index + content-addressed blobs under `{cache_dir}/store/`; cache hits hardlink those blobs into `target/`
 - **Cache keys**: Deterministic blake3 hash of rustc version, crate name, source, dependencies, and normalized flags — portable across machines
-
-Incremental compilation is automatically disabled when kache wraps rustc (`CARGO_INCREMENTAL=0`), since kache's artifact caching subsumes it and avoids APFS-related corruption on macOS.
 
 ## Remote service
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Incremental compilation is automatically disabled when kache wraps rustc (`CARGO
 
 ## Remote service
 
+Warning: server-side kache is still work in progress. Treat the planner service and chart as experimental until the deployment model, auth integration, and HA behavior are hardened.
+
 An optional remote planner service lives in [`crates/kache-service`](crates/kache-service). It persists planner state in an embedded SurrealDB database, serves planner endpoints over HTTP, and safely returns `use_fallback` when the database has no matching candidates.
 
 Useful commands:
@@ -158,7 +160,15 @@ cargo run -p kache-service
 helm upgrade --install kache-service ./charts/kache-service
 ```
 
-The chart in [`charts/kache-service`](charts/kache-service) is intentionally small: one `Deployment`, one `Service`, optional `PersistentVolumeClaim`, security defaults, health probes, and optional bearer-token wiring through an existing `Secret`. It does not bundle ingress or cluster-level policy.
+The chart in [`charts/kache-service`](charts/kache-service) is intentionally small: one `Deployment`, one `Service`, optional `PersistentVolumeClaim`, security defaults, health probes, optional `kunobi-auth` bearer-token wiring through an existing `Secret`, and optional `kunobi-ha` Lease-based leader election. It does not bundle ingress or cluster-level policy.
+
+Bearer-token auth is enabled by pointing the chart at an existing secret. Clients must send the same token through `KACHE_PLANNER_TOKEN`.
+
+```yaml
+auth:
+  existingSecret: kache-planner-token
+  existingSecretKey: token
+```
 
 The service stores its embedded planner database at `/var/lib/kache/planner.db` by default. The chart supports either ephemeral storage for preview/dev environments or a PVC for persisted state:
 
@@ -173,3 +183,14 @@ planner:
 ```
 
 For bootstrap/migration only, the service can still import a legacy JSON planner snapshot on startup via `KACHE_PLANNER_SEED_STATE_FILE`.
+
+For highly available deployments, enable leader election and raise the replica count. Followers stay healthy but not ready until they acquire the Kubernetes Lease:
+
+```yaml
+replicaCount: 2
+ha:
+  enabled: true
+  leaseName: kache-service
+```
+
+When combining HA with PVC-backed planner state, use storage that can be mounted by all scheduled replicas, or keep `replicaCount: 1`.

--- a/charts/kache-service/templates/NOTES.txt
+++ b/charts/kache-service/templates/NOTES.txt
@@ -4,5 +4,10 @@
 2. Point kache clients at the planner:
   KACHE_PLANNER_ENDPOINT=http://{{ include "kache-service.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
 
-3. If bearer auth is enabled, make sure clients also set:
+3. If kunobi-auth bearer-token auth is enabled, make sure clients also set:
   KACHE_PLANNER_TOKEN=<matching token>
+
+{{- if .Values.ha.enabled }}
+4. HA leader election is enabled with Lease:
+  {{ .Release.Namespace }}/{{ .Values.ha.leaseName }}
+{{- end }}

--- a/charts/kache-service/templates/_helpers.tpl
+++ b/charts/kache-service/templates/_helpers.tpl
@@ -53,3 +53,14 @@ Planner image reference.
 {{- $tag := .Values.image.tag | default "latest" -}}
 {{- printf "%s:%s" .Values.image.repository $tag -}}
 {{- end }}
+
+{{/*
+ServiceAccount name used when HA leader election is enabled.
+*/}}
+{{- define "kache-service.serviceAccountName" -}}
+{{- if .Values.ha.serviceAccount.name }}
+{{- .Values.ha.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- include "kache-service.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/kache-service/templates/deployment.yaml
+++ b/charts/kache-service/templates/deployment.yaml
@@ -22,7 +22,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.ha.enabled }}
+      serviceAccountName: {{ include "kache-service.serviceAccountName" . }}
+      automountServiceAccountToken: true
+      {{- else }}
       automountServiceAccountToken: false
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -58,6 +63,20 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.auth.existingSecret | quote }}
                   key: {{ .Values.auth.existingSecretKey | quote }}
+            {{- end }}
+            {{- if .Values.ha.enabled }}
+            - name: KACHE_HA_ENABLED
+              value: "true"
+            - name: KACHE_HA_LEASE_NAME
+              value: {{ .Values.ha.leaseName | quote }}
+            - name: KACHE_HA_NAMESPACE
+              {{- if .Values.ha.namespace }}
+              value: {{ .Values.ha.namespace | quote }}
+              {{- else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+              {{- end }}
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/kache-service/templates/rbac.yaml
+++ b/charts/kache-service/templates/rbac.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.ha.enabled }}
+{{- if .Values.ha.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kache-service.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kache-service.labels" . | nindent 4 }}
+---
+{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "kache-service.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kache-service.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kache-service.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kache-service.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kache-service.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "kache-service.fullname" . }}-leader-election
+{{- end }}

--- a/charts/kache-service/values.schema.json
+++ b/charts/kache-service/values.schema.json
@@ -97,6 +97,34 @@
       },
       "required": ["existingSecret", "existingSecretKey"]
     },
+    "ha": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "leaseName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "serviceAccount": {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": ["create", "name"]
+        }
+      },
+      "required": ["enabled", "leaseName", "namespace", "serviceAccount"]
+    },
     "logLevel": {
       "type": "string",
       "minLength": 1
@@ -153,6 +181,7 @@
     "imagePullSecrets",
     "planner",
     "auth",
+    "ha",
     "logLevel",
     "service",
     "podAnnotations",

--- a/charts/kache-service/values.yaml
+++ b/charts/kache-service/values.yaml
@@ -27,6 +27,14 @@ auth:
   existingSecret: ""
   existingSecretKey: token
 
+ha:
+  enabled: false
+  leaseName: kache-service
+  namespace: ""
+  serviceAccount:
+    create: true
+    name: ""
+
 logLevel: "kache_service=info"
 
 service:

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -13,10 +13,14 @@ async-trait = "0.1"
 axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 kache-core = { path = "../kache-core", default-features = false, features = ["planning"] }
+k8s-openapi = { version = "0.27", features = ["v1_34"] }
+kube = { version = "3", features = ["client"] }
+kunobi-auth = { git = "https://github.com/kunobi-ninja/kunobi-auth.git", tag = "v0.3.0", default-features = false, features = ["server"] }
+kunobi-ha = { git = "https://github.com/kunobi-ninja/kunobi-ha.git", branch = "main" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 surrealdb = { version = "3.0.5", features = ["kv-surrealkv"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal", "sync"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 

--- a/crates/kache-service/src/lib.rs
+++ b/crates/kache-service/src/lib.rs
@@ -2,19 +2,28 @@ use anyhow::{Context, Result};
 use axum::{
     Json, Router,
     extract::State,
-    http::{HeaderMap, StatusCode, header},
+    http::StatusCode,
     routing::{get, post},
 };
 use kache_core::{
     BuildIntent, PlannerDataSource, PrefetchDisposition, PrefetchPlan, build_prefetch_plan,
 };
+use kunobi_auth::{
+    AuthError, AuthIdentity,
+    server::{AuthnProvider, OptionalAuth},
+};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::{
     net::SocketAddr,
     path::PathBuf,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{SystemTime, UNIX_EPOCH},
 };
+use tokio::sync::{RwLock, watch};
 
 mod state;
 
@@ -43,13 +52,32 @@ pub struct PlannerConfig {
     pub planner_name: String,
     pub db_path: PathBuf,
     pub seed_state_file: Option<PathBuf>,
+    pub ha: HaConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HaConfig {
+    pub enabled: bool,
+    pub namespace: Option<String>,
+    pub lease_name: String,
+}
+
+impl Default for HaConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            namespace: None,
+            lease_name: "kache-service".to_string(),
+        }
+    }
 }
 
 #[derive(Clone)]
 struct AppState {
     token: Option<String>,
     planner_name: String,
-    repository: Option<SharedPlannerDataSource>,
+    repository: Arc<RwLock<Option<SharedPlannerDataSource>>>,
+    ready: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -71,12 +99,17 @@ fn app_with_repository(
     let state = AppState {
         token: normalize_optional(config.token),
         planner_name: normalize_name(config.planner_name),
-        repository,
+        repository: Arc::new(RwLock::new(repository)),
+        ready: Arc::new(AtomicBool::new(true)),
     };
 
+    router(state)
+}
+
+fn router(state: AppState) -> Router {
     Router::new()
         .route("/healthz", get(healthz))
-        .route("/readyz", get(healthz))
+        .route("/readyz", get(readyz))
         .route("/v1/prefetch-plan", post(prefetch_plan))
         .route("/v2/prefetch-plan", post(prefetch_plan))
         .with_state(state)
@@ -85,7 +118,22 @@ fn app_with_repository(
 pub async fn serve(config: PlannerConfig) -> Result<()> {
     let bind = config.bind;
     let planner_name = normalize_name(config.planner_name.clone());
-    let app = app(config).await?;
+    let state = AppState {
+        token: normalize_optional(config.token.clone()),
+        planner_name: planner_name.clone(),
+        repository: Arc::new(RwLock::new(None)),
+        ready: Arc::new(AtomicBool::new(false)),
+    };
+    let app = router(state.clone());
+    let (ha_done_tx, ha_done_rx) = watch::channel(false);
+
+    if config.ha.enabled {
+        spawn_leader_task(config.clone(), state, ha_done_tx);
+    } else {
+        let repository = load_repository(&config).await?;
+        *state.repository.write().await = repository;
+        state.ready.store(true, Ordering::Release);
+    }
 
     let listener = tokio::net::TcpListener::bind(bind)
         .await
@@ -97,9 +145,67 @@ pub async fn serve(config: PlannerConfig) -> Result<()> {
     tracing::info!(bind = %local_addr, planner = %planner_name, "planner listening");
 
     axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(shutdown_signal(ha_done_rx))
         .await
         .context("running planner server")
+}
+
+fn spawn_leader_task(config: PlannerConfig, state: AppState, ha_done_tx: watch::Sender<bool>) {
+    tokio::spawn(async move {
+        if let Err(error) = run_leader(config, state).await {
+            tracing::error!(%error, "HA leader task failed");
+        }
+        let _ = ha_done_tx.send(true);
+    });
+}
+
+async fn run_leader(config: PlannerConfig, state: AppState) -> Result<()> {
+    let namespace = ha_namespace(&config.ha)?;
+    let lease_name = normalize_name(config.ha.lease_name.clone());
+    let client = kube::Client::try_default()
+        .await
+        .context("creating Kubernetes client for HA leader election")?;
+    let leader =
+        kunobi_ha::leader::LeaderElection::builder(client, namespace.clone(), lease_name.clone())
+            .build();
+
+    tracing::info!(namespace = %namespace, lease = %lease_name, "waiting for kache planner leadership");
+    let mut guard = leader
+        .acquire()
+        .await
+        .context("acquiring kache planner leadership")?;
+    tracing::info!(namespace = %namespace, lease = %lease_name, "acquired kache planner leadership");
+
+    let repository = load_repository(&config).await?;
+    *state.repository.write().await = repository;
+    state.ready.store(true, Ordering::Release);
+
+    guard.lost().await;
+    state.ready.store(false, Ordering::Release);
+    *state.repository.write().await = None;
+    tracing::warn!(namespace = %namespace, lease = %lease_name, "lost kache planner leadership");
+    Ok(())
+}
+
+fn ha_namespace(config: &HaConfig) -> Result<String> {
+    normalize_optional(config.namespace.clone())
+        .or_else(|| normalize_optional(std::env::var("POD_NAMESPACE").ok()))
+        .or_else(|| read_service_account_namespace().ok())
+        .context(
+            "HA leader election requires KACHE_HA_NAMESPACE or a mounted service account namespace",
+        )
+}
+
+fn read_service_account_namespace() -> Result<String> {
+    std::fs::read_to_string("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+        .context("reading service account namespace")
+        .map(|s| s.trim().to_string())
+        .and_then(|s| {
+            if s.is_empty() {
+                anyhow::bail!("service account namespace is empty");
+            }
+            Ok(s)
+        })
 }
 
 async fn load_repository(config: &PlannerConfig) -> Result<Option<SharedPlannerDataSource>> {
@@ -133,14 +239,53 @@ async fn healthz(State(state): State<AppState>) -> Json<HealthResponse> {
     })
 }
 
+async fn readyz(State(state): State<AppState>) -> Result<Json<HealthResponse>, StatusCode> {
+    if !state.ready.load(Ordering::Acquire) {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    Ok(Json(HealthResponse {
+        status: "ok".to_string(),
+        planner: state.planner_name.clone(),
+        version: VERSION.to_string(),
+    }))
+}
+
+impl AuthnProvider for AppState {
+    async fn authenticate(&self, token: &str) -> Result<AuthIdentity, AuthError> {
+        match self.token.as_deref() {
+            Some(expected) if token == expected => Ok(AuthIdentity {
+                provider: "kache".to_string(),
+                identity: "planner-client".to_string(),
+                method: "token".to_string(),
+                claims: HashMap::new(),
+            }),
+            Some(_) => Err(AuthError::Unauthorized("invalid bearer token".to_string())),
+            None => Ok(AuthIdentity {
+                provider: "kache".to_string(),
+                identity: "anonymous".to_string(),
+                method: "none".to_string(),
+                claims: HashMap::new(),
+            }),
+        }
+    }
+}
+
 async fn prefetch_plan(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    OptionalAuth(identity): OptionalAuth,
     Json(intent): Json<BuildIntent>,
 ) -> Result<Json<PrefetchPlan>, StatusCode> {
-    authorize(&headers, state.token.as_deref())?;
+    if state.token.is_some() && identity.is_none() {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
 
-    let Some(repository) = state.repository.as_ref() else {
+    if !state.ready.load(Ordering::Acquire) {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    let repository = state.repository.read().await;
+    let Some(repository) = repository.as_ref() else {
         tracing::info!(
             planner = %state.planner_name,
             crate_count = intent.crate_names.len(),
@@ -188,22 +333,6 @@ async fn prefetch_plan(
     Ok(Json(plan))
 }
 
-fn authorize(headers: &HeaderMap, expected_token: Option<&str>) -> Result<(), StatusCode> {
-    let Some(expected_token) = expected_token else {
-        return Ok(());
-    };
-
-    let token = headers
-        .get(header::AUTHORIZATION)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.strip_prefix("Bearer "));
-
-    match token {
-        Some(token) if token == expected_token => Ok(()),
-        _ => Err(StatusCode::UNAUTHORIZED),
-    }
-}
-
 fn next_plan_id() -> String {
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -221,7 +350,7 @@ fn fallback_plan(planner_name: &str) -> PrefetchPlan {
     }
 }
 
-async fn shutdown_signal() {
+async fn shutdown_signal(mut ha_done_rx: watch::Receiver<bool>) {
     let ctrl_c = async {
         tokio::signal::ctrl_c()
             .await
@@ -242,6 +371,13 @@ async fn shutdown_signal() {
     tokio::select! {
         _ = ctrl_c => {}
         _ = terminate => {}
+        _ = async {
+            while ha_done_rx.changed().await.is_ok() {
+                if *ha_done_rx.borrow() {
+                    break;
+                }
+            }
+        } => {}
     }
 }
 
@@ -249,6 +385,7 @@ async fn shutdown_signal() {
 mod tests {
     use super::*;
     use axum::body::Body;
+    use axum::http::header;
     use http_body_util::BodyExt;
     use kache_core::PrefetchCandidate;
     use std::collections::HashMap;
@@ -262,6 +399,7 @@ mod tests {
                 planner_name: "planner".to_string(),
                 db_path: PathBuf::from(DEFAULT_DB_PATH),
                 seed_state_file: None,
+                ha: HaConfig::default(),
             },
             repository,
         )

--- a/crates/kache-service/src/main.rs
+++ b/crates/kache-service/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-use kache_service::{DEFAULT_DB_PATH, PlannerConfig, VERSION};
+use kache_service::{DEFAULT_DB_PATH, HaConfig, PlannerConfig, VERSION};
 use std::{net::SocketAddr, path::PathBuf};
 
 #[derive(Debug, Parser)]
@@ -25,6 +25,18 @@ struct Cli {
     /// Optional legacy JSON seed file imported into the planner database on startup
     #[arg(long, env = "KACHE_PLANNER_SEED_STATE_FILE")]
     seed_state_file: Option<PathBuf>,
+
+    /// Enable Kubernetes Lease-based leader election via kunobi-ha
+    #[arg(long, env = "KACHE_HA_ENABLED", default_value_t = false)]
+    ha_enabled: bool,
+
+    /// Namespace containing the HA Lease; defaults to the pod namespace
+    #[arg(long, env = "KACHE_HA_NAMESPACE")]
+    ha_namespace: Option<String>,
+
+    /// Kubernetes Lease name used for HA leader election
+    #[arg(long, env = "KACHE_HA_LEASE_NAME", default_value = "kache-service")]
+    ha_lease_name: String,
 }
 
 #[tokio::main]
@@ -38,6 +50,11 @@ async fn main() -> Result<()> {
         planner_name: cli.planner_name,
         db_path: cli.db_path,
         seed_state_file: cli.seed_state_file,
+        ha: HaConfig {
+            enabled: cli.ha_enabled,
+            namespace: cli.ha_namespace,
+            lease_name: cli.ha_lease_name,
+        },
     })
     .await
 }

--- a/docs/kache-docs/getting-started/configuration.mdx
+++ b/docs/kache-docs/getting-started/configuration.mdx
@@ -8,7 +8,7 @@ description: Config file, environment variables, and the TUI editor.
 kache reads configuration from three places, in order of priority:
 
 1. **Environment variables** — always win, useful for CI overrides
-2. **Config file** — `~/.config/kache/config.toml` (respects `XDG_CONFIG_HOME`, overridden by `KACHE_CONFIG`)
+2. **Config file** — selected from the config file priority below
 3. **Defaults** — sensible values that work without any configuration
 
 ## Config file
@@ -20,6 +20,12 @@ kache config
 ```
 
 The TUI editor shows all fields with their current values, marks which ones are coming from env vars, and lets you toggle or edit them interactively.
+
+Config file priority:
+
+1. `KACHE_CONFIG`, when set
+2. The nearest project-local `.kache.toml`, walking up from the current directory
+3. User config at `~/.config/kache/config.toml`, respecting `XDG_CONFIG_HOME`
 
 A minimal config that enables a remote cache looks like this:
 
@@ -35,7 +41,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 
 | Environment variable | Config key | Default | Description |
 |---|---|---|---|
-| `KACHE_CACHE_DIR` | `cache.local_store` | `~/.cache/kache` | Local cache directory |
+| `KACHE_CACHE_DIR` | `cache.local_store` | `~/Library/Caches/kache` on macOS, `~/.cache/kache` on Linux | Local cache directory |
 | `KACHE_MAX_SIZE` | `cache.local_max_size` | `50GiB` | Maximum local store size |
 | `KACHE_CONFIG` | — | XDG config path | Explicit config file path |
 | `KACHE_S3_BUCKET` | `cache.remote.bucket` | — | S3 bucket name |
@@ -49,6 +55,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly |
 | `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd compression level (1–22) |
 | `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `16` | Max concurrent S3 operations |
+| `KACHE_S3_POOL_IDLE_SECS` | `cache.s3_pool_idle_secs` | `300` | How long an idle S3 connection is kept in the HTTP pool. Higher values reuse warm TLS sessions across build phases; lower this if you sit behind a load balancer that drops idle connections aggressively |
 | `KACHE_DAEMON_IDLE_TIMEOUT` | `cache.daemon_idle_timeout_secs` | `600` | Idle daemon shutdown timeout in seconds (`0` disables auto-shutdown) |
 | `KACHE_DISABLED` | — | `0` | Disable caching entirely (pass-through to rustc) |
 | `KACHE_LOG` | — | `kache=warn` | Log level for stderr output |
@@ -56,6 +63,24 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_PROGRESS` | — | `auto` | CI progress lines: `always`, `never`, or `auto` |
 
 `KACHE_PROGRESS=auto` (the default) prints per-crate progress lines to stderr when stderr is not a terminal. In CI this is usually the right behavior without any configuration.
+
+## Credential resolution order
+
+Remote S3 credentials are resolved in this order:
+
+1. `KACHE_S3_ACCESS_KEY` + `KACHE_S3_SECRET_KEY`
+2. AWS profile from `cache.remote.profile` or `KACHE_S3_PROFILE`
+3. AWS default chain, such as `AWS_ACCESS_KEY_ID`, `~/.aws/credentials [default]`, or IAM roles
+
+For Ceph, MinIO, or R2, set `cache.remote.endpoint` or `KACHE_S3_ENDPOINT`.
+
+```toml title="Ceph example"
+[cache.remote]
+type = "s3"
+bucket = "build-cache"
+endpoint = "https://s3.example.com"
+profile = "ceph"
+```
 
 ## Size values
 
@@ -80,7 +105,7 @@ The file log is written to `~/Library/Logs/kache/kache.log` on macOS and `~/.cac
 ## Local store layout
 
 ```
-~/.cache/kache/
+~/.cache/kache/           # Linux example
 ├── index.db          # SQLite index (WAL mode)
 ├── events.jsonl      # build event log
 ├── daemon.sock       # daemon unix socket

--- a/docs/kache-docs/remote-cache/sync.mdx
+++ b/docs/kache-docs/remote-cache/sync.mdx
@@ -13,6 +13,7 @@ description: Manually synchronize the local cache with S3 using kache sync.
 kache sync              # pull missing artifacts + push new local artifacts
 kache sync --pull       # download only
 kache sync --push       # upload only
+kache sync --all        # pull all artifacts, ignoring Cargo.lock filtering
 kache sync --dry-run    # preview what would transfer, make no changes
 ```
 
@@ -52,6 +53,16 @@ kache sync --push
 The `--pull` step fills the local store so that `cargo build` finds local hits instead of remote hits. This is faster because local hits don't involve a daemon RPC round-trip.
 
 When the daemon is running and remote is configured, it handles uploads automatically in the background after each compilation. Use `kache sync --push` only in workflows where you want an explicit, synchronous upload step — for example, when the daemon isn't running or you want to ensure the cache is populated before the runner terminates.
+
+## S3 layout
+
+Artifacts are organized by crate name for efficient filtered listing:
+
+```text
+{prefix}/{crate_name}/{cache_key}.tar.zst
+```
+
+The default prefix is `artifacts`. For example, `serde` artifacts may live under `artifacts/serde/...`.
 
 ## Dry run
 


### PR DESCRIPTION
## Summary
- Integrates kache-service auth through `kunobi-auth` while keeping the existing bearer-token behavior.
- Adds optional `kunobi-ha` Kubernetes Lease leader election with readiness gating.
- Extends the Helm chart with HA values, ServiceAccount/RBAC, HA env wiring, and README/NOTES guidance.
- Refocuses the README on local kache usage, hardlinks, and zero-copy behavior.
- Moves detailed `sync` and configuration reference material into docs.
- Documents that server-side kache is still work in progress.

## Validation
- `mise exec -- cargo test -p kache-service`
- `helm lint ./charts/kache-service`
- `helm template kache ./charts/kache-service --set ha.enabled=true --set replicaCount=2`
- `git diff --check`

## Notes
- This PR does not deploy to `_platform`.
- For HA with PVC-backed planner state, the storage must support all scheduled replicas or `replicaCount` should stay at 1.