### PR TITLE
test(e2e): binary-content inspection in [verify] (forbidden_substrings)

### DIFF
--- a/crates/kache-e2e/src/fixture.rs
+++ b/crates/kache-e2e/src/fixture.rs
@@ -66,6 +66,16 @@ pub struct Commands {
 /// Runs after every successful `build` step. The contract: spawn `run`,
 /// wait up to `timeout_s`, assert `expected_exit_code` and that every
 /// string in `expected_stdout_contains` appears in stdout.
+///
+/// Optionally inspects the binary file's bytes (via `strings`) for
+/// substrings that must NOT appear — a defense-in-depth check that
+/// catches output-byte path leaks. Without this, the harness only
+/// sees runtime behavior, so a binary embedding the wrong path
+/// passes verify whenever the path happens to still resolve at
+/// runtime (e.g. cold/warm/noop populated it). With it, a leak in
+/// `--remap-path-prefix` injection (or any future regression that
+/// embeds machine-local paths in DWARF / panic strings / track_caller)
+/// surfaces structurally.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Verify {
     /// Shell command (relative paths resolve against fixture dir).
@@ -76,6 +86,14 @@ pub struct Verify {
     pub expected_stdout_contains: Vec<String>,
     #[serde(default = "default_verify_timeout")]
     pub timeout_s: u64,
+    /// Optional binary-content inspection. The harness reads the
+    /// artifact at [`Verify::run`] (the executable path) via
+    /// `strings`, then checks that NONE of these substrings appear.
+    /// Use to assert "no machine-local paths leaked into this
+    /// binary's debug info" (e.g. `["/Users/", "/home/", "/private/tmp/"]`).
+    /// Empty / unset = skip the check entirely.
+    #[serde(default)]
+    pub forbidden_substrings: Vec<String>,
 }
 
 fn default_verify_timeout() -> u64 {

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -490,10 +490,92 @@ fn run_verify(spec: &Verify, fixture: &Fixture, cwd: &Path, cache_dir: &Path) ->
         }
     }
 
+    // Optional binary-content inspection: read the artifact via
+    // `strings` and grep for substrings that must NOT appear. Catches
+    // output-byte path leaks the runtime check can't see (e.g. a
+    // path embedded in DWARF that happens to still resolve at the
+    // restored location). `strings` is on every macOS / Linux dev
+    // box (part of binutils); on Windows we'd use `dumpbin` (out of
+    // scope until Windows e2e — see #77).
+    if let Some(reason) = inspect_binary(&spec.run, cwd, &spec.forbidden_substrings) {
+        return VerifyResult {
+            exit_code,
+            stdout,
+            passed: false,
+            failure_reason: Some(reason),
+        };
+    }
+
     VerifyResult {
         exit_code,
         stdout,
         passed: true,
         failure_reason: None,
     }
+}
+
+/// Read the binary at `run_cmd` (which is the verify command — its
+/// first whitespace-separated token is the executable path) via
+/// `strings`, return `Some(reason)` if any forbidden substring is
+/// found, `None` otherwise.
+///
+/// Empty `forbidden` list = no inspection. Failure to spawn `strings`
+/// or read its output is treated as "skip" not "fail" — the inspection
+/// is best-effort defense-in-depth, not a load-bearing check. The
+/// metric assertions and the runtime verify already exist; this just
+/// adds another lens on top.
+fn inspect_binary(run_cmd: &str, cwd: &Path, forbidden: &[String]) -> Option<String> {
+    if forbidden.is_empty() {
+        return None;
+    }
+    // The verify command can be a full shell expression; the binary
+    // path is the first token. Splitting on whitespace handles the
+    // common case (`./target/release/foo` or `./build/foo`); fixtures
+    // with more exotic verify commands can opt out by leaving
+    // `forbidden_substrings` empty.
+    let bin_token = run_cmd.split_whitespace().next()?;
+    let bin_path = if bin_token.starts_with('/') {
+        std::path::PathBuf::from(bin_token)
+    } else {
+        cwd.join(bin_token)
+    };
+    if !bin_path.exists() {
+        // Defensive — if the verify command has already failed at
+        // the spawn step, we wouldn't be here. So a missing binary
+        // is more likely a fixture misconfig.
+        return Some(format!(
+            "binary inspection: artifact not found at `{}`",
+            bin_path.display()
+        ));
+    }
+
+    let strings_output = Command::new("strings")
+        .arg(&bin_path)
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !strings_output.status.success() {
+        // Couldn't run `strings` — skip silently. CI on a host
+        // without binutils will see this as "no inspection ran",
+        // which is OK; the test still has its other assertions.
+        return None;
+    }
+    let bytes = strings_output.stdout;
+    let haystack = String::from_utf8_lossy(&bytes);
+    for needle in forbidden {
+        if haystack.contains(needle.as_str()) {
+            // Show a small window around the first hit for diagnostic
+            // value (which file / construct exposed the leak).
+            let idx = haystack.find(needle.as_str()).unwrap_or(0);
+            let start = idx.saturating_sub(40);
+            let end = (idx + needle.len() + 80).min(haystack.len());
+            return Some(format!(
+                "binary contains forbidden substring `{}` in {}: ...{}...",
+                needle,
+                bin_path.display(),
+                &haystack[start..end].replace('\n', " ")
+            ));
+        }
+    }
+    None
 }

--- a/test-projects/multi-dep/kache-fixture.toml
+++ b/test-projects/multi-dep/kache-fixture.toml
@@ -20,6 +20,19 @@ clean = "rm -rf target"
 [verify]
 run = "./target/release/multi-dep"
 expected_stdout_contains = ["kache-test", "version"]
+# Defense-in-depth for multi-prefix --remap-path-prefix (PR #74). A
+# correctly-built binary embeds source path strings only via stable
+# sentinels (`<CARGO_HOME>/...`, `<HOME>/...`, etc.). If a regression
+# ever drops the multi-prefix injection or breaks the sentinel
+# substitution, the binary would carry machine-local prefixes
+# instead — `strings <bin> | grep` on these would fire, failing
+# verify before the bug ships.
+forbidden_substrings = [
+    "/Users/",
+    "/home/",
+    "/private/tmp/",
+    "/private/var/",
+]
 
 [assertions.cold]
 # Cold build must populate the cache; serde + transitive deps means


### PR DESCRIPTION
## Summary

Adds the missing axis to the e2e harness identified during PR #74 review: **inspect output bytes, not just runtime behavior**. Without this, a future regression in \`--remap-path-prefix\` injection (or any future debug-info path embedding) slips through verify whenever the leaked path happens to still resolve at runtime. With it, the test surface gains a structural check that catches output-byte leaks the moment they appear.

## What ships

- New \`forbidden_substrings: Vec<String>\` field on the \`[verify]\` schema. The harness reads the binary at \`Verify::run\` via \`strings\`, fails verify if ANY listed substring appears. Empty / unset = skip (default).

- \`multi-dep\` fixture now declares \`forbidden_substrings = ["/Users/", "/home/", "/private/tmp/", "/private/var/"]\` — locks in the multi-prefix \`--remap-path-prefix\` contract from #74 permanently. Other fixtures can opt in as their contracts solidify.

- \`inspect_binary\` helper: best-effort defense-in-depth. Failure to spawn \`strings\` (e.g. CI host without binutils) is treated as "skip" not "fail" — metric assertions and runtime verify remain the load-bearing checks; this is an extra lens. Diagnostic failure shows the offending substring + a 120-char window for quick triage.

## Validation

End-to-end sanity check: temporarily added \`"kache-test"\` (a known-present string from the fixture's stdout) to \`forbidden_substrings\`. Inspection correctly failed with:

\`\`\`
binary contains forbidden substring \`kache-test\` in /.../target/release/multi-dep:
...sult::unwrap()\` on an \`Err\` valueversionkache-test nametrue 9E;EE EEE...
\`\`\`

After reverting, all 5 fixtures pass including the new check on multi-dep.

## Test plan

- [x] All 5 e2e fixtures pass with binary inspection enabled on \`multi-dep\`
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Sanity-checked the inspection actually catches a leak by inserting a known-present string

## Closes

Tier-1 #1 from the post-#74 path-handling follow-up enumeration. Tier 1 #2 (Windows) and the Tier 2-4 backlog tracked in #77, #78, #79, #80, #81.