### PR TITLE
fix(e2e): carry the toolchain pin into the relocate phase

### DIFF
--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -593,7 +593,35 @@ fn prepare_relocated_dir(src: &Path) -> Result<TempDir> {
             status
         );
     }
+    copy_toolchain_pin(src, dst.path());
     Ok(dst)
+}
+
+/// Carry the active Rust toolchain pin into the relocated tree.
+///
+/// The cold/warm/noop phases build the fixture in place inside the
+/// worktree, where rustup applies the repo's `rust-toolchain.toml`.
+/// The relocated copy lives in a tempdir with no such file anywhere up
+/// its path, so a build there would fall back to rustup's *default*
+/// toolchain — a different `rustc`. Since `rustc`'s version is part of
+/// every cache key, that mismatch masquerades as a relocate cache miss,
+/// turning a pure path-portability test into an accidental toolchain
+/// test (kache issue #96).
+///
+/// Copying the pin (found by walking up from the fixture dir) into the
+/// relocated dir makes both builds resolve the same toolchain. A no-op
+/// when no pin exists — both locations then use rustup's default,
+/// which is already consistent.
+fn copy_toolchain_pin(src: &Path, dst: &Path) {
+    for dir in src.ancestors() {
+        for name in ["rust-toolchain.toml", "rust-toolchain"] {
+            let pin = dir.join(name);
+            if pin.is_file() {
+                let _ = std::fs::copy(&pin, dst.join(name));
+                return;
+            }
+        }
+    }
 }
 
 /// Run one shell command in `cwd` with the fixture's env.

--- a/test-projects/multi-dep/kache-fixture.toml
+++ b/test-projects/multi-dep/kache-fixture.toml
@@ -50,21 +50,22 @@ min_hit_rate_pct = 50.0
 should_not_recompile = true
 recompile_marker = "Compiling"
 
-# Same source built from a *different* absolute path with the same
-# cache. EXPECTED TO FAIL today: rustc cache keys leak the build
-# directory into the hash, so a relocated build misses some entries
-# even though the source is byte-identical. PR3 (PathNormalizer)
-# will make this pass by stripping machine-local prefixes.
+# Same source built from a *different* absolute path against the same
+# cache. Must hit EVERY cached entry (max_misses = 0): rustc cache
+# keys are path-portable — PathNormalizer strips machine-local
+# prefixes, so byte-identical source produces byte-identical keys no
+# matter where the build runs.
 #
-# The contract is strict: same source → must hit EVERY cached entry
-# (max_misses = 0). Loose thresholds like `min_hit_rate_pct = 50`
-# would not catch the bug — a few leaked path components per crate
-# can still leave the bulk hitting cleanly. Strict zero-miss makes
-# the leak unambiguous.
+# Strict zero-miss is deliberate. A loose threshold
+# (`min_hit_rate_pct = 50`) would not catch a *partial* path leak — a
+# few leaked components per crate still leaves the bulk hitting
+# cleanly. This fixture is the regression guard for that leak class.
 #
-# Keeping the assertion declared now means: (a) the bug class is
-# visible end-to-end, not just in a unit test; (b) the day PR3
-# lands, this fixture is the regression guard for free.
+# The harness copies the repo's `rust-toolchain.toml` into the
+# relocated tree (see `prepare_relocated_dir`), so the relocated build
+# resolves the same rustc as the in-place phases. Without that, a
+# toolchain mismatch — rustc's version is in every cache key — would
+# masquerade as a relocate miss (kache #96).
 [assertions.relocate]
 min_hits = 1
 max_misses = 0

--- a/test-projects/rust-c-ffi/kache-fixture.toml
+++ b/test-projects/rust-c-ffi/kache-fixture.toml
@@ -37,7 +37,8 @@ should_not_recompile = true
 recompile_marker = "Compiling"
 
 # Same contract as multi-dep — see that fixture for the full
-# rationale. Strict zero-miss; will fail until PR3 lands.
+# rationale. Strict zero-miss: relocated byte-identical source must
+# hit every cached entry.
 [assertions.relocate]
 min_hits = 1
 max_misses = 0


### PR DESCRIPTION
## Summary

The e2e harness's `relocate` phase copies a fixture into a tempdir and rebuilds it there to verify cache keys are path-portable. But the tempdir is *outside* the worktree, so rustup no longer sees the repo's `rust-toolchain.toml` pin — the relocated build silently used a different default `rustc` (1.94.1) than the in-place `cold`/`warm` phases (1.95). `rustc_version` is part of every cache key, so this surfaced as a **total relocate cache miss**, failing the `multi-dep` and `rust-c-ffi` fixtures.

- `prepare_relocated_dir` now copies the active toolchain pin (found by walking up from the fixture dir) into the relocated tree, so both builds resolve the same compiler. `relocate` again tests only what it is meant to — path portability.
- This had been **misdiagnosed** as a path leak in the rustc cache key. With the toolchain held constant, relocated builds produce byte-identical keys for *every* crate — `PathNormalizer` was already correct. The stale `relocate` comments in the `multi-dep` / `rust-c-ffi` fixtures (which blamed a non-existent path leak and a "PR3 will fix it" that had long landed) are refreshed.

## Test plan

- [x] Full e2e harness passes — all 6 fixtures, including `multi-dep` + `rust-c-ffi` `relocate` (13 hits / 0 misses, previously 0 / 13)
- [x] `cargo fmt --check`, `cargo clippy -p kache-e2e --all-targets`, `cargo test -p kache-e2e` all clean
- [ ] CI green on macOS + Linux

Fixes #96.