### PR TITLE
ci(coverage): bump threshold to 35% (push-only) + HTML artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,19 +53,27 @@ jobs:
           tool: cargo-tarpaulin
       - name: Run repo verification
         run: just ci
-      - name: Check coverage threshold (25%)
+      - name: Check coverage threshold (35%, push only)
+        if: github.event_name == 'push'
         run: |
           python3 -c "
           import json, sys
           data = json.load(open('tarpaulin-report.json'))
           coverage = data['coverage']
-          threshold = 25.0
+          threshold = 35.0
           print(f'Coverage: {coverage:.1f}%')
           if coverage < threshold:
               print(f'FAIL: below threshold {threshold}%')
               sys.exit(1)
           print(f'OK: >= {threshold}%')
           "
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-html
+          path: tarpaulin-report.html
+          retention-days: 14
 
   # --- Windows exploratory check (non-blocking) ---
   # Surfaces remaining Windows porting work for issue #45. Allowed to fail

--- a/Justfile
+++ b/Justfile
@@ -74,10 +74,12 @@ fmt-check:
 helm-lint:
   helm lint charts/kache-service
 
-# Run tarpaulin coverage and emit JSON.
+# Run tarpaulin coverage and emit JSON + HTML reports.
+# JSON drives the CI threshold check; HTML is uploaded as a CI artifact
+# (and used locally by `just coverage-open`).
 [group('coverage')]
 coverage:
-  cargo tarpaulin --engine llvm --all-features --workspace --out Json
+  cargo tarpaulin --engine llvm --all-features --workspace --out Json --out Html
 
 # Run tarpaulin coverage and open the HTML report locally.
 [group('coverage')]


### PR DESCRIPTION
## Summary

Two simple coverage-visibility improvements on top of the existing tarpaulin setup. Independent of [#53](https://github.com/kunobi-ninja/kache/pull/53) and [#54](https://github.com/kunobi-ninja/kache/pull/54).

1. **Threshold 25% → 35%, push-only.** Local measurement (excluding integration tests that fail inside worktrees) shows 35.4% on main. The check runs only on push to main (not on PRs) so contributors aren't blocked by absolute coverage in unrelated work; main keeps the floor.

2. **HTML coverage artifact.** Tarpaulin now emits Json + Html in one run; CI uploads the HTML as a 14-day artifact (`coverage-html`). Reviewers can download and inspect uncovered lines without running tarpaulin locally. Uses `if: always()` so the report is available even when other steps fail.

The `just coverage` recipe was updated to emit Json + Html in one run, so local results stay parity with CI.

No external coverage service. Per-PR regression detection / diff-coverage gating (the kunobi-frontend pattern) is deliberately not in this PR — would be follow-up work if the simple setup proves insufficient.

## Test plan

- [x] `just coverage` runs locally and produces both outputs (`tarpaulin-report.json`, `tarpaulin-report.html`)
- [x] Local coverage at 35.4% — meets the new threshold
- [ ] CI on this PR: threshold step is *skipped* (it's a PR, not a push)
- [ ] CI on the eventual merge to main: threshold check enforces 35%
- [ ] HTML report appears as a downloadable artifact in the workflow run