### PR TITLE
Fix release metadata, binstall URLs, and doctor diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3335,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.0.0"
+version = "0.3.0"
 edition = "2024"
 description = "Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — just hardlinks locally and S3 for sharing."
 license = "Apache-2.0"
@@ -58,7 +58,7 @@ assert_cmd = "2"
 predicates = "3"
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/{ version }/{ name }-{ target }.tar.gz"
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"
 pkg-fmt = "tgz"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ kache is useful even before remote cache is configured:
 mise use -g github:kunobi-ninja/kache@latest
 
 # cargo (build from source)
-cargo install --git https://github.com/kunobi-ninja/kache
+cargo install --git https://github.com/kunobi-ninja/kache kache
 
 # cargo-binstall (downloads pre-built binary, requires cargo-binstall)
 cargo binstall --git https://github.com/kunobi-ninja/kache kache

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.0.0"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.0.0"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.0.0"
+version = "0.3.0"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -18,7 +18,7 @@ kache requires Rust 1.95 or later (it uses `let ... && let` chains and other rec
     mise use -g github:kunobi-ninja/kache@latest
 
     # or pin a specific version
-    mise use -g github:kunobi-ninja/kache@0.3.1
+    mise use -g github:kunobi-ninja/kache@0.3.0
     ```
 
     To pin kache in your project so every contributor gets the same version, add it to your `mise.toml`:
@@ -34,14 +34,14 @@ kache requires Rust 1.95 or later (it uses `let ... && let` chains and other rec
     [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) downloads the pre-built binary from GitHub releases without compiling.
 
     ```sh
-    cargo binstall kache
+    cargo binstall --git https://github.com/kunobi-ninja/kache kache
     ```
 
-    If a pre-built binary isn't available for your target, cargo-binstall falls back to compiling from source automatically.
+    If a pre-built binary isn't available for your target, use the source install method below.
   </Tab>
   <Tab value="from source">
     ```sh
-    cargo install --git https://github.com/kunobi-ninja/kache
+    cargo install --git https://github.com/kunobi-ninja/kache kache
     ```
 
     This compiles kache with your local toolchain. It takes a couple of minutes and supports macOS and Linux. Windows is not supported and fails compilation explicitly.
@@ -65,7 +65,7 @@ Pre-built binaries are available for:
 kache --version
 ```
 
-You should see a version string like `kache 0.3.1`. If the command isn't found, make sure the binary is on your `PATH` (mise handles this automatically).
+You should see a version string like `kache 0.3.0`. If the command isn't found, make sure the binary is on your `PATH` (mise handles this automatically).
 
 ## Next: enable kache for cargo
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11,8 +11,12 @@ fn kache_binary() -> PathBuf {
 }
 
 fn build_kache() {
+    // Bootstrap the binary under test without any configured wrapper. The wrapper
+    // behavior is exercised below by setting RUSTC_WRAPPER to this fresh binary.
     let status = std::process::Command::new("cargo")
-        .args(["build"])
+        .args(["build", "--config", "build.rustc-wrapper=\"\""])
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
         .status()
         .expect("failed to build kache");
     assert!(status.success(), "kache build failed");
@@ -21,6 +25,25 @@ fn build_kache() {
 fn isolated_config_path(cache_dir: &Path) -> PathBuf {
     // Prevent tests from inheriting the developer's real ~/.config/kache/config.toml.
     cache_dir.join("config.toml")
+}
+
+#[test]
+fn test_cli_version_matches_package_version() {
+    build_kache();
+    assert_ne!(
+        env!("CARGO_PKG_VERSION"),
+        "0.0.0",
+        "release builds must not use the placeholder package version"
+    );
+
+    Command::new(kache_binary())
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(format!(
+            "kache {}",
+            env!("CARGO_PKG_VERSION")
+        )));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Bump the kache workspace package versions from `0.0.0` to `0.3.0` so `kache --version` and Cargo install metadata report the released version.
- Point cargo-binstall metadata at `v{ version }` release tags, matching the GitHub release asset paths.
- Update install docs for this multi-package repository and add an integration test guarding against placeholder release versions.
- Teach `kache doctor` that a running `sccache` daemon is healthy when configured as `KACHE_FALLBACK` / `[cache].fallback`.
- Exclude Unix zombie processes from daemon liveness checks so doctor/restart do not treat defunct PIDs as live socket blockers.

## Root Cause

The GitHub release tags were versioned, but the Cargo package metadata still used `0.0.0`. `clap` reads `CARGO_PKG_VERSION` at build time, so git/source installs baked in `kache 0.0.0`. cargo-binstall also resolved that placeholder package version and could not install a matching crates.io package.

Separately, doctor still assumed any running `sccache` daemon was migration residue, even though kache now supports sccache as a fallback wrapper. Daemon process detection also used `kill(pid, 0)`, which reports Unix zombies as existing processes.

Fixes #44.
Fixes #52.

## Validation

- `cargo fmt --check`
- `cargo check --package kache --config 'build.rustc-wrapper=""'`
- `cargo test --test integration_test --config 'build.rustc-wrapper=""'`
- `cargo test --package kache sccache --config 'build.rustc-wrapper=""'`
- `cargo test --package kache process_stat_zombie_detection_uses_leading_state --config 'build.rustc-wrapper=""'`
- `env KACHE_FALLBACK=sccache cargo run --quiet --config 'build.rustc-wrapper=""' -- doctor` shows sccache as a passing fallback check
- `cargo run --quiet --config 'build.rustc-wrapper=""' -- --version` -> `kache 0.3.0`
- `cargo binstall --manifest-path /Users/lenij/zondax/kache-fix-issues-44-52/Cargo.toml kache --strategies crate-meta-data --root /private/tmp/kache-binstall-test --force --no-confirm` -> installed `kache 0.3.0`