### PR TITLE
fix(doctor): clean stale lock files with --fix on Windows

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1843,15 +1843,35 @@ pub fn doctor(
             && crate::daemon::find_daemon_pids().is_empty()
             && crate::daemon::send_stats_request(cfg, false, None, None).is_err()
         {
-            checks.push(Check {
-                label: "Stale locks",
-                pass: false,
-                detail: format!(
-                    "{} legacy lock file(s) from a previous daemon",
-                    stale_files.len()
-                ),
-                fix: Some("kache daemon restart  (removes stale files and starts fresh)".into()),
-            });
+            if fix {
+                for f in &stale_files {
+                    let _ = std::fs::remove_file(f);
+                }
+                checks.push(Check {
+                    label: "Stale locks",
+                    pass: true,
+                    detail: format!(
+                        "removed {} legacy lock file(s)",
+                        stale_files.len()
+                    ),
+                    fix: None,
+                });
+            } else {
+                let fix_hint = if cfg!(windows) {
+                    "kache doctor --fix  (removes stale lock files)"
+                } else {
+                    "kache daemon restart  (removes stale files and starts fresh)"
+                };
+                checks.push(Check {
+                    label: "Stale locks",
+                    pass: false,
+                    detail: format!(
+                        "{} legacy lock file(s) from a previous daemon",
+                        stale_files.len()
+                    ),
+                    fix: Some(fix_hint.into()),
+                });
+            }
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1850,10 +1850,7 @@ pub fn doctor(
                 checks.push(Check {
                     label: "Stale locks",
                     pass: true,
-                    detail: format!(
-                        "removed {} legacy lock file(s)",
-                        stale_files.len()
-                    ),
+                    detail: format!("removed {} legacy lock file(s)", stale_files.len()),
                     fix: None,
                 });
             } else {


### PR DESCRIPTION
## Summary
- `kache doctor --fix` now removes stale daemon lock files directly
- On Windows, the fix hint points to `kache doctor --fix` instead of `kache daemon restart` (which is unsupported)
- On Unix, the existing `kache daemon restart` hint is preserved

Closes #61

## Test plan
- [x] Verified `kache doctor` shows `→ kache doctor --fix` on Windows
- [x] Verified `kache doctor --fix` removes stale lock files and shows `✓ Stale locks — removed 2 legacy lock file(s)`
- [x] Verified subsequent `kache doctor` no longer reports stale locks
- [ ] CI passes on Linux (no regression)