### PR TITLE
feat(windows): swap to rustls-aws-lc and add exploratory CI (#45)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"7e146550-c408-49c0-a06c-5be0a5cba6d9","pid":13417,"procStart":"Wed May 13 09:50:03 2026","acquiredAt":1778674347304}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"7e146550-c408-49c0-a06c-5be0a5cba6d9","pid":13417,"procStart":"Wed May 13 09:50:03 2026","acquiredAt":1778674347304}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,20 @@ jobs:
           print(f'OK: >= {threshold}%')
           "
 
+  # --- Windows exploratory check (non-blocking) ---
+  # Surfaces remaining Windows porting work for issue #45. Allowed to fail
+  # until the daemon (UnixStream/UnixListener), wrapper flock, and other
+  # unix-only paths get Windows arms. Remove `continue-on-error` once green.
+  windows-check:
+    name: Windows check (exploratory)
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: cargo check (x86_64-pc-windows-msvc)
+        run: cargo check --target x86_64-pc-windows-msvc
+
   # --- Release (only on v* tags) ---
   release:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/planning/*
 
 # Git worktrees
 .worktrees/
+.claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3107,8 +3107,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
 dependencies = [
  "doctest-file",
+ "futures-core",
  "libc",
  "recvmsg",
+ "tokio",
  "widestring",
  "windows-sys 0.61.2",
 ]
@@ -3349,6 +3351,7 @@ dependencies = [
  "dirs",
  "filetime",
  "futures",
+ "interprocess",
  "kache-core",
  "libc",
  "predicates",
@@ -3363,6 +3366,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.61.2",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,10 @@ futures = "0.3"
 libc = "0.2"
 tempfile = "3"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+interprocess = { version = "2.4.2", features = ["tokio"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "3"
 blake3 = "1"
 aws-sdk-s3 = "1"
 aws-config = "1"
-aws-smithy-http-client = { version = "1", features = ["rustls-ring"] }
+aws-smithy-http-client = { version = "1", features = ["rustls-aws-lc"] }
 kache-core = { path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+#[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::RwLock;
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -217,10 +217,7 @@ fn daemon_state_is_recent(state: &DaemonCoordState) -> bool {
     age_ms <= DAEMON_COORD_STALE_AFTER.as_millis() as u64
 }
 
-fn process_is_alive(pid: u32) -> bool {
-    let rc = unsafe { libc::kill(pid as i32, 0) };
-    rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
-}
+use crate::platform::is_process_alive as process_is_alive;
 
 fn wait_for_run_lock_release(socket_path: &Path, timeout: Duration) -> Result<bool> {
     let deadline = Instant::now() + timeout;
@@ -236,17 +233,13 @@ fn wait_for_run_lock_release(socket_path: &Path, timeout: Duration) -> Result<bo
 }
 
 fn terminate_daemon_pid(pid: u32, socket_path: &Path) -> Result<bool> {
-    unsafe {
-        libc::kill(pid as i32, libc::SIGTERM);
-    }
+    crate::platform::terminate_process(pid);
 
     if wait_for_run_lock_release(socket_path, Duration::from_secs(1))? {
         return Ok(true);
     }
 
-    unsafe {
-        libc::kill(pid as i32, libc::SIGKILL);
-    }
+    crate::platform::kill_process(pid);
 
     wait_for_run_lock_release(socket_path, Duration::from_secs(1))
 }
@@ -1914,16 +1907,13 @@ pub fn run_server(config: &Config) -> Result<()> {
         .open(&lock_path)
         .context("opening daemon run lock file")?;
 
-    use std::os::unix::io::AsRawFd;
-    let got_lock =
-        unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0;
-
-    if !got_lock {
+    // Cross-platform exclusive lock: flock(2) on Unix, LockFileEx on Windows.
+    if lock_file.try_lock().is_err() {
         tracing::info!("another daemon holds the run lock, exiting");
         return Ok(());
     }
 
-    // Hold lock_file (and thus the flock) for the daemon's entire lifetime.
+    // Hold lock_file (and thus the lock) for the daemon's entire lifetime.
     let _lock = lock_file;
     let coord = DaemonCoordFile::for_socket(&socket_path);
     coord
@@ -2581,17 +2571,7 @@ fn is_client_disconnect(e: &std::io::Error) -> bool {
     ) || e.raw_os_error() == Some(32) // EPIPE on macOS may report as ErrorKind::Other
 }
 
-async fn shutdown_signal() {
-    use tokio::signal::unix::{SignalKind, signal};
-
-    let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
-    let mut sigint = signal(SignalKind::interrupt()).expect("SIGINT handler");
-
-    tokio::select! {
-        _ = sigterm.recv() => {}
-        _ = sigint.recv() => {}
-    }
-}
+use crate::platform::wait_for_shutdown as shutdown_signal;
 
 // ── Client ───────────────────────────────────────────────────────
 
@@ -2894,24 +2874,20 @@ pub fn send_shutdown_request(config: &Config) -> Result<()> {
             {
                 tracing::info!(
                     pid = state.pid,
-                    "socket unreachable, sending SIGTERM to daemon process"
+                    "socket unreachable, terminating daemon process"
                 );
-                unsafe {
-                    libc::kill(state.pid as i32, libc::SIGTERM);
-                }
+                crate::platform::terminate_process(state.pid);
                 if wait_for_run_lock_release(&socket_path, Duration::from_secs(3))? {
                     let _ = std::fs::remove_file(&socket_path);
                     eprintln!("daemon stopped (terminated stale process)");
                     return Ok(());
                 }
-                // SIGTERM didn't work, escalate to SIGKILL.
+                // Graceful termination didn't work, escalate to force kill.
                 tracing::warn!(
                     pid = state.pid,
-                    "SIGTERM did not stop daemon, sending SIGKILL"
+                    "daemon did not stop, force-killing"
                 );
-                unsafe {
-                    libc::kill(state.pid as i32, libc::SIGKILL);
-                }
+                crate::platform::kill_process(state.pid);
                 if wait_for_run_lock_release(&socket_path, Duration::from_secs(2))? {
                     let _ = std::fs::remove_file(&socket_path);
                     eprintln!("daemon stopped (killed stale process)");
@@ -2956,21 +2932,17 @@ pub fn force_recover(config: &Config) -> Result<()> {
     if !pids.is_empty() {
         tracing::info!(?pids, "killing lingering kache daemon processes");
         for &pid in &pids {
-            unsafe {
-                libc::kill(pid as i32, libc::SIGTERM);
-            }
+            crate::platform::terminate_process(pid);
         }
-        // Give the SIGTERM a moment to land.
+        // Give the graceful terminate a moment to land.
         std::thread::sleep(Duration::from_millis(500));
         for &pid in &pids {
             if process_is_alive(pid) {
-                tracing::warn!(pid, "SIGTERM did not land, escalating to SIGKILL");
-                unsafe {
-                    libc::kill(pid as i32, libc::SIGKILL);
-                }
+                tracing::warn!(pid, "graceful terminate did not land, force-killing");
+                crate::platform::kill_process(pid);
             }
         }
-        // Allow the OS a moment to reap zombies and release flocks.
+        // Allow the OS a moment to reap zombies and release locks.
         std::thread::sleep(Duration::from_millis(200));
     }
 
@@ -3169,9 +3141,7 @@ pub fn start_daemon_background() -> Result<bool> {
             .open(&lock_path)
             .context("opening daemon lock file")?;
 
-        use std::os::unix::io::AsRawFd;
-        let got_lock =
-            unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0;
+        let got_lock = lock_file.try_lock().is_ok();
 
         if !got_lock {
             tracing::debug!("daemon start already in progress, waiting for socket");
@@ -3320,12 +3290,10 @@ fn daemon_run_lock_is_held(socket_path: &Path) -> Result<bool> {
         .open(&run_lock_path)
         .context("opening daemon run lock probe file")?;
 
-    use std::os::unix::io::AsRawFd;
-    let got_lock =
-        unsafe { libc::flock(run_lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0;
-
-    if got_lock {
-        unsafe { libc::flock(run_lock_file.as_raw_fd(), libc::LOCK_UN) };
+    // Probe: if we can acquire the lock, no daemon is running. Releases
+    // immediately on drop (or via explicit unlock below).
+    if run_lock_file.try_lock().is_ok() {
+        let _ = run_lock_file.unlock();
         Ok(false)
     } else {
         Ok(true)
@@ -3420,11 +3388,10 @@ mod tests {
                 .truncate(false)
                 .open(&run_lock_path)
                 .unwrap();
-            use std::os::unix::io::AsRawFd;
-            assert_eq!(unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) }, 0);
+            file.lock().unwrap();
             tx.send(()).unwrap();
             std::thread::sleep(hold_for);
-            unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+            let _ = file.unlock();
         });
         rx.recv().unwrap();
         handle

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1929,6 +1929,15 @@ pub fn run_server(config: &Config) -> Result<()> {
     rt.block_on(server_main(config, coord))
 }
 
+#[cfg(not(unix))]
+async fn server_main(_config: &Config, _coord: DaemonCoordFile) -> Result<()> {
+    // Daemon RPC needs a cross-platform IPC primitive. On Windows we'd use
+    // named pipes via interprocess::local_socket, which is the follow-up.
+    tracing::warn!("kache daemon is not yet supported on Windows (see #45)");
+    Ok(())
+}
+
+#[cfg(unix)]
 async fn server_main(config: &Config, coord: DaemonCoordFile) -> Result<()> {
     let socket_path = config.socket_path();
     std::fs::create_dir_all(socket_path.parent().unwrap())?;
@@ -2471,6 +2480,7 @@ async fn monolithic_manifest_prefetch(
     }
 }
 
+#[cfg(unix)]
 async fn handle_connection(
     stream: UnixStream,
     daemon: &Arc<Daemon>,
@@ -3033,6 +3043,7 @@ fn restart_daemon_for_stale_client(config: &Config) -> Result<bool> {
     let _ = send_request_with_timeout(&socket_path, &Request::Shutdown, Duration::from_secs(2));
 
     // Give the old daemon a brief chance to exit before spawning a fresh one.
+    #[cfg(unix)]
     for _ in 0..4 {
         if std::os::unix::net::UnixStream::connect(&socket_path).is_err() {
             break;
@@ -3044,11 +3055,27 @@ fn restart_daemon_for_stale_client(config: &Config) -> Result<bool> {
 }
 
 /// Send a request to the daemon via Unix socket, return the response line.
+#[cfg(unix)]
 fn send_request(socket_path: &Path, req: &Request) -> Result<String> {
     send_request_with_timeout(socket_path, req, std::time::Duration::from_secs(30))
 }
 
+#[cfg(not(unix))]
+fn send_request(_socket_path: &Path, _req: &Request) -> Result<String> {
+    anyhow::bail!("daemon RPC not yet supported on Windows (see #45)")
+}
+
 /// Send a request to the daemon via Unix socket with a configurable read timeout.
+#[cfg(not(unix))]
+fn send_request_with_timeout(
+    _socket_path: &Path,
+    _req: &Request,
+    _read_timeout: std::time::Duration,
+) -> Result<String> {
+    anyhow::bail!("daemon RPC not yet supported on Windows (see #45)")
+}
+
+#[cfg(unix)]
 fn send_request_with_timeout(
     socket_path: &Path,
     req: &Request,
@@ -3097,6 +3124,12 @@ fn send_request_with_timeout(
 ///
 /// This avoids the read-timeout failures that occur when the daemon's runtime
 /// is saturated (e.g. during S3 key-cache population at startup).
+#[cfg(not(unix))]
+fn send_request_fire_and_forget(_socket_path: &Path, _req: &Request) -> Result<()> {
+    anyhow::bail!("daemon RPC not yet supported on Windows (see #45)")
+}
+
+#[cfg(unix)]
 fn send_request_fire_and_forget(socket_path: &Path, req: &Request) -> Result<()> {
     use std::io::Write;
     use std::os::unix::net::UnixStream as StdUnixStream;
@@ -3166,7 +3199,10 @@ pub fn start_daemon_background() -> Result<bool> {
             return Ok(false);
         }
 
-        // We hold the lock. Check if daemon is already running.
+        // We hold the lock. Check if daemon is already running. On Windows
+        // the daemon RPC layer is stubbed, so this short-circuits to "not
+        // running" and we proceed to attempt a (stubbed) spawn.
+        #[cfg(unix)]
         if socket_path.exists() && std::os::unix::net::UnixStream::connect(&socket_path).is_ok() {
             let my_epoch = build_epoch();
             let is_stale = my_epoch > 0
@@ -3313,6 +3349,7 @@ fn wait_for_socket_until(
     let deadline = Instant::now() + timeout;
 
     while Instant::now() < deadline {
+        #[cfg(unix)]
         if socket_path.exists() && std::os::unix::net::UnixStream::connect(socket_path).is_ok() {
             return Ok(true);
         }
@@ -3342,6 +3379,7 @@ fn wait_for_socket_until(
         std::thread::sleep(DAEMON_START_POLL_INTERVAL);
     }
 
+    #[cfg(unix)]
     if socket_path.exists() && std::os::unix::net::UnixStream::connect(socket_path).is_ok() {
         return Ok(true);
     }
@@ -3371,7 +3409,11 @@ fn wait_for_socket_until(
 
 // ── Tests ────────────────────────────────────────────────────────
 
-#[cfg(test)]
+// Daemon tests exercise the Unix socket transport directly and are gated to
+// Unix targets. Windows uses a different IPC primitive (named pipes) that
+// will be migrated in a follow-up PR; until then the daemon's RPC paths are
+// no-ops on Windows.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::sync::mpsc;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
+#[cfg(unix)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 #[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
@@ -2582,6 +2583,7 @@ fn is_client_disconnect(e: &std::io::Error) -> bool {
     ) || e.raw_os_error() == Some(32) // EPIPE on macOS may report as ErrorKind::Other
 }
 
+#[cfg(unix)]
 use crate::platform::wait_for_shutdown as shutdown_signal;
 
 // ── Client ───────────────────────────────────────────────────────

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2896,10 +2896,7 @@ pub fn send_shutdown_request(config: &Config) -> Result<()> {
                     return Ok(());
                 }
                 // Graceful termination didn't work, escalate to force kill.
-                tracing::warn!(
-                    pid = state.pid,
-                    "daemon did not stop, force-killing"
-                );
+                tracing::warn!(pid = state.pid, "daemon did not stop, force-killing");
                 crate::platform::kill_process(state.pid);
                 if wait_for_run_lock_release(&socket_path, Duration::from_secs(2))? {
                     let _ = std::fs::remove_file(&socket_path);

--- a/src/link.rs
+++ b/src/link.rs
@@ -174,16 +174,21 @@ pub fn rewrite_depinfo(depinfo_path: &Path, project_dir: &Path, mode: DepInfoMod
         DepInfoMode::Expand => content.replace("./", &project_prefix),
     };
 
-    // For hardlinked files, we need to unlink first to avoid modifying the store copy
+    // For hardlinked files, we need to unlink first to avoid modifying the store copy.
+    // Windows has hardlinks too (NTFS), but std exposes no portable nlink count;
+    // fs::write on Windows opens with FILE_SHARE_WRITE and truncates the underlying
+    // file just like Unix, so the same hazard applies. Conservatively remove on
+    // Windows if the file exists — cheap, correct, and avoids the nlink check.
+    #[cfg(unix)]
     if let Ok(meta) = fs::metadata(depinfo_path) {
-        // If nlink > 1, it's a hardlink — need to break the link first
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::MetadataExt;
-            if meta.nlink() > 1 {
-                let _ = fs::remove_file(depinfo_path);
-            }
+        use std::os::unix::fs::MetadataExt;
+        if meta.nlink() > 1 {
+            let _ = fs::remove_file(depinfo_path);
         }
+    }
+    #[cfg(not(unix))]
+    if depinfo_path.exists() {
+        let _ = fs::remove_file(depinfo_path);
     }
 
     fs::write(depinfo_path, rewritten)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,14 @@
+// Until the daemon IPC layer is ported off Unix sockets (#45), the daemon
+// server/client code and many of its supporting helpers (planner, transfer
+// counters, S3 key cache, prefetch plumbing) become unused on non-unix
+// builds. Allow the resulting dead-code warnings on those targets so the
+// binary compiles; remove this once the interprocess migration lands.
+#![cfg_attr(
+    not(unix),
+    allow(dead_code, unused_imports, unused_variables, unused_assignments)
+)]
+
 mod args;
-mod platform;
 mod build_intent;
 mod cache_key;
 mod cli;
@@ -11,6 +20,7 @@ mod events;
 mod fallback_planner;
 mod link;
 mod planner_client;
+mod platform;
 mod remote;
 mod remote_layout;
 mod remote_plan;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#[cfg(target_os = "windows")]
-compile_error!("kache does not support Windows. Supported platforms are macOS and Linux.");
-
 mod args;
 mod build_intent;
 mod cache_key;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod args;
+mod platform;
 mod build_intent;
 mod cache_key;
 mod cli;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -64,7 +64,7 @@ pub fn kill_process(pid: u32) {
 #[cfg(windows)]
 fn windows_terminate(pid: u32) {
     use windows_sys::Win32::Foundation::CloseHandle;
-    use windows_sys::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_TERMINATE, TerminateProcess};
 
     let handle = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
     if handle.is_null() {
@@ -95,7 +95,7 @@ pub fn current_uid() -> u32 {
 pub async fn wait_for_shutdown() {
     #[cfg(unix)]
     {
-        use tokio::signal::unix::{signal, SignalKind};
+        use tokio::signal::unix::{SignalKind, signal};
         let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
         let mut sigint = signal(SignalKind::interrupt()).expect("SIGINT handler");
         tokio::select! {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,120 @@
+//! Cross-platform helpers for process management and signal handling.
+//!
+//! The daemon needs to:
+//!   - probe whether a recorded PID is still alive (recovery from crashes)
+//!   - politely ask another process to exit, then force-kill if it didn't
+//!   - wait for an OS-level shutdown signal to flush state and exit cleanly
+//!
+//! On Unix these all map to libc primitives (kill(2), signal(2)).
+//! On Windows they map to OpenProcess/TerminateProcess and the Windows
+//! console-control events surfaced by tokio::signal::windows.
+
+#[cfg(unix)]
+pub fn is_process_alive(pid: u32) -> bool {
+    // kill(pid, 0) returns 0 if the process exists; EPERM also means it
+    // exists but is owned by another user.
+    let rc = unsafe { libc::kill(pid as i32, 0) };
+    rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(windows)]
+pub fn is_process_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, STILL_ACTIVE,
+    };
+
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        return false;
+    }
+    let mut code: u32 = 0;
+    let ok = unsafe { GetExitCodeProcess(handle, &mut code) };
+    unsafe { CloseHandle(handle) };
+    ok != 0 && code == STILL_ACTIVE as u32
+}
+
+/// Politely request a process to exit. On Unix this sends SIGTERM; on
+/// Windows there is no graceful kill-by-PID path, so this forcefully
+/// terminates the process (same as `kill_process`). Callers that need
+/// graceful shutdown should prefer the daemon's own RPC `Shutdown` request.
+pub fn terminate_process(pid: u32) {
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(pid as i32, libc::SIGTERM);
+    }
+    #[cfg(windows)]
+    {
+        windows_terminate(pid);
+    }
+}
+
+/// Forcefully kill a process. SIGKILL on Unix, TerminateProcess on Windows.
+pub fn kill_process(pid: u32) {
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(pid as i32, libc::SIGKILL);
+    }
+    #[cfg(windows)]
+    {
+        windows_terminate(pid);
+    }
+}
+
+#[cfg(windows)]
+fn windows_terminate(pid: u32) {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+
+    let handle = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
+    if handle.is_null() {
+        return;
+    }
+    unsafe {
+        TerminateProcess(handle, 1);
+        CloseHandle(handle);
+    }
+}
+
+/// Current effective UID. Returns `libc::getuid()` on Unix. On Windows
+/// there is no equivalent — UIDs are part of macOS launchctl target
+/// strings (`gui/{uid}/...`) and that whole code path is macOS-only, so a
+/// stub returning 0 keeps the rest of `service.rs` compilable.
+#[cfg(unix)]
+pub fn current_uid() -> u32 {
+    unsafe { libc::getuid() }
+}
+
+#[cfg(not(unix))]
+pub fn current_uid() -> u32 {
+    0
+}
+
+/// Resolve when the OS asks the daemon to stop. SIGTERM/SIGINT on Unix,
+/// Ctrl+C / console-close on Windows.
+pub async fn wait_for_shutdown() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
+        let mut sigint = signal(SignalKind::interrupt()).expect("SIGINT handler");
+        tokio::select! {
+            _ = sigterm.recv() => {}
+            _ = sigint.recv() => {}
+        }
+    }
+    #[cfg(windows)]
+    {
+        use tokio::signal::windows::{ctrl_break, ctrl_c, ctrl_close, ctrl_shutdown};
+        let mut cc = ctrl_c().expect("ctrl_c handler");
+        let mut cb = ctrl_break().expect("ctrl_break handler");
+        let mut cl = ctrl_close().expect("ctrl_close handler");
+        let mut cs = ctrl_shutdown().expect("ctrl_shutdown handler");
+        tokio::select! {
+            _ = cc.recv() => {}
+            _ = cb.recv() => {}
+            _ = cl.recv() => {}
+            _ = cs.recv() => {}
+        }
+    }
+}

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -19,9 +19,9 @@ pub fn is_process_alive(pid: u32) -> bool {
 
 #[cfg(windows)]
 pub fn is_process_alive(pid: u32) -> bool {
-    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
     use windows_sys::Win32::System::Threading::{
-        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, STILL_ACTIVE,
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
     };
 
     let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
@@ -31,7 +31,7 @@ pub fn is_process_alive(pid: u32) -> bool {
     let mut code: u32 = 0;
     let ok = unsafe { GetExitCodeProcess(handle, &mut code) };
     unsafe { CloseHandle(handle) };
-    ok != 0 && code == STILL_ACTIVE as u32
+    ok != 0 && code as i32 == STILL_ACTIVE
 }
 
 /// Politely request a process to exit. On Unix this sends SIGTERM; on

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -92,7 +92,7 @@ pub async fn create_s3_client(
     let mut s3_config = aws_sdk_s3::config::Builder::from(&sdk_config).force_path_style(true);
 
     let http_client = SmithyHttpClientBuilder::new()
-        .tls_provider(tls::Provider::Rustls(CryptoMode::Ring))
+        .tls_provider(tls::Provider::Rustls(CryptoMode::AwsLc))
         .pool_idle_timeout(Duration::from_secs(pool_idle_secs))
         .build_https();
     s3_config = s3_config.http_client(http_client);

--- a/src/service.rs
+++ b/src/service.rs
@@ -404,10 +404,19 @@ pub fn status() -> Result<()> {
         println!("  Service:  \x1b[33munsupported platform\x1b[0m");
     }
 
-    // 2. Daemon running? (check Unix socket)
+    // 2. Daemon running? (check IPC socket)
     let running = if let Some(ref cfg) = config {
         let sock = cfg.socket_path();
-        sock.exists() && std::os::unix::net::UnixStream::connect(&sock).is_ok()
+        #[cfg(unix)]
+        {
+            sock.exists() && std::os::unix::net::UnixStream::connect(&sock).is_ok()
+        }
+        #[cfg(not(unix))]
+        {
+            // Windows daemon IPC is stubbed pending interprocess migration.
+            let _ = sock;
+            false
+        }
     } else {
         false
     };

--- a/src/service.rs
+++ b/src/service.rs
@@ -81,7 +81,7 @@ pub fn install() -> Result<()> {
 fn install_launchd(exe: &std::path::Path) -> Result<()> {
     let plist = plist_path();
     let legacy_plist = legacy_plist_path();
-    let uid = unsafe { libc::getuid() };
+    let uid = crate::platform::current_uid();
 
     // If already installed, stop old service first
     if plist.exists() || legacy_plist.exists() {
@@ -262,7 +262,7 @@ pub fn kickstart() -> Result<bool> {
         if !plist.exists() {
             return Ok(false);
         }
-        let uid = unsafe { libc::getuid() };
+        let uid = crate::platform::current_uid();
         let target = format!("gui/{uid}/{LABEL}");
         // `kickstart -k` stops the service if running and starts it again.
         let out = std::process::Command::new("launchctl")
@@ -308,7 +308,7 @@ pub fn uninstall() -> Result<()> {
 fn uninstall_launchd() -> Result<()> {
     let plist = plist_path();
     let legacy_plist = legacy_plist_path();
-    let uid = unsafe { libc::getuid() };
+    let uid = crate::platform::current_uid();
     let had_plist = plist.exists();
     let had_legacy_plist = legacy_plist.exists();
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1118,10 +1118,8 @@ impl Store {
         let content = fs::read_to_string(lock_path).unwrap_or_default();
         if let Ok(pid) = content.trim().parse::<u32>() {
             // Check if the process is still alive
-            unsafe {
-                if libc::kill(pid as i32, 0) != 0 {
-                    return Ok(true); // Process doesn't exist
-                }
+            if !crate::platform::is_process_alive(pid) {
+                return Ok(true); // Process doesn't exist
             }
             // Check if lock file is older than 1 hour (safety net)
             if let Ok(meta) = fs::metadata(lock_path)

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -566,10 +566,9 @@ fn maybe_trigger_prefetch(config: &Config, args: &RustcArgs) {
     else {
         return;
     };
-    use std::os::unix::io::AsRawFd;
-    let got_lock =
-        unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0;
-    if !got_lock {
+    // std::fs::File::try_lock (1.89+) is cross-platform: flock(2) on Unix,
+    // LockFileEx on Windows. Lock auto-releases when `lock_file` is dropped.
+    if lock_file.try_lock().is_err() {
         return; // Another wrapper is already sending the prefetch hint
     }
 


### PR DESCRIPTION
Substantial first pass at Windows support for [#45](https://github.com/kunobi-ninja/kache/issues/45). Both Linux and exploratory Windows CI are now green.

## What lands

- **TLS / `ring`:** swap `aws-smithy-http-client` from `rustls-ring` to `rustls-aws-lc`. The modern rustls 0.23 path no longer pulls `ring` (AWS recommends `aws-lc-rs` over `ring`, especially for ARM64 / no-Perl builds).
- **`compile_error!`** for Windows in `src/main.rs` is removed.
- **`src/platform.rs`** new module with cross-platform helpers:
  - `is_process_alive(pid)` — `kill(pid, 0)` on Unix; `OpenProcess` + `GetExitCodeProcess` on Windows.
  - `terminate_process(pid)` / `kill_process(pid)` — SIGTERM / SIGKILL on Unix; `TerminateProcess` on Windows.
  - `wait_for_shutdown()` — `tokio::signal::unix(SIGTERM|SIGINT)` on Unix; `tokio::signal::windows(ctrl_c|ctrl_break|ctrl_close|ctrl_shutdown)` on Windows.
  - `current_uid()` — `libc::getuid()` on Unix; stub (used only by macOS launchctl code).
- **File locks** (`libc::flock` × 5) → `std::fs::File::try_lock` / `lock` / `unlock` (stable in std since 1.89; uses LockFileEx on Windows).
- **`libc::kill` call sites** (8) → routed through `platform::{terminate_process, kill_process, is_process_alive}`.
- **CI:** new `windows-check` job runs `cargo check --target x86_64-pc-windows-msvc`. Started as `continue-on-error` and is now passing.
- **Windows-only dep:** `windows-sys` 0.61 with `Win32_Foundation` + `Win32_System_Threading` features.
- **Interprocess crate** added (`interprocess = { version = "2.4.2", features = ["tokio"] }`) ready for the upcoming IPC migration.

## Known limitation (the daemon is unix-only for now)

The daemon's RPC layer is built on `tokio::net::UnixStream`/`UnixListener` + `std::os::unix::net::*`. Porting that to **named pipes via `interprocess::local_socket`** is a substantial refactor and is the natural next PR.

For this PR, the daemon's server entry, connection handler, and `send_*` client functions are cfg-gated to Unix. On Windows:
- `kache daemon run` logs `"kache daemon is not yet supported on Windows (see #45)"` and exits cleanly.
- `daemon::send_*` returns `Err("daemon RPC not yet supported on Windows (see #45)")`.
- `kache service status` shows `Daemon: not running`.

Because most daemon helper code becomes unused on Windows, a temporary crate-level `#![cfg_attr(not(unix), allow(dead_code, ...))]` is in place. **It is intentionally temporary** — a comment in `src/main.rs` points at #45 and notes it should be removed once the interprocess migration lands.

## Other Windows-shaped fixes

- `wrapper.rs` flock → `File::try_lock`.
- `daemon.rs` × 4 flock sites → `File::try_lock` / `lock` / `unlock`.
- `link.rs` depinfo hardlink check: nlink path stays unix-only; on Windows, conservatively remove-then-rewrite when the file exists.
- `service.rs` daemon-status probe is cfg-gated.

## What still needs to be done (follow-up PR scope)

1. **IPC migration** — replace `Unix*Stream`/`Unix*Listener` with `interprocess::local_socket` (sync + tokio) types. Adapt the path-to-name conversion (Unix `to_fs_name::<GenericFilePath>()` / Windows `to_ns_name::<GenericNamespaced>()` from a stable per-cache-dir identifier).
2. **Remove the dead-code allow** once the migration lands.
3. **Re-enable daemon tests on Windows** (`#[cfg(all(test, unix))]` → just `#[cfg(test)]`).
4. **Build artifact** — add `x86_64-pc-windows-msvc` to the release workflow's matrix once the daemon works.

## Test plan

- [x] `cargo build` passes locally on macOS
- [x] `cargo test --bin kache` — 338/338 pass
- [x] CI: Linux job green
- [x] CI: Windows `cargo check` exploratory job green