### PR TITLE
build: enable LTO, codegen-units=1, and strip for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,11 @@ predicates = "3"
 pkg-url = "{ repo }/releases/download/{ version }/{ name }-{ target }.tar.gz"
 pkg-fmt = "tgz"
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = "symbols"
+
 [lints.rust]
 warnings = "deny"
 


### PR DESCRIPTION
## Summary
- Adds a `[profile.release]` section with `lto = "fat"`, `codegen-units = 1`, and `strip = "symbols"`.
- Affects release builds only — dev/debug builds and developer iteration time are unaffected.
- Produces smaller, faster release binaries (including artifacts built by CI / cargo-binstall).

Closes #42

## Test plan
- [x] `cargo check --release` succeeds with the new profile
- [ ] Confirm CI release pipeline still builds artifacts cleanly