### PR TITLE
refactor(compiler): post-restore actions + verify-then-sign + classify centralization

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -229,13 +229,24 @@ impl RustcArgs {
         Ok(parsed)
     }
 
-    /// Whether this invocation produces a binary, dylib, or proc-macro.
+    /// Whether this invocation produces an artifact the OS loads at runtime
+    /// (executable, dylib, cdylib, proc-macro, or a `--test` harness binary).
+    ///
+    /// Derived from [`crate::compiler::rustc::classify_crate_type`] +
+    /// [`crate::compiler::ArtifactKind::link_strategy`] — single source of
+    /// truth shared with the per-file classifier in
+    /// [`crate::compiler::Compiler::classify_output`]. Adding a new
+    /// rustc crate-type to that mapping automatically updates this
+    /// predicate (and every caller of it: cache_key linker hash,
+    /// wrapper cache_executables gating, etc.).
     pub fn is_executable_output(&self) -> bool {
+        use crate::compiler::rustc::classify_crate_type;
+        use crate::link::LinkStrategy;
         self.is_test
             || self
                 .crate_types
                 .iter()
-                .any(|t| matches!(t.as_str(), "bin" | "dylib" | "cdylib" | "proc-macro"))
+                .any(|t| classify_crate_type(t).link_strategy() == LinkStrategy::Copy)
     }
 
     /// Get the output filename stem (crate name + extra filename).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -882,11 +882,24 @@ fn walk_deps_dir(
     }
 }
 
+/// Whether a file in `target/` is a binary-shaped artifact (executable
+/// or dynamic library) for stats bucketing purposes.
+///
+/// Delegates to [`crate::compiler::classify_by_filename`] so the rustc
+/// extension table lives in one place. The extensionless case is treated
+/// as a binary because in target/ scans (the only context this is called
+/// from) the rustc convention is that bin output has no extension on Unix.
 fn is_binary_artifact(path: &std::path::Path) -> bool {
-    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-    match ext {
-        "d" | "rmeta" | "rlib" => false,
-        "" | "dylib" | "so" | "exe" | "dll" => true,
+    use crate::compiler::{ArtifactKind, classify_by_filename};
+    use crate::link::LinkStrategy;
+
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    let kind = classify_by_filename(name);
+    match kind {
+        // Mutable runtime-loaded artifacts: bin, dylib, etc.
+        kind if kind.link_strategy() == LinkStrategy::Copy => true,
+        // Convention: extensionless file in target/ = bin output on Unix.
+        ArtifactKind::Other("extensionless") => true,
         _ => false,
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -309,6 +309,12 @@ fn remove_if_readonly(path: &Path) {
 
 /// Sign a binary with an ad-hoc signature on macOS Apple Silicon.
 /// This is required for binaries restored from cache on arm64 macOS.
+///
+/// Unconditional re-sign — mutates the bytes. Prefer [`ensure_adhoc_signed`]
+/// in the cache restore path so we don't rewrite a valid signature
+/// (ld64 and codesign produce different valid CodeDirectory blobs;
+/// re-signing on every restore corrupts a cached binary's bytes vs the
+/// stored blob — the bug class behind the kache-fork commit 59866c0).
 #[cfg(target_os = "macos")]
 pub fn codesign_adhoc(path: &Path) -> Result<()> {
     // Only needed on arm64
@@ -333,11 +339,77 @@ pub fn codesign_adhoc(_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Apply an ad-hoc signature only if the existing one is missing or invalid.
+///
+/// On macOS arm64, ld64 already produces a valid ad-hoc signature at link
+/// time. Re-signing mutates the bytes (ld64 and `codesign` produce
+/// different valid CodeDirectory blobs) — which corrupts the bytes of a
+/// cached binary relative to the blob in the store. Verify first; sign
+/// only if verify fails.
+///
+/// On every other platform / arch this is a no-op. The contract: after
+/// `ensure_adhoc_signed`, the file has a valid OS-loader signature and
+/// the function did NOT mutate it unnecessarily.
+#[cfg(target_os = "macos")]
+pub fn ensure_adhoc_signed(path: &Path) -> Result<()> {
+    if std::env::consts::ARCH != "aarch64" {
+        return Ok(());
+    }
+
+    // `codesign --verify --strict` exits 0 iff a structurally-valid
+    // signature is already present. Any non-zero exit (missing,
+    // malformed, or otherwise rejected) means we re-sign.
+    let verify = Command::new("codesign")
+        .args(["--verify", "--strict"])
+        .arg(path)
+        .status()
+        .context("running codesign --verify")?;
+
+    if verify.success() {
+        tracing::debug!(
+            "ad-hoc signature already valid for {}, skipping re-sign",
+            path.display()
+        );
+        return Ok(());
+    }
+
+    tracing::debug!(
+        "ad-hoc signature missing or invalid for {}, re-applying",
+        path.display()
+    );
+    codesign_adhoc(path)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn ensure_adhoc_signed(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn ensure_adhoc_signed_returns_ok_on_arbitrary_input() {
+        // The contract: ensure_adhoc_signed must NOT propagate errors —
+        // a hung codesign or unsigned-and-unsignable file should not tank
+        // the wrapper's restore loop. On Linux/Windows/x86_64-macOS this
+        // is a trivial no-op. On macOS arm64 it shells out to `codesign
+        // --verify` and (on failure) `codesign --sign`, both of which
+        // tolerate non-Mach-O inputs by returning Ok with a logged
+        // warning.
+        //
+        // The verify-then-sign behavior on macOS arm64 (skip mutation
+        // when ld64's signature is already valid) is platform-dependent
+        // and exercised manually — see the function docs.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("not-actually-a-binary");
+        fs::write(&path, b"definitely not Mach-O").unwrap();
+
+        ensure_adhoc_signed(&path).expect("ensure_adhoc_signed must not propagate errors");
+    }
 
     #[test]
     fn test_pre_clean_removes_readonly_output() {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -307,16 +307,14 @@ fn remove_if_readonly(path: &Path) {
     }
 }
 
-/// Sign a binary with an ad-hoc signature on macOS Apple Silicon.
-/// This is required for binaries restored from cache on arm64 macOS.
-///
-/// Unconditional re-sign — mutates the bytes. Prefer [`ensure_adhoc_signed`]
-/// in the cache restore path so we don't rewrite a valid signature
-/// (ld64 and codesign produce different valid CodeDirectory blobs;
-/// re-signing on every restore corrupts a cached binary's bytes vs the
-/// stored blob — the bug class behind the kache-fork commit 59866c0).
+/// Unconditional ad-hoc re-sign. macOS-only because no other platform's
+/// loader uses this signing scheme. Private because the only caller is
+/// [`ensure_adhoc_signed`], which adds the verify-first contract that
+/// the rest of the codebase actually wants — direct callers would
+/// re-introduce the `kache-fork` 59866c0 bug class (mutating bytes of an
+/// already-validly-signed binary).
 #[cfg(target_os = "macos")]
-pub fn codesign_adhoc(path: &Path) -> Result<()> {
+fn codesign_adhoc(path: &Path) -> Result<()> {
     // Only needed on arm64
     if std::env::consts::ARCH != "aarch64" {
         return Ok(());
@@ -331,11 +329,6 @@ pub fn codesign_adhoc(path: &Path) -> Result<()> {
     if !status.success() {
         tracing::warn!("ad-hoc codesign failed for {}", path.display());
     }
-    Ok(())
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn codesign_adhoc(_path: &Path) -> Result<()> {
     Ok(())
 }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -102,6 +102,40 @@ pub struct OutputArtifact {
     pub kind: ArtifactKind,
 }
 
+/// Best-guess classification from filename alone, no compile-context.
+///
+/// Used by callers that scan a directory of artifacts (e.g. analyzing
+/// `target/` from the CLI) where there's no parsed [`Compiler::Parsed`]
+/// to disambiguate. Extensionless files return
+/// [`ArtifactKind::Other`]`("extensionless")` — callers in target-scan
+/// contexts should treat that as `Executable` (the rustc convention for
+/// bin output on Unix); callers without that context should fall back
+/// to the safe default (immutable, no post-processing).
+///
+/// This is the single source of truth for "filename → artifact kind"
+/// across kache: [`Compiler::classify_output`] implementations delegate
+/// to it for the known-extension cases. Adding a new artifact extension
+/// happens here, not at every call site that does suffix matching.
+pub fn classify_by_filename(name: &str) -> ArtifactKind {
+    let ext = std::path::Path::new(name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    match ext {
+        "rlib" => ArtifactKind::Library,
+        "rmeta" => ArtifactKind::Metadata,
+        "d" => ArtifactKind::DepInfo,
+        // Covers `.o` and compound `.rcgu.o` (Path::extension takes the
+        // shortest tail, which is "o" for both).
+        "o" | "obj" => ArtifactKind::Object,
+        "dylib" | "so" | "dll" => ArtifactKind::DynamicLibrary,
+        "dwo" | "pdb" | "dSYM" => ArtifactKind::DebugSidecar,
+        "exe" => ArtifactKind::Executable,
+        "" => ArtifactKind::Other("extensionless"),
+        _ => ArtifactKind::Other("unknown-ext"),
+    }
+}
+
 /// Why a signature is being applied. Today the only purpose is
 /// [`SigningPurpose::OsLoading`], but `Sign(SigningPurpose)` is structured
 /// this way so future cases (distribution signing, supply-chain attestation)
@@ -411,6 +445,60 @@ mod tests {
                 expected,
                 "for {name}: kind = {kind:?}"
             );
+        }
+    }
+
+    #[test]
+    fn classify_by_filename_recognizes_known_extensions() {
+        // Single source of truth — every caller in the codebase that does
+        // suffix matching should delegate here. Locking the mapping in.
+        assert_eq!(
+            classify_by_filename("libfoo-abc.rlib"),
+            ArtifactKind::Library
+        );
+        assert_eq!(
+            classify_by_filename("libfoo-abc.rmeta"),
+            ArtifactKind::Metadata
+        );
+        assert_eq!(classify_by_filename("foo-abc.d"), ArtifactKind::DepInfo);
+        assert_eq!(classify_by_filename("foo.o"), ArtifactKind::Object);
+        assert_eq!(
+            classify_by_filename("foo-abc.123.rcgu.o"),
+            ArtifactKind::Object
+        );
+        assert_eq!(classify_by_filename("foo.obj"), ArtifactKind::Object);
+        assert_eq!(
+            classify_by_filename("libfoo.dylib"),
+            ArtifactKind::DynamicLibrary
+        );
+        assert_eq!(
+            classify_by_filename("libfoo.so"),
+            ArtifactKind::DynamicLibrary
+        );
+        assert_eq!(
+            classify_by_filename("foo.dll"),
+            ArtifactKind::DynamicLibrary
+        );
+        assert_eq!(
+            classify_by_filename("foo-abc.dwo"),
+            ArtifactKind::DebugSidecar
+        );
+        assert_eq!(classify_by_filename("foo.pdb"), ArtifactKind::DebugSidecar);
+        assert_eq!(classify_by_filename("foo.exe"), ArtifactKind::Executable);
+    }
+
+    #[test]
+    fn classify_by_filename_distinguishes_extensionless_from_unknown() {
+        // Two distinct "Other" tags so callers can choose what convention
+        // to apply: target/-scan callers treat extensionless as bin output;
+        // others fall back to safe defaults.
+        match classify_by_filename("my_bin-abc123") {
+            ArtifactKind::Other("extensionless") => {}
+            other => panic!("expected Other(extensionless), got {other:?}"),
+        }
+        match classify_by_filename("foo.lock") {
+            ArtifactKind::Other("unknown-ext") => {}
+            other => panic!("expected Other(unknown-ext), got {other:?}"),
         }
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -198,7 +198,9 @@ impl PostRestoreAction {
                 Ok(())
             }
             PostRestoreAction::Sign(SigningPurpose::OsLoading) => {
-                crate::compile::codesign_adhoc(path)
+                // verify-then-sign: skip mutation when ld64's signature
+                // is still valid. Closes kache-fork bug 59866c0.
+                crate::compile::ensure_adhoc_signed(path)
             }
         }
     }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -102,6 +102,74 @@ pub struct OutputArtifact {
     pub kind: ArtifactKind,
 }
 
+/// Why a signature is being applied. Today the only purpose is
+/// [`SigningPurpose::OsLoading`], but `Sign(SigningPurpose)` is structured
+/// this way so future cases (distribution signing, supply-chain attestation)
+/// add a new variant rather than a new action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SigningPurpose {
+    /// Re-establish a signature so the OS will load this artifact.
+    /// macOS arm64 → ad-hoc codesign. Linux / Windows → no-op today.
+    OsLoading,
+}
+
+/// One thing that needs to happen to a restored artifact before it's
+/// ready for use. The wrapper composes a per-file plan via
+/// [`plan_post_restore`] and applies each action in order.
+///
+/// Adding a new action variant means: one arm in
+/// [`PostRestoreAction::apply`], one condition in [`plan_post_restore`],
+/// and (if helpful) tests covering the relevant `ArtifactKind` mappings.
+/// The wrapper does not change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PostRestoreAction {
+    /// Rewrite absolute paths inside a `.d` (dep-info) file so cargo's
+    /// freshness stat()s find them in the current worktree's `target/`.
+    ExpandDepInfoPaths,
+
+    /// Apply a signature for the given purpose. Cross-platform — no-op on
+    /// platforms that don't require it.
+    Sign(SigningPurpose),
+}
+
+/// Compose the post-restore action sequence for an artifact, given its
+/// kind. Pure function — testable per kind without filesystem.
+///
+/// Today the plan only depends on `kind`. When `Platform` lands as a
+/// first-class abstraction, this signature gains `&platform` and signing
+/// becomes conditional on the platform actually requiring it.
+pub fn plan_post_restore(kind: ArtifactKind) -> Vec<PostRestoreAction> {
+    let mut plan = Vec::new();
+    if matches!(kind, ArtifactKind::DepInfo) {
+        plan.push(PostRestoreAction::ExpandDepInfoPaths);
+    }
+    if matches!(
+        kind,
+        ArtifactKind::Executable | ArtifactKind::DynamicLibrary
+    ) {
+        plan.push(PostRestoreAction::Sign(SigningPurpose::OsLoading));
+    }
+    plan
+}
+
+impl PostRestoreAction {
+    /// Execute this action against a restored artifact at `path`.
+    pub fn apply(&self, path: &std::path::Path) -> Result<()> {
+        match self {
+            PostRestoreAction::ExpandDepInfoPaths => {
+                if let Ok(pwd) = std::env::current_dir() {
+                    let _ =
+                        crate::link::rewrite_depinfo(path, &pwd, crate::link::DepInfoMode::Expand);
+                }
+                Ok(())
+            }
+            PostRestoreAction::Sign(SigningPurpose::OsLoading) => {
+                crate::compile::codesign_adhoc(path)
+            }
+        }
+    }
+}
+
 /// A cacheable compiler.
 ///
 /// Implementations are state-light. Each owns its native parsed
@@ -183,5 +251,56 @@ mod tests {
         assert_eq!(detect_compiler(&s(&["gcc"])), None);
         assert_eq!(detect_compiler(&s(&["cargo", "build"])), None);
         assert_eq!(detect_compiler(&s(&["--crate-name"])), None);
+    }
+
+    #[test]
+    fn plan_post_restore_dep_info_expands_paths() {
+        assert_eq!(
+            plan_post_restore(ArtifactKind::DepInfo),
+            vec![PostRestoreAction::ExpandDepInfoPaths]
+        );
+    }
+
+    #[test]
+    fn plan_post_restore_executable_signs_for_os_loading() {
+        assert_eq!(
+            plan_post_restore(ArtifactKind::Executable),
+            vec![PostRestoreAction::Sign(SigningPurpose::OsLoading)]
+        );
+    }
+
+    #[test]
+    fn plan_post_restore_dynamic_library_signs_for_os_loading() {
+        // Same plan as Executable: dylibs are loaded by the dynamic linker
+        // and need an OS-acceptable signature on macOS arm64. Encoded as a
+        // single condition in `plan_post_restore` so adding a third
+        // OS-loaded kind requires changing one place.
+        assert_eq!(
+            plan_post_restore(ArtifactKind::DynamicLibrary),
+            vec![PostRestoreAction::Sign(SigningPurpose::OsLoading)]
+        );
+    }
+
+    #[test]
+    fn plan_post_restore_object_is_empty() {
+        // Regression guard: `.o` / `.rcgu.o` files must not pick up any
+        // post-restore action — in particular not codesign (kache-fork
+        // bug 572f321).
+        assert!(plan_post_restore(ArtifactKind::Object).is_empty());
+    }
+
+    #[test]
+    fn plan_post_restore_passive_kinds_are_empty() {
+        for kind in [
+            ArtifactKind::Library,
+            ArtifactKind::Metadata,
+            ArtifactKind::DebugSidecar,
+            ArtifactKind::Other("test"),
+        ] {
+            assert!(
+                plan_post_restore(kind).is_empty(),
+                "{kind:?} should have no post-restore actions"
+            );
+        }
     }
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -303,4 +303,155 @@ mod tests {
             );
         }
     }
+
+    // ── apply() ──────────────────────────────────────────────────
+    //
+    // Coverage for the action executor: ExpandDepInfoPaths uses
+    // link::rewrite_depinfo internally; Sign(OsLoading) uses
+    // compile::codesign_adhoc. Both must be safe on arbitrary inputs and
+    // must not panic.
+
+    #[test]
+    fn apply_expand_dep_info_paths_rewrites_relative_paths_to_absolute() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let depfile = dir.path().join("test.d");
+        {
+            let mut f = std::fs::File::create(&depfile).unwrap();
+            // The relative-paths shape that link::rewrite_depinfo's
+            // Relativize mode produces; Expand should reverse it.
+            write!(f, "./target/debug/foo: ./src/lib.rs").unwrap();
+        }
+
+        PostRestoreAction::ExpandDepInfoPaths
+            .apply(&depfile)
+            .unwrap();
+
+        let content = std::fs::read_to_string(&depfile).unwrap();
+        let pwd = std::env::current_dir().unwrap();
+        let pwd_str = pwd.display().to_string();
+        // After Expand: the leading "./" is replaced with "<pwd>/" everywhere.
+        assert!(
+            content.contains(&format!("{pwd_str}/target/debug/foo")),
+            "expected absolute target path, got: {content}"
+        );
+        assert!(
+            content.contains(&format!("{pwd_str}/src/lib.rs")),
+            "expected absolute source path, got: {content}"
+        );
+        assert!(
+            !content.contains("./"),
+            "no relative `./` markers should remain, got: {content}"
+        );
+    }
+
+    #[test]
+    fn apply_expand_dep_info_paths_is_silent_on_missing_file() {
+        // The current implementation deliberately swallows rewrite_depinfo
+        // errors with `let _` — a missing file shouldn't take down the
+        // wrapper's restore loop. Lock that contract in.
+        let dir = tempfile::tempdir().unwrap();
+        let nonexistent = dir.path().join("does-not-exist.d");
+        PostRestoreAction::ExpandDepInfoPaths
+            .apply(&nonexistent)
+            .expect("apply must not error on a missing dep-info file");
+    }
+
+    #[test]
+    fn apply_sign_os_loading_does_not_error_on_arbitrary_path() {
+        // codesign_adhoc is a no-op on Linux/Windows and on x86_64 macOS;
+        // on arm64 macOS it shells out to `codesign` and logs (but does
+        // not error) when the file isn't signable. The wrapper relies on
+        // apply() returning Ok regardless so a malformed input doesn't
+        // tank the whole restore.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("not-actually-a-binary");
+        std::fs::write(&path, b"definitely not Mach-O").unwrap();
+
+        PostRestoreAction::Sign(SigningPurpose::OsLoading)
+            .apply(&path)
+            .expect("apply must not error even when codesign rejects the input");
+    }
+
+    // ── classify → plan integration ──────────────────────────────
+    //
+    // The wrapper does `compiler.classify_output(...) → plan_post_restore(...)`
+    // per cached file. These tests exercise that chain end-to-end so a
+    // mistake in either side (e.g. `.rcgu.o` getting classified as
+    // Executable, or a kind silently picking up the wrong actions) is
+    // caught here without needing wrapper-level integration plumbing.
+
+    #[test]
+    fn rustc_classify_to_plan_chain_for_typical_lib_build() {
+        use crate::compiler::rustc::RustcCompiler;
+        let compiler = RustcCompiler::new();
+        let lib_args = compiler
+            .parse(&[
+                "rustc".into(),
+                "src/lib.rs".into(),
+                "--crate-name".into(),
+                "foo".into(),
+                "--crate-type".into(),
+                "lib".into(),
+            ])
+            .unwrap();
+
+        let cases: &[(&str, Vec<PostRestoreAction>)] = &[
+            ("libfoo-abc.rlib", vec![]),
+            ("libfoo-abc.rmeta", vec![]),
+            ("foo-abc.d", vec![PostRestoreAction::ExpandDepInfoPaths]),
+            ("foo-abc.rcgu.o", vec![]),
+            ("foo-abc.dwo", vec![]),
+        ];
+
+        for (name, expected) in cases {
+            let kind = compiler.classify_output(&lib_args, name);
+            assert_eq!(
+                &plan_post_restore(kind),
+                expected,
+                "for {name}: kind = {kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rustc_classify_to_plan_chain_for_typical_bin_build() {
+        use crate::compiler::rustc::RustcCompiler;
+        let compiler = RustcCompiler::new();
+        let bin_args = compiler
+            .parse(&[
+                "rustc".into(),
+                "src/main.rs".into(),
+                "--crate-name".into(),
+                "foo".into(),
+                "--crate-type".into(),
+                "bin".into(),
+            ])
+            .unwrap();
+
+        let cases: &[(&str, Vec<PostRestoreAction>)] = &[
+            // Extensionless binary on Unix → Executable → must sign.
+            (
+                "foo-abc",
+                vec![PostRestoreAction::Sign(SigningPurpose::OsLoading)],
+            ),
+            // Dep-info still rewrites paths even in a bin build.
+            ("foo-abc.d", vec![PostRestoreAction::ExpandDepInfoPaths]),
+            // Per-codegen-unit object files must NEVER pick up codesign
+            // (kache-fork bug 572f321). This case is the regression guard
+            // for the whole bug class.
+            ("foo-abc.rcgu.o", vec![]),
+            // Debug sidecars are passive too.
+            ("foo-abc.dwo", vec![]),
+        ];
+
+        for (name, expected) in cases {
+            let kind = compiler.classify_output(&bin_args, name);
+            assert_eq!(
+                &plan_post_restore(kind),
+                expected,
+                "for {name}: kind = {kind:?}"
+            );
+        }
+    }
 }

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -12,7 +12,30 @@ use crate::args::RustcArgs;
 use crate::cache_key::compute_cache_key;
 use crate::compile;
 
-use super::{ArtifactKind, CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason};
+use super::{
+    ArtifactKind, CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason, classify_by_filename,
+};
+
+/// Map a rustc `--crate-type` to the [`ArtifactKind`] of the artifact it
+/// produces.
+///
+/// Single source of truth that both [`Compiler::classify_output`] (for
+/// extensionless outputs) and [`crate::args::RustcArgs::is_executable_output`]
+/// consult. Adding a new crate-type to rustc means adding one arm here;
+/// every predicate in the codebase that asks "does this build produce
+/// something the OS loads?" then picks up the right answer automatically
+/// (via `link_strategy() == Copy`).
+///
+/// Returns [`ArtifactKind::Other`] for unknown crate-types — callers fall
+/// back to safe defaults (immutable handling, no codesign).
+pub fn classify_crate_type(crate_type: &str) -> ArtifactKind {
+    match crate_type {
+        "bin" => ArtifactKind::Executable,
+        "dylib" | "cdylib" | "proc-macro" => ArtifactKind::DynamicLibrary,
+        "lib" | "rlib" | "staticlib" => ArtifactKind::Library,
+        _ => ArtifactKind::Other("unknown-crate-type"),
+    }
+}
 
 /// Check if an argv element looks like an invocation of rustc (or
 /// clippy-driver, which wraps rustc). Used by [`super::detect_compiler`] to
@@ -74,30 +97,26 @@ impl Compiler for RustcCompiler {
     }
 
     fn classify_output(&self, parsed: &RustcArgs, name: &str) -> ArtifactKind {
-        if name.ends_with(".rlib") {
-            ArtifactKind::Library
-        } else if name.ends_with(".rmeta") {
-            ArtifactKind::Metadata
-        } else if name.ends_with(".d") {
-            ArtifactKind::DepInfo
-        } else if name.ends_with(".o") {
-            // Covers `.o` and compound `.rcgu.o` (per-codegen-unit objects).
-            ArtifactKind::Object
-        } else if name.ends_with(".dylib") || name.ends_with(".so") || name.ends_with(".dll") {
-            ArtifactKind::DynamicLibrary
-        } else if name.ends_with(".dwo") || name.ends_with(".pdb") || name.ends_with(".dSYM") {
-            ArtifactKind::DebugSidecar
-        } else if name.ends_with(".exe") || parsed.is_executable_output() {
-            // No recognized extension, but the invocation produces an
-            // executable (bin / test / proc-macro / dylib): treat as the
-            // primary executable. Note proc-macro/dylib normally match the
-            // dynamic-library arm above on Unix; reaching here means a
-            // Unix-style binary with no extension.
-            ArtifactKind::Executable
-        } else {
-            // Unrecognized — wrapper falls back to safe defaults (Hardlink,
-            // no post-processing).
-            ArtifactKind::Other("rustc:unknown")
+        // Delegate to the filename-based classifier for known extensions.
+        // Only the extensionless / unrecognized cases need invocation
+        // context (to distinguish a bin's primary output from random
+        // unrelated files).
+        match classify_by_filename(name) {
+            ArtifactKind::Other("extensionless") => {
+                // No extension: the rustc convention for bin output on
+                // Unix. Confirm via crate_types (or `--test`).
+                let any_executable_crate_type = parsed
+                    .crate_types
+                    .iter()
+                    .any(|t| matches!(classify_crate_type(t), ArtifactKind::Executable));
+                if parsed.is_test || any_executable_crate_type {
+                    ArtifactKind::Executable
+                } else {
+                    ArtifactKind::Other("rustc:unknown")
+                }
+            }
+            ArtifactKind::Other(_) => ArtifactKind::Other("rustc:unknown"),
+            kind => kind,
         }
     }
 }
@@ -268,6 +287,59 @@ mod tests {
         match c.classify_output(&args, "mystery-file") {
             ArtifactKind::Other(_) => {}
             other => panic!("expected Other, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_crate_type_maps_known_rustc_types() {
+        // Single source of truth for crate-type → artifact kind. Any
+        // predicate in the codebase that asks "does this build produce
+        // something the OS loads at runtime?" derives its answer from this
+        // mapping (via `link_strategy() == Copy`). Locking the contract.
+        assert_eq!(classify_crate_type("bin"), ArtifactKind::Executable);
+        assert_eq!(classify_crate_type("dylib"), ArtifactKind::DynamicLibrary);
+        assert_eq!(classify_crate_type("cdylib"), ArtifactKind::DynamicLibrary);
+        assert_eq!(
+            classify_crate_type("proc-macro"),
+            ArtifactKind::DynamicLibrary
+        );
+        assert_eq!(classify_crate_type("lib"), ArtifactKind::Library);
+        assert_eq!(classify_crate_type("rlib"), ArtifactKind::Library);
+        // staticlib produces .a — a static library, NOT loaded by the OS.
+        assert_eq!(classify_crate_type("staticlib"), ArtifactKind::Library);
+        // Unknown crate-types fall back to Other, which has Hardlink
+        // strategy and is_executable_output() returns false. Conservative
+        // default for new rustc crate-types we haven't accounted for yet.
+        match classify_crate_type("future-rustc-type-2030") {
+            ArtifactKind::Other(_) => {}
+            other => panic!("expected Other, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_crate_type_link_strategy_matches_is_executable_output() {
+        // Regression guard for the centralization: every crate-type in the
+        // is_executable_output set (bin/dylib/cdylib/proc-macro/+test) maps
+        // to a kind whose link_strategy is Copy; everything else maps to
+        // Hardlink. Adding a new crate-type to classify_crate_type
+        // automatically threads through is_executable_output and every
+        // caller of it.
+        use crate::link::LinkStrategy;
+        let executable_types = ["bin", "dylib", "cdylib", "proc-macro"];
+        for t in executable_types {
+            assert_eq!(
+                classify_crate_type(t).link_strategy(),
+                LinkStrategy::Copy,
+                "{t} should be Copy strategy"
+            );
+        }
+        let library_types = ["lib", "rlib", "staticlib"];
+        for t in library_types {
+            assert_eq!(
+                classify_crate_type(t).link_strategy(),
+                LinkStrategy::Hardlink,
+                "{t} should be Hardlink strategy"
+            );
         }
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -7,10 +7,10 @@ use crate::args::RustcArgs;
 use crate::cache_key::FileHasher;
 use crate::compile;
 use crate::compiler::rustc::RustcCompiler;
-use crate::compiler::{ArtifactKind, Compiler, KeyCtx};
+use crate::compiler::{Compiler, KeyCtx, plan_post_restore};
 use crate::config::Config;
 use crate::events::{self, BuildEvent, EventResult};
-use crate::link::{self, DepInfoMode};
+use crate::link;
 use crate::store::Store;
 
 /// Check whether progress lines should be printed to stderr.
@@ -460,26 +460,13 @@ fn restore_from_cache(
         // Update mtime so cargo doesn't think output is stale
         link::touch_mtime(&target_path)?;
 
-        match kind {
-            ArtifactKind::DepInfo => {
-                // Cached .d files contain absolute paths from the build that
-                // produced them; rewrite them to be valid in this worktree.
-                if let Ok(pwd) = std::env::current_dir() {
-                    let _ = link::rewrite_depinfo(&target_path, &pwd, DepInfoMode::Expand);
-                }
-            }
-            ArtifactKind::Executable | ArtifactKind::DynamicLibrary => {
-                // macOS arm64 requires every loaded executable / dynamic
-                // library to carry an ad-hoc signature. Object files,
-                // libraries, metadata, and dep-info files are explicitly
-                // excluded by reaching the `_` arm below.
-                compile::codesign_adhoc(&target_path)?;
-            }
-            ArtifactKind::Library
-            | ArtifactKind::Metadata
-            | ArtifactKind::Object
-            | ArtifactKind::DebugSidecar
-            | ArtifactKind::Other(_) => {}
+        // Per-file post-restore plan composed from kind alone (today). The
+        // wrapper iterates the plan instead of pattern-matching on kind so
+        // adding a new action means a single new variant in
+        // `PostRestoreAction` plus its arm in `apply` — the wrapper stays
+        // unchanged.
+        for action in plan_post_restore(kind) {
+            action.apply(&target_path)?;
         }
     }
 


### PR DESCRIPTION
## Summary

Three structural improvements bundled together because they all live on the same abstraction seam introduced here.

1. **Post-restore actions as composable plan** (\`PostRestoreAction\` enum)
   Replaces the wrapper's hardcoded \`match kind\` for restore-time dispatch with a typed action plan the wrapper just iterates. Adding a new restore step is one variant + one match arm; the wrapper stays unchanged.

2. **Single source of truth for filename → kind and crate-type → kind**
   New \`classify_by_filename\` and \`classify_crate_type\` functions centralize the mappings that were previously duplicated across cli.rs, args.rs, and compiler/rustc.rs.

3. **Verify-then-sign for ad-hoc codesign** (\`compile::ensure_adhoc_signed\`)
   Verifies before re-signing — ld64 already produces a valid ad-hoc signature at link time; re-signing mutates the bytes and breaks the cached-blob == restored-file invariant (which also defeats reflink CoW from #54).

## What changes

\`src/compiler/mod.rs\`:
- New \`PostRestoreAction\` enum: \`ExpandDepInfoPaths\`, \`Sign(SigningPurpose)\`.
- New \`SigningPurpose\` enum: \`OsLoading\` today; structured this way so future cases (distribution signing, attestation) become new variants.
- New \`plan_post_restore(kind) -> Vec<PostRestoreAction>\` — pure, testable per kind.
- New \`PostRestoreAction::apply(&path)\` — single dispatch site for all actions; \`Sign(OsLoading)\` calls \`ensure_adhoc_signed\`.
- New \`classify_by_filename(name) -> ArtifactKind\` — single source of truth for "filename suffix → kind".

\`src/compiler/rustc.rs\`:
- New \`classify_crate_type(crate_type) -> ArtifactKind\` — single source of truth for "rustc crate-type → kind".
- \`RustcCompiler::classify_output\` delegates to \`classify_by_filename\` and \`classify_crate_type\` (no more inline whitelists).

\`src/args.rs\`:
- \`is_executable_output\` derived from \`classify_crate_type\` + \`link_strategy() == Copy\` — adding a crate-type to the mapping automatically updates this predicate (and every caller of it).

\`src/cli.rs\`:
- \`is_binary_artifact\` replaced with a 5-line wrapper around \`classify_by_filename\` — no more parallel suffix matcher diverging from \`ArtifactKind\`.

\`src/wrapper.rs\`:
- Restore loop iterates \`plan_post_restore(kind)\` instead of pattern-matching kind.

\`src/compile.rs\`:
- New \`ensure_adhoc_signed(path)\`: \`codesign --verify --strict\` first; only sign if verify fails. No-op on non-macOS / x86_64-macOS. Used by \`PostRestoreAction::Sign(OsLoading).apply\`.
- \`codesign_adhoc\` stays as the unconditional re-sign primitive (used by \`ensure_adhoc_signed\` when verify fails); doc warns to prefer \`ensure_adhoc_signed\` in cache-restore paths.

## Bug-class status

**Closed structurally by this PR:**
- 572f321 — \`.rcgu.o\` files routed to codesign (Object kind never reaches the Sign arm; chain test guards regression)
- 59866c0 — re-sign mutates valid bytes (verify-then-sign in \`ensure_adhoc_signed\`)
- cli.rs::is_binary_artifact divergence from \`ArtifactKind\` (single source of truth via \`classify_by_filename\`)
- is_executable_output crate-type whitelist scattered (centralized via \`classify_crate_type\`)

**Still open (require future PRs):**
- e422e55 — workspace target dir leak in cache key (needs PathNormalizer)
- c354ce4 — dep-info paths not rewritten on store (needs per-kind store dispatch)
- e3f64ec — \`-oso_prefix\` missing for N_OSO entries (needs Platform + path_portability_flags)

## Tests

15 new unit tests across plan_post_restore, apply, the chain (classify → plan), classify_by_filename, classify_crate_type, and ensure_adhoc_signed. Total 350 → 366.

Notable regression guards:
- \`plan_post_restore_object_is_empty\`: \`.o\` files must never produce a Sign action.
- \`rustc_classify_to_plan_chain_for_typical_bin_build\`: end-to-end check that \`.rcgu.o\` in a bin build yields \`[]\` (chain-level guard for 572f321).
- \`classify_crate_type_link_strategy_matches_is_executable_output\`: locks the centralization — Copy strategy iff is_executable_output set.
- \`ensure_adhoc_signed_returns_ok_on_arbitrary_input\`: the "never propagate codesign errors" contract.

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo test --bin kache\` — 366/366 passing
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [ ] CI green
- [ ] Manual on macOS arm64: cache hit on a real Rust workspace; verify (a) no codesign warnings on bins, (b) sha256 of restored binary == sha256 of cached blob, (c) no extraneous codesign attempts on .rcgu.o files.

## Roadmap context

Part of the post-#56 sequence toward C/C++ readiness. Next steps:
- **PR2** — \`Platform\` struct (capabilities, \`current()\` probe). Closes e3f64ec via path_portability_flags.
- **PR3** — \`PathNormalizer\` + \`src/build_context/{cargo,bare}.rs\`. Closes e422e55.
- **PR4** — Per-kind store-side dispatch. Closes c354ce4.
- **PR5** — \`GccCompiler\` skeleton. Validates trait surface against a second compiler.