### PR TITLE
refactor(compiler): introduce Compiler trait, route rustc through it

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,17 +1,7 @@
 use anyhow::{Result, bail};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-/// Check if a string looks like a path to rustc (or clippy-driver, which wraps rustc).
-pub fn looks_like_rustc(arg: &str) -> bool {
-    let path = Path::new(arg);
-    match path.file_name() {
-        Some(name) => {
-            let name = name.to_string_lossy();
-            name == "rustc" || name.starts_with("rustc") || name == "clippy-driver"
-        }
-        None => false,
-    }
-}
+use crate::compiler::rustc::looks_like_rustc;
 
 /// Parsed rustc invocation arguments relevant to caching.
 #[derive(Debug, Clone)]

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -73,8 +73,42 @@ pub fn detect_compiler(args: &[String]) -> Option<CompilerKind> {
     if args.is_empty() {
         return None;
     }
-    if crate::args::looks_like_rustc(&args[0]) {
+    if rustc::looks_like_rustc(&args[0]) {
         return Some(CompilerKind::Rustc);
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(args: &[&str]) -> Vec<String> {
+        args.iter().map(|a| a.to_string()).collect()
+    }
+
+    #[test]
+    fn detect_compiler_returns_none_for_empty_argv() {
+        assert_eq!(detect_compiler(&[]), None);
+    }
+
+    #[test]
+    fn detect_compiler_recognizes_rustc_paths() {
+        assert_eq!(detect_compiler(&s(&["rustc"])), Some(CompilerKind::Rustc));
+        assert_eq!(
+            detect_compiler(&s(&["/usr/bin/rustc", "src/lib.rs"])),
+            Some(CompilerKind::Rustc)
+        );
+        assert_eq!(
+            detect_compiler(&s(&["clippy-driver"])),
+            Some(CompilerKind::Rustc)
+        );
+    }
+
+    #[test]
+    fn detect_compiler_returns_none_for_non_rustc() {
+        assert_eq!(detect_compiler(&s(&["gcc"])), None);
+        assert_eq!(detect_compiler(&s(&["cargo", "build"])), None);
+        assert_eq!(detect_compiler(&s(&["--crate-name"])), None);
+    }
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,0 +1,80 @@
+//! Compiler abstraction.
+//!
+//! Each supported compiler (today: rustc; planned: gcc, clang, msvc) implements
+//! the [`Compiler`] trait. The wrapper picks an implementation based on argv[0]
+//! inspection ([`detect_compiler`]) and dispatches by static type — there is no
+//! `dyn Compiler`, intentionally, because each compiler keeps its native parsed
+//! representation as an associated type.
+//!
+//! **Phase 0 scope.** The trait covers the operations with a clean generic
+//! shape today: `parse`, `refuse_reasons`, `cache_key`, `execute`. Storage
+//! metadata (crate types, features, target/profile) and restoration logic
+//! still touch [`crate::args::RustcArgs`] fields directly in
+//! [`crate::wrapper`]; those move behind the trait when adding a second
+//! compiler forces the abstraction. Forward-looking surface (output-artifact
+//! categorization, version-probe identity) lands with the PR that needs it.
+
+use anyhow::Result;
+
+pub mod rustc;
+
+pub use crate::compile::CompileResult;
+
+/// Identifies a compiler family.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompilerKind {
+    Rustc,
+    // Future: Gcc, Clang, Msvc
+}
+
+/// Reason an invocation cannot be cached. Empty list = cacheable.
+#[derive(Debug, Clone)]
+pub enum RefuseReason {
+    /// Not a primary compilation (e.g. `--print`, `-vV`, query mode).
+    NotPrimary,
+}
+
+/// Compiler-agnostic context passed to [`Compiler::cache_key`].
+pub struct KeyCtx<'a> {
+    pub file_hasher: &'a crate::cache_key::FileHasher,
+}
+
+/// A cacheable compiler.
+///
+/// Implementations are state-light. Each owns its native parsed
+/// representation as `Self::Parsed` so we don't flatten compiler-specific
+/// shapes into one generic struct.
+pub trait Compiler {
+    type Parsed;
+
+    fn kind(&self) -> CompilerKind;
+
+    /// Parse raw argv into the compiler's native representation.
+    /// Caller has already established this is the right compiler kind via
+    /// [`detect_compiler`].
+    fn parse(&self, args: &[String]) -> Result<Self::Parsed>;
+
+    /// Reasons (if any) this invocation must bypass the cache.
+    /// Empty Vec = cacheable.
+    fn refuse_reasons(&self, parsed: &Self::Parsed) -> Vec<RefuseReason>;
+
+    /// Compute the cache key for a parsed invocation.
+    fn cache_key(&self, parsed: &Self::Parsed, ctx: &KeyCtx<'_>) -> Result<String>;
+
+    /// Execute the compilation, capturing exit code, stdout, stderr, and
+    /// the list of output files produced.
+    fn execute(&self, parsed: &Self::Parsed) -> Result<CompileResult>;
+}
+
+/// Detect which compiler family an argv vector is invoking.
+/// Returns `None` if no supported compiler matches — caller should fall
+/// through to direct execution.
+pub fn detect_compiler(args: &[String]) -> Option<CompilerKind> {
+    if args.is_empty() {
+        return None;
+    }
+    if crate::args::looks_like_rustc(&args[0]) {
+        return Some(CompilerKind::Rustc);
+    }
+    None
+}

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -6,12 +6,27 @@
 //! callers a stable shape that future compilers (gcc, clang) will match.
 
 use anyhow::Result;
+use std::path::Path;
 
 use crate::args::RustcArgs;
 use crate::cache_key::compute_cache_key;
 use crate::compile;
 
 use super::{CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason};
+
+/// Check if an argv element looks like an invocation of rustc (or
+/// clippy-driver, which wraps rustc). Used by [`super::detect_compiler`] to
+/// route argv into the rustc dispatch path.
+pub fn looks_like_rustc(arg: &str) -> bool {
+    let path = Path::new(arg);
+    match path.file_name() {
+        Some(name) => {
+            let name = name.to_string_lossy();
+            name == "rustc" || name.starts_with("rustc") || name == "clippy-driver"
+        }
+        None => false,
+    }
+}
 
 #[derive(Default)]
 pub struct RustcCompiler;
@@ -56,5 +71,57 @@ impl Compiler for RustcCompiler {
             parsed.extra_filename.as_deref(),
             parsed.has_coverage_instrumentation(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(args: &[&str]) -> Vec<String> {
+        args.iter().map(|a| a.to_string()).collect()
+    }
+
+    #[test]
+    fn looks_like_rustc_matches_rustc_and_clippy_driver() {
+        assert!(looks_like_rustc("rustc"));
+        assert!(looks_like_rustc("/usr/bin/rustc"));
+        assert!(looks_like_rustc(
+            "/home/user/.rustup/toolchains/stable/bin/rustc"
+        ));
+        assert!(looks_like_rustc("clippy-driver"));
+        assert!(looks_like_rustc("/path/to/bin/clippy-driver"));
+        assert!(!looks_like_rustc("gcc"));
+        assert!(!looks_like_rustc("--crate-name"));
+    }
+
+    #[test]
+    fn kind_is_rustc() {
+        assert_eq!(RustcCompiler::new().kind(), CompilerKind::Rustc);
+    }
+
+    #[test]
+    fn refuse_reasons_returns_not_primary_for_query_invocations() {
+        // `rustc -vV` is a version query, not a primary compilation
+        let parsed = RustcCompiler::new().parse(&s(&["rustc", "-vV"])).unwrap();
+        let reasons = RustcCompiler::new().refuse_reasons(&parsed);
+        assert!(matches!(reasons.as_slice(), [RefuseReason::NotPrimary]));
+    }
+
+    #[test]
+    fn refuse_reasons_empty_for_primary_compilation() {
+        let parsed = RustcCompiler::new()
+            .parse(&s(&[
+                "rustc",
+                "src/lib.rs",
+                "--crate-name",
+                "foo",
+                "--crate-type",
+                "lib",
+            ]))
+            .unwrap();
+        assert!(parsed.is_primary);
+        let reasons = RustcCompiler::new().refuse_reasons(&parsed);
+        assert!(reasons.is_empty());
     }
 }

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -1,0 +1,60 @@
+//! Rustc implementation of the [`Compiler`] trait.
+//!
+//! Phase 0: a thin facade over the existing free functions in
+//! [`crate::args`], [`crate::cache_key`], and [`crate::compile`]. Those
+//! functions remain the canonical implementations; the trait simply gives
+//! callers a stable shape that future compilers (gcc, clang) will match.
+
+use anyhow::Result;
+
+use crate::args::RustcArgs;
+use crate::cache_key::compute_cache_key;
+use crate::compile;
+
+use super::{CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason};
+
+#[derive(Default)]
+pub struct RustcCompiler;
+
+impl RustcCompiler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Compiler for RustcCompiler {
+    type Parsed = RustcArgs;
+
+    fn kind(&self) -> CompilerKind {
+        CompilerKind::Rustc
+    }
+
+    fn parse(&self, args: &[String]) -> Result<RustcArgs> {
+        RustcArgs::parse(args)
+    }
+
+    fn refuse_reasons(&self, parsed: &RustcArgs) -> Vec<RefuseReason> {
+        let mut reasons = Vec::new();
+        if !parsed.is_primary {
+            reasons.push(RefuseReason::NotPrimary);
+        }
+        reasons
+    }
+
+    fn cache_key(&self, parsed: &RustcArgs, ctx: &KeyCtx<'_>) -> Result<String> {
+        compute_cache_key(parsed, ctx.file_hasher)
+    }
+
+    fn execute(&self, parsed: &RustcArgs) -> Result<CompileResult> {
+        compile::run_rustc(
+            &parsed.rustc,
+            parsed.inner_rustc.as_deref(),
+            &parsed.all_args,
+            parsed.output.as_deref(),
+            parsed.out_dir.as_deref(),
+            parsed.crate_name.as_deref(),
+            parsed.extra_filename.as_deref(),
+            parsed.has_coverage_instrumentation(),
+        )
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -497,19 +497,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_looks_like_rustc() {
-        assert!(args::looks_like_rustc("rustc"));
-        assert!(args::looks_like_rustc("/usr/bin/rustc"));
-        assert!(args::looks_like_rustc(
-            "/home/user/.rustup/toolchains/stable/bin/rustc"
-        ));
-        assert!(args::looks_like_rustc("clippy-driver"));
-        assert!(args::looks_like_rustc("/path/to/bin/clippy-driver"));
-        assert!(!args::looks_like_rustc("gcc"));
-        assert!(!args::looks_like_rustc("--crate-name"));
-    }
-
-    #[test]
     fn test_parse_duration_hours() {
         assert_eq!(parse_duration_hours("7d"), Some(168));
         assert_eq!(parse_duration_hours("24h"), Some(24));

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod build_intent;
 mod cache_key;
 mod cli;
 mod compile;
+mod compiler;
 mod config;
 mod config_tui;
 mod daemon;
@@ -255,7 +256,7 @@ enum LogMode {
 }
 
 fn detect_log_mode(env_args: &[String]) -> LogMode {
-    if env_args.len() >= 2 && args::looks_like_rustc(&env_args[1]) {
+    if env_args.len() >= 2 && compiler::detect_compiler(&env_args[1..]).is_some() {
         return LogMode::Wrapper;
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -4,8 +4,10 @@ use chrono::Utc;
 use std::path::Path;
 
 use crate::args::RustcArgs;
-use crate::cache_key::{FileHasher, compute_cache_key};
+use crate::cache_key::FileHasher;
 use crate::compile;
+use crate::compiler::rustc::RustcCompiler;
+use crate::compiler::{Compiler, KeyCtx};
 use crate::config::Config;
 use crate::events::{self, BuildEvent, EventResult};
 use crate::link::{self, DepInfoMode, LinkStrategy};
@@ -64,8 +66,14 @@ fn print_progress(crate_name: &str, result: EventResult, elapsed_ms: u64, size: 
 pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let start = std::time::Instant::now();
 
-    // Parse the rustc arguments (wrapper_args[0] is the rustc path)
-    let args = RustcArgs::parse(wrapper_args).context("parsing rustc arguments")?;
+    // Parse the rustc arguments (wrapper_args[0] is the rustc path).
+    // Routed through the Compiler trait — see src/compiler/mod.rs. RustcArgs
+    // remains the canonical parsed shape; the trait gives us a stable contract
+    // when adding gcc/clang.
+    let compiler = RustcCompiler::new();
+    let args = compiler
+        .parse(wrapper_args)
+        .context("parsing rustc arguments")?;
     let store = if args.is_primary || (config.clean_incremental && args.incremental.is_some()) {
         match Store::open(config) {
             Ok(store) => Some(store),
@@ -90,8 +98,16 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         );
     }
 
-    // If this isn't a primary compilation (no source file), just pass through to rustc
-    if !args.is_primary {
+    // Bypass the cache when the compiler tells us we can't safely cache this
+    // invocation (today: only NotPrimary; future: response files, coverage,
+    // time macros, etc.).
+    let refuse = compiler.refuse_reasons(&args);
+    if !refuse.is_empty() {
+        tracing::debug!(
+            "{:?}: bypassing cache, reasons={:?}",
+            compiler.kind(),
+            refuse
+        );
         return passthrough(&args);
     }
 
@@ -119,7 +135,10 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // Compute the cache key
     let key_start = std::time::Instant::now();
     let file_hasher = FileHasher::new();
-    let cache_key = match compute_cache_key(&args, &file_hasher) {
+    let key_ctx = KeyCtx {
+        file_hasher: &file_hasher,
+    };
+    let cache_key = match compiler.cache_key(&args, &key_ctx) {
         Ok(key) => key,
         Err(e) => {
             tracing::warn!("failed to compute cache key for {}: {}", crate_name, e);
@@ -285,16 +304,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         &cache_key[..16]
     );
     let compile_start = std::time::Instant::now();
-    let result = compile::run_rustc(
-        &args.rustc,
-        args.inner_rustc.as_deref(),
-        &args.all_args,
-        args.output.as_deref(),
-        args.out_dir.as_deref(),
-        args.crate_name.as_deref(),
-        args.extra_filename.as_deref(),
-        args.has_coverage_instrumentation(),
-    )?;
+    let result = compiler.execute(&args)?;
     let compile_time_ms = compile_start.elapsed().as_millis() as u64;
 
     // Print rustc output


### PR DESCRIPTION
## Summary

Phase 0 of multi-compiler support. Introduces a `Compiler` trait abstraction so adding gcc/clang/msvc later is additive rather than invasive — without changing any Rust behavior today.

- New `src/compiler/{mod.rs, rustc.rs}` defining the trait and a `RustcCompiler` impl that delegates to existing `args`/`cache_key`/`compile` free functions.
- The wrapper dispatches `parse`, `refuse_reasons`, `cache_key`, and `execute` through the trait. Wrapper-mode detection in `main.rs` now goes through `compiler::detect_compiler` instead of `args::looks_like_rustc` directly.
- Rustc-specific field access in the wrapper (`crate_name`, `crate_types`, `features`, `target`, `get_codegen_opt`, ...) stays direct for now; that surface moves behind the trait when adding a second compiler forces the abstraction. Forward-looking surface (`OutputArtifact`/`ArtifactKind`, version-probe identity) is deliberately omitted — it lands with the PR that needs it.

## Design notes

- **Associated `type Parsed`** so each compiler keeps its native parsed shape (rustc's 18-field `RustcArgs`) rather than flattening into one generic struct. Dispatch is monomorphized at one site in the wrapper; no `dyn Compiler`.
- **`RefuseReason::NotPrimary`** today — designed to grow (response files, coverage, time macros, split-dwarf, ...) as gcc/clang work surfaces those cases.
- **`KeyCtx`** is the seam for compiler-agnostic dependencies passed to `cache_key` (today: `FileHasher`; future: env, project root).
- No behavior change is the explicit goal of this PR. Future PRs in the series add gcc/clang impls.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --bin kache` — 338/338 passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] CI passes on Linux + macOS
- [ ] Manual: `cargo build` of a real Rust workspace with this binary as `RUSTC_WRAPPER` produces the same cache hits/misses as before

## Out of scope (follow-ups)

- `OutputArtifact` / `ArtifactKind` enum — comes with the gcc PR
- Real `rustc -vV` version probe inside `RustcCompiler`
- Storage-metadata abstraction (crate types, features, target/profile flow into `Store::put_with_compile_time`)
- Restoration logic abstraction (`restore_from_cache` still uses rustc-specific link strategy)