### PR TITLE
fix(path-normalizer): remap the rustc CWD so DWARF comp_dir is clean

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -22,7 +22,13 @@ use std::path::Path;
 /// everything else the key hashed identical → same key, so a check's
 /// metadata-only entry could be served to a build needing the
 /// `.rlib`. The composition changed, so v4 entries are invalidated.
-const CACHE_KEY_VERSION: u32 = 5;
+///
+/// v6: `PathNormalizer` gained a rule for the rustc working directory
+/// → `<WORKSPACE>`, so `--remap-path-prefix` now also rewrites DWARF
+/// `DW_AT_comp_dir` (rustc records the raw CWD there). Debug builds
+/// previously leaked the build path through `comp_dir`; the remapped
+/// output is byte-incompatible with v5, so the bump invalidates it.
+const CACHE_KEY_VERSION: u32 = 6;
 
 /// Compute the blake3 cache key for a rustc invocation.
 ///

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -135,12 +135,23 @@ impl PathNormalizer {
     /// (workspace inside `$HOME`, target dir inside workspace) the
     /// inner prefix wins:
     ///
-    /// 1. `workspace_root` (if provided) → `<WORKSPACE>`
-    /// 2. `$CARGO_TARGET_DIR` → `<TARGET>`
-    /// 3. `$CARGO_HOME` (or default `~/.cargo`) → `<CARGO_HOME>`
-    /// 4. `$RUSTUP_HOME` (or default `~/.rustup`) → `<RUSTUP_HOME>`
-    /// 5. `$HOME` → `<HOME>`
-    /// 6. system tempdir (`std::env::temp_dir()`) → `<TMPDIR>`
+    /// 1. current working directory → `<WORKSPACE>`
+    /// 2. `workspace_root` (if provided) → `<WORKSPACE>`
+    /// 3. `$CARGO_TARGET_DIR` → `<TARGET>`
+    /// 4. `$CARGO_HOME` (or default `~/.cargo`) → `<CARGO_HOME>`
+    /// 5. `$RUSTUP_HOME` (or default `~/.rustup`) → `<RUSTUP_HOME>`
+    /// 6. `$HOME` → `<HOME>`
+    /// 7. system tempdir (`std::env::temp_dir()`) → `<TMPDIR>`
+    ///
+    /// Rule 1 is what rewrites rustc's DWARF `DW_AT_comp_dir` — rustc
+    /// records its working directory there verbatim, and the other
+    /// rules only rewrite it if one's prefix matches the CWD exactly.
+    /// Without rule 1 a debug build leaks the build path through
+    /// `comp_dir` (and any dSYM derived from it). kache runs as
+    /// RUSTC_WRAPPER with no `chdir`, so the wrapper's CWD is the CWD
+    /// rustc records. For a workspace member it is more specific than
+    /// `workspace_root` (the repo root); for a single package they
+    /// coincide and the dedup below collapses them.
     ///
     /// Tempdir lands last because it can be unrelated to user paths
     /// (`/tmp` on Linux, `/var/folders/.../T` on macOS) — it's
@@ -148,6 +159,14 @@ impl PathNormalizer {
     /// flow through tempdirs.
     pub fn from_env(workspace_root: Option<&Path>) -> Self {
         let mut rules = Vec::new();
+
+        push_rule_with_variants(
+            &mut rules,
+            std::env::current_dir()
+                .ok()
+                .and_then(|p| canonical_string(&p)),
+            "<WORKSPACE>",
+        );
 
         push_rule_with_variants(
             &mut rules,
@@ -612,6 +631,37 @@ mod tests {
         assert!(
             out.contains("<TMPDIR>") || out.contains("<HOME>") || out.starts_with('<'),
             "expected a sentinel for tempdir-based path, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn from_env_includes_cwd_rule_for_comp_dir() {
+        // The CWD rule is what rewrites rustc's DWARF `DW_AT_comp_dir`:
+        // rustc records its working directory there verbatim, and the
+        // other rules only rewrite it if one's prefix matches the CWD
+        // exactly. Without this rule a debug build leaks the build path
+        // through `comp_dir`. kache runs as RUSTC_WRAPPER with no
+        // `chdir`, so the wrapper CWD is the CWD rustc records.
+        let cwd = std::env::current_dir().unwrap();
+        let canonical = canonical_string(&cwd).expect("cwd must canonicalize");
+        let n = PathNormalizer::from_env(None);
+
+        // The CWD must normalize to a sentinel (`<WORKSPACE>` — possibly
+        // shadowed by an inner rule, hence the looser `starts_with`).
+        let normalized = n.normalize(format!("{canonical}/src/main.rs"));
+        assert!(
+            normalized.starts_with('<'),
+            "CWD path should normalize to a sentinel, got {normalized:?}"
+        );
+
+        // ...and the rule must surface as an injected `--remap-path-prefix`
+        // so rustc rewrites `comp_dir` at compile time.
+        let remaps = n.remap_args();
+        assert!(
+            remaps
+                .iter()
+                .any(|a| a == &format!("--remap-path-prefix={canonical}=<WORKSPACE>")),
+            "from_env must emit a CWD remap arg; got {remaps:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

rustc records its working directory verbatim as DWARF `DW_AT_comp_dir`. kache injects `--remap-path-prefix` from `PathNormalizer`'s rules — but none of them had a prefix matching the CWD *exactly*, so `comp_dir` was left as a raw machine-local path in every cached crate's debug info.

Verified before the fix — a debug build, even with kache's remapping injected:
```
DW_AT_comp_dir ("/private/tmp/cdtest")
```

This is a path leak in cached debug artifacts (the cached `.rlib`s of dependencies carry it) and it breaks byte-identical caching across build paths.

## Fix

Add a `PathNormalizer` rule mapping the **current working directory → `<WORKSPACE>`**. kache runs as `RUSTC_WRAPPER` with no `chdir`, so the wrapper's CWD is the CWD rustc records. The rule is pushed first (most-specific) and dedups against `workspace_root` when they coincide (the single-package case).

Verified after the fix:
```
DW_AT_comp_dir ("<WORKSPACE>")
```

`CACHE_KEY_VERSION` 5 → 6: the remap set changed, so debug builds emit byte-different DWARF — prior entries must become unreachable.

## Notes

This came out of the macOS OSO investigation. `comp_dir` was the one leak class `--remap-path-prefix` was missing (the OSO debug-map and the executable-side work are separate, deferred). It applies to **every** cached crate's DWARF on debug builds — release has no debug info, so the all-`--release` e2e fixtures don't exercise it; debug-build e2e coverage lands with the OSO work.

## Test plan

- [x] `cargo test --bin kache` — 516 pass, incl. new `from_env_includes_cwd_rule_for_comp_dir`
- [x] `cargo fmt --all --check` + `cargo clippy --all-targets`
- [x] e2e — all 6 fixtures green (the remap change is regression-free)
- [x] manual: `dwarfdump --debug-info` confirms `DW_AT_comp_dir` → `<WORKSPACE>`