### PR TITLE
fix(cc): make compiled objects path-independent (#78)

### DIFF
--- a/crates/kache-e2e/src/assertions.rs
+++ b/crates/kache-e2e/src/assertions.rs
@@ -107,6 +107,52 @@ pub fn diff_artifact_check(
     }
 }
 
+/// Differential relocate check: a cache-restored artifact (built at the
+/// relocated path with kache hitting) must be byte-identical to a FRESH
+/// real compile at that *same* relocated path (kache disabled).
+///
+/// This is strictly stronger than [`diff_artifact_check`] on the
+/// relocate phase. That check compares the relocate hit against the
+/// cold baseline — but a relocate *hit* restores the very blob cold
+/// cached, so the comparison only proves store/restore fidelity, not
+/// path-independence. Here `fresh` is a genuine compile at the new
+/// path: byte-equality positively proves no machine-local build path
+/// leaked into the artifact, so a cross-path cache hit is provably safe.
+///
+/// `restored` is the cache-hit relocate-phase artifact; `fresh` is the
+/// `KACHE_DISABLED=1` compile at the relocated path. The check is named
+/// `relocate_diff_match[<artifact>]` — distinct from `diff_match[...]`
+/// so both appear side-by-side in results JSON.
+pub fn relocate_diff_artifact_check(
+    artifact: &str,
+    restored: &[u8],
+    fresh: &[u8],
+) -> AssertionCheck {
+    // Box-leak the artifact-qualified name for `name: &'static str`;
+    // bounded — a fixture declares a small fixed set of artifacts.
+    let name: &'static str = Box::leak(format!("relocate_diff_match[{artifact}]").into_boxed_str());
+    let passed = restored == fresh;
+    let actual = if passed {
+        format!("byte-identical ({} bytes)", fresh.len())
+    } else {
+        let first = restored.iter().zip(fresh).position(|(a, b)| a != b);
+        format!(
+            "differs (restored {} B, fresh {} B{})",
+            restored.len(),
+            fresh.len(),
+            first
+                .map(|i| format!(", first at byte {i}"))
+                .unwrap_or_default()
+        )
+    };
+    AssertionCheck {
+        name,
+        expected: "byte-identical to fresh compile at relocated path".to_string(),
+        actual,
+        passed,
+    }
+}
+
 /// Apply [`MetricAssertions`] against a [`ReportSummary`]. Each declared
 /// constraint produces one check; absent constraints are silently skipped
 /// (this is how a fixture opts in to only the assertions it cares about).
@@ -367,5 +413,25 @@ mod tests {
         // loudly rather than silently pass.
         let check = diff_artifact_check("build/foo.o", None, &[1, 2, 3]);
         assert!(!check.passed);
+    }
+
+    #[test]
+    fn relocate_diff_artifact_check_passes_on_identical_bytes() {
+        let restored = vec![1u8, 2, 3, 4];
+        let check = relocate_diff_artifact_check("build/foo.o", &restored, &[1, 2, 3, 4]);
+        assert!(check.passed);
+        assert!(check.actual.contains("byte-identical"));
+        assert_eq!(check.name, "relocate_diff_match[build/foo.o]");
+    }
+
+    #[test]
+    fn relocate_diff_artifact_check_fails_on_differing_bytes() {
+        // A cache-restored artifact that differs from a fresh compile
+        // at the relocated path means a build path leaked into the
+        // cached blob — surfaced with the first differing byte.
+        let restored = vec![1u8, 2, 3, 4];
+        let check = relocate_diff_artifact_check("build/foo.o", &restored, &[1, 2, 9, 4]);
+        assert!(!check.passed);
+        assert!(check.actual.contains("first at byte 2"));
     }
 }

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -21,7 +21,7 @@ use tempfile::TempDir;
 
 use crate::assertions::{
     AssertionCheck, all_passed, apply_metric_assertions, apply_noop_assertions,
-    count_misses_by_crate,
+    count_misses_by_crate, relocate_diff_artifact_check,
 };
 use crate::fixture::{Fixture, Verify};
 use crate::report;
@@ -101,15 +101,8 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
     );
 
     // Defensive: stop any inherited daemon from a previous fixture's
-    // run before we start measuring. Errors are intentionally swallowed
-    // — `daemon stop` failing because nothing was running is normal.
-    let _ = Command::new(kache_path)
-        .arg("daemon")
-        .arg("stop")
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
+    // run before we start measuring.
+    stop_daemon(kache_path, cache_dir.path());
 
     // Per-phase report deltas: snapshot the cumulative kache report
     // before each phase, subtract afterwards. Without this, `kache
@@ -188,7 +181,7 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
                     cache_dir.path(),
                 );
 
-                let (result, post) = run_phase(
+                let (mut result, post) = run_phase(
                     Phase::Relocate,
                     fixture,
                     relocated.path(),
@@ -205,6 +198,27 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
                     prev_summary = s;
                     prev_event_count = c;
                 }
+
+                // Differential relocate check: the relocate phase above
+                // built with kache enabled, so its `[diff]` artifacts
+                // are cache-restored. Now rebuild the SAME relocated
+                // tree against a fresh empty cache (kache misses → real
+                // compiles) and prove the restored bytes equal a
+                // genuine fresh compile at the new path. Only runs for
+                // `[diff]` fixtures whose relocate phase passed — a
+                // fresh-vs-restored compare is meaningless if the
+                // relocate build itself failed. Failures append to
+                // `result` and flip its status.
+                if result.status == "pass" && fixture.diff.is_some() {
+                    let extra = differential_relocate_check(fixture, relocated.path(), kache_path);
+                    if !extra.is_empty() {
+                        if !all_passed(&extra) {
+                            result.status = "fail".to_string();
+                        }
+                        result.assertions.extend(extra);
+                    }
+                }
+
                 let relocate_failed = result.status == "fail";
                 phase_results.push(result);
                 // `relocated` (TempDir) drops here, removing the copy.
@@ -323,6 +337,123 @@ fn run_relocate_modified(
         diff_baseline,
     )?;
     Ok(result)
+}
+
+/// Differential relocate check — the strong form of the `[diff]` test.
+///
+/// The relocate phase (already run by the caller) built the fixture at
+/// a fresh absolute path with kache **enabled**, so its `[diff]`
+/// artifacts are *cache-restored* blobs. The existing `diff_match[...]`
+/// check compares those against the cold baseline — but a relocate hit
+/// restores the very blob cold cached, so that comparison only proves
+/// store/restore fidelity, not path-independence.
+///
+/// This closes that gap: it snapshots the cache-restored artifacts,
+/// then re-cleans the relocated tree and rebuilds it against a brand-
+/// new **empty** cache. With nothing to hit, kache misses every unit
+/// and runs its real compile path — the *same* path that populated the
+/// shared cache at cold — yielding a faithful fresh kache build at the
+/// relocated path. Byte-equality between the restored and the fresh
+/// artifacts positively proves no machine-local build path leaked into
+/// the cached artifact, so a cross-path cache hit is provably safe.
+///
+/// The fresh build must NOT use `KACHE_DISABLED`: that bypasses kache's
+/// compile path entirely (straight passthrough to the bare compiler),
+/// so it would miss kache's own object-normalizing flags — e.g. the
+/// `-ffile-prefix-map` injection — and the comparison would be
+/// apples-to-oranges. A cache *miss* is the correct baseline.
+///
+/// Returns one `relocate_diff_match[<artifact>]` check per `[diff]`
+/// artifact. Setup failures (clean/build/read) surface as a failed
+/// check rather than aborting. `kache_path` is used only to stop the
+/// fresh cache's daemon before its `TempDir` is removed.
+fn differential_relocate_check(
+    fixture: &Fixture,
+    relocated: &Path,
+    kache_path: &Path,
+) -> Vec<AssertionCheck> {
+    let Some(diff) = &fixture.diff else {
+        return Vec::new();
+    };
+
+    // (1) Snapshot the cache-restored artifacts the relocate build left
+    // on disk. A missing artifact here is a fixture misconfiguration —
+    // surface it as a failed check, mirroring `diff_artifact_present`.
+    let mut restored: Vec<(String, Vec<u8>)> = Vec::with_capacity(diff.artifacts.len());
+    let mut failures: Vec<AssertionCheck> = Vec::new();
+    for artifact in &diff.artifacts {
+        match std::fs::read(relocated.join(artifact)) {
+            Ok(bytes) => restored.push((artifact.clone(), bytes)),
+            Err(e) => failures.push(AssertionCheck {
+                name: "relocate_diff_restored_present",
+                expected: format!("readable cache-restored artifact `{artifact}`"),
+                actual: format!("{e}"),
+                passed: false,
+            }),
+        }
+    }
+    if !failures.is_empty() {
+        return failures;
+    }
+
+    // (2) Re-clean and rebuild the SAME relocated tree against a fresh
+    // EMPTY cache. With nothing to hit, kache misses every unit and
+    // runs its real compile path — the genuine fresh-build baseline.
+    let fresh_cache = match TempDir::new() {
+        Ok(dir) => dir,
+        Err(e) => {
+            return vec![AssertionCheck {
+                name: "relocate_diff_cache",
+                expected: "fresh cache directory created".to_string(),
+                actual: format!("{e}"),
+                passed: false,
+            }];
+        }
+    };
+    for (step_name, cmd) in [
+        ("relocate_diff_clean", &fixture.commands.clean),
+        ("relocate_diff_build", &fixture.commands.build),
+    ] {
+        let failure = match run_step(cmd, fixture, relocated, fresh_cache.path()) {
+            Ok(s) if s.exit.success() => None,
+            Ok(s) => Some(format!("exit {}", s.exit.code().unwrap_or(1))),
+            Err(e) => Some(format!("{e:?}")),
+        };
+        if let Some(actual) = failure {
+            stop_daemon(kache_path, fresh_cache.path());
+            return vec![AssertionCheck {
+                name: step_name,
+                expected: "fresh-cache step succeeds".to_string(),
+                actual,
+                passed: false,
+            }];
+        }
+    }
+    // The fresh build may have spawned a daemon bound to `fresh_cache`;
+    // stop it before the TempDir drops and removes the directory.
+    stop_daemon(kache_path, fresh_cache.path());
+
+    // (3) + (4) Snapshot the fresh artifacts and byte-compare each
+    // against the cache-restored snapshot from step (1).
+    let mut checks = Vec::with_capacity(restored.len());
+    for (artifact, restored_bytes) in &restored {
+        match std::fs::read(relocated.join(artifact)) {
+            Ok(fresh) => {
+                checks.push(relocate_diff_artifact_check(
+                    artifact,
+                    restored_bytes,
+                    &fresh,
+                ));
+            }
+            Err(e) => checks.push(AssertionCheck {
+                name: "relocate_diff_fresh_present",
+                expected: format!("readable fresh-compile artifact `{artifact}`"),
+                actual: format!("{e}"),
+                passed: false,
+            }),
+        }
+    }
+    checks
 }
 
 /// Apply the fixture's single find/replace edit to a source file in a
@@ -622,6 +753,22 @@ fn copy_toolchain_pin(src: &Path, dst: &Path) {
             }
         }
     }
+}
+
+/// Best-effort: stop any kache daemon bound to `cache_dir`.
+///
+/// Errors are swallowed — `daemon stop` failing because nothing is
+/// running is normal. Called at fixture startup, and after the
+/// differential relocate check's fresh-cache build, so no daemon holds
+/// a cache directory while its `TempDir` is being removed.
+fn stop_daemon(kache_path: &Path, cache_dir: &Path) {
+    let _ = Command::new(kache_path)
+        .arg("daemon")
+        .arg("stop")
+        .env("KACHE_CACHE_DIR", cache_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
 }
 
 /// Run one shell command in `cwd` with the fixture's env.

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -681,6 +681,25 @@ fn flag_is_cache_safe(arg: &str) -> bool {
     false
 }
 
+/// The `-ffile-prefix-map` flag that rewrites the absolute build
+/// directory to a relative `.`.
+///
+/// A `-g` compile bakes the absolute build directory into the object's
+/// DWARF (`DW_AT_comp_dir`) and into `__FILE__` expansions, so the same
+/// source compiled at two different paths yields byte-different
+/// objects. kache is content-addressed: an object cached at one path
+/// and restored at another would then carry a stale machine-local
+/// build path. Mapping the build dir to `.` makes the object
+/// path-independent — the cc analogue of the `--remap-path-prefix`
+/// kache injects for rustc (kache #78).
+///
+/// `None` if the working directory can't be resolved; the compile then
+/// runs unmodified — no worse than before.
+fn file_prefix_map_arg() -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    Some(format!("-ffile-prefix-map={}=.", cwd.display()))
+}
+
 #[derive(Default)]
 pub struct CcCompiler;
 
@@ -871,10 +890,17 @@ impl Compiler for CcCompiler {
     }
 
     fn execute(&self, parsed: &CcArgs) -> Result<CompileResult> {
-        // Invoke the underlying compiler with the original argv.
+        // Invoke the underlying compiler with the original argv, plus a
+        // `-ffile-prefix-map` so the object doesn't embed the absolute
+        // build directory — see `file_prefix_map_arg`. Appended last so
+        // it wins over any user-supplied map for the same prefix.
         crate::opcounts::record_compiler_run();
-        let output = Command::new(&parsed.program)
-            .args(&parsed.rest)
+        let mut command = Command::new(&parsed.program);
+        command.args(&parsed.rest);
+        if let Some(flag) = file_prefix_map_arg() {
+            command.arg(flag);
+        }
+        let output = command
             .output()
             .with_context(|| format!("executing {}", parsed.program))?;
         let exit_code = output.status.code().unwrap_or(1);
@@ -1628,6 +1654,18 @@ mod tests {
             result.is_err(),
             "execute() must return Err when the compiler binary can't be spawned"
         );
+    }
+
+    #[test]
+    fn file_prefix_map_arg_maps_the_cwd_to_dot() {
+        // `execute` injects this so a `-g` object doesn't embed the
+        // absolute build directory — making it path-independent.
+        let arg = file_prefix_map_arg().expect("cwd resolves in tests");
+        assert!(
+            arg.starts_with("-ffile-prefix-map="),
+            "unexpected flag shape: {arg}"
+        );
+        assert!(arg.ends_with("=."), "build dir must map to `.`: {arg}");
     }
 
     #[cfg(unix)]

--- a/test-projects/multi-dep/kache-fixture.toml
+++ b/test-projects/multi-dep/kache-fixture.toml
@@ -34,6 +34,15 @@ forbidden_substrings = [
     "/private/var/",
 ]
 
+# Differential test on the final linked binary. `target/release/multi-dep`
+# is a stable name (unlike the hash-suffixed `.rlib`s), so it can be
+# enumerated here — and it is the integral of every cached crate: a
+# path leak in any restored rlib would surface in the linked binary.
+# `relocate_diff_match` then proves the cross-path cache hit produces a
+# byte-identical binary to a fresh build at the relocated path.
+[diff]
+artifacts = ["target/release/multi-dep"]
+
 [assertions.cold]
 # Cold build must populate the cache; serde + transitive deps means
 # this should comfortably exceed a handful of entries.

--- a/test-projects/rust-c-ffi/kache-fixture.toml
+++ b/test-projects/rust-c-ffi/kache-fixture.toml
@@ -23,6 +23,15 @@ clean = "rm -rf target"
 run = "./target/release/rust-c-ffi"
 expected_stdout_contains = ["rust+C FFI: 3 + 4 = 7"]
 
+# Differential test on the final linked binary — the integral of the
+# Rust crates AND the build.rs-compiled C objects. `relocate_diff_match`
+# proves a cross-path cache hit yields a byte-identical binary to a
+# fresh build at the relocated path. This is the mixed-language case:
+# it exercises whether build.rs-generated `OUT_DIR` content leaks a
+# machine-local path that `--remap-path-prefix` doesn't reach.
+[diff]
+artifacts = ["target/release/rust-c-ffi"]
+
 [assertions.cold]
 min_entries_after = 1
 


### PR DESCRIPTION
## Summary

A `-g` cc compile bakes the **absolute build directory** into the object's DWARF (`DW_AT_comp_dir`) and into `__FILE__` expansions. kache is a content-addressed cache, so an object cached at one path and restored at another then carries a stale machine-local build path.

- **`fix(cc)`** — `CcCompiler::execute` injects `-ffile-prefix-map=<cwd>=.`, rewriting the build directory to a relative `.`. Objects become path-independent — the cc analogue of the `--remap-path-prefix` kache already injects for rustc.
- **`feat(e2e)`** — new `relocate_diff_match[<artifact>]` check: it rebuilds the relocated tree against a **fresh empty cache** (kache misses → real compiles) and byte-compares the cache-restored artifacts against that fresh build. Positive, CI-enforced proof that no build path leaked into the cached artifact. (The fresh baseline is a cache *miss*, not `KACHE_DISABLED` — a disabled kache bypasses the compile path and its normalizing flags.)
- **`test(e2e)`** — extends the differential check to the Rust fixtures (`multi-dep`, `rust-c-ffi`) via `[diff]` on their final linked binaries.

The differential check surfaced the bug; this PR fixes it, and the check now passes across **C, C++, pure Rust, and Rust + build.rs/C-FFI** — every cacheable artifact is differentially proven byte-identical between a cross-path cache hit and a fresh build at the new path.

Refs #78. The broader cross-machine scope of that issue — SDKROOT sentinel, Mach-O OSO record stripping — remains.

## Test plan

- [x] Full e2e harness — 6/6 fixtures pass
- [x] `relocate_diff_match` byte-identical for `c-hello`, `cpp-hello`, `multi-dep`, `rust-c-ffi`
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets`, `cargo test --workspace` all clean
- [ ] CI green on macOS (clang) + Linux (gcc)