### PR TITLE
refactor(compiler): centralize per-artifact dispatch via ArtifactKind

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -6,15 +6,20 @@
 //! `dyn Compiler`, intentionally, because each compiler keeps its native parsed
 //! representation as an associated type.
 //!
-//! **Phase 0 scope.** The trait covers the operations with a clean generic
-//! shape today: `parse`, `refuse_reasons`, `cache_key`, `execute`. Storage
-//! metadata (crate types, features, target/profile) and restoration logic
-//! still touch [`crate::args::RustcArgs`] fields directly in
-//! [`crate::wrapper`]; those move behind the trait when adding a second
-//! compiler forces the abstraction. Forward-looking surface (output-artifact
-//! categorization, version-probe identity) lands with the PR that needs it.
+//! **Scope.** The trait covers the operations with a clean generic shape
+//! today: `parse`, `refuse_reasons`, `cache_key`, `execute`, and
+//! `classify_output` (per-file kind classification used by the wrapper to
+//! dispatch link strategy and post-restore processing without filename
+//! pattern matching). Storage metadata (crate types, features,
+//! target/profile) and the restore loop's path resolution still touch
+//! [`crate::args::RustcArgs`] fields directly in [`crate::wrapper`]; those
+//! move behind the trait when adding a second compiler forces the
+//! abstraction.
 
 use anyhow::Result;
+use std::path::PathBuf;
+
+use crate::link::LinkStrategy;
 
 pub mod rustc;
 
@@ -37,6 +42,64 @@ pub enum RefuseReason {
 /// Compiler-agnostic context passed to [`Compiler::cache_key`].
 pub struct KeyCtx<'a> {
     pub file_hasher: &'a crate::cache_key::FileHasher,
+}
+
+/// Categorization of a compiler output file.
+///
+/// Used by the wrapper to drive two decisions per restored file without
+/// scattering filename pattern matching: which [`LinkStrategy`] to use, and
+/// which post-restore processing to apply (dep-info path expansion, codesign,
+/// etc.). Centralizing the dispatch on `ArtifactKind` is what makes "skip
+/// codesign for `.o`" or "rewrite paths in `.d`" structurally enforced
+/// instead of dependent on remembering to add a string-suffix check at every
+/// call site.
+///
+/// Open enum: future compilers extend with [`ArtifactKind::Other`] without
+/// touching shared code; the safe default for an unrecognized kind is
+/// `Hardlink` + no post-processing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactKind {
+    /// Linkable static library (`.rlib`, future C/C++ `.a` / `.lib`).
+    Library,
+    /// Dynamic library (`.dylib`, `.so`, `.dll`). Mutable post-build on
+    /// macOS (codesigning).
+    DynamicLibrary,
+    /// Metadata-only artifact (Rust `.rmeta`).
+    Metadata,
+    /// Object file (`.o`, `.obj`, `.rcgu.o`). Linker input only — never loaded
+    /// directly, never codesigned.
+    Object,
+    /// Dependency-info file (`.d`). Content references absolute paths that
+    /// need rewriting on store/restore for cross-worktree portability.
+    DepInfo,
+    /// Executable. Mutable post-build (codesigning, stripping).
+    Executable,
+    /// Debug info sidecar (`.dwo`, `.pdb`, `.dSYM`).
+    DebugSidecar,
+    /// Compiler-specific output that doesn't fit the categories above.
+    /// Defaults to immutable handling.
+    Other(&'static str),
+}
+
+impl ArtifactKind {
+    /// Link strategy for restoring this kind. Mutable artifacts (executables,
+    /// dynamic libraries) must end up as independent files on filesystems
+    /// without CoW reflink, so post-build mutations don't propagate into the
+    /// cache blob. Immutable kinds may share an inode (hardlink fallback).
+    pub fn link_strategy(self) -> LinkStrategy {
+        match self {
+            ArtifactKind::Executable | ArtifactKind::DynamicLibrary => LinkStrategy::Copy,
+            _ => LinkStrategy::Hardlink,
+        }
+    }
+}
+
+/// A compiler output file with its [`ArtifactKind`] for dispatch purposes.
+#[allow(dead_code)] // produced by future Compiler::outputs(), not yet wired
+#[derive(Debug, Clone)]
+pub struct OutputArtifact {
+    pub path: PathBuf,
+    pub kind: ArtifactKind,
 }
 
 /// A cacheable compiler.
@@ -64,6 +127,16 @@ pub trait Compiler {
     /// Execute the compilation, capturing exit code, stdout, stderr, and
     /// the list of output files produced.
     fn execute(&self, parsed: &Self::Parsed) -> Result<CompileResult>;
+
+    /// Classify an output file by its filename, given the parsed invocation
+    /// for context (e.g. crate type to disambiguate executables from
+    /// libraries when both share a no-extension shape).
+    ///
+    /// `name` is the filename only — no path components. Returns
+    /// [`ArtifactKind::Other`] when the file doesn't match any known pattern;
+    /// callers default to immutable / no-post-processing behavior in that
+    /// case.
+    fn classify_output(&self, parsed: &Self::Parsed, name: &str) -> ArtifactKind;
 }
 
 /// Detect which compiler family an argv vector is invoking.

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -252,7 +252,10 @@ mod tests {
             c.classify_output(&args, "foo-abc123"),
             ArtifactKind::Executable
         );
-        assert_eq!(c.classify_output(&args, "foo.exe"), ArtifactKind::Executable);
+        assert_eq!(
+            c.classify_output(&args, "foo.exe"),
+            ArtifactKind::Executable
+        );
     }
 
     #[test]

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -12,7 +12,7 @@ use crate::args::RustcArgs;
 use crate::cache_key::compute_cache_key;
 use crate::compile;
 
-use super::{CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason};
+use super::{ArtifactKind, CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason};
 
 /// Check if an argv element looks like an invocation of rustc (or
 /// clippy-driver, which wraps rustc). Used by [`super::detect_compiler`] to
@@ -72,6 +72,34 @@ impl Compiler for RustcCompiler {
             parsed.has_coverage_instrumentation(),
         )
     }
+
+    fn classify_output(&self, parsed: &RustcArgs, name: &str) -> ArtifactKind {
+        if name.ends_with(".rlib") {
+            ArtifactKind::Library
+        } else if name.ends_with(".rmeta") {
+            ArtifactKind::Metadata
+        } else if name.ends_with(".d") {
+            ArtifactKind::DepInfo
+        } else if name.ends_with(".o") {
+            // Covers `.o` and compound `.rcgu.o` (per-codegen-unit objects).
+            ArtifactKind::Object
+        } else if name.ends_with(".dylib") || name.ends_with(".so") || name.ends_with(".dll") {
+            ArtifactKind::DynamicLibrary
+        } else if name.ends_with(".dwo") || name.ends_with(".pdb") || name.ends_with(".dSYM") {
+            ArtifactKind::DebugSidecar
+        } else if name.ends_with(".exe") || parsed.is_executable_output() {
+            // No recognized extension, but the invocation produces an
+            // executable (bin / test / proc-macro / dylib): treat as the
+            // primary executable. Note proc-macro/dylib normally match the
+            // dynamic-library arm above on Unix; reaching here means a
+            // Unix-style binary with no extension.
+            ArtifactKind::Executable
+        } else {
+            // Unrecognized — wrapper falls back to safe defaults (Hardlink,
+            // no post-processing).
+            ArtifactKind::Other("rustc:unknown")
+        }
+    }
 }
 
 #[cfg(test)]
@@ -123,5 +151,120 @@ mod tests {
         assert!(parsed.is_primary);
         let reasons = RustcCompiler::new().refuse_reasons(&parsed);
         assert!(reasons.is_empty());
+    }
+
+    fn lib_args() -> RustcArgs {
+        RustcCompiler::new()
+            .parse(&s(&[
+                "rustc",
+                "src/lib.rs",
+                "--crate-name",
+                "foo",
+                "--crate-type",
+                "lib",
+            ]))
+            .unwrap()
+    }
+
+    fn bin_args() -> RustcArgs {
+        RustcCompiler::new()
+            .parse(&s(&[
+                "rustc",
+                "src/main.rs",
+                "--crate-name",
+                "foo",
+                "--crate-type",
+                "bin",
+            ]))
+            .unwrap()
+    }
+
+    #[test]
+    fn classify_output_recognizes_rust_library_artifacts() {
+        let c = RustcCompiler::new();
+        let args = lib_args();
+        assert_eq!(
+            c.classify_output(&args, "libfoo-abc123.rlib"),
+            ArtifactKind::Library
+        );
+        assert_eq!(
+            c.classify_output(&args, "libfoo-abc123.rmeta"),
+            ArtifactKind::Metadata
+        );
+        assert_eq!(
+            c.classify_output(&args, "foo-abc123.d"),
+            ArtifactKind::DepInfo
+        );
+    }
+
+    #[test]
+    fn classify_output_recognizes_object_files_including_rcgu() {
+        // Regression guard: `.rcgu.o` files must classify as Object so the
+        // restore loop never sends them to codesign (kache-fork bug 572f321).
+        let c = RustcCompiler::new();
+        let args = bin_args();
+        assert_eq!(
+            c.classify_output(&args, "foo-abc.123.rcgu.o"),
+            ArtifactKind::Object
+        );
+        assert_eq!(c.classify_output(&args, "foo.o"), ArtifactKind::Object);
+    }
+
+    #[test]
+    fn classify_output_recognizes_dynamic_libraries_per_platform() {
+        let c = RustcCompiler::new();
+        let args = lib_args();
+        assert_eq!(
+            c.classify_output(&args, "libfoo.dylib"),
+            ArtifactKind::DynamicLibrary
+        );
+        assert_eq!(
+            c.classify_output(&args, "libfoo.so"),
+            ArtifactKind::DynamicLibrary
+        );
+        assert_eq!(
+            c.classify_output(&args, "foo.dll"),
+            ArtifactKind::DynamicLibrary
+        );
+    }
+
+    #[test]
+    fn classify_output_recognizes_debug_sidecars() {
+        let c = RustcCompiler::new();
+        let args = bin_args();
+        assert_eq!(
+            c.classify_output(&args, "foo-abc.dwo"),
+            ArtifactKind::DebugSidecar
+        );
+        assert_eq!(
+            c.classify_output(&args, "foo.pdb"),
+            ArtifactKind::DebugSidecar
+        );
+    }
+
+    #[test]
+    fn classify_output_treats_extensionless_bin_outputs_as_executable() {
+        // A bin crate emits a no-extension file (`my_bin-abc123`); the
+        // classifier needs invocation context to recognize it.
+        let c = RustcCompiler::new();
+        let args = bin_args();
+        assert_eq!(
+            c.classify_output(&args, "foo-abc123"),
+            ArtifactKind::Executable
+        );
+        assert_eq!(c.classify_output(&args, "foo.exe"), ArtifactKind::Executable);
+    }
+
+    #[test]
+    fn classify_output_falls_back_to_other_for_unrecognized_in_lib_build() {
+        // Same extensionless name in a lib build: no executable context, so
+        // we don't blindly call it Executable. Other("...") makes the
+        // wrapper take the safe default (Hardlink, no post-processing).
+        let c = RustcCompiler::new();
+        let args = lib_args();
+        match c.classify_output(&args, "mystery-file") {
+            ArtifactKind::Other(_) => {}
+            other => panic!("expected Other, got {other:?}"),
+        }
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -7,10 +7,10 @@ use crate::args::RustcArgs;
 use crate::cache_key::FileHasher;
 use crate::compile;
 use crate::compiler::rustc::RustcCompiler;
-use crate::compiler::{Compiler, KeyCtx};
+use crate::compiler::{ArtifactKind, Compiler, KeyCtx};
 use crate::config::Config;
 use crate::events::{self, BuildEvent, EventResult};
-use crate::link::{self, DepInfoMode, LinkStrategy};
+use crate::link::{self, DepInfoMode};
 use crate::store::Store;
 
 /// Check whether progress lines should be printed to stderr.
@@ -169,7 +169,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         } else {
             tracing::debug!("local cache hit for {} ({})", crate_name, &cache_key[..16]);
             let restore_start = std::time::Instant::now();
-            restore_from_cache(config, &store, &args, &meta)?;
+            restore_from_cache(config, &compiler, &store, &args, &meta)?;
             let restore_ms = restore_start.elapsed().as_millis() as u64;
             let elapsed = start.elapsed().as_millis() as u64;
             let size: u64 = meta.files.iter().map(|f| f.size).sum();
@@ -226,7 +226,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                         EventResult::RemoteHit
                     };
                     let restore_start = std::time::Instant::now();
-                    restore_from_cache(config, &store, &args, &meta)?;
+                    restore_from_cache(config, &compiler, &store, &args, &meta)?;
                     let restore_ms = restore_start.elapsed().as_millis() as u64;
                     let elapsed = start.elapsed().as_millis() as u64;
                     let size: u64 = meta.files.iter().map(|f| f.size).sum();
@@ -269,7 +269,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                 // It's now available
                 if let Some(meta) = store.get(&cache_key)? {
                     let restore_start = std::time::Instant::now();
-                    restore_from_cache(config, &store, &args, &meta)?;
+                    restore_from_cache(config, &compiler, &store, &args, &meta)?;
                     let restore_ms = restore_start.elapsed().as_millis() as u64;
                     let elapsed = start.elapsed().as_millis() as u64;
                     let size: u64 = meta.files.iter().map(|f| f.size).sum();
@@ -400,6 +400,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 /// Restore cached artifacts to the target output paths.
 fn restore_from_cache(
     _config: &Config,
+    compiler: &RustcCompiler,
     store: &Store,
     args: &RustcArgs,
     meta: &crate::store::EntryMeta,
@@ -411,12 +412,6 @@ fn restore_from_cache(
         dir.clone()
     } else {
         anyhow::bail!("no output path (-o) or output directory (--out-dir) in args");
-    };
-
-    let strategy = if args.is_executable_output() {
-        LinkStrategy::Copy
-    } else {
-        LinkStrategy::Hardlink
     };
 
     for cached_file in &meta.files {
@@ -444,27 +439,47 @@ fn restore_from_cache(
             output_dir.join(&cached_file.name)
         };
 
-        link::link_to_target(&store_path, &target_path, strategy).with_context(|| {
-            format!(
-                "linking {} -> {}",
-                store_path.display(),
-                target_path.display()
-            )
-        })?;
+        // Per-file dispatch by artifact kind. The classification + match
+        // here is the structural enforcement: link strategy and post-restore
+        // processing both derive from `kind`, not from ad-hoc filename
+        // suffix checks at every call site. Adding a new compiler later
+        // (gcc, clang) just needs its own `classify_output`; the dispatch
+        // below is reused unchanged.
+        let kind = compiler.classify_output(args, &cached_file.name);
+
+        link::link_to_target(&store_path, &target_path, kind.link_strategy()).with_context(
+            || {
+                format!(
+                    "linking {} -> {}",
+                    store_path.display(),
+                    target_path.display()
+                )
+            },
+        )?;
 
         // Update mtime so cargo doesn't think output is stale
         link::touch_mtime(&target_path)?;
 
-        // Handle dep-info files: expand relative paths
-        if cached_file.name.ends_with(".d")
-            && let Ok(pwd) = std::env::current_dir()
-        {
-            let _ = link::rewrite_depinfo(&target_path, &pwd, DepInfoMode::Expand);
-        }
-
-        // macOS code signing for executables
-        if args.is_executable_output() && !cached_file.name.ends_with(".d") {
-            compile::codesign_adhoc(&target_path)?;
+        match kind {
+            ArtifactKind::DepInfo => {
+                // Cached .d files contain absolute paths from the build that
+                // produced them; rewrite them to be valid in this worktree.
+                if let Ok(pwd) = std::env::current_dir() {
+                    let _ = link::rewrite_depinfo(&target_path, &pwd, DepInfoMode::Expand);
+                }
+            }
+            ArtifactKind::Executable | ArtifactKind::DynamicLibrary => {
+                // macOS arm64 requires every loaded executable / dynamic
+                // library to carry an ad-hoc signature. Object files,
+                // libraries, metadata, and dep-info files are explicitly
+                // excluded by reaching the `_` arm below.
+                compile::codesign_adhoc(&target_path)?;
+            }
+            ArtifactKind::Library
+            | ArtifactKind::Metadata
+            | ArtifactKind::Object
+            | ArtifactKind::DebugSidecar
+            | ArtifactKind::Other(_) => {}
         }
     }
 


### PR DESCRIPTION
## Summary

Stacked on [#53](https://github.com/kunobi-ninja/kache/pull/53). Promotes per-file dispatch from filename-suffix matching at every call site to a centralized `match` on a typed `ArtifactKind`. Makes a class of bugs (codesign called on `.o`, etc.) structurally impossible instead of "remember to add a guard."

## Why

The wrapper's restore loop used to look like:

\`\`\`rust
let strategy = if args.is_executable_output() { Copy } else { Hardlink };
...
if cached_file.name.ends_with(".d") { rewrite_depinfo(...) }
if args.is_executable_output() && !cached_file.name.ends_with(".d") {
    codesign_adhoc(...)
}
\`\`\`

This shape made multiple bug classes invisible:

- `.o` / `.rcgu.o` files in bin builds were sent to codesign because the suffix guard only excluded `.d`. codesign fails with a warning on every restore.
- Link strategy was bin-vs-lib, ignoring per-file kind (a `.d` inside a bin build was also Copy).
- Store and restore had no shared classifier, so any future store-side per-kind processing had to re-implement the same suffix matching.

## What changes

\`src/compiler/mod.rs\`:
- \`ArtifactKind\` enum (Library, DynamicLibrary, Metadata, Object, DepInfo, Executable, DebugSidecar, Other(&'static str))
- \`ArtifactKind::link_strategy()\` collapses the per-file link decision
- New trait method \`Compiler::classify_output(&self, parsed, name) -> ArtifactKind\`
- \`OutputArtifact { path, kind }\` added (\`#[allow(dead_code)]\` for now) for the future \`Compiler::outputs()\` PR

\`src/compiler/rustc.rs\`:
- \`RustcCompiler::classify_output\` implements the rust-specific extension table; falls back to \`Other(...)\` when no pattern matches
- 6 new unit tests covering each kind plus the regression case (\`.rcgu.o\` must not be Executable)

\`src/wrapper.rs\`:
- \`restore_from_cache\` accepts \`compiler: &RustcCompiler\` and dispatches per-file:

\`\`\`rust
let kind = compiler.classify_output(args, &cached_file.name);
link::link_to_target(.., kind.link_strategy())?;
match kind {
    ArtifactKind::DepInfo => rewrite_depinfo(...),
    ArtifactKind::Executable | ArtifactKind::DynamicLibrary => codesign_adhoc(...),
    _ => {}
}
\`\`\`

The \`match\` is exhaustive — adding a new \`ArtifactKind\` variant forces a compile error at this dispatch, which is exactly the structural enforcement we want.

## Bug classes this prevents (by structure, not by guard)

- **Codesign called on \`.o\` / intermediates.** Object files have \`kind == Object\` and reach the \`_\` arm — they can never accidentally route to codesign.
- **Per-file link strategy mismatched.** \`.d\` files in bin builds now hardlink (immutable text); previously they were copied because the strategy was bin-vs-lib.
- **Store/restore asymmetric per-kind processing.** Future PRs adding store-side dispatch (e.g. relativize dep-info paths at store time) reuse \`classify_output\`; no parallel suffix matching to drift.

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo test --bin kache\` — 350/350 passing (was 344, +6 new)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [ ] CI green
- [ ] Manual: cache hit on a real Rust workspace produces identical \`target/\` to a cold build (no extraneous codesign warnings)

## Stacked on #53

Base branch is \`refactor/compiler-trait\` (PR #53). When that lands, this PR will rebase onto main automatically; the diff shown here is just the incremental change vs the trait skeleton.