### PR TITLE
fix(restore): compute artifact content before materializing it

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -193,12 +193,22 @@ pub enum SigningPurpose {
 
 /// One thing that needs to happen to a restored artifact before it's
 /// ready for use. The wrapper composes a per-file plan via
-/// [`plan_post_restore`] and applies each action in order.
+/// [`plan_post_restore`].
 ///
-/// Adding a new action variant means: one arm in
-/// [`PostRestoreAction::apply`], one condition in [`plan_post_restore`],
-/// and (if helpful) tests covering the relevant `ArtifactKind` mappings.
-/// The wrapper does not change.
+/// An action is one of two kinds, distinguished by
+/// [`PostRestoreAction::is_content_transform`]:
+///   - a **content transform** — kache computes the new bytes itself
+///     ([`PostRestoreAction::transform`]); applied in memory against the
+///     store blob *before* the file is materialized, so the restored
+///     file is written once already in final form.
+///   - an **external mutation** — an OS tool rewrites the file in place
+///     ([`PostRestoreAction::apply`]); run after the file is
+///     materialized as a private, writable copy the tool can safely mutate.
+///
+/// Adding a new action variant means: classify it in
+/// `is_content_transform`, one arm in `transform` or `apply`, one
+/// condition in [`plan_post_restore`]. The wrapper restore loop does not
+/// change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PostRestoreAction {
     /// Rewrite absolute paths inside a `.d` (dep-info) file so cargo's
@@ -231,42 +241,86 @@ pub fn plan_post_restore(kind: ArtifactKind) -> Vec<PostRestoreAction> {
 }
 
 impl PostRestoreAction {
-    /// Execute this action against a restored artifact at `path`.
+    /// True if this action rewrites the artifact's *content*, with kache
+    /// computing the new bytes itself (dep-info path expansion).
     ///
-    /// `anchor` is the directory dep-info (`.d`) relative paths are
-    /// expanded against — cargo's target dir for this invocation (see
-    /// [`crate::args::RustcArgs::target_dir`]). It MUST be the same anchor
-    /// the store side relativized with, or the relativize→expand round
-    /// trip produces paths cargo's freshness `stat()`s cannot find. The
-    /// previous implementation anchored on `std::env::current_dir()` —
-    /// which, since cargo runs rustc with cwd = the *package source dir*,
-    /// matched nothing in `.d` content, so the expand was a silent no-op
-    /// and cached `.d` blobs kept the producing worktree's absolute
-    /// paths. `Sign` ignores `anchor`.
+    /// Content transforms are applied **in memory against the store
+    /// blob, before the file is materialized** ([`Self::transform`]) —
+    /// the restore loop writes the result as a fresh file rather than
+    /// linking the blob and patching it in place, which would fail on a
+    /// read-only or inode-shared restore.
     ///
-    /// `platform` is the host abstraction for OS-specific concerns
-    /// (codesigning today; debug-path rewriting and similar concerns
-    /// later). Passing it explicitly — rather than calling
-    /// `platform::current()` here — keeps tests deterministic: a unit
-    /// test can inject a counting / failing / no-op platform without
-    /// needing the real host to behave a particular way.
-    pub fn apply(
-        &self,
-        path: &std::path::Path,
-        anchor: &std::path::Path,
-        platform: &dyn Platform,
-    ) -> Result<()> {
+    /// False for actions that hand the file to an external OS tool
+    /// (codesign), which needs a real, writable, private file on disk;
+    /// those run via [`Self::apply`] after materialization.
+    pub fn is_content_transform(self) -> bool {
+        match self {
+            PostRestoreAction::ExpandDepInfoPaths => true,
+            PostRestoreAction::Sign(_) => false,
+        }
+    }
+
+    /// Apply this action as an in-memory content transform: store-blob
+    /// bytes in, final restored bytes out.
+    ///
+    /// `anchor` is the directory dep-info (`.d`) relative paths expand
+    /// against — cargo's target dir for *this* invocation (see
+    /// [`crate::args::RustcArgs::target_dir`]). It MUST be the same kind
+    /// of anchor the store side relativized with, or the
+    /// relativize→expand round trip produces paths cargo's freshness
+    /// `stat()`s cannot find.
+    ///
+    /// Only meaningful when [`Self::is_content_transform`] is true;
+    /// other actions return the input unchanged.
+    pub fn transform(self, content: Vec<u8>, anchor: &std::path::Path) -> Vec<u8> {
         match self {
             PostRestoreAction::ExpandDepInfoPaths => {
-                let _ =
-                    crate::link::rewrite_depinfo(path, anchor, crate::link::DepInfoMode::Expand);
-                Ok(())
+                // dep-info is UTF-8 text. If a `.d` somehow is not valid
+                // UTF-8, pass it through untouched rather than risk
+                // corrupting it.
+                match String::from_utf8(content) {
+                    Ok(text) => crate::link::rewrite_depinfo_content(
+                        &text,
+                        anchor,
+                        crate::link::DepInfoMode::Expand,
+                    )
+                    .into_bytes(),
+                    Err(e) => e.into_bytes(),
+                }
             }
+            PostRestoreAction::Sign(_) => content,
+        }
+    }
+
+    /// Execute this action as an external mutation of an
+    /// already-materialized file.
+    ///
+    /// The caller guarantees `path` is a **private, writable** file —
+    /// not a shared link to a store blob — because external tools mutate
+    /// the file in place and must never reach the cache blob. Only
+    /// meaningful when [`Self::is_content_transform`] is false.
+    ///
+    /// `platform` is the host abstraction for OS-specific concerns
+    /// (codesigning today; debug-path rewriting later). Passing it
+    /// explicitly — rather than calling `platform::current()` here —
+    /// keeps tests deterministic: a unit test can inject a counting /
+    /// failing / no-op platform.
+    pub fn apply(&self, path: &std::path::Path, platform: &dyn Platform) -> Result<()> {
+        match self {
             PostRestoreAction::Sign(SigningPurpose::OsLoading) => {
                 // Verify-then-sign lives inside the platform impl so
                 // the kache-fork bug 59866c0 (mutating already-valid
                 // signatures) can't be reintroduced from this site.
                 platform.ensure_binary_loadable(path)
+            }
+            PostRestoreAction::ExpandDepInfoPaths => {
+                // A content transform — handled in memory via
+                // `transform()` before materialization, never here.
+                debug_assert!(
+                    false,
+                    "ExpandDepInfoPaths is a content transform; route it through transform()"
+                );
+                Ok(())
             }
         }
     }
@@ -441,41 +495,33 @@ mod tests {
         }
     }
 
-    // ── apply() ──────────────────────────────────────────────────
+    // ── transform() / apply() ────────────────────────────────────
     //
-    // Coverage for the action executor: ExpandDepInfoPaths uses
-    // link::rewrite_depinfo internally; Sign(OsLoading) routes through
-    // the injected Platform. Both must be safe on arbitrary inputs and
-    // must not panic.
+    // Coverage for the action executors. ExpandDepInfoPaths is a content
+    // transform: it maps store-blob bytes to final bytes in memory.
+    // Sign(OsLoading) is an external mutation routed through the
+    // injected Platform.
 
-    /// Convenience for tests that don't care which platform impl runs;
-    /// the actual codesign behavior is exercised in
-    /// `compiler::platform::tests` and on macOS arm64 in CI/locally.
-    fn test_platform() -> Box<dyn Platform> {
-        Box::new(crate::compiler::platform::LinuxPlatform)
+    #[test]
+    fn expand_dep_info_paths_is_a_content_transform() {
+        // The classification that routes an action to `transform` (in
+        // memory, pre-materialization) vs `apply` (external, post-).
+        assert!(PostRestoreAction::ExpandDepInfoPaths.is_content_transform());
+        assert!(!PostRestoreAction::Sign(SigningPurpose::OsLoading).is_content_transform());
     }
 
     #[test]
-    fn apply_expand_dep_info_paths_rewrites_relative_paths_against_anchor() {
-        use std::io::Write;
-        let dir = tempfile::tempdir().unwrap();
-        let depfile = dir.path().join("test.d");
-        {
-            let mut f = std::fs::File::create(&depfile).unwrap();
-            // The relative-paths shape that link::rewrite_depinfo's
-            // Relativize mode produces; Expand should reverse it.
-            write!(f, "./target/debug/foo: ./src/lib.rs").unwrap();
-        }
-
+    fn transform_expand_dep_info_paths_roots_relative_paths_at_anchor() {
+        // The relative-paths shape `rewrite_depinfo_content`'s Relativize
+        // mode produces; Expand (the restore-side transform) reverses it.
         // The anchor is the restoring build's target dir — NOT the
-        // process cwd. Expand must root the `./` paths there.
+        // process cwd.
+        let blob = b"./target/debug/foo: ./src/lib.rs".to_vec();
         let anchor = std::path::Path::new("/restored/worktree");
-        PostRestoreAction::ExpandDepInfoPaths
-            .apply(&depfile, anchor, &*test_platform())
-            .unwrap();
 
-        let content = std::fs::read_to_string(&depfile).unwrap();
-        // After Expand: the leading "./" is replaced with "<anchor>/" everywhere.
+        let out = PostRestoreAction::ExpandDepInfoPaths.transform(blob, anchor);
+        let content = String::from_utf8(out).unwrap();
+
         assert!(
             content.contains("/restored/worktree/target/debug/foo"),
             "expected anchor-rooted target path, got: {content}"
@@ -491,15 +537,14 @@ mod tests {
     }
 
     #[test]
-    fn apply_expand_dep_info_paths_is_silent_on_missing_file() {
-        // The current implementation deliberately swallows rewrite_depinfo
-        // errors with `let _` — a missing file shouldn't take down the
-        // wrapper's restore loop. Lock that contract in.
-        let dir = tempfile::tempdir().unwrap();
-        let nonexistent = dir.path().join("does-not-exist.d");
-        PostRestoreAction::ExpandDepInfoPaths
-            .apply(&nonexistent, dir.path(), &*test_platform())
-            .expect("apply must not error on a missing dep-info file");
+    fn transform_expand_dep_info_paths_passes_through_non_utf8() {
+        // A `.d` is always UTF-8 in practice, but the transform must
+        // never corrupt bytes it can't interpret — it returns them
+        // unchanged rather than panicking.
+        let blob = vec![0xff, 0xfe, 0x00, 0x42];
+        let out = PostRestoreAction::ExpandDepInfoPaths
+            .transform(blob.clone(), std::path::Path::new("/anchor"));
+        assert_eq!(out, blob);
     }
 
     #[test]
@@ -515,27 +560,13 @@ mod tests {
 
         let platform = CountingPlatform::new();
         PostRestoreAction::Sign(SigningPurpose::OsLoading)
-            .apply(&path, dir.path(), &platform)
+            .apply(&path, &platform)
             .expect("apply must not error even when the platform impl is a no-op");
         assert_eq!(
             platform.ensure_calls(),
             1,
             "Sign(OsLoading) must dispatch to platform.ensure_binary_loadable exactly once"
         );
-    }
-
-    #[test]
-    fn apply_expand_dep_info_paths_does_not_call_platform() {
-        // Confirms ExpandDepInfoPaths is purely filesystem work and
-        // doesn't accidentally route through the platform layer (which
-        // would be a code smell — depinfo rewriting is OS-agnostic).
-        use crate::compiler::platform::tests::CountingPlatform;
-        let dir = tempfile::tempdir().unwrap();
-        let depfile = dir.path().join("nope.d");
-
-        let platform = CountingPlatform::new();
-        let _ = PostRestoreAction::ExpandDepInfoPaths.apply(&depfile, dir.path(), &platform);
-        assert_eq!(platform.ensure_calls(), 0);
     }
 
     // ── classify → plan integration ──────────────────────────────

--- a/src/link.rs
+++ b/src/link.rs
@@ -38,17 +38,8 @@ pub fn link_to_target(store_path: &Path, target_path: &Path, strategy: LinkStrat
             .with_context(|| format!("creating parent dir for {}", target_path.display()))?;
     }
 
-    // Remove existing file at target (link/clone calls fail if dst exists)
-    if target_path.exists() || target_path.symlink_metadata().is_ok() {
-        #[cfg(windows)]
-        if let Ok(meta) = fs::metadata(target_path) {
-            let mut perms = meta.permissions();
-            perms.set_readonly(false);
-            let _ = fs::set_permissions(target_path, perms);
-        }
-        fs::remove_file(target_path)
-            .with_context(|| format!("removing existing file at {}", target_path.display()))?;
-    }
+    // Remove existing file at target (link/clone calls fail if dst exists).
+    clear_target(target_path)?;
 
     // Try reflink first. CoW gives us zero-copy *and* mutations don't
     // propagate to the cache blob — strictly better than hardlink when
@@ -187,6 +178,49 @@ fn copy_file(src: &Path, dst: &Path, executable: bool) -> Result<()> {
     Ok(())
 }
 
+/// Remove any file already at `target_path` so a fresh clone / hardlink /
+/// write can take its place. A previous restore may have left a
+/// read-only hardlink or reflink of a store blob here.
+fn clear_target(target_path: &Path) -> Result<()> {
+    if target_path.exists() || target_path.symlink_metadata().is_ok() {
+        #[cfg(windows)]
+        if let Ok(meta) = fs::metadata(target_path) {
+            let mut perms = meta.permissions();
+            perms.set_readonly(false);
+            let _ = fs::set_permissions(target_path, perms);
+        }
+        fs::remove_file(target_path)
+            .with_context(|| format!("removing existing file at {}", target_path.display()))?;
+    }
+    Ok(())
+}
+
+/// Materialize a restored artifact from content computed in memory.
+///
+/// Used when a post-restore content transform changed the bytes (dep-info
+/// path expansion): the final content is written as a fresh, independent,
+/// writable (`0o644`) file. By construction it shares no inode with the
+/// store blob and is not read-only — this is the "compute the final
+/// bytes, then materialize" path, as opposed to linking the blob and
+/// patching it in place (which fails on a read-only or inode-shared
+/// restore).
+pub fn write_restored(target_path: &Path, content: &[u8]) -> Result<()> {
+    if let Some(parent) = target_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent dir for {}", target_path.display()))?;
+    }
+    clear_target(target_path)?;
+    fs::write(target_path, content)
+        .with_context(|| format!("writing restored file {}", target_path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(target_path, fs::Permissions::from_mode(0o644))
+            .with_context(|| format!("setting perms on {}", target_path.display()))?;
+    }
+    Ok(())
+}
+
 /// Update the mtime of a file to the current time.
 /// For hardlinked files, this also updates the store copy (same inode),
 /// which conveniently acts as an LRU access time update.
@@ -221,23 +255,42 @@ pub fn touch_mtime(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Rewrite a .d (dep-info) file: replace absolute paths with relative paths for storing,
-/// or expand relative paths back to absolute for restoring.
+/// Pure dep-info path rewrite: relativize absolute project paths to `./`,
+/// or expand `./` back to absolute. No I/O.
+///
+/// This is the in-memory half of the transform. The restore side calls
+/// it directly — it computes the final `.d` content from the store blob
+/// and materializes the result with [`write_restored`], so it never
+/// rewrites a restored, possibly read-only, possibly inode-shared file in
+/// place. The store side reaches it via [`rewrite_depinfo`].
+pub fn rewrite_depinfo_content(content: &str, project_dir: &Path, mode: DepInfoMode) -> String {
+    let project_prefix = format!("{}/", project_dir.display());
+    match mode {
+        DepInfoMode::Relativize => content.replace(&project_prefix, "./"),
+        DepInfoMode::Expand => content.replace("./", &project_prefix),
+    }
+}
+
+/// Rewrite a `.d` (dep-info) file in place.
+///
+/// Used on the **store** side, where the file is the build's own
+/// freshly-written, writable dep-info. The restore side does NOT use this
+/// — it computes the rewritten content in memory via
+/// [`rewrite_depinfo_content`] and materializes it with [`write_restored`],
+/// honoring "compute the final bytes, then materialize" rather than
+/// patching a restored file in place.
 pub fn rewrite_depinfo(depinfo_path: &Path, project_dir: &Path, mode: DepInfoMode) -> Result<()> {
     let content = fs::read_to_string(depinfo_path)
         .with_context(|| format!("reading dep-info file {}", depinfo_path.display()))?;
 
-    let project_prefix = format!("{}/", project_dir.display());
-    let rewritten = match mode {
-        DepInfoMode::Relativize => content.replace(&project_prefix, "./"),
-        DepInfoMode::Expand => content.replace("./", &project_prefix),
-    };
+    let rewritten = rewrite_depinfo_content(&content, project_dir, mode);
 
-    // For hardlinked files, we need to unlink first to avoid modifying the store copy.
-    // Windows has hardlinks too (NTFS), but std exposes no portable nlink count;
-    // fs::write on Windows opens with FILE_SHARE_WRITE and truncates the underlying
-    // file just like Unix, so the same hazard applies. Conservatively remove on
-    // Windows if the file exists — cheap, correct, and avoids the nlink check.
+    // Defense-in-depth: if the file is hardlinked (nlink > 1), unlink
+    // first so the in-place write can't mutate a shared inode. On the
+    // store side `Store::put` copies blobs rather than hardlinking, so
+    // this rarely fires — but it keeps `rewrite_depinfo` safe for any
+    // caller. Windows exposes no portable nlink count; remove
+    // unconditionally there.
     #[cfg(unix)]
     if let Ok(meta) = fs::metadata(depinfo_path) {
         use std::os::unix::fs::MetadataExt;
@@ -481,5 +534,60 @@ mod tests {
         // Must be executable (cargo test will try to run this)
         let mode = fs::metadata(&dst).unwrap().permissions().mode();
         assert_eq!(mode & 0o755, 0o755, "expected 0o755, got {mode:#o}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_restored_over_readonly_blob_link_isolates_and_stays_writable() {
+        // The bug this guards: on restore, a `.d` was linked to the
+        // read-only store blob, then a post-restore rewrite tried to
+        // edit it in place — failing on the 0o444 mode (reflink case)
+        // or corrupting the shared blob (hardlink case). `write_restored`
+        // instead materializes the final content as a fresh file.
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let blob = dir.path().join("blob.d");
+        let target = dir.path().join("sub/restored.d");
+
+        // A read-only store blob, and a prior restore that hardlinked it
+        // into place (the worst case — shared inode + read-only).
+        fs::write(&blob, b"OLD RELATIVIZED CONTENT").unwrap();
+        fs::set_permissions(&blob, fs::Permissions::from_mode(0o444)).unwrap();
+        fs::create_dir_all(target.parent().unwrap()).unwrap();
+        fs::hard_link(&blob, &target).unwrap();
+
+        write_restored(&target, b"NEW EXPANDED CONTENT").unwrap();
+
+        // Final content is in place...
+        assert_eq!(fs::read(&target).unwrap(), b"NEW EXPANDED CONTENT");
+        // ...the restored file is writable (an in-place edit could not
+        // have failed on it)...
+        let mode = fs::metadata(&target).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o200,
+            0o200,
+            "restored file must be writable: {mode:#o}"
+        );
+        // ...it shares no inode with the blob...
+        assert_ne!(
+            fs::metadata(&target).unwrap().ino(),
+            fs::metadata(&blob).unwrap().ino(),
+            "restored file must not share an inode with the store blob"
+        );
+        // ...and the store blob is byte-for-byte untouched.
+        assert_eq!(fs::read(&blob).unwrap(), b"OLD RELATIVIZED CONTENT");
+        assert!(
+            fs::metadata(&blob).unwrap().permissions().readonly(),
+            "store blob must remain read-only"
+        );
+    }
+
+    #[test]
+    fn write_restored_creates_missing_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("a/b/c/out.d");
+        write_restored(&target, b"content").unwrap();
+        assert_eq!(fs::read(&target).unwrap(), b"content");
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -807,34 +807,68 @@ fn restore_from_cache(
             output_dir.join(&cached_file.name)
         };
 
-        // Per-file dispatch by artifact kind. The classification + match
-        // here is the structural enforcement: link strategy and post-restore
-        // processing both derive from `kind`, not from ad-hoc filename
-        // suffix checks at every call site. Adding a new compiler later
-        // (gcc, clang) just needs its own `classify_output`; the dispatch
-        // below is reused unchanged.
+        // Per-file dispatch by artifact kind: `classify_output` picks
+        // the kind, `plan_post_restore` the actions — no ad-hoc filename
+        // matching at the call site.
         let kind = compiler.classify_output(args, &cached_file.name);
+        let plan = plan_post_restore(kind);
 
-        link::link_to_target(&store_path, &target_path, kind.link_strategy()).with_context(
-            || {
-                format!(
-                    "linking {} -> {}",
-                    store_path.display(),
-                    target_path.display()
-                )
-            },
-        )?;
+        // Invariant: compute the artifact's final bytes BEFORE
+        // materializing it — never materialize a shared link to the
+        // store blob and then patch it in place (that fails on a
+        // read-only or inode-shared restore). A content transform
+        // (dep-info path expansion) is computed in memory against the
+        // blob; an external mutation (codesign) runs afterwards on the
+        // materialized, private, writable file.
+        let transforms: Vec<_> = plan
+            .iter()
+            .copied()
+            .filter(|a| a.is_content_transform())
+            .collect();
 
-        // Update mtime so cargo doesn't think output is stale
+        // `Some(bytes)` => a transform changed the content; materialize a
+        // fresh writable file. `None` => no transform, or it was a no-op
+        // — link the blob directly (reflink/CoW when supported, zero-copy).
+        let transformed: Option<Vec<u8>> = if transforms.is_empty() {
+            None
+        } else {
+            let blob = std::fs::read(&store_path)
+                .with_context(|| format!("reading blob {}", store_path.display()))?;
+            let mut content = blob.clone();
+            for action in &transforms {
+                content = action.transform(content, &depinfo_anchor);
+            }
+            if content == blob { None } else { Some(content) }
+        };
+
+        match transformed {
+            Some(content) => {
+                link::write_restored(&target_path, &content).with_context(|| {
+                    format!("materializing transformed {}", target_path.display())
+                })?;
+            }
+            None => {
+                link::link_to_target(&store_path, &target_path, kind.link_strategy())
+                    .with_context(|| {
+                        format!(
+                            "linking {} -> {}",
+                            store_path.display(),
+                            target_path.display()
+                        )
+                    })?;
+            }
+        }
+
+        // Update mtime so cargo doesn't treat the restored output as stale.
         link::touch_mtime(&target_path)?;
 
-        // Per-file post-restore plan composed from kind alone (today). The
-        // wrapper iterates the plan instead of pattern-matching on kind so
-        // adding a new action means a single new variant in
-        // `PostRestoreAction` plus its arm in `apply` — the wrapper stays
-        // unchanged.
-        for action in plan_post_restore(kind) {
-            action.apply(&target_path, &depinfo_anchor, &*platform)?;
+        // External mutations (codesign) run after materialization, on the
+        // now private, writable file. Content transforms were already
+        // applied in memory above.
+        for action in &plan {
+            if !action.is_content_transform() {
+                action.apply(&target_path, &*platform)?;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The restore loop linked each cached file to its target — a hardlink/reflink of the store blob — and *then* ran post-restore actions that mutate it. For dep-info (`.d`) files the mutation is an in-place rewrite (`ExpandDepInfoPaths`), and "materialize then patch" is unsound:

- Store blobs are read-only (`0o444`). On a CoW filesystem the `.d` is reflinked, inheriting `0o444` with `nlink == 1`. `rewrite_depinfo`'s `nlink > 1` guard does not fire, so it tries `fs::write` on a read-only file → `EACCES`. `PostRestoreAction::apply` **swallowed the error**, so the restored `.d` was silently left in its stored, relativized form (`./debug/deps/...`) instead of expanded to absolute paths.
- It only "worked" on Linux/ext4 by accident: no reflink → hardlink → `nlink > 1` → the guard fires → remove-then-write produces a fresh writable file.

So #100's restore-side dep-info expansion was a **silent no-op on macOS/APFS**.

## Fix

Invert the order — **compute the final bytes, then materialize**. `PostRestoreAction` is split into two kinds:

- **content transforms** (`ExpandDepInfoPaths`) — kache computes the new bytes itself. Applied in memory against the store blob via `transform()`, *before* materialization. If the bytes changed, the result is written as a fresh, independent, writable file (`link::write_restored`); if unchanged, the blob is linked zero-copy.
- **external mutations** (`Sign`) — an OS tool rewrites the file. Run via `apply()` *after* the file is materialized as a private, writable copy.

This never links-then-patches, so there is no read-only blob to fail on and no shared inode to corrupt — on any filesystem. `apply` no longer swallows errors. No cache-key change.

## Verification

- A warm cache restore on macOS now yields a **writable `.d` with expanded absolute paths** — vs. the broken read-only, relativized `./debug/deps/...` before.
- 517 unit tests pass; `fmt` + `clippy` clean.
- All 6 e2e fixtures green.

## Test plan

- [x] `cargo test --bin kache` — incl. new `write_restored` regression test (read-only blob link → isolated writable file, blob untouched) and `transform()` tests
- [x] `cargo fmt --all --check` + `cargo clippy --all-targets`
- [x] e2e harness — all fixtures pass
- [x] manual: cold/clean/warm cycle confirms restored `.d` is writable + expanded