### PR TITLE
fix(compiler): ad-hoc codesign verify-then-sign instead of unconditional

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -309,6 +309,12 @@ fn remove_if_readonly(path: &Path) {
 
 /// Sign a binary with an ad-hoc signature on macOS Apple Silicon.
 /// This is required for binaries restored from cache on arm64 macOS.
+///
+/// Unconditional re-sign — mutates the bytes. Prefer [`ensure_adhoc_signed`]
+/// in the cache restore path so we don't rewrite a valid signature
+/// (ld64 and codesign produce different valid CodeDirectory blobs;
+/// re-signing on every restore corrupts a cached binary's bytes vs the
+/// stored blob — the bug class behind the kache-fork commit 59866c0).
 #[cfg(target_os = "macos")]
 pub fn codesign_adhoc(path: &Path) -> Result<()> {
     // Only needed on arm64
@@ -333,11 +339,77 @@ pub fn codesign_adhoc(_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Apply an ad-hoc signature only if the existing one is missing or invalid.
+///
+/// On macOS arm64, ld64 already produces a valid ad-hoc signature at link
+/// time. Re-signing mutates the bytes (ld64 and `codesign` produce
+/// different valid CodeDirectory blobs) — which corrupts the bytes of a
+/// cached binary relative to the blob in the store. Verify first; sign
+/// only if verify fails.
+///
+/// On every other platform / arch this is a no-op. The contract: after
+/// `ensure_adhoc_signed`, the file has a valid OS-loader signature and
+/// the function did NOT mutate it unnecessarily.
+#[cfg(target_os = "macos")]
+pub fn ensure_adhoc_signed(path: &Path) -> Result<()> {
+    if std::env::consts::ARCH != "aarch64" {
+        return Ok(());
+    }
+
+    // `codesign --verify --strict` exits 0 iff a structurally-valid
+    // signature is already present. Any non-zero exit (missing,
+    // malformed, or otherwise rejected) means we re-sign.
+    let verify = Command::new("codesign")
+        .args(["--verify", "--strict"])
+        .arg(path)
+        .status()
+        .context("running codesign --verify")?;
+
+    if verify.success() {
+        tracing::debug!(
+            "ad-hoc signature already valid for {}, skipping re-sign",
+            path.display()
+        );
+        return Ok(());
+    }
+
+    tracing::debug!(
+        "ad-hoc signature missing or invalid for {}, re-applying",
+        path.display()
+    );
+    codesign_adhoc(path)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn ensure_adhoc_signed(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn ensure_adhoc_signed_returns_ok_on_arbitrary_input() {
+        // The contract: ensure_adhoc_signed must NOT propagate errors —
+        // a hung codesign or unsigned-and-unsignable file should not tank
+        // the wrapper's restore loop. On Linux/Windows/x86_64-macOS this
+        // is a trivial no-op. On macOS arm64 it shells out to `codesign
+        // --verify` and (on failure) `codesign --sign`, both of which
+        // tolerate non-Mach-O inputs by returning Ok with a logged
+        // warning.
+        //
+        // The verify-then-sign behavior on macOS arm64 (skip mutation
+        // when ld64's signature is already valid) is platform-dependent
+        // and exercised manually — see the function docs.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("not-actually-a-binary");
+        fs::write(&path, b"definitely not Mach-O").unwrap();
+
+        ensure_adhoc_signed(&path).expect("ensure_adhoc_signed must not propagate errors");
+    }
 
     #[test]
     fn test_pre_clean_removes_readonly_output() {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -198,7 +198,9 @@ impl PostRestoreAction {
                 Ok(())
             }
             PostRestoreAction::Sign(SigningPurpose::OsLoading) => {
-                crate::compile::codesign_adhoc(path)
+                // verify-then-sign: skip mutation when ld64's signature
+                // is still valid. Closes kache-fork bug 59866c0.
+                crate::compile::ensure_adhoc_signed(path)
             }
         }
     }


### PR DESCRIPTION
## Summary

Stacked on [#65](https://github.com/kunobi-ninja/kache/pull/65). Closes the bug class behind kache-fork commit 59866c0: re-signing a restored binary mutates its bytes.

## Why

ld64 (the linker) and \`codesign\` produce different valid CodeDirectory blobs for the same input — both acceptable to the kernel, but byte-different. kache today restores a binary from cache, then unconditionally re-applies \`codesign\`, and the resulting file diverges from the blob in the store.

The bug never showed as a runtime failure (kernel accepts both blobs) but it broke a real invariant kache relies on: **the bytes of the restored file == the bytes of the cached blob**. With reflink restoration ([#54](https://github.com/kunobi-ninja/kache/pull/54)) this also defeats CoW — the codesign rewrite breaks the cow share.

## What changes

- New \`compile::ensure_adhoc_signed(path)\`. Verifies via \`codesign --verify --strict\` first; only re-signs if verify fails. On non-macOS / x86_64-macOS this is a trivial no-op (same as the unconditional \`codesign_adhoc\`).
- \`PostRestoreAction::Sign(SigningPurpose::OsLoading).apply\` calls \`ensure_adhoc_signed\` instead of \`codesign_adhoc\` — picks up the fix through the abstraction introduced in #65 with no other caller changes.
- \`codesign_adhoc\` itself stays as the unconditional re-sign primitive (used by \`ensure_adhoc_signed\` when verify fails). Its doc warns to prefer \`ensure_adhoc_signed\` in cache-restore paths.

## Tests

- \`ensure_adhoc_signed_returns_ok_on_arbitrary_input\`: locks the "never propagate codesign errors" contract on Linux/Windows/x86_64-macOS. Verify-then-sign behavior on arm64-macOS itself is platform-dependent and exercised manually — documented in the function.

Total tests: 365 → 366. Build / fmt / clippy clean.

## Bug-class status (cumulative through #56, #65, this PR)

**Closed by structure:**
- 572f321 (.rcgu.o → codesign)
- cli.rs::is_binary_artifact divergence
- is_executable_output crate-type list scattered
- **59866c0 (re-sign mutates valid bytes)** ← this PR

**Not yet closed (require future PRs):**
- e422e55 (workspace target dir leak) — needs PathNormalizer (PR3)
- c354ce4 (dep-info store-side rewrite) — needs per-kind store dispatch (PR4)
- e3f64ec (-oso_prefix) — needs Platform + path_portability_flags (PR2)

## Stacked on #65

Base branch is \`refactor/post-restore-action\`. When that lands, this PR rebases onto main; the diff shown is just the incremental change vs #65.

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo test --bin kache\` — 366/366 passing
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [ ] CI green
- [ ] Manual on macOS arm64: \`cargo build\` populates kache cache; second \`cargo clean && cargo build\` restores. Verify (a) no codesign warnings on bins (b) the bytes of the restored binary match the cached blob (sha256 compare).