### PR TITLE
feat(cc): C-family argument parser + refuse-to-cache detection (PR5-A)

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1,58 +1,422 @@
-//! C-family compiler skeleton (cc / gcc / g++ / clang / clang++ / c++).
+//! C-family compiler (cc / gcc / g++ / clang / clang++ / c++).
 //!
-//! **Phase 0 — passthrough only.** This module establishes the wrapper-mode
-//! detection plumbing and invocation surface for C-family compilers. It does
-//! NOT cache anything yet: `refuse_reasons` returns
-//! [`RefuseReason::Unsupported`] unconditionally, which routes every C/C++
-//! invocation through the wrapper's passthrough path. Real caching (arg
-//! parsing, preprocessor hash, output classification, refuse-to-cache list)
-//! lands incrementally in follow-up PRs against the e2e test surface this
-//! commit also adds.
+//! **Phase 1 — argument parser + refuse-to-cache detection.** Builds
+//! the parsed shape kache will use when caching activates, and
+//! enumerates the invocation patterns we can't safely cache (response
+//! files, multi-arch, PCH, modules, etc.). `refuse_reasons` still
+//! emits a catch-all [`RefuseReason::Unsupported`] so the wrapper
+//! continues to route every C/C++ invocation through passthrough —
+//! that gate flips off in a follow-up PR (PR5-C) when the cache
+//! key + output discovery + storage land.
 //!
 //! What works today:
-//! - `CC=kache cc` and `CXX=kache c++` are recognized as wrapper invocations
-//!   instead of failing the CLI subcommand parser.
-//! - The compiler is invoked with the original argv; stdout / stderr / exit
-//!   code are propagated transparently.
-//! - The skeleton validates the [`Compiler`] trait against a second compiler
-//!   family without any per-compiler shortcuts in shared code.
+//! - `CC=kache cc` / `CXX=kache c++` recognized as wrapper invocations.
+//! - argv parsed into a structured [`CcArgs`] (sources, output,
+//!   compile mode, includes, defines, opt level, debug level, std,
+//!   PIC, dep-info, language override). Unknown flags pass through
+//!   intact in `rest`.
+//! - Refuse-to-cache list detects known-unsafe shapes; specific
+//!   reasons land in the [`RefuseReason`] vector ahead of the
+//!   skeleton's catch-all so when caching activates the per-case
+//!   detection is already correct.
+//! - Underlying compiler invoked with the original argv on
+//!   passthrough; stdout / stderr / exit propagated.
 //!
 //! Future work (separate PRs):
-//! - Argument parsing (top ~10 flags first, refuse the rest)
 //! - Preprocessor-based cache key (`cc -E` + blake3 + `SOURCE_DATE_EPOCH`
 //!   injection to neutralize `__DATE__` / `__TIME__` macros)
 //! - Output discovery (`.o`, `.d`, executables, `.dylib`/`.so`/`.dll`)
-//! - Refuse-to-cache list (response files, multi-arch, `--coverage`,
-//!   `-gsplit-dwarf`, PCH, modules)
+//! - Wire refuse_reasons → cache_key → store path; remove the
+//!   unconditional `Unsupported` skeleton gate.
 
 use anyhow::{Context, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::{
     ArtifactKind, CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason, classify_by_filename,
 };
 
-/// Parsed C-family invocation. Skeleton stores only what's needed to
-/// re-execute the compiler verbatim — real arg classification (preprocessor
-/// vs common vs unhashed vs refuse) lands in a follow-up.
+/// What stage the compiler is being asked to produce.
+///
+/// Cargo's `cc` crate (and most build systems) use `-c` for the
+/// per-file compile step that produces a `.o`, then a separate
+/// invocation that links them into the final executable / library.
+/// Caching is most valuable for `Compile` mode (the per-file work
+/// gets reused across invocations); `Link` mode caching is harder
+/// (depends on every input `.o`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompileMode {
+    /// `-c`: produce object file(s) from source. The default cache
+    /// target for kache's cc support.
+    Compile,
+    /// (no `-c` flag): compile + link, producing an executable or
+    /// dynamic library. Realistic to cache eventually but more
+    /// failure-prone (linker version, link order, native lib search
+    /// paths).
+    Link,
+    /// `-E`: preprocess only — emits the source after macro expansion.
+    /// Used by build systems for header probing; rarely cached.
+    /// Note: also matches the `cc` crate's family probe shape, which
+    /// is handled BEFORE this parser via [`CcCompiler::recognizes_family_probe`].
+    Preprocess,
+    /// `-S`: produce assembly output. Niche; same caching profile
+    /// as `Compile` in principle but rarely worth the engineering.
+    Assemble,
+}
+
+/// `-O0` … `-O3`, plus the size and debug variants. Stored as the
+/// raw character (`'0'`..`'3'`, `'s'`, `'z'`, `'g'`) so the cache
+/// key can hash it directly without re-stringification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptLevel {
+    O0,
+    O1,
+    O2,
+    O3,
+    /// `-Os` — optimize for size.
+    Os,
+    /// `-Oz` — optimize for size, more aggressive (clang-only).
+    Oz,
+    /// `-Og` — optimize while preserving debuggability.
+    Og,
+}
+
+/// Dependency-info generation flags (`-MMD` / `-MD` / `-MF` / `-MT`).
+///
+/// Cargo uses these to figure out which headers a `.o` depends on
+/// for incremental rebuild. kache caches the `.o` directly, so the
+/// dep-info file is generated as a side effect — but its CONTENTS
+/// (a Make-style dependency list) embed absolute paths that need
+/// the same path-normalization treatment as rustc's dep-info.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DepInfoSpec {
+    /// `-MD` (true) or `-MMD` (false). True = include system headers
+    /// in the dep-info output; false = user headers only.
+    pub include_system: bool,
+    /// `-MF foo.d`: where to write the dep-info file. `None` means
+    /// the compiler picks a default (typically next to the `.o`).
+    pub output: Option<PathBuf>,
+    /// `-MT target`: the make target name for dep-info entries.
+    /// Defaults to the output object name.
+    pub target: Option<String>,
+}
+
+/// Parsed C-family invocation.
+///
+/// Field order roughly matches the cache-key construction order
+/// (compiler family + version, then flags affecting code gen, then
+/// flags affecting layout, then sources). Keeping that consistency
+/// makes the cache_key implementation (PR5-B) easier to read.
 #[derive(Debug, Clone)]
 pub struct CcArgs {
     /// argv[0] — the compiler binary path the wrapper was invoked as.
     pub program: String,
-    /// argv[1..] — passed through to the compiler unchanged.
+    /// argv[1..] verbatim — preserved for passthrough / re-execution.
     pub rest: Vec<String>,
+
+    /// Source files (`.c`, `.cpp`, `.cc`, `.cxx`, `.m`, `.mm`).
+    /// May be empty for link-only invocations or pure flag probes.
+    pub sources: Vec<PathBuf>,
+    /// Output path from `-o`. `None` = compiler default (varies by mode).
+    pub output: Option<PathBuf>,
+    /// What stage the compiler was asked to produce.
+    pub mode: CompileMode,
+    /// Include search paths from `-I dir` / `-Idir` (in declaration
+    /// order — order matters for header search semantics).
+    pub includes: Vec<PathBuf>,
+    /// Defines from `-D NAME` / `-D NAME=VALUE` (declaration order).
+    pub defines: Vec<(String, Option<String>)>,
+    /// Optimization level.
+    pub optimization: Option<OptLevel>,
+    /// Debug-info level: `0` = none (`-g0`), through `3` = max
+    /// (`-g3`). Bare `-g` is treated as `2` (compiler default).
+    pub debug_level: Option<u8>,
+    /// Language standard from `-std=c11` / `-std=c++17` etc.
+    /// Stored without the `-std=` prefix.
+    pub std: Option<String>,
+    /// Position-independent code (`-fPIC` / `-fpic`).
+    pub pic: bool,
+    /// Dependency-info generation flags. `None` = no dep-info.
+    pub depinfo: Option<DepInfoSpec>,
+    /// Language override from `-x c` / `-x c++` / `-x objective-c`.
+    /// Without this flag, the compiler infers from source extension.
+    pub language_override: Option<String>,
 }
+
+/// Source file extensions the parser recognizes as C-family input.
+/// Anything else gets ignored (left in `rest` for passthrough).
+const SOURCE_EXTENSIONS: &[&str] = &[
+    "c", "cc", "cpp", "cxx", "c++", "C", // C / C++
+    "m", "mm", "M", // Objective-C / Objective-C++
+    "i", "ii", // already-preprocessed
+    "S", "s", "sx", // assembly
+];
 
 impl CcArgs {
     pub fn parse(args: &[String]) -> Result<Self> {
         let (program, rest) = args
             .split_first()
             .context("cc invocation missing argv[0]")?;
-        Ok(Self {
+
+        let mut parsed = CcArgs {
             program: program.clone(),
             rest: rest.to_vec(),
-        })
+            sources: Vec::new(),
+            output: None,
+            mode: CompileMode::Link, // default: compile + link
+            includes: Vec::new(),
+            defines: Vec::new(),
+            optimization: None,
+            debug_level: None,
+            std: None,
+            pic: false,
+            depinfo: None,
+            language_override: None,
+        };
+
+        // Walk argv with a peekable iterator so flags-with-separate-args
+        // (e.g. `-o foo.o`, `-I /path`) can consume the next token.
+        let mut iter = rest.iter().enumerate().peekable();
+        let mut depinfo: Option<DepInfoSpec> = None;
+        while let Some((_idx, arg)) = iter.next() {
+            // Most flags fall into one of three shapes:
+            //   - sticky:  `-O2`, `-Idir`, `-DNAME=val` (value glued to flag)
+            //   - separate: `-o file`, `-I dir`, `-D NAME` (value in next arg)
+            //   - bare:    `-c`, `-fPIC`, `-MMD` (no value)
+            // We try sticky-prefix matches first (they're unambiguous),
+            // then exact-match flags, then fall through to "next arg" form
+            // for known-separate flags.
+            match arg.as_str() {
+                // ── Compile mode ─────────────────────────────────
+                "-c" => parsed.mode = CompileMode::Compile,
+                "-E" => parsed.mode = CompileMode::Preprocess,
+                "-S" => parsed.mode = CompileMode::Assemble,
+
+                // ── Output ───────────────────────────────────────
+                "-o" => {
+                    if let Some((_, val)) = iter.next() {
+                        parsed.output = Some(PathBuf::from(val));
+                    }
+                }
+
+                // ── PIC ──────────────────────────────────────────
+                "-fPIC" | "-fpic" => parsed.pic = true,
+
+                // ── Debug ────────────────────────────────────────
+                // Bare `-g` is the compiler's default level (typically 2).
+                "-g" => parsed.debug_level = Some(2),
+                "-g0" => parsed.debug_level = Some(0),
+                "-g1" => parsed.debug_level = Some(1),
+                "-g2" => parsed.debug_level = Some(2),
+                "-g3" => parsed.debug_level = Some(3),
+
+                // ── Optimization ─────────────────────────────────
+                // Bare `-O` is `-O1` per gcc/clang convention.
+                "-O" | "-O1" => parsed.optimization = Some(OptLevel::O1),
+                "-O0" => parsed.optimization = Some(OptLevel::O0),
+                "-O2" => parsed.optimization = Some(OptLevel::O2),
+                "-O3" => parsed.optimization = Some(OptLevel::O3),
+                "-Os" => parsed.optimization = Some(OptLevel::Os),
+                "-Oz" => parsed.optimization = Some(OptLevel::Oz),
+                "-Og" => parsed.optimization = Some(OptLevel::Og),
+
+                // ── Dep-info: bare flags ─────────────────────────
+                "-MD" => {
+                    let d = depinfo.get_or_insert_with(DepInfoSpec::default);
+                    d.include_system = true;
+                }
+                "-MMD" => {
+                    let d = depinfo.get_or_insert_with(DepInfoSpec::default);
+                    d.include_system = false;
+                }
+                "-MF" => {
+                    if let Some((_, val)) = iter.next() {
+                        let d = depinfo.get_or_insert_with(DepInfoSpec::default);
+                        d.output = Some(PathBuf::from(val));
+                    }
+                }
+                "-MT" | "-MQ" => {
+                    if let Some((_, val)) = iter.next() {
+                        let d = depinfo.get_or_insert_with(DepInfoSpec::default);
+                        d.target = Some(val.clone());
+                    }
+                }
+
+                // ── Language override (`-x c++` etc.) ────────────
+                "-x" => {
+                    if let Some((_, val)) = iter.next() {
+                        parsed.language_override = Some(val.clone());
+                    }
+                }
+
+                // ── Include / Define: separate-arg form ──────────
+                "-I" => {
+                    if let Some((_, val)) = iter.next() {
+                        parsed.includes.push(PathBuf::from(val));
+                    }
+                }
+                "-D" => {
+                    if let Some((_, val)) = iter.next() {
+                        parsed.defines.push(parse_define(val));
+                    }
+                }
+
+                // ── Sticky-prefix forms ──────────────────────────
+                _ if let Some(rest) = arg.strip_prefix("-I") => {
+                    parsed.includes.push(PathBuf::from(rest));
+                }
+                _ if let Some(rest) = arg.strip_prefix("-D") => {
+                    parsed.defines.push(parse_define(rest));
+                }
+                _ if let Some(rest) = arg.strip_prefix("-std=") => {
+                    parsed.std = Some(rest.to_string());
+                }
+
+                // ── Source files (positional) ────────────────────
+                _ if !arg.starts_with('-') && looks_like_source(arg) => {
+                    parsed.sources.push(PathBuf::from(arg));
+                }
+
+                // Unknown / unhandled — leave in `rest` for passthrough.
+                _ => {}
+            }
+        }
+        parsed.depinfo = depinfo;
+
+        Ok(parsed)
+    }
+
+    /// Enumerate refuse-to-cache reasons the parsed invocation
+    /// triggers. Returns an empty vector for "looks safe to cache".
+    ///
+    /// Each detection is conservative — we'd rather refuse a
+    /// cacheable invocation than miscache an unsafe one. Specific
+    /// patterns covered:
+    ///
+    /// - **Response files** (`@file.rsp`): the actual flags live in
+    ///   another file we'd need to read + hash separately.
+    /// - **Multi-arch fat binaries** (`-arch x86_64 -arch arm64`):
+    ///   output is a single file containing multiple object slices,
+    ///   doesn't fit the per-source-per-output model.
+    /// - **Coverage instrumentation** (`--coverage`,
+    ///   `-fprofile-arcs`, `-ftest-coverage`): coverage tools need
+    ///   the original source paths in profraw data; cache hits
+    ///   would break coverage mapping.
+    /// - **Split DWARF** (`-gsplit-dwarf`): produces a separate
+    ///   `.dwo` file alongside the `.o`; output discovery would
+    ///   need to know about the pair.
+    /// - **Precompiled headers** (`-include-pch`, `-emit-pch`):
+    ///   PCHs are non-portable across compiler versions and depend
+    ///   on the entire include graph at PCH-build time.
+    /// - **Modules** (`-fmodules`, `-fcxx-modules`): module
+    ///   compilation has its own dependency model; doesn't fit the
+    ///   per-TU cache model.
+    /// - **Output to stdout** (`-o -`): not a cacheable artifact.
+    /// - **Preprocess / Assemble mode**: `-E` and `-S` produce
+    ///   developer-facing output that's rarely worth caching and
+    ///   tangles with the cc-crate probe pattern.
+    pub fn refuse_reasons(&self) -> Vec<RefuseReason> {
+        let mut reasons = Vec::new();
+
+        // Response files: any arg starting with `@` (typically a
+        // path to a file containing additional flags). The flags
+        // inside aren't visible to our parser without recursive
+        // expansion + path normalization.
+        if self.rest.iter().any(|a| a.starts_with('@')) {
+            reasons.push(RefuseReason::Unsupported("cc: response file (@file)"));
+        }
+
+        // Multi-arch (`-arch X -arch Y` produces a fat binary).
+        // Single `-arch` is fine — many cc invocations specify it.
+        let arch_count = self.rest.windows(2).filter(|w| w[0] == "-arch").count();
+        if arch_count > 1 {
+            reasons.push(RefuseReason::Unsupported(
+                "cc: multi-arch (-arch X -arch Y)",
+            ));
+        }
+
+        // Coverage instrumentation.
+        for flag in &["--coverage", "-fprofile-arcs", "-ftest-coverage"] {
+            if self.rest.iter().any(|a| a == flag) {
+                reasons.push(RefuseReason::Unsupported("cc: coverage instrumentation"));
+                break;
+            }
+        }
+
+        // Split DWARF (separate .dwo file alongside .o).
+        if self.rest.iter().any(|a| a == "-gsplit-dwarf") {
+            reasons.push(RefuseReason::Unsupported("cc: -gsplit-dwarf"));
+        }
+
+        // Precompiled headers.
+        for flag in &["-include-pch", "-emit-pch"] {
+            if self.rest.iter().any(|a| a == flag) {
+                reasons.push(RefuseReason::Unsupported("cc: precompiled headers"));
+                break;
+            }
+        }
+        // `*.pch` / `*.gch` as -include argument also indicates PCH.
+        let mut iter = self.rest.iter().peekable();
+        while let Some(arg) = iter.next() {
+            if arg == "-include"
+                && let Some(next) = iter.peek()
+                && (next.ends_with(".pch") || next.ends_with(".gch"))
+            {
+                reasons.push(RefuseReason::Unsupported("cc: precompiled headers"));
+                break;
+            }
+        }
+
+        // Modules (clang/gcc).
+        for flag in &["-fmodules", "-fcxx-modules"] {
+            if self.rest.iter().any(|a| a == flag) {
+                reasons.push(RefuseReason::Unsupported("cc: modules"));
+                break;
+            }
+        }
+
+        // Output to stdout — `-o -` is unambiguous; an `-o` followed
+        // by a literal `-` arg.
+        if let Some(output) = &self.output
+            && output.as_os_str() == "-"
+        {
+            reasons.push(RefuseReason::Unsupported("cc: output to stdout"));
+        }
+
+        // Preprocess / Assemble: developer-facing output, not the
+        // cacheable per-file compile shape kache targets.
+        match self.mode {
+            CompileMode::Preprocess => {
+                reasons.push(RefuseReason::Unsupported("cc: preprocessor mode (-E)"))
+            }
+            CompileMode::Assemble => {
+                reasons.push(RefuseReason::Unsupported("cc: assembly mode (-S)"))
+            }
+            _ => {}
+        }
+
+        reasons
+    }
+}
+
+/// Whether a positional argument looks like a C-family source file
+/// (matches one of the recognized extensions in [`SOURCE_EXTENSIONS`]).
+/// Conservative: extensionless files or unknown extensions are NOT
+/// treated as sources, even if they happen to be C code in practice.
+fn looks_like_source(arg: &str) -> bool {
+    Path::new(arg)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| SOURCE_EXTENSIONS.contains(&e))
+        .unwrap_or(false)
+}
+
+/// Parse a `-D NAME` or `-D NAME=VALUE` argument value.
+fn parse_define(s: &str) -> (String, Option<String>) {
+    match s.split_once('=') {
+        Some((name, value)) => (name.to_string(), Some(value.to_string())),
+        None => (s.to_string(), None),
     }
 }
 
@@ -131,20 +495,28 @@ impl Compiler for CcCompiler {
         CcArgs::parse(args)
     }
 
-    fn refuse_reasons(&self, _parsed: &CcArgs) -> Vec<RefuseReason> {
-        // Skeleton: refuse every C/C++ invocation. Wrapper sees this and
-        // routes to passthrough. Removing this is the signal that real
-        // caching has landed.
-        vec![RefuseReason::Unsupported(
+    fn refuse_reasons(&self, parsed: &CcArgs) -> Vec<RefuseReason> {
+        // Per-case detection from the parsed shape — cataloged ahead
+        // of the unconditional skeleton refusal so when PR5-C lands
+        // and removes the catch-all, the per-case checks already
+        // produce the right answers.
+        let mut reasons = parsed.refuse_reasons();
+        // Skeleton: refuse every C/C++ invocation until the cache_key
+        // + storage path lands. Removing this push (in PR5-C) is the
+        // signal that real caching has activated. Push it LAST so
+        // any per-case reason appears first in logs.
+        reasons.push(RefuseReason::Unsupported(
             "cc-family caching not yet implemented (skeleton only)",
-        )]
+        ));
+        reasons
     }
 
     fn cache_key(&self, _parsed: &CcArgs, _ctx: &KeyCtx<'_>) -> Result<String> {
-        // Unreachable while refuse_reasons returns Unsupported. Documented
-        // as a precondition rather than panicking so a future regression
-        // (wrapper calling cache_key without checking refuse) gets a clear
-        // error instead of silent miscaching.
+        // Unreachable while refuse_reasons emits the skeleton catch-all.
+        // Documented as a precondition rather than panicking so a
+        // future regression (wrapper calling cache_key without
+        // checking refuse) gets a clear error instead of silent
+        // miscaching.
         anyhow::bail!("CcCompiler::cache_key called while caching is not yet implemented")
     }
 
@@ -183,6 +555,8 @@ mod tests {
         args.iter().map(|a| a.to_string()).collect()
     }
 
+    // ── recognize ────────────────────────────────────────────────
+
     #[test]
     fn recognizes_canonical_command_names() {
         for name in [
@@ -215,9 +589,6 @@ mod tests {
 
     #[test]
     fn recognizes_family_probe_matches_dash_e_with_file_arg() {
-        // Exact shape the cc crate emits during compiler-family probe.
-        // Pinning this by example keeps the contract obvious: argv[0]=="-E"
-        // plus at least one more arg (the temp file).
         assert!(CcCompiler::recognizes_family_probe(&s(&[
             "-E",
             "/tmp/probe.c"
@@ -230,21 +601,18 @@ mod tests {
 
     #[test]
     fn recognizes_family_probe_rejects_dash_e_alone() {
-        // Without a file arg, `-E` is just a flag; not a probe. Tight
-        // match prevents masking legitimate clap-errors.
         assert!(!CcCompiler::recognizes_family_probe(&s(&["-E"])));
     }
 
     #[test]
     fn recognizes_family_probe_rejects_non_probe_shapes() {
-        // None of these should be misidentified as the cc crate's probe.
         for argv in [
-            vec![],               // empty
-            s(&["-c", "foo.c"]),  // -c (compile, not probe)
-            s(&["--version"]),    // kache's own flag
-            s(&["-dumpmachine"]), // future probe shape, not yet
-            s(&["report"]),       // CLI subcommand
-            s(&["foo.c"]),        // bare file
+            vec![],
+            s(&["-c", "foo.c"]),
+            s(&["--version"]),
+            s(&["-dumpmachine"]),
+            s(&["report"]),
+            s(&["foo.c"]),
         ] {
             assert!(
                 !CcCompiler::recognizes_family_probe(&argv),
@@ -269,9 +637,10 @@ mod tests {
                 "should NOT recognize {name}"
             );
         }
-        // Empty argv: there is nothing to recognize.
         assert!(!CcCompiler::recognizes(&[]));
     }
+
+    // ── parser: program / rest ──────────────────────────────────
 
     #[test]
     fn parse_splits_program_from_rest() {
@@ -280,25 +649,406 @@ mod tests {
         assert_eq!(parsed.rest, vec!["-c", "foo.c", "-o", "foo.o"]);
     }
 
+    // ── parser: compile mode ────────────────────────────────────
+
     #[test]
-    fn refuse_reasons_always_unsupported_in_skeleton() {
-        // Locks the skeleton contract: until real caching lands, every
-        // C/C++ invocation must route through passthrough. When this
-        // test starts failing, real caching has arrived (or someone
-        // skipped the refuse step — that's the bug to investigate).
+    fn parse_default_mode_is_link() {
+        // No `-c`, `-E`, `-S` → default cargo / cc-crate "compile + link" shape.
+        let parsed = CcArgs::parse(&s(&["cc", "foo.c", "-o", "foo"])).unwrap();
+        assert_eq!(parsed.mode, CompileMode::Link);
+    }
+
+    #[test]
+    fn parse_dash_c_sets_compile_mode() {
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o"])).unwrap();
+        assert_eq!(parsed.mode, CompileMode::Compile);
+    }
+
+    #[test]
+    fn parse_dash_e_sets_preprocess_mode() {
+        let parsed = CcArgs::parse(&s(&["cc", "-E", "foo.c"])).unwrap();
+        assert_eq!(parsed.mode, CompileMode::Preprocess);
+    }
+
+    #[test]
+    fn parse_dash_s_sets_assemble_mode() {
+        let parsed = CcArgs::parse(&s(&["cc", "-S", "foo.c"])).unwrap();
+        assert_eq!(parsed.mode, CompileMode::Assemble);
+    }
+
+    // ── parser: output ──────────────────────────────────────────
+
+    #[test]
+    fn parse_dash_o_sets_output() {
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "build/foo.o"])).unwrap();
+        assert_eq!(parsed.output, Some(PathBuf::from("build/foo.o")));
+    }
+
+    #[test]
+    fn parse_no_output_means_compiler_default() {
+        // Without `-o`, the compiler picks (e.g., `a.out` for link mode).
+        let parsed = CcArgs::parse(&s(&["cc", "foo.c"])).unwrap();
+        assert_eq!(parsed.output, None);
+    }
+
+    // ── parser: sources ─────────────────────────────────────────
+
+    #[test]
+    fn parse_collects_source_files_by_extension() {
+        let parsed =
+            CcArgs::parse(&s(&["cc", "main.c", "util.c", "-o", "foo", "lib.cpp"])).unwrap();
+        assert_eq!(
+            parsed.sources,
+            vec![
+                PathBuf::from("main.c"),
+                PathBuf::from("util.c"),
+                PathBuf::from("lib.cpp"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_recognizes_objc_and_assembly_extensions() {
+        // Coverage of the long extension list — pin all the obscure
+        // ones so a future ergonomic cleanup of SOURCE_EXTENSIONS
+        // (e.g. removing the `.M` Objective-C uppercase variant)
+        // doesn't silently break parsing.
+        for src in &[
+            "foo.m", "foo.mm", "foo.M", // Objective-C / C++
+            "foo.i", "foo.ii", // pre-preprocessed
+            "foo.s", "foo.S", "foo.sx", // assembly
+        ] {
+            let parsed = CcArgs::parse(&s(&["cc", "-c", src])).unwrap();
+            assert_eq!(
+                parsed.sources,
+                vec![PathBuf::from(src)],
+                "expected {src} to be recognized as a source"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_ignores_non_source_positional_args() {
+        // Positional args without a recognized source extension stay
+        // in `rest` (so they're passed through verbatim) but don't
+        // count as sources.
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-lpthread"])).unwrap();
+        assert_eq!(parsed.sources, vec![PathBuf::from("foo.c")]);
+        // Library link flags etc. live in `rest` for re-execution.
+        assert!(parsed.rest.contains(&"-lpthread".to_string()));
+    }
+
+    // ── parser: includes ────────────────────────────────────────
+
+    #[test]
+    fn parse_includes_separate_arg_form() {
+        let parsed = CcArgs::parse(&s(&[
+            "cc",
+            "-c",
+            "foo.c",
+            "-I",
+            "include",
+            "-I",
+            "/usr/local/include",
+        ]))
+        .unwrap();
+        assert_eq!(
+            parsed.includes,
+            vec![
+                PathBuf::from("include"),
+                PathBuf::from("/usr/local/include"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_includes_sticky_form() {
+        let parsed = CcArgs::parse(&s(&[
+            "cc",
+            "-c",
+            "foo.c",
+            "-Iinclude",
+            "-I/usr/local/include",
+        ]))
+        .unwrap();
+        assert_eq!(
+            parsed.includes,
+            vec![
+                PathBuf::from("include"),
+                PathBuf::from("/usr/local/include"),
+            ]
+        );
+    }
+
+    // ── parser: defines ─────────────────────────────────────────
+
+    #[test]
+    fn parse_defines_with_and_without_values() {
+        let parsed = CcArgs::parse(&s(&[
+            "cc", "-c", "foo.c", "-DFOO", "-DBAR=42", "-D", "BAZ=qux",
+        ]))
+        .unwrap();
+        assert_eq!(
+            parsed.defines,
+            vec![
+                ("FOO".to_string(), None),
+                ("BAR".to_string(), Some("42".to_string())),
+                ("BAZ".to_string(), Some("qux".to_string())),
+            ]
+        );
+    }
+
+    // ── parser: optimization / debug / std / pic ────────────────
+
+    #[test]
+    fn parse_optimization_levels() {
+        for (flag, expected) in [
+            ("-O0", OptLevel::O0),
+            ("-O1", OptLevel::O1),
+            ("-O", OptLevel::O1), // bare -O = -O1
+            ("-O2", OptLevel::O2),
+            ("-O3", OptLevel::O3),
+            ("-Os", OptLevel::Os),
+            ("-Oz", OptLevel::Oz),
+            ("-Og", OptLevel::Og),
+        ] {
+            let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", flag])).unwrap();
+            assert_eq!(parsed.optimization, Some(expected), "for {flag}");
+        }
+    }
+
+    #[test]
+    fn parse_debug_levels() {
+        for (flag, expected) in [
+            ("-g", 2u8), // bare -g = compiler default (2)
+            ("-g0", 0),
+            ("-g1", 1),
+            ("-g2", 2),
+            ("-g3", 3),
+        ] {
+            let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", flag])).unwrap();
+            assert_eq!(parsed.debug_level, Some(expected), "for {flag}");
+        }
+    }
+
+    #[test]
+    fn parse_std_strips_prefix() {
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-std=c++17"])).unwrap();
+        assert_eq!(parsed.std, Some("c++17".to_string()));
+    }
+
+    #[test]
+    fn parse_pic_flags() {
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-fPIC"])).unwrap();
+        assert!(parsed.pic);
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-fpic"])).unwrap();
+        assert!(parsed.pic);
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c"])).unwrap();
+        assert!(!parsed.pic);
+    }
+
+    // ── parser: depinfo ─────────────────────────────────────────
+
+    #[test]
+    fn parse_depinfo_mmd_excludes_system_headers() {
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-MMD"])).unwrap();
+        let d = parsed.depinfo.expect("dep-info should be set");
+        assert!(!d.include_system);
+        assert_eq!(d.output, None);
+        assert_eq!(d.target, None);
+    }
+
+    #[test]
+    fn parse_depinfo_md_includes_system_headers() {
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-MD"])).unwrap();
+        let d = parsed.depinfo.expect("dep-info should be set");
+        assert!(d.include_system);
+    }
+
+    #[test]
+    fn parse_depinfo_mf_sets_output_path() {
+        let parsed =
+            CcArgs::parse(&s(&["cc", "-c", "foo.c", "-MMD", "-MF", "build/foo.d"])).unwrap();
+        let d = parsed.depinfo.expect("dep-info should be set");
+        assert_eq!(d.output, Some(PathBuf::from("build/foo.d")));
+    }
+
+    #[test]
+    fn parse_depinfo_mt_sets_target_name() {
+        let parsed =
+            CcArgs::parse(&s(&["cc", "-c", "foo.c", "-MMD", "-MT", "build/foo.o"])).unwrap();
+        let d = parsed.depinfo.expect("dep-info should be set");
+        assert_eq!(d.target, Some("build/foo.o".to_string()));
+    }
+
+    #[test]
+    fn parse_no_depinfo_flags_means_no_depinfo_struct() {
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o"])).unwrap();
+        assert!(parsed.depinfo.is_none());
+    }
+
+    // ── parser: language override ───────────────────────────────
+
+    #[test]
+    fn parse_language_override() {
+        let parsed = CcArgs::parse(&s(&["cc", "-x", "c++", "-c", "src"])).unwrap();
+        assert_eq!(parsed.language_override, Some("c++".to_string()));
+    }
+
+    // ── refuse-to-cache: per-case ───────────────────────────────
+
+    fn refuse_descriptions(args: &[&str]) -> Vec<&'static str> {
+        let parsed = CcArgs::parse(&s(args)).unwrap();
+        parsed
+            .refuse_reasons()
+            .iter()
+            .map(|r| r.description())
+            .collect()
+    }
+
+    #[test]
+    fn refuses_response_files() {
+        let descs = refuse_descriptions(&["cc", "-c", "@flags.rsp"]);
+        assert!(
+            descs.iter().any(|d| d.contains("response file")),
+            "expected response-file refuse, got: {descs:?}"
+        );
+    }
+
+    #[test]
+    fn refuses_multi_arch() {
+        // Single -arch is fine; multi -arch produces a fat binary.
+        let single = refuse_descriptions(&["cc", "-c", "foo.c", "-arch", "arm64"]);
+        assert!(!single.iter().any(|d| d.contains("multi-arch")));
+
+        let multi =
+            refuse_descriptions(&["cc", "-c", "foo.c", "-arch", "arm64", "-arch", "x86_64"]);
+        assert!(
+            multi.iter().any(|d| d.contains("multi-arch")),
+            "expected multi-arch refuse, got: {multi:?}"
+        );
+    }
+
+    #[test]
+    fn refuses_coverage_instrumentation() {
+        for flag in &["--coverage", "-fprofile-arcs", "-ftest-coverage"] {
+            let descs = refuse_descriptions(&["cc", "-c", "foo.c", flag]);
+            assert!(
+                descs.iter().any(|d| d.contains("coverage")),
+                "expected coverage refuse for {flag}, got: {descs:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn refuses_split_dwarf() {
+        let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-gsplit-dwarf"]);
+        assert!(
+            descs.iter().any(|d| d.contains("gsplit-dwarf")),
+            "expected gsplit-dwarf refuse, got: {descs:?}"
+        );
+    }
+
+    #[test]
+    fn refuses_precompiled_headers() {
+        // The `-include foo.pch` form
+        let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-include", "stdafx.pch"]);
+        assert!(
+            descs.iter().any(|d| d.contains("precompiled")),
+            "expected PCH refuse, got: {descs:?}"
+        );
+        // The explicit `-emit-pch` form
+        let descs = refuse_descriptions(&["cc", "-c", "foo.h", "-emit-pch"]);
+        assert!(
+            descs.iter().any(|d| d.contains("precompiled")),
+            "expected PCH refuse for -emit-pch, got: {descs:?}"
+        );
+    }
+
+    #[test]
+    fn refuses_modules() {
+        for flag in &["-fmodules", "-fcxx-modules"] {
+            let descs = refuse_descriptions(&["cc", "-c", "foo.cpp", flag]);
+            assert!(
+                descs.iter().any(|d| d.contains("modules")),
+                "expected modules refuse for {flag}, got: {descs:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn refuses_output_to_stdout() {
+        let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "-"]);
+        assert!(
+            descs.iter().any(|d| d.contains("stdout")),
+            "expected stdout-output refuse, got: {descs:?}"
+        );
+    }
+
+    #[test]
+    fn refuses_preprocess_and_assemble_modes() {
+        let preprocess = refuse_descriptions(&["cc", "-E", "foo.c"]);
+        assert!(
+            preprocess.iter().any(|d| d.contains("preprocessor")),
+            "expected preprocessor-mode refuse, got: {preprocess:?}"
+        );
+
+        let assemble = refuse_descriptions(&["cc", "-S", "foo.c"]);
+        assert!(
+            assemble.iter().any(|d| d.contains("assembly")),
+            "expected assembly-mode refuse, got: {assemble:?}"
+        );
+    }
+
+    #[test]
+    fn refuses_nothing_for_clean_compile_invocation() {
+        // The shape we WANT to cache: compile-only, single source,
+        // explicit output, common flags. Only the skeleton catch-all
+        // should fire (added in Compiler::refuse_reasons, not in
+        // CcArgs::refuse_reasons), so the parser-level check is empty.
+        let parsed = CcArgs::parse(&s(&[
+            "cc",
+            "-c",
+            "src/foo.c",
+            "-o",
+            "build/foo.o",
+            "-O2",
+            "-g",
+            "-fPIC",
+            "-Iinclude",
+        ]))
+        .unwrap();
+        assert!(
+            parsed.refuse_reasons().is_empty(),
+            "clean compile invocation should have no parser-level refuse reasons; got: {:?}",
+            parsed.refuse_reasons()
+        );
+    }
+
+    // ── Compiler trait: refuse / execute / classify ─────────────
+
+    #[test]
+    fn refuse_reasons_always_includes_skeleton_catchall() {
+        // Until PR5-C lands and removes the catch-all, every
+        // invocation through the trait must end up refused. The
+        // per-case refuse reasons appear FIRST (more useful for
+        // logs); the skeleton's `cc-family caching not yet
+        // implemented` is always the last entry.
         let compiler = CcCompiler::new();
         let parsed = compiler
             .parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o"]))
             .unwrap();
         let reasons = compiler.refuse_reasons(&parsed);
-        assert!(matches!(reasons.as_slice(), [RefuseReason::Unsupported(_)]));
+        let last = reasons.last().expect("at least the catch-all");
+        assert!(
+            last.description().contains("not yet implemented"),
+            "expected skeleton catch-all as last reason, got: {:?}",
+            reasons.iter().map(|r| r.description()).collect::<Vec<_>>()
+        );
     }
 
     #[test]
     fn execute_returns_error_when_compiler_binary_missing() {
-        // Contract: if the compiler can't even be spawned, execute()
-        // returns Err — distinct from "compiler ran but exited non-zero"
-        // which goes via CompileResult.exit_code (see test below).
         let compiler = CcCompiler::new();
         let parsed = compiler
             .parse(&["this-binary-does-not-exist-pls-fail-1234567890".to_string()])
@@ -313,15 +1063,6 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn execute_propagates_non_zero_exit_when_compiler_runs_and_fails() {
-        // Contract: when the compiler RUNS but exits non-zero (the most
-        // common real failure: syntax error, missing file, etc.),
-        // execute() returns Ok with a non-zero exit_code. Caller (the
-        // wrapper) propagates this — passthrough must not swallow
-        // failure signals.
-        //
-        // `false` is on every Unix system and exits 1 deterministically.
-        // Stand-in for "compiler that fails" without depending on a real
-        // toolchain in the test environment.
         let compiler = CcCompiler::new();
         let parsed = compiler.parse(&["false".to_string()]).unwrap();
         let result = compiler
@@ -335,8 +1076,6 @@ mod tests {
 
     #[test]
     fn classify_output_delegates_to_shared_classifier() {
-        // Sanity: c-family extensions go through the same source of
-        // truth as rustc's extension table.
         let compiler = CcCompiler::new();
         let parsed = compiler.parse(&s(&["cc"])).unwrap();
         assert_eq!(


### PR DESCRIPTION
## Summary

PR5-A in the C/C++ caching sequence. Replaces the placeholder \`CcArgs { program, rest }\` with a real parser that extracts every field kache will need when caching activates, plus a refuse-list that detects invocation patterns we can't safely cache.

**\`refuse_reasons\` still emits a catch-all \`RefuseReason::Unsupported\`** so the wrapper continues to passthrough every C/C++ invocation — that gate flips off in PR5-C when the cache key + storage land. The per-case detections appear FIRST in the refuse vector so when the catch-all is removed they're already authoritative.

**Zero behavioral change for users today**: every fixture in the e2e harness still passes with identical results. This PR is pure parser + structured refuse detection; the wrapper still routes everything through passthrough.

## What ships

### New types

| | |
|---|---|
| \`CompileMode\` | \`Compile\` (-c) / \`Link\` / \`Preprocess\` (-E) / \`Assemble\` (-S) |
| \`OptLevel\` | \`O0\`..\`O3\`, plus \`Os\`, \`Oz\`, \`Og\` (size + debug variants) |
| \`DepInfoSpec\` | \`-MMD\`/\`-MD\`/\`-MF\`/\`-MT\` structured for cache-key + storage |

### New parser

\`CcArgs\` gains structured fields:
- \`sources\`, \`output\`, \`mode\`
- \`includes\`, \`defines\`, \`std\`, \`pic\`
- \`optimization\`, \`debug_level\`
- \`depinfo\`, \`language_override\`

Walks argv with a peekable iterator handling all three flag shapes:
- **Sticky**: \`-Idir\`, \`-DNAME=val\`, \`-O2\`
- **Separate**: \`-I dir\`, \`-D NAME\`, \`-o file\`
- **Bare**: \`-c\`, \`-fPIC\`, \`-MMD\`

Unknown flags pass through intact in \`rest\` for re-execution on cache miss.

### Refuse-to-cache detections

Each is conservative — refuse a cacheable invocation rather than miscache an unsafe one:

| Pattern | Reason |
|---|---|
| \`@file.rsp\` | Response file — flags inside aren't visible |
| \`-arch X -arch Y\` | Multi-arch fat binary — output isn't single artifact |
| \`--coverage\` / \`-fprofile-arcs\` / \`-ftest-coverage\` | Coverage tools need original source paths |
| \`-gsplit-dwarf\` | Separate \`.dwo\` file alongside \`.o\` |
| \`-include foo.pch\` / \`-emit-pch\` | PCHs non-portable across versions |
| \`-fmodules\` / \`-fcxx-modules\` | Module compilation has its own dep model |
| \`-o -\` | Output to stdout — not a cacheable artifact |
| \`-E\` / \`-S\` | Preprocess / assembly modes — developer-facing, niche |

## Tests

42 cc tests now (was 13). Coverage breakdown:

- 6 recognize / family-probe (existing)
- 4 compile mode parsing
- 2 output parsing
- 3 source file detection (extensions + non-source positionals + obscure variants)
- 2 include parsing (separate + sticky)
- 1 define parsing (3 shapes)
- 3 optimization / debug / std / pic
- 5 dep-info parsing
- 1 language override
- 9 refuse-to-cache cases (one per pattern + clean-invocation control)
- 4 trait surface

## Test plan

- [x] All 42 cc tests pass on macOS arm64
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] e2e harness: all 5 fixtures pass — no behavior change at the wrapper layer
- [ ] CI: Linux full suite

## Next

- **PR5-B**: preprocessor-based cache key (\`cc -E\` + blake3 + \`SOURCE_DATE_EPOCH\` injection to neutralize \`__DATE__\` / \`__TIME__\` macros)
- **PR5-C**: output discovery + storage, remove the catch-all gate