### PR TITLE
Improve TUI loading state and docs screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,84 @@ The repo uses `just` as its single task runner. `mise.toml` pins the local Rust 
 
 Durations use human-friendly format: `7d`, `24h`, `30m`.
 
+## Screenshots
+
+`kache monitor`:
+
+```text
+ [1] Build   [2] Projects  [3] Store   [4] Transfer
+┌ kache monitor ────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  Store: 45.0 GiB / 50.0 GiB [ 90.1%]    11004 entries                                                             │
+│  Hit rate: 61% count | 42% weighted | 79% miss-time    Remote: not configured                                     │
+│  Dedup: 8.2 GiB saved (18.1%)    Blobs: 36.9 GiB physical    Hardlinks: 4.9 GiB via 7023 hardlinks    Scan: idle  │
+│  Transfer: ↑ 0 uploading  ↓ 0 downloading                                                                         │
+│  rustc-wrapper=kache via ~/.cargo/config.toml ✓    unknown                                                        │
+│  kache v0.1.0 (epoch 1777305862)    daemon: v0.1.0 (epoch 1777305862)    Cache: ~/Library/Caches/kache            │
+│                                                                                                                   │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ Live Build ───────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ Hit Rate (recent) ────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  No data yet                                                                                                      │
+│                                                                                                                   │
+│                                                                                                                   │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+  q: quit  f: filter  ↑↓: scroll  Tab: next  c: clear  1/2/3/4: tabs
+```
+
+`kache clean`:
+
+```text
+┌ kache clean ──────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ 8 dirs (73.2 GiB total, 7.4 GiB cached)    Selected: 0 (0 B)                                                      │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ Select directories to remove ─────────────────────────────────────────────────────────────────────────────────────┐
+│ [ ]  workspace/compiler-core/target                                             34.7 GiB    5.7 GiB [debug, release]│
+│ [ ]  workspace/build-cache/target                                               15.4 GiB   49.1 MiB [debug, release]│
+│ [ ]  workspace/desktop-app/crates/app/target                                    13.8 GiB    9.4 MiB [debug]         │
+│ [ ]  workspace/service-api/target                                                3.0 GiB  239.2 MiB [debug]         │
+│ [ ]  workspace/frontend/packages/graph-core/target                               2.2 GiB  635.6 MiB [debug]         │
+│ [ ]  workspace/auth-service/target                                               1.5 GiB  727.4 MiB [debug]         │
+│ [ ]  workspace/metrics/target                                                    1.5 GiB        0 B [debug]         │
+│ [ ]  workspace/frontend/packages/ipc-plugin/target                               1.1 GiB  152.8 MiB [debug]         │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ workspace/compiler-core/target — 34.7 GiB total, 5.7 GiB cached (16%) ────────────────────────────────────────────┐
+│  incremental:        0 B   build:  433.3 MiB   deps (local):   28.4 GiB                                           │
+│  fingerprint:    5.9 MiB   binaries: 239.5 MiB   other:           6.9 KiB                                         │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ space: toggle  a: select all  n: select none  enter: delete selected  q: cancel                                   │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
 ## Remote cache and configuration
 
 `kache sync` can pull from and push to S3-compatible storage directly, without the daemon. Pulls are filtered by the current workspace's `Cargo.lock` by default. See [Sync](docs/kache-docs/remote-cache/sync.mdx) for the full command behavior and S3 layout.

--- a/docs/kache-docs/commands/reference.mdx
+++ b/docs/kache-docs/commands/reference.mdx
@@ -120,6 +120,44 @@ kache clean [--dry-run]
 
 Recursively finds all `target/` directories under the current directory and removes them. Reports disk usage per directory before deleting.
 
+Example TUI:
+
+```text
+┌ kache clean ──────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ 8 dirs (73.2 GiB total, 7.4 GiB cached)    Selected: 0 (0 B)                                                      │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ Select directories to remove ─────────────────────────────────────────────────────────────────────────────────────┐
+│ [ ]  workspace/compiler-core/target                                             34.7 GiB    5.7 GiB [debug, release]│
+│ [ ]  workspace/build-cache/target                                               15.4 GiB   49.1 MiB [debug, release]│
+│ [ ]  workspace/desktop-app/crates/app/target                                    13.8 GiB    9.4 MiB [debug]         │
+│ [ ]  workspace/service-api/target                                                3.0 GiB  239.2 MiB [debug]         │
+│ [ ]  workspace/frontend/packages/graph-core/target                               2.2 GiB  635.6 MiB [debug]         │
+│ [ ]  workspace/auth-service/target                                               1.5 GiB  727.4 MiB [debug]         │
+│ [ ]  workspace/metrics/target                                                    1.5 GiB        0 B [debug]         │
+│ [ ]  workspace/frontend/packages/ipc-plugin/target                               1.1 GiB  152.8 MiB [debug]         │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ workspace/compiler-core/target — 34.7 GiB total, 5.7 GiB cached (16%) ────────────────────────────────────────────┐
+│  incremental:        0 B   build:  433.3 MiB   deps (local):   28.4 GiB                                           │
+│  fingerprint:    5.9 MiB   binaries: 239.5 MiB   other:           6.9 KiB                                         │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ space: toggle  a: select all  n: select none  enter: delete selected  q: cancel                                   │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
 ```sh
 kache clean --dry-run    # preview what would be deleted
 kache clean              # delete all target/ directories

--- a/docs/kache-docs/monitor.mdx
+++ b/docs/kache-docs/monitor.mdx
@@ -7,6 +7,44 @@ description: Reading and using the live TUI dashboard.
 
 Running `kache` with no arguments (or `kache monitor`) opens a live TUI dashboard that shows what's happening in your cache in real time. It refreshes automatically and doesn't require the daemon to be running.
 
+Example:
+
+```text
+ [1] Build   [2] Projects  [3] Store   [4] Transfer
+┌ kache monitor ────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  Store: 45.0 GiB / 50.0 GiB [ 90.1%]    11004 entries                                                             │
+│  Hit rate: 61% count | 42% weighted | 79% miss-time    Remote: not configured                                     │
+│  Dedup: 8.2 GiB saved (18.1%)    Blobs: 36.9 GiB physical    Hardlinks: 4.9 GiB via 7023 hardlinks    Scan: idle  │
+│  Transfer: ↑ 0 uploading  ↓ 0 downloading                                                                         │
+│  rustc-wrapper=kache via ~/.cargo/config.toml ✓    unknown                                                        │
+│  kache v0.1.0 (epoch 1777305862)    daemon: v0.1.0 (epoch 1777305862)    Cache: ~/Library/Caches/kache            │
+│                                                                                                                   │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ Live Build ───────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+│                                                                                                                   │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ Hit Rate (recent) ────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  No data yet                                                                                                      │
+│                                                                                                                   │
+│                                                                                                                   │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+  q: quit  f: filter  ↑↓: scroll  Tab: next  c: clear  1/2/3/4: tabs
+```
+
 ## Header
 
 The header line at the top of the monitor shows the current state of your local store and remote:
@@ -15,8 +53,10 @@ The header line at the top of the monitor shows the current state of your local 
 |---|---|
 | `Store` | Bytes used vs. the configured maximum (`KACHE_MAX_SIZE`) |
 | `Hit rate` | Breakdown of cache outcomes over the displayed window: local / prefetch / remote / miss |
-| `Deduplicated` | Estimated bytes saved by hardlink sharing across project `target/` directories |
-| `Dedup` | Whether the background deduplication scan is currently running (`active`) or idle |
+| `Dedup` | Logical bytes saved by storing shared blobs once |
+| `Blobs` | Physical bytes used by blob files in the local store |
+| `Hardlinks` | Estimated bytes saved by hardlink sharing across project `target/` directories |
+| `Scan` | Whether the background hardlink scan is still calculating, scanning, or idle |
 | `Transfer` | Number of uploads and downloads currently in-flight via the daemon |
 
 ## Tabs

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -120,6 +120,7 @@ struct AppState {
 
     // Store + event stats (daemon-first snapshot)
     stats_snapshot: StatsSnapshot,
+    stats_loaded: bool,
     last_stats_fetch: Instant,
 
     // Projects tab (shared with background scanner thread for target/ scanning)
@@ -211,6 +212,7 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
         sort_mode: SortMode::Size,
         store_scroll: 0,
         stats_snapshot,
+        stats_loaded: false,
         last_stats_fetch: Instant::now() - SNAPSHOT_REFRESH_INTERVAL, // trigger immediate first fetch
         project_scan,
         last_project_refresh: Instant::now(),
@@ -265,6 +267,7 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
             state.prev_bytes_uploaded = new_snap.bytes_uploaded;
             state.prev_bytes_downloaded = new_snap.bytes_downloaded;
             state.stats_snapshot = new_snap;
+            state.stats_loaded = true;
             state.stats_fetch_in_flight = false;
         }
 
@@ -508,11 +511,15 @@ fn draw_build_tab(frame: &mut Frame, state: &AppState, area: Rect) {
 
 fn draw_stats_bar(frame: &mut Frame, state: &AppState, area: Rect) {
     let snap = &state.stats_snapshot;
-    let daemon_tag = match (snap.daemon_connected, state.service_installed) {
-        (true, true) => "",
-        (true, false) => " (no service)",
-        (false, true) => " (daemon offline)",
-        (false, false) => " (daemon offline, no service)",
+    let daemon_tag = if !state.stats_loaded {
+        " (loading)"
+    } else {
+        match (snap.daemon_connected, state.service_installed) {
+            (true, true) => "",
+            (true, false) => " (no service)",
+            (false, true) => " (daemon offline)",
+            (false, false) => " (daemon offline, no service)",
+        }
     };
     let block = Block::bordered().title(format!(" kache monitor{daemon_tag} "));
 
@@ -547,7 +554,9 @@ fn draw_stats_bar(frame: &mut Frame, state: &AppState, area: Rect) {
 
     let kache_version = crate::VERSION;
 
-    let daemon_info = if snap.daemon_connected && !snap.daemon_version.is_empty() {
+    let daemon_info = if !state.stats_loaded {
+        "daemon: checking".to_string()
+    } else if snap.daemon_connected && !snap.daemon_version.is_empty() {
         let epoch = snap.daemon_build_epoch;
         let my_epoch = crate::daemon::build_epoch();
         if epoch == my_epoch {
@@ -574,8 +583,8 @@ fn draw_stats_bar(frame: &mut Frame, state: &AppState, area: Rect) {
 
         let scan_part = if let Ok(scan_stats) = state.project_scan.lock() {
             let ls = &scan_stats.link_stats;
-            let dedup_status = if scan_stats.scanning {
-                "scanning"
+            let dedup_status = if !state.stats_loaded || scan_stats.scanning {
+                "calculating"
             } else {
                 "idle"
             };
@@ -604,12 +613,16 @@ fn draw_stats_bar(frame: &mut Frame, state: &AppState, area: Rect) {
                 pct,
                 ByteSize(bs.total_blob_size),
             )
-        } else {
+        } else if state.stats_loaded {
             format!("  Dedup: {scan_part}")
+        } else {
+            "  Dedup: calculating...".to_string()
         }
     };
 
-    let transfer_line = if snap.daemon_connected {
+    let transfer_line = if !state.stats_loaded {
+        "  Transfer: calculating...".to_string()
+    } else if snap.daemon_connected {
         format!(
             "  Transfer: ↑ {} uploading  ↓ {} downloading",
             snap.pending_uploads, snap.active_downloads,
@@ -618,37 +631,48 @@ fn draw_stats_bar(frame: &mut Frame, state: &AppState, area: Rect) {
         "  Transfer: n/a (daemon offline)".to_string()
     };
 
-    let count_hit_rate = crate::cli::count_hit_rate(&snap.event_stats);
-    let weighted_hit_rate = crate::cli::compile_weighted_hit_rate(&snap.event_stats);
-    let miss_time_share = if snap.event_stats.total_elapsed_ms > 0 {
-        Some(
-            (snap.event_stats.miss_elapsed_ms as f64 / snap.event_stats.total_elapsed_ms as f64)
-                * 100.0,
-        )
+    let hit_line = if !state.stats_loaded {
+        format!("  Hit rate: calculating...    Remote: {remote_status}")
     } else {
-        None
+        let count_hit_rate = crate::cli::count_hit_rate(&snap.event_stats);
+        let weighted_hit_rate = crate::cli::compile_weighted_hit_rate(&snap.event_stats);
+        let miss_time_share = if snap.event_stats.total_elapsed_ms > 0 {
+            Some(
+                (snap.event_stats.miss_elapsed_ms as f64
+                    / snap.event_stats.total_elapsed_ms as f64)
+                    * 100.0,
+            )
+        } else {
+            None
+        };
+
+        match (weighted_hit_rate, miss_time_share) {
+            (Some(weighted), Some(miss_share)) => format!(
+                "  Hit rate: {count_hit_rate:.0}% count | {weighted:.0}% weighted | {miss_share:.0}% miss-time    Remote: {remote_status}",
+            ),
+            (Some(weighted), None) => format!(
+                "  Hit rate: {count_hit_rate:.0}% count | {weighted:.0}% weighted    Remote: {remote_status}",
+            ),
+            _ => format!(
+                "  Hit rate: {local_pct:.0}% local | {remote_pct:.0}% remote | {miss_pct:.0}% miss    Remote: {remote_status}",
+            ),
+        }
     };
 
-    let hit_line = match (weighted_hit_rate, miss_time_share) {
-        (Some(weighted), Some(miss_share)) => format!(
-            "  Hit rate: {count_hit_rate:.0}% count | {weighted:.0}% weighted | {miss_share:.0}% miss-time    Remote: {remote_status}",
-        ),
-        (Some(weighted), None) => format!(
-            "  Hit rate: {count_hit_rate:.0}% count | {weighted:.0}% weighted    Remote: {remote_status}",
-        ),
-        _ => format!(
-            "  Hit rate: {local_pct:.0}% local | {remote_pct:.0}% remote | {miss_pct:.0}% miss    Remote: {remote_status}",
-        ),
-    };
-
-    let text = vec![
+    let store_line = if state.stats_loaded {
         Line::from(format!(
             "  Store: {} / {} [{:>5.1}%]    {} entries",
             ByteSize(snap.total_size),
             ByteSize(snap.max_size),
             store_pct,
             snap.entry_count,
-        )),
+        ))
+    } else {
+        Line::from("  Store: calculating...")
+    };
+
+    let text = vec![
+        store_line,
         Line::from(hit_line),
         Line::from(dedup_line),
         Line::from(transfer_line),


### PR DESCRIPTION
## Summary
- avoid showing zero-valued monitor stats before the first stats snapshot has loaded
- show loading/calculating copy for store, hit rate, scan, transfer, and daemon status during initial monitor refresh
- add anonymized ASCII screenshots for kache monitor and kache clean to the README and docs

## Validation
- git fetch https://github.com/kunobi-ninja/kache.git dev and git rev-list --left-right --count FETCH_HEAD...HEAD -> 0 23
- mise exec -- cargo fmt --check
- mise exec -- cargo check
- git diff --check