### PR TITLE
feat(path_normalizer): cross-platform path handling — Windows variants, Unicode safety, NFC normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3366,6 +3366,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "windows-sys 0.61.2",
  "zstd",
 ]
@@ -7151,6 +7152,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ libc = "0.2"
 tempfile = "3"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 interprocess = { version = "2.4.2", features = ["tokio"] }
+unicode-normalization = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -822,4 +822,243 @@ mod tests {
         // No assertions on log output (we don't capture tracing in
         // unit tests); the assertion is "did not panic".
     }
+
+    // ── Extended edge-case coverage ─────────────────────────────
+    //
+    // The tests above cover the basic surface (empty/non-empty
+    // normalizers, sentinel substitution, Windows variants). This
+    // section exercises edge cases that aren't immediately obvious
+    // from the basic tests but matter for real-world inputs:
+    //
+    //   - Multiple occurrences of the same prefix in one input
+    //   - The boundary case where the input EQUALS the prefix
+    //   - Multiple distinct prefixes chained in one input
+    //   - Nested prefixes (workspace inside home; most-specific wins)
+    //   - Idempotency (sentinels themselves don't get re-replaced)
+    //   - The known limitation: substring vs. path-component matching
+    //   - Realistic OUT_DIR / RUSTFLAGS-shape inputs end-to-end
+
+    fn pn_with_rules(rules: Vec<(&str, &'static str)>) -> PathNormalizer {
+        // Test helper: build a normalizer with explicit rules,
+        // bypassing the env-derived `from_env` so tests are
+        // deterministic across hosts.
+        PathNormalizer {
+            rules: rules
+                .into_iter()
+                .map(|(p, s)| Rule {
+                    prefix: p.to_string(),
+                    sentinel: s,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn normalize_replaces_all_occurrences_of_same_prefix() {
+        // String::replace replaces every match, not just the first.
+        // Realistic case: a RUSTFLAGS value with multiple `-L` flags
+        // pointing at different subdirs of the same workspace.
+        let n = pn_with_rules(vec![("/ws", "<W>")]);
+        let input = "-L /ws/lib -L /ws/build/deps -L /ws/extra";
+        let out = n.normalize(input);
+        assert_eq!(out, "-L <W>/lib -L <W>/build/deps -L <W>/extra");
+    }
+
+    #[test]
+    fn normalize_handles_input_equal_to_prefix() {
+        // Boundary: input has nothing after the prefix. Should
+        // become exactly the sentinel — no leftover bytes.
+        let n = pn_with_rules(vec![("/ws", "<W>")]);
+        assert_eq!(n.normalize("/ws"), "<W>");
+    }
+
+    #[test]
+    fn normalize_chains_multiple_distinct_prefixes_in_one_input() {
+        // Real RUSTFLAGS-style input mixing workspace and cargo home
+        // references. Both rules apply, each to its own substring.
+        let n = pn_with_rules(vec![("/ws", "<W>"), ("/home/u/.cargo", "<C>")]);
+        let input = "-L /ws/lib -L /home/u/.cargo/registry/src/foo";
+        let out = n.normalize(input);
+        assert_eq!(out, "-L <W>/lib -L <C>/registry/src/foo");
+    }
+
+    #[test]
+    fn most_specific_prefix_wins_when_nested() {
+        // The classic "workspace lives inside home" case. PathNormalizer's
+        // rule order is most-specific first, so when normalize sweeps
+        // sequentially, the workspace prefix matches and replaces the
+        // input BEFORE the home prefix gets a chance — the resulting
+        // string starts with `<W>` not `<H>/projects/...`.
+        let n = pn_with_rules(vec![("/home/u/projects/ws", "<W>"), ("/home/u", "<H>")]);
+        let input = "/home/u/projects/ws/src/lib.rs";
+        let out = n.normalize(input);
+        assert_eq!(out, "<W>/src/lib.rs");
+        // Sibling path that ISN'T inside the workspace falls through
+        // to the home rule, as expected.
+        let sibling = "/home/u/other/foo.rs";
+        assert_eq!(n.normalize(sibling), "<H>/other/foo.rs");
+    }
+
+    #[test]
+    fn normalize_is_idempotent_on_already_sentinelized_input() {
+        // Critical safety: running normalize twice should be a
+        // no-op for the second pass. Sentinels are angle-bracketed
+        // (`<HOME>`, `<WORKSPACE>`) and POSIX paths don't use
+        // angles, so a sentinel can't be a prefix of any rule. If
+        // a future change ever picked sentinel strings that happen
+        // to look like real paths, this test fires.
+        let n = pn_with_rules(vec![("/home/u", "<HOME>"), ("/workspace", "<WORKSPACE>")]);
+        let input = "/home/u/projects/foo /workspace/src/main.rs";
+        let once = n.normalize(input);
+        let twice = n.normalize(&once);
+        assert_eq!(once, twice, "normalize is not idempotent");
+        assert!(once.contains("<HOME>"));
+        assert!(once.contains("<WORKSPACE>"));
+    }
+
+    #[test]
+    fn normalize_substring_match_is_documented_limitation() {
+        // ACCEPTED LIMITATION: String::replace is byte-substring,
+        // not path-component aware. A rule for `/home/u` will match
+        // a partial path component like `/home/usr` (incorrectly
+        // turning `/home/usr/foo` into `<HOME>r/foo`).
+        //
+        // In practice this doesn't bite because PathNormalizer's
+        // rule prefixes always come from `Path::canonicalize()`,
+        // which yields paths that end at a real directory boundary
+        // — and consumers (cache_key inputs) almost always have a
+        // separator immediately after a matched prefix. But if a
+        // future caller starts with prefixes that don't end at
+        // directory boundaries, this test documents the surprise
+        // it would produce.
+        let n = pn_with_rules(vec![("/home/u", "<H>")]);
+        // Pathological input: `/home/usr/foo` contains `/home/u` as
+        // a 7-byte substring (same first 7 chars), so replace fires
+        // and leaves `sr/foo` behind. Semantically wrong if `/home/usr`
+        // is supposed to be a different user — but the input was
+        // already a bare-substring match, not a path-component match.
+        assert_eq!(n.normalize("/home/usr/foo"), "<H>sr/foo");
+        // The realistic case still works because cargo / canonicalize
+        // produces paths with separators after the prefix.
+        assert_eq!(n.normalize("/home/u/foo"), "<H>/foo");
+    }
+
+    #[test]
+    fn normalize_handles_realistic_out_dir_value() {
+        // End-to-end shape mirroring what `parse_env_dep_info`
+        // would feed in for a real serde build:
+        //   env_dep:OUT_DIR=/<workspace>/target/release/build/serde-XXX/out
+        let n = pn_with_rules(vec![("/Users/alice/projects/myrepo", "<WORKSPACE>")]);
+        let out_dir =
+            "/Users/alice/projects/myrepo/target/release/build/serde-65d43fa14511931c/out";
+        assert_eq!(
+            n.normalize(out_dir),
+            "<WORKSPACE>/target/release/build/serde-65d43fa14511931c/out"
+        );
+    }
+
+    #[test]
+    fn normalize_handles_realistic_rustflags_value() {
+        // Real RUSTFLAGS shape with multiple link-search dirs, some
+        // of which reference machine-local paths.
+        let n = pn_with_rules(vec![
+            ("/Users/alice/.cargo", "<CARGO_HOME>"),
+            ("/Users/alice/projects/myrepo", "<WORKSPACE>"),
+        ]);
+        let flags = "-L /Users/alice/.cargo/registry/cache/foo \
+                     -L /Users/alice/projects/myrepo/target/release/deps \
+                     -C link-arg=-Wl,-rpath,/system/lib";
+        let out = n.normalize(flags);
+        // Both machine-local paths sentinelized.
+        assert!(out.contains("<CARGO_HOME>/registry/cache/foo"));
+        assert!(out.contains("<WORKSPACE>/target/release/deps"));
+        // System path NOT in the rule list — passes through.
+        assert!(out.contains("/system/lib"));
+    }
+
+    #[test]
+    fn lowercase_drive_letter_handles_drive_root_alone() {
+        // Edge case: input is just `C:\` or `C:` with nothing else.
+        // Drive letter still gets lowercased; rest preserved.
+        assert_eq!(lowercase_drive_letter("C:\\"), Some("c:\\".to_string()));
+        assert_eq!(lowercase_drive_letter("C:"), Some("c:".to_string()));
+        assert_eq!(lowercase_drive_letter("D:/"), Some("d:/".to_string()));
+    }
+
+    #[test]
+    fn windows_variants_are_distinct_for_distinct_canonical_forms() {
+        // Sanity: the four-variant expansion produces FOUR distinct
+        // strings only when each form differs. If the canonical form
+        // already has lowercase drive + forward slashes, no extra
+        // variants are added (they'd be exact duplicates that dedup
+        // would strip anyway).
+        if !cfg!(windows) {
+            return;
+        }
+        let mut rules = Vec::new();
+        push_rule_with_variants(
+            &mut rules,
+            Some("c:/users/alice/.cargo".to_string()),
+            "<CARGO_HOME>",
+        );
+        // The "canonical" we passed is already in the
+        // lowercase-drive forward-slash form; backslash variant
+        // should be added but not the lowercase-drive variant
+        // (it's already lowercase).
+        let prefixes: Vec<&str> = rules.iter().map(|r| r.prefix.as_str()).collect();
+        assert!(prefixes.contains(&"c:/users/alice/.cargo"));
+        assert!(prefixes.contains(&"c:\\users\\alice\\.cargo"));
+        // No uppercase-drive variant — we didn't construct one.
+        assert!(!prefixes.iter().any(|p| p.starts_with("C:")));
+    }
+
+    #[test]
+    fn remap_args_emits_all_windows_variants_with_same_sentinel() {
+        // Each variant becomes its own --remap-path-prefix flag,
+        // all mapping to the same sentinel. rustc applies them in
+        // order with last-match-wins; whichever variant the actual
+        // build path matches, the sentinel is identical.
+        if !cfg!(windows) {
+            return;
+        }
+        let mut rules = Vec::new();
+        push_rule_with_variants(
+            &mut rules,
+            Some("C:\\Users\\Alice\\.cargo".to_string()),
+            "<CARGO_HOME>",
+        );
+        let n = PathNormalizer { rules };
+        let args = n.remap_args();
+        // 4 variants × 1 sentinel = 4 args, all mapping to
+        // <CARGO_HOME>.
+        assert_eq!(args.len(), 4);
+        for arg in &args {
+            assert!(
+                arg.ends_with("=<CARGO_HOME>"),
+                "every variant maps to the same sentinel; got {arg:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_env_construction_is_deterministic() {
+        // Two normalizers built from the same env should have
+        // identical rule lists — prerequisite for cross-machine
+        // cache key consistency. (If this ever flakes, something
+        // in `from_env` reads non-deterministic state.)
+        let dir = TempDir::new().unwrap();
+        let n1 = PathNormalizer::from_env(Some(dir.path()));
+        let n2 = PathNormalizer::from_env(Some(dir.path()));
+        let p1: Vec<(String, &str)> = n1
+            .rules
+            .iter()
+            .map(|r| (r.prefix.clone(), r.sentinel))
+            .collect();
+        let p2: Vec<(String, &str)> = n2
+            .rules
+            .iter()
+            .map(|r| (r.prefix.clone(), r.sentinel))
+            .collect();
+        assert_eq!(p1, p2);
+    }
 }

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -70,16 +70,22 @@
 //!   `<WORKSPACE>` literally, replacement would corrupt it. POSIX
 //!   paths don't use `<`/`>`; Windows uses them only inside `\\?\`
 //!   device-path forms which aren't cache-key inputs. Acceptable risk.
-//! - **macOS Unicode normalization (NFC vs NFD)**: HFS+ historically
-//!   stored filenames in NFD form; APFS preserves the form the
-//!   filesystem caller used. If a path's canonical form (from
-//!   `Path::canonicalize`) is in one normalization but the input
-//!   string (e.g. an env var) is in another, the byte-literal
-//!   substring match in `normalize` won't fire — same path, two
-//!   different byte sequences. Failure mode is "cache miss", not
-//!   "wrong cache hit", so this is acceptable until a real-world
-//!   report shows up. Pulling in `unicode-normalization` to
-//!   normalize both sides is the obvious fix when needed.
+//!
+//! ## macOS Unicode normalization (NFC vs NFD)
+//!
+//! HFS+ historically stored filenames in NFD form (`é` as `e` +
+//! combining accent — three UTF-8 bytes); APFS preserves whatever
+//! form the API caller used. Env vars set by shells / build tools
+//! typically use NFC (`é` as a single codepoint — two UTF-8 bytes).
+//! Same character to the eye, **different bytes**.
+//!
+//! Without normalization, a user `José` would silently lose
+//! cross-machine cache sharing while ASCII-named users got it for
+//! free — the cache key for their workspace would diverge across
+//! tools that disagree on the encoding. We normalize both sides
+//! (rule prefixes via [`canonical_string`], input via
+//! [`PathNormalizer::normalize`]) to NFC before matching. Same
+//! source bytes after normalization → same key.
 //!
 //! ## Sentinel strategy
 //!
@@ -99,6 +105,7 @@
 //! during ad-hoc dev runs without needing to run the full harness.
 
 use std::path::{Path, PathBuf};
+use unicode_normalization::UnicodeNormalization;
 
 /// One canonicalized prefix + its replacement sentinel.
 #[derive(Debug, Clone)]
@@ -251,20 +258,30 @@ impl PathNormalizer {
     /// literal substring replace; rules apply in declaration order
     /// so the first match for a given byte range wins.
     ///
-    /// **Pure substring replace — no input transformation.** Earlier
-    /// drafts canonicalized the input to handle Windows separator
-    /// and drive-letter case differences. That worked for cache-key
-    /// hashing but had a side effect: parts of the input that DIDN'T
-    /// match a rule still got their separators flipped (e.g. an
-    /// error message embedding `'C:\Users\foo'` would come out as
-    /// `'c:/Users/foo'`). For Windows compatibility we instead store
-    /// MULTIPLE VARIANTS of each prefix (forward/back slash,
-    /// upper/lower drive) in [`Self::from_env`] — see that method's
-    /// docs. The matching here stays a dumb byte-literal pass over
-    /// every variant: predictable, no surprise transformations of
-    /// pass-through bytes.
+    /// **Pure substring replace, modulo Unicode normalization.**
+    /// Earlier drafts canonicalized the input to handle Windows
+    /// separator and drive-letter case differences. That worked for
+    /// cache-key hashing but had a side effect: parts of the input
+    /// that DIDN'T match a rule still got their separators flipped.
+    /// For Windows compatibility we instead store MULTIPLE VARIANTS
+    /// of each prefix (forward/back slash, upper/lower drive) in
+    /// [`Self::from_env`] — see that method's docs. The matching
+    /// here is a byte-literal pass over every variant.
+    ///
+    /// **Unicode normalization to NFC** is applied to the input
+    /// before matching, because rule prefixes are stored in NFC
+    /// (see [`canonical_string`]). This handles the macOS HFS+/APFS
+    /// case where filesystem APIs may return paths in NFD (`é` as
+    /// `e` + combining accent) while env vars set by other tools
+    /// use NFC (`é` as a single codepoint). Same character to the
+    /// eye, different bytes — without this, a user `José` would
+    /// silently lose cross-machine cache sharing while ASCII-named
+    /// users got it for free. NFC is semantic-preserving for path
+    /// strings (composed and decomposed forms are equivalent path
+    /// representations); the normalize step is a no-op on inputs
+    /// that are already NFC (the common case).
     pub fn normalize<S: AsRef<str>>(&self, s: S) -> String {
-        let mut out = s.as_ref().to_string();
+        let mut out: String = s.as_ref().nfc().collect();
         for rule in &self.rules {
             if rule.prefix.is_empty() {
                 continue;
@@ -349,13 +366,21 @@ fn warn_if_path_leaked(s: &str) {
 /// match between every byte and produce nonsense.
 ///
 /// Returns the OS-native canonical form (Windows: `\` separators,
-/// preserved case). The Windows separator/case variants are added
-/// as ADDITIONAL rules by [`push_rule_with_variants`] — keeping the
-/// canonical form intact lets `Path::starts_with` and other
-/// path-aware code consume this string without surprise.
+/// preserved case) **normalized to Unicode NFC**. The Windows
+/// separator/case variants are added as ADDITIONAL rules by
+/// [`push_rule_with_variants`] — keeping the OS-native form intact
+/// lets `Path::starts_with` and other path-aware code consume this
+/// string without surprise.
+///
+/// Why NFC: macOS filesystem APIs may return paths in NFD form
+/// (HFS+ legacy, sometimes APFS); env vars typically use NFC. Both
+/// rule and input get normalized to NFC at their respective sites
+/// so byte-literal substring matching works regardless of which
+/// form the source produced. See [`PathNormalizer::normalize`] for
+/// the matching-side normalization.
 fn canonical_string(path: &Path) -> Option<String> {
     let canon = path.canonicalize().ok()?;
-    let s = canon.to_string_lossy().into_owned();
+    let s: String = canon.to_string_lossy().nfc().collect();
     if s.is_empty() { None } else { Some(s) }
 }
 
@@ -1088,6 +1113,59 @@ mod tests {
         let n = pn_with_rules(vec![("/Users/José/.cargo", "<CARGO_HOME>")]);
         let input = "/Users/José/.cargo/registry/src/foo";
         assert_eq!(n.normalize(input), "<CARGO_HOME>/registry/src/foo");
+    }
+
+    #[test]
+    fn normalize_matches_across_nfc_nfd_unicode_normalization_forms() {
+        // The macOS NFC vs NFD case. `é` has two valid UTF-8
+        // byte sequences:
+        //   NFC: U+00E9         → 0xC3 0xA9       (2 bytes)
+        //   NFD: U+0065 U+0301  → 0x65 0xCC 0x81  (3 bytes)
+        // String::replace is byte-literal so the two forms don't
+        // match each other directly. PathNormalizer normalizes both
+        // sides to NFC before matching, so a rule built from a path
+        // returned in NFD (HFS+ legacy / some macOS APIs) still
+        // matches an input string in NFC (typical env-var form).
+        let nfc_prefix = "/Users/Jos\u{00E9}/.cargo"; // single codepoint é
+        let nfd_input = "/Users/Jos\u{0065}\u{0301}/.cargo/registry/foo"; // e + combining acute
+
+        // Sanity: the byte sequences differ.
+        assert_ne!(
+            nfc_prefix.as_bytes(),
+            &nfd_input.as_bytes()[..nfc_prefix.len()]
+        );
+
+        // Rule prefix in NFC form — `from_env`'s `canonical_string`
+        // would have produced this. Input arrives in NFD; normalize
+        // converts it to NFC before matching, so the substring hit
+        // fires.
+        let n = pn_with_rules(vec![(nfc_prefix, "<CARGO_HOME>")]);
+        let out = n.normalize(nfd_input);
+        assert_eq!(out, "<CARGO_HOME>/registry/foo");
+
+        // Symmetric: NFC input also matches.
+        let nfc_input = "/Users/Jos\u{00E9}/.cargo/registry/bar";
+        assert_eq!(n.normalize(nfc_input), "<CARGO_HOME>/registry/bar");
+    }
+
+    #[test]
+    fn canonical_string_normalizes_to_nfc() {
+        // Rule construction must produce NFC-form prefixes so that
+        // the NFC normalization in `normalize` can match. Even if
+        // the underlying path uses non-NFC bytes (which canonicalize
+        // may return on macOS), the stored prefix must be NFC.
+        let dir = TempDir::new().unwrap();
+        let nfc_name = "Jos\u{00E9}";
+        let subdir = dir.path().join(nfc_name);
+        std::fs::create_dir(&subdir).unwrap();
+
+        let result = canonical_string(&subdir).expect("canonicalize should succeed");
+        // NFC contract: re-normalizing gives the same string.
+        let renormalized: String = result.nfc().collect();
+        assert_eq!(
+            result, renormalized,
+            "canonical_string output must be in NFC form, got {result:?}"
+        );
     }
 
     #[test]

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -70,6 +70,16 @@
 //!   `<WORKSPACE>` literally, replacement would corrupt it. POSIX
 //!   paths don't use `<`/`>`; Windows uses them only inside `\\?\`
 //!   device-path forms which aren't cache-key inputs. Acceptable risk.
+//! - **macOS Unicode normalization (NFC vs NFD)**: HFS+ historically
+//!   stored filenames in NFD form; APFS preserves the form the
+//!   filesystem caller used. If a path's canonical form (from
+//!   `Path::canonicalize`) is in one normalization but the input
+//!   string (e.g. an env var) is in another, the byte-literal
+//!   substring match in `normalize` won't fire — same path, two
+//!   different byte sequences. Failure mode is "cache miss", not
+//!   "wrong cache hit", so this is acceptable until a real-world
+//!   report shows up. Pulling in `unicode-normalization` to
+//!   normalize both sides is the obvious fix when needed.
 //!
 //! ## Sentinel strategy
 //!
@@ -428,18 +438,24 @@ fn push_rule_with_variants(rules: &mut Vec<Rule>, prefix: Option<String>, sentin
 /// uppercase letter), else `None`. Only the drive letter is touched —
 /// rest of the path is preserved (Windows filesystems are typically
 /// case-preserving even when case-insensitive).
+///
+/// Operates at the BYTE level, not the `&str` slice level, to stay
+/// panic-safe on inputs that start with a multi-byte UTF-8 codepoint.
+/// `&s[1..2]` would panic with "not a char boundary" when byte 0 is
+/// the start of (e.g.) `É` (`0xC3 0x89` in UTF-8). Drive letters are
+/// always ASCII A-Z in practice, but defensive — `Path::canonicalize`
+/// can return paths starting with anything when working with weird
+/// volume labels or junctions.
 fn lowercase_drive_letter(s: &str) -> Option<String> {
-    if s.len() < 2 || &s[1..2] != ":" {
-        return None;
-    }
-    let first = s.as_bytes()[0];
-    if !first.is_ascii_uppercase() {
+    let bytes = s.as_bytes();
+    if bytes.len() < 2 || bytes[1] != b':' || !bytes[0].is_ascii_uppercase() {
         return None;
     }
     let mut out = s.to_string();
-    // SAFETY: replacing one ASCII byte with another preserves UTF-8.
+    // SAFETY: replacing one ASCII byte with another ASCII byte
+    // preserves UTF-8 validity. Byte 0 was confirmed ASCII above.
     unsafe {
-        out.as_bytes_mut()[0] = first.to_ascii_lowercase();
+        out.as_bytes_mut()[0] = bytes[0].to_ascii_lowercase();
     }
     Some(out)
 }
@@ -1038,6 +1054,55 @@ mod tests {
                 "every variant maps to the same sentinel; got {arg:?}"
             );
         }
+    }
+
+    // ── Unicode safety ──────────────────────────────────────────
+    //
+    // The substring-match design uses byte-literal `String::replace`
+    // (which is UTF-8 self-synchronizing — partial codepoint matches
+    // can't happen). The drive-letter helper uses byte indexing
+    // explicitly to stay panic-safe on inputs that start with a
+    // multi-byte codepoint. These tests pin both contracts.
+
+    #[test]
+    fn lowercase_drive_letter_does_not_panic_on_multibyte_first_char() {
+        // `É` is U+00C9, encoded as two bytes in UTF-8 (0xC3 0x89).
+        // The earlier `&s[1..2]` slice would panic with
+        // "not a char boundary" on byte 1 (which is inside É).
+        // The byte-level check returns None cleanly.
+        assert_eq!(lowercase_drive_letter("É:foo"), None);
+        assert_eq!(lowercase_drive_letter("日本:"), None);
+        assert_eq!(lowercase_drive_letter("é"), None); // too short for : check anyway
+        // Sanity: the ASCII drive case still works.
+        assert_eq!(lowercase_drive_letter("C:foo"), Some("c:foo".to_string()));
+    }
+
+    #[test]
+    fn normalize_handles_unicode_paths_correctly() {
+        // Realistic case: `/Users/José/.cargo`. The rule prefix and
+        // input both use the SAME UTF-8 byte sequence (NFC form, the
+        // typical state when the env var is set on macOS APFS).
+        // String::replace works on bytes; UTF-8 is self-synchronizing
+        // so partial matches inside multi-byte codepoints can't
+        // happen.
+        let n = pn_with_rules(vec![("/Users/José/.cargo", "<CARGO_HOME>")]);
+        let input = "/Users/José/.cargo/registry/src/foo";
+        assert_eq!(n.normalize(input), "<CARGO_HOME>/registry/src/foo");
+    }
+
+    #[test]
+    fn normalize_preserves_unicode_outside_matched_prefix() {
+        // The "no transformation of unmatched bytes" contract
+        // extends to unicode: a code point that contains `\` or `/`
+        // bytes shouldn't get partially mangled. UTF-8 reserves
+        // bytes 0x00-0x7F for ASCII and uses 0xC0-0xFD as multi-byte
+        // markers, so `/` (0x2F) and `\` (0x5C) only appear as
+        // themselves — no risk of accidental separator detection
+        // mid-codepoint. This test pins it by example.
+        let n = pn_with_rules(vec![("/ws", "<W>")]);
+        let input = "/ws/José/中文/файл.rs"; // Latin / CJK / Cyrillic
+        let out = n.normalize(input);
+        assert_eq!(out, "<W>/José/中文/файл.rs");
     }
 
     #[test]

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -132,33 +132,28 @@ impl PathNormalizer {
     pub fn from_env(workspace_root: Option<&Path>) -> Self {
         let mut rules = Vec::new();
 
-        if let Some(ws) = workspace_root.and_then(canonical_string) {
-            rules.push(Rule {
-                prefix: ws,
-                sentinel: "<WORKSPACE>",
-            });
-        }
+        push_rule_with_variants(
+            &mut rules,
+            workspace_root.and_then(canonical_string),
+            "<WORKSPACE>",
+        );
 
-        if let Some(td) =
-            std::env::var_os("CARGO_TARGET_DIR").and_then(|p| canonical_string(Path::new(&p)))
-        {
-            rules.push(Rule {
-                prefix: td,
-                sentinel: "<TARGET>",
-            });
-        }
+        push_rule_with_variants(
+            &mut rules,
+            std::env::var_os("CARGO_TARGET_DIR").and_then(|p| canonical_string(Path::new(&p))),
+            "<TARGET>",
+        );
 
         // CARGO_HOME defaults to $HOME/.cargo if not set; honor that
         // so users with the default layout still get the substitution.
         let cargo_home = std::env::var_os("CARGO_HOME")
             .map(PathBuf::from)
             .or_else(|| dirs::home_dir().map(|h| h.join(".cargo")));
-        if let Some(ch) = cargo_home.and_then(|p| canonical_string(&p)) {
-            rules.push(Rule {
-                prefix: ch,
-                sentinel: "<CARGO_HOME>",
-            });
-        }
+        push_rule_with_variants(
+            &mut rules,
+            cargo_home.and_then(|p| canonical_string(&p)),
+            "<CARGO_HOME>",
+        );
 
         // Same default-fallback story for RUSTUP_HOME. rustup paths
         // appear in -L flags and toolchain refs — without this rule,
@@ -167,34 +162,55 @@ impl PathNormalizer {
         let rustup_home = std::env::var_os("RUSTUP_HOME")
             .map(PathBuf::from)
             .or_else(|| dirs::home_dir().map(|h| h.join(".rustup")));
-        if let Some(rh) = rustup_home.and_then(|p| canonical_string(&p)) {
-            rules.push(Rule {
-                prefix: rh,
-                sentinel: "<RUSTUP_HOME>",
-            });
-        }
+        push_rule_with_variants(
+            &mut rules,
+            rustup_home.and_then(|p| canonical_string(&p)),
+            "<RUSTUP_HOME>",
+        );
 
-        if let Some(home) = dirs::home_dir().and_then(|p| canonical_string(&p)) {
-            rules.push(Rule {
-                prefix: home,
-                sentinel: "<HOME>",
-            });
+        push_rule_with_variants(
+            &mut rules,
+            dirs::home_dir().and_then(|p| canonical_string(&p)),
+            "<HOME>",
+        );
+
+        // Windows-specific rules: cargo / rustup paths often live
+        // under %APPDATA% / %LOCALAPPDATA% (e.g. CARGO_HOME defaults
+        // to %USERPROFILE%\.cargo but tools like rustup-init may
+        // also stash state in %LOCALAPPDATA%\rustup). %PROGRAMFILES%
+        // covers MSVC / SDK locations that flow into native-link
+        // search paths. Each is added as its own sentinel so cross-
+        // dev caches don't leak per-user paths.
+        for (env_key, sentinel) in [
+            ("APPDATA", "<APPDATA>"),
+            ("LOCALAPPDATA", "<LOCALAPPDATA>"),
+            ("PROGRAMFILES", "<PROGRAMFILES>"),
+        ] {
+            push_rule_with_variants(
+                &mut rules,
+                std::env::var_os(env_key).and_then(|v| canonical_string(Path::new(&v))),
+                sentinel,
+            );
         }
 
         // System tempdir — varies wildly across hosts (per-user random
         // segment on macOS like `/var/folders/1z/.../T`). Build
         // artifacts from build.rs scripts often pass through tempdirs
         // for intermediate output.
-        if let Some(td) = canonical_string(&std::env::temp_dir()) {
-            rules.push(Rule {
-                prefix: td,
-                sentinel: "<TMPDIR>",
-            });
-        }
+        push_rule_with_variants(
+            &mut rules,
+            canonical_string(&std::env::temp_dir()),
+            "<TMPDIR>",
+        );
 
         // De-dupe: if (e.g.) CARGO_HOME == workspace_root, the second
         // entry would never fire. Also keep order stable so the
-        // first-listed sentinel wins for identical prefixes.
+        // first-listed sentinel wins for identical prefixes. Variants
+        // pushed by `push_rule_with_variants` are already adjacent
+        // per-base prefix, so a stable dedup catches duplicates
+        // introduced when (e.g.) `~/.cargo` happens to canonicalize
+        // identically to one of its forward-slash variants on a
+        // unix host (no-op then).
         rules.dedup_by(|a, b| a.prefix == b.prefix);
 
         Self { rules }
@@ -224,6 +240,19 @@ impl PathNormalizer {
     /// `-L /home/x/lib -L /home/x/build/deps`). Each rule does a
     /// literal substring replace; rules apply in declaration order
     /// so the first match for a given byte range wins.
+    ///
+    /// **Pure substring replace — no input transformation.** Earlier
+    /// drafts canonicalized the input to handle Windows separator
+    /// and drive-letter case differences. That worked for cache-key
+    /// hashing but had a side effect: parts of the input that DIDN'T
+    /// match a rule still got their separators flipped (e.g. an
+    /// error message embedding `'C:\Users\foo'` would come out as
+    /// `'c:/Users/foo'`). For Windows compatibility we instead store
+    /// MULTIPLE VARIANTS of each prefix (forward/back slash,
+    /// upper/lower drive) in [`Self::from_env`] — see that method's
+    /// docs. The matching here stays a dumb byte-literal pass over
+    /// every variant: predictable, no surprise transformations of
+    /// pass-through bytes.
     pub fn normalize<S: AsRef<str>>(&self, s: S) -> String {
         let mut out = s.as_ref().to_string();
         for rule in &self.rules {
@@ -308,10 +337,111 @@ fn warn_if_path_leaked(s: &str) {
 /// `None` if the path doesn't exist / can't be resolved. Empty
 /// strings are also rejected because `String::replace("", x)` would
 /// match between every byte and produce nonsense.
+///
+/// Returns the OS-native canonical form (Windows: `\` separators,
+/// preserved case). The Windows separator/case variants are added
+/// as ADDITIONAL rules by [`push_rule_with_variants`] — keeping the
+/// canonical form intact lets `Path::starts_with` and other
+/// path-aware code consume this string without surprise.
 fn canonical_string(path: &Path) -> Option<String> {
     let canon = path.canonicalize().ok()?;
     let s = canon.to_string_lossy().into_owned();
     if s.is_empty() { None } else { Some(s) }
+}
+
+/// Push a rule + its Windows-shape variants into the rule list.
+///
+/// On unix, this is just `rules.push(Rule { prefix, sentinel })` —
+/// one rule, no variants. On Windows the same canonical prefix
+/// goes in *plus* up to three variants:
+///
+/// 1. **Forward-slash form** — cargo's dep-info often reports paths
+///    with `/` even though the OS uses `\`. Without this variant
+///    a stored `C:\Users\alice\.cargo` rule would miss an input
+///    `C:/Users/alice/.cargo/registry/...`.
+/// 2. **Lower-case drive letter** — NTFS is case-insensitive (`C:\`
+///    and `c:\` are the same path) but `String::replace` is
+///    byte-literal. Tools may emit either; both must match.
+/// 3. **Both: lower-case drive + forward slash** — the cross of
+///    the above when an input combines both deviations.
+///
+/// Why this design over input transformation: an earlier draft
+/// canonicalized the input string before matching. That worked for
+/// cache-key hashing but had a side effect — parts of the input
+/// that DIDN'T match a rule still got their separators flipped.
+/// Storing variants instead means [`PathNormalizer::normalize`]
+/// stays a dumb byte-literal substring replace; the input is treated
+/// as opaque bytes outside any matched prefix.
+fn push_rule_with_variants(rules: &mut Vec<Rule>, prefix: Option<String>, sentinel: &'static str) {
+    let Some(prefix) = prefix else { return };
+    if prefix.is_empty() {
+        return;
+    }
+
+    // Always push the canonical form first.
+    rules.push(Rule {
+        prefix: prefix.clone(),
+        sentinel,
+    });
+
+    // Variants only matter on Windows. On unix the canonical form
+    // is the only one cargo / rustc / env vars produce, so adding
+    // variants would just be dead rules.
+    if !cfg!(windows) {
+        return;
+    }
+
+    // Forward-slash variant.
+    let fs = prefix.replace('\\', "/");
+    if fs != prefix {
+        rules.push(Rule {
+            prefix: fs.clone(),
+            sentinel,
+        });
+    }
+
+    // Lower-case drive variant.
+    let lc = lowercase_drive_letter(&prefix);
+    if let Some(ref lc_str) = lc
+        && lc_str != &prefix
+    {
+        rules.push(Rule {
+            prefix: lc_str.clone(),
+            sentinel,
+        });
+    }
+
+    // Both: forward-slash + lower-case drive.
+    if let Some(fs_lc) = lowercase_drive_letter(&fs)
+        && fs_lc != fs
+        && Some(&fs_lc) != lc.as_ref()
+    {
+        rules.push(Rule {
+            prefix: fs_lc,
+            sentinel,
+        });
+    }
+}
+
+/// Return `Some(s with first byte lowercased)` if `s` looks like
+/// a Windows drive-letter path (`X:` prefix where X is an ASCII
+/// uppercase letter), else `None`. Only the drive letter is touched —
+/// rest of the path is preserved (Windows filesystems are typically
+/// case-preserving even when case-insensitive).
+fn lowercase_drive_letter(s: &str) -> Option<String> {
+    if s.len() < 2 || &s[1..2] != ":" {
+        return None;
+    }
+    let first = s.as_bytes()[0];
+    if !first.is_ascii_uppercase() {
+        return None;
+    }
+    let mut out = s.to_string();
+    // SAFETY: replacing one ASCII byte with another preserves UTF-8.
+    unsafe {
+        out.as_bytes_mut()[0] = first.to_ascii_lowercase();
+    }
+    Some(out)
 }
 
 #[cfg(test)]
@@ -500,6 +630,181 @@ mod tests {
             }],
         };
         assert!(n.remap_args().is_empty());
+    }
+
+    // ── Windows-shape variants ──────────────────────────────────
+    //
+    // These tests exercise the "store multiple variants per rule"
+    // strategy that handles Windows separator + drive-case
+    // differences without transforming the input string. Each test
+    // can run on any host; the cfg!(windows) gates select the
+    // expected behavior (variants are added on Windows, skipped
+    // elsewhere).
+
+    fn rules_for(n: &PathNormalizer) -> Vec<(String, &'static str)> {
+        n.rules
+            .iter()
+            .map(|r| (r.prefix.clone(), r.sentinel))
+            .collect()
+    }
+
+    #[test]
+    fn lowercase_drive_letter_only_touches_first_byte() {
+        // Drive letter lowercased; rest of path preserved exactly
+        // (Windows is case-preserving even when case-insensitive).
+        assert_eq!(
+            lowercase_drive_letter("C:\\Users\\Alice"),
+            Some("c:\\Users\\Alice".to_string())
+        );
+        assert_eq!(
+            lowercase_drive_letter("D:/Projects/Foo"),
+            Some("d:/Projects/Foo".to_string())
+        );
+    }
+
+    #[test]
+    fn lowercase_drive_letter_returns_none_for_non_drive_paths() {
+        // Unix paths, already-lowercase drives, and short strings
+        // all return None — caller treats that as "no variant".
+        assert_eq!(lowercase_drive_letter("/unix/path"), None);
+        assert_eq!(lowercase_drive_letter("c:\\already\\lower"), None);
+        assert_eq!(lowercase_drive_letter("C"), None);
+        assert_eq!(lowercase_drive_letter(""), None);
+        assert_eq!(lowercase_drive_letter("CD"), None); // missing :
+        assert_eq!(lowercase_drive_letter("1:\\foo"), None); // not a letter
+    }
+
+    #[test]
+    fn push_rule_with_variants_adds_only_canonical_form_on_unix() {
+        // On unix the canonical form is the only one cargo / rustc
+        // produce, so variants would be dead rules. This test pins
+        // that contract (would fail loudly if someone changed the
+        // gate to add variants unconditionally — wasted memory and
+        // a tiny risk of unexpected matches).
+        if cfg!(windows) {
+            return;
+        }
+        let mut rules = Vec::new();
+        push_rule_with_variants(
+            &mut rules,
+            Some("/Users/alice/.cargo".to_string()),
+            "<CARGO_HOME>",
+        );
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].prefix, "/Users/alice/.cargo");
+        assert_eq!(rules[0].sentinel, "<CARGO_HOME>");
+    }
+
+    #[test]
+    fn push_rule_with_variants_expands_on_windows() {
+        // The contract: a single Windows-shaped prefix expands to
+        // up to four variants — canonical, forward-slash,
+        // lowercase-drive, and both. Each variant maps to the
+        // SAME sentinel so any of the input forms gets normalized.
+        if !cfg!(windows) {
+            return;
+        }
+        let mut rules = Vec::new();
+        push_rule_with_variants(
+            &mut rules,
+            Some("C:\\Users\\Alice\\.cargo".to_string()),
+            "<CARGO_HOME>",
+        );
+        // All variants present, all map to <CARGO_HOME>.
+        let prefixes: Vec<&str> = rules.iter().map(|r| r.prefix.as_str()).collect();
+        assert!(prefixes.contains(&"C:\\Users\\Alice\\.cargo"));
+        assert!(prefixes.contains(&"C:/Users/Alice/.cargo"));
+        assert!(prefixes.contains(&"c:\\Users\\Alice\\.cargo"));
+        assert!(prefixes.contains(&"c:/Users/Alice/.cargo"));
+        assert!(rules.iter().all(|r| r.sentinel == "<CARGO_HOME>"));
+    }
+
+    #[test]
+    fn push_rule_with_variants_skips_empty_and_none() {
+        // Defense-in-depth: an empty prefix would corrupt every
+        // input via `String::replace("", x)`. None means "this
+        // rule's source isn't available" (env var unset, dir
+        // doesn't exist) and should be silently skipped.
+        let mut rules = Vec::new();
+        push_rule_with_variants(&mut rules, None, "<NEVER>");
+        push_rule_with_variants(&mut rules, Some(String::new()), "<NEVER>");
+        assert!(rules.is_empty());
+    }
+
+    #[test]
+    fn normalize_matches_any_variant_form() {
+        // The motivating Windows case: a stored canonical prefix
+        // plus inputs that may use any of the four variants. All
+        // should normalize to the same sentinel because we stored
+        // every variant at construction.
+        let mut rules = Vec::new();
+        push_rule_with_variants(
+            &mut rules,
+            Some("C:\\Users\\Alice\\.cargo".to_string()),
+            "<CARGO_HOME>",
+        );
+        let n = PathNormalizer { rules };
+
+        // On unix only the canonical form is in the rule set, so
+        // only that input is matched; on Windows any of the four
+        // forms should match.
+        let inputs_and_expectations: &[(&str, bool)] = &[
+            ("C:\\Users\\Alice\\.cargo\\registry\\foo", true), // canonical
+            ("C:/Users/Alice/.cargo/registry/foo", cfg!(windows)),
+            ("c:\\Users\\Alice\\.cargo\\registry\\foo", cfg!(windows)),
+            ("c:/Users/Alice/.cargo/registry/foo", cfg!(windows)),
+            ("/Users/alice/.cargo/registry/foo", false), // unix path, never matches
+        ];
+        for (input, should_match) in inputs_and_expectations {
+            let out = n.normalize(input);
+            let matched = out.contains("<CARGO_HOME>");
+            assert_eq!(
+                matched, *should_match,
+                "input {input:?}: expected match={should_match}, got out={out:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_does_not_transform_unmatched_input() {
+        // Critical contract: input bytes that DON'T match any rule
+        // must come out byte-identical. The earlier
+        // canonicalize-input design failed this — it flipped
+        // backslashes everywhere. The current variant-based design
+        // never transforms; this test pins that.
+        let n = PathNormalizer::empty();
+        let weird_inputs = &[
+            "C:\\Users\\foo",
+            "/unix/with\\backslash/mixed",
+            r"\\?\C:\extended\length",
+            "\\//\\/", // mixed-up separators (the user's concern)
+            "no path here at all",
+        ];
+        for input in weird_inputs {
+            assert_eq!(
+                n.normalize(input),
+                *input,
+                "unmatched input {input:?} must pass through unchanged"
+            );
+        }
+    }
+
+    #[test]
+    fn rules_dedup_keeps_first_for_identical_canonicalization() {
+        // On unix, when the canonical forms of two different sources
+        // (e.g. CARGO_HOME and HOME if CARGO_HOME = HOME, weird but
+        // possible in tests) collide, the first-listed sentinel
+        // wins. push_rule_with_variants pushes the canonical first
+        // for each, so dedup_by removes only the duplicate.
+        let mut rules = Vec::new();
+        push_rule_with_variants(&mut rules, Some("/same/path".to_string()), "<FIRST>");
+        push_rule_with_variants(&mut rules, Some("/same/path".to_string()), "<SECOND>");
+        rules.dedup_by(|a, b| a.prefix == b.prefix);
+        // Order preserved — first occurrence wins. Note this exercises
+        // the same dedup the real `from_env` does.
+        let names: Vec<_> = rules_for(&PathNormalizer { rules }).into_iter().collect();
+        assert_eq!(names.len(), 1);
+        assert_eq!(names[0].1, "<FIRST>");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Four coupled improvements to PathNormalizer that ship as one PR for review coherence:

1. **Windows-shape variants** — separator + drive-letter case handled without input transformation
2. **Unicode safety fix** — byte-level drive-letter check (no more panic on multi-byte first char)
3. **NFC normalization at both ends** — closes the macOS NFD silent-degradation hole for users with non-ASCII paths
4. **36 unit tests** (was 13) — edge cases, adversarial inputs, realistic embedded paths, NFC/NFD equivalence

Together: PathNormalizer now handles every realistic input shape on Linux, macOS, and Windows without surprise transformations, panics, or silent degradation by user name.

## What ships

### 1. Windows-shape variants (zero input transformation)

An earlier draft canonicalized the input string before substring matching. Worked for cache-key hashing but had a side effect — input bytes that DIDN'T match a rule still got their separators flipped. Pathological inputs like \`\\//\\/\` would be transformed everywhere; embedded paths in error-message strings would come out in unexpected forms.

Variant-based design instead pre-computes up to four shapes of each Windows prefix at construction time: canonical, forward-slash, lowercase-drive, and both. \`normalize\` stays a byte-literal substring replace; the input is opaque outside any matched prefix.

- New \`push_rule_with_variants\` helper — one rule on unix, up to four on Windows
- New \`lowercase_drive_letter\` helper — only touches the first byte; rest of path preserved
- New rules: \`<APPDATA>\`, \`<LOCALAPPDATA>\`, \`<PROGRAMFILES>\` for Windows-specific dev paths

### 2. Unicode safety fix

\`lowercase_drive_letter\` previously used \`&s[1..2]\` which **panics** with "not a char boundary" when byte 0 is the start of a multi-byte UTF-8 codepoint (\`É\` = \`0xC3 0x89\`). Real Windows drive letters are always ASCII A-Z, but \`Path::canonicalize\` can return arbitrary path bytes — code that panics on input shape is a latent bug.

Switched to byte-level indexing via \`as_bytes()\`. UTF-8 byte indexing is always safe; ASCII-uppercase check ensures the modified byte preserves UTF-8 validity.

### 3. NFC normalization at both ends

\`é\` has two valid UTF-8 byte sequences:
- **NFC**: \`U+00E9\` → \`0xC3 0xA9\` (2 bytes)
- **NFD**: \`U+0065 U+0301\` → \`0x65 0xCC 0x81\` (3 bytes)

Same character to the eye, **different bytes**. macOS HFS+ stored everything in NFD; APFS preserves the form the API caller used. Env vars typically use NFC. Without normalization:

| | ASCII-named user | Non-ASCII-named user |
|---|---|---|
| Cross-machine cache hits | Work as designed | Silently degraded |
| Diagnosis | n/a | Trace shows \`/Users/José/...\` for both — looks identical, bytes differ |

Failure mode was "miss" not "wrong hit", so technically harmless — but the result is a quiet discrimination bug (worse cache for users with non-ASCII names). ~30KB compiled overhead from the \`unicode-normalization\` crate is the right trade.

Both sides normalize to NFC before matching:
- \`canonical_string\` (rule construction): \`.nfc()\` after \`canonicalize()\`
- \`normalize\` (input matching): \`.nfc()\` at the start

NFC is semantic-preserving for path strings — composed and decomposed forms are equivalent representations. The step is a no-op for inputs already in NFC (the common case).

### 4. Extended test coverage (13 → 36 tests)

| Area | Tests |
|---|---|
| Real-world \`normalize\` shapes | 3 (multiple occurrences, input==prefix, multi-prefix chaining) |
| Rule precedence | 1 (most-specific wins when nested) |
| Idempotency / sentinel safety | 1 |
| Windows variants | 6 (drive-root edge cases, no-duplicate variants, all 4 in \`remap_args\`, etc.) |
| Realistic embedded inputs | 2 (OUT_DIR-shape, RUSTFLAGS-shape) |
| Determinism | 1 (same env → same rules) |
| Documented limitations | 1 (substring vs path-component matching) |
| Unicode safety | 3 (multi-byte first char no-panic, realistic paths, multi-script preservation) |
| **NFC/NFD equivalence** | **2** (cross-form matching, canonical_string outputs NFC) |

## What's NOT in this PR

- **Windows e2e runner**: separate work. The harness has unix-isms (cp -R, make-based fixtures); the PathNormalizer fix is well-bounded enough to ship ahead. Tracked in #77.
- Other path-handling edge cases (container paths, NixOS, UNC) — \`priority:low\` in #78–#81.

## Test plan

- [x] All 36 path_normalizer unit tests pass on macOS arm64
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Verified the panic reproducer (\`É:foo\`) no longer panics
- [x] Verified cross-NFC/NFD substring matching with hand-crafted byte sequences (NFC prefix + NFD input → match fires)
- [ ] CI: Linux full suite + e2e harness (still passes — no harness changes)

## Closes

Tier-1 #2 from the post-#74 path-handling follow-up. Replaces / supersedes #85 (test branch was cherry-picked into this PR).