### PR TITLE
feat: improve prefetch telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ A drop-in `RUSTC_WRAPPER` that caches compilation artifacts using blake3 hashing
 
 :warning: The remote server is still work in progress. The goal is to optimize prefetching from workspace manifests, dependency history, and build intent, so clients can warm the right artifacts before rustc asks for them. Local caching and direct S3 sync are the stable paths today.
 
+## Why try kache?
+
+- **Drop-in Rust caching**: set `RUSTC_WRAPPER=kache`; no build-system rewrite required.
+- **Fast local hits**: restored artifacts are hardlinked into `target/`, not copied byte-by-byte.
+- **Less duplicate junk**: content-addressed blobs mean identical outputs are stored once and reused many times.
+- **Works before the server exists**: local cache and direct S3 sync are useful today; the planner service is optional.
+- **Bring your own object store**: AWS S3, Ceph, MinIO, and R2 are first-class targets.
+- **Debuggable by design**: `kache monitor`, `kache why-miss`, and `kache report` explain what happened instead of asking you to trust a black box.
+
 ## Why local kache is fast
 
 kache is useful even before remote cache is configured:

--- a/README.md
+++ b/README.md
@@ -10,15 +10,6 @@ A drop-in `RUSTC_WRAPPER` that caches compilation artifacts using blake3 hashing
 
 :warning: The remote server is still work in progress. The goal is to optimize prefetching from workspace manifests, dependency history, and build intent, so clients can warm the right artifacts before rustc asks for them. Local caching and direct S3 sync are the stable paths today.
 
-## Why try kache?
-
-- **Drop-in Rust caching**: set `RUSTC_WRAPPER=kache`; no build-system rewrite required.
-- **Fast local hits**: restored artifacts are hardlinked into `target/`, not copied byte-by-byte.
-- **Less duplicate junk**: content-addressed blobs mean identical outputs are stored once and reused many times.
-- **Works before the server exists**: local cache and direct S3 sync are useful today; the planner service is optional.
-- **Bring your own object store**: AWS S3, Ceph, MinIO, and R2 are first-class targets.
-- **Debuggable by design**: `kache monitor`, `kache why-miss`, and `kache report` explain what happened instead of asking you to trust a black box.
-
 ## Why local kache is fast
 
 kache is useful even before remote cache is configured:

--- a/src/build_intent.rs
+++ b/src/build_intent.rs
@@ -1,10 +1,17 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use crate::args::RustcArgs;
 use kache_core::BuildIntent;
 
-pub fn discover() -> Option<BuildIntent> {
-    let crate_names = discover_crate_names_bfs()?;
+struct MetadataDiscovery {
+    crate_names: Vec<String>,
+    workspace_root: Option<PathBuf>,
+}
+
+pub fn discover(args: Option<&RustcArgs>) -> Option<BuildIntent> {
+    let metadata = discover_metadata(args)?;
+    let crate_names = metadata.crate_names;
     if crate_names.is_empty() {
         return None;
     }
@@ -14,9 +21,14 @@ pub fn discover() -> Option<BuildIntent> {
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
 
+    let lock_path = metadata
+        .workspace_root
+        .as_deref()
+        .map(|root| root.join("Cargo.lock"))
+        .unwrap_or_else(|| PathBuf::from("Cargo.lock"));
     let cargo_lock_deps = namespace
         .as_ref()
-        .and_then(|_| load_cargo_lock_deps(Path::new("Cargo.lock")))
+        .and_then(|_| load_cargo_lock_deps(&lock_path))
         .unwrap_or_default();
 
     Some(BuildIntent {
@@ -49,24 +61,89 @@ fn load_cargo_lock_deps(lock_path: &Path) -> Option<Vec<(String, String)>> {
         .ok()
 }
 
-fn discover_crate_names_bfs() -> Option<Vec<String>> {
-    let output = std::process::Command::new("cargo")
+fn discover_metadata(args: Option<&RustcArgs>) -> Option<MetadataDiscovery> {
+    for manifest_path in candidate_manifest_paths(args) {
+        if let Some(discovery) = run_cargo_metadata(Some(&manifest_path)) {
+            return Some(discovery);
+        }
+    }
+
+    run_cargo_metadata(None)
+}
+
+fn candidate_manifest_paths(args: Option<&RustcArgs>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(out_dir) = args.and_then(|a| a.out_dir.as_deref())
+        && let Some(path) = manifest_from_target_out_dir(out_dir)
+        && path.is_file()
+    {
+        candidates.push(path);
+    }
+
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let path = PathBuf::from(manifest_dir).join("Cargo.toml");
+        if path.is_file() && !candidates.iter().any(|existing| existing == &path) {
+            candidates.push(path);
+        }
+    }
+
+    candidates
+}
+
+fn manifest_from_target_out_dir(out_dir: &Path) -> Option<PathBuf> {
+    for ancestor in out_dir.ancestors() {
+        if ancestor.file_name().and_then(|name| name.to_str()) == Some("target") {
+            return ancestor.parent().map(|root| root.join("Cargo.toml"));
+        }
+    }
+    None
+}
+
+fn run_cargo_metadata(manifest_path: Option<&Path>) -> Option<MetadataDiscovery> {
+    let mut command = std::process::Command::new("cargo");
+    command
         .args(["metadata", "--format-version", "1"])
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
+        .stderr(std::process::Stdio::null());
+
+    if let Some(path) = manifest_path {
+        command.arg("--manifest-path").arg(path);
+    }
+
+    let output = command.output().ok()?;
 
     if !output.status.success() {
         return None;
     }
 
-    parse_metadata_crate_names_bfs(&output.stdout)
+    parse_metadata(&output.stdout)
 }
 
+fn parse_metadata(metadata_json: &[u8]) -> Option<MetadataDiscovery> {
+    let value: serde_json::Value = serde_json::from_slice(metadata_json).ok()?;
+    let crate_names = parse_metadata_value_crate_names_bfs(&value)?;
+    let workspace_root = value
+        .get("workspace_root")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from);
+
+    Some(MetadataDiscovery {
+        crate_names,
+        workspace_root,
+    })
+}
+
+#[cfg(test)]
 fn parse_metadata_crate_names_bfs(metadata_json: &[u8]) -> Option<Vec<String>> {
     let value: serde_json::Value = serde_json::from_slice(metadata_json).ok()?;
+    parse_metadata_value_crate_names_bfs(&value)
+}
 
+fn parse_metadata_value_crate_names_bfs(value: &serde_json::Value) -> Option<Vec<String>> {
     let packages = value.get("packages")?.as_array()?;
     let mut id_to_name: HashMap<String, String> = HashMap::new();
     for pkg in packages {
@@ -186,6 +263,42 @@ mod tests {
 
         let names = parse_metadata_crate_names_bfs(metadata.as_bytes()).unwrap();
         assert_eq!(names, vec!["serde"]);
+    }
+
+    #[test]
+    fn test_parse_metadata_preserves_workspace_root() {
+        let metadata = r#"{
+          "workspace_root": "/repo/apps/tauri/src-tauri",
+          "packages": [
+            {"id": "serde 1.0.0 (registry)", "name": "serde"},
+            {"id": "app 0.1.0 (path)", "name": "app"}
+          ],
+          "resolve": {
+            "nodes": [
+              {"id": "app 0.1.0 (path)", "deps": [
+                {"pkg": "serde 1.0.0 (registry)"}
+              ]},
+              {"id": "serde 1.0.0 (registry)", "deps": []}
+            ]
+          }
+        }"#;
+
+        let discovery = parse_metadata(metadata.as_bytes()).unwrap();
+        assert_eq!(discovery.crate_names, vec!["serde", "app"]);
+        assert_eq!(
+            discovery.workspace_root.as_deref(),
+            Some(Path::new("/repo/apps/tauri/src-tauri"))
+        );
+    }
+
+    #[test]
+    fn test_manifest_from_target_out_dir_uses_target_parent() {
+        let manifest = manifest_from_target_out_dir(Path::new(
+            "/repo/apps/tauri/src-tauri/target/release/deps",
+        ))
+        .unwrap();
+
+        assert_eq!(manifest, Path::new("/repo/apps/tauri/src-tauri/Cargo.toml"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2473,6 +2473,15 @@ pub fn save_manifest(
     let key = manifest_key
         .map(String::from)
         .unwrap_or_else(default_manifest_key);
+    let env_namespace = std::env::var("KACHE_NAMESPACE")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let effective_namespace = namespace
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(String::from)
+        .or(env_namespace);
 
     let manifest = crate::remote::BuildManifest {
         version: 3,
@@ -2495,7 +2504,7 @@ pub fn save_manifest(
             .await?;
 
         // Upload sharded build-manifest indexes if namespace is provided and Cargo.lock exists
-        if let Some(ns) = namespace {
+        if let Some(ns) = effective_namespace.as_deref() {
             let lock_path = std::path::Path::new("Cargo.lock");
             if lock_path.exists() {
                 let shard_count = upload_shards(
@@ -2511,6 +2520,8 @@ pub fn save_manifest(
             } else {
                 eprintln!("No Cargo.lock found, skipping shard upload");
             }
+        } else {
+            eprintln!("No namespace provided, skipping shard upload");
         }
 
         Ok::<(), anyhow::Error>(())

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -575,11 +575,21 @@ pub struct TransferEvent {
     pub direction: TransferDirection,
     #[serde(default)]
     pub format: String,
+    #[serde(default)]
+    pub cache_key: String,
+    #[serde(default)]
+    pub object_key: String,
     pub compressed_bytes: u64,
     pub elapsed_ms: u64,
     /// Time spent on S3 GET + body collection only (excludes decompression/disk I/O).
     #[serde(default)]
     pub network_ms: u64,
+    /// Time spent waiting for an S3 concurrency permit.
+    #[serde(default)]
+    pub semaphore_wait_ms: u64,
+    /// Time spent on HEAD/existence checks before the transfer.
+    #[serde(default)]
+    pub head_ms: u64,
     /// Time spent waiting for response headers across all GET requests (ms).
     #[serde(default)]
     pub request_ms: u64,
@@ -595,9 +605,15 @@ pub struct TransferEvent {
     /// Time spent in zstd decompression (ms). 0 for uploads or older entries.
     #[serde(default)]
     pub decompress_ms: u64,
+    /// Time spent extracting the downloaded archive to the local store.
+    #[serde(default)]
+    pub extract_ms: u64,
     /// Time spent on disk I/O (fs::write + permissions + atomic rename), ms.
     #[serde(default)]
     pub disk_io_ms: u64,
+    /// Time spent importing downloaded metadata into SQLite.
+    #[serde(default)]
+    pub import_ms: u64,
     /// Time spent in zstd compression for uploads (ms).
     #[serde(default)]
     pub compression_ms: u64,
@@ -615,7 +631,7 @@ pub struct TransferEvent {
 }
 
 const fn default_transfer_schema() -> u32 {
-    1
+    2
 }
 
 pub(crate) struct TransferCounters {
@@ -1104,15 +1120,21 @@ impl Daemon {
                     crate_name: job.crate_name.clone(),
                     direction: TransferDirection::Upload,
                     format: ul.format.to_string(),
+                    cache_key: job.key.clone(),
+                    object_key: String::new(),
                     compressed_bytes: ul.transfer.compressed_bytes,
                     elapsed_ms,
                     network_ms: ul.transfer.network_ms,
+                    semaphore_wait_ms: 0,
+                    head_ms: 0,
                     request_ms: 0,
                     body_ms: 0,
                     request_count: 0,
                     original_bytes: 0,
                     decompress_ms: 0,
+                    extract_ms: 0,
                     disk_io_ms: 0,
+                    import_ms: 0,
                     compression_ms: ul.transfer.compression_ms,
                     head_checks_ms: ul.transfer.head_checks_ms,
                     blobs_skipped: 0,
@@ -1139,15 +1161,21 @@ impl Daemon {
                     crate_name: job.crate_name.clone(),
                     direction: TransferDirection::Upload,
                     format: plan.transfer_format().to_string(),
+                    cache_key: job.key.clone(),
+                    object_key: String::new(),
                     compressed_bytes: 0,
                     elapsed_ms,
                     network_ms: 0,
+                    semaphore_wait_ms: 0,
+                    head_ms: 0,
                     request_ms: 0,
                     body_ms: 0,
                     request_count: 0,
                     original_bytes: 0,
                     decompress_ms: 0,
+                    extract_ms: 0,
                     disk_io_ms: 0,
+                    import_ms: 0,
                     compression_ms: 0,
                     head_checks_ms: 0,
                     blobs_skipped: 0,
@@ -1205,6 +1233,8 @@ impl Daemon {
 
         let cn = &req.crate_name;
         let mut needs_head_probe = false;
+        let mut head_ms = 0u64;
+        let mut semaphore_wait_ms = 0u64;
 
         // Check key cache first (no semaphore needed for in-memory lookup)
         match self.key_cache.check(&req.key).await {
@@ -1257,10 +1287,15 @@ impl Daemon {
         let layout = plan.layout(client, remote);
 
         if needs_head_probe {
+            let semaphore_start = Instant::now();
             let Ok(_permit) = self.s3_semaphore.acquire().await else {
                 return Response::err("S3 semaphore closed");
             };
-            match layout.exists_entry(&req.key, cn).await {
+            semaphore_wait_ms += semaphore_start.elapsed().as_millis() as u64;
+            let head_start = Instant::now();
+            let exists = layout.exists_entry(&req.key, cn).await;
+            head_ms += head_start.elapsed().as_millis() as u64;
+            match exists {
                 Ok(false) => {
                     self.remote_health.note_head_probe_success();
                     return Response::found(false);
@@ -1304,10 +1339,12 @@ impl Daemon {
         self.downloading.write().await.insert(req.key.clone());
 
         // Acquire semaphore for download
+        let semaphore_start = Instant::now();
         let Ok(_permit) = self.s3_semaphore.acquire().await else {
             self.downloading.write().await.remove(&req.key);
             return Response::err("S3 semaphore closed");
         };
+        semaphore_wait_ms += semaphore_start.elapsed().as_millis() as u64;
 
         // Download to local store using the current remote layout.
         let entry_dir = PathBuf::from(&req.entry_dir);
@@ -1320,6 +1357,15 @@ impl Daemon {
         let result = match download_result {
             Ok(dl) => {
                 let elapsed_ms = start.elapsed().as_millis() as u64;
+                let import_start = Instant::now();
+                let import_ms = if let Err(e) =
+                    self.with_store(|store| store.import_restored_entry(&req.key))
+                {
+                    tracing::warn!("failed to import downloaded entry {}: {e}", &req.key);
+                    0
+                } else {
+                    import_start.elapsed().as_millis() as u64
+                };
                 self.transfer_counters
                     .downloads_completed
                     .fetch_add(1, Ordering::Relaxed);
@@ -1331,15 +1377,21 @@ impl Daemon {
                     crate_name: cn.to_string(),
                     direction: TransferDirection::Download,
                     format: dl.format.to_string(),
+                    cache_key: req.key.clone(),
+                    object_key: dl.object_key,
                     compressed_bytes: dl.compressed_bytes,
                     elapsed_ms,
                     network_ms: dl.network_ms,
+                    semaphore_wait_ms,
+                    head_ms,
                     request_ms: dl.request_ms,
                     body_ms: dl.body_ms,
                     request_count: dl.request_count,
                     original_bytes: dl.original_bytes,
                     decompress_ms: dl.decompress_ms,
+                    extract_ms: dl.extract_ms,
                     disk_io_ms: dl.disk_io_ms,
+                    import_ms,
                     compression_ms: 0,
                     head_checks_ms: 0,
                     blobs_skipped: dl.blobs_skipped,
@@ -1350,10 +1402,6 @@ impl Daemon {
                         .unwrap_or_default()
                         .as_secs(),
                 });
-                // Commit to SQLite so store.get() can find it
-                if let Err(e) = self.with_store(|store| store.import_restored_entry(&req.key)) {
-                    tracing::warn!("failed to import downloaded entry {}: {e}", &req.key);
-                }
                 Response::found(true)
             }
             Err(e) => {
@@ -1366,15 +1414,21 @@ impl Daemon {
                     crate_name: cn.to_string(),
                     direction: TransferDirection::Download,
                     format: plan.transfer_format().to_string(),
+                    cache_key: req.key.clone(),
+                    object_key: String::new(),
                     compressed_bytes: 0,
                     elapsed_ms,
                     network_ms: 0,
+                    semaphore_wait_ms,
+                    head_ms,
                     request_ms: 0,
                     body_ms: 0,
                     request_count: 0,
                     original_bytes: 0,
                     decompress_ms: 0,
+                    extract_ms: 0,
                     disk_io_ms: 0,
+                    import_ms: 0,
                     compression_ms: 0,
                     head_checks_ms: 0,
                     blobs_skipped: 0,
@@ -1509,11 +1563,13 @@ impl Daemon {
                 let download_plan = crate::remote_plan::RemotePlanner::new(&d.config)
                     .plan(crate::remote_plan::RemoteWorkload::Prefetch);
                 in_flight.push(tokio::spawn(async move {
+                    let semaphore_start = Instant::now();
                     let Ok(_permit) = sem.acquire().await else {
                         tracing::warn!("prefetch: semaphore closed for {}", key);
                         d.downloading.write().await.remove(&key);
                         return;
                     };
+                    let semaphore_wait_ms = semaphore_start.elapsed().as_millis() as u64;
                     let client = match d.get_s3_client().await {
                         Ok(c) => c,
                         Err(_) => {
@@ -1538,6 +1594,15 @@ impl Daemon {
                     match download_result {
                         Ok(dl) => {
                             let elapsed_ms = start.elapsed().as_millis() as u64;
+                            let import_start = Instant::now();
+                            let import_ms = if let Err(e) =
+                                d.with_store(|store| store.import_restored_entry(&key))
+                            {
+                                tracing::warn!("prefetch import failed for {}: {e}", key);
+                                0
+                            } else {
+                                import_start.elapsed().as_millis() as u64
+                            };
                             d.transfer_counters
                                 .downloads_completed
                                 .fetch_add(1, Ordering::Relaxed);
@@ -1549,15 +1614,21 @@ impl Daemon {
                                 crate_name: crate_name.clone(),
                                 direction: TransferDirection::Download,
                                 format: dl.format.to_string(),
+                                cache_key: key.clone(),
+                                object_key: dl.object_key,
                                 compressed_bytes: dl.compressed_bytes,
                                 elapsed_ms,
                                 network_ms: dl.network_ms,
+                                semaphore_wait_ms,
+                                head_ms: 0,
                                 request_ms: dl.request_ms,
                                 body_ms: dl.body_ms,
                                 request_count: dl.request_count,
                                 original_bytes: dl.original_bytes,
                                 decompress_ms: dl.decompress_ms,
+                                extract_ms: dl.extract_ms,
                                 disk_io_ms: dl.disk_io_ms,
+                                import_ms,
                                 compression_ms: 0,
                                 head_checks_ms: 0,
                                 blobs_skipped: dl.blobs_skipped,
@@ -1568,10 +1639,6 @@ impl Daemon {
                                     .unwrap_or_default()
                                     .as_secs(),
                             });
-                            if let Err(e) = d.with_store(|store| store.import_restored_entry(&key))
-                            {
-                                tracing::warn!("prefetch import failed for {}: {e}", key);
-                            }
                             // Track as prefetched for PrefetchHit attribution
                             d.prefetched_keys.write().await.insert(key.clone());
                         }
@@ -1585,15 +1652,21 @@ impl Daemon {
                                 crate_name: crate_name.clone(),
                                 direction: TransferDirection::Download,
                                 format: download_plan.transfer_format().to_string(),
+                                cache_key: key.clone(),
+                                object_key: String::new(),
                                 compressed_bytes: 0,
                                 elapsed_ms,
                                 network_ms: 0,
+                                semaphore_wait_ms,
+                                head_ms: 0,
                                 request_ms: 0,
                                 body_ms: 0,
                                 request_count: 0,
                                 original_bytes: 0,
                                 decompress_ms: 0,
+                                extract_ms: 0,
                                 disk_io_ms: 0,
+                                import_ms: 0,
                                 compression_ms: 0,
                                 head_checks_ms: 0,
                                 blobs_skipped: 0,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -11,6 +11,8 @@ use crate::config::RemoteConfig;
 /// Result of a download operation with timing breakdown.
 pub struct DownloadResult {
     pub format: &'static str,
+    /// Remote object key fetched for this download.
+    pub object_key: String,
     pub compressed_bytes: u64,
     /// Uncompressed size in bytes.
     pub original_bytes: u64,
@@ -24,6 +26,11 @@ pub struct DownloadResult {
     pub request_count: u32,
     /// Time spent in zstd decompression (ms).
     pub decompress_ms: u64,
+    /// Time spent extracting the downloaded archive to the local store (ms).
+    ///
+    /// For streaming pack formats this includes zstd decode, tar unpacking,
+    /// and filesystem writes.
+    pub extract_ms: u64,
     /// Time spent on disk I/O (fs::write + permissions + atomic rename), ms.
     pub disk_io_ms: u64,
     /// Number of v2 blobs that were already local (skipped download).

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -112,21 +112,23 @@ impl<'a> RemoteLayout<'a> {
         let compressed = body.into_bytes();
         let compressed_len = compressed.len() as u64;
 
-        let decompress_start = std::time::Instant::now();
+        let extract_start = std::time::Instant::now();
         let decoder = zstd::stream::Decoder::new(std::io::Cursor::new(&compressed))
             .context("creating v3 zstd decoder")?;
         let original_bytes = extract_entry_pack(decoder, entry_dir)?;
-        let decompress_ms = decompress_start.elapsed().as_millis() as u64;
+        let extract_ms = extract_start.elapsed().as_millis() as u64;
 
         Ok(DownloadResult {
             format: "v3",
+            object_key,
             compressed_bytes: compressed_len,
             original_bytes,
             network_ms: request_ms + body_ms,
             request_ms,
             body_ms,
             request_count: 1,
-            decompress_ms,
+            decompress_ms: 0,
+            extract_ms,
             disk_io_ms: 0,
             blobs_skipped: 0,
             blobs_total: 0,

--- a/src/report.rs
+++ b/src/report.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
+use crate::cli::format_duration_ms;
 use crate::config::Config;
 use crate::daemon::{TransferDirection, TransferEvent};
 use crate::events::{self, BuildEvent, EventResult};
@@ -104,16 +105,32 @@ pub struct NetworkAnalysis {
     pub avg_download_ms: f64,
     pub p95_download_ms: u64,
     pub max_download_ms: u64,
-    /// Throughput based on total wall-clock time (includes decompression + disk I/O).
+    /// Throughput based on total wall-clock time (includes local restore work).
     pub throughput_mbps: f64,
     /// Throughput based on network time only (S3 GET + body collection).
     pub network_throughput_mbps: f64,
+    /// Throughput based on response body time only.
+    #[serde(default)]
+    pub body_throughput_mbps: f64,
+    /// Largest aggregate phase for successful downloads, derived from raw phase totals.
+    #[serde(default)]
+    pub dominant_download_phase: String,
+    #[serde(default)]
+    pub dominant_download_phase_ms: u64,
+    #[serde(default)]
+    pub dominant_download_phase_pct: f64,
     /// Time spent waiting for response headers across GET requests.
     #[serde(default)]
     pub total_request_ms: u64,
     /// Time spent reading response bodies across GET requests.
     #[serde(default)]
     pub total_body_ms: u64,
+    /// Time spent waiting for S3 concurrency permits.
+    #[serde(default)]
+    pub total_semaphore_wait_ms: u64,
+    /// Time spent on HEAD/existence checks before downloads.
+    #[serde(default)]
+    pub total_head_ms: u64,
     /// Total number of GET requests issued for successful downloads.
     #[serde(default)]
     pub total_get_requests: u32,
@@ -123,8 +140,14 @@ pub struct NetworkAnalysis {
     pub original_bytes_down: u64,
     /// Total time spent in zstd decompression (ms).
     pub total_decompress_ms: u64,
+    /// Total time spent extracting downloaded archives (ms).
+    #[serde(default)]
+    pub total_extract_ms: u64,
     /// Disk I/O time for downloads (directly measured when available), ms.
     pub total_disk_io_ms: u64,
+    /// Total time spent importing downloaded entries into SQLite.
+    #[serde(default)]
+    pub total_import_ms: u64,
     /// Total upload compression time (ms).
     #[serde(default)]
     pub total_compression_ms: u64,
@@ -170,10 +193,18 @@ pub struct TransferDetail {
     pub direction: String,
     #[serde(default)]
     pub format: String,
+    #[serde(default)]
+    pub cache_key: String,
+    #[serde(default)]
+    pub object_key: String,
     pub compressed_bytes: u64,
     pub elapsed_ms: u64,
     #[serde(default)]
     pub network_ms: u64,
+    #[serde(default)]
+    pub semaphore_wait_ms: u64,
+    #[serde(default)]
+    pub head_ms: u64,
     #[serde(default)]
     pub request_ms: u64,
     #[serde(default)]
@@ -181,7 +212,11 @@ pub struct TransferDetail {
     #[serde(default)]
     pub decompress_ms: u64,
     #[serde(default)]
+    pub extract_ms: u64,
+    #[serde(default)]
     pub disk_io_ms: u64,
+    #[serde(default)]
+    pub import_ms: u64,
     #[serde(default)]
     pub request_count: u32,
     #[serde(default)]
@@ -431,11 +466,15 @@ fn build_network_analysis(transfers: &[TransferEvent], top: usize) -> NetworkAna
     let mut total_network_ms = 0u64;
     let mut total_request_ms = 0u64;
     let mut total_body_ms = 0u64;
+    let mut total_semaphore_wait_ms = 0u64;
+    let mut total_head_ms = 0u64;
     let mut total_get_requests = 0u32;
     let mut total_original_bytes = 0u64;
     let mut total_decompress_ms = 0u64;
+    let mut total_extract_ms = 0u64;
     let mut total_disk_io_ms_measured = 0u64;
     let mut has_disk_io_measurement = false;
+    let mut total_import_ms = 0u64;
     let mut total_compression_ms = 0u64;
     let mut total_head_checks_ms = 0u64;
     let mut blobs_skipped = 0u32;
@@ -465,6 +504,10 @@ fn build_network_analysis(transfers: &[TransferEvent], top: usize) -> NetworkAna
                     total_download_bytes += t.compressed_bytes;
                     total_original_bytes += t.original_bytes;
                     total_decompress_ms += t.decompress_ms;
+                    total_extract_ms += t.extract_ms;
+                    total_import_ms += t.import_ms;
+                    total_semaphore_wait_ms += t.semaphore_wait_ms;
+                    total_head_ms += t.head_ms;
                     total_request_ms += t.request_ms;
                     total_body_ms += t.body_ms;
                     total_get_requests += t.request_count;
@@ -525,6 +568,13 @@ fn build_network_analysis(transfers: &[TransferEvent], top: usize) -> NetworkAna
         0.0
     };
 
+    // Body-only throughput isolates raw object-store transfer once bytes start flowing.
+    let body_throughput_mbps = if total_body_ms > 0 {
+        (total_download_bytes as f64 / (1024.0 * 1024.0)) / (total_body_ms as f64 / 1000.0)
+    } else {
+        0.0
+    };
+
     // Slowest downloads
     let mut download_details: Vec<TransferDetail> = transfers
         .iter()
@@ -539,13 +589,19 @@ fn build_network_analysis(transfers: &[TransferEvent], top: usize) -> NetworkAna
                 crate_name: t.crate_name.clone(),
                 direction: "download".to_string(),
                 format: t.format.clone(),
+                cache_key: t.cache_key.clone(),
+                object_key: t.object_key.clone(),
                 compressed_bytes: t.compressed_bytes,
                 elapsed_ms: t.elapsed_ms,
                 network_ms: t.network_ms,
+                semaphore_wait_ms: t.semaphore_wait_ms,
+                head_ms: t.head_ms,
                 request_ms: t.request_ms,
                 body_ms: t.body_ms,
                 decompress_ms: t.decompress_ms,
+                extract_ms: t.extract_ms,
                 disk_io_ms: t.disk_io_ms,
+                import_ms: t.import_ms,
                 request_count: t.request_count,
                 blobs_skipped: t.blobs_skipped,
                 blobs_total: t.blobs_total,
@@ -566,7 +622,28 @@ fn build_network_analysis(transfers: &[TransferEvent], top: usize) -> NetworkAna
     let total_disk_io_ms = if has_disk_io_measurement {
         total_disk_io_ms_measured
     } else {
-        total_download_ms.saturating_sub(total_network_ms + total_decompress_ms)
+        total_download_ms.saturating_sub(total_network_ms + total_decompress_ms + total_extract_ms)
+    };
+    let phase_totals = [
+        ("wait", total_semaphore_wait_ms),
+        ("HEAD", total_head_ms),
+        ("request", total_request_ms),
+        ("body", total_body_ms),
+        ("decompress", total_decompress_ms),
+        ("extract", total_extract_ms),
+        ("import", total_import_ms),
+        ("disk", total_disk_io_ms),
+    ];
+    let phase_total_ms: u64 = phase_totals.iter().map(|(_, ms)| *ms).sum();
+    let (dominant_phase, dominant_phase_ms) = phase_totals
+        .iter()
+        .copied()
+        .max_by_key(|(_, ms)| *ms)
+        .unwrap_or(("unknown", 0));
+    let dominant_phase_pct = if phase_total_ms > 0 {
+        dominant_phase_ms as f64 / phase_total_ms as f64 * 100.0
+    } else {
+        0.0
     };
 
     NetworkAnalysis {
@@ -581,13 +658,21 @@ fn build_network_analysis(transfers: &[TransferEvent], top: usize) -> NetworkAna
         max_download_ms,
         throughput_mbps: (throughput_mbps * 10.0).round() / 10.0,
         network_throughput_mbps: (network_throughput_mbps * 10.0).round() / 10.0,
+        body_throughput_mbps: (body_throughput_mbps * 10.0).round() / 10.0,
+        dominant_download_phase: dominant_phase.to_string(),
+        dominant_download_phase_ms: dominant_phase_ms,
+        dominant_download_phase_pct: (dominant_phase_pct * 10.0).round() / 10.0,
         total_request_ms,
         total_body_ms,
+        total_semaphore_wait_ms,
+        total_head_ms,
         total_get_requests,
         compression_ratio: (compression_ratio * 10.0).round() / 10.0,
         original_bytes_down: total_original_bytes,
         total_decompress_ms,
+        total_extract_ms,
         total_disk_io_ms,
+        total_import_ms,
         total_compression_ms,
         total_head_checks_ms,
         blobs_skipped,
@@ -671,6 +756,26 @@ fn generate_suggestions(
             suggestions.push(format!(
                 "Downloads fan out to {:.1} GETs per cache hit — check remote layout granularity or prefer pack-first downloads on CI",
                 net.total_get_requests as f64 / net.downloads_ok as f64
+            ));
+        }
+        if net.total_semaphore_wait_ms > 10_000 {
+            suggestions.push(format!(
+                "S3 semaphore wait totaled {} — tune concurrency only if the object store can absorb it",
+                format_duration_ms(net.total_semaphore_wait_ms)
+            ));
+        }
+        if net.total_request_ms > 30_000 && net.total_request_ms > net.total_body_ms {
+            suggestions.push(format!(
+                "Request/header latency ({}) exceeds body transfer ({}) — check RGW/request path, connection reuse, or object fan-out",
+                format_duration_ms(net.total_request_ms),
+                format_duration_ms(net.total_body_ms)
+            ));
+        }
+        if net.total_extract_ms > 30_000 && net.total_extract_ms > net.total_body_ms {
+            suggestions.push(format!(
+                "Archive extract time ({}) exceeds body transfer ({}) — profile zstd/tar extraction and SQLite import separately",
+                format_duration_ms(net.total_extract_ms),
+                format_duration_ms(net.total_body_ms)
             ));
         }
     }
@@ -787,9 +892,21 @@ pub fn format_markdown(report: &BuildReport) -> String {
             net.network_throughput_mbps
         ));
         lines.push(format!(
-            "| Throughput (incl. decompress) | {:.1} MB/s |",
+            "| Throughput (body only) | {:.1} MB/s |",
+            net.body_throughput_mbps
+        ));
+        lines.push(format!(
+            "| Throughput (incl. restore) | {:.1} MB/s |",
             net.throughput_mbps
         ));
+        if !net.dominant_download_phase.is_empty() && net.dominant_download_phase_ms > 0 {
+            lines.push(format!(
+                "| Dominant download phase | {} — {} ({:.1}%) |",
+                net.dominant_download_phase,
+                format_duration_ms(net.dominant_download_phase_ms),
+                net.dominant_download_phase_pct
+            ));
+        }
         if net.compression_ratio > 0.0 {
             lines.push(format!(
                 "| Compression ratio | {:.1}x ({} → {}) |",
@@ -798,11 +915,22 @@ pub fn format_markdown(report: &BuildReport) -> String {
                 format_bytes(net.bytes_down)
             ));
         }
-        if net.total_decompress_ms > 0 || net.total_disk_io_ms > 0 {
+        if net.total_semaphore_wait_ms > 0
+            || net.total_head_ms > 0
+            || net.total_decompress_ms > 0
+            || net.total_extract_ms > 0
+            || net.total_import_ms > 0
+            || net.total_disk_io_ms > 0
+        {
             lines.push(format!(
-                "| Time breakdown | network {}ms, decompress {}ms, disk I/O {}ms |",
-                net.avg_download_ms as u64 * net.downloads_ok as u64,
+                "| Time breakdown | wait {}ms, HEAD {}ms, request {}ms, body {}ms, decompress {}ms, extract {}ms, import {}ms, disk I/O {}ms |",
+                net.total_semaphore_wait_ms,
+                net.total_head_ms,
+                net.total_request_ms,
+                net.total_body_ms,
                 net.total_decompress_ms,
+                net.total_extract_ms,
+                net.total_import_ms,
                 net.total_disk_io_ms
             ));
         }
@@ -829,16 +957,42 @@ pub fn format_markdown(report: &BuildReport) -> String {
         // Slowest downloads
         if !net.slowest_downloads.is_empty() {
             lines.push("#### Slowest Downloads".to_string());
-            lines.push("| Crate | Size | Latency | Throughput |".to_string());
-            lines.push("|---|---|---|---|".to_string());
+            lines.push(
+                "| Crate | Size | Time | Key | Wait/HEAD | Req/Body | Extract/Import |".to_string(),
+            );
+            lines.push("|---|---|---|---|---|---|---|".to_string());
             for d in &net.slowest_downloads {
+                let key = if d.cache_key.is_empty() {
+                    "?"
+                } else {
+                    &d.cache_key[..d.cache_key.len().min(12)]
+                };
                 lines.push(format!(
-                    "| `{}` | {} | {}ms | {:.1} MB/s |",
+                    "| `{}` | {} | {}ms | `{}` | {}/{}ms | {}/{}ms | {}/{}ms |",
                     d.crate_name,
                     format_bytes(d.compressed_bytes),
                     d.elapsed_ms,
-                    d.throughput_mbps,
+                    key,
+                    d.semaphore_wait_ms,
+                    d.head_ms,
+                    d.request_ms,
+                    d.body_ms,
+                    d.extract_ms.max(d.decompress_ms),
+                    d.import_ms,
                 ));
+            }
+            let repro_keys: Vec<_> = net
+                .slowest_downloads
+                .iter()
+                .filter(|d| !d.object_key.is_empty())
+                .take(3)
+                .collect();
+            if !repro_keys.is_empty() {
+                lines.push(String::new());
+                lines.push("Raw object keys for reproduction:".to_string());
+                for d in repro_keys {
+                    lines.push(format!("- `{}`: `{}`", d.crate_name, d.object_key));
+                }
             }
             lines.push(String::new());
         }
@@ -1019,10 +1173,17 @@ pub fn format_github(report: &BuildReport) -> String {
 
         lines.push(String::new());
         lines.push("<details>".to_string());
+        let dominant_summary =
+            if !net.dominant_download_phase.is_empty() && net.dominant_download_phase_ms > 0 {
+                format!(", dominant {}", net.dominant_download_phase)
+            } else {
+                String::new()
+            };
         lines.push(format!(
-            "<summary><strong>Network</strong> — {} downloaded, {:.0} MB/s</summary>",
+            "<summary><strong>Network</strong> — {} downloaded, {:.0} MB/s body{}</summary>",
             format_bytes(net.bytes_down),
-            net_tp,
+            net.body_throughput_mbps,
+            dominant_summary
         ));
         lines.push(String::new());
         lines.push("| | |".to_string());
@@ -1067,9 +1228,17 @@ pub fn format_github(report: &BuildReport) -> String {
             ));
         }
         lines.push(format!(
-            "| Throughput | {:.1} MB/s network · {:.1} MB/s end-to-end |",
-            net_tp, net.throughput_mbps
+            "| Throughput | {:.1} MB/s body · {:.1} MB/s request+body · {:.1} MB/s end-to-end |",
+            net.body_throughput_mbps, net_tp, net.throughput_mbps
         ));
+        if !net.dominant_download_phase.is_empty() && net.dominant_download_phase_ms > 0 {
+            lines.push(format!(
+                "| Dominant download phase | {} — {} ({:.1}%) |",
+                net.dominant_download_phase,
+                format_duration_ms(net.dominant_download_phase_ms),
+                net.dominant_download_phase_pct
+            ));
+        }
         if net.compression_ratio > 0.0 {
             lines.push(format!(
                 "| Compression | {:.1}x ({} → {}) |",
@@ -1078,12 +1247,22 @@ pub fn format_github(report: &BuildReport) -> String {
                 format_bytes(net.bytes_down)
             ));
         }
-        if net.total_decompress_ms > 0 || net.total_disk_io_ms > 0 {
+        if net.total_semaphore_wait_ms > 0
+            || net.total_head_ms > 0
+            || net.total_decompress_ms > 0
+            || net.total_extract_ms > 0
+            || net.total_import_ms > 0
+            || net.total_disk_io_ms > 0
+        {
             lines.push(format!(
-                "| Time split | request {}ms · body {}ms · decompress {}ms · disk {}ms |",
+                "| Time split | wait {}ms · HEAD {}ms · request {}ms · body {}ms · decompress {}ms · extract {}ms · import {}ms · disk {}ms |",
+                net.total_semaphore_wait_ms,
+                net.total_head_ms,
                 net.total_request_ms,
                 net.total_body_ms,
                 net.total_decompress_ms,
+                net.total_extract_ms,
+                net.total_import_ms,
                 net.total_disk_io_ms
             ));
         }
@@ -1110,21 +1289,48 @@ pub fn format_github(report: &BuildReport) -> String {
             lines.push(String::new());
             lines.push("**Slowest downloads:**".to_string());
             lines.push(String::new());
-            lines.push("| Crate | Fmt | Size | Time | GETs | Req/Body | Decomp/Disk |".to_string());
-            lines.push("|-------|-----|------|------|------|----------|-------------|".to_string());
+            lines.push(
+                "| Crate | Fmt | Size | Time | GETs | Key | Wait/HEAD | Req/Body | Extract/Import |"
+                    .to_string(),
+            );
+            lines.push(
+                "|-------|-----|------|------|------|-----|-----------|----------|----------------|"
+                    .to_string(),
+            );
             for d in net.slowest_downloads.iter().take(5) {
+                let key = if d.cache_key.is_empty() {
+                    "?"
+                } else {
+                    &d.cache_key[..d.cache_key.len().min(12)]
+                };
                 lines.push(format!(
-                    "| `{}` | {} | {} | {}ms | {} | {}/{}ms | {}/{}ms |",
+                    "| `{}` | {} | {} | {}ms | {} | `{}` | {}/{}ms | {}/{}ms | {}/{}ms |",
                     d.crate_name,
                     if d.format.is_empty() { "?" } else { &d.format },
                     format_bytes(d.compressed_bytes),
                     d.elapsed_ms,
                     d.request_count,
+                    key,
+                    d.semaphore_wait_ms,
+                    d.head_ms,
                     d.request_ms,
                     d.body_ms,
-                    d.decompress_ms,
-                    d.disk_io_ms,
+                    d.extract_ms.max(d.decompress_ms),
+                    d.import_ms,
                 ));
+            }
+            let repro_keys: Vec<_> = net
+                .slowest_downloads
+                .iter()
+                .filter(|d| !d.object_key.is_empty())
+                .take(3)
+                .collect();
+            if !repro_keys.is_empty() {
+                lines.push(String::new());
+                lines.push("Raw object keys for reproduction:".to_string());
+                for d in repro_keys {
+                    lines.push(format!("- `{}`: `{}`", d.crate_name, d.object_key));
+                }
             }
         }
         lines.push(String::new());
@@ -1289,9 +1495,17 @@ pub fn format_text(report: &BuildReport) -> String {
             net.avg_download_ms, net.p95_download_ms, net.max_download_ms
         ));
         lines.push(format!(
-            "  Throughput: {:.1} MB/s network, {:.1} MB/s incl. decompress",
-            net.network_throughput_mbps, net.throughput_mbps
+            "  Throughput: {:.1} MB/s body, {:.1} MB/s request+body, {:.1} MB/s incl. restore",
+            net.body_throughput_mbps, net.network_throughput_mbps, net.throughput_mbps
         ));
+        if !net.dominant_download_phase.is_empty() && net.dominant_download_phase_ms > 0 {
+            lines.push(format!(
+                "  Dominant phase: {} — {} ({:.1}%)",
+                net.dominant_download_phase,
+                format_duration_ms(net.dominant_download_phase_ms),
+                net.dominant_download_phase_pct
+            ));
+        }
         if net.compression_ratio > 0.0 {
             lines.push(format!(
                 "  Compression: {:.1}x ratio ({} → {})",
@@ -1300,11 +1514,22 @@ pub fn format_text(report: &BuildReport) -> String {
                 format_bytes(net.bytes_down)
             ));
         }
-        if net.total_decompress_ms > 0 || net.total_disk_io_ms > 0 {
+        if net.total_semaphore_wait_ms > 0
+            || net.total_head_ms > 0
+            || net.total_decompress_ms > 0
+            || net.total_extract_ms > 0
+            || net.total_import_ms > 0
+            || net.total_disk_io_ms > 0
+        {
             lines.push(format!(
-                "  Time split: network {}ms, decompress {}ms, disk I/O {}ms",
-                net.avg_download_ms as u64 * net.downloads_ok as u64,
+                "  Time split: wait {}ms, HEAD {}ms, request {}ms, body {}ms, decompress {}ms, extract {}ms, import {}ms, disk I/O {}ms",
+                net.total_semaphore_wait_ms,
+                net.total_head_ms,
+                net.total_request_ms,
+                net.total_body_ms,
                 net.total_decompress_ms,
+                net.total_extract_ms,
+                net.total_import_ms,
                 net.total_disk_io_ms
             ));
         }
@@ -1416,19 +1641,25 @@ mod tests {
         ok: bool,
     ) -> TransferEvent {
         TransferEvent {
-            schema: 1,
+            schema: 2,
             crate_name: crate_name.to_string(),
             direction,
             format: format.to_string(),
+            cache_key: format!("{crate_name}-key"),
+            object_key: format!("prefix/v3/packs/{crate_name}/{crate_name}-key.tar.zst"),
             compressed_bytes,
             elapsed_ms,
             network_ms: elapsed_ms / 2, // simulate network = half of total
+            semaphore_wait_ms: 0,
+            head_ms: 0,
             request_ms: elapsed_ms / 5,
             body_ms: elapsed_ms / 3,
             request_count: 4,
             original_bytes: compressed_bytes * 3, // simulate ~3x compression ratio
             decompress_ms: elapsed_ms / 4,        // simulate decompress = quarter of total
+            extract_ms: 0,
             disk_io_ms: 0,
+            import_ms: 0,
             compression_ms: 0,
             head_checks_ms: 0,
             blobs_skipped: 0,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -182,7 +182,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     // Build-session detection: send prefetch hint before remote work.
     // Placed after local-hit check so warm-cache invocations skip this entirely.
-    maybe_trigger_prefetch(config);
+    maybe_trigger_prefetch(config, &args);
 
     // 2. Check remote cache via daemon (if configured)
     if config.remote.is_some() {
@@ -535,7 +535,7 @@ fn log_event(
 /// Uses a marker file with flock to ensure only one wrapper process per
 /// build session sends the hint — without this, N parallel rustc invocations
 /// would all race past the check and send duplicate prefetch requests.
-fn maybe_trigger_prefetch(config: &Config) {
+fn maybe_trigger_prefetch(config: &Config, args: &RustcArgs) {
     if config.remote.is_none() {
         return;
     }
@@ -582,7 +582,7 @@ fn maybe_trigger_prefetch(config: &Config) {
     // Gather ALL dependency crate names in compilation order (leaves first).
     // This gives the daemon a comprehensive prefetch list that works even on
     // cold CI runners where the local SQLite store is empty.
-    let build_intent = match crate::build_intent::discover() {
+    let build_intent = match crate::build_intent::discover(Some(args)) {
         Some(intent) => intent,
         _ => return,
     };


### PR DESCRIPTION
## Summary

- improve build intent discovery so prefetch uses the workspace manifest inferred from rustc `--out-dir`
- let `save-manifest` use `KACHE_NAMESPACE` when `--namespace` is omitted, enabling shard uploads from CI env
- add raw transfer telemetry for S3/cache restores: cache/object keys, semaphore wait, HEAD, request, body, extract, import, and disk timing
- expand reports with raw phase splits, body/request+body/end-to-end throughput, and object keys for reproducing slow downloads

## Why

CI showed high remote hit rates but low prefetch contribution and several minutes spent in restore. The old report mixed some local restore work into broad network/decompress buckets, making it hard to tell whether time was in RGW/S3 request path, body transfer, local extraction, or SQLite import.

## Validation

- `mise exec -- cargo fmt --all`
- `mise exec -- cargo test report`
- `mise exec -- cargo test --workspace`