### PR TITLE
Handle stale daemon service upgrades

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1877,19 +1877,18 @@ pub fn doctor(
     //     the current `kache`, the daemon will relaunch the wrong binary.
     if let Some(service_path) = crate::service::service_file_path()
         && service_path.exists()
+        && let Some(mismatch) = crate::service::service_exe_mismatch(&service_path)
     {
-        if let Some(mismatch) = crate::service::service_exe_mismatch(&service_path) {
-            checks.push(Check {
-                label: "Service exe",
-                pass: false,
-                detail: format!(
-                    "plist points to {} but current exe is {}",
-                    mismatch.installed.display(),
-                    mismatch.current.display()
-                ),
-                fix: Some("kache daemon install  (re-registers against current binary)".into()),
-            });
-        }
+        checks.push(Check {
+            label: "Service exe",
+            pass: false,
+            detail: format!(
+                "plist points to {} but current exe is {}",
+                mismatch.installed.display(),
+                mismatch.current.display()
+            ),
+            fix: Some("kache daemon install  (re-registers against current binary)".into()),
+        });
     }
 
     // Print

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1824,6 +1824,23 @@ pub fn doctor(
                         .into(),
                 ),
             });
+        } else if pids.len() > 1 {
+            let pids_str = pids
+                .iter()
+                .map(|p| p.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            checks.push(Check {
+                label: "Daemon processes",
+                pass: false,
+                detail: format!(
+                    "{} daemon processes running (pid {pids_str}), expected 1",
+                    pids.len()
+                ),
+                fix: Some(
+                    "kache daemon restart  (keeps one daemon and removes stale processes)".into(),
+                ),
+            });
         }
     }
 
@@ -1861,20 +1878,14 @@ pub fn doctor(
     if let Some(service_path) = crate::service::service_file_path()
         && service_path.exists()
     {
-        let current_exe = std::env::current_exe()
-            .ok()
-            .and_then(|p| p.canonicalize().ok());
-        let installed_exe = crate::service::parse_exe_from_service_file(&service_path);
-        if let (Some(current), Some(installed)) = (current_exe, installed_exe)
-            && current != installed
-        {
+        if let Some(mismatch) = crate::service::service_exe_mismatch(&service_path) {
             checks.push(Check {
                 label: "Service exe",
                 pass: false,
                 detail: format!(
                     "plist points to {} but current exe is {}",
-                    installed.display(),
-                    current.display()
+                    mismatch.installed.display(),
+                    mismatch.current.display()
                 ),
                 fix: Some("kache daemon install  (re-registers against current binary)".into()),
             });
@@ -3456,10 +3467,22 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
     // ── Step 2: daemon service ───────────────────────────────────
     let service_path = crate::service::service_file_path();
     let service_installed = service_path.as_ref().is_some_and(|p| p.exists());
+    let service_mismatch = service_path
+        .as_deref()
+        .filter(|p| p.exists())
+        .and_then(crate::service::service_exe_mismatch);
     let mut service_action_taken = false;
 
     if no_service {
         println!("  \x1b[33m→\x1b[0m skipping service install (--no-service)");
+    } else if let Some(mismatch) = service_mismatch {
+        println!("  \x1b[33m→\x1b[0m update daemon service to current kache binary");
+        println!("    installed: {}", mismatch.installed.display());
+        println!("    current:   {}", mismatch.current.display());
+        if !check && prompt_yes_no("Update service?", true, yes)? {
+            crate::service::install()?;
+            service_action_taken = true;
+        }
     } else if service_installed {
         println!(
             "  \x1b[32m✓\x1b[0m daemon service already installed at {}",

--- a/src/service.rs
+++ b/src/service.rs
@@ -504,14 +504,14 @@ pub fn status() -> Result<()> {
     }
 
     // 6. Exe path mismatch warning
-    if let Some(ref path) = installed_service_path {
-        if let Some(mismatch) = service_exe_mismatch(path) {
-            println!();
-            println!("  \x1b[33mWarning: installed exe differs from current exe\x1b[0m");
-            println!("    installed: {}", mismatch.installed.display());
-            println!("    current:   {}", mismatch.current.display());
-            println!("    run `kache daemon install` to update");
-        }
+    if let Some(ref path) = installed_service_path
+        && let Some(mismatch) = service_exe_mismatch(path)
+    {
+        println!();
+        println!("  \x1b[33mWarning: installed exe differs from current exe\x1b[0m");
+        println!("    installed: {}", mismatch.installed.display());
+        println!("    current:   {}", mismatch.current.display());
+        println!("    run `kache daemon install` to update");
     }
 
     println!();

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const LABEL: &str = "ninja.kunobi.kache";
 const PLIST_NAME: &str = "ninja.kunobi.kache.plist";
@@ -56,6 +56,36 @@ fn stop_launchd_service(uid: u32, label: &str, plist: &std::path::Path) {
         let _ = std::process::Command::new("launchctl")
             .args(["unload", &plist.display().to_string()])
             .output();
+    }
+}
+
+fn launchd_service_registered(uid: u32) -> bool {
+    std::process::Command::new("launchctl")
+        .args(["print", &format!("gui/{uid}/{LABEL}")])
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServiceExeMismatch {
+    pub installed: PathBuf,
+    pub current: PathBuf,
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+pub(crate) fn service_exe_mismatch(path: &Path) -> Option<ServiceExeMismatch> {
+    let installed = parse_exe_from_service_file(path)?;
+    let current = std::env::current_exe()
+        .ok()
+        .map(|p| canonical_or_original(&p))?;
+
+    if canonical_or_original(&installed) == current {
+        None
+    } else {
+        Some(ServiceExeMismatch { installed, current })
     }
 }
 
@@ -156,17 +186,32 @@ fn install_launchd(exe: &std::path::Path) -> Result<()> {
 
     match bootstrap {
         Ok(out) if out.status.success() => {}
-        _ => {
+        bootstrap_result => {
             // Fallback to legacy load
             let load = std::process::Command::new("launchctl")
                 .args(["load", "-w", &plist.display().to_string()])
                 .output()
                 .context("running launchctl load")?;
             if !load.status.success() {
+                let bootstrap_stderr = bootstrap_result
+                    .as_ref()
+                    .ok()
+                    .map(|out| String::from_utf8_lossy(&out.stderr).trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_else(|| "launchctl bootstrap failed".to_string());
                 let stderr = String::from_utf8_lossy(&load.stderr);
-                anyhow::bail!("launchctl load failed: {stderr}");
+                anyhow::bail!(
+                    "launchctl bootstrap failed: {bootstrap_stderr}; launchctl load failed: {stderr}"
+                );
             }
         }
+    }
+
+    if !launchd_service_registered(uid) {
+        anyhow::bail!(
+            "launchctl did not register {LABEL}; try running `launchctl bootstrap gui/{uid} {}`",
+            plist.display()
+        );
     }
 
     println!("Service installed and started.");
@@ -460,18 +505,11 @@ pub fn status() -> Result<()> {
 
     // 6. Exe path mismatch warning
     if let Some(ref path) = installed_service_path {
-        let current_exe = std::env::current_exe()
-            .ok()
-            .and_then(|p| p.canonicalize().ok());
-        let installed_exe = parse_exe_from_service_file(path);
-
-        if let (Some(current), Some(installed)) = (current_exe, installed_exe)
-            && current != installed
-        {
+        if let Some(mismatch) = service_exe_mismatch(path) {
             println!();
             println!("  \x1b[33mWarning: installed exe differs from current exe\x1b[0m");
-            println!("    installed: {}", installed.display());
-            println!("    current:   {}", current.display());
+            println!("    installed: {}", mismatch.installed.display());
+            println!("    current:   {}", mismatch.current.display());
             println!("    run `kache daemon install` to update");
         }
     }
@@ -543,6 +581,28 @@ pub fn log() -> Result<()> {
 mod tests {
     use super::*;
     use std::fs;
+
+    fn write_service_file(path: &Path, exe: &Path) {
+        if cfg!(target_os = "macos") {
+            let content = format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{}</string>
+        <string>daemon</string>
+        <string>run</string>
+    </array>
+</dict>
+</plist>"#,
+                exe.display()
+            );
+            fs::write(path, content).unwrap();
+        } else if cfg!(target_os = "linux") {
+            fs::write(path, format!("ExecStart={} daemon run\n", exe.display())).unwrap();
+        }
+    }
 
     #[test]
     fn test_plist_path() {
@@ -637,6 +697,39 @@ WantedBy=default.target
 
         let result = parse_exe_from_service_file(&file);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_service_exe_mismatch_accepts_current_exe() {
+        if !(cfg!(target_os = "macos") || cfg!(target_os = "linux")) {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let service_file = dir.path().join("service");
+        let current = std::env::current_exe().unwrap();
+        write_service_file(&service_file, &current);
+
+        assert_eq!(service_exe_mismatch(&service_file), None);
+    }
+
+    #[test]
+    fn test_service_exe_mismatch_detects_stale_exe() {
+        if !(cfg!(target_os = "macos") || cfg!(target_os = "linux")) {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let service_file = dir.path().join("service");
+        let stale = dir.path().join("old-kache");
+        write_service_file(&service_file, &stale);
+
+        let mismatch = service_exe_mismatch(&service_file).unwrap();
+        assert_eq!(mismatch.installed, stale);
+        assert_eq!(
+            mismatch.current,
+            canonical_or_original(&std::env::current_exe().unwrap())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- detect daemon service files that point at a stale kache binary
- let `kache init` update the service to the current binary
- improve doctor/status reporting for stale services and multiple daemon processes
- verify launchd registration after install and report clearer bootstrap/load failures

## Validation
- `cargo fmt --check`
- `env -u RUSTC_WRAPPER cargo test service_exe_mismatch`

Note: the first test run with local `RUSTC_WRAPPER=kache` failed before compiling due to a readonly cache database, so validation was rerun with the wrapper disabled.