### PR TITLE
fix(cache-key): exclude `-Clinker=<path>` from the key (v6 -> v7)

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -31,7 +31,16 @@ use std::path::{Path, PathBuf};
 /// `DW_AT_comp_dir` (rustc records the raw CWD there). Debug builds
 /// previously leaked the build path through `comp_dir`; the remapped
 /// output is byte-incompatible with v5, so the bump invalidates it.
-const CACHE_KEY_VERSION: u32 = 6;
+///
+/// v7: `-Clinker=<path>` is no longer part of the key. mozbuild (and any
+/// build that points rustc at a bootstrapped toolchain) sets
+/// `-Clinker=/abs/path/to/clang++`, which previously baked the
+/// machine-local path into the key — every clone produced a distinct
+/// key for the same crate (Firefox bench measured 0.2% cross-clone key
+/// stability). The linker's *identity* is still hashed via
+/// `linker:<--version output>` (see `get_linker_identity`), which is
+/// path-independent. Existing v6 entries become unreachable.
+const CACHE_KEY_VERSION: u32 = 7;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
 /// Compute the blake3 cache key for a rustc invocation.
@@ -130,7 +139,13 @@ pub fn compute_cache_key(
         .iter()
         .filter(|(k, _)| {
             // Skip incremental as it's path-dependent.
-            k != "incremental"
+            // Skip linker because its value is a machine-local absolute
+            // path on toolchain-bootstrapping builds (Firefox/mozbuild
+            // sets `-Clinker=/abs/path/to/clang++`). The linker's
+            // semantic identity is captured separately via
+            // `get_linker_identity` (its `--version` output) which is
+            // path-independent.
+            k != "incremental" && k != "linker"
         })
         .collect();
     codegen_opts.sort_by_key(|(k, _)| k.as_str());
@@ -1179,6 +1194,44 @@ mod tests {
         let key1 = compute_cache_key(&parsed1, &fh, &pn).unwrap();
         let key2 = compute_cache_key(&parsed2, &fh, &pn).unwrap();
         assert_eq!(key1, key2);
+    }
+
+    /// Regression for Finding B from the Firefox bench: mozbuild sets
+    /// `-Clinker=/abs/path/to/clang++`, and v6 baked that path into the
+    /// key — every clone hashed differently. The linker's semantic
+    /// identity is still captured via `linker:<--version>` so the key
+    /// stays sensitive to a different toolchain.
+    #[test]
+    fn cache_key_ignores_linker_path() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+
+        let mk = |linker: &str| -> Vec<String> {
+            vec![
+                "rustc".to_string(),
+                "--crate-name".to_string(),
+                "mylib".to_string(),
+                source.to_string_lossy().to_string(),
+                "--crate-type".to_string(),
+                "lib".to_string(),
+                "-C".to_string(),
+                format!("linker={linker}"),
+            ]
+        };
+
+        let fh = FileHasher::new();
+        let pn = PathNormalizer::empty();
+        let a = compute_cache_key(&RustcArgs::parse(&mk("/Users/alice/clang++")).unwrap(), &fh, &pn)
+            .unwrap();
+        let b = compute_cache_key(
+            &RustcArgs::parse(&mk("/home/runner/clang++")).unwrap(),
+            &fh,
+            &pn,
+        )
+        .unwrap();
+        assert_eq!(a, b, "linker path must not affect the cache key");
     }
 
     #[test]

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -1,5 +1,5 @@
 use crate::args::RustcArgs;
-use crate::path_normalizer::PathNormalizer;
+use crate::path_normalizer::{PathNormalizer, check_for_path_leak};
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, params};
 use std::cell::{Cell, RefCell};
@@ -77,6 +77,10 @@ pub fn compute_cache_key(
         .target
         .as_deref()
         .unwrap_or_else(|| host_target_triple());
+    // `--target=` can be a path to a custom target JSON spec (Firefox /
+    // embedded toolchains do this) — flag any absolute machine-local path
+    // that lands here unsentinelized.
+    check_for_path_leak(target, "target");
     hasher.update(b"target:");
     hasher.update(target.as_bytes());
     hasher.update(b"\n");
@@ -134,6 +138,11 @@ pub fn compute_cache_key(
         hasher.update(b"codegen:");
         hasher.update(key.as_bytes());
         if let Some(v) = value {
+            // `-Clink-arg=`, `-Clink-args=…`, `-Cprofile-use=…`, etc. can
+            // carry absolute paths. None of these go through
+            // PathNormalizer (they're rustc-controlled flags, not env);
+            // flag any leaked path so the field is identifiable.
+            check_for_path_leak(v, &format!("codegen:{key}"));
             hasher.update(b"=");
             hasher.update(v.as_bytes());
             tracing::trace!("[key:{}] codegen:{}={}", crate_name, key, v);
@@ -158,6 +167,10 @@ pub fn compute_cache_key(
         .collect();
     cfgs.sort();
     for cfg in &cfgs {
+        // Build-script `cargo:rustc-cfg=…` lines reach us as raw strings;
+        // mozbuild / embedded crates sometimes emit cfgs that embed
+        // generated paths. None go through PathNormalizer — flag leaks.
+        check_for_path_leak(cfg, "cfg");
         hasher.update(b"cfg:");
         hasher.update(cfg.as_bytes());
         hasher.update(b"\n");
@@ -244,6 +257,11 @@ pub fn compute_cache_key(
                         "[key:{}] OUT_DIR used as runtime value; keeping absolute",
                         crate_name
                     );
+                    // Keep-absolute branch: by design the raw path stays
+                    // in the key (binary embeds it via `env!`). Still
+                    // record the leak so the verdict surface attributes
+                    // key instability here rather than "unknown".
+                    check_for_path_leak(val, &format!("env_dep:{var}[keep-absolute]"));
                     val.clone()
                 } else {
                     path_normalizer.normalize(val)
@@ -319,6 +337,11 @@ pub fn compute_cache_key(
     cargo_cfgs.sort_by(|(a, _), (b, _)| a.cmp(b));
     tracing::trace!("[key:{}] cargo_cfg_count={}", crate_name, cargo_cfgs.len());
     for (key, value) in &cargo_cfgs {
+        // Cargo derives CARGO_CFG_* from `--cfg` flags. Build scripts (and
+        // mozbuild specifically) emit cfgs that can embed absolute paths;
+        // those land here uncensored. Flag leaks so the offending var
+        // name is visible in the warn.
+        check_for_path_leak(value, &format!("cargo_cfg:{key}"));
         hasher.update(key.as_bytes());
         hasher.update(b"=");
         hasher.update(value.as_bytes());

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -273,10 +273,13 @@ pub fn compute_cache_key(
                         crate_name
                     );
                     // Keep-absolute branch: by design the raw path stays
-                    // in the key (binary embeds it via `env!`). Still
-                    // record the leak so the verdict surface attributes
-                    // key instability here rather than "unknown".
-                    check_for_path_leak(val, &format!("env_dep:{var}[keep-absolute]"));
+                    // in the key (binary embeds it via `env!`). Do *not*
+                    // emit a leak warn here — it's not an unintended
+                    // leak, and (less obviously) cargo fingerprints
+                    // RUSTC_WRAPPER stderr to decide build freshness:
+                    // any per-invocation noise from this branch (e.g. a
+                    // timestamped warn) makes cargo recompile spuriously
+                    // on noop, breaking the `out-dir-runtime` fixture.
                     val.clone()
                 } else {
                     path_normalizer.normalize(val)

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -1223,8 +1223,12 @@ mod tests {
 
         let fh = FileHasher::new();
         let pn = PathNormalizer::empty();
-        let a = compute_cache_key(&RustcArgs::parse(&mk("/Users/alice/clang++")).unwrap(), &fh, &pn)
-            .unwrap();
+        let a = compute_cache_key(
+            &RustcArgs::parse(&mk("/Users/alice/clang++")).unwrap(),
+            &fh,
+            &pn,
+        )
+        .unwrap();
         let b = compute_cache_key(
             &RustcArgs::parse(&mk("/home/runner/clang++")).unwrap(),
             &fh,

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -341,10 +341,11 @@ impl PathNormalizer {
     }
 }
 
-/// Defense-in-depth: scan a normalized string for substrings that
-/// still look like machine-local absolute paths and emit a warning.
+/// Defense-in-depth: scan a string for substrings that look like
+/// machine-local absolute paths and emit a warning naming the
+/// context (which hash field, which value).
 ///
-/// The relocate e2e phase already catches these by failing the build
+/// The relocate e2e phase already catches leaks by failing the build
 /// when keys diverge across paths, but this gives a faster signal
 /// during ad-hoc dev runs (a `KACHE_LOG=warn` user sees the leak the
 /// first time they hit it instead of waiting for the full harness).
@@ -353,7 +354,12 @@ impl PathNormalizer {
 /// positives on legitimate strings that happen to contain `/`. The
 /// list is intentionally conservative: missing a leak is preferable
 /// to spamming the log on innocuous values.
-fn warn_if_path_leaked(s: &str) {
+///
+/// `context` names where the value came from (e.g. `"normalize"`,
+/// `"codegen:link-arg"`, `"cargo_cfg:MOZ_OBJ_DIR"`). It surfaces in the
+/// warn so the offending field is identifiable without re-running with
+/// trace-level logging.
+pub(crate) fn check_for_path_leak(value: &str, context: &str) {
     const SUSPICIOUS_PREFIXES: &[&str] = &[
         "/Users/",       // macOS home
         "/home/",        // Linux home
@@ -363,20 +369,26 @@ fn warn_if_path_leaked(s: &str) {
         "C:\\Users\\",   // Windows home
     ];
     for prefix in SUSPICIOUS_PREFIXES {
-        if let Some(idx) = s.find(prefix) {
+        if let Some(idx) = value.find(prefix) {
             // Show a small window around the leak to make it easier
             // to identify (env var name etc.) without dumping the
             // whole value, which could be huge.
             let start = idx.saturating_sub(40);
-            let end = (idx + prefix.len() + 40).min(s.len());
+            let end = (idx + prefix.len() + 40).min(value.len());
             tracing::warn!(
-                "PathNormalizer: residual absolute path detected (prefix `{}`) in normalized value: ...{}...",
+                "residual absolute path detected in `{}` (prefix `{}`): ...{}...",
+                context,
                 prefix,
-                &s[start..end]
+                &value[start..end]
             );
             return;
         }
     }
+}
+
+/// Back-compat shim retained for `PathNormalizer::normalize` callers.
+fn warn_if_path_leaked(s: &str) {
+    check_for_path_leak(s, "PathNormalizer::normalize");
 }
 
 /// Canonicalize `path` to a string for prefix matching, or return


### PR DESCRIPTION
## Summary

Two commits, both motivated by Finding B from the Firefox compile-cache benchmark:

1. **`feat(cache-key): scan every un-normalized field for path leaks`** — promotes `warn_if_path_leaked` to a `pub(crate)` helper with a context label and sprinkles it at the five sites where hashable values go straight into the key without passing through `PathNormalizer::normalize`: `target`, `codegen:*` values, `cfg` flags, `CARGO_CFG_*` env values, and the `env_dep:OUT_DIR[keep-absolute]` branch. Now any residual path leak names the offending field in the warn (e.g. ``residual absolute path detected in `codegen:linker` ``), both as defense-in-depth and as the diagnostic signal that pinpointed Finding B.

2. **`fix(cache-key): exclude -Clinker=<path> from the key (v6 -> v7)`** — mozbuild (and any toolchain-bootstrapping build) sets `-Clinker=/abs/path/to/clang++` on every rustc invocation. v6 hashed that value raw, so every clone of the same source tree got a distinct key for the same crate. The linker's *semantic identity* is still captured via `linker:<--version output>` (path-independent) — so the key stays toolchain-sensitive but path-portable. `CACHE_KEY_VERSION` bumped 6 → 7. Regression test pins the behavior.

## Bench evidence

Measured on a Firefox 151.0 release build (single-machine, two independent shallow clones, ~22 min cold each):

| Metric | v6 | v7 | Δ |
|---|---|---|---|
| Cross-clone key stability | 0.2% | 88.1% | **+87.9 pp** |
| Hit rate (count) | 1.1% | 89.5% | **+88 pp** |
| Weighted hit rate (by compile-time) | 0.3% | 40.3% | **+40 pp** |
| Storage actually restored | 23.6 MB | 3.0 GB | **127×** |
| `PathNormalizer` leak warns during warm | 127 | 0 | fixed |

Warm wall-clock didn't drop dramatically yet because a handful of heavyweight Mozilla workspace crates (`gkrust_shared`, `style`, `webrender`, etc.) still miss for a separate non-path-leak reason — that's a follow-up ("Finding C"), not in scope here.

## Test plan

- [x] `cargo test --workspace --release` — 581 tests pass; new regression test `cache_key::tests::cache_key_ignores_linker_path` pinned.
- [x] `just e2e` — all 10 fixtures green, including `rust-debug` (the relocate guard).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] Manual: full Firefox bench validates the v6 → v7 numbers above.

## Notes for the reviewer

- The cache-key version bump (`CACHE_KEY_VERSION 6 → 7`) invalidates all existing v6 entries — expected and documented.
- The diagnostic helper's marker string `residual absolute path detected` is preserved (consumers grep for it).
- The bench harness that produced the v6/v7 evidence is on a separate branch (`bench/firefox`) and will arrive in a follow-up PR.