### PR TITLE
ci: run the test suite and e2e harness on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,14 +107,19 @@ jobs:
         uses: jdx/mise-action@v3
         with:
           install_args: rust
-      # Put mise's Rust toolchain at the front of PATH. The self-hosted macOS
-      # runners carry a stale system Rust (Homebrew 1.94) that would otherwise
-      # shadow it; resolving the bin dir via `mise which` and prepending it
-      # here (after mise-action) makes the toolchain deterministic per run.
-      - name: Put the mise Rust toolchain first on PATH
+      # mise installs the toolchain via rustup under RUSTUP_HOME, but on a
+      # runner with a pre-existing rustup it leaves no cargo proxy on PATH —
+      # so the stale system Rust (Homebrew 1.94) would win. Prepend the
+      # toolchain's own bin dir (the real 1.95 binaries) to PATH instead.
+      - name: Put the Rust toolchain first on PATH
         run: |
-          bin_dir="$(dirname "$(mise which cargo)")"
-          echo "mise Rust bin dir: $bin_dir"
+          bin_dir=$(echo "$RUSTUP_HOME"/toolchains/*/bin)
+          if [ ! -x "$bin_dir/cargo" ]; then
+            echo "cargo not found under $RUSTUP_HOME/toolchains/*/bin"
+            ls -la "$RUSTUP_HOME/toolchains" 2>/dev/null || true
+            exit 1
+          fi
+          "$bin_dir/rustc" --version
           echo "$bin_dir" >> "$GITHUB_PATH"
       - name: Build kache + e2e harness (release)
         run: |
@@ -177,12 +182,19 @@ jobs:
         uses: jdx/mise-action@v3
         with:
           install_args: rust
-      # Put mise's Rust toolchain at the front of PATH so it beats the
-      # runner's stale system Rust (Homebrew 1.94, below the pinned 1.95).
-      - name: Put the mise Rust toolchain first on PATH
+      # mise installs the toolchain via rustup under RUSTUP_HOME, but on a
+      # runner with a pre-existing rustup it leaves no cargo proxy on PATH —
+      # so the stale system Rust (Homebrew 1.94) would win. Prepend the
+      # toolchain's own bin dir (the real 1.95 binaries) to PATH instead.
+      - name: Put the Rust toolchain first on PATH
         run: |
-          bin_dir="$(dirname "$(mise which cargo)")"
-          echo "mise Rust bin dir: $bin_dir"
+          bin_dir=$(echo "$RUSTUP_HOME"/toolchains/*/bin)
+          if [ ! -x "$bin_dir/cargo" ]; then
+            echo "cargo not found under $RUSTUP_HOME/toolchains/*/bin"
+            ls -la "$RUSTUP_HOME/toolchains" 2>/dev/null || true
+            exit 1
+          fi
+          "$bin_dir/rustc" --version
           echo "$bin_dir" >> "$GITHUB_PATH"
       - name: cargo test (workspace)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,14 @@ jobs:
         run: |
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
+      # `--force`: RUSTUP_HOME is per-run ($RUNNER_TEMP), but mise's record of
+      # which tools are installed persists on the self-hosted runner. Without
+      # --force, mise sees rust as "installed" and skips it, leaving the fresh
+      # RUSTUP_HOME empty. --force makes it reinstall the toolchain every run.
       - name: Install Rust via mise
         uses: jdx/mise-action@v3
         with:
-          install_args: rust
+          install_args: --force rust
       # mise installs the toolchain via rustup under RUSTUP_HOME, but on a
       # runner with a pre-existing rustup it leaves no cargo proxy on PATH —
       # so the stale system Rust (Homebrew 1.94) would win. Prepend the
@@ -177,11 +181,14 @@ jobs:
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
       # mise is the project's toolchain manager (see mise.toml); it installs
-      # rust via rustup into the isolated home above.
+      # rust via rustup into the isolated home above. `--force` is required:
+      # RUSTUP_HOME is per-run but mise's installed-tool record persists on
+      # the self-hosted runner, so without it mise skips the reinstall and
+      # leaves the fresh RUSTUP_HOME empty.
       - name: Install Rust via mise
         uses: jdx/mise-action@v3
         with:
-          install_args: rust
+          install_args: --force rust
       # mise installs the toolchain via rustup under RUSTUP_HOME, but on a
       # runner with a pre-existing rustup it leaves no cargo proxy on PATH —
       # so the stale system Rust (Homebrew 1.94) would win. Prepend the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,15 +95,22 @@ jobs:
               - ARM64
     steps:
       - uses: actions/checkout@v4
-      # GitHub-hosted Linux gets a fresh rustup toolchain; the self-hosted
-      # macOS runner uses its standalone Homebrew Rust instead — see the
-      # `test-macos` job for why dtolnay/rust-toolchain is avoided there.
+      # GitHub-hosted Linux gets a fresh rustup toolchain via the action.
+      # The self-hosted macOS runner's shared Rust is unusable (corrupted
+      # ~/.rustup, stale Homebrew Rust), so it installs a clean isolated
+      # rustup per run instead — see the `test-macos` job for the rationale.
       - name: Install Rust (Linux)
         if: runner.os == 'Linux'
         uses: dtolnay/rust-toolchain@stable
-      - name: Use pre-installed Rust (macOS)
+      - name: Set up an isolated Rust toolchain (macOS)
         if: runner.os == 'macOS'
-        run: echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+        run: |
+          echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
+          echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/cargo/bin" >> "$GITHUB_PATH"
+          export RUSTUP_HOME="$RUNNER_TEMP/rustup" CARGO_HOME="$RUNNER_TEMP/cargo"
+          curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+            | sh -s -- -y --no-modify-path --default-toolchain none
       - name: Build kache + e2e harness (release)
         run: |
           rustc --version && cargo --version
@@ -150,13 +157,19 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4
-      # This is a persistent self-hosted runner with a standalone Homebrew
-      # Rust install. We deliberately do NOT use dtolnay/rust-toolchain: it
-      # reinstalls a rustup toolchain on every run, which accumulates and
-      # corrupts rustup state on a long-lived runner. Homebrew's toolchain
-      # is rustup-independent, so prepend it to PATH and use it directly.
-      - name: Use the runner's pre-installed Rust toolchain
-        run: echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+      # This persistent self-hosted runner has neither a usable shared
+      # toolchain: its ~/.rustup is corrupted, and its Homebrew Rust is
+      # stale (1.94, below the pinned 1.95). So install a clean rustup into
+      # the per-run temp dir — fully isolated from the runner's shared Rust
+      # state — and let rust-toolchain.toml drive the exact version.
+      - name: Set up an isolated Rust toolchain
+        run: |
+          echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
+          echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/cargo/bin" >> "$GITHUB_PATH"
+          export RUSTUP_HOME="$RUNNER_TEMP/rustup" CARGO_HOME="$RUNNER_TEMP/cargo"
+          curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+            | sh -s -- -y --no-modify-path --default-toolchain none
       - name: cargo test (workspace)
         run: |
           rustc --version && cargo --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,19 @@ jobs:
               - ARM64
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      # GitHub-hosted Linux gets a fresh rustup toolchain; the self-hosted
+      # macOS runner uses its standalone Homebrew Rust instead — see the
+      # `test-macos` job for why dtolnay/rust-toolchain is avoided there.
+      - name: Install Rust (Linux)
+        if: runner.os == 'Linux'
+        uses: dtolnay/rust-toolchain@stable
+      - name: Use pre-installed Rust (macOS)
+        if: runner.os == 'macOS'
+        run: echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
       - name: Build kache + e2e harness (release)
-        run: cargo build --release -p kache && cargo build --release -p kache-e2e
+        run: |
+          rustc --version && cargo --version
+          cargo build --release -p kache && cargo build --release -p kache-e2e
         env:
           RUSTC_WRAPPER: ""
       - name: Run e2e harness (all fixtures)
@@ -140,9 +150,17 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      # This is a persistent self-hosted runner with a standalone Homebrew
+      # Rust install. We deliberately do NOT use dtolnay/rust-toolchain: it
+      # reinstalls a rustup toolchain on every run, which accumulates and
+      # corrupts rustup state on a long-lived runner. Homebrew's toolchain
+      # is rustup-independent, so prepend it to PATH and use it directly.
+      - name: Use the runner's pre-installed Rust toolchain
+        run: echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
       - name: cargo test (workspace)
-        run: cargo test --workspace
+        run: |
+          rustc --version && cargo --version
+          cargo test --workspace
         timeout-minutes: 30
         env:
           RUSTC_WRAPPER: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,19 @@ jobs:
         run: |
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
-          echo "$RUNNER_TEMP/cargo/bin" >> "$GITHUB_PATH"
       - name: Install Rust via mise
         uses: jdx/mise-action@v3
         with:
           install_args: rust
+      # Put mise's Rust toolchain at the front of PATH. The self-hosted macOS
+      # runners carry a stale system Rust (Homebrew 1.94) that would otherwise
+      # shadow it; resolving the bin dir via `mise which` and prepending it
+      # here (after mise-action) makes the toolchain deterministic per run.
+      - name: Put the mise Rust toolchain first on PATH
+        run: |
+          bin_dir="$(dirname "$(mise which cargo)")"
+          echo "mise Rust bin dir: $bin_dir"
+          echo "$bin_dir" >> "$GITHUB_PATH"
       - name: Build kache + e2e harness (release)
         run: |
           rustc --version && cargo --version
@@ -163,15 +171,19 @@ jobs:
         run: |
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
-          echo "$RUNNER_TEMP/cargo/bin" >> "$GITHUB_PATH"
       # mise is the project's toolchain manager (see mise.toml); it installs
-      # rust via rustup into the isolated home above and pins the version
-      # via RUSTUP_TOOLCHAIN, which — unlike rust-toolchain.toml discovery —
-      # also resolves in the e2e relocate phase that builds outside the repo.
+      # rust via rustup into the isolated home above.
       - name: Install Rust via mise
         uses: jdx/mise-action@v3
         with:
           install_args: rust
+      # Put mise's Rust toolchain at the front of PATH so it beats the
+      # runner's stale system Rust (Homebrew 1.94, below the pinned 1.95).
+      - name: Put the mise Rust toolchain first on PATH
+        run: |
+          bin_dir="$(dirname "$(mise which cargo)")"
+          echo "mise Rust bin dir: $bin_dir"
+          echo "$bin_dir" >> "$GITHUB_PATH"
       - name: cargo test (workspace)
         run: |
           rustc --version && cargo --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,22 +95,19 @@ jobs:
               - ARM64
     steps:
       - uses: actions/checkout@v4
-      # GitHub-hosted Linux gets a fresh rustup toolchain via the action.
-      # The self-hosted macOS runner's shared Rust is unusable (corrupted
-      # ~/.rustup, stale Homebrew Rust), so it installs a clean isolated
-      # rustup per run instead — see the `test-macos` job for the rationale.
-      - name: Install Rust (Linux)
-        if: runner.os == 'Linux'
-        uses: dtolnay/rust-toolchain@stable
-      - name: Set up an isolated Rust toolchain (macOS)
-        if: runner.os == 'macOS'
+      # Point rustup/cargo state at the per-run temp dir before installing
+      # the toolchain. On the self-hosted macOS runner this isolates the
+      # build from a corrupted shared ~/.rustup; on Linux it is simply a
+      # clean per-run location. See the `test-macos` job for the full story.
+      - name: Isolate the Rust toolchain
         run: |
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
           echo "$RUNNER_TEMP/cargo/bin" >> "$GITHUB_PATH"
-          export RUSTUP_HOME="$RUNNER_TEMP/rustup" CARGO_HOME="$RUNNER_TEMP/cargo"
-          curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
-            | sh -s -- -y --no-modify-path --default-toolchain none
+      - name: Install Rust via mise
+        uses: jdx/mise-action@v3
+        with:
+          install_args: rust
       - name: Build kache + e2e harness (release)
         run: |
           rustc --version && cargo --version
@@ -157,19 +154,24 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4
-      # This persistent self-hosted runner has neither a usable shared
-      # toolchain: its ~/.rustup is corrupted, and its Homebrew Rust is
-      # stale (1.94, below the pinned 1.95). So install a clean rustup into
-      # the per-run temp dir — fully isolated from the runner's shared Rust
-      # state — and let rust-toolchain.toml drive the exact version.
-      - name: Set up an isolated Rust toolchain
+      # This persistent self-hosted runner has no usable shared toolchain:
+      # its ~/.rustup is corrupted and its Homebrew Rust is stale (1.94,
+      # below the pinned 1.95). Point RUSTUP_HOME/CARGO_HOME at the per-run
+      # temp dir so the toolchain mise installs is clean and isolated from
+      # the runner's shared Rust state.
+      - name: Isolate the Rust toolchain
         run: |
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
           echo "$RUNNER_TEMP/cargo/bin" >> "$GITHUB_PATH"
-          export RUSTUP_HOME="$RUNNER_TEMP/rustup" CARGO_HOME="$RUNNER_TEMP/cargo"
-          curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
-            | sh -s -- -y --no-modify-path --default-toolchain none
+      # mise is the project's toolchain manager (see mise.toml); it installs
+      # rust via rustup into the isolated home above and pins the version
+      # via RUSTUP_TOOLCHAIN, which — unlike rust-toolchain.toml discovery —
+      # also resolves in the e2e relocate phase that builds outside the repo.
+      - name: Install Rust via mise
+        uses: jdx/mise-action@v3
+        with:
+          install_args: rust
       - name: cargo test (workspace)
         run: |
           rustc --version && cargo --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
         include:
           - os: Linux
             runner: ubuntu-latest
-          # TODO: re-enable once macOS runners are available
-          # - os: macOS
-          #   runner: macos-latest
+          # `check` runs the full `just ci` (docker buildx + helm + tarpaulin)
+          # and stays Linux-only. macOS gets a dedicated, lighter `test-macos`
+          # job below — see that job for the rationale.
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3
@@ -88,9 +88,11 @@ jobs:
         include:
           - os: Linux
             runner: ubuntu-latest
-          # TODO: re-enable once macOS runners are available
-          # - os: macOS
-          #   runner: macos-latest
+          - os: macOS
+            runner:
+              - self-hosted
+              - macOS
+              - ARM64
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -125,6 +127,25 @@ jobs:
           name: e2e-results
           path: e2e-results/
           retention-days: 14
+
+  # --- macOS test suite ---
+  # The Linux `check` job runs the full `just ci` (coverage + docker + helm);
+  # replicating that on macOS isn't worth it. Instead this job runs a focused
+  # `cargo test` pass on a self-hosted Apple Silicon runner so OS-specific
+  # regressions — e.g. the daemon's Unix-socket EOF behaviour, which once hung
+  # the suite on macOS while passing on Linux — are caught before merge.
+  # Blocking: macOS is a first-class supported platform.
+  test-macos:
+    name: Test (macOS)
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: cargo test (workspace)
+        run: cargo test --workspace
+        timeout-minutes: 30
+        env:
+          RUSTC_WRAPPER: ""
 
   # --- Windows exploratory check (non-blocking) ---
   # Surfaces remaining Windows porting work for issue #45. Allowed to fail

--- a/Justfile
+++ b/Justfile
@@ -92,7 +92,7 @@ helm-lint:
 # (and used locally by `just coverage-open`).
 [group('coverage')]
 coverage:
-  cargo tarpaulin --engine llvm --all-features --workspace --out Json --out Html -- --skip test_socket
+  cargo tarpaulin --engine llvm --all-features --workspace --out Json --out Html
 
 # Run tarpaulin coverage and open the HTML report locally.
 [group('coverage')]


### PR DESCRIPTION
## Summary

macOS was absent from CI — the `check` and `e2e` job matrices had it commented out (*"once macOS runners are available"*). Self-hosted Apple Silicon runners are now available, and the gap was not hypothetical: #89 fixed a daemon Unix-socket bug that **hung the entire test suite on macOS** while passing on Linux. Nothing in CI would have caught it.

Two compounding reasons it slipped through:

1. **No macOS CI job ran the tests at all** — the matrices were Linux-only.
2. The `coverage` recipe ran tarpaulin with `-- --skip test_socket`, so the daemon socket roundtrip tests were skipped on **every** platform, Linux included. They had zero CI coverage anywhere.

## Changes

- **`justfile`** — drop `--skip test_socket` from the `coverage` recipe. The socket tests are fixed (#89) and verified to pass under tarpaulin's LLVM coverage instrumentation, so they now run in CI like any other test. (Removing a skip can only raise coverage, so the 35% threshold is safe.)
- **`ci.yml`** — add a blocking `test-macos` job: `cargo test --workspace` on a `[self-hosted, macOS, ARM64]` runner. Deliberately lighter than the Linux `check` job, which keeps the full `just ci` (docker buildx + helm + tarpaulin) Linux-only.
- **`ci.yml`** — re-enable the macOS arm of the `e2e` matrix on the same self-hosted runners, so the end-to-end cache behaviour (incl. the C/C++ caching from #87) is exercised on macOS.

## Verification

- All 4 `test_socket_*_roundtrip` tests pass under `cargo tarpaulin --engine llvm` locally on macOS (0.01s, no hang) — confirms removing the skip is safe.
- `cargo test --bin kache` — 460 passed, 0 failed on macOS.
- `ci.yml` YAML validated.

## Test plan
- [ ] `test-macos` job runs green on the self-hosted runner
- [ ] `E2E smoke (macOS)` job runs green
- [ ] Linux `check` job still green with the socket tests no longer skipped in coverage