### PR TITLE
chore: pre-0.2.0 polish — Cargo.toml metadata + tighter README description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 description = "Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — just hardlinks locally and S3 for sharing."
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"
+homepage = "https://kunobi.ninja/docs/kache"
+keywords = ["build-cache", "rustc-wrapper", "blake3", "cargo"]
+categories = ["development-tools::build-utils", "caching"]
 rust-version = "1.95"
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — just hardlinks locally and S3 for sharing.
 
-A drop-in `RUSTC_WRAPPER` that caches compilation artifacts using blake3 hashing, shares them via hardlinks to save disk space, and optionally syncs to S3-compatible storage (AWS, Ceph, MinIO, R2) for distributed caching across machines.
+A drop-in `RUSTC_WRAPPER` that caches Rust compilation artifacts. Cache keys are blake3 hashes of normalized rustc invocations; cache hits restore via hardlinks, and identical blobs are stored once and shared. Optional S3 sync (AWS, Ceph, MinIO, R2) shares the cache across machines.
 
 Local caching and direct S3 sync are stable today.
 


### PR DESCRIPTION
## Summary

Tiny polish so v0.2.0 has a real diff over v0.1.2 (rather than just being a renumber).

- **Cargo.toml** gains `homepage`, `keywords`, and `categories`. Helps GitHub topics, search engines, and (if/when published) crates.io discoverability. No `sccache` keyword — naming a competitor in our own metadata isn't a great look.
- **README** splits the long single-sentence project description (line 10, ~40 words) into three shorter sentences. Calls out determinism explicitly ("blake3 hashes of normalized rustc invocations") since that's why cross-machine cache sharing actually works.

(Replaces #40, which closed automatically when its source branch was renamed.)

## Test plan

- [ ] \`cargo metadata --format-version 1 --no-deps | jq '.packages[0] | {keywords, categories, homepage}'\` returns the expected fields
- [ ] README renders correctly on GitHub (paragraph break preserved, no formatting drift)