### PR TITLE
ci: fall back to GitHub-hosted macOS runners outside kunobi-ninja

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,16 @@ jobs:
         include:
           - os: Linux
             runner: ubuntu-latest
+          # Use the self-hosted Apple Silicon runners only inside
+          # kunobi-ninja and not for fork PRs; otherwise fall back to a
+          # GitHub-hosted runner (a fork cannot reach our runners, so a
+          # hardcoded label would queue forever). NOTE: this is a
+          # convenience fallback, not a security control — for a `pull_request`
+          # the fork's own copy of this file runs, so a fork can override it.
+          # Fork PRs are gated by the repo's "require approval" Actions
+          # setting, which is the actual boundary.
           - os: macOS
-            runner:
-              - self-hosted
-              - macOS
-              - ARM64
+            runner: ${{ (github.repository_owner == 'kunobi-ninja' && github.event.pull_request.head.repo.fork != true) && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
     steps:
       - uses: actions/checkout@v4
       # Point rustup/cargo state at the per-run temp dir before installing
@@ -168,7 +173,11 @@ jobs:
   # Blocking: macOS is a first-class supported platform.
   test-macos:
     name: Test (macOS)
-    runs-on: [self-hosted, macOS, ARM64]
+    # Self-hosted Apple Silicon inside kunobi-ninja (non-fork); GitHub-hosted
+    # otherwise so forks can still run this job. Convenience only — see the
+    # matching note on the `e2e` job; fork PRs are gated by the repo's
+    # "require approval" Actions setting, not by this expression.
+    runs-on: ${{ (github.repository_owner == 'kunobi-ninja' && github.event.pull_request.head.repo.fork != true) && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
     steps:
       - uses: actions/checkout@v4
       # This persistent self-hosted runner has no usable shared toolchain:


### PR DESCRIPTION
## Summary

The macOS CI jobs (`test-macos`, the macOS arm of `e2e`) hardcoded `runs-on: [self-hosted, macOS, ARM64]`. A fork cannot reach the `kunobi` self-hosted runners, so on a fork those jobs would **queue forever**.

Make `runs-on` conditional:

```yaml
runs-on: ${{ (github.repository_owner == 'kunobi-ninja'
  && github.event.pull_request.head.repo.fork != true)
  && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
```

- In **`kunobi-ninja/kache`**, non-fork (push / internal branch PR) → self-hosted Apple Silicon.
- **Fork PR** to kunobi-ninja, or a **fork's own** push CI → GitHub-hosted `macos-latest`.

Linux is unchanged — it already runs on GitHub-hosted `ubuntu-latest`.

## Not a security control

For a `pull_request`, GitHub runs the workflow file **from the PR head** — the fork's copy — so a fork can edit this expression (or any `run:` step). This conditional only fixes the *non-malicious* "fork CI hangs" case.

Keeping fork-PR code off the self-hosted runners is the job of the repo setting **Settings → Actions → General → "Fork pull request workflows from outside collaborators" → require approval for all external contributors**. That setting — not this PR — is the actual boundary. Recommend enabling it (and keeping no secrets on the runners; ideally make them ephemeral).

## Test plan
- [ ] CI on this branch (inside kunobi-ninja, non-fork) still schedules the macOS jobs on the self-hosted runners and passes.