### PR TITLE
test(e2e): differential + invalidation checks for C/C++ caching

### DIFF
--- a/crates/kache-e2e/src/assertions.rs
+++ b/crates/kache-e2e/src/assertions.rs
@@ -63,6 +63,50 @@ pub fn count_misses_by_crate(events: &[Event]) -> HashMap<String, u64> {
     by_crate
 }
 
+/// Differential check: a cache-hit phase's restored artifact must be
+/// byte-identical to the cold build's real-compiler output.
+///
+/// `baseline` is the cold-phase bytes for this artifact, or `None` if
+/// cold never recorded it (a fixture misconfiguration — surfaced as a
+/// failed check rather than silently skipped).
+pub fn diff_artifact_check(
+    artifact: &str,
+    baseline: Option<&Vec<u8>>,
+    actual: &[u8],
+) -> AssertionCheck {
+    // Box-leak the artifact-qualified name for `name: &'static str`;
+    // bounded — a fixture declares a small fixed set of artifacts.
+    let name: &'static str = Box::leak(format!("diff_match[{artifact}]").into_boxed_str());
+    let Some(base) = baseline else {
+        return AssertionCheck {
+            name,
+            expected: "cold-phase baseline recorded".to_string(),
+            actual: "no baseline — cold did not produce this artifact".to_string(),
+            passed: false,
+        };
+    };
+    let passed = base.as_slice() == actual;
+    let actual = if passed {
+        format!("byte-identical ({} bytes)", actual.len())
+    } else {
+        let first = base.iter().zip(actual).position(|(a, b)| a != b);
+        format!(
+            "differs (cold {} B, restored {} B{})",
+            base.len(),
+            actual.len(),
+            first
+                .map(|i| format!(", first at byte {i}"))
+                .unwrap_or_default()
+        )
+    };
+    AssertionCheck {
+        name,
+        expected: "byte-identical to cold build".to_string(),
+        actual,
+        passed,
+    }
+}
+
 /// Apply [`MetricAssertions`] against a [`ReportSummary`]. Each declared
 /// constraint produces one check; absent constraints are silently skipped
 /// (this is how a fixture opts in to only the assertions it cares about).
@@ -291,5 +335,30 @@ mod tests {
         let clean = apply_noop_assertions(&spec, "Finished `release` profile");
         assert!(!all_passed(&recompiled));
         assert!(all_passed(&clean));
+    }
+
+    #[test]
+    fn diff_artifact_check_passes_on_identical_bytes() {
+        let base = vec![1u8, 2, 3, 4];
+        let check = diff_artifact_check("build/foo.o", Some(&base), &[1, 2, 3, 4]);
+        assert!(check.passed);
+        assert!(check.actual.contains("byte-identical"));
+    }
+
+    #[test]
+    fn diff_artifact_check_fails_on_differing_bytes() {
+        let base = vec![1u8, 2, 3, 4];
+        let check = diff_artifact_check("build/foo.o", Some(&base), &[1, 2, 9, 4]);
+        assert!(!check.passed);
+        // The first differing byte is reported for diagnostics.
+        assert!(check.actual.contains("first at byte 2"));
+    }
+
+    #[test]
+    fn diff_artifact_check_fails_when_no_baseline() {
+        // Cold never recorded the artifact → can't compare → fail
+        // loudly rather than silently pass.
+        let check = diff_artifact_check("build/foo.o", None, &[1, 2, 3]);
+        assert!(!check.passed);
     }
 }

--- a/crates/kache-e2e/src/fixture.rs
+++ b/crates/kache-e2e/src/fixture.rs
@@ -46,10 +46,54 @@ pub struct Fixture {
     #[serde(default)]
     pub assertions: PhaseAssertions,
 
+    /// Optional differential test — artifact files whose bytes must be
+    /// identical between the cold build (a real compile) and every
+    /// cache-hit phase. See [`DiffSpec`].
+    pub diff: Option<DiffSpec>,
+
+    /// Optional invalidation test — a source edit that must force a
+    /// recompile in the `relocate-modified` phase. See [`ModifySpec`].
+    pub modify: Option<ModifySpec>,
+
     /// Absolute path to the fixture directory (set at load time, not
     /// in the toml).
     #[serde(skip)]
     pub dir: PathBuf,
+}
+
+/// Differential-test spec (`[diff]` in the fixture toml).
+///
+/// Runtime verification only proves the built program *behaves*
+/// right — a subtly wrong `.o` that still prints the expected output
+/// would pass. This pins the artifact down at the byte level: the
+/// object a cache hit restores must be byte-for-byte identical to the
+/// one the real compiler produced on the cold build. Catches
+/// store/restore corruption and wrong-key miscaches.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DiffSpec {
+    /// Artifact paths relative to the project root (e.g.
+    /// `build/foo.o`). Compared after cold (the baseline) and after
+    /// every cache-hit phase.
+    pub artifacts: Vec<String>,
+}
+
+/// Invalidation-test spec (`[modify]` in the fixture toml).
+///
+/// Drives the `relocate-modified` phase: relocate the project, apply
+/// this one find/replace edit to a source file, rebuild. The build
+/// MUST be a cache miss — proving the key stays content-sensitive even
+/// across a relocation. Guards the stale-restore bug class (a content
+/// change wrongly served from cache).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModifySpec {
+    /// Source file to edit, relative to the project root.
+    pub file: String,
+    /// Substring to replace. Must occur in `file`, or the harness
+    /// fails the phase — a no-op edit would make the test vacuous.
+    pub find: String,
+    /// Replacement substring. Must change the preprocessed/compiled
+    /// output (not just a comment) so the cache key actually diverges.
+    pub replace: String,
 }
 
 /// Required shell commands. `build` runs the compiler under kache;
@@ -115,6 +159,14 @@ pub struct PhaseAssertions {
     /// Per-fixture opt-in. Reuses [`MetricAssertions`] (same
     /// `min_hits`, `min_hit_rate_pct`, `max_misses` etc.).
     pub relocate: Option<MetricAssertions>,
+    /// Relocate-then-modify phase: the project is relocated AND a
+    /// source file is edited (see [`ModifySpec`]) before the build.
+    /// The contract is the inverse of `relocate` — the build MUST
+    /// miss (`min_misses = 1`), proving the cache key reacts to
+    /// content changes and does not serve a stale artifact.
+    /// Deserialized from `[assertions.relocate-modified]`.
+    #[serde(rename = "relocate-modified")]
+    pub relocate_modified: Option<MetricAssertions>,
 }
 
 /// Assertions applied against `kache report --format json` output.

--- a/crates/kache-e2e/src/result.rs
+++ b/crates/kache-e2e/src/result.rs
@@ -35,7 +35,7 @@ pub struct FixtureResult {
 
 #[derive(Debug, Serialize)]
 pub struct PhaseResult {
-    /// `"cold" | "warm" | "noop"`.
+    /// `"cold" | "warm" | "noop" | "relocate" | "relocate-modified"`.
     pub phase: String,
     pub status: String,
     /// Wall-clock seconds for the build step (last step in the phase).

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -45,6 +45,14 @@ pub enum Phase {
     /// invisible because every other phase rebuilds at the same
     /// path and trivially hits.
     Relocate,
+    /// Relocate, then edit a source file before building. The inverse
+    /// of `Relocate`: where that phase proves the key is
+    /// path-*independent* (a relocated build hits), this proves the
+    /// key is still content-*sensitive* — the edited build MUST miss.
+    /// Together they pin the key from both sides and guard the
+    /// stale-restore bug class (a content change wrongly served from
+    /// cache). Only runs when the fixture declares `[modify]`.
+    RelocateModified,
 }
 
 impl Phase {
@@ -54,6 +62,7 @@ impl Phase {
             Phase::Warm => "warm",
             Phase::Noop => "noop",
             Phase::Relocate => "relocate",
+            Phase::RelocateModified => "relocate-modified",
         }
     }
 
@@ -64,6 +73,15 @@ impl Phase {
     /// target/ along.
     fn cleans_first(self) -> bool {
         !matches!(self, Phase::Noop)
+    }
+
+    /// Should this phase run the fixture's `[verify]` (run the binary,
+    /// check stdout)? Every phase but `relocate-modified` does — that
+    /// phase deliberately edits the source, so the program's output
+    /// changes and the fixture's stdout contract no longer applies.
+    /// Its contract is purely "the cache missed", checked via metrics.
+    fn runs_verify(self) -> bool {
+        !matches!(self, Phase::RelocateModified)
     }
 }
 
@@ -107,12 +125,19 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
     let mut prev_summary = report::empty_summary();
     let mut prev_event_count: usize = 0;
 
+    // Differential-test baseline: `artifact path → bytes` captured on
+    // the cold build (a real compile). Every cache-hit phase compares
+    // its restored artifact against this. Rolls forward through all
+    // phases; empty unless the fixture declares `[diff]`.
+    let mut diff_baseline: std::collections::HashMap<String, Vec<u8>> =
+        std::collections::HashMap::new();
+
     // `relocate` is held outside the loop because it needs its own
     // `cwd` (a copy of the fixture in a fresh tempdir) — kept distinct
     // here so the in-place phases (cold/warm/noop) stay simple and the
     // relocate-specific dir lifecycle doesn't leak into them.
     let phases = [Phase::Cold, Phase::Warm, Phase::Noop];
-    let mut phase_results = Vec::with_capacity(phases.len() + 1);
+    let mut phase_results = Vec::with_capacity(phases.len() + 2);
     let mut short_circuit = false;
     for phase in phases {
         let (result, post) = run_phase(
@@ -123,6 +148,7 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
             cache_dir.path(),
             &prev_summary,
             prev_event_count,
+            &mut diff_baseline,
         )?;
         if let Some((s, c)) = post {
             prev_summary = s;
@@ -162,7 +188,7 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
                     cache_dir.path(),
                 );
 
-                let (result, _post) = run_phase(
+                let (result, post) = run_phase(
                     Phase::Relocate,
                     fixture,
                     relocated.path(),
@@ -170,9 +196,34 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
                     cache_dir.path(),
                     &prev_summary,
                     prev_event_count,
+                    &mut diff_baseline,
                 )?;
+                // Roll the report cursor forward so the
+                // relocate-modified phase's delta reflects only its
+                // own events, not relocate's.
+                if let Some((s, c)) = post {
+                    prev_summary = s;
+                    prev_event_count = c;
+                }
+                let relocate_failed = result.status == "fail";
                 phase_results.push(result);
                 // `relocated` (TempDir) drops here, removing the copy.
+
+                // relocate-modified: relocate again, edit a source
+                // file, rebuild — the build MUST miss. Skipped if the
+                // fixture declares no `[modify]`, or if relocate
+                // itself failed (a modified build is meaningless then).
+                if !relocate_failed && let Some(modify) = &fixture.modify {
+                    phase_results.push(run_relocate_modified(
+                        fixture,
+                        modify,
+                        kache_path,
+                        cache_dir.path(),
+                        &prev_summary,
+                        prev_event_count,
+                        &mut diff_baseline,
+                    )?);
+                }
             }
             Err(e) => {
                 // Surface as a fail with diagnostic context. We don't
@@ -214,6 +265,84 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
     })
 }
 
+/// Drive the `relocate-modified` phase: copy the fixture to a fresh
+/// path, apply the fixture's one source edit, then run the phase.
+///
+/// Copy / edit failures are recorded as a failed [`PhaseResult`]
+/// rather than raised — matching how the relocate phase treats a
+/// `cp` hiccup, so one fixture's setup glitch never aborts the run.
+fn run_relocate_modified(
+    fixture: &Fixture,
+    modify: &crate::fixture::ModifySpec,
+    kache_path: &Path,
+    cache_dir: &Path,
+    prev_summary: &crate::report::ReportSummary,
+    prev_event_count: usize,
+    diff_baseline: &mut std::collections::HashMap<String, Vec<u8>>,
+) -> Result<PhaseResult> {
+    let fail = |name: &'static str, expected: String, actual: String| PhaseResult {
+        phase: Phase::RelocateModified.name().to_string(),
+        status: "fail".to_string(),
+        build_wall_s: 0,
+        build_exit_code: -1,
+        verify: None,
+        kache_report: serde_json::json!({}),
+        assertions: vec![AssertionCheck {
+            name,
+            expected,
+            actual,
+            passed: false,
+        }],
+    };
+
+    let relocated = match prepare_relocated_dir(&fixture.dir) {
+        Ok(d) => d,
+        Err(e) => {
+            return Ok(fail(
+                "prepare_relocated_dir",
+                "successful copy".to_string(),
+                format!("{e:?}"),
+            ));
+        }
+    };
+    if let Err(e) = apply_modification(relocated.path(), modify) {
+        return Ok(fail(
+            "apply_modification",
+            format!("replace `{}` in {}", modify.find, modify.file),
+            format!("{e:?}"),
+        ));
+    }
+    let (result, _post) = run_phase(
+        Phase::RelocateModified,
+        fixture,
+        relocated.path(),
+        kache_path,
+        cache_dir,
+        prev_summary,
+        prev_event_count,
+        diff_baseline,
+    )?;
+    Ok(result)
+}
+
+/// Apply the fixture's single find/replace edit to a source file in a
+/// relocated copy. Fails loudly if `find` is absent — a no-op edit
+/// would make the `relocate-modified` phase test nothing.
+fn apply_modification(dir: &Path, modify: &crate::fixture::ModifySpec) -> Result<()> {
+    let path = dir.join(&modify.file);
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading {} for modification", path.display()))?;
+    if !content.contains(&modify.find) {
+        anyhow::bail!(
+            "`{}` not found in {} — the edit would be a no-op",
+            modify.find,
+            modify.file
+        );
+    }
+    std::fs::write(&path, content.replace(&modify.find, &modify.replace))
+        .with_context(|| format!("writing modified {}", path.display()))
+}
+
 /// Run a single phase: optional clean, build, verify, fetch report,
 /// apply assertions. Returns a [`PhaseResult`] regardless of outcome —
 /// failures are recorded, not raised. (Errors that prevent recording
@@ -230,6 +359,14 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
 /// phase's metrics reflect ITS work, not the cumulative since fixture
 /// start. The post-phase summary is returned so the caller can roll
 /// it forward as `prev_summary` for the next phase.
+///
+/// `diff_baseline` carries the differential-test state: the cold phase
+/// records each declared artifact's bytes into it; cache-hit phases
+/// read it back and assert byte-equality.
+// Orchestration glue — the inputs are genuinely independent (phase,
+// dirs, the rolling report cursor, the rolling diff baseline). Bundling
+// them into a struct would obscure more than it clarifies.
+#[allow(clippy::too_many_arguments)]
 fn run_phase(
     phase: Phase,
     fixture: &Fixture,
@@ -238,6 +375,7 @@ fn run_phase(
     cache_dir: &Path,
     prev_summary: &crate::report::ReportSummary,
     prev_event_count: usize,
+    diff_baseline: &mut std::collections::HashMap<String, Vec<u8>>,
 ) -> Result<(PhaseResult, Option<(crate::report::ReportSummary, usize)>)> {
     if phase.cleans_first() {
         let status = run_step(&fixture.commands.clean, fixture, cwd, cache_dir)?;
@@ -290,11 +428,17 @@ fn run_phase(
         ));
     }
 
-    // Verify: run the artifact, check stdout contract.
-    let verify = fixture
-        .verify
-        .as_ref()
-        .map(|v| run_verify(v, fixture, cwd, cache_dir));
+    // Verify: run the artifact, check stdout contract. Skipped for
+    // `relocate-modified` — that phase edits the source, so the
+    // program's output no longer matches the fixture's contract.
+    let verify = if phase.runs_verify() {
+        fixture
+            .verify
+            .as_ref()
+            .map(|v| run_verify(v, fixture, cwd, cache_dir))
+    } else {
+        None
+    };
 
     let (typed, raw) = report::fetch(kache_path, cache_dir)?;
     // Per-phase delta: subtract the previous cumulative summary so
@@ -343,7 +487,48 @@ fn run_phase(
             .as_ref()
             .map(|spec| apply_metric_assertions(spec, &delta, &phase_misses_by_crate, new_events))
             .unwrap_or_default(),
+        Phase::RelocateModified => fixture
+            .assertions
+            .relocate_modified
+            .as_ref()
+            .map(|spec| apply_metric_assertions(spec, &delta, &phase_misses_by_crate, new_events))
+            .unwrap_or_default(),
     };
+
+    // Differential check: a cache-hit phase's restored artifact must
+    // be byte-identical to the cold build's real-compiler output.
+    // Cold records the baseline; warm + relocate compare against it.
+    // (noop restores nothing; relocate-modified's artifact differs by
+    // design — neither is a hit-vs-fresh comparison.)
+    if let Some(diff) = &fixture.diff {
+        for artifact in &diff.artifacts {
+            match std::fs::read(cwd.join(artifact)) {
+                Ok(bytes) => match phase {
+                    Phase::Cold => {
+                        diff_baseline.insert(artifact.clone(), bytes);
+                    }
+                    Phase::Warm | Phase::Relocate => {
+                        checks.push(crate::assertions::diff_artifact_check(
+                            artifact,
+                            diff_baseline.get(artifact),
+                            &bytes,
+                        ));
+                    }
+                    Phase::Noop | Phase::RelocateModified => {}
+                },
+                Err(e) => {
+                    if matches!(phase, Phase::Cold | Phase::Warm | Phase::Relocate) {
+                        checks.push(AssertionCheck {
+                            name: "diff_artifact_present",
+                            expected: format!("readable artifact `{artifact}`"),
+                            actual: format!("{e}"),
+                            passed: false,
+                        });
+                    }
+                }
+            }
+        }
+    }
 
     // Verify failures count toward phase pass/fail too.
     let verify_passed = verify.as_ref().map(|v| v.passed).unwrap_or(true);

--- a/test-projects/c-hello/kache-fixture.toml
+++ b/test-projects/c-hello/kache-fixture.toml
@@ -19,6 +19,22 @@ clean = "make clean"
 run = "./build/foo"
 expected_stdout_contains = ["hello from bar"]
 
+# Differential test: the object a cache hit restores must be
+# byte-for-byte identical to the one the real compiler produced on the
+# cold build. Runtime verify only proves the program behaves right; a
+# subtly wrong .o that still prints "hello from bar" would slip past it.
+[diff]
+artifacts = ["build/foo.o"]
+
+# Invalidation test: drives the relocate-modified phase. The project is
+# relocated AND bar.h's greeting is edited — changing the macro value,
+# so the preprocessor expansion (and thus the cache key) diverges. The
+# rebuild MUST miss; a hit here would be a stale-restore bug.
+[modify]
+file = "src/bar.h"
+find = "hello from bar"
+replace = "edited greeting"
+
 # Cold: the object compile is a miss → one entry lands in the cache.
 # Op-counts: kache runs the preprocessor once (cache key) and, on the
 # miss, the compiler once.
@@ -52,4 +68,12 @@ should_not_recompile = false
 [assertions.relocate]
 min_hits = 1
 max_compiler_runs = 0
+max_preprocessor_runs = 1
+
+# Relocate-modified: relocated AND edited (see [modify]). The inverse
+# of relocate — the edited source MUST miss and recompile. `min_misses`
+# is the headline; the op-counts confirm exactly one compile ran.
+[assertions.relocate-modified]
+min_misses = 1
+max_compiler_runs = 1
 max_preprocessor_runs = 1

--- a/test-projects/cpp-hello/kache-fixture.toml
+++ b/test-projects/cpp-hello/kache-fixture.toml
@@ -19,6 +19,18 @@ clean = "make clean"
 run = "./build/foo"
 expected_stdout_contains = ["hello from bar", "sum=15"]
 
+# Differential test: the cache-restored object must be byte-identical
+# to the cold build's real-compiler output. See c-hello for rationale.
+[diff]
+artifacts = ["build/foo.o"]
+
+# Invalidation test: relocate AND edit bar.hpp's greeting — the changed
+# source must force a recompile (cache miss), never a stale hit.
+[modify]
+file = "src/bar.hpp"
+find = "hello from bar"
+replace = "edited greeting"
+
 # Cold: the `-c` compile of foo.cpp is a miss → one cache entry.
 # Op-counts: one preprocessor run (cache key) + one compiler run.
 [assertions.cold]
@@ -42,4 +54,11 @@ should_not_recompile = false
 [assertions.relocate]
 min_hits = 1
 max_compiler_runs = 0
+max_preprocessor_runs = 1
+
+# Relocate-modified: relocated AND edited — the changed source MUST
+# miss and recompile.
+[assertions.relocate-modified]
+min_misses = 1
+max_compiler_runs = 1
 max_preprocessor_runs = 1


### PR DESCRIPTION
## Summary

Continuing the C/C++ work — this hardens the **correctness** side. The harness previously only checked that a built program *runs and prints the right thing*. That catches gross miscaching, but a subtly wrong `.o` that still produces correct output would pass unnoticed. Two new checks close that gap — directly addressing the roadmap's existential *"silent miscache → wrong `.o` in a release binary"* risk.

## Differential test — `[diff]`

A fixture declares artifact paths:

```toml
[diff]
artifacts = ["build/foo.o"]
```

The **cold** build (a real compile) records each artifact's bytes; every **cache-hit** phase (warm, relocate) asserts its restored artifact is **byte-for-byte identical** to that baseline. Catches store/restore corruption and wrong-key miscaches that runtime verification simply can't see.

## Invalidation test — `[modify]` + the `relocate-modified` phase

```toml
[modify]
file = "src/bar.h"
find = "hello from bar"
replace = "edited greeting"
```

A new phase relocates the project, applies that one edit, and rebuilds — the build **MUST miss** (`min_misses = 1`). Where `relocate` proves the key is path-*independent* (a relocated build hits), this proves it stays content-*sensitive* across a relocation. That's the **stale-restore bug class** — a content change wrongly served from cache — pinned down explicitly. (Verify is skipped for this phase: the edited program's output no longer matches the fixture contract; the phase's contract is purely "the cache missed".)

`relocate` + `relocate-modified` now bracket the cache key from both sides.

## Fixtures

`c-hello` / `cpp-hello` opt into both — diff `build/foo.o`, and edit the `bar` header's greeting (a macro / string-literal change, so the preprocessor expansion and thus the cache key actually diverge — not a comment, which `cc -E -P` would strip).

## Verification

- `cargo test -p kache-e2e` — 11 passed (3 new `diff_artifact_check` tests).
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` clean.
- Ran the harness on the cc fixtures — both new checks evaluate and pass:

```
c-hello   warm               diff_match[build/foo.o]  byte-identical (2312 bytes)     OK
          relocate           diff_match[build/foo.o]  byte-identical (2312 bytes)     OK
          relocate-modified  min_misses               actual=1                       OK
cpp-hello warm               diff_match[build/foo.o]  byte-identical (179376 bytes)   OK
          relocate-modified  min_misses               actual=1                       OK
```

## Test plan
- [ ] CI green (Linux + macOS); c-hello / cpp-hello pass with the new `[diff]` / `[modify]` checks