### PR TITLE
feat(log): opt-in file logging in wrapper mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -296,37 +296,56 @@ fn init_logging(mode: LogMode) {
     };
 
     // File layer: persistent log at info level (overridable via KACHE_LOG_FILE).
-    // Skipped in wrapper mode to avoid 2 extra syscalls (stat + open) per crate —
-    // the daemon already captures all important events.  CLI/daemon mode gets
-    // the file layer for diagnostics.
-    let file_layer = if mode == LogMode::Wrapper {
-        None
-    } else {
-        (|| -> Option<_> {
-            let path = diagnostic_log_path();
-            std::fs::create_dir_all(path.parent()?).ok()?;
+    //
+    // CLI/daemon mode: always enabled at the default `kache.log` path — these
+    // run rarely, so 2 syscalls (stat + open) per invocation is fine.
+    //
+    // Wrapper mode: cargo can fan out hundreds of `kache rustc …` processes
+    // per build, so the file layer is OFF by default to avoid the per-crate
+    // syscalls. Opt in by setting `KACHE_LOG_FILE` explicitly — useful for
+    // diagnostics when cargo would otherwise eat wrapper stderr. The path
+    // can be overridden via `KACHE_LOG_FILE_PATH` (e.g. the e2e bench writes
+    // a per-phase wrapper.log so each cold/warm phase has a clean log).
+    let file_layer = {
+        let wrapper_opted_in =
+            mode == LogMode::Wrapper && std::env::var_os("KACHE_LOG_FILE").is_some();
+        let enable_file_layer = mode != LogMode::Wrapper || wrapper_opted_in;
 
-            // Simple rotation: truncate if file exceeds 5 MB.
-            if std::fs::metadata(&path).is_ok_and(|m| m.len() > MAX_LOG_BYTES) {
-                let _ = std::fs::write(&path, b"--- log rotated ---\n");
-            }
+        if !enable_file_layer {
+            None
+        } else {
+            (|| -> Option<_> {
+                let path = std::env::var_os("KACHE_LOG_FILE_PATH")
+                    .map(PathBuf::from)
+                    .unwrap_or_else(diagnostic_log_path);
+                std::fs::create_dir_all(path.parent()?).ok()?;
 
-            let file = std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&path)
-                .ok()?;
+                // Simple rotation: truncate if file exceeds 5 MB.
+                // Skipped when a custom path is provided — the caller owns
+                // the file lifecycle (e.g. the bench wipes it per phase).
+                if std::env::var_os("KACHE_LOG_FILE_PATH").is_none()
+                    && std::fs::metadata(&path).is_ok_and(|m| m.len() > MAX_LOG_BYTES)
+                {
+                    let _ = std::fs::write(&path, b"--- log rotated ---\n");
+                }
 
-            let file_filter = EnvFilter::try_from_env("KACHE_LOG_FILE")
-                .unwrap_or_else(|_| "kache=info".parse().unwrap());
+                let file = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&path)
+                    .ok()?;
 
-            Some(
-                fmt::layer()
-                    .with_ansi(false)
-                    .with_writer(Mutex::new(file))
-                    .with_filter(file_filter),
-            )
-        })()
+                let file_filter = EnvFilter::try_from_env("KACHE_LOG_FILE")
+                    .unwrap_or_else(|_| "kache=info".parse().unwrap());
+
+                Some(
+                    fmt::layer()
+                        .with_ansi(false)
+                        .with_writer(Mutex::new(file))
+                        .with_filter(file_filter),
+                )
+            })()
+        }
     };
 
     tracing_subscriber::registry()


### PR DESCRIPTION
## Summary

In RUSTC_WRAPPER mode, kache's stderr is captured by cargo and cached as
compiler diagnostics — replayed on every subsequent build. To avoid
spamming stale warnings, kache's wrapper-mode logging is **silent by
default**: useful in production, but maddening when debugging cache
misses, restore failures, or key composition issues, because there's no
way to see what kache is doing without poisoning cargo's diagnostic
state.

This change adds two env vars to opt into a file logging layer in
wrapper mode, bypassing cargo's stderr capture entirely:

| Env var | Effect |
|---|---|
| `KACHE_LOG_FILE` | tracing filter spec (e.g. `kache=warn`, `kache=trace`); presence enables the file layer in wrapper mode |
| `KACHE_LOG_FILE_PATH` | overrides the default `kache.log` path; when set, kache also skips its 5 MB rotation (the caller owns the file lifecycle) |

## Behaviour by mode

- **Normal wrapper users**: unchanged. The file layer stays off, no
  per-crate syscall overhead.
- **CLI / daemon mode**: unchanged — file layer was always on at the
  default `kache.log` path; existing `KACHE_LOG_FILE` filter handling
  preserved.
- **Opt-in wrapper debug session**: set `KACHE_LOG_FILE=kache=warn` (and
  optionally `KACHE_LOG_FILE_PATH=…`); kache writes to the file
  regardless of how cargo handles stderr.

## Use cases

- Debugging wrapper-mode behaviour (cache misses, restore paths,
  passthrough reasons) without cargo storing the stderr as fake compiler
  warnings.
- Tooling (CI harnesses, dashboards) that want kache logs without
  parsing cargo's tee'd stderr.
- The Firefox bench harness (follow-up PR) uses this to capture
  `PathNormalizer` leak-detector warns per phase into
  `wrapper-<phase>.log`.

## Test plan

- [x] `just check` clean (581 workspace tests, fmt, clippy).
- [x] Smoke test: `RUSTC_WRAPPER=kache KACHE_LOG_FILE=kache=info KACHE_LOG_FILE_PATH=/tmp/w.log cargo build` against a tiny crate — wrapper log is populated; cargo's stderr stays clean.
- [x] Existing wrapper-mode default behaviour unchanged: without
  `KACHE_LOG_FILE` set, no file is created and no extra syscalls happen
  per crate.

## Notes for the reviewer

- The change is contained in `src/main.rs::init_logging`. The file
  layer was previously hard-gated off in wrapper mode; the gate now
  also accepts an explicit opt-in via `KACHE_LOG_FILE`.
- The 5 MB rotation is skipped only when `KACHE_LOG_FILE_PATH` is set —
  rationale is that a caller specifying a custom path is responsible
  for cleanup (e.g. the bench truncates the file at the start of each
  phase). The default-path code path still rotates.
- No public-API surface changes; no schema changes; no migration.