### PR TITLE
fix(rustc): path-portable dep-info — relocated cache hits stay fresh

### DIFF
--- a/crates/kache-e2e/src/fixture.rs
+++ b/crates/kache-e2e/src/fixture.rs
@@ -167,6 +167,20 @@ pub struct PhaseAssertions {
     /// Deserialized from `[assertions.relocate-modified]`.
     #[serde(rename = "relocate-modified")]
     pub relocate_modified: Option<MetricAssertions>,
+    /// Relocate-noop phase: a SECOND build in the relocated tree,
+    /// without cleaning, right after `relocate`. Reuses
+    /// [`NoopAssertions`] — the contract is "nothing recompiles".
+    ///
+    /// Unlike the in-place `noop`, this catches stale dep-info: a
+    /// `relocate` cache hit restores each crate's `.d` file, and if
+    /// that `.d` carries the producing build's absolute paths, cargo's
+    /// freshness `stat()` fails at the relocated path and recompiles
+    /// the crate on the next build. The in-place `noop` rebuilds where
+    /// the `.d` paths are trivially valid, so only this phase exposes
+    /// the bug. Per-fixture opt-in; declaring it is what makes the
+    /// phase run at all. Deserialized from `[assertions.relocate-noop]`.
+    #[serde(rename = "relocate-noop")]
+    pub relocate_noop: Option<NoopAssertions>,
 }
 
 /// Assertions applied against `kache report --format json` output.

--- a/crates/kache-e2e/src/result.rs
+++ b/crates/kache-e2e/src/result.rs
@@ -35,7 +35,7 @@ pub struct FixtureResult {
 
 #[derive(Debug, Serialize)]
 pub struct PhaseResult {
-    /// `"cold" | "warm" | "noop" | "relocate" | "relocate-modified"`.
+    /// `"cold" | "warm" | "noop" | "relocate" | "relocate-noop" | "relocate-modified"`.
     pub phase: String,
     pub status: String,
     /// Wall-clock seconds for the build step (last step in the phase).

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -53,6 +53,23 @@ pub enum Phase {
     /// stale-restore bug class (a content change wrongly served from
     /// cache). Only runs when the fixture declares `[modify]`.
     RelocateModified,
+    /// Build a *second* time in the relocated directory, without
+    /// cleaning, immediately after `Relocate`. The contract: nothing
+    /// recompiles.
+    ///
+    /// `Relocate` proves a relocated build *hits* the cache; it does
+    /// not prove the build it leaves behind is *stable*. The cache
+    /// hits restore each crate's dep-info (`.d`) file, and cargo reads
+    /// those `.d` files on the next build to decide what is up to
+    /// date. If a cached `.d` carries the producing build's absolute
+    /// paths, cargo's freshness `stat()` fails at the relocated path,
+    /// the crate is marked dirty, and the next build recompiles it —
+    /// a cache hit that bought nothing. The in-place `Noop` phase
+    /// cannot catch this: it rebuilds where the `.d` paths are
+    /// trivially valid. `RelocateNoop` is the only phase that exposes
+    /// stale dep-info paths. Per-fixture opt-in via
+    /// `[assertions.relocate-noop]`.
+    RelocateNoop,
 }
 
 impl Phase {
@@ -63,16 +80,18 @@ impl Phase {
             Phase::Noop => "noop",
             Phase::Relocate => "relocate",
             Phase::RelocateModified => "relocate-modified",
+            Phase::RelocateNoop => "relocate-noop",
         }
     }
 
-    /// Should this phase run a `clean` step before `build`? `noop`
-    /// skips the clean (that's literally what makes it the no-op test);
+    /// Should this phase run a `clean` step before `build`? `noop` and
+    /// `relocate-noop` skip the clean (that's literally what makes them
+    /// no-op tests — they rebuild on top of a populated tree);
     /// `relocate` runs in a fresh dir that's already clean, but we
     /// still run `clean` defensively in case `cp -R` brought a stale
     /// target/ along.
     fn cleans_first(self) -> bool {
-        !matches!(self, Phase::Noop)
+        !matches!(self, Phase::Noop | Phase::RelocateNoop)
     }
 
     /// Should this phase run the fixture's `[verify]` (run the binary,
@@ -191,12 +210,43 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
                     prev_event_count,
                     &mut diff_baseline,
                 )?;
-                // Roll the report cursor forward so the
-                // relocate-modified phase's delta reflects only its
-                // own events, not relocate's.
+                // Roll the report cursor forward so the following
+                // phases' deltas reflect only their own events.
                 if let Some((s, c)) = post {
                     prev_summary = s;
                     prev_event_count = c;
+                }
+
+                // relocate-noop: build a SECOND time in the SAME
+                // relocated tree, without cleaning. The relocate phase
+                // above cache-hit every crate and restored their
+                // dep-info (`.d`) files; this phase proves those `.d`
+                // files carry paths valid at the relocated location —
+                // i.e. cargo's freshness check finds them and does NOT
+                // recompile. Must run BEFORE `differential_relocate_check`,
+                // which re-cleans the tree and rebuilds it cold against
+                // a fresh cache (which would write fresh, trivially-valid
+                // `.d` files and mask the stale-dep-info bug). Opt-in:
+                // only fixtures declaring `[assertions.relocate-noop]`.
+                // Held in an Option so it is pushed AFTER the relocate
+                // phase result (which the diff check below still mutates).
+                let mut relocate_noop_result: Option<PhaseResult> = None;
+                if result.status == "pass" && fixture.assertions.relocate_noop.is_some() {
+                    let (noop_result, post) = run_phase(
+                        Phase::RelocateNoop,
+                        fixture,
+                        relocated.path(),
+                        kache_path,
+                        cache_dir.path(),
+                        &prev_summary,
+                        prev_event_count,
+                        &mut diff_baseline,
+                    )?;
+                    if let Some((s, c)) = post {
+                        prev_summary = s;
+                        prev_event_count = c;
+                    }
+                    relocate_noop_result = Some(noop_result);
                 }
 
                 // Differential relocate check: the relocate phase above
@@ -208,7 +258,8 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
                 // `[diff]` fixtures whose relocate phase passed — a
                 // fresh-vs-restored compare is meaningless if the
                 // relocate build itself failed. Failures append to
-                // `result` and flip its status.
+                // `result` and flip its status. Runs after relocate-noop
+                // because it re-cleans the relocated tree.
                 if result.status == "pass" && fixture.diff.is_some() {
                     let extra = differential_relocate_check(fixture, relocated.path(), kache_path);
                     if !extra.is_empty() {
@@ -219,8 +270,14 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
                     }
                 }
 
-                let relocate_failed = result.status == "fail";
+                let mut relocate_failed = result.status == "fail";
                 phase_results.push(result);
+                if let Some(noop_result) = relocate_noop_result {
+                    if noop_result.status == "fail" {
+                        relocate_failed = true;
+                    }
+                    phase_results.push(noop_result);
+                }
                 // `relocated` (TempDir) drops here, removing the copy.
 
                 // relocate-modified: relocate again, edit a source
@@ -610,7 +667,13 @@ fn run_phase(
             .assertions
             .noop
             .as_ref()
-            .map(|spec| apply_noop_assertions(spec, &build.stdout))
+            .map(|spec| apply_noop_assertions(spec, &build.combined_output()))
+            .unwrap_or_default(),
+        Phase::RelocateNoop => fixture
+            .assertions
+            .relocate_noop
+            .as_ref()
+            .map(|spec| apply_noop_assertions(spec, &build.combined_output()))
             .unwrap_or_default(),
         Phase::Relocate => fixture
             .assertions
@@ -645,7 +708,7 @@ fn run_phase(
                             &bytes,
                         ));
                     }
-                    Phase::Noop | Phase::RelocateModified => {}
+                    Phase::Noop | Phase::RelocateNoop | Phase::RelocateModified => {}
                 },
                 Err(e) => {
                     if matches!(phase, Phase::Cold | Phase::Warm | Phase::Relocate) {
@@ -695,6 +758,20 @@ fn run_phase(
 struct StepOutcome {
     exit: std::process::ExitStatus,
     stdout: String,
+    stderr: String,
+}
+
+impl StepOutcome {
+    /// stdout and stderr concatenated. The no-op assertions grep this:
+    /// cargo prints its `Compiling <crate>` progress lines to **stderr**,
+    /// not stdout, so checking stdout alone would never see a recompile
+    /// and the assertion would pass vacuously.
+    fn combined_output(&self) -> String {
+        let mut s = String::with_capacity(self.stdout.len() + self.stderr.len());
+        s.push_str(&self.stdout);
+        s.push_str(&self.stderr);
+        s
+    }
 }
 
 /// Copy `src` (a fixture directory) into a fresh tempdir for the
@@ -774,9 +851,12 @@ fn stop_daemon(kache_path: &Path, cache_dir: &Path) {
 /// Run one shell command in `cwd` with the fixture's env.
 ///
 /// Uses `sh -c` so commands can include redirects / pipes naturally.
-/// stdout is captured (assertions read it for `recompile_marker`);
-/// stderr is inherited so failures are visible in CI logs without
-/// needing to crack open results.json.
+/// Both stdout and stderr are captured: the no-op assertions grep the
+/// combined output for `recompile_marker`, and cargo prints its
+/// `Compiling <crate>` progress lines to **stderr**, not stdout — so
+/// capturing stdout alone would let a recompile slip past the check.
+/// Both streams are echoed afterwards so CI logs still show what
+/// happened without cracking open results.json.
 ///
 /// `cwd` is decoupled from `fixture.dir` so the relocate phase can
 /// run the same command in a copy of the fixture at a different
@@ -788,17 +868,19 @@ fn run_step(cmd: &str, fixture: &Fixture, cwd: &Path, cache_dir: &Path) -> Resul
         .current_dir(cwd)
         .env("KACHE_CACHE_DIR", cache_dir)
         .envs(&fixture.env)
-        .stderr(Stdio::inherit())
         .output()
         .with_context(|| format!("spawning `{cmd}` in {}", cwd.display()))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    // Echo build stdout so CI logs show what happened, even though
-    // we capture it for assertion checks.
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    // Echo both streams so CI logs show what happened, even though we
+    // capture them for assertion checks.
     eprint!("{stdout}");
+    eprint!("{stderr}");
     Ok(StepOutcome {
         exit: output.status,
         stdout,
+        stderr,
     })
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,10 +1,10 @@
 use anyhow::{Result, bail};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::compiler::rustc::RustcCompiler;
 
 /// Parsed rustc invocation arguments relevant to caching.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RustcArgs {
     /// Path to the rustc binary (first arg from cargo when using RUSTC_WRAPPER)
     pub rustc: PathBuf,
@@ -293,6 +293,46 @@ impl RustcArgs {
             .and_then(|p| p.parent())
             .and_then(|p| p.parent())
             .map(std::path::Path::to_path_buf)
+    }
+
+    /// Derive the cargo target directory (e.g. `<workspace>/target`) from
+    /// the rustc args.
+    ///
+    /// This is the anchor for dep-info (`.d`) path rewriting. Cargo invokes
+    /// rustc with cwd = the package source dir — *not* the target dir — so
+    /// `std::env::current_dir()` cannot be used. Cargo's output layout is
+    /// stable enough to infer the target dir from the args instead:
+    ///
+    /// - `--out-dir` is `<target>/<profile>/deps` for libs/bins → walk up 2.
+    /// - `-o` for a build script is
+    ///   `<target>/<profile>/build/<pkg>/build_script_build-<hash>`; walk up
+    ///   to the ancestor named `deps` or `build`, then take its grandparent.
+    ///
+    /// Store and restore must agree on this anchor: the store side
+    /// relativizes the `.d` against it (`<target>/...` → `./...`) and the
+    /// restore side expands `./...` back against *this* invocation's target
+    /// dir. Because the `.d`'s paths are all rooted under `<target>`, the
+    /// relativize→expand round-trip yields paths valid at whatever location
+    /// the restoring build runs from.
+    ///
+    /// Returns `None` for invocations outside cargo's layout (e.g. ad-hoc
+    /// `rustc -o /tmp/prog`), so dep-info rewriting is skipped rather than
+    /// anchored to a wrong directory.
+    pub fn target_dir(&self) -> Option<PathBuf> {
+        if let Some(od) = &self.out_dir {
+            return od.parent()?.parent().map(Path::to_path_buf);
+        }
+        let out = self.output.as_deref()?;
+        let mut cursor = out.parent();
+        while let Some(dir) = cursor {
+            if let Some(name) = dir.file_name()
+                && (name == "deps" || name == "build")
+            {
+                return dir.parent()?.parent().map(Path::to_path_buf);
+            }
+            cursor = dir.parent();
+        }
+        None
     }
 
     /// Get the output filename stem (crate name + extra filename).
@@ -796,6 +836,59 @@ mod tests {
         .collect();
         let parsed = RustcArgs::parse(&args).unwrap();
         assert!(!parsed.has_coverage_instrumentation());
+    }
+
+    #[test]
+    fn test_target_dir_from_out_dir() {
+        // Lib/bin compiles: --out-dir is `<target>/<profile>/deps`.
+        let args = RustcArgs {
+            out_dir: Some(PathBuf::from("/work/proj/target/debug/deps")),
+            ..Default::default()
+        };
+        assert_eq!(args.target_dir(), Some(PathBuf::from("/work/proj/target")));
+    }
+
+    #[test]
+    fn test_target_dir_from_build_script_output() {
+        // Build scripts: -o is
+        // `<target>/<profile>/build/<pkg>/build_script_build-<hash>`.
+        let args = RustcArgs {
+            output: Some(PathBuf::from(
+                "/work/proj/target/debug/build/serde-abc123/build_script_build-abc123",
+            )),
+            ..Default::default()
+        };
+        assert_eq!(args.target_dir(), Some(PathBuf::from("/work/proj/target")));
+    }
+
+    #[test]
+    fn test_target_dir_prefers_out_dir_over_output() {
+        // Cargo passes both --out-dir and -o for a lib/bin; --out-dir is
+        // the reliable `<target>/<profile>/deps` shape, so it wins.
+        let args = RustcArgs {
+            out_dir: Some(PathBuf::from("/work/proj/target/release/deps")),
+            output: Some(PathBuf::from(
+                "/work/proj/target/release/deps/libfoo-abc.rlib",
+            )),
+            ..Default::default()
+        };
+        assert_eq!(args.target_dir(), Some(PathBuf::from("/work/proj/target")));
+    }
+
+    #[test]
+    fn test_target_dir_returns_none_for_ad_hoc_rustc() {
+        // An ad-hoc `rustc -o /tmp/prog` has no cargo layout to anchor
+        // to — return None so dep-info rewriting is skipped.
+        let args = RustcArgs {
+            output: Some(PathBuf::from("/tmp/somewhere/myprog")),
+            ..Default::default()
+        };
+        assert_eq!(args.target_dir(), None);
+    }
+
+    #[test]
+    fn test_target_dir_none_when_no_paths() {
+        assert_eq!(RustcArgs::default().target_dir(), None);
     }
 
     #[test]

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -233,19 +233,33 @@ pub fn plan_post_restore(kind: ArtifactKind) -> Vec<PostRestoreAction> {
 impl PostRestoreAction {
     /// Execute this action against a restored artifact at `path`.
     ///
+    /// `anchor` is the directory dep-info (`.d`) relative paths are
+    /// expanded against — cargo's target dir for this invocation (see
+    /// [`crate::args::RustcArgs::target_dir`]). It MUST be the same anchor
+    /// the store side relativized with, or the relativize→expand round
+    /// trip produces paths cargo's freshness `stat()`s cannot find. The
+    /// previous implementation anchored on `std::env::current_dir()` —
+    /// which, since cargo runs rustc with cwd = the *package source dir*,
+    /// matched nothing in `.d` content, so the expand was a silent no-op
+    /// and cached `.d` blobs kept the producing worktree's absolute
+    /// paths. `Sign` ignores `anchor`.
+    ///
     /// `platform` is the host abstraction for OS-specific concerns
     /// (codesigning today; debug-path rewriting and similar concerns
     /// later). Passing it explicitly — rather than calling
     /// `platform::current()` here — keeps tests deterministic: a unit
     /// test can inject a counting / failing / no-op platform without
     /// needing the real host to behave a particular way.
-    pub fn apply(&self, path: &std::path::Path, platform: &dyn Platform) -> Result<()> {
+    pub fn apply(
+        &self,
+        path: &std::path::Path,
+        anchor: &std::path::Path,
+        platform: &dyn Platform,
+    ) -> Result<()> {
         match self {
             PostRestoreAction::ExpandDepInfoPaths => {
-                if let Ok(pwd) = std::env::current_dir() {
-                    let _ =
-                        crate::link::rewrite_depinfo(path, &pwd, crate::link::DepInfoMode::Expand);
-                }
+                let _ =
+                    crate::link::rewrite_depinfo(path, anchor, crate::link::DepInfoMode::Expand);
                 Ok(())
             }
             PostRestoreAction::Sign(SigningPurpose::OsLoading) => {
@@ -442,7 +456,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_expand_dep_info_paths_rewrites_relative_paths_to_absolute() {
+    fn apply_expand_dep_info_paths_rewrites_relative_paths_against_anchor() {
         use std::io::Write;
         let dir = tempfile::tempdir().unwrap();
         let depfile = dir.path().join("test.d");
@@ -453,21 +467,22 @@ mod tests {
             write!(f, "./target/debug/foo: ./src/lib.rs").unwrap();
         }
 
+        // The anchor is the restoring build's target dir — NOT the
+        // process cwd. Expand must root the `./` paths there.
+        let anchor = std::path::Path::new("/restored/worktree");
         PostRestoreAction::ExpandDepInfoPaths
-            .apply(&depfile, &*test_platform())
+            .apply(&depfile, anchor, &*test_platform())
             .unwrap();
 
         let content = std::fs::read_to_string(&depfile).unwrap();
-        let pwd = std::env::current_dir().unwrap();
-        let pwd_str = pwd.display().to_string();
-        // After Expand: the leading "./" is replaced with "<pwd>/" everywhere.
+        // After Expand: the leading "./" is replaced with "<anchor>/" everywhere.
         assert!(
-            content.contains(&format!("{pwd_str}/target/debug/foo")),
-            "expected absolute target path, got: {content}"
+            content.contains("/restored/worktree/target/debug/foo"),
+            "expected anchor-rooted target path, got: {content}"
         );
         assert!(
-            content.contains(&format!("{pwd_str}/src/lib.rs")),
-            "expected absolute source path, got: {content}"
+            content.contains("/restored/worktree/src/lib.rs"),
+            "expected anchor-rooted source path, got: {content}"
         );
         assert!(
             !content.contains("./"),
@@ -483,7 +498,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let nonexistent = dir.path().join("does-not-exist.d");
         PostRestoreAction::ExpandDepInfoPaths
-            .apply(&nonexistent, &*test_platform())
+            .apply(&nonexistent, dir.path(), &*test_platform())
             .expect("apply must not error on a missing dep-info file");
     }
 
@@ -500,7 +515,7 @@ mod tests {
 
         let platform = CountingPlatform::new();
         PostRestoreAction::Sign(SigningPurpose::OsLoading)
-            .apply(&path, &platform)
+            .apply(&path, dir.path(), &platform)
             .expect("apply must not error even when the platform impl is a no-op");
         assert_eq!(
             platform.ensure_calls(),
@@ -519,7 +534,7 @@ mod tests {
         let depfile = dir.path().join("nope.d");
 
         let platform = CountingPlatform::new();
-        let _ = PostRestoreAction::ExpandDepInfoPaths.apply(&depfile, &platform);
+        let _ = PostRestoreAction::ExpandDepInfoPaths.apply(&depfile, dir.path(), &platform);
         assert_eq!(platform.ensure_calls(), 0);
     }
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -255,7 +255,6 @@ pub fn rewrite_depinfo(depinfo_path: &Path, project_dir: &Path, mode: DepInfoMod
 }
 
 #[derive(Debug, Clone, Copy)]
-#[allow(dead_code)]
 pub enum DepInfoMode {
     /// Replace absolute project paths with "./" for cross-project cache sharing
     Relativize,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -8,7 +8,9 @@ use crate::cache_key::FileHasher;
 use crate::compile;
 use crate::compiler::cc::CcCompiler;
 use crate::compiler::rustc::RustcCompiler;
-use crate::compiler::{Compiler, KeyCtx, plan_post_restore, platform};
+use crate::compiler::{
+    ArtifactKind, Compiler, KeyCtx, classify_by_filename, plan_post_restore, platform,
+};
 use crate::config::Config;
 use crate::events::{self, BuildEvent, EventResult};
 use crate::link;
@@ -633,6 +635,20 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         _ => "release",
     };
 
+    // Relativize dep-info (`.d`) files before they are cached so the
+    // stored blob is worktree-independent. cargo records each crate's
+    // inputs in its `.d` by *absolute* path; without this, a cached
+    // `.d` carries the producing build's paths, and a build that
+    // restores it at a different location finds those paths missing on
+    // its freshness `stat()` and recompiles — a cache hit that saved
+    // nothing. `store.put*` hashes the file at its on-disk source path,
+    // so we rewrite in place; the matching expand below restores the
+    // absolute paths the *current* build's cargo still needs to see.
+    let depinfo_anchor = args.target_dir();
+    if let Some(anchor) = depinfo_anchor.as_deref() {
+        rewrite_depinfo_outputs(&result.output_files, anchor, link::DepInfoMode::Relativize);
+    }
+
     let store_start = std::time::Instant::now();
     if let Err(e) = store.put_with_compile_time(
         &cache_key,
@@ -649,6 +665,13 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         tracing::warn!("failed to store cache entry: {}", e);
     }
     let store_ms = store_start.elapsed().as_millis() as u64;
+
+    // Expand the on-disk `.d` files back to absolute paths. The store
+    // already captured the relativized form above; this leaves the
+    // current build's `.d` valid for cargo's own freshness checks.
+    if let Some(anchor) = depinfo_anchor.as_deref() {
+        rewrite_depinfo_outputs(&result.output_files, anchor, link::DepInfoMode::Expand);
+    }
 
     // 6. Async upload to remote (if configured) — sends job to the daemon
     if config.remote.is_some() {
@@ -686,6 +709,37 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     Ok(result.exit_code)
 }
 
+/// Rewrite every dep-info (`.d`) file in a set of compiler output files,
+/// in place, against `anchor`.
+///
+/// `output_files` is `(source_path, store_name)` pairs as handed to
+/// `Store::put*`. Dep-info files are identified structurally via
+/// [`ArtifactKind::DepInfo`] — the same classification the restore loop
+/// uses — rather than by an ad-hoc `.d` suffix check, so the store and
+/// restore sides stay in lock-step on what counts as a `.d`.
+///
+/// Rewrite failures are logged and skipped, not propagated: a malformed
+/// `.d` must not abort an otherwise-successful cache store.
+fn rewrite_depinfo_outputs(
+    output_files: &[(std::path::PathBuf, String)],
+    anchor: &Path,
+    mode: link::DepInfoMode,
+) {
+    for (source_path, store_name) in output_files {
+        if classify_by_filename(store_name) != ArtifactKind::DepInfo {
+            continue;
+        }
+        if let Err(e) = link::rewrite_depinfo(source_path, anchor, mode) {
+            tracing::warn!(
+                "failed to rewrite dep-info {} ({:?}): {}",
+                source_path.display(),
+                mode,
+                e
+            );
+        }
+    }
+}
+
 /// Restore cached artifacts to the target output paths.
 fn restore_from_cache(
     _config: &Config,
@@ -702,6 +756,19 @@ fn restore_from_cache(
     } else {
         anyhow::bail!("no output path (-o) or output directory (--out-dir) in args");
     };
+
+    // Anchor for dep-info (`.d`) path expansion. Cached `.d` blobs hold
+    // paths relativized against the *producing* build's target dir
+    // (`<target>/...` → `./...`); on restore they must be re-rooted at
+    // *this* invocation's target dir so cargo's freshness `stat()`s find
+    // them. `args.target_dir()` derives that from `--out-dir` / `-o` —
+    // cargo's cwd is the package source dir, so it cannot be used.
+    // Falls back to cwd only for ad-hoc invocations outside cargo's
+    // layout, where there is no cached `.d` to rewrite anyway.
+    let depinfo_anchor = args
+        .target_dir()
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| Path::new(".").to_path_buf());
 
     // One platform per restore, shared across every cached file. The
     // detect call is cheap (cfg cascade) but doing it once keeps the
@@ -767,7 +834,7 @@ fn restore_from_cache(
         // `PostRestoreAction` plus its arm in `apply` — the wrapper stays
         // unchanged.
         for action in plan_post_restore(kind) {
-            action.apply(&target_path, &*platform)?;
+            action.apply(&target_path, &depinfo_anchor, &*platform)?;
         }
     }
 
@@ -966,6 +1033,95 @@ fn clean_incremental_dir(config: &Config, args: &RustcArgs) {
             "failed to clean incremental dir {}: {}",
             incr_dir.display(),
             e
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// `rewrite_depinfo_outputs` rewrites `.d` files in place and the
+    /// relativize→expand round trip re-roots the cached blob's paths at
+    /// the restoring build's target dir — the property that lets a `.d`
+    /// produced at one location be restored valid at another.
+    #[test]
+    fn rewrite_depinfo_outputs_round_trips_d_files_across_target_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let depfile = dir.path().join("foo-abc.d");
+        let producing_target = std::path::Path::new("/build/worktree-a/target");
+        std::fs::write(
+            &depfile,
+            format!(
+                "{}/release/deps/libfoo-abc.rlib: src/lib.rs",
+                producing_target.display()
+            ),
+        )
+        .unwrap();
+
+        let outputs = vec![(depfile.clone(), "foo-abc.d".to_string())];
+
+        // Store side: relativize against the producing build's target dir.
+        rewrite_depinfo_outputs(&outputs, producing_target, link::DepInfoMode::Relativize);
+        let stored = std::fs::read_to_string(&depfile).unwrap();
+        assert!(
+            stored.starts_with("./release/deps/libfoo-abc.rlib:"),
+            "stored `.d` must be relativized, got: {stored}"
+        );
+        assert!(
+            !stored.contains("/build/worktree-a/"),
+            "no producing-worktree path may survive relativization: {stored}"
+        );
+
+        // Restore side: expand against a *different* target dir.
+        let restoring_target = std::path::Path::new("/build/worktree-b/target");
+        rewrite_depinfo_outputs(&outputs, restoring_target, link::DepInfoMode::Expand);
+        let restored = std::fs::read_to_string(&depfile).unwrap();
+        assert!(
+            restored.starts_with("/build/worktree-b/target/release/deps/libfoo-abc.rlib:"),
+            "restored `.d` must be re-rooted at the restoring target dir, got: {restored}"
+        );
+        // Source paths that were already package-relative are untouched.
+        assert!(restored.contains("src/lib.rs"), "got: {restored}");
+    }
+
+    /// Only `.d` files are touched — the helper identifies them via
+    /// `ArtifactKind::DepInfo`, so an `.rlib` (or any non-`.d` artifact)
+    /// in the same output set is left byte-for-byte intact.
+    #[test]
+    fn rewrite_depinfo_outputs_ignores_non_dep_info_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let rlib = dir.path().join("libfoo-abc.rlib");
+        // Content that *looks* rewritable but must not be: an `.rlib` is
+        // not dep-info, so the helper must skip it entirely.
+        let original = "/build/worktree-a/target/release/deps/x";
+        std::fs::write(&rlib, original).unwrap();
+
+        let outputs = vec![(rlib.clone(), "libfoo-abc.rlib".to_string())];
+        rewrite_depinfo_outputs(
+            &outputs,
+            std::path::Path::new("/build/worktree-a/target"),
+            link::DepInfoMode::Relativize,
+        );
+
+        assert_eq!(
+            std::fs::read_to_string(&rlib).unwrap(),
+            original,
+            "non-`.d` artifacts must be left untouched"
+        );
+    }
+
+    /// A missing `.d` file is logged and skipped, not propagated — a
+    /// malformed output set must never abort an otherwise-good store.
+    #[test]
+    fn rewrite_depinfo_outputs_is_silent_on_missing_file() {
+        let outputs = vec![(PathBuf::from("/nonexistent/foo.d"), "foo.d".to_string())];
+        // Must not panic.
+        rewrite_depinfo_outputs(
+            &outputs,
+            std::path::Path::new("/some/target"),
+            link::DepInfoMode::Relativize,
         );
     }
 }

--- a/test-projects/multi-dep/kache-fixture.toml
+++ b/test-projects/multi-dep/kache-fixture.toml
@@ -78,3 +78,19 @@ recompile_marker = "Compiling"
 [assertions.relocate]
 min_hits = 1
 max_misses = 0
+
+# A SECOND build in the relocated tree, without cleaning, right after
+# `relocate`. The relocate phase cache-hit every crate and restored
+# their dep-info (`.d`) files; this phase proves those `.d` files hold
+# paths valid at the relocated location.
+#
+# cargo records each crate's input files in its `.d` by ABSOLUTE path
+# and `stat()`s them on every freshness check. A cached `.d` that keeps
+# the producing worktree's `target/` paths fails that stat at the
+# relocated path — cargo marks the crate dirty and recompiles it on the
+# next build. The cache hit then bought nothing. The in-place `noop`
+# phase cannot catch this: it rebuilds where the `.d` paths are
+# trivially valid. This phase is the regression guard for that class.
+[assertions.relocate-noop]
+should_not_recompile = true
+recompile_marker = "Compiling"


### PR DESCRIPTION
## Summary

kache caches rustc's dep-info `.d` files. cargo reads the `.d` to decide crate freshness — it lists each crate's inputs by **absolute path** and `stat()`s them. A `.d` restored across a path boundary (a different worktree, a different machine) holds the *producing* build's `target/` paths; the stat fails, cargo marks the crate dirty and **recompiles it**. The cross-machine cache hit happened but saved nothing — silently defeating kache's core value.

The path-rewriting machinery existed but was inert: the store side never relativized, and the restore side expanded against the wrong directory (`current_dir()` — the package *source* dir, not the target dir).

- **`fix(rustc)`** — `.d` paths are now rewritten around the cache, both sides anchored on the cargo target dir: relativized on store, expanded against the current build's target dir on restore. New `RustcArgs::target_dir()` provides the anchor (from `--out-dir`, or by walking `-o` for build scripts). A `.d` produced at path A round-trips to valid path-B paths.
- **`test(e2e)`** — new `relocate-noop` phase: after `relocate`, build *again* in the relocated tree without cleaning, and assert nothing recompiles. No existing phase caught this — each runs a single build; the `.d` bug bites the *next* one.

Adding the phase surfaced a latent harness bug: `should_not_recompile` grepped **stdout**, but cargo prints `Compiling` to **stderr** — so the existing in-place `noop` assertion had been passing vacuously. `run_step` now captures and checks both streams.

Verified before/after on `multi-dep`: without the fix, `relocate-noop` fails (cargo recompiles `serde_core` / `serde` / `serde_json` / `multi-dep` from stale `.d` paths); with it, it passes.

## Test plan

- [x] Full e2e harness — 6/6 fixtures pass; `multi-dep` `relocate-noop` green
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets`, `cargo test --workspace` (542 tests) all clean
- [ ] CI green on macOS (clang) + Linux (gcc)