### PR TITLE
Show passthrough reasons in monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ kache is useful even before remote cache is configured:
 
 ## Screenshots
 
-`kache monitor` — live cache dashboard (Build / Projects / Store / Transfer tabs):
+`kache monitor` — live cache dashboard (Build / Projects / Store / Transfer / Passthrough tabs):
 
 ![kache monitor TUI cycling through tabs against a populated cache](assets/monitor.gif)
 

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -56,7 +56,7 @@ If you'd rather wire things up manually, see [Quick start](/docs/getting-started
 kache monitor [--since <duration>]
 ```
 
-Opens the live TUI dashboard. `--since` controls how far back the build event log is read when the monitor starts. Defaults to showing all available events.
+Opens the live TUI dashboard. `--since` controls how far back the build event log is read when the monitor starts. Defaults to showing all available events. The Passthrough tab lists uncached invocations with their reason and fallback/direct route.
 
 ```sh
 kache monitor --since 24h

--- a/docs/monitor.mdx
+++ b/docs/monitor.mdx
@@ -7,12 +7,12 @@ description: Reading and using the live TUI dashboard.
 
 Running `kache` with no arguments (or `kache monitor`) opens a live TUI dashboard that shows what's happening in your cache in real time. It refreshes automatically and doesn't require the daemon to be running.
 
-![kache monitor TUI cycling through Build, Projects, Store, and Transfer tabs against a populated cache](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/monitor.gif)
+![kache monitor TUI cycling through Build, Projects, Store, Transfer, and Passthrough tabs against a populated cache](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/monitor.gif)
 
 Static layout for reference:
 
 ```text
- [1] Build   [2] Projects  [3] Store   [4] Transfer
+ [1] Build   [2] Projects  [3] Store   [4] Transfer   [5] Passthrough
 ┌ kache monitor ────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  Store: 45.0 GiB / 50.0 GiB [ 90.1%]    11004 entries                                                             │
 │  Hit rate: 61% count | 42% weighted | 79% miss-time    Remote: not configured                                     │
@@ -44,7 +44,7 @@ Static layout for reference:
 │                                                                                                                   │
 │                                                                                                                   │
 └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-  q: quit  f: filter  ↑↓: scroll  Tab: next  c: clear  1/2/3/4: tabs
+  q: quit  f: filter  ↑↓: scroll  Tab: next  c: clear  1-5: tabs
 ```
 
 ## Header
@@ -92,14 +92,18 @@ Press `f` to filter by crate name.
 
 A log of recent S3 uploads and downloads, with transfer rates and artifact sizes. Useful for verifying that the daemon is uploading new artifacts and that remote hits are flowing in correctly.
 
+### 5 — Passthrough
+
+A table of invocations kache passed through instead of caching. Each row shows the crate or source, whether the generic fallback path handled it, the exit code, and the reason kache declined to cache it.
+
 ## Keyboard shortcuts
 
 ```
 q           quit
 Tab         next tab
-1 / 2 / 3 / 4    switch to tab by number
+1 / 2 / 3 / 4 / 5    switch to tab by number
 ↑ / ↓       scroll
-f           filter (Build and Store tabs)
+f           filter (Build, Store, and Passthrough tabs)
 c           clear build event list (Build tab)
 r           refresh project list (Projects tab)
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,8 +30,8 @@ pub struct Config {
     /// behind a load balancer with an aggressive idle timeout that may drop
     /// connections silently.
     pub s3_pool_idle_secs: u64,
-    /// A secondary compiler-wrapper to hand passed-through compiles to
-    /// (e.g. `sccache`). When kache declines to cache a compile, it
+    /// A secondary compiler-wrapper to hand passed-through compiles to.
+    /// When kache declines to cache a compile, it
     /// runs `<fallback> <compiler> <args>` instead of the bare
     /// compiler — so the fallback gets a chance to cache what kache
     /// doesn't. `None` = plain passthrough. Set via `KACHE_FALLBACK`
@@ -77,8 +77,8 @@ pub(crate) struct CacheFileConfig {
     pub(crate) s3_concurrency: Option<u32>,
     pub(crate) daemon_idle_timeout_secs: Option<u64>,
     pub(crate) s3_pool_idle_secs: Option<u64>,
-    /// Secondary compiler-wrapper for passed-through compiles
-    /// (e.g. `"sccache"`). See [`Config::fallback`].
+    /// Secondary compiler-wrapper for passed-through compiles.
+    /// See [`Config::fallback`].
     pub(crate) fallback: Option<String>,
 }
 
@@ -262,9 +262,8 @@ impl Config {
             })
             .unwrap_or(DEFAULT_S3_POOL_IDLE_SECS);
 
-        // Fallback compiler-wrapper for passed-through compiles (e.g.
-        // sccache). Env wins over the file; empty / "off" / "none"
-        // disables it.
+        // Fallback compiler-wrapper for passed-through compiles. Env
+        // wins over the file; empty / "off" / "none" disables it.
         let fallback = std::env::var("KACHE_FALLBACK")
             .ok()
             .or_else(|| {

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -169,7 +169,7 @@ fn build_fields(file_config: &FileConfig, env: &EnvOverrides) -> Vec<FormField> 
             value: cache.and_then(|c| c.fallback.clone()).unwrap_or_default(),
             env_var: "KACHE_FALLBACK",
             env_value: env_val("KACHE_FALLBACK"),
-            default_hint: "(none — e.g. sccache)",
+            default_hint: "(none)",
             validation_error: None,
             env_locked: env.fallback,
         },

--- a/src/events.rs
+++ b/src/events.rs
@@ -24,7 +24,8 @@ pub struct BuildEvent {
     #[serde(default)]
     pub cache_key: String,
     /// Event schema version: 0 = legacy, 1 = prefetch-aware,
-    /// 2 = compile-cost-aware, 3 = op-count-aware, 4 = probe-count-aware.
+    /// 2 = compile-cost-aware, 3 = op-count-aware, 4 = probe-count-aware,
+    /// 5 = passthrough details.
     #[serde(default)]
     pub schema: u32,
     /// Cache key computation time (ms).
@@ -54,6 +55,19 @@ pub struct BuildEvent {
     /// records 0.
     #[serde(default)]
     pub probe_runs: u32,
+    /// Why kache passed the invocation through instead of caching it.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub passthrough_reason: String,
+    /// Whether a configured fallback wrapper handled the passthrough.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub fallback: bool,
+    /// Exit code from the passthrough command.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -65,6 +79,7 @@ pub enum EventResult {
     RemoteHit,
     Miss,
     Error,
+    Passthrough,
     Skipped,
 }
 
@@ -76,6 +91,7 @@ impl std::fmt::Display for EventResult {
             EventResult::RemoteHit => write!(f, "remote_hit"),
             EventResult::Miss => write!(f, "miss"),
             EventResult::Error => write!(f, "error"),
+            EventResult::Passthrough => write!(f, "passthrough"),
             EventResult::Skipped => write!(f, "skipped"),
         }
     }
@@ -386,7 +402,7 @@ pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
                 };
             }
             EventResult::Error => stats.errors += 1,
-            EventResult::Skipped => {}
+            EventResult::Passthrough | EventResult::Skipped => continue,
         }
         stats.total_size += event.size;
         stats.total_elapsed_ms += event.elapsed_ms;
@@ -420,7 +436,7 @@ mod tests {
             compile_time_ms,
             size,
             cache_key: cache_key.to_string(),
-            schema: 4,
+            schema: 5,
             key_ms: 0,
             lookup_ms: 0,
             restore_ms: 0,
@@ -428,6 +444,9 @@ mod tests {
             compiler_runs: 0,
             preprocessor_runs: 0,
             probe_runs: 0,
+            passthrough_reason: String::new(),
+            fallback: false,
+            exit_code: None,
         }
     }
 
@@ -445,7 +464,7 @@ mod tests {
             compile_time_ms: 250,
             size: 3145728,
             cache_key: "abc123".to_string(),
-            schema: 4,
+            schema: 5,
             key_ms: 0,
             lookup_ms: 0,
             restore_ms: 0,
@@ -453,6 +472,9 @@ mod tests {
             compiler_runs: 0,
             preprocessor_runs: 0,
             probe_runs: 0,
+            passthrough_reason: String::new(),
+            fallback: false,
+            exit_code: None,
         };
 
         log_event(&log_path, &event).unwrap();
@@ -525,6 +547,7 @@ mod tests {
         assert_eq!(EventResult::RemoteHit.to_string(), "remote_hit");
         assert_eq!(EventResult::Miss.to_string(), "miss");
         assert_eq!(EventResult::Error.to_string(), "error");
+        assert_eq!(EventResult::Passthrough.to_string(), "passthrough");
         assert_eq!(EventResult::Skipped.to_string(), "skipped");
     }
 
@@ -581,10 +604,11 @@ mod tests {
             test_event("d", EventResult::Miss, 1000, 950, 500, "k3"),
             test_event("e", EventResult::Error, 5, 0, 0, "k4"),
             test_event("f", EventResult::Skipped, 0, 0, 0, "k5"),
+            test_event("g", EventResult::Passthrough, 25, 0, 0, ""),
         ];
 
         let stats = compute_stats(&events);
-        assert_eq!(stats.total, 6);
+        assert_eq!(stats.total, 7);
         assert_eq!(stats.local_hits, 1);
         assert_eq!(stats.prefetch_hits, 1);
         assert_eq!(stats.remote_hits, 1);

--- a/src/report.rs
+++ b/src/report.rs
@@ -275,7 +275,7 @@ pub fn generate_report(config: &Config, hours: u64, top: usize) -> Result<BuildR
     // Build CrateDetail list
     let all_events: Vec<CrateDetail> = build_events
         .iter()
-        .filter(|e| !matches!(e.result, EventResult::Skipped))
+        .filter(|e| !matches!(e.result, EventResult::Skipped | EventResult::Passthrough))
         .map(to_crate_detail)
         .collect();
 
@@ -1639,7 +1639,7 @@ mod tests {
             compile_time_ms,
             size,
             cache_key: cache_key.to_string(),
-            schema: 4,
+            schema: 5,
             key_ms: 0,
             lookup_ms: 0,
             restore_ms: 0,
@@ -1647,6 +1647,9 @@ mod tests {
             compiler_runs: 0,
             preprocessor_runs: 0,
             probe_runs: 0,
+            passthrough_reason: String::new(),
+            fallback: false,
+            exit_code: None,
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -24,6 +24,7 @@ enum Tab {
     Projects,
     Store,
     Transfer,
+    Passthrough,
 }
 
 fn tab_needs_entries(tab: Tab) -> bool {
@@ -130,6 +131,7 @@ struct AppState {
 
     // Transfer tab
     transfer_scroll: usize,
+    passthrough_scroll: usize,
     prev_bytes_uploaded: u64,
     prev_bytes_downloaded: u64,
     upload_speed_bps: f64,
@@ -218,6 +220,7 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
         last_project_refresh: Instant::now(),
         project_scroll: 0,
         transfer_scroll: 0,
+        passthrough_scroll: 0,
         prev_bytes_uploaded: 0,
         prev_bytes_downloaded: 0,
         upload_speed_bps: 0.0,
@@ -399,6 +402,7 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
             state.last_stats_fetch = Instant::now() - SNAPSHOT_REFRESH_INTERVAL;
         }
         KeyCode::Char('4') => state.active_tab = Tab::Transfer,
+        KeyCode::Char('5') => state.active_tab = Tab::Passthrough,
         KeyCode::BackTab | KeyCode::Tab => match state.active_tab {
             Tab::Build => {
                 state.active_tab = Tab::Projects;
@@ -409,7 +413,8 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
                 state.last_stats_fetch = Instant::now() - SNAPSHOT_REFRESH_INTERVAL;
             }
             Tab::Store => state.active_tab = Tab::Transfer,
-            Tab::Transfer => state.active_tab = Tab::Build,
+            Tab::Transfer => state.active_tab = Tab::Passthrough,
+            Tab::Passthrough => state.active_tab = Tab::Build,
         },
         // Scrolling
         KeyCode::Up => match state.active_tab {
@@ -417,12 +422,16 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
             Tab::Projects => state.project_scroll = state.project_scroll.saturating_sub(1),
             Tab::Store => state.store_scroll = state.store_scroll.saturating_sub(1),
             Tab::Transfer => state.transfer_scroll = state.transfer_scroll.saturating_sub(1),
+            Tab::Passthrough => {
+                state.passthrough_scroll = state.passthrough_scroll.saturating_sub(1)
+            }
         },
         KeyCode::Down => match state.active_tab {
             Tab::Build => state.scroll_offset += 1,
             Tab::Projects => state.project_scroll += 1,
             Tab::Store => state.store_scroll += 1,
             Tab::Transfer => state.transfer_scroll += 1,
+            Tab::Passthrough => state.passthrough_scroll += 1,
         },
         // Build tab
         KeyCode::Char('f') if state.active_tab == Tab::Build => {
@@ -437,6 +446,9 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
             state.last_stats_fetch = Instant::now() - SNAPSHOT_REFRESH_INTERVAL;
         }
         KeyCode::Char('f') if state.active_tab == Tab::Store => {
+            state.filter_active = true;
+        }
+        KeyCode::Char('f') if state.active_tab == Tab::Passthrough => {
             state.filter_active = true;
         }
         // Projects tab: force refresh
@@ -466,6 +478,7 @@ fn draw_ui(frame: &mut Frame, state: &AppState) {
         Tab::Projects => draw_projects_tab(frame, state, chunks[1]),
         Tab::Store => draw_store_tab(frame, state, chunks[1]),
         Tab::Transfer => draw_transfer_tab(frame, state, chunks[1]),
+        Tab::Passthrough => draw_passthrough_tab(frame, state, chunks[1]),
     }
 }
 
@@ -488,6 +501,8 @@ fn draw_tab_bar(frame: &mut Frame, state: &AppState, area: Rect) {
         Span::styled("[3] Store ", style_for(Tab::Store)),
         Span::raw("  "),
         Span::styled("[4] Transfer ", style_for(Tab::Transfer)),
+        Span::raw("  "),
+        Span::styled("[5] Passthrough ", style_for(Tab::Passthrough)),
     ]);
     frame.render_widget(Paragraph::new(tabs), area);
 }
@@ -724,6 +739,7 @@ fn draw_live_build(frame: &mut Frame, state: &AppState, area: Rect) {
                 EventResult::RemoteHit => ("↓", Style::default().fg(Color::Blue)),
                 EventResult::Miss => ("✗", Style::default().fg(Color::Yellow)),
                 EventResult::Error => ("!", Style::default().fg(Color::Red)),
+                EventResult::Passthrough => ("→", Style::default().fg(Color::Magenta)),
                 EventResult::Skipped => ("→", Style::default().fg(Color::DarkGray)),
             };
 
@@ -797,7 +813,7 @@ fn draw_build_help(frame: &mut Frame, state: &AppState, area: Rect) {
     let help = if state.filter_active {
         format!("  filter: {}_ (Esc to close)", state.filter)
     } else {
-        "  q: quit  f: filter  ↑↓: scroll  Tab: next  c: clear  1/2/3/4: tabs".to_string()
+        "  q: quit  f: filter  ↑↓: scroll  Tab: next  c: clear  1-5: tabs".to_string()
     };
 
     let paragraph = Paragraph::new(help).style(Style::default().fg(Color::DarkGray));
@@ -957,7 +973,7 @@ fn draw_store_help(frame: &mut Frame, state: &AppState, area: Rect) {
     let help = if state.filter_active {
         format!("  filter: {}_ (Esc to close)", state.filter)
     } else {
-        "  q: quit  s: sort  f: filter  ↑↓: scroll  Tab: next  1/2/3/4: tabs".to_string()
+        "  q: quit  s: sort  f: filter  ↑↓: scroll  Tab: next  1-5: tabs".to_string()
     };
 
     let paragraph = Paragraph::new(help).style(Style::default().fg(Color::DarkGray));
@@ -1278,7 +1294,7 @@ fn draw_projects_totals(frame: &mut Frame, state: &AppState, area: Rect) {
 }
 
 fn draw_projects_help(frame: &mut Frame, area: Rect) {
-    let help = "  q: quit  r: refresh  ↑↓: scroll  Tab: next  1/2/3/4: tabs";
+    let help = "  q: quit  r: refresh  ↑↓: scroll  Tab: next  1-5: tabs";
 
     let paragraph = Paragraph::new(help).style(Style::default().fg(Color::DarkGray));
     frame.render_widget(paragraph, area);
@@ -1499,7 +1515,109 @@ fn draw_recent_transfers(frame: &mut Frame, state: &AppState, area: Rect) {
 }
 
 fn draw_transfer_help(frame: &mut Frame, area: Rect) {
-    let help = "  q: quit  ↑↓: scroll  Tab: next  1/2/3/4: tabs";
+    let help = "  q: quit  ↑↓: scroll  Tab: next  1-5: tabs";
+    let paragraph = Paragraph::new(help).style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(paragraph, area);
+}
+
+// ── Passthrough tab ───────────────────────────────────────────────────────
+
+fn draw_passthrough_tab(frame: &mut Frame, state: &AppState, area: Rect) {
+    let chunks = Layout::vertical([
+        Constraint::Min(5),    // Passthrough table
+        Constraint::Length(1), // Help bar
+    ])
+    .split(area);
+
+    draw_passthrough_table(frame, state, chunks[0]);
+    draw_passthrough_help(frame, state, chunks[1]);
+}
+
+fn draw_passthrough_table(frame: &mut Frame, state: &AppState, area: Rect) {
+    let events: Vec<&BuildEvent> = state
+        .events
+        .iter()
+        .filter(|event| matches!(event.result, EventResult::Passthrough))
+        .filter(|event| {
+            state.filter.is_empty()
+                || event.crate_name.contains(&state.filter)
+                || event.passthrough_reason.contains(&state.filter)
+        })
+        .collect();
+
+    let block = Block::bordered()
+        .title(format!(" Passthroughs ({}) ", events.len()))
+        .border_style(Style::default().fg(Color::Cyan));
+
+    if events.is_empty() {
+        let msg = if state.filter.is_empty() {
+            "  No passthroughs yet"
+        } else {
+            "  No passthroughs match the filter"
+        };
+        frame.render_widget(Paragraph::new(msg).block(block), area);
+        return;
+    }
+
+    let header = Row::new(vec!["Time", "Crate", "Route", "Exit", "Reason"])
+        .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let visible_rows = (area.height as usize).saturating_sub(3);
+    let skip = state
+        .passthrough_scroll
+        .min(events.len().saturating_sub(visible_rows));
+
+    let rows: Vec<Row> = events
+        .iter()
+        .rev()
+        .skip(skip)
+        .take(visible_rows)
+        .map(|event| {
+            let exit = event
+                .exit_code
+                .map(|code| code.to_string())
+                .unwrap_or_default();
+            let route = if event.fallback { "fallback" } else { "direct" };
+            let reason = if event.passthrough_reason.is_empty() {
+                "unknown"
+            } else {
+                &event.passthrough_reason
+            };
+
+            let exit_style = match event.exit_code {
+                Some(0) => Style::default().fg(Color::Green),
+                Some(_) => Style::default().fg(Color::Red),
+                None => Style::default().fg(Color::DarkGray),
+            };
+
+            Row::new(vec![
+                Cell::from(event.ts.format("%H:%M:%S").to_string()),
+                Cell::from(event.crate_name.clone()),
+                Cell::from(route).style(Style::default().fg(Color::Magenta)),
+                Cell::from(exit).style(exit_style),
+                Cell::from(reason.to_string()),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(9),
+        Constraint::Min(18),
+        Constraint::Length(10),
+        Constraint::Length(6),
+        Constraint::Percentage(45),
+    ];
+
+    let table = Table::new(rows, widths).header(header).block(block);
+    frame.render_widget(table, area);
+}
+
+fn draw_passthrough_help(frame: &mut Frame, state: &AppState, area: Rect) {
+    let help = if state.filter_active {
+        format!("  filter: {}_ (Esc to close)", state.filter)
+    } else {
+        "  q: quit  f: filter  ↑↓: scroll  Tab: next  1-5: tabs".to_string()
+    };
     let paragraph = Paragraph::new(help).style(Style::default().fg(Color::DarkGray));
     frame.render_widget(paragraph, area);
 }
@@ -1514,5 +1632,6 @@ mod tests {
         assert!(!tab_needs_entries(Tab::Projects));
         assert!(tab_needs_entries(Tab::Store));
         assert!(!tab_needs_entries(Tab::Transfer));
+        assert!(!tab_needs_entries(Tab::Passthrough));
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -44,6 +44,7 @@ fn print_progress(crate_name: &str, result: EventResult, elapsed_ms: u64, size: 
         EventResult::Miss if level < 2 => return,
         EventResult::Miss => "miss",
         EventResult::Error => "error",
+        EventResult::Passthrough => return,
         EventResult::Skipped => return,
     };
 
@@ -110,6 +111,15 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         .parse(wrapper_args)
         .context("parsing cc-family arguments")?;
 
+    // The crate-name slot in events / metadata is the source file
+    // name for cc — the closest analogue to rustc's crate name.
+    let crate_name = parsed
+        .sources
+        .first()
+        .and_then(|s| s.file_name())
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "unknown".to_string());
+
     // Refuse-to-cache check: non-empty = this invocation isn't a
     // cacheable single-source `-c` compile (link mode, multi-arch,
     // PCH, modules, etc. — see CcArgs::refuse_reasons). Passthrough.
@@ -121,17 +131,14 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             compiler.kind(),
             reasons.join("; ")
         );
-        return cc_passthrough(&parsed, config.fallback.as_deref());
+        return cc_passthrough_with_event(
+            config,
+            &parsed,
+            &crate_name,
+            start,
+            format!("refused: {}", reasons.join("; ")),
+        );
     }
-
-    // The crate-name slot in events / metadata is the source file
-    // name for cc — the closest analogue to rustc's crate name.
-    let crate_name = parsed
-        .sources
-        .first()
-        .and_then(|s| s.file_name())
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "unknown".to_string());
 
     let current_dir = std::env::current_dir().ok();
     let exclude_roots: Vec<_> = current_dir.iter().cloned().collect();
@@ -139,28 +146,26 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         && Config::source_excluded(source, &exclude_roots)
     {
         tracing::debug!("cc source excluded from cache: {}", source.display());
-        let elapsed = start.elapsed().as_millis() as u64;
-        log_event(
+        return cc_passthrough_with_event(
             config,
+            &parsed,
             &crate_name,
-            EventResult::Skipped,
-            elapsed,
-            0,
-            0,
-            "",
-            0,
-            0,
-            0,
-            0,
+            start,
+            format!("source excluded: {}", source.display()),
         );
-        return cc_passthrough(&parsed, config.fallback.as_deref());
     }
 
     let store = match Store::open(config) {
         Ok(store) => store,
         Err(e) => {
             tracing::warn!("failed to open store for cc: {}", e);
-            return cc_passthrough(&parsed, config.fallback.as_deref());
+            return cc_passthrough_with_event(
+                config,
+                &parsed,
+                &crate_name,
+                start,
+                format!("store unavailable: {e}"),
+            );
         }
     };
 
@@ -184,7 +189,13 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                 crate_name,
                 e
             );
-            return cc_passthrough(&parsed, config.fallback.as_deref());
+            return cc_passthrough_with_event(
+                config,
+                &parsed,
+                &crate_name,
+                start,
+                format!("cache key failed: {e}"),
+            );
         }
     };
     let key_ms = key_start.elapsed().as_millis() as u64;
@@ -297,17 +308,20 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
 /// Run a cc-family invocation without caching — invoke the compiler
 /// with the original argv, propagate stdout / stderr / exit.
-fn cc_passthrough(parsed: &crate::compiler::cc::CcArgs, fallback: Option<&str>) -> Result<i32> {
-    // Configured fallback wrapper (e.g. sccache): `<fallback> <cc>
-    // <args>`. kache's C/C++ coverage is narrower than its rustc
-    // support, so the fallback is most valuable on this path. Falls
-    // through to a plain passthrough if the fallback is not on PATH.
+fn cc_passthrough(
+    parsed: &crate::compiler::cc::CcArgs,
+    fallback: Option<&str>,
+) -> Result<PassthroughOutput> {
+    // Configured fallback wrapper: `<fallback> <cc> <args>`.
+    // kache's C/C++ coverage is narrower than its rustc support, so
+    // the fallback is most valuable on this path. Falls through to a
+    // plain passthrough if the fallback is not on PATH.
     if let Some(fb) = fallback {
         let mut cmd = std::process::Command::new(fb);
         cmd.arg(&parsed.program);
         cmd.args(&parsed.rest);
-        if let Some(code) = run_fallback(cmd, fb)? {
-            return Ok(code);
+        if let Some(output) = run_fallback(cmd, fb)? {
+            return Ok(output);
         }
     }
 
@@ -319,7 +333,10 @@ fn cc_passthrough(parsed: &crate::compiler::cc::CcArgs, fallback: Option<&str>) 
     if !result.stderr.is_empty() {
         eprint!("{}", result.stderr);
     }
-    Ok(result.exit_code)
+    Ok(PassthroughOutput {
+        exit_code: result.exit_code,
+        fallback: false,
+    })
 }
 
 /// Restore a cached cc object file to the invocation's `-o` target.
@@ -406,6 +423,8 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         );
     }
 
+    let crate_name = args.crate_name.as_deref().unwrap_or("unknown");
+
     // Bypass the cache when the compiler tells us we can't safely cache this
     // invocation (today: only NotPrimary; future: response files, coverage,
     // time macros, etc.).
@@ -417,10 +436,15 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             compiler.kind(),
             reasons.join("; ")
         );
-        return passthrough(&args, config.fallback.as_deref());
+        return passthrough_with_event(
+            config,
+            &args,
+            crate_name,
+            start,
+            format!("refused: {}", reasons.join("; ")),
+        );
     }
 
-    let crate_name = args.crate_name.as_deref().unwrap_or("unknown");
     let current_dir = std::env::current_dir().ok();
     let workspace_root = args.workspace_root().or_else(|| current_dir.clone());
     let exclude_roots: Vec<_> = workspace_root
@@ -433,21 +457,13 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         && Config::source_excluded(source, &exclude_roots)
     {
         tracing::debug!("rustc source excluded from cache: {}", source.display());
-        let elapsed = start.elapsed().as_millis() as u64;
-        log_event(
+        return passthrough_with_event(
             config,
+            &args,
             crate_name,
-            EventResult::Skipped,
-            elapsed,
-            0,
-            0,
-            "",
-            0,
-            0,
-            0,
-            0,
+            start,
+            format!("source excluded: {}", source.display()),
         );
-        return passthrough(&args, config.fallback.as_deref());
     }
 
     // Skip-cache only for *user-facing* executables (`bin` / `--test`).
@@ -459,20 +475,13 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // that broke downstream cache keys via `extern:` hashes.
     if args.is_user_facing_executable() && !config.cache_executables {
         tracing::debug!("skipping cache for user-facing executable: {}", crate_name);
-        log_event(
+        return passthrough_with_event(
             config,
+            &args,
             crate_name,
-            EventResult::Skipped,
-            0,
-            0,
-            0,
-            "",
-            0,
-            0,
-            0,
-            0,
+            start,
+            "user-facing executable (cache_executables=false)",
         );
-        return passthrough(&args, config.fallback.as_deref());
     }
 
     // Compute the cache key
@@ -494,7 +503,13 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         Ok(key) => key,
         Err(e) => {
             tracing::warn!("failed to compute cache key for {}: {}", crate_name, e);
-            return passthrough(&args, config.fallback.as_deref());
+            return passthrough_with_event(
+                config,
+                &args,
+                crate_name,
+                start,
+                format!("cache key failed: {e}"),
+            );
         }
     };
     let key_ms = key_start.elapsed().as_millis() as u64;
@@ -503,7 +518,9 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     let store = match store {
         Some(store) => store,
-        None => return passthrough(&args, config.fallback.as_deref()),
+        None => {
+            return passthrough_with_event(config, &args, crate_name, start, "store unavailable");
+        }
     };
 
     // 1. Check local store
@@ -645,7 +662,13 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             // If waiting failed, fall through to compile
             tracing::warn!("wait for {} failed, compiling ourselves", crate_name);
             // Compile without caching
-            return passthrough(&args, config.fallback.as_deref());
+            return passthrough_with_event(
+                config,
+                &args,
+                crate_name,
+                start,
+                "build lock wait failed",
+            );
         }
     };
 
@@ -936,17 +959,26 @@ fn restore_from_cache(
     Ok(())
 }
 
-/// Run a configured fallback compiler-wrapper (e.g. `sccache`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PassthroughOutput {
+    exit_code: i32,
+    fallback: bool,
+}
+
+/// Run a configured fallback compiler-wrapper.
 ///
 /// `cmd` is the fully-built `<fallback> <compiler> <args...>` command.
-/// Returns `Some(exit_code)` if the fallback ran; returns `None` — so
+/// Returns `Some(output)` if the fallback ran; returns `None` — so
 /// the caller does a plain passthrough — when the fallback binary is
 /// not found on `PATH`. A misconfigured fallback must never fail a
 /// build, so `NotFound` degrades gracefully; any other spawn error
 /// propagates.
-fn run_fallback(mut cmd: std::process::Command, name: &str) -> Result<Option<i32>> {
+fn run_fallback(mut cmd: std::process::Command, name: &str) -> Result<Option<PassthroughOutput>> {
     match cmd.status() {
-        Ok(status) => Ok(Some(status.code().unwrap_or(1))),
+        Ok(status) => Ok(Some(PassthroughOutput {
+            exit_code: status.code().unwrap_or(1),
+            fallback: true,
+        })),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             tracing::warn!(
                 "[kache] fallback wrapper `{}` not found on PATH — plain passthrough",
@@ -965,7 +997,7 @@ fn run_fallback(mut cmd: std::process::Command, name: &str) -> Result<Option<i32
 /// so the fallback gets a chance. Even on the plain passthrough path,
 /// we strip incremental flags to prevent APFS-related corruption in
 /// git worktrees on macOS.
-fn passthrough(args: &RustcArgs, fallback: Option<&str>) -> Result<i32> {
+fn passthrough(args: &RustcArgs, fallback: Option<&str>) -> Result<PassthroughOutput> {
     let filtered = compile::strip_incremental_flags(&args.all_args);
     let stripped = args.all_args.len() - filtered.len();
     if stripped > 0 {
@@ -976,9 +1008,9 @@ fn passthrough(args: &RustcArgs, fallback: Option<&str>) -> Result<i32> {
         );
     }
 
-    // Configured fallback wrapper (e.g. sccache): `<fallback> <rustc>
-    // [<inner-rustc>] <args>`. Falls through to a plain passthrough if
-    // the fallback binary is not on PATH.
+    // Configured fallback wrapper: `<fallback> <rustc> [<inner-rustc>]
+    // <args>`. Falls through to a plain passthrough if the fallback
+    // binary is not on PATH.
     if let Some(fb) = fallback {
         let mut cmd = std::process::Command::new(fb);
         cmd.env("CARGO_INCREMENTAL", "0");
@@ -987,8 +1019,8 @@ fn passthrough(args: &RustcArgs, fallback: Option<&str>) -> Result<i32> {
             cmd.arg(inner);
         }
         cmd.args(&filtered);
-        if let Some(code) = run_fallback(cmd, fb)? {
-            return Ok(code);
+        if let Some(output) = run_fallback(cmd, fb)? {
+            return Ok(output);
         }
     }
 
@@ -1002,7 +1034,46 @@ fn passthrough(args: &RustcArgs, fallback: Option<&str>) -> Result<i32> {
     let status = cmd
         .status()
         .with_context(|| format!("executing {}", args.rustc.display()))?;
-    Ok(status.code().unwrap_or(1))
+    Ok(PassthroughOutput {
+        exit_code: status.code().unwrap_or(1),
+        fallback: false,
+    })
+}
+
+fn passthrough_with_event<R: Into<String>>(
+    config: &Config,
+    args: &RustcArgs,
+    crate_name: &str,
+    start: std::time::Instant,
+    reason: R,
+) -> Result<i32> {
+    let output = passthrough(args, config.fallback.as_deref())?;
+    log_passthrough_event(
+        config,
+        crate_name,
+        start.elapsed().as_millis() as u64,
+        reason.into(),
+        &output,
+    );
+    Ok(output.exit_code)
+}
+
+fn cc_passthrough_with_event<R: Into<String>>(
+    config: &Config,
+    parsed: &crate::compiler::cc::CcArgs,
+    crate_name: &str,
+    start: std::time::Instant,
+    reason: R,
+) -> Result<i32> {
+    let output = cc_passthrough(parsed, config.fallback.as_deref())?;
+    log_passthrough_event(
+        config,
+        crate_name,
+        start.elapsed().as_millis() as u64,
+        reason.into(),
+        &output,
+    );
+    Ok(output.exit_code)
 }
 
 /// Log a build event.
@@ -1019,6 +1090,66 @@ fn log_event(
     restore_ms: u64,
     store_ms: u64,
 ) {
+    log_event_details(
+        config,
+        crate_name,
+        result,
+        elapsed_ms,
+        compile_time_ms,
+        size,
+        cache_key,
+        key_ms,
+        lookup_ms,
+        restore_ms,
+        store_ms,
+        String::new(),
+        false,
+        None,
+    );
+}
+
+fn log_passthrough_event(
+    config: &Config,
+    crate_name: &str,
+    elapsed_ms: u64,
+    reason: String,
+    output: &PassthroughOutput,
+) {
+    log_event_details(
+        config,
+        crate_name,
+        EventResult::Passthrough,
+        elapsed_ms,
+        0,
+        0,
+        "",
+        0,
+        0,
+        0,
+        0,
+        reason,
+        output.fallback,
+        Some(output.exit_code),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn log_event_details(
+    config: &Config,
+    crate_name: &str,
+    result: EventResult,
+    elapsed_ms: u64,
+    compile_time_ms: u64,
+    size: u64,
+    cache_key: &str,
+    key_ms: u64,
+    lookup_ms: u64,
+    restore_ms: u64,
+    store_ms: u64,
+    passthrough_reason: String,
+    fallback: bool,
+    exit_code: Option<i32>,
+) {
     let event = BuildEvent {
         ts: Utc::now(),
         crate_name: crate_name.to_string(),
@@ -1028,7 +1159,7 @@ fn log_event(
         compile_time_ms,
         size,
         cache_key: cache_key.to_string(),
-        schema: 4,
+        schema: 5,
         key_ms,
         lookup_ms,
         restore_ms,
@@ -1038,6 +1169,9 @@ fn log_event(
         compiler_runs: crate::opcounts::compiler_runs(),
         preprocessor_runs: crate::opcounts::preprocessor_runs(),
         probe_runs: crate::opcounts::probe_runs(),
+        passthrough_reason,
+        fallback,
+        exit_code,
     };
     let _ = events::log_event(&config.event_log_path(), &event);
     let _ = events::rotate_if_needed(
@@ -1279,6 +1413,12 @@ mod tests {
         // `true` exists on every unix and exits 0 — the fallback ran,
         // so its exit code is returned.
         let cmd = std::process::Command::new("true");
-        assert!(matches!(run_fallback(cmd, "true"), Ok(Some(0))));
+        assert!(matches!(
+            run_fallback(cmd, "true"),
+            Ok(Some(PassthroughOutput {
+                exit_code: 0,
+                fallback: true
+            }))
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- log explicit `passthrough` build events with reason, fallback/direct route, and exit code
- show passthroughs in the live Build tab and a new `[5] Passthrough` monitor tab
- update monitor docs and keep fallback wording generic

## Validation
- `cargo fmt`
- `cargo test --package kache events --config build.rustc-wrapper=""`
- `cargo test --package kache wrapper --config build.rustc-wrapper=""`
- `cargo check --package kache --config build.rustc-wrapper=""`
- `cargo test --package kache --config build.rustc-wrapper=""`
- `cargo test --package kache tui --config build.rustc-wrapper=""`