### PR TITLE
feat(e2e): deterministic op-count metrics + assertions

### DIFF
--- a/crates/kache-e2e/src/assertions.rs
+++ b/crates/kache-e2e/src/assertions.rs
@@ -71,10 +71,15 @@ pub fn count_misses_by_crate(events: &[Event]) -> HashMap<String, u64> {
 /// (the delta between pre/post event snapshots). Required because
 /// per-crate assertions can't be derived from the aggregate summary —
 /// the summary's `misses` field is a sum, not a per-name breakdown.
+///
+/// `phase_events` is this phase's event slice — used to sum the
+/// op-count fields (`compiler_runs`, `preprocessor_runs`) for the
+/// `max_*_runs` assertions, which the aggregate summary doesn't carry.
 pub fn apply_metric_assertions(
     spec: &MetricAssertions,
     summary: &ReportSummary,
     phase_misses_by_crate: &HashMap<String, u64>,
+    phase_events: &[Event],
 ) -> Vec<AssertionCheck> {
     let mut checks = Vec::new();
     if let Some(min) = spec.min_entries_after {
@@ -126,6 +131,18 @@ pub fn apply_metric_assertions(
             actual: actual.to_string(),
             passed,
         });
+    }
+    // Op-count budgets: summed across this phase's events. These are
+    // deterministic (counts, not timings) so they gate CI reliably —
+    // `max_compiler_runs = 0` is the headline "the cache actually
+    // skipped the compile" assertion.
+    if let Some(max) = spec.max_compiler_runs {
+        let total: u32 = phase_events.iter().map(|e| e.compiler_runs).sum();
+        checks.push(AssertionCheck::max("max_compiler_runs", max, total));
+    }
+    if let Some(max) = spec.max_preprocessor_runs {
+        let total: u32 = phase_events.iter().map(|e| e.preprocessor_runs).sum();
+        checks.push(AssertionCheck::max("max_preprocessor_runs", max, total));
     }
     checks
 }
@@ -199,8 +216,10 @@ mod tests {
             max_misses: None,
             min_hit_rate_pct: None,
             min_misses_per_crate: HashMap::new(),
+            max_compiler_runs: None,
+            max_preprocessor_runs: None,
         };
-        let checks = apply_metric_assertions(&spec, &summary(0, 0, 0, 0.0), &HashMap::new());
+        let checks = apply_metric_assertions(&spec, &summary(0, 0, 0, 0.0), &HashMap::new(), &[]);
         assert!(checks.is_empty());
     }
 
@@ -214,8 +233,10 @@ mod tests {
             max_misses: None,
             min_hit_rate_pct: None,
             min_misses_per_crate: HashMap::new(),
+            max_compiler_runs: None,
+            max_preprocessor_runs: None,
         };
-        let checks = apply_metric_assertions(&spec, &summary(5, 0, 5, 100.0), &HashMap::new());
+        let checks = apply_metric_assertions(&spec, &summary(5, 0, 5, 100.0), &HashMap::new(), &[]);
         assert!(all_passed(&checks));
     }
 
@@ -229,8 +250,10 @@ mod tests {
             max_misses: None,
             min_hit_rate_pct: None,
             min_misses_per_crate: HashMap::new(),
+            max_compiler_runs: None,
+            max_preprocessor_runs: None,
         };
-        let checks = apply_metric_assertions(&spec, &summary(0, 5, 5, 0.0), &HashMap::new());
+        let checks = apply_metric_assertions(&spec, &summary(0, 5, 5, 0.0), &HashMap::new(), &[]);
         assert!(!all_passed(&checks));
         assert_eq!(checks[0].actual, "0");
         assert_eq!(checks[0].expected, ">= 1");

--- a/crates/kache-e2e/src/fixture.rs
+++ b/crates/kache-e2e/src/fixture.rs
@@ -154,6 +154,16 @@ pub struct MetricAssertions {
     /// could mask a false hit on the OUT_DIR-using crate.
     #[serde(default)]
     pub min_misses_per_crate: std::collections::HashMap<String, u64>,
+    /// Upper bound on the compiler spawns summed across this phase's
+    /// events. `0` is the headline cache assertion — a phase that
+    /// fully hits must not spawn the compiler at all. Deterministic
+    /// (a count, not a timing), so it is safe to gate CI on.
+    pub max_compiler_runs: Option<u32>,
+    /// Upper bound on the preprocessor spawns (`cc -E`) summed across
+    /// this phase's events. Documents the per-compile C/C++ key
+    /// overhead and guards against a regression that runs the
+    /// preprocessor more than once per compile.
+    pub max_preprocessor_runs: Option<u32>,
 }
 
 /// No-op phase assertions. The no-op phase rebuilds without cleaning;

--- a/crates/kache-e2e/src/report.rs
+++ b/crates/kache-e2e/src/report.rs
@@ -35,6 +35,14 @@ pub struct Event {
     /// `"hit"` | `"miss"` | other future variants. Compared as a
     /// string to stay compatible with kache adding new event kinds.
     pub result: String,
+    /// Times kache spawned the underlying compiler for this event
+    /// (0 on a hit, 1 on a miss). `#[serde(default)]` so reports from
+    /// an older kache without the field still deserialize.
+    #[serde(default)]
+    pub compiler_runs: u32,
+    /// Times kache spawned the preprocessor (`cc -E`) for this event.
+    #[serde(default)]
+    pub preprocessor_runs: u32,
 }
 
 /// Subset of the `summary` block that assertions read against.

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -323,13 +323,13 @@ fn run_phase(
             .assertions
             .cold
             .as_ref()
-            .map(|spec| apply_metric_assertions(spec, &delta, &phase_misses_by_crate))
+            .map(|spec| apply_metric_assertions(spec, &delta, &phase_misses_by_crate, new_events))
             .unwrap_or_default(),
         Phase::Warm => fixture
             .assertions
             .warm
             .as_ref()
-            .map(|spec| apply_metric_assertions(spec, &delta, &phase_misses_by_crate))
+            .map(|spec| apply_metric_assertions(spec, &delta, &phase_misses_by_crate, new_events))
             .unwrap_or_default(),
         Phase::Noop => fixture
             .assertions
@@ -341,7 +341,7 @@ fn run_phase(
             .assertions
             .relocate
             .as_ref()
-            .map(|spec| apply_metric_assertions(spec, &delta, &phase_misses_by_crate))
+            .map(|spec| apply_metric_assertions(spec, &delta, &phase_misses_by_crate, new_events))
             .unwrap_or_default(),
     };
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -37,6 +37,7 @@ pub fn run_rustc(
     // files and fails with "output file is not writeable".
     pre_clean_outputs(output_path, out_dir, crate_name, extra_filename);
 
+    crate::opcounts::record_compiler_run();
     let mut cmd = Command::new(rustc);
 
     // Double-wrapper (RUSTC_WRAPPER + RUSTC_WORKSPACE_WRAPPER): the workspace

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -512,6 +512,7 @@ fn build_preprocess_args(parsed: &CcArgs) -> Vec<String> {
 /// dependency tracking needed.
 fn preprocess_hash(parsed: &CcArgs) -> Result<String> {
     let pp_args = build_preprocess_args(parsed);
+    crate::opcounts::record_preprocessor_run();
     let output = Command::new(&parsed.program)
         .args(&pp_args)
         // Pin the build timestamp. gcc + clang both honor
@@ -698,6 +699,7 @@ impl Compiler for CcCompiler {
 
     fn execute(&self, parsed: &CcArgs) -> Result<CompileResult> {
         // Invoke the underlying compiler with the original argv.
+        crate::opcounts::record_compiler_run();
         let output = Command::new(&parsed.program)
             .args(&parsed.rest)
             .output()

--- a/src/events.rs
+++ b/src/events.rs
@@ -23,7 +23,8 @@ pub struct BuildEvent {
     pub size: u64,
     #[serde(default)]
     pub cache_key: String,
-    /// Event schema version: 0 = legacy, 1 = prefetch-aware, 2 = compile-cost-aware.
+    /// Event schema version: 0 = legacy, 1 = prefetch-aware,
+    /// 2 = compile-cost-aware, 3 = op-count-aware.
     #[serde(default)]
     pub schema: u32,
     /// Cache key computation time (ms).
@@ -38,6 +39,15 @@ pub struct BuildEvent {
     /// Store put time — tar + compress + dedup + SQLite (misses only, ms).
     #[serde(default)]
     pub store_ms: u64,
+    /// Times kache spawned the underlying compiler for this build.
+    /// 0 on a cache hit, 1 on a miss. Deterministic — independent of
+    /// machine speed — so the e2e harness can assert on it.
+    #[serde(default)]
+    pub compiler_runs: u32,
+    /// Times kache spawned the preprocessor (`cc -E`) for this build —
+    /// once per C/C++ compile to derive the cache key, 0 for rustc.
+    #[serde(default)]
+    pub preprocessor_runs: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -404,11 +414,13 @@ mod tests {
             compile_time_ms,
             size,
             cache_key: cache_key.to_string(),
-            schema: 2,
+            schema: 3,
             key_ms: 0,
             lookup_ms: 0,
             restore_ms: 0,
             store_ms: 0,
+            compiler_runs: 0,
+            preprocessor_runs: 0,
         }
     }
 
@@ -426,11 +438,13 @@ mod tests {
             compile_time_ms: 250,
             size: 3145728,
             cache_key: "abc123".to_string(),
-            schema: 2,
+            schema: 3,
             key_ms: 0,
             lookup_ms: 0,
             restore_ms: 0,
             store_ms: 0,
+            compiler_runs: 0,
+            preprocessor_runs: 0,
         };
 
         log_event(&log_path, &event).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod daemon;
 mod events;
 mod fallback_planner;
 mod link;
+mod opcounts;
 mod path_normalizer;
 mod planner_client;
 mod platform;

--- a/src/opcounts.rs
+++ b/src/opcounts.rs
@@ -1,0 +1,67 @@
+//! Process-global counters for the external programs kache spawns
+//! while handling one compile.
+//!
+//! Each `kache` wrapper invocation is its own process and handles
+//! exactly one compile, so a process-global counter read when the build
+//! event is logged reflects that compile's work — no per-call plumbing
+//! through the `Compiler` trait is needed.
+//!
+//! Unlike timings, these counts are **deterministic**: they do not
+//! depend on machine speed, runner load, or filesystem-cache warmth. So
+//! the e2e harness can assert on them as a perf-regression guard — e.g.
+//! "a warm cache hit must not spawn the compiler" — with the same
+//! reliability as a correctness assertion. Wall-clock budgets cannot do
+//! that across the self-hosted / GitHub-hosted runner mix.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static COMPILER_RUNS: AtomicU32 = AtomicU32::new(0);
+static PREPROCESSOR_RUNS: AtomicU32 = AtomicU32::new(0);
+
+/// Record that kache spawned the underlying compiler — `rustc`, or a
+/// C-family `cc -c` compile. A cache hit must record zero of these; a
+/// miss records one.
+pub fn record_compiler_run() {
+    COMPILER_RUNS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record that kache spawned the preprocessor (`cc -E`) — currently
+/// done once per C/C++ compile to derive the cache key. Always zero for
+/// rustc, which has no separate preprocess step.
+pub fn record_preprocessor_run() {
+    PREPROCESSOR_RUNS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Compiler spawns recorded so far in this process.
+pub fn compiler_runs() -> u32 {
+    COMPILER_RUNS.load(Ordering::Relaxed)
+}
+
+/// Preprocessor spawns recorded so far in this process.
+pub fn preprocessor_runs() -> u32 {
+    PREPROCESSOR_RUNS.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The counters are process-global and only ever increment (no
+    // reset), so these assertions are safe under parallel test
+    // execution: `after > before` holds regardless of what other
+    // tests increment concurrently.
+
+    #[test]
+    fn record_compiler_run_increments_monotonically() {
+        let before = compiler_runs();
+        record_compiler_run();
+        assert!(compiler_runs() > before);
+    }
+
+    #[test]
+    fn record_preprocessor_run_increments_monotonically() {
+        let before = preprocessor_runs();
+        record_preprocessor_run();
+        assert!(preprocessor_runs() > before);
+    }
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -185,6 +185,14 @@ pub struct CrateDetail {
     pub overhead_ms: u64,
     pub size: u64,
     pub cache_key: String,
+    /// Times kache spawned the underlying compiler (0 on a hit, 1 on a
+    /// miss). Deterministic; the e2e harness asserts on it.
+    #[serde(default)]
+    pub compiler_runs: u32,
+    /// Times kache spawned the preprocessor (`cc -E`) — once per C/C++
+    /// compile for the cache key, 0 for rustc.
+    #[serde(default)]
+    pub preprocessor_runs: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -450,6 +458,8 @@ fn to_crate_detail(e: &BuildEvent) -> CrateDetail {
         overhead_ms: overhead,
         size: e.size,
         cache_key: e.cache_key.clone(),
+        compiler_runs: e.compiler_runs,
+        preprocessor_runs: e.preprocessor_runs,
     }
 }
 
@@ -1624,11 +1634,13 @@ mod tests {
             compile_time_ms,
             size,
             cache_key: cache_key.to_string(),
-            schema: 2,
+            schema: 3,
             key_ms: 0,
             lookup_ms: 0,
             restore_ms: 0,
             store_ms: 0,
+            compiler_runs: 0,
+            preprocessor_runs: 0,
         }
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -823,11 +823,15 @@ fn log_event(
         compile_time_ms,
         size,
         cache_key: cache_key.to_string(),
-        schema: 2,
+        schema: 3,
         key_ms,
         lookup_ms,
         restore_ms,
         store_ms,
+        // Read the process-global op-counters: this `kache` process
+        // handled exactly this one compile, so the counts are its own.
+        compiler_runs: crate::opcounts::compiler_runs(),
+        preprocessor_runs: crate::opcounts::preprocessor_runs(),
     };
     let _ = events::log_event(&config.event_log_path(), &event);
     let _ = events::rotate_if_needed(

--- a/test-projects/c-hello/kache-fixture.toml
+++ b/test-projects/c-hello/kache-fixture.toml
@@ -20,12 +20,21 @@ run = "./build/foo"
 expected_stdout_contains = ["hello from bar"]
 
 # Cold: the object compile is a miss → one entry lands in the cache.
+# Op-counts: kache runs the preprocessor once (cache key) and, on the
+# miss, the compiler once.
 [assertions.cold]
 min_entries_after = 1
+max_compiler_runs = 1
+max_preprocessor_runs = 1
 
 # Warm: clean wipes build/, the rebuild's compile hits the cache.
+# `max_compiler_runs = 0` is the deterministic proof the hit skipped
+# the compile entirely. The preprocessor still runs once (it derives
+# the key) — that's the overhead a future direct mode would remove.
 [assertions.warm]
 min_hits = 1
+max_compiler_runs = 0
+max_preprocessor_runs = 1
 
 # Noop: `make` sees build/foo.o + build/foo up to date and does
 # nothing. No `cc` invocation, no kache event. make emits no
@@ -42,3 +51,5 @@ should_not_recompile = false
 # parallel of multi-dep's relocate contract.
 [assertions.relocate]
 min_hits = 1
+max_compiler_runs = 0
+max_preprocessor_runs = 1

--- a/test-projects/cpp-hello/kache-fixture.toml
+++ b/test-projects/cpp-hello/kache-fixture.toml
@@ -20,12 +20,19 @@ run = "./build/foo"
 expected_stdout_contains = ["hello from bar", "sum=15"]
 
 # Cold: the `-c` compile of foo.cpp is a miss → one cache entry.
+# Op-counts: one preprocessor run (cache key) + one compiler run.
 [assertions.cold]
 min_entries_after = 1
+max_compiler_runs = 1
+max_preprocessor_runs = 1
 
 # Warm: clean + rebuild → the compile hits.
+# `max_compiler_runs = 0` proves the hit skipped the compile; the
+# preprocessor still runs once to derive the key.
 [assertions.warm]
 min_hits = 1
+max_compiler_runs = 0
+max_preprocessor_runs = 1
 
 [assertions.noop]
 should_not_recompile = false
@@ -34,3 +41,5 @@ should_not_recompile = false
 # the relocated build's compile hits.
 [assertions.relocate]
 min_hits = 1
+max_compiler_runs = 0
+max_preprocessor_runs = 1


### PR DESCRIPTION
## Summary

Adds **operation counts** to kache's build events so the e2e harness can guard caching *performance* — without timing assertions.

Why not timing: absolute `*_ms` budgets are flaky across the self-hosted / GitHub-hosted runner mix, runner load, and FS-cache warmth. Counts (how many subprocesses kache spawned) are **deterministic** — independent of machine speed — so they gate CI as reliably as a correctness check, and they're the honest measure of "how much work the cache skipped."

## kache side

- New `opcounts` module — process-global counters. Each `kache` wrapper invocation is one process handling one compile, so the counter read at event-log time is that compile's own (no per-call plumbing through the `Compiler` trait).
- `record_compiler_run()` at the rustc and `cc -c` spawn sites; `record_preprocessor_run()` at the `cc -E` cache-key site.
- `BuildEvent` and `CrateDetail` carry `compiler_runs` + `preprocessor_runs` (`#[serde(default)]`, event schema bumped to 3); they flow through `kache report --format json`.

## e2e harness

- `Event` reads the two fields; `MetricAssertions` gains `max_compiler_runs` / `max_preprocessor_runs`, summed across a phase's events.
- `c-hello` / `cpp-hello` assert the contract:
  - **cold** → `compiler_runs ≤ 1` (one miss = one compile), `preprocessor_runs ≤ 1` (key derivation)
  - **warm** / **relocate** → `compiler_runs ≤ 0` (the hit skipped the compile), `preprocessor_runs ≤ 1`

`max_compiler_runs = 0` on warm/relocate is the headline — a deterministic proof the cache hit did no compile, where before only the hit/miss count implied it. `preprocessor_runs` documents the per-compile C/C++ cache-key overhead — the figure a future "direct mode" would drive to 0.

## Verification

- `cargo test --bin kache` — 462 passed, 0 failed (includes 2 new `opcounts` tests).
- `cargo test -p kache-e2e` — 8 passed.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` clean.
- Ran the harness on the cc fixtures — the new assertions evaluate and pass:

```
c-hello   cold      max_compiler_runs     actual=1  (<= 1)  OK
          warm      max_compiler_runs     actual=0  (<= 0)  OK
          warm      max_preprocessor_runs actual=1  (<= 1)  OK
          relocate  max_compiler_runs     actual=0  (<= 0)  OK
cpp-hello  ... (identical)
```

## Test plan
- [ ] CI green (Linux + macOS), e2e fixtures pass with the new assertions