### PR TITLE
feat(cc): single-source C/C++ object caching (PR5-B + PR5-C)

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1,33 +1,33 @@
 //! C-family compiler (cc / gcc / g++ / clang / clang++ / c++).
 //!
-//! **Phase 1 — argument parser + refuse-to-cache detection.** Builds
-//! the parsed shape kache will use when caching activates, and
-//! enumerates the invocation patterns we can't safely cache (response
-//! files, multi-arch, PCH, modules, etc.). `refuse_reasons` still
-//! emits a catch-all [`RefuseReason::Unsupported`] so the wrapper
-//! continues to route every C/C++ invocation through passthrough —
-//! that gate flips off in a follow-up PR (PR5-C) when the cache
-//! key + output discovery + storage land.
+//! **C/C++ caching is live for the single-source `-c` compile.**
+//! A `cc -c foo.c -o foo.o` invocation gets a content-addressed
+//! cache entry; an identical re-invocation restores the `.o` without
+//! running the compiler.
 //!
-//! What works today:
-//! - `CC=kache cc` / `CXX=kache c++` recognized as wrapper invocations.
-//! - argv parsed into a structured [`CcArgs`] (sources, output,
-//!   compile mode, includes, defines, opt level, debug level, std,
-//!   PIC, dep-info, language override). Unknown flags pass through
-//!   intact in `rest`.
-//! - Refuse-to-cache list detects known-unsafe shapes; specific
-//!   reasons land in the [`RefuseReason`] vector ahead of the
-//!   skeleton's catch-all so when caching activates the per-case
-//!   detection is already correct.
-//! - Underlying compiler invoked with the original argv on
-//!   passthrough; stdout / stderr / exit propagated.
+//! What's cached:
+//! - **`-c` object compiles**, exactly one source per invocation.
+//!   The cache key is the preprocessor expansion (`cc -E -P` with
+//!   `SOURCE_DATE_EPOCH` pinned) plus compiler identity, target
+//!   arch, and codegen flags. The preprocessor hash captures the
+//!   source and every transitively-included header, so any header
+//!   change invalidates the key with no separate dependency
+//!   tracking. `-E -P` strips line markers so header *paths* don't
+//!   leak — the key is portable across machines and worktrees.
+//!
+//! What passes through (refused, see [`CcArgs::refuse_reasons`]):
+//! - Link mode (whole-program caching is a separate, harder problem)
+//! - Preprocess (`-E`) / assemble (`-S`) modes
+//! - Multi-source compiles, multi-arch fat binaries
+//! - Response files, coverage instrumentation, split DWARF,
+//!   precompiled headers, modules, output-to-stdout
 //!
 //! Future work (separate PRs):
-//! - Preprocessor-based cache key (`cc -E` + blake3 + `SOURCE_DATE_EPOCH`
-//!   injection to neutralize `__DATE__` / `__TIME__` macros)
-//! - Output discovery (`.o`, `.d`, executables, `.dylib`/`.so`/`.dll`)
-//! - Wire refuse_reasons → cache_key → store path; remove the
-//!   unconditional `Unsupported` skeleton gate.
+//! - Link-mode / whole-executable caching
+//! - `ar` archive caching
+//! - Cross-machine cache sharing for C/C++ artifacts: SDKROOT
+//!   sentinel + Mach-O OSO record stripping (issue #78)
+//! - Dep-info (`.d`) file caching alongside the `.o`
 
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
@@ -384,20 +384,148 @@ impl CcArgs {
             reasons.push(RefuseReason::Unsupported("cc: output to stdout"));
         }
 
-        // Preprocess / Assemble: developer-facing output, not the
-        // cacheable per-file compile shape kache targets.
+        // Mode gate: kache caches only the `-c` object-compile step.
+        //   - Link: whole-program caching (depends on every input .o,
+        //     linker version, link order) — a much harder problem,
+        //     deferred. The default mode, so this refusal is common.
+        //   - Preprocess (-E) / Assemble (-S): developer-facing output,
+        //     rarely worth caching, and -E tangles with the cc-crate
+        //     family probe.
         match self.mode {
+            CompileMode::Compile => {}
+            CompileMode::Link => reasons.push(RefuseReason::Unsupported(
+                "cc: link mode (whole-program caching not yet supported)",
+            )),
             CompileMode::Preprocess => {
                 reasons.push(RefuseReason::Unsupported("cc: preprocessor mode (-E)"))
             }
             CompileMode::Assemble => {
                 reasons.push(RefuseReason::Unsupported("cc: assembly mode (-S)"))
             }
-            _ => {}
+        }
+
+        // Single-source contract: kache caches exactly one source per
+        // invocation (one .o out). Multi-source `-c a.c b.c` produces
+        // several .o files — uncommon (cargo's `cc` crate does one
+        // source per invocation); zero sources is a link-only / probe
+        // step. Both fall outside the per-translation-unit cache model.
+        if self.sources.len() != 1 {
+            reasons.push(RefuseReason::Unsupported("cc: not a single-source compile"));
         }
 
         reasons
     }
+
+    /// The object file a `-c` compile produces.
+    ///
+    /// `-o <path>` if explicit; otherwise the gcc/clang default —
+    /// the source file's stem with a `.o` extension, in the current
+    /// working directory. Returns `None` only for degenerate
+    /// invocations with no source (which `refuse_reasons` already
+    /// rejects, so callers on the cache path won't hit `None`).
+    pub fn object_output_path(&self) -> Option<PathBuf> {
+        if let Some(o) = &self.output {
+            return Some(o.clone());
+        }
+        let stem = self.sources.first()?.file_stem()?;
+        Some(PathBuf::from(format!("{}.o", stem.to_string_lossy())))
+    }
+
+    /// Target architecture for cache-key / metadata purposes:
+    /// an explicit `-arch X` if present, else the host arch.
+    pub fn cache_target_arch(&self) -> String {
+        cc_target_arch(self)
+    }
+}
+
+/// Cache key schema version for C-family compiles. Bump when the key
+/// composition changes in a way that could collide with old entries.
+const CC_CACHE_KEY_VERSION: u32 = 1;
+
+/// Run `<program> --version` and return its first line — the compiler
+/// identity string for the cache key. gcc / clang / Apple clang each
+/// emit a distinct, version-stamped first line, so this captures
+/// "would this exact compiler produce the same code".
+fn cc_compiler_version(program: &str) -> Result<String> {
+    let output = Command::new(program)
+        .arg("--version")
+        .output()
+        .with_context(|| format!("running `{program} --version`"))?;
+    if !output.status.success() {
+        anyhow::bail!("`{program} --version` exited {}", output.status);
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .unwrap_or("unknown")
+        .to_string())
+}
+
+/// Resolve the target architecture for the cache key: an explicit
+/// `-arch X` flag if present, else the host arch. (Multi-`-arch` is
+/// refused upstream, so at most one value is found here.)
+fn cc_target_arch(parsed: &CcArgs) -> String {
+    parsed
+        .rest
+        .windows(2)
+        .find(|w| w[0] == "-arch")
+        .map(|w| w[1].clone())
+        .unwrap_or_else(|| std::env::consts::ARCH.to_string())
+}
+
+/// Build the argv for a preprocess-only run: the original args with
+/// mode/output/dep-info flags stripped and `-E -P` forced.
+///
+/// - `-c` / `-S` removed — we force `-E` (preprocess only).
+/// - `-o <arg>` removed — preprocessed output must go to stdout, not
+///   a file (we capture and hash it).
+/// - `-MMD` / `-MD` / `-MF` / `-MT` / `-MQ` / `-MP` / `-MG` removed —
+///   dep-info generation is irrelevant to preprocessor *content* and
+///   `-MF` would redirect output.
+/// - `-E -P` prepended. `-P` suppresses line markers
+///   (`# 1 "/abs/path/header.h"`), so the hash captures expanded
+///   *content* without leaking machine-local header paths — that's
+///   what makes the key portable across machines.
+fn build_preprocess_args(parsed: &CcArgs) -> Vec<String> {
+    let mut out = vec!["-E".to_string(), "-P".to_string()];
+    let mut iter = parsed.rest.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "-c" | "-S" => {}
+            "-o" | "-MF" | "-MT" | "-MQ" => {
+                iter.next(); // also drop the flag's value
+            }
+            "-MMD" | "-MD" | "-MP" | "-MG" => {}
+            _ => out.push(arg.clone()),
+        }
+    }
+    out
+}
+
+/// Hash the preprocessor expansion of the translation unit.
+///
+/// Runs `<cc> -E -P ...` with `SOURCE_DATE_EPOCH` pinned so the
+/// `__DATE__` / `__TIME__` macros expand deterministically (without
+/// this the hash would change every second → ~0% hit rate). The
+/// expansion includes every `#include`d header transitively, so any
+/// header change invalidates the key automatically — no separate
+/// dependency tracking needed.
+fn preprocess_hash(parsed: &CcArgs) -> Result<String> {
+    let pp_args = build_preprocess_args(parsed);
+    let output = Command::new(&parsed.program)
+        .args(&pp_args)
+        // Pin the build timestamp. gcc + clang both honor
+        // SOURCE_DATE_EPOCH for __DATE__ / __TIME__ expansion.
+        .env("SOURCE_DATE_EPOCH", "0")
+        .output()
+        .with_context(|| format!("running preprocessor `{}`", parsed.program))?;
+    if !output.status.success() {
+        // Preprocess failed — the real compile would also fail.
+        // Bail so the wrapper falls back to passthrough, which runs
+        // the real compiler and surfaces the real diagnostic.
+        anyhow::bail!("preprocessor exited {} for cache key", output.status);
+    }
+    Ok(blake3::hash(&output.stdout).to_hex().to_string())
 }
 
 /// Whether a positional argument looks like a C-family source file
@@ -496,44 +624,111 @@ impl Compiler for CcCompiler {
     }
 
     fn refuse_reasons(&self, parsed: &CcArgs) -> Vec<RefuseReason> {
-        // Per-case detection from the parsed shape — cataloged ahead
-        // of the unconditional skeleton refusal so when PR5-C lands
-        // and removes the catch-all, the per-case checks already
-        // produce the right answers.
-        let mut reasons = parsed.refuse_reasons();
-        // Skeleton: refuse every C/C++ invocation until the cache_key
-        // + storage path lands. Removing this push (in PR5-C) is the
-        // signal that real caching has activated. Push it LAST so
-        // any per-case reason appears first in logs.
-        reasons.push(RefuseReason::Unsupported(
-            "cc-family caching not yet implemented (skeleton only)",
-        ));
-        reasons
+        // Per-case detection from the parsed shape. The skeleton
+        // catch-all is gone — single-source `-c` compiles with no
+        // unsafe flags now produce an EMPTY refuse list, which is the
+        // signal to the wrapper that this invocation is cacheable.
+        parsed.refuse_reasons()
     }
 
-    fn cache_key(&self, _parsed: &CcArgs, _ctx: &KeyCtx<'_>) -> Result<String> {
-        // Unreachable while refuse_reasons emits the skeleton catch-all.
-        // Documented as a precondition rather than panicking so a
-        // future regression (wrapper calling cache_key without
-        // checking refuse) gets a clear error instead of silent
-        // miscaching.
-        anyhow::bail!("CcCompiler::cache_key called while caching is not yet implemented")
+    fn cache_key(&self, parsed: &CcArgs, _ctx: &KeyCtx<'_>) -> Result<String> {
+        // Preconditions (guaranteed by the wrapper checking
+        // refuse_reasons first): `-c` mode, exactly one source.
+        let mut hasher = blake3::Hasher::new();
+
+        hasher.update(b"cc_key_version:");
+        hasher.update(CC_CACHE_KEY_VERSION.to_string().as_bytes());
+        hasher.update(b"\n");
+
+        // Compiler identity: family name (cc / gcc / clang — affects
+        // codegen defaults) + the version string.
+        let program_name = Path::new(&parsed.program)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(parsed.program.as_str());
+        hasher.update(b"compiler:");
+        hasher.update(program_name.as_bytes());
+        hasher.update(b"\n");
+        let version = cc_compiler_version(&parsed.program)?;
+        hasher.update(b"compiler_version:");
+        hasher.update(version.as_bytes());
+        hasher.update(b"\n");
+
+        // Target architecture.
+        hasher.update(b"arch:");
+        hasher.update(cc_target_arch(parsed).as_bytes());
+        hasher.update(b"\n");
+
+        // Codegen-affecting flags. These are partly redundant with
+        // the preprocessor hash (defines affect macro expansion,
+        // -std gates language features) but the redundancy is cheap
+        // and defends against e.g. -std affecting codegen without
+        // changing the expanded text.
+        if let Some(opt) = parsed.optimization {
+            hasher.update(b"opt:");
+            hasher.update(format!("{opt:?}").as_bytes());
+            hasher.update(b"\n");
+        }
+        if let Some(dbg) = parsed.debug_level {
+            hasher.update(b"debug:");
+            hasher.update(&[dbg]);
+            hasher.update(b"\n");
+        }
+        if let Some(std) = &parsed.std {
+            hasher.update(b"std:");
+            hasher.update(std.as_bytes());
+            hasher.update(b"\n");
+        }
+        hasher.update(b"pic:");
+        hasher.update(&[parsed.pic as u8]);
+        hasher.update(b"\n");
+
+        // Preprocessor expansion — the load-bearing input. Captures
+        // the source plus every transitively-included header plus
+        // macro expansion. `-E -P` strips line markers so header
+        // PATHS don't leak (cross-machine portable); SOURCE_DATE_EPOCH
+        // pins __DATE__/__TIME__ (stable across builds).
+        let pp_hash = preprocess_hash(parsed)?;
+        hasher.update(b"preprocessed:");
+        hasher.update(pp_hash.as_bytes());
+        hasher.update(b"\n");
+
+        Ok(hasher.finalize().to_hex().to_string())
     }
 
     fn execute(&self, parsed: &CcArgs) -> Result<CompileResult> {
-        // Plain passthrough: invoke the underlying compiler with the
-        // original argv, capture stdout/stderr/exit. No output discovery
-        // (caching not active), so output_files stays empty.
+        // Invoke the underlying compiler with the original argv.
         let output = Command::new(&parsed.program)
             .args(&parsed.rest)
             .output()
             .with_context(|| format!("executing {}", parsed.program))?;
+        let exit_code = output.status.code().unwrap_or(1);
+
+        // Output discovery: on a successful `-c` compile, the object
+        // file is the cacheable artifact. Skip on failure (nothing to
+        // cache) or non-Compile mode (refused upstream anyway). The
+        // store name is the bare filename so restore can place it at
+        // whatever `-o` path the warm invocation requests.
+        let output_files = if exit_code == 0 && parsed.mode == CompileMode::Compile {
+            match parsed.object_output_path() {
+                Some(obj) if obj.exists() => {
+                    let name = obj
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_default();
+                    vec![(obj, name)]
+                }
+                _ => Vec::new(),
+            }
+        } else {
+            Vec::new()
+        };
 
         Ok(CompileResult {
-            exit_code: output.status.code().unwrap_or(1),
+            exit_code,
             stdout: String::from_utf8_lossy(&output.stdout).to_string(),
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-            output_files: Vec::new(),
+            output_files,
         })
     }
 
@@ -1028,23 +1223,116 @@ mod tests {
     // ── Compiler trait: refuse / execute / classify ─────────────
 
     #[test]
-    fn refuse_reasons_always_includes_skeleton_catchall() {
-        // Until PR5-C lands and removes the catch-all, every
-        // invocation through the trait must end up refused. The
-        // per-case refuse reasons appear FIRST (more useful for
-        // logs); the skeleton's `cc-family caching not yet
-        // implemented` is always the last entry.
+    fn refuse_reasons_empty_for_cacheable_single_source_compile() {
+        // The skeleton catch-all is GONE. A single-source `-c`
+        // compile with no unsafe flags now produces an EMPTY refuse
+        // list — that's the signal to the wrapper that the
+        // invocation is cacheable. When this test starts failing,
+        // either a new refuse rule landed (intentional) or caching
+        // got accidentally disabled (the bug to investigate).
         let compiler = CcCompiler::new();
         let parsed = compiler
             .parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o"]))
             .unwrap();
-        let reasons = compiler.refuse_reasons(&parsed);
-        let last = reasons.last().expect("at least the catch-all");
         assert!(
-            last.description().contains("not yet implemented"),
-            "expected skeleton catch-all as last reason, got: {:?}",
-            reasons.iter().map(|r| r.description()).collect::<Vec<_>>()
+            compiler.refuse_reasons(&parsed).is_empty(),
+            "single-source -c compile must be cacheable, got: {:?}",
+            compiler
+                .refuse_reasons(&parsed)
+                .iter()
+                .map(|r| r.description())
+                .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn refuse_reasons_refuses_link_mode() {
+        // Link (the default mode — no `-c`) is not cacheable in this
+        // phase. Whole-program caching is a separate, harder problem.
+        let compiler = CcCompiler::new();
+        let parsed = compiler.parse(&s(&["cc", "foo.c", "-o", "foo"])).unwrap();
+        let descs: Vec<_> = compiler
+            .refuse_reasons(&parsed)
+            .iter()
+            .map(|r| r.description())
+            .collect();
+        assert!(
+            descs.iter().any(|d| d.contains("link mode")),
+            "link invocation must be refused, got: {descs:?}"
+        );
+    }
+
+    #[test]
+    fn refuse_reasons_refuses_multi_source_compile() {
+        // `-c a.c b.c` produces two .o files — outside the
+        // single-translation-unit cache model.
+        let compiler = CcCompiler::new();
+        let parsed = compiler.parse(&s(&["cc", "-c", "a.c", "b.c"])).unwrap();
+        let descs: Vec<_> = compiler
+            .refuse_reasons(&parsed)
+            .iter()
+            .map(|r| r.description())
+            .collect();
+        assert!(
+            descs.iter().any(|d| d.contains("single-source")),
+            "multi-source compile must be refused, got: {descs:?}"
+        );
+    }
+
+    // ── object_output_path ──────────────────────────────────────
+
+    #[test]
+    fn object_output_path_uses_explicit_dash_o() {
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "src/foo.c", "-o", "build/foo.o"])).unwrap();
+        assert_eq!(
+            parsed.object_output_path(),
+            Some(PathBuf::from("build/foo.o"))
+        );
+    }
+
+    #[test]
+    fn object_output_path_defaults_to_source_stem_dot_o() {
+        // Without `-o`, gcc/clang default the object name to the
+        // source stem + `.o` in the current directory.
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "src/foo.c"])).unwrap();
+        assert_eq!(parsed.object_output_path(), Some(PathBuf::from("foo.o")));
+    }
+
+    // ── build_preprocess_args ───────────────────────────────────
+
+    #[test]
+    fn build_preprocess_args_forces_dash_e_dash_p_and_strips_mode() {
+        let parsed =
+            CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o", "-O2", "-Iinc"])).unwrap();
+        let pp = build_preprocess_args(&parsed);
+        // -E -P prepended.
+        assert_eq!(&pp[0], "-E");
+        assert_eq!(&pp[1], "-P");
+        // -c and -o <arg> stripped (no file redirection of pp output).
+        assert!(!pp.iter().any(|a| a == "-c"));
+        assert!(!pp.iter().any(|a| a == "-o"));
+        assert!(!pp.iter().any(|a| a == "foo.o"));
+        // Preprocessing-relevant flags kept.
+        assert!(pp.iter().any(|a| a == "-O2"));
+        assert!(pp.iter().any(|a| a == "-Iinc"));
+        assert!(pp.iter().any(|a| a == "foo.c"));
+    }
+
+    #[test]
+    fn build_preprocess_args_strips_dep_info_flags() {
+        // -MF would redirect dep-info output; -MMD/-MD/-MT are
+        // irrelevant to preprocessor *content*. All stripped.
+        let parsed = CcArgs::parse(&s(&[
+            "cc", "-c", "foo.c", "-MMD", "-MF", "foo.d", "-MT", "foo.o",
+        ]))
+        .unwrap();
+        let pp = build_preprocess_args(&parsed);
+        for stripped in &["-MMD", "-MF", "foo.d", "-MT", "foo.o"] {
+            assert!(
+                !pp.iter().any(|a| a == stripped),
+                "{stripped} should be stripped from preprocess args, got {pp:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -93,21 +93,24 @@ pub fn run_cc_probe(args: &[String]) -> Result<i32> {
 /// Run kache as a C-family compiler wrapper (`CC=kache cc`,
 /// `CXX=kache c++`, etc.).
 ///
-/// **Skeleton only — no caching yet.** Invokes the underlying compiler
-/// transparently and propagates exit / stdout / stderr. Validates that
-/// the wrapper-mode dispatch and the [`crate::compiler::cc::CcCompiler`]
-/// trait surface work end-to-end against a second compiler family
-/// without touching the rustc path. Real C/C++ caching lands as
-/// follow-up PRs that flip [`crate::compiler::cc::CcCompiler::refuse_reasons`]
-/// to selectively allow invocations through this same entry point.
-pub fn run_cc(_config: &Config, wrapper_args: &[String]) -> Result<i32> {
+/// Caches the single-source `-c` object compile: parse → refuse-check
+/// → cache key (preprocessor hash) → local store lookup → restore the
+/// `.o` on hit, or compile + store on miss. Everything else (link
+/// mode, multi-source, unsafe flags) routes through [`cc_passthrough`].
+///
+/// This is the local-cache path. Remote cache + build-lock
+/// coordination (which `wrapper::run` has for rustc) are deliberate
+/// follow-ups — single-machine caching is the shipped concept.
+pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
+    let start = std::time::Instant::now();
     let compiler = CcCompiler::new();
     let parsed = compiler
         .parse(wrapper_args)
         .context("parsing cc-family arguments")?;
 
-    // Today every cc invocation refuses cache; iterating the list lets a
-    // future PR flip individual reasons off without changing this caller.
+    // Refuse-to-cache check: non-empty = this invocation isn't a
+    // cacheable single-source `-c` compile (link mode, multi-arch,
+    // PCH, modules, etc. — see CcArgs::refuse_reasons). Passthrough.
     let refuse = compiler.refuse_reasons(&parsed);
     if !refuse.is_empty() {
         let reasons: Vec<&str> = refuse.iter().map(|r| r.description()).collect();
@@ -116,9 +119,161 @@ pub fn run_cc(_config: &Config, wrapper_args: &[String]) -> Result<i32> {
             compiler.kind(),
             reasons.join("; ")
         );
+        return cc_passthrough(&parsed);
     }
 
+    // The crate-name slot in events / metadata is the source file
+    // name for cc — the closest analogue to rustc's crate name.
+    let crate_name = parsed
+        .sources
+        .first()
+        .and_then(|s| s.file_name())
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let store = match Store::open(config) {
+        Ok(store) => store,
+        Err(e) => {
+            tracing::warn!("failed to open store for cc: {}", e);
+            return cc_passthrough(&parsed);
+        }
+    };
+
+    // Compute the cache key (runs `cc -E -P` for the preprocessor
+    // hash). On any failure — preprocessor error, missing compiler —
+    // fall back to passthrough, which runs the real compiler and
+    // surfaces the real diagnostic.
+    let key_start = std::time::Instant::now();
+    let file_hasher = crate::cache_key::FileHasher::new();
+    let path_normalizer = crate::path_normalizer::PathNormalizer::empty();
+    let key_ctx = KeyCtx {
+        file_hasher: &file_hasher,
+        path_normalizer: &path_normalizer,
+    };
+    let cache_key = match compiler.cache_key(&parsed, &key_ctx) {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::debug!(
+                "cc cache key failed for {}: {} — passthrough",
+                crate_name,
+                e
+            );
+            return cc_passthrough(&parsed);
+        }
+    };
+    let key_ms = key_start.elapsed().as_millis() as u64;
+    tracing::debug!("cc cache key for {}: {}", crate_name, &cache_key[..16]);
+
+    // ── Local cache lookup ───────────────────────────────────────
+    let lookup_start = std::time::Instant::now();
+    let lookup = store.get(&cache_key)?;
+    let lookup_ms = lookup_start.elapsed().as_millis() as u64;
+    if let Some(meta) = lookup {
+        if meta.files.is_empty() {
+            // Poisoned entry (earlier bug) — evict and recompile.
+            tracing::warn!("cc cache entry for {} has no files, evicting", crate_name);
+            let _ = store.remove_entry(&cache_key);
+        } else {
+            let restore_start = std::time::Instant::now();
+            restore_cc_from_cache(&store, &parsed, &meta)?;
+            let restore_ms = restore_start.elapsed().as_millis() as u64;
+            let elapsed = start.elapsed().as_millis() as u64;
+            let size: u64 = meta.files.iter().map(|f| f.size).sum();
+            tracing::debug!(
+                "cc local cache hit for {} ({})",
+                crate_name,
+                &cache_key[..16]
+            );
+            log_event(
+                config,
+                &crate_name,
+                EventResult::LocalHit,
+                elapsed,
+                meta.compile_time_ms,
+                size,
+                &cache_key,
+                key_ms,
+                lookup_ms,
+                restore_ms,
+                0,
+            );
+            print_progress(&crate_name, EventResult::LocalHit, elapsed, size);
+            // Replay the cached compiler diagnostics so warnings still
+            // surface on a cache hit.
+            if !meta.stdout.is_empty() {
+                print!("{}", meta.stdout);
+            }
+            if !meta.stderr.is_empty() {
+                eprint!("{}", meta.stderr);
+            }
+            return Ok(0);
+        }
+    }
+
+    // ── Cache miss — compile, then store ─────────────────────────
+    let compile_start = std::time::Instant::now();
     let result = compiler.execute(&parsed)?;
+    let compile_time_ms = compile_start.elapsed().as_millis() as u64;
+
+    if !result.stdout.is_empty() {
+        print!("{}", result.stdout);
+    }
+    if !result.stderr.is_empty() {
+        eprint!("{}", result.stderr);
+    }
+
+    // Only store on a clean compile that actually produced its
+    // object file. A failed compile (exit != 0) or one whose output
+    // discovery came up empty is not cacheable — return the exit
+    // code and let cargo see the failure.
+    let store_start = std::time::Instant::now();
+    if result.exit_code == 0 && !result.output_files.is_empty() {
+        let target = parsed.cache_target_arch();
+        if let Err(e) = store.put_with_compile_time(
+            &cache_key,
+            &crate_name,
+            &[], // crate_types: n/a for cc objects
+            &[], // features: n/a
+            &target,
+            "", // profile: n/a (opt level is in the key)
+            &result.output_files,
+            &result.stdout,
+            &result.stderr,
+            compile_time_ms,
+        ) {
+            tracing::warn!("failed to store cc cache entry for {}: {}", crate_name, e);
+        }
+    }
+    let store_ms = store_start.elapsed().as_millis() as u64;
+
+    let elapsed = start.elapsed().as_millis() as u64;
+    let size: u64 = result
+        .output_files
+        .iter()
+        .map(|(p, _)| std::fs::metadata(p).map(|m| m.len()).unwrap_or(0))
+        .sum();
+    log_event(
+        config,
+        &crate_name,
+        EventResult::Miss,
+        elapsed,
+        compile_time_ms,
+        size,
+        &cache_key,
+        key_ms,
+        lookup_ms,
+        0,
+        store_ms,
+    );
+    print_progress(&crate_name, EventResult::Miss, elapsed, size);
+    Ok(result.exit_code)
+}
+
+/// Run a cc-family invocation without caching — invoke the compiler
+/// with the original argv, propagate stdout / stderr / exit.
+fn cc_passthrough(parsed: &crate::compiler::cc::CcArgs) -> Result<i32> {
+    let compiler = CcCompiler::new();
+    let result = compiler.execute(parsed)?;
     if !result.stdout.is_empty() {
         print!("{}", result.stdout);
     }
@@ -126,6 +281,51 @@ pub fn run_cc(_config: &Config, wrapper_args: &[String]) -> Result<i32> {
         eprint!("{}", result.stderr);
     }
     Ok(result.exit_code)
+}
+
+/// Restore a cached cc object file to the invocation's `-o` target.
+///
+/// A `-c` compile has exactly one cached artifact (the `.o`). The
+/// blob is content-addressed in the store; we link it to wherever
+/// the warm invocation's `-o` points. Object files need no
+/// post-restore processing (no codesign, no path rewriting) — they
+/// get linked into a final binary later, and that link step (or its
+/// own cache entry) handles loader concerns.
+fn restore_cc_from_cache(
+    store: &Store,
+    parsed: &crate::compiler::cc::CcArgs,
+    meta: &crate::store::EntryMeta,
+) -> Result<()> {
+    let target = parsed
+        .object_output_path()
+        .context("cc restore: cannot determine object output path")?;
+    // Single-source `-c` ⇒ exactly one cached file. Take the first;
+    // the empty-files case was already filtered by the caller.
+    let cached = &meta.files[0];
+    let blob = store.blob_path(&cached.hash);
+    if !blob.exists() {
+        anyhow::bail!(
+            "cc restore: blob missing for {} (hash {})",
+            cached.name,
+            &cached.hash[..16.min(cached.hash.len())]
+        );
+    }
+    if let Some(parent) = target.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("cc restore: creating {}", parent.display()))?;
+    }
+    let kind = crate::compiler::classify_by_filename(&cached.name);
+    link::link_to_target(&blob, &target, kind.link_strategy()).with_context(|| {
+        format!(
+            "cc restore: linking {} -> {}",
+            blob.display(),
+            target.display()
+        )
+    })?;
+    link::touch_mtime(&target)?;
+    Ok(())
 }
 
 /// Run kache in RUSTC_WRAPPER mode.

--- a/test-projects/c-hello/kache-fixture.toml
+++ b/test-projects/c-hello/kache-fixture.toml
@@ -1,11 +1,10 @@
 # kache-e2e fixture: minimal C project built with make.
 #
-# Today this verifies the **passthrough contract** for the cc-family
-# wrapper skeleton: `CC=kache cc` is recognized, the underlying compiler
-# runs, the binary works. When real C/C++ caching lands and CcCompiler::
-# refuse_reasons stops returning Unsupported unconditionally, the
-# `max_entries_after` assertions below flip to `min_*` ones — same
-# fixture, contract diff visible in git history.
+# C/C++ caching is live: the Makefile's `-c` compile step
+# (`cc -O0 -g -Isrc -c src/foo.c -o build/foo.o`) is cache-eligible;
+# the link step (`cc build/foo.o -o build/foo`) is link-mode and
+# passes through. So each build produces exactly one cacheable
+# event — the object compile.
 
 name = "c-hello"
 
@@ -20,23 +19,26 @@ clean = "make clean"
 run = "./build/foo"
 expected_stdout_contains = ["hello from bar"]
 
-# Skeleton contract: C/C++ wrapper passes through but caches nothing,
-# so the cache stays empty across cold and warm.
+# Cold: the object compile is a miss → one entry lands in the cache.
 [assertions.cold]
-max_entries_after = 0
+min_entries_after = 1
 
+# Warm: clean wipes build/, the rebuild's compile hits the cache.
 [assertions.warm]
-max_entries_after = 0
+min_hits = 1
 
-# The skeleton can't deliver no-op semantics yet (no caching → make
-# always recompiles when the .o is missing, but we don't even clean
-# differently). Mark the contract as "recompilation OK for now"; flip
-# to `true` + a marker the day caching lands.
+# Noop: `make` sees build/foo.o + build/foo up to date and does
+# nothing. No `cc` invocation, no kache event. make emits no
+# "Compiling"-style marker, so the contract is just "the phase
+# runs clean" — `should_not_recompile = false` (no marker to
+# assert against; make's own incrementality is what's exercised).
 [assertions.noop]
 should_not_recompile = false
 
-# Skeleton: nothing is cached, so the relocated build also caches
-# nothing. Locks the current contract; flips to `min_hits = 1` the
-# day C/C++ caching activates (PR5+).
+# Relocate: same source built at a different absolute path with the
+# shared cache. The cc cache key is the preprocessor expansion
+# (`cc -E -P`, line markers stripped) — path-independent by
+# construction — so the relocated compile HITS. This is the C/C++
+# parallel of multi-dep's relocate contract.
 [assertions.relocate]
-max_entries_after = 0
+min_hits = 1

--- a/test-projects/cpp-hello/kache-fixture.toml
+++ b/test-projects/cpp-hello/kache-fixture.toml
@@ -1,9 +1,10 @@
 # kache-e2e fixture: minimal C++ project built with make.
 #
-# Same passthrough-contract validation as c-hello, on the C++ side:
-# `CXX=kache c++`, std::vector / std::string_view / template instantiation
-# stress the preprocessor through real STL headers. When real caching
-# lands, the assertion shape flips parallel to c-hello.
+# C/C++ caching is live (see c-hello for the full rationale). The C++
+# side additionally stresses the preprocessor cache key through real
+# STL headers — std::vector / std::string_view / template
+# instantiation all expand via `cc -E -P`, so the key reflects the
+# full transitive include of `<vector>`, `<string_view>`, etc.
 
 name = "cpp-hello"
 
@@ -18,15 +19,18 @@ clean = "make clean"
 run = "./build/foo"
 expected_stdout_contains = ["hello from bar", "sum=15"]
 
+# Cold: the `-c` compile of foo.cpp is a miss → one cache entry.
 [assertions.cold]
-max_entries_after = 0
+min_entries_after = 1
 
+# Warm: clean + rebuild → the compile hits.
 [assertions.warm]
-max_entries_after = 0
+min_hits = 1
 
 [assertions.noop]
 should_not_recompile = false
 
-# Skeleton parallel to c-hello — see that fixture for the full rationale.
+# Relocate: preprocessor-expansion cache key is path-independent →
+# the relocated build's compile hits.
 [assertions.relocate]
-max_entries_after = 0
+min_hits = 1


### PR DESCRIPTION
## Summary

Makes the cc-family wrapper actually **cache `-c` object compiles** — the first end-to-end C/C++ caching in kache. Combines PR5-B (cache key) and PR5-C (storage/restore) into one PR since neither is testable without the other.

Builds on #86 (PR5-A: the C-family argument parser + refuse-to-cache detection).

### Cache key (PR5-B)
- Key is the **preprocessor expansion** of the source — `cc -E -P` with `SOURCE_DATE_EPOCH=0`, line markers stripped — blake3-hashed.
- Mixed in: compiler name + version, target arch, and the normalized opt / debug / std / PIC flags.
- Preprocessor-based keying is **path-independent by construction**, so a build relocated to a different absolute path still hits — the C/C++ parallel of the `relocate` e2e contract.

### Storage + restore (PR5-C)
- `wrapper::run_cc` now runs a full lookup/store/restore flow: parse → refuse-check (passthrough when refused) → compute key → probe store → on hit link the cached `.o` blob to the object output path; on miss execute + store.
- `refuse_reasons()` now refuses link mode and multi-source invocations — only single-source `-c` compiles are cacheable; the skeleton catch-all is removed.
- `execute()` discovers the object output on a successful Compile-mode run.

### e2e
- Flips the `c-hello` / `cpp-hello` fixtures from skeleton no-cache assertions to real caching contracts: cold miss, warm hit, relocate hit.

## Deferred (not in this PR)
Link-mode caching, `ar` archive caching, cross-machine cc sharing (SDKROOT/OSO — #78), dep-info `.d` caching, remote cache + build-lock for cc.

## Test plan
- [x] `cargo test --bin kache` — 456 passed, 0 failed (4 daemon socket-roundtrip tests filtered out: they hang environmentally and are untouched by this change)
- [x] 48 cc unit tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] e2e harness: all 5 fixtures green — `c-hello`/`cpp-hello` show cold=1 miss, warm=1 hit, noop=0 delta, relocate=1 hit
- [x] Manual: cold compile → miss; warm → "cc local cache hit"; header change → new key; `-O2` change → new key