### PR TITLE
feat(windows): replace libc::flock with std::fs::File::try_lock

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -566,10 +566,9 @@ fn maybe_trigger_prefetch(config: &Config, args: &RustcArgs) {
     else {
         return;
     };
-    use std::os::unix::io::AsRawFd;
-    let got_lock =
-        unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0;
-    if !got_lock {
+    // std::fs::File::try_lock (1.89+) is cross-platform: flock(2) on Unix,
+    // LockFileEx on Windows. Lock auto-releases when `lock_file` is dropped.
+    if lock_file.try_lock().is_err() {
         return; // Another wrapper is already sending the prefetch hint
     }
 


### PR DESCRIPTION
Step 2 toward [#45](https://github.com/kunobi-ninja/kache/issues/45). Stacked on [#50](https://github.com/kunobi-ninja/kache/pull/50).

## Summary

`std::fs::File::try_lock` has been stable since Rust 1.89 (this repo's MSRV is 1.95) and is cross-platform: `flock(2)` on Unix, `LockFileEx` on Windows. Same semantics as what we had: non-blocking exclusive lock, auto-released on `Drop`.

The only call site is the prefetch-hint coordinator in [src/wrapper.rs](src/wrapper.rs) — used to ensure only one wrapper process per cargo invocation sends the prefetch hint to the daemon.

## Why not a third-party crate?

Originally planned to use `fs4`, but `std` covers our use case without adding a dep. `fs4` would be needed only if we wanted shared (read) locks or blocking acquisition, neither of which we use.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test --bin kache` passes (338/338)
- [ ] CI: existing Linux job passes