### PR TITLE
fix(cc): pass through the cc-crate compiler-family probe

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -67,7 +67,8 @@ impl RustcArgs {
         // Detect double-wrapper: if args[1] also looks like a compiler, this is
         // RUSTC_WRAPPER + RUSTC_WORKSPACE_WRAPPER. The inner path is the actual
         // rustc that the workspace wrapper (args[0]) expects as its first arg.
-        let (inner_rustc, rustc_args) = if args.len() >= 3 && RustcCompiler::recognizes(&args[1..]) {
+        let (inner_rustc, rustc_args) = if args.len() >= 3 && RustcCompiler::recognizes(&args[1..])
+        {
             (Some(PathBuf::from(&args[1])), &args[2..])
         } else {
             (None, &args[1..])

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, bail};
 use std::path::PathBuf;
 
-use crate::compiler::rustc::looks_like_rustc;
+use crate::compiler::rustc::RustcCompiler;
 
 /// Parsed rustc invocation arguments relevant to caching.
 #[derive(Debug, Clone)]
@@ -67,7 +67,7 @@ impl RustcArgs {
         // Detect double-wrapper: if args[1] also looks like a compiler, this is
         // RUSTC_WRAPPER + RUSTC_WORKSPACE_WRAPPER. The inner path is the actual
         // rustc that the workspace wrapper (args[0]) expects as its first arg.
-        let (inner_rustc, rustc_args) = if args.len() >= 3 && looks_like_rustc(&args[1]) {
+        let (inner_rustc, rustc_args) = if args.len() >= 3 && RustcCompiler::recognizes(&args[1..]) {
             (Some(PathBuf::from(&args[1])), &args[2..])
         } else {
             (None, &args[1..])

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -239,12 +239,12 @@ mod tests {
     fn recognizes_family_probe_rejects_non_probe_shapes() {
         // None of these should be misidentified as the cc crate's probe.
         for argv in [
-            vec![],              // empty
-            s(&["-c", "foo.c"]), // -c (compile, not probe)
-            s(&["--version"]),   // kache's own flag
-            s(&["-dumpmachine"]),// future probe shape, not yet
-            s(&["report"]),      // CLI subcommand
-            s(&["foo.c"]),       // bare file
+            vec![],               // empty
+            s(&["-c", "foo.c"]),  // -c (compile, not probe)
+            s(&["--version"]),    // kache's own flag
+            s(&["-dumpmachine"]), // future probe shape, not yet
+            s(&["report"]),       // CLI subcommand
+            s(&["foo.c"]),        // bare file
         ] {
             assert!(
                 !CcCompiler::recognizes_family_probe(&argv),

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -33,44 +33,6 @@ use super::{
     ArtifactKind, CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason, classify_by_filename,
 };
 
-/// Recognise the `cc` Rust crate's compiler-family probe shape:
-/// `kache -E <file>`. Documented in
-/// [`super::CompilerKind::CcProbe`] — the `cc` crate strips the
-/// trailing compiler arg from `CC="kache cc"` before probing, so
-/// without explicit passthrough kache would clap-error on argv[1] and
-/// the probe would silently fall back to a default family guess.
-///
-/// Match is intentionally tight (`-E` + at least one more arg). Other
-/// probe shapes (`-?`, `-dumpmachine`, `-dumpversion`) can land here
-/// when their absence becomes a real symptom — over-broad matching
-/// would mask legitimate CLI typos as compiler invocations.
-pub fn looks_like_cc_probe(args: &[String]) -> bool {
-    args.len() >= 2 && args[0] == "-E"
-}
-
-/// Recognise a C-family compiler invocation by argv[0].
-///
-/// Matches: `cc`, `gcc`, `g++`, `clang`, `clang++`, `c++`, plus version
-/// suffixes like `gcc-13`, `clang-15`. Path-prefixed forms
-/// (`/usr/bin/cc`) work via [`Path::file_name`].
-pub fn looks_like_cc(arg: &str) -> bool {
-    let path = Path::new(arg);
-    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-        return false;
-    };
-
-    // Exact matches for the canonical command names.
-    if matches!(name, "cc" | "c++" | "gcc" | "g++" | "clang" | "clang++") {
-        return true;
-    }
-
-    // Versioned variants: gcc-13, clang-15, g++-12, etc.
-    let stem = name.split('-').next().unwrap_or("");
-    matches!(stem, "cc" | "c++" | "gcc" | "g++" | "clang" | "clang++")
-        && name.len() > stem.len()
-        && name.as_bytes()[stem.len()] == b'-'
-}
-
 /// Parsed C-family invocation. Skeleton stores only what's needed to
 /// re-execute the compiler verbatim — real arg classification (preprocessor
 /// vs common vs unhashed vs refuse) lands in a follow-up.
@@ -100,6 +62,61 @@ pub struct CcCompiler;
 impl CcCompiler {
     pub fn new() -> Self {
         Self
+    }
+
+    /// Does this argv invoke a C-family compiler?
+    ///
+    /// Matches `cc`, `c++`, `gcc`, `g++`, `clang`, `clang++` and
+    /// versioned variants (`gcc-13`, `clang++-17`). Path-prefixed
+    /// forms (`/usr/bin/cc`) work via [`Path::file_name`].
+    ///
+    /// Owns its own detection rule so `super::detect_compiler` is a
+    /// thin delegating dispatch rather than a central registry of
+    /// "what's a compiler" knowledge.
+    pub fn recognizes(args: &[String]) -> bool {
+        let Some(arg0) = args.first() else {
+            return false;
+        };
+        let path = Path::new(arg0);
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            return false;
+        };
+
+        // Exact matches for the canonical command names.
+        if matches!(name, "cc" | "c++" | "gcc" | "g++" | "clang" | "clang++") {
+            return true;
+        }
+
+        // Versioned variants: gcc-13, clang-15, g++-12, etc.
+        let stem = name.split('-').next().unwrap_or("");
+        matches!(stem, "cc" | "c++" | "gcc" | "g++" | "clang" | "clang++")
+            && name.len() > stem.len()
+            && name.as_bytes()[stem.len()] == b'-'
+    }
+
+    /// Does this argv match the `cc` Rust crate's compiler-family
+    /// probe shape, `kache -E <file>`?
+    ///
+    /// The cc crate uses this probe to detect compiler family
+    /// (gcc / clang / MSVC) by reading `__VERSION__` from preprocessor
+    /// output. It hardcodes `Command::new(program).arg("-E").arg(file)`,
+    /// dropping any trailing args from `CC="kache cc"` — so without
+    /// explicit passthrough kache would clap-error and the probe
+    /// would silently fall back to a default family guess. Today
+    /// that's a logged warning; once C/C++ caching lands and family
+    /// identifies the cache key, it becomes silent miscaching across
+    /// machines.
+    ///
+    /// Match is intentionally tight (`-E` + at least one more arg).
+    /// Other probe shapes (`-?`, `-dumpmachine`, `-dumpversion`) can
+    /// land here when their absence becomes a real symptom —
+    /// over-broad matching would mask legitimate CLI typos.
+    ///
+    /// **Not a [`CompilerKind`].** A probe is a non-compiler invocation
+    /// pattern that happens to need passthrough. The dispatch in
+    /// `run_wrapper_mode` checks this *before* the compiler match.
+    pub fn recognizes_family_probe(args: &[String]) -> bool {
+        args.len() >= 2 && args[0] == "-E"
     }
 }
 
@@ -167,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    fn looks_like_cc_matches_canonical_command_names() {
+    fn recognizes_canonical_command_names() {
         for name in [
             "cc",
             "c++",
@@ -179,56 +196,65 @@ mod tests {
             "/usr/bin/gcc",
             "/usr/local/bin/clang++",
         ] {
-            assert!(looks_like_cc(name), "should recognize {name}");
+            assert!(
+                CcCompiler::recognizes(&s(&[name])),
+                "should recognize {name}"
+            );
         }
     }
 
     #[test]
-    fn looks_like_cc_matches_versioned_variants() {
+    fn recognizes_versioned_variants() {
         for name in ["gcc-13", "clang-15", "g++-12", "clang++-17"] {
-            assert!(looks_like_cc(name), "should recognize versioned {name}");
+            assert!(
+                CcCompiler::recognizes(&s(&[name])),
+                "should recognize versioned {name}"
+            );
         }
     }
 
     #[test]
-    fn looks_like_cc_probe_matches_dash_e_with_file_arg() {
+    fn recognizes_family_probe_matches_dash_e_with_file_arg() {
         // Exact shape the cc crate emits during compiler-family probe.
         // Pinning this by example keeps the contract obvious: argv[0]=="-E"
         // plus at least one more arg (the temp file).
-        assert!(looks_like_cc_probe(&s(&["-E", "/tmp/probe.c"])));
-        assert!(looks_like_cc_probe(&s(&[
+        assert!(CcCompiler::recognizes_family_probe(&s(&[
+            "-E",
+            "/tmp/probe.c"
+        ])));
+        assert!(CcCompiler::recognizes_family_probe(&s(&[
             "-E",
             "/tmp/detect_compiler_family.c"
         ])));
     }
 
     #[test]
-    fn looks_like_cc_probe_rejects_dash_e_alone() {
+    fn recognizes_family_probe_rejects_dash_e_alone() {
         // Without a file arg, `-E` is just a flag; not a probe. Tight
         // match prevents masking legitimate clap-errors.
-        assert!(!looks_like_cc_probe(&s(&["-E"])));
+        assert!(!CcCompiler::recognizes_family_probe(&s(&["-E"])));
     }
 
     #[test]
-    fn looks_like_cc_probe_rejects_non_probe_shapes() {
+    fn recognizes_family_probe_rejects_non_probe_shapes() {
         // None of these should be misidentified as the cc crate's probe.
         for argv in [
-            vec![],                     // empty
-            s(&["-c", "foo.c"]),        // -c (compile, not probe)
-            s(&["--version"]),          // kache's own flag
-            s(&["-dumpmachine"]),       // future probe shape, not yet
-            s(&["report"]),             // CLI subcommand
-            s(&["foo.c"]),              // bare file
+            vec![],              // empty
+            s(&["-c", "foo.c"]), // -c (compile, not probe)
+            s(&["--version"]),   // kache's own flag
+            s(&["-dumpmachine"]),// future probe shape, not yet
+            s(&["report"]),      // CLI subcommand
+            s(&["foo.c"]),       // bare file
         ] {
             assert!(
-                !looks_like_cc_probe(&argv),
+                !CcCompiler::recognizes_family_probe(&argv),
                 "should NOT recognize {argv:?} as cc-probe"
             );
         }
     }
 
     #[test]
-    fn looks_like_cc_rejects_non_c_compilers() {
+    fn recognizes_rejects_non_c_compilers() {
         for name in [
             "rustc",
             "ld",
@@ -238,8 +264,13 @@ mod tests {
             "ccache",
             "--crate-name",
         ] {
-            assert!(!looks_like_cc(name), "should NOT recognize {name}");
+            assert!(
+                !CcCompiler::recognizes(&s(&[name])),
+                "should NOT recognize {name}"
+            );
         }
+        // Empty argv: there is nothing to recognize.
+        assert!(!CcCompiler::recognizes(&[]));
     }
 
     #[test]

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -33,6 +33,21 @@ use super::{
     ArtifactKind, CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason, classify_by_filename,
 };
 
+/// Recognise the `cc` Rust crate's compiler-family probe shape:
+/// `kache -E <file>`. Documented in
+/// [`super::CompilerKind::CcProbe`] — the `cc` crate strips the
+/// trailing compiler arg from `CC="kache cc"` before probing, so
+/// without explicit passthrough kache would clap-error on argv[1] and
+/// the probe would silently fall back to a default family guess.
+///
+/// Match is intentionally tight (`-E` + at least one more arg). Other
+/// probe shapes (`-?`, `-dumpmachine`, `-dumpversion`) can land here
+/// when their absence becomes a real symptom — over-broad matching
+/// would mask legitimate CLI typos as compiler invocations.
+pub fn looks_like_cc_probe(args: &[String]) -> bool {
+    args.len() >= 2 && args[0] == "-E"
+}
+
 /// Recognise a C-family compiler invocation by argv[0].
 ///
 /// Matches: `cc`, `gcc`, `g++`, `clang`, `clang++`, `c++`, plus version
@@ -172,6 +187,43 @@ mod tests {
     fn looks_like_cc_matches_versioned_variants() {
         for name in ["gcc-13", "clang-15", "g++-12", "clang++-17"] {
             assert!(looks_like_cc(name), "should recognize versioned {name}");
+        }
+    }
+
+    #[test]
+    fn looks_like_cc_probe_matches_dash_e_with_file_arg() {
+        // Exact shape the cc crate emits during compiler-family probe.
+        // Pinning this by example keeps the contract obvious: argv[0]=="-E"
+        // plus at least one more arg (the temp file).
+        assert!(looks_like_cc_probe(&s(&["-E", "/tmp/probe.c"])));
+        assert!(looks_like_cc_probe(&s(&[
+            "-E",
+            "/tmp/detect_compiler_family.c"
+        ])));
+    }
+
+    #[test]
+    fn looks_like_cc_probe_rejects_dash_e_alone() {
+        // Without a file arg, `-E` is just a flag; not a probe. Tight
+        // match prevents masking legitimate clap-errors.
+        assert!(!looks_like_cc_probe(&s(&["-E"])));
+    }
+
+    #[test]
+    fn looks_like_cc_probe_rejects_non_probe_shapes() {
+        // None of these should be misidentified as the cc crate's probe.
+        for argv in [
+            vec![],                     // empty
+            s(&["-c", "foo.c"]),        // -c (compile, not probe)
+            s(&["--version"]),          // kache's own flag
+            s(&["-dumpmachine"]),       // future probe shape, not yet
+            s(&["report"]),             // CLI subcommand
+            s(&["foo.c"]),              // bare file
+        ] {
+            assert!(
+                !looks_like_cc_probe(&argv),
+                "should NOT recognize {argv:?} as cc-probe"
+            );
         }
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -38,18 +38,13 @@ pub enum CompilerKind {
     /// clang vs apple-clang vs MSVC) become relevant when arg parsing
     /// lands and matter per-impl, not at the dispatch layer.
     Cc,
-    /// A C-family compiler-family probe — specifically the `cc` Rust
-    /// crate's `kache -E <file>` invocation. The `cc` crate uses this
-    /// to detect compiler family (gcc / clang / MSVC) by reading
-    /// `__VERSION__` etc. from preprocessor output. It hardcodes
-    /// `Command::new(program).arg("-E").arg(file)`, dropping any
-    /// trailing args from `CC="kache cc"` — so without explicit
-    /// passthrough kache clap-errors and the probe falls back to a
-    /// default family assumption. Today that's a logged warning;
-    /// once C/C++ caching lands and family identifies the cache key,
-    /// it becomes silent miscaching across machines.
-    CcProbe,
-    // Future: Msvc (different argv shape, separate variant)
+    // Future: Msvc (different argv shape, separate variant).
+    //
+    // Compiler-family *probes* (e.g. `kache -E <file>`) are NOT a
+    // compiler kind — they're a non-compiler invocation pattern that
+    // happens to need passthrough. Detected separately via
+    // `cc::looks_like_cc_probe` and dispatched in `run_wrapper_mode`
+    // before the compiler match.
 }
 
 /// Reason an invocation cannot be cached. Empty list = cacheable.
@@ -291,7 +286,8 @@ pub trait Compiler {
 
 /// Detect which compiler family an argv vector is invoking.
 /// Returns `None` if no supported compiler matches — caller should fall
-/// through to direct execution.
+/// through to direct execution (or to compiler-family probe handling
+/// via [`cc::looks_like_cc_probe`], which is its own concern).
 pub fn detect_compiler(args: &[String]) -> Option<CompilerKind> {
     if args.is_empty() {
         return None;
@@ -301,9 +297,6 @@ pub fn detect_compiler(args: &[String]) -> Option<CompilerKind> {
     }
     if cc::looks_like_cc(&args[0]) {
         return Some(CompilerKind::Cc);
-    }
-    if cc::looks_like_cc_probe(args) {
-        return Some(CompilerKind::CcProbe);
     }
     None
 }
@@ -346,19 +339,17 @@ mod tests {
     }
 
     #[test]
-    fn detect_compiler_recognizes_cc_probe() {
-        // The shape kache sees when the `cc` Rust crate runs
-        // `Command::new(program).arg("-E").arg(tmp.path())` after
-        // dropping the trailing `cc` from CC="kache cc". Routing this
-        // through CcProbe → wrapper::run_cc_probe is what keeps the
-        // probe answering with the real underlying compiler family.
-        assert_eq!(
-            detect_compiler(&s(&["-E", "/tmp/probe.c"])),
-            Some(CompilerKind::CcProbe)
-        );
+    fn detect_compiler_returns_none_for_cc_probe_shape() {
+        // The cc-crate compiler-family probe (`kache -E <file>`) is
+        // intentionally NOT a CompilerKind — it's a non-compiler
+        // invocation pattern handled separately in run_wrapper_mode
+        // via `cc::looks_like_cc_probe`. Asserting None here pins
+        // that boundary: detect_compiler must not grow into a
+        // grab-bag of "anything kache should passthrough".
+        assert_eq!(detect_compiler(&s(&["-E", "/tmp/probe.c"])), None);
         assert_eq!(
             detect_compiler(&s(&["-E", "/tmp/detect_compiler_family.c"])),
-            Some(CompilerKind::CcProbe)
+            None
         );
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -38,6 +38,17 @@ pub enum CompilerKind {
     /// clang vs apple-clang vs MSVC) become relevant when arg parsing
     /// lands and matter per-impl, not at the dispatch layer.
     Cc,
+    /// A C-family compiler-family probe — specifically the `cc` Rust
+    /// crate's `kache -E <file>` invocation. The `cc` crate uses this
+    /// to detect compiler family (gcc / clang / MSVC) by reading
+    /// `__VERSION__` etc. from preprocessor output. It hardcodes
+    /// `Command::new(program).arg("-E").arg(file)`, dropping any
+    /// trailing args from `CC="kache cc"` — so without explicit
+    /// passthrough kache clap-errors and the probe falls back to a
+    /// default family assumption. Today that's a logged warning;
+    /// once C/C++ caching lands and family identifies the cache key,
+    /// it becomes silent miscaching across machines.
+    CcProbe,
     // Future: Msvc (different argv shape, separate variant)
 }
 
@@ -291,6 +302,9 @@ pub fn detect_compiler(args: &[String]) -> Option<CompilerKind> {
     if cc::looks_like_cc(&args[0]) {
         return Some(CompilerKind::Cc);
     }
+    if cc::looks_like_cc_probe(args) {
+        return Some(CompilerKind::CcProbe);
+    }
     None
 }
 
@@ -328,6 +342,23 @@ mod tests {
         assert_eq!(
             detect_compiler(&s(&["/usr/bin/cc", "-c", "foo.c"])),
             Some(CompilerKind::Cc)
+        );
+    }
+
+    #[test]
+    fn detect_compiler_recognizes_cc_probe() {
+        // The shape kache sees when the `cc` Rust crate runs
+        // `Command::new(program).arg("-E").arg(tmp.path())` after
+        // dropping the trailing `cc` from CC="kache cc". Routing this
+        // through CcProbe → wrapper::run_cc_probe is what keeps the
+        // probe answering with the real underlying compiler family.
+        assert_eq!(
+            detect_compiler(&s(&["-E", "/tmp/probe.c"])),
+            Some(CompilerKind::CcProbe)
+        );
+        assert_eq!(
+            detect_compiler(&s(&["-E", "/tmp/detect_compiler_family.c"])),
+            Some(CompilerKind::CcProbe)
         );
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -43,8 +43,8 @@ pub enum CompilerKind {
     // Compiler-family *probes* (e.g. `kache -E <file>`) are NOT a
     // compiler kind — they're a non-compiler invocation pattern that
     // happens to need passthrough. Detected separately via
-    // `cc::looks_like_cc_probe` and dispatched in `run_wrapper_mode`
-    // before the compiler match.
+    // `CcCompiler::recognizes_family_probe` and dispatched in
+    // `run_wrapper_mode` before the compiler match.
 }
 
 /// Reason an invocation cannot be cached. Empty list = cacheable.
@@ -285,17 +285,21 @@ pub trait Compiler {
 }
 
 /// Detect which compiler family an argv vector is invoking.
-/// Returns `None` if no supported compiler matches — caller should fall
-/// through to direct execution (or to compiler-family probe handling
-/// via [`cc::looks_like_cc_probe`], which is its own concern).
+///
+/// Each compiler impl owns its own `recognizes` rule; this function is
+/// just the dispatch table. Adding a new compiler family means adding
+/// a new `CompilerKind` variant + its impl + one arm here — no central
+/// "registry of recognizers" to keep in sync.
+///
+/// Returns `None` if no supported compiler matches — caller should
+/// fall through to direct execution (or to compiler-family probe
+/// handling via [`cc::CcCompiler::recognizes_family_probe`], which is
+/// its own concern, not a compiler kind).
 pub fn detect_compiler(args: &[String]) -> Option<CompilerKind> {
-    if args.is_empty() {
-        return None;
-    }
-    if rustc::looks_like_rustc(&args[0]) {
+    if rustc::RustcCompiler::recognizes(args) {
         return Some(CompilerKind::Rustc);
     }
-    if cc::looks_like_cc(&args[0]) {
+    if cc::CcCompiler::recognizes(args) {
         return Some(CompilerKind::Cc);
     }
     None
@@ -343,9 +347,9 @@ mod tests {
         // The cc-crate compiler-family probe (`kache -E <file>`) is
         // intentionally NOT a CompilerKind — it's a non-compiler
         // invocation pattern handled separately in run_wrapper_mode
-        // via `cc::looks_like_cc_probe`. Asserting None here pins
-        // that boundary: detect_compiler must not grow into a
-        // grab-bag of "anything kache should passthrough".
+        // via `CcCompiler::recognizes_family_probe`. Asserting None
+        // here pins that boundary: detect_compiler must not grow into
+        // a grab-bag of "anything kache should passthrough".
         assert_eq!(detect_compiler(&s(&["-E", "/tmp/probe.c"])), None);
         assert_eq!(
             detect_compiler(&s(&["-E", "/tmp/detect_compiler_family.c"])),

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -37,26 +37,37 @@ pub fn classify_crate_type(crate_type: &str) -> ArtifactKind {
     }
 }
 
-/// Check if an argv element looks like an invocation of rustc (or
-/// clippy-driver, which wraps rustc). Used by [`super::detect_compiler`] to
-/// route argv into the rustc dispatch path.
-pub fn looks_like_rustc(arg: &str) -> bool {
-    let path = Path::new(arg);
-    match path.file_name() {
-        Some(name) => {
-            let name = name.to_string_lossy();
-            name == "rustc" || name.starts_with("rustc") || name == "clippy-driver"
-        }
-        None => false,
-    }
-}
-
 #[derive(Default)]
 pub struct RustcCompiler;
 
 impl RustcCompiler {
     pub fn new() -> Self {
         Self
+    }
+
+    /// Does this argv invoke rustc (or clippy-driver, which wraps it)?
+    ///
+    /// Owns its own detection rule — `super::detect_compiler` delegates
+    /// here so a future Msvc / etc. compiler doesn't require editing a
+    /// central registry: it just adds its own `recognizes` and one new
+    /// arm in `detect_compiler`. The arm is forced by the compile
+    /// error on adding a `CompilerKind` variant, not by remembering to
+    /// update an opaque list.
+    ///
+    /// Inspects only `argv[0]`. Path-prefixed forms (`/usr/bin/rustc`)
+    /// work via [`Path::file_name`].
+    pub fn recognizes(args: &[String]) -> bool {
+        let Some(arg0) = args.first() else {
+            return false;
+        };
+        let path = Path::new(arg0);
+        match path.file_name() {
+            Some(name) => {
+                let name = name.to_string_lossy();
+                name == "rustc" || name.starts_with("rustc") || name == "clippy-driver"
+            }
+            None => false,
+        }
     }
 }
 
@@ -130,16 +141,20 @@ mod tests {
     }
 
     #[test]
-    fn looks_like_rustc_matches_rustc_and_clippy_driver() {
-        assert!(looks_like_rustc("rustc"));
-        assert!(looks_like_rustc("/usr/bin/rustc"));
-        assert!(looks_like_rustc(
+    fn recognizes_rustc_and_clippy_driver() {
+        assert!(RustcCompiler::recognizes(&s(&["rustc"])));
+        assert!(RustcCompiler::recognizes(&s(&["/usr/bin/rustc"])));
+        assert!(RustcCompiler::recognizes(&s(&[
             "/home/user/.rustup/toolchains/stable/bin/rustc"
-        ));
-        assert!(looks_like_rustc("clippy-driver"));
-        assert!(looks_like_rustc("/path/to/bin/clippy-driver"));
-        assert!(!looks_like_rustc("gcc"));
-        assert!(!looks_like_rustc("--crate-name"));
+        ])));
+        assert!(RustcCompiler::recognizes(&s(&["clippy-driver"])));
+        assert!(RustcCompiler::recognizes(&s(&[
+            "/path/to/bin/clippy-driver"
+        ])));
+        assert!(!RustcCompiler::recognizes(&s(&["gcc"])));
+        assert!(!RustcCompiler::recognizes(&s(&["--crate-name"])));
+        // Empty argv: there is nothing to recognize.
+        assert!(!RustcCompiler::recognizes(&[]));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,8 +256,15 @@ enum LogMode {
 }
 
 fn detect_log_mode(env_args: &[String]) -> LogMode {
-    if env_args.len() >= 2 && compiler::detect_compiler(&env_args[1..]).is_some() {
-        return LogMode::Wrapper;
+    if env_args.len() >= 2 {
+        let after = &env_args[1..];
+        // Real compiler invocation (rustc / cc-family) OR a cc-crate
+        // family probe (`kache -E <file>`). Both want wrapper-mode
+        // logging (off by default — cargo would otherwise cache the
+        // stderr as a stale compiler diagnostic).
+        if compiler::detect_compiler(after).is_some() || compiler::cc::looks_like_cc_probe(after) {
+            return LogMode::Wrapper;
+        }
     }
 
     match env_args.get(1).map(String::as_str) {
@@ -477,13 +484,24 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
         std::process::exit(status.code().unwrap_or(1));
     }
 
+    // Compiler-family probe (`kache -E <file>` from the `cc` Rust
+    // crate) — handled before compiler dispatch because it is NOT a
+    // compiler invocation: it's a passthrough to the system default
+    // `cc` so the cc crate sees the real underlying compiler's
+    // preprocessor output. Keeping this branch separate from the
+    // compiler match keeps `CompilerKind` semantically clean
+    // ("which compiler family is this?", not "which kind of thing
+    // should kache do?").
+    if compiler::cc::looks_like_cc_probe(args) {
+        std::process::exit(wrapper::run_cc_probe(args)?);
+    }
+
     // Dispatch by detected compiler kind. detect_log_mode already verified
     // there's a recognized compiler at args[0], so the None branch is just
     // defensive (matches detect_compiler's contract).
     let exit_code = match compiler::detect_compiler(args) {
         Some(compiler::CompilerKind::Rustc) => wrapper::run(&config, args)?,
         Some(compiler::CompilerKind::Cc) => wrapper::run_cc(&config, args)?,
-        Some(compiler::CompilerKind::CcProbe) => wrapper::run_cc_probe(args)?,
         None => anyhow::bail!(
             "wrapper-mode dispatched but no compiler matched argv[0] = {:?}",
             args.first()

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,6 +483,7 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
     let exit_code = match compiler::detect_compiler(args) {
         Some(compiler::CompilerKind::Rustc) => wrapper::run(&config, args)?,
         Some(compiler::CompilerKind::Cc) => wrapper::run_cc(&config, args)?,
+        Some(compiler::CompilerKind::CcProbe) => wrapper::run_cc_probe(args)?,
         None => anyhow::bail!(
             "wrapper-mode dispatched but no compiler matched argv[0] = {:?}",
             args.first()

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,9 @@ fn detect_log_mode(env_args: &[String]) -> LogMode {
         // family probe (`kache -E <file>`). Both want wrapper-mode
         // logging (off by default — cargo would otherwise cache the
         // stderr as a stale compiler diagnostic).
-        if compiler::detect_compiler(after).is_some() || compiler::cc::looks_like_cc_probe(after) {
+        if compiler::detect_compiler(after).is_some()
+            || compiler::cc::CcCompiler::recognizes_family_probe(after)
+        {
             return LogMode::Wrapper;
         }
     }
@@ -492,7 +494,7 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
     // compiler match keeps `CompilerKind` semantically clean
     // ("which compiler family is this?", not "which kind of thing
     // should kache do?").
-    if compiler::cc::looks_like_cc_probe(args) {
+    if compiler::cc::CcCompiler::recognizes_family_probe(args) {
         std::process::exit(wrapper::run_cc_probe(args)?);
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -60,6 +60,36 @@ fn print_progress(crate_name: &str, result: EventResult, elapsed_ms: u64, size: 
     eprintln!("[kache] {crate_name}: {label} ({elapsed_str}{size_str})");
 }
 
+/// Forward a `cc`-crate compiler-family probe (`kache -E <file>`) to
+/// the system default `cc`.
+///
+/// **Why this exists.** When `CC="kache cc"`, the `cc` Rust crate
+/// detects compiler family by running `Command::new(program).arg("-E").
+/// arg(tmp.path())` — and `program` is just the first whitespace-split
+/// component (`kache`), with the trailing `cc` arg dropped. So kache
+/// gets called with argv that starts with a flag, not a recognized
+/// compiler. Without this passthrough, kache clap-errors and the cc
+/// crate falls back to a default family guess. That's a logged warning
+/// today; once C/C++ caching lands and family identifies the cache
+/// key, it becomes silent miscaching across machines.
+///
+/// **Why we use system `cc`.** The probe is family-detection — the
+/// answer the cc crate wants is whatever the underlying compiler would
+/// say. Forwarding to `cc` from PATH gets the right answer on every
+/// unix host. If `cc` isn't on PATH, the spawn returns an error and
+/// the probe still fails — same end state as today, no regression.
+///
+/// stdout / stderr inherit so the cc crate reads the preprocessor
+/// output verbatim. Exit code propagates so a real probe failure
+/// (missing system cc, malformed probe file) still surfaces.
+pub fn run_cc_probe(args: &[String]) -> Result<i32> {
+    let status = std::process::Command::new("cc")
+        .args(args)
+        .status()
+        .context("spawning system `cc` to forward cc-crate compiler-family probe")?;
+    Ok(status.code().unwrap_or(1))
+}
+
 /// Run kache as a C-family compiler wrapper (`CC=kache cc`,
 /// `CXX=kache c++`, etc.).
 ///


### PR DESCRIPTION
## Summary

When \`CC=\"kache cc\"\`, the [cc Rust crate](https://docs.rs/cc/latest/cc/) probes for compiler family by running \`Command::new(program).arg(\"-E\").arg(tmp.path())\` — and \`program\` is just the first whitespace-split token (\`kache\`), with the trailing \`cc\` arg dropped before the probe. Without explicit handling, kache clap-errors on \`argv[1]=-E\`, the probe fails, and the cc crate falls back to a default family assumption.

Today: logged warning per build.rs (\`Compiler family detection failed\`) + degraded family detection. Once C/C++ caching lands and compiler family becomes part of the cache key, this becomes **silent miscaching across machines** (clang host produces entries that a gcc host happily restores).

## Approach

- New \`CompilerKind::CcProbe\` variant; \`detect_compiler\` recognizes the \`-E <file>\` argv shape via \`compiler::cc::looks_like_cc_probe\`.
- New \`wrapper::run_cc_probe\` forwards to \`cc\` from PATH, inheriting stdout/stderr/exit. The cc crate reads the underlying compiler's preprocessor output verbatim and identifies the right family.
- \`run_wrapper_mode\` dispatches the new variant alongside \`Rustc\` / \`Cc\`.

The probe matcher is intentionally tight (\`-E\` + at least one more arg). Other shapes (\`-?\`, \`-dumpmachine\`, \`-dumpversion\`) can land when their absence becomes a real symptom — over-broad matching would mask legitimate CLI typos as compiler invocations.

## Test plan

- [x] 6 new unit tests covering \`looks_like_cc_probe\` shape, \`detect_compiler\` arm
- [x] Manual reproduction: \`./target/release/kache -E /tmp/probe.c\` now exits 0 with real preprocessor output (was: \`exit 2\`, clap-error)
- [x] e2e harness against \`test-projects/rust-c-ffi\` no longer emits the \`Compiler family detection failed\` warning
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [ ] CI Linux: e2e harness + lint