### PR TITLE
test(e2e): falsifiability — negative-control mode + direct dep-info assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,20 @@ jobs:
             --kache ./target/release/kache \
             --fixtures ./test-projects \
             --out e2e-results/results.json
+      - name: Run e2e negative-control (falsifiability check)
+        # Reruns every fixture with kache disabled (KACHE_DISABLED=1)
+        # and asserts each result FLIPS to a failure — a fixture that
+        # still passes with kache off has a vacuous test that does not
+        # actually exercise caching. Independent signal; `always()` so
+        # it runs even when the harness run above failed, as long as
+        # the build produced the binaries.
+        if: always()
+        run: |
+          ./target/release/kache-e2e \
+            --kache ./target/release/kache \
+            --fixtures ./test-projects \
+            --negative-control \
+            --out e2e-results/negative-control.json
       - name: Show aggregated e2e results
         if: always()
         run: |

--- a/crates/kache-e2e/src/bin/kache-e2e.rs
+++ b/crates/kache-e2e/src/bin/kache-e2e.rs
@@ -39,6 +39,15 @@ struct Args {
     /// during local iteration.
     #[arg(long)]
     only: Option<String>,
+
+    /// Falsifiability check. Reruns every fixture with kache disabled
+    /// (`KACHE_DISABLED=1`) and asserts each result FLIPS to a failure
+    /// — a fixture whose caching assertions still pass with kache off
+    /// has a vacuous test. Fixtures marked `negative_control_exempt`
+    /// (passthrough fixtures) must still pass. Exits 0 iff every
+    /// fixture behaved as expected.
+    #[arg(long)]
+    negative_control: bool,
 }
 
 fn main() -> Result<()> {
@@ -84,16 +93,51 @@ fn main() -> Result<()> {
         "Fixtures: {}",
         fixtures.keys().cloned().collect::<Vec<_>>().join(", ")
     );
+    if args.negative_control {
+        // SAFETY: set once here, before the sequential fixture loop —
+        // the harness is single-threaded at this point. Disables kache
+        // for every fixture build so we can assert the suite genuinely
+        // depends on kache (see the `--negative-control` doc).
+        unsafe { std::env::set_var("KACHE_DISABLED", "1") };
+        eprintln!("Mode:     negative-control (KACHE_DISABLED=1 — fixtures must flip to fail)");
+    }
     eprintln!();
 
     let mut fixture_results = Vec::new();
     let mut any_failed = false;
     for fixture in fixtures.values() {
         let result = runner::run_fixture(fixture, &kache_path)?;
-        if result.status != "pass" {
-            any_failed = true;
+        let passed = result.status == "pass";
+        if args.negative_control {
+            // Falsifiability verdict: with kache disabled a non-exempt
+            // fixture MUST fail (its caching assertions cannot be met);
+            // an exempt passthrough fixture must still pass. Either
+            // mismatch means the fixture's test does not actually
+            // exercise kache.
+            let want_pass = fixture.negative_control_exempt;
+            let ok = passed == want_pass;
+            if !ok {
+                any_failed = true;
+            }
+            let verdict = if ok {
+                "falsifiable"
+            } else if want_pass {
+                "BROKEN — exempt fixture should still pass"
+            } else {
+                "VACUOUS — test passes even with kache disabled"
+            };
+            eprintln!(
+                "=> {}: kache-disabled run {} [{}]",
+                result.name,
+                if passed { "PASSED" } else { "failed" },
+                verdict,
+            );
+        } else {
+            if !passed {
+                any_failed = true;
+            }
+            eprintln!("=> {}: {}", result.name, result.status);
         }
-        eprintln!("=> {}: {}", result.name, result.status);
         eprintln!();
         fixture_results.push(result);
     }
@@ -114,9 +158,23 @@ fn main() -> Result<()> {
     eprintln!("Results written to {}", args.out.display());
 
     if any_failed {
-        eprintln!("FAIL: one or more fixtures failed");
+        eprintln!(
+            "{}",
+            if args.negative_control {
+                "FAIL: negative-control — a fixture's test is vacuous (see above)"
+            } else {
+                "FAIL: one or more fixtures failed"
+            }
+        );
         std::process::exit(1);
     }
-    eprintln!("PASS: all fixtures green");
+    eprintln!(
+        "{}",
+        if args.negative_control {
+            "PASS: negative-control — every fixture is falsifiable"
+        } else {
+            "PASS: all fixtures green"
+        }
+    );
     Ok(())
 }

--- a/crates/kache-e2e/src/fixture.rs
+++ b/crates/kache-e2e/src/fixture.rs
@@ -55,6 +55,18 @@ pub struct Fixture {
     /// recompile in the `relocate-modified` phase. See [`ModifySpec`].
     pub modify: Option<ModifySpec>,
 
+    /// Exempt this fixture from the `--negative-control` falsifiability
+    /// check. That check reruns every fixture with `KACHE_DISABLED=1`
+    /// and asserts the result flips to a failure — proving the
+    /// fixture's caching assertions genuinely depend on kache. A
+    /// passthrough fixture (e.g. `c-passthrough`) has no such
+    /// assertion: disabling kache is indistinguishable from the
+    /// refuse-and-passthrough it already exercises, so it legitimately
+    /// still passes. Mark those `true` so negative-control expects a
+    /// pass, not a flip.
+    #[serde(default)]
+    pub negative_control_exempt: bool,
+
     /// Absolute path to the fixture directory (set at load time, not
     /// in the toml).
     #[serde(skip)]

--- a/crates/kache-e2e/src/fixture.rs
+++ b/crates/kache-e2e/src/fixture.rs
@@ -67,6 +67,19 @@ pub struct Fixture {
     #[serde(default)]
     pub negative_control_exempt: bool,
 
+    /// Assert that restored dep-info (`.d`) files are path-expanded.
+    ///
+    /// kache relativizes `.d` files on store (`<target>/...` → `./...`)
+    /// and must expand them back on restore. A restored `.d` still
+    /// carrying the `./debug/` / `./release/` relativization sentinel
+    /// means the restore-side expansion silently failed — the #100 bug
+    /// class. This is a *direct* artifact assertion: it inspects the
+    /// `.d` content rather than relying on the `should_not_recompile`
+    /// proxy, which can pass even when the `.d` is broken. Opt-in — set
+    /// `true` for Rust fixtures whose dependencies get `.d`s cached.
+    #[serde(default)]
+    pub check_depinfo: bool,
+
     /// Absolute path to the fixture directory (set at load time, not
     /// in the toml).
     #[serde(skip)]

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -724,6 +724,22 @@ fn run_phase(
         }
     }
 
+    // Direct dep-info assertion: a restored `.d` must be path-expanded,
+    // not left in kache's relativized form. This inspects the `.d`
+    // content itself — unlike the `should_not_recompile` proxy, which
+    // can pass even when the restored `.d` is broken (the #100 bug:
+    // cargo treated a simple crate Fresh regardless). Opt-in per
+    // fixture via `check_depinfo`.
+    if fixture.check_depinfo {
+        let reason = inspect_restored_depinfo(cwd);
+        checks.push(AssertionCheck {
+            name: "depinfo_expanded",
+            expected: "restored .d files carry no relativization sentinel".to_string(),
+            actual: reason.clone().unwrap_or_else(|| "ok".to_string()),
+            passed: reason.is_none(),
+        });
+    }
+
     // Verify failures count toward phase pass/fail too.
     let verify_passed = verify.as_ref().map(|v| v.passed).unwrap_or(true);
     if let Some(v) = &verify {
@@ -1020,4 +1036,91 @@ fn inspect_binary(run_cmd: &str, cwd: &Path, forbidden: &[String]) -> Option<Str
         }
     }
     None
+}
+
+/// Scan every dep-info (`.d`) file under `root` for kache's target-dir
+/// relativization sentinel.
+///
+/// kache relativizes `.d` files on store (`<target>/...` → `./...`) and
+/// must expand them back on restore. A real rustc `.d` writes its
+/// output targets as ABSOLUTE paths, so a restored `.d` containing
+/// `./debug/` or `./release/` can only mean the restore-side expansion
+/// silently failed (the #100 bug class — the in-place `noop` /
+/// `should_not_recompile` proxy can miss it because cargo may treat a
+/// simple crate Fresh regardless). Returns `Some(reason)` naming the
+/// first offending file, or `None` if every `.d` is clean.
+fn inspect_restored_depinfo(root: &Path) -> Option<String> {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("d") {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            for sentinel in ["./debug/", "./release/"] {
+                if content.contains(sentinel) {
+                    return Some(format!(
+                        "restored dep-info `{}` carries kache's relativization \
+                         sentinel `{}` — the restore-side path expansion did not run",
+                        path.display(),
+                        sentinel,
+                    ));
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::inspect_restored_depinfo;
+
+    #[test]
+    fn inspect_restored_depinfo_passes_on_absolute_paths() {
+        // A correct rustc `.d`: output targets are absolute.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("crate-abc.d"),
+            "/abs/proj/target/debug/deps/crate-abc.rlib: /abs/proj/src/lib.rs\n",
+        )
+        .unwrap();
+        assert!(inspect_restored_depinfo(dir.path()).is_none());
+    }
+
+    #[test]
+    fn inspect_restored_depinfo_catches_relativization_sentinel() {
+        // A `.d` left in kache's relativized form — the #100 bug
+        // signature. Must be caught.
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("target/debug/deps");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            nested.join("crate-abc.d"),
+            "./debug/deps/crate-abc.rlib: src/lib.rs\n",
+        )
+        .unwrap();
+        let reason = inspect_restored_depinfo(dir.path());
+        assert!(reason.is_some(), "must catch a `./debug/` relativized .d");
+        assert!(reason.unwrap().contains("./debug/"));
+    }
+
+    #[test]
+    fn inspect_restored_depinfo_no_d_files_is_clean() {
+        // A fixture with no `.d` files at all (e.g. a C `make` build):
+        // nothing to check, trivially clean.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("main.c"), "int main(){}").unwrap();
+        assert!(inspect_restored_depinfo(dir.path()).is_none());
+    }
 }

--- a/test-projects/c-passthrough/kache-fixture.toml
+++ b/test-projects/c-passthrough/kache-fixture.toml
@@ -19,6 +19,12 @@
 
 name = "c-passthrough"
 
+# Exempt from `--negative-control`: this fixture's contract is "kache
+# caches nothing here" (the compile is refused → passthrough). Disabling
+# kache is indistinguishable from that, so it legitimately still passes
+# with KACHE_DISABLED=1 — there is no caching assertion to flip to fail.
+negative_control_exempt = true
+
 [env]
 CC = "$KACHE cc"
 

--- a/test-projects/exclude-c/kache-fixture.toml
+++ b/test-projects/exclude-c/kache-fixture.toml
@@ -6,6 +6,13 @@
 
 name = "exclude-c"
 
+# Exempt from `--negative-control`: this fixture's contract is a
+# negative — `max_entries_after = 0`, "kache caches nothing here"
+# (the source is excluded). That holds whether kache is excluding,
+# enabled, or disabled, so it legitimately still passes under
+# KACHE_DISABLED=1 — there is no caching assertion to flip to fail.
+negative_control_exempt = true
+
 [env]
 CC = "$KACHE cc"
 

--- a/test-projects/exclude-rust/kache-fixture.toml
+++ b/test-projects/exclude-rust/kache-fixture.toml
@@ -6,6 +6,13 @@
 
 name = "exclude-rust"
 
+# Exempt from `--negative-control`: this fixture's contract is a
+# negative — `max_entries_after = 0`, "kache caches nothing here"
+# (the source is excluded). That holds whether kache is excluding,
+# enabled, or disabled, so it legitimately still passes under
+# KACHE_DISABLED=1 — there is no caching assertion to flip to fail.
+negative_control_exempt = true
+
 [env]
 RUSTC_WRAPPER = "$KACHE"
 KACHE_CACHE_EXECUTABLES = "1"

--- a/test-projects/multi-dep/kache-fixture.toml
+++ b/test-projects/multi-dep/kache-fixture.toml
@@ -6,6 +6,12 @@
 
 name = "multi-dep"
 
+# Directly assert restored dep-info is path-expanded — this fixture's
+# dependency graph means several `.d` files get cached and restored.
+# Catches the #100 silent-restore bug without relying on the
+# `should_not_recompile` proxy.
+check_depinfo = true
+
 [env]
 RUSTC_WRAPPER = "$KACHE"
 # Wire CC/CXX too so any -sys crate that sneaks into the dep graph

--- a/test-projects/rust-c-ffi/kache-fixture.toml
+++ b/test-projects/rust-c-ffi/kache-fixture.toml
@@ -10,6 +10,12 @@
 
 name = "rust-c-ffi"
 
+# Directly assert restored dep-info is path-expanded — the Rust crates
+# here get their `.d` files cached and restored. Catches the #100
+# silent-restore bug without relying on the `should_not_recompile`
+# proxy.
+check_depinfo = true
+
 [env]
 RUSTC_WRAPPER = "$KACHE"
 CC  = "$KACHE cc"


### PR DESCRIPTION
## Summary

A test that cannot fail is decoration. This session found one — the `.d`-expand restore (#100) was silently broken on macOS, yet `relocate-noop`'s `should_not_recompile` still passed. This PR closes that gap two ways (grouped per request — one PR, not several):

### 1. Negative-control mode — `kache-e2e --negative-control`

Reruns every fixture with `KACHE_DISABLED=1` and asserts each result **flips to a failure**. A fixture whose caching assertions still pass with kache off has a *vacuous* test → reported `VACUOUS`, run exits non-zero. Wired into the `e2e` CI job as an independent step.

Negative-contract fixtures (`c-passthrough`, `exclude-c`, `exclude-rust` — their contract is "kache caches nothing here") legitimately still pass; they opt out via `negative_control_exempt = true`. The check itself flagged `exclude-c`/`exclude-rust` as needing the annotation — that *is* it working.

### 2. Direct dep-info assertion — `check_depinfo`

Replaces the `should_not_recompile` proxy with a *direct artifact* check: the harness scans every restored `.d` for kache's relativization sentinel (`./debug/` / `./release/`) — paths a real rustc `.d` never writes. A leftover means the restore-side path expansion silently failed (the #100 bug). Enabled on `multi-dep` and `rust-c-ffi`.

## Verified

- **Negative-control:** all 8 fixtures falsifiable — 5 flip to fail, 3 exempt pass.
- **`check_depinfo` falsifiability:** against `#102`-era (buggy) kache, `warm` *fails* (restored `.d` carries the sentinel); against current `main` (#103 fixed), every phase *passes*. It catches exactly the bug the proxy missed.
- Normal e2e: all 8 fixtures green.

## Test plan

- [x] `cargo test -p kache-e2e` — incl. new `inspect_restored_depinfo` tests
- [x] `cargo fmt` + `cargo clippy -p kache-e2e` clean
- [x] `kache-e2e --negative-control` — exit 0, every fixture falsifiable
- [x] normal e2e — all fixtures green, `depinfo_expanded` green on every cache-hit phase