### PR TITLE
refactor(compiler): extract Platform trait for OS-specific concerns

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -307,102 +307,18 @@ fn remove_if_readonly(path: &Path) {
     }
 }
 
-/// Unconditional ad-hoc re-sign. macOS-only because no other platform's
-/// loader uses this signing scheme. Private because the only caller is
-/// [`ensure_adhoc_signed`], which adds the verify-first contract that
-/// the rest of the codebase actually wants — direct callers would
-/// re-introduce the `kache-fork` 59866c0 bug class (mutating bytes of an
-/// already-validly-signed binary).
-#[cfg(target_os = "macos")]
-fn codesign_adhoc(path: &Path) -> Result<()> {
-    // Only needed on arm64
-    if std::env::consts::ARCH != "aarch64" {
-        return Ok(());
-    }
-
-    let status = Command::new("codesign")
-        .args(["--sign", "-", "--force"])
-        .arg(path)
-        .status()
-        .context("running codesign")?;
-
-    if !status.success() {
-        tracing::warn!("ad-hoc codesign failed for {}", path.display());
-    }
-    Ok(())
-}
-
-/// Apply an ad-hoc signature only if the existing one is missing or invalid.
-///
-/// On macOS arm64, ld64 already produces a valid ad-hoc signature at link
-/// time. Re-signing mutates the bytes (ld64 and `codesign` produce
-/// different valid CodeDirectory blobs) — which corrupts the bytes of a
-/// cached binary relative to the blob in the store. Verify first; sign
-/// only if verify fails.
-///
-/// On every other platform / arch this is a no-op. The contract: after
-/// `ensure_adhoc_signed`, the file has a valid OS-loader signature and
-/// the function did NOT mutate it unnecessarily.
-#[cfg(target_os = "macos")]
-pub fn ensure_adhoc_signed(path: &Path) -> Result<()> {
-    if std::env::consts::ARCH != "aarch64" {
-        return Ok(());
-    }
-
-    // `codesign --verify --strict` exits 0 iff a structurally-valid
-    // signature is already present. Any non-zero exit (missing,
-    // malformed, or otherwise rejected) means we re-sign.
-    let verify = Command::new("codesign")
-        .args(["--verify", "--strict"])
-        .arg(path)
-        .status()
-        .context("running codesign --verify")?;
-
-    if verify.success() {
-        tracing::debug!(
-            "ad-hoc signature already valid for {}, skipping re-sign",
-            path.display()
-        );
-        return Ok(());
-    }
-
-    tracing::debug!(
-        "ad-hoc signature missing or invalid for {}, re-applying",
-        path.display()
-    );
-    codesign_adhoc(path)
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn ensure_adhoc_signed(_path: &Path) -> Result<()> {
-    Ok(())
-}
+// NOTE: ad-hoc codesign logic used to live here behind
+// `#[cfg(target_os = "macos")]`. It now lives on
+// `crate::compiler::platform::MacOsPlatform::ensure_binary_loadable`,
+// reachable from any caller (including the future cc store path) via
+// the `Platform` trait. Restore-time dispatch flows through
+// `PostRestoreAction::Sign(SigningPurpose::OsLoading)`.
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
-
-    #[test]
-    fn ensure_adhoc_signed_returns_ok_on_arbitrary_input() {
-        // The contract: ensure_adhoc_signed must NOT propagate errors —
-        // a hung codesign or unsigned-and-unsignable file should not tank
-        // the wrapper's restore loop. On Linux/Windows/x86_64-macOS this
-        // is a trivial no-op. On macOS arm64 it shells out to `codesign
-        // --verify` and (on failure) `codesign --sign`, both of which
-        // tolerate non-Mach-O inputs by returning Ok with a logged
-        // warning.
-        //
-        // The verify-then-sign behavior on macOS arm64 (skip mutation
-        // when ld64's signature is already valid) is platform-dependent
-        // and exercised manually — see the function docs.
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("not-actually-a-binary");
-        fs::write(&path, b"definitely not Mach-O").unwrap();
-
-        ensure_adhoc_signed(&path).expect("ensure_adhoc_signed must not propagate errors");
-    }
 
     #[test]
     fn test_pre_clean_removes_readonly_output() {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -22,7 +22,10 @@ use std::path::PathBuf;
 use crate::link::LinkStrategy;
 
 pub mod cc;
+pub mod platform;
 pub mod rustc;
+
+pub use platform::Platform;
 
 pub use crate::compile::CompileResult;
 
@@ -212,7 +215,14 @@ pub fn plan_post_restore(kind: ArtifactKind) -> Vec<PostRestoreAction> {
 
 impl PostRestoreAction {
     /// Execute this action against a restored artifact at `path`.
-    pub fn apply(&self, path: &std::path::Path) -> Result<()> {
+    ///
+    /// `platform` is the host abstraction for OS-specific concerns
+    /// (codesigning today; debug-path rewriting and similar concerns
+    /// later). Passing it explicitly — rather than calling
+    /// `platform::current()` here — keeps tests deterministic: a unit
+    /// test can inject a counting / failing / no-op platform without
+    /// needing the real host to behave a particular way.
+    pub fn apply(&self, path: &std::path::Path, platform: &dyn Platform) -> Result<()> {
         match self {
             PostRestoreAction::ExpandDepInfoPaths => {
                 if let Ok(pwd) = std::env::current_dir() {
@@ -222,9 +232,10 @@ impl PostRestoreAction {
                 Ok(())
             }
             PostRestoreAction::Sign(SigningPurpose::OsLoading) => {
-                // verify-then-sign: skip mutation when ld64's signature
-                // is still valid. Closes kache-fork bug 59866c0.
-                crate::compile::ensure_adhoc_signed(path)
+                // Verify-then-sign lives inside the platform impl so
+                // the kache-fork bug 59866c0 (mutating already-valid
+                // signatures) can't be reintroduced from this site.
+                platform.ensure_binary_loadable(path)
             }
         }
     }
@@ -382,9 +393,16 @@ mod tests {
     // ── apply() ──────────────────────────────────────────────────
     //
     // Coverage for the action executor: ExpandDepInfoPaths uses
-    // link::rewrite_depinfo internally; Sign(OsLoading) uses
-    // compile::codesign_adhoc. Both must be safe on arbitrary inputs and
+    // link::rewrite_depinfo internally; Sign(OsLoading) routes through
+    // the injected Platform. Both must be safe on arbitrary inputs and
     // must not panic.
+
+    /// Convenience for tests that don't care which platform impl runs;
+    /// the actual codesign behavior is exercised in
+    /// `compiler::platform::tests` and on macOS arm64 in CI/locally.
+    fn test_platform() -> Box<dyn Platform> {
+        Box::new(crate::compiler::platform::LinuxPlatform)
+    }
 
     #[test]
     fn apply_expand_dep_info_paths_rewrites_relative_paths_to_absolute() {
@@ -399,7 +417,7 @@ mod tests {
         }
 
         PostRestoreAction::ExpandDepInfoPaths
-            .apply(&depfile)
+            .apply(&depfile, &*test_platform())
             .unwrap();
 
         let content = std::fs::read_to_string(&depfile).unwrap();
@@ -428,24 +446,44 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let nonexistent = dir.path().join("does-not-exist.d");
         PostRestoreAction::ExpandDepInfoPaths
-            .apply(&nonexistent)
+            .apply(&nonexistent, &*test_platform())
             .expect("apply must not error on a missing dep-info file");
     }
 
     #[test]
-    fn apply_sign_os_loading_does_not_error_on_arbitrary_path() {
-        // codesign_adhoc is a no-op on Linux/Windows and on x86_64 macOS;
-        // on arm64 macOS it shells out to `codesign` and logs (but does
-        // not error) when the file isn't signable. The wrapper relies on
-        // apply() returning Ok regardless so a malformed input doesn't
-        // tank the whole restore.
+    fn apply_sign_os_loading_routes_through_platform() {
+        // The dispatch contract: Sign(OsLoading) must hand off to the
+        // platform's ensure_binary_loadable, not re-implement codesign
+        // logic in-line. CountingPlatform proves the call happened
+        // exactly once per apply().
+        use crate::compiler::platform::tests::CountingPlatform;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("not-actually-a-binary");
         std::fs::write(&path, b"definitely not Mach-O").unwrap();
 
+        let platform = CountingPlatform::new();
         PostRestoreAction::Sign(SigningPurpose::OsLoading)
-            .apply(&path)
-            .expect("apply must not error even when codesign rejects the input");
+            .apply(&path, &platform)
+            .expect("apply must not error even when the platform impl is a no-op");
+        assert_eq!(
+            platform.ensure_calls(),
+            1,
+            "Sign(OsLoading) must dispatch to platform.ensure_binary_loadable exactly once"
+        );
+    }
+
+    #[test]
+    fn apply_expand_dep_info_paths_does_not_call_platform() {
+        // Confirms ExpandDepInfoPaths is purely filesystem work and
+        // doesn't accidentally route through the platform layer (which
+        // would be a code smell — depinfo rewriting is OS-agnostic).
+        use crate::compiler::platform::tests::CountingPlatform;
+        let dir = tempfile::tempdir().unwrap();
+        let depfile = dir.path().join("nope.d");
+
+        let platform = CountingPlatform::new();
+        let _ = PostRestoreAction::ExpandDepInfoPaths.apply(&depfile, &platform);
+        assert_eq!(platform.ensure_calls(), 0);
     }
 
     // ── classify → plan integration ──────────────────────────────

--- a/src/compiler/platform.rs
+++ b/src/compiler/platform.rs
@@ -94,6 +94,12 @@ pub fn current() -> Box<dyn Platform> {
 /// macOS implementation. Currently handles ad-hoc codesigning on
 /// arm64; other macOS variants (x86_64, future archs) fall through to
 /// no-op because their loaders don't enforce the same requirement.
+///
+/// `#[allow(dead_code)]` for the same reason as [`LinuxPlatform`] —
+/// on a Linux or Windows build, `current()` doesn't construct it but
+/// cross-platform unit tests do, and the symmetric availability lets
+/// any future test pin the macOS dispatch shape from any host.
+#[allow(dead_code)]
 pub struct MacOsPlatform;
 
 impl Platform for MacOsPlatform {

--- a/src/compiler/platform.rs
+++ b/src/compiler/platform.rs
@@ -1,0 +1,293 @@
+//! Platform abstraction for OS-specific behavior on cached artifacts.
+//!
+//! Today the only behavior that varies per platform on the cache hot
+//! path is **binary loadability**: macOS arm64 requires every executable
+//! and dynamic library to carry a valid ad-hoc signature, or `dyld`
+//! refuses to load it. Linux and Windows have no such requirement.
+//!
+//! Before this module, that lived behind `#[cfg(target_os = "macos")]`
+//! arms in [`crate::compile`]. The cfg approach has two costs:
+//!
+//! 1. **Untestable from the wrong host.** Linux developers couldn't
+//!    write a unit test that exercised the macOS code path because it
+//!    didn't compile. Bugs in the macOS path landed only when a macOS
+//!    runner happened to catch them.
+//! 2. **Open to duplication.** When the C-family wrapper lands real
+//!    caching, restored C/C++ executables need codesigning too. Without
+//!    a trait, the cc store path would re-implement the same `cfg` arm
+//!    — and the same bug class would be back.
+//!
+//! The trait isolates *what* needs to happen ("ensure this binary is
+//! loadable") from *how* the host accomplishes it. The cc store path
+//! gets codesign for free by routing through
+//! [`super::PostRestoreAction::Sign`], which dispatches via `Platform`.
+//!
+//! ## Future methods
+//!
+//! New trait methods land when their callers exist (no speculative
+//! interface bloat). Concrete cases on the roadmap:
+//!
+//! - `source_date_epoch() -> Option<u64>` — for the C/C++ preprocessor
+//!   cache key. Honored by gcc + clang; neutralizes `__DATE__` /
+//!   `__TIME__` macros.
+//! - `rewrite_debug_paths(path)` — to fix Mach-O OSO records on macOS
+//!   (kache-fork bug e3f64ec). Likely lands alongside the
+//!   `PathNormalizer` work where the compile-time vs post-restore
+//!   choice becomes well-defined.
+//! - `probe_compiler(path) -> CompilerInfo` — for cc cache keys to
+//!   know gcc-vs-clang-vs-MSVC.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+use std::process::Command;
+
+/// Platform-specific behavior the cache layer needs to apply to
+/// restored artifacts. One impl per OS; today only [`MacOsPlatform`]
+/// does non-trivial work.
+///
+/// The trait is `Send + Sync` so a single instance can be constructed
+/// at startup and shared across the wrapper's restore loops.
+pub trait Platform: Send + Sync {
+    /// Short identifier used in tracing output. Stable across versions
+    /// so log filters and dashboards can match on it.
+    fn name(&self) -> &'static str;
+
+    /// Apply a signature only if the existing one is missing or
+    /// invalid, so the OS will load this artifact.
+    ///
+    /// **Contract**: must be idempotent and must NOT mutate bytes when
+    /// an existing signature is already valid. The mutation cost is
+    /// real — re-signing changes the file's content hash, which
+    /// corrupts the cached blob's identity (kache-fork bug 59866c0).
+    /// Each impl is responsible for the verify-then-sign sequence;
+    /// callers do not guard.
+    ///
+    /// **Failure handling**: best-effort. A failed signature attempt
+    /// logs a warning and returns `Ok(())`; it must not abort the
+    /// wrapper's restore loop. Returning `Err` is reserved for
+    /// failures so structural that the next action would also fail
+    /// (e.g. the path doesn't exist).
+    fn ensure_binary_loadable(&self, path: &Path) -> Result<()>;
+}
+
+/// Detect the current host platform.
+///
+/// Returns a boxed trait object so callers don't carry a generic
+/// `Platform` parameter through every type. The dispatch cost is
+/// negligible relative to the work each method does (codesign shells
+/// out; the vtable lookup is in the noise).
+pub fn current() -> Box<dyn Platform> {
+    #[cfg(target_os = "macos")]
+    {
+        Box::new(MacOsPlatform)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        Box::new(LinuxPlatform)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        Box::new(WindowsPlatform)
+    }
+}
+
+/// macOS implementation. Currently handles ad-hoc codesigning on
+/// arm64; other macOS variants (x86_64, future archs) fall through to
+/// no-op because their loaders don't enforce the same requirement.
+pub struct MacOsPlatform;
+
+impl Platform for MacOsPlatform {
+    fn name(&self) -> &'static str {
+        "macos"
+    }
+
+    fn ensure_binary_loadable(&self, path: &Path) -> Result<()> {
+        // Compiled in on every host so unit tests can construct
+        // MacOsPlatform from Linux. The actual `codesign` invocation
+        // is gated below — a Linux test that calls into this method
+        // gets Ok(()) because the host check fails, no `codesign`
+        // process is spawned.
+        if std::env::consts::ARCH != "aarch64" {
+            return Ok(());
+        }
+        if std::env::consts::OS != "macos" {
+            return Ok(());
+        }
+
+        // verify-then-sign: skip mutation when ld64's signature is
+        // still valid. `codesign --verify --strict` exits 0 iff a
+        // structurally-valid signature is already present.
+        let verify = Command::new("codesign")
+            .args(["--verify", "--strict"])
+            .arg(path)
+            .status()
+            .context("running codesign --verify")?;
+
+        if verify.success() {
+            tracing::debug!(
+                "ad-hoc signature already valid for {}, skipping re-sign",
+                path.display()
+            );
+            return Ok(());
+        }
+
+        tracing::debug!(
+            "ad-hoc signature missing or invalid for {}, re-applying",
+            path.display()
+        );
+        let status = Command::new("codesign")
+            .args(["--sign", "-", "--force"])
+            .arg(path)
+            .status()
+            .context("running codesign --sign")?;
+
+        if !status.success() {
+            tracing::warn!("ad-hoc codesign failed for {}", path.display());
+        }
+        Ok(())
+    }
+}
+
+/// Linux implementation. The kernel doesn't enforce signatures on
+/// ELF binaries, so [`Platform::ensure_binary_loadable`] is a no-op.
+/// Lives as a concrete struct (not a unit `()`) so it can grow
+/// methods independently of the macOS impl when Linux-specific
+/// concerns appear.
+///
+/// `#[allow(dead_code)]` because cross-platform unit tests construct
+/// `LinuxPlatform` from a macOS host (and vice versa) to exercise the
+/// dispatch shape without spawning real `codesign` / `signtool`. On a
+/// non-Linux production build, no caller constructs it — but having
+/// the struct compile keeps the test surface symmetric.
+#[allow(dead_code)]
+pub struct LinuxPlatform;
+
+impl Platform for LinuxPlatform {
+    fn name(&self) -> &'static str {
+        "linux"
+    }
+
+    fn ensure_binary_loadable(&self, _path: &Path) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Windows implementation. Authenticode signing is not enforced for
+/// load-time loading of unsigned PE binaries (only for kernel-mode
+/// drivers and SmartScreen), so [`Platform::ensure_binary_loadable`]
+/// is a no-op. When PE/PDB-specific handling lands, it goes here.
+///
+/// See [`LinuxPlatform`] for the `#[allow(dead_code)]` rationale.
+#[allow(dead_code)]
+pub struct WindowsPlatform;
+
+impl Platform for WindowsPlatform {
+    fn name(&self) -> &'static str {
+        "windows"
+    }
+
+    fn ensure_binary_loadable(&self, _path: &Path) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Test double: counts calls to each method so dispatch tests can
+    /// assert the wrapper's restore loop routes through `Platform`
+    /// rather than re-implementing OS-specific behavior in-line.
+    pub struct CountingPlatform {
+        ensure_binary_loadable_calls: AtomicUsize,
+    }
+
+    impl CountingPlatform {
+        pub fn new() -> Self {
+            Self {
+                ensure_binary_loadable_calls: AtomicUsize::new(0),
+            }
+        }
+
+        pub fn ensure_calls(&self) -> usize {
+            self.ensure_binary_loadable_calls.load(Ordering::Relaxed)
+        }
+    }
+
+    impl Platform for CountingPlatform {
+        fn name(&self) -> &'static str {
+            "counting"
+        }
+        fn ensure_binary_loadable(&self, _path: &Path) -> Result<()> {
+            self.ensure_binary_loadable_calls
+                .fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn current_returns_a_platform_named_after_the_host() {
+        // Sanity: detection picks the right impl for this build target.
+        let platform = current();
+        let expected = if cfg!(target_os = "macos") {
+            "macos"
+        } else if cfg!(target_os = "linux") {
+            "linux"
+        } else if cfg!(target_os = "windows") {
+            "windows"
+        } else {
+            // The cfg cascade in `current` covers exactly these three.
+            // If this branch fires, `current` needs a new arm.
+            panic!("unsupported host OS in test")
+        };
+        assert_eq!(platform.name(), expected);
+    }
+
+    #[test]
+    fn linux_ensure_binary_loadable_is_noop_for_any_path() {
+        // Documents the contract: Linux impl never errors and never
+        // touches the file. Even nonexistent paths are fine because
+        // the loader concern doesn't exist on this OS.
+        let platform = LinuxPlatform;
+        platform
+            .ensure_binary_loadable(Path::new("/no/such/file"))
+            .unwrap();
+    }
+
+    #[test]
+    fn windows_ensure_binary_loadable_is_noop_for_any_path() {
+        let platform = WindowsPlatform;
+        platform
+            .ensure_binary_loadable(Path::new("/no/such/file"))
+            .unwrap();
+    }
+
+    #[test]
+    fn macos_ensure_binary_loadable_does_not_propagate_errors() {
+        // Two paths exercised by this single test depending on host:
+        //
+        // - Linux / Windows / x86_64 macOS: the impl bails on the host
+        //   check and returns Ok without spawning anything.
+        // - macOS arm64: the impl shells out to `codesign --verify`
+        //   (which fails on a missing file) and then `codesign --sign`
+        //   (which also fails); the contract is that both failures get
+        //   logged and the function still returns Ok, so a single
+        //   malformed input doesn't tank the wrapper's restore loop.
+        let platform = MacOsPlatform;
+        platform
+            .ensure_binary_loadable(Path::new("/no/such/file"))
+            .unwrap();
+    }
+
+    #[test]
+    fn counting_platform_records_ensure_calls() {
+        // Sanity for the test double itself; consumers in other tests
+        // rely on `ensure_calls()` returning truthful counts.
+        let platform = CountingPlatform::new();
+        assert_eq!(platform.ensure_calls(), 0);
+        platform.ensure_binary_loadable(Path::new("/x")).unwrap();
+        platform.ensure_binary_loadable(Path::new("/y")).unwrap();
+        assert_eq!(platform.ensure_calls(), 2);
+    }
+}

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -8,7 +8,7 @@ use crate::cache_key::FileHasher;
 use crate::compile;
 use crate::compiler::cc::CcCompiler;
 use crate::compiler::rustc::RustcCompiler;
-use crate::compiler::{Compiler, KeyCtx, plan_post_restore};
+use crate::compiler::{Compiler, KeyCtx, plan_post_restore, platform};
 use crate::config::Config;
 use crate::events::{self, BuildEvent, EventResult};
 use crate::link;
@@ -454,6 +454,18 @@ fn restore_from_cache(
         anyhow::bail!("no output path (-o) or output directory (--out-dir) in args");
     };
 
+    // One platform per restore, shared across every cached file. The
+    // detect call is cheap (cfg cascade) but doing it once keeps the
+    // tracing context coherent and lets a future per-restore override
+    // (e.g. cross-restore from a Linux cache to a macOS host) plug in
+    // at one site.
+    let platform = platform::current();
+    tracing::debug!(
+        "restoring {} files via platform={}",
+        meta.files.len(),
+        platform.name()
+    );
+
     for cached_file in &meta.files {
         // Resolve from blob store (content-addressed)
         let store_path = store.blob_path(&cached_file.hash);
@@ -506,7 +518,7 @@ fn restore_from_cache(
         // `PostRestoreAction` plus its arm in `apply` — the wrapper stays
         // unchanged.
         for action in plan_post_restore(kind) {
-            action.apply(&target_path)?;
+            action.apply(&target_path, &*platform)?;
         }
     }
 


### PR DESCRIPTION
## Summary

Extract macOS-specific behavior from `#[cfg(target_os = \"macos\")]` arms in `src/compile.rs` into a `Platform` trait under `src/compiler/platform.rs`. Three concrete impls (`MacOsPlatform`, `LinuxPlatform`, `WindowsPlatform`) — only `MacOsPlatform` does non-trivial work today (verify-then-sign via `codesign`).

`PostRestoreAction::apply` takes `&dyn Platform`. Wrapper constructs one via `platform::current()` per restore loop.

This is **PR2** in the architectural-prevention chain captured in [docs/plan.md](https://github.com/kunobi-ninja/kache/blob/main/docs/plan.md).

## Why a trait, not just `#[cfg]`

The cfg approach had two real costs:

1. **Untestable from the wrong host.** Linux devs couldn't write unit tests against the macOS code path. Bugs landed only when a macOS runner caught them.
2. **Open to duplication.** When the cc wrapper lands real caching (PR5), restored C/C++ executables need codesigning too. Without a trait, the cc store path would grow its own `#[cfg(macos)]` arm — reintroducing the same kache-fork bug class (572f321, 59866c0) the rustc path already structurally avoided.

With the trait:
- `MacOsPlatform` compiles on every host (host check inside the impl bails before spawning `codesign`)
- Dispatch is verified via `CountingPlatform` (test double) — proves `Sign(OsLoading)` routes through the trait, no real macOS runner needed
- C/C++ caching gets codesign for free by emitting the existing `Sign(OsLoading)` action

## Surface area kept minimal

Just `name()` + `ensure_binary_loadable()`. Future trait methods land when their callers exist (no speculative interface bloat). The module docs flag the roadmap: `source_date_epoch()` for cc cache keys, `rewrite_debug_paths()` for the OSO record bug class, `probe_compiler()` for cc family detection.

## Test plan

- [x] `cargo test --workspace` — 380+11+8+7+5 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] E2E harness against multi-dep on macOS arm64 (verifies real codesign dispatch through the trait): pass
- [ ] CI: Linux full suite + e2e harness (needs runner)
- [ ] Manual smoke: warm rebuild on macOS arm64 produces a runnable binary (codesign through `MacOsPlatform::ensure_binary_loadable` matches old behavior)