### PR TITLE
docs: pre-launch onboarding pack (CI, contributing, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug report
+about: Something is broken or behaves unexpectedly
+title: ""
+labels: bug
+---
+
+## What happened
+
+<!-- One or two sentences describing the problem. -->
+
+## Expected behaviour
+
+<!-- What did you expect to happen instead? -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- `kache --version`:
+- OS and version (e.g. macOS 15.4, Ubuntu 24.04):
+- Rust toolchain (`rustc --version`):
+- Install method (mise / cargo-binstall / cargo install):
+- Remote backend (none / S3 / R2 / MinIO / other):
+
+## Logs
+
+<!--
+Re-run the failing command with verbose logging and paste the relevant
+output. Redact credentials.
+
+    KACHE_LOG=kache=debug cargo build 2>&1 | tee /tmp/kache.log
+
+Also useful when relevant:
+    kache doctor --verify
+    kache stats
+-->
+
+```
+```
+
+## Additional context
+
+<!-- Anything else that might help — recent changes, workspace size,
+unusual project layout, custom RUSTFLAGS, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest a new capability or improvement
+title: ""
+labels: enhancement
+---
+
+## Problem
+
+<!-- What are you trying to do that kache currently makes hard or
+impossible? Describe the situation, not the solution. -->
+
+## Proposed solution
+
+<!-- What change would solve it? CLI surface, config, behaviour. -->
+
+## Alternatives considered
+
+<!-- Workarounds you've tried, or other designs you weighed. -->
+
+## Use case
+
+<!-- Concrete scenario(s) where this would help — workspace shape,
+team size, CI setup, etc. Helps gauge generality. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Thanks for sending a PR! Keep it focused on a single change — unrelated
+refactors are easier to review separately. See CONTRIBUTING.md for the
+full process.
+-->
+
+## Summary
+
+<!-- What does this PR change and why? Link related issues. -->
+
+## Test plan
+
+<!-- How did you verify the change? Commands run, scenarios covered.
+Include before/after numbers for performance changes. -->
+
+- [ ]
+
+## Checklist
+
+- [ ] `just check` passes locally (fmt + clippy + tests)
+- [ ] New behaviour is covered by tests where it makes sense
+- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
+- [ ] User-visible changes (CLI, config, output) are reflected in the README or relevant docs

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ kache doctor
 
 `kache init` is idempotent — re-run it any time to repair configuration. If you prefer to configure things by hand, just export `RUSTC_WRAPPER=kache` or add it to `~/.cargo/config.toml` under `[build]`.
 
+## Use in CI
+
+[`kache-action`](https://github.com/kunobi-ninja/kache-action) installs kache, wires it as `RUSTC_WRAPPER`, and persists the cache between runs. Drop one line into your workflow:
+
+```yaml
+- uses: kunobi-ninja/kache-action@v1
+```
+
+That uses GitHub Actions cache by default. For S3-backed caching shared across repos or runners, pass `s3-bucket` plus credentials — see the action's README for the full input list.
+
 ## Development
 
 ```sh
@@ -169,3 +179,7 @@ ha:
 ```
 
 When combining HA with PVC-backed planner state, use storage that can be mounted by all scheduled replicas, or keep `replicaCount: 1`.
+
+## Contributing
+
+Bug reports, feature ideas, and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev setup, coding conventions, and PR process. To report a security vulnerability privately, follow [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
## Summary

Tighten the on-ramp before pushing kache to TWiR. Four small, complementary additions:

- **README → `Use in CI`**: link to [`kunobi-ninja/kache-action`](https://github.com/kunobi-ninja/kache-action) with the one-liner `uses:` syntax. The action has existed since March but the main README never advertised it, so a CI-curious reader had no path from the project page to the workflow integration.
- **README → `Contributing` footer**: surface the existing [CONTRIBUTING.md](CONTRIBUTING.md) and [SECURITY.md](SECURITY.md). Both files were already in the repo with full content; the README just didn't link them.
- **`.github/ISSUE_TEMPLATE/`**: `bug_report.md` and `feature_request.md` so incoming reports include version / OS / `KACHE_LOG=kache=debug` output upfront — much less round-tripping for the maintainer.
- **`.github/PULL_REQUEST_TEMPLATE.md`**: summary + test plan + checklist (just check, conventional commits, docs updated).

Out of scope (intentionally) — would need human judgement, not in this PR:
- Opening labelled `good first issue` items (needs decisions about *what* to file)
- Repo metadata: GitHub Topics, social preview image
- Updating `kache-action`'s README, which still references the old `zondax/kache-action@v1` URL instead of `kunobi-ninja/kache-action@v1` — separate repo, separate PR

## Test plan

- [ ] Render the README on GitHub and confirm the new `Use in CI` block sits between Quick start and Development, and the `Contributing` footer appears after `Remote service`
- [ ] Open a fresh issue on a clone — the bug-report template should appear by default
- [ ] Open a draft PR — the PR template should populate the description automatically