### PR TITLE
fix(cc): allow Gecko/Darwin baseline flags (#114)

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -644,7 +644,47 @@ fn flag_is_cache_safe(arg: &str) -> bool {
         return true;
     }
 
-    // (2) Preprocessor-captured: the flag's entire compile-time effect
+    // (2) Codegen flags whose effect is captured by the resolved
+    //     `cc -###` invocation that the cache key hashes (see
+    //     `cache_key` — the `resolved:` tokens). Clang expands every
+    //     user-facing flag here into `-cc1` arguments; identical user
+    //     flags produce identical resolved tokens and different flags
+    //     produce different ones, so the cache key distinguishes the
+    //     resulting objects without kache modeling each flag.
+    //
+    //     This set was selected from the Firefox/Gecko Darwin baseline
+    //     (kunobi-ninja/kache#114) — they cover ~4,400 single-source
+    //     compiles that previously passed through unnecessarily. Each
+    //     flag is one of:
+    //       - target/version selectors (`-mmacosx-version-min=`)
+    //       - codegen knobs whose `-cc1` form is deterministic given
+    //         the user-facing form (frame-pointer, fp-contract, stack
+    //         protector, unwind tables, alias analysis, math errno,
+    //         strict flex array length)
+    //       - pthread feature switch (adds `_REENTRANT`, which the
+    //         preprocessor expansion already captures)
+    //
+    //     If a future compiler returns `None` from the `-###` probe,
+    //     these flags would silently no-op for keying — but the same
+    //     would already be true for `-O2`/`-fPIC`/etc. via the same
+    //     path. The probe is the single source of truth.
+    if arg.starts_with("-mmacosx-version-min=")
+        || arg.starts_with("-fstrict-flex-arrays=")
+        || arg.starts_with("-ffp-contract=")
+        || matches!(
+            arg,
+            "-pthread"
+                | "-fstack-protector-strong"
+                | "-fno-math-errno"
+                | "-fno-strict-aliasing"
+                | "-fno-omit-frame-pointer"
+                | "-funwind-tables"
+        )
+    {
+        return true;
+    }
+
+    // (3) Preprocessor-captured: the flag's entire compile-time effect
     //     is the header content / macros the `cc -E -P` expansion
     //     sees, and the cache key hashes that expansion verbatim.
     if arg.starts_with("-D")          // -DNAME      / -D NAME
@@ -660,7 +700,7 @@ fn flag_is_cache_safe(arg: &str) -> bool {
         return true;
     }
 
-    // (3) No effect on the object of a successful compile: warnings
+    // (4) No effect on the object of a successful compile: warnings
     //     (incl. `-Werror` — changes success/failure, not the bytes),
     //     dependency-file generation (writes a `.d` sidecar), and
     //     build mechanics. `-W?,` passthrough forms (`-Wl,`, `-Wp,`,
@@ -1399,7 +1439,6 @@ mod tests {
             "-march=native",
             "-mtune=skylake",
             "-mavx2",
-            "-mmacosx-version-min=14.0",
             // unmodeled optimization / debug variants
             "-Ofast",
             "-gdwarf-5",
@@ -1457,6 +1496,100 @@ mod tests {
             assert!(
                 !descs.iter().any(|d| d.contains("unsupported flag")),
                 "{flag} is cache-safe and must NOT trip the allow-list, got: {descs:?}"
+            );
+        }
+    }
+
+    /// Gecko/Darwin baseline flags (kunobi-ninja/kache#114): codegen
+    /// knobs whose effect is captured by clang's `cc -###` resolved
+    /// invocation (which the cache key already hashes), so they're
+    /// cache-safe even though kache doesn't model them explicitly.
+    ///
+    /// Each was previously refused as "unsupported flag" and forced
+    /// passthrough on Firefox builds — over 4,400 single-source
+    /// compiles per build, per the issue's evidence.
+    #[test]
+    fn allow_list_accepts_gecko_darwin_baseline_flags() {
+        for flag in &[
+            "-mmacosx-version-min=10.15",
+            "-mmacosx-version-min=11.0",
+            "-pthread",
+            "-fstack-protector-strong",
+            "-fstrict-flex-arrays=1",
+            "-fstrict-flex-arrays=3",
+            "-fno-math-errno",
+            "-fno-strict-aliasing",
+            "-ffp-contract=off",
+            "-ffp-contract=on",
+            "-fno-omit-frame-pointer",
+            "-funwind-tables",
+        ] {
+            let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
+            assert!(
+                !descs.iter().any(|d| d.contains("unsupported flag")),
+                "{flag} should be allow-listed (Gecko/Darwin baseline), got: {descs:?}"
+            );
+        }
+    }
+
+    /// A representative Firefox-style C compile: pile the full
+    /// Gecko/Darwin baseline onto one `cc -c` invocation and assert
+    /// the allow-list accepts it. This is the headline contract from
+    /// #114: this exact shape should *cache*, not passthrough.
+    #[test]
+    fn allow_list_accepts_realistic_firefox_compile() {
+        let descs = refuse_descriptions(&[
+            "cc",
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o",
+            "-O2",
+            "-g",
+            "-std=gnu11",
+            "-mmacosx-version-min=10.15",
+            "-pthread",
+            "-fno-strict-aliasing",
+            "-fno-math-errno",
+            "-funwind-tables",
+            "-fstack-protector-strong",
+            "-fno-omit-frame-pointer",
+            "-ffp-contract=off",
+            "-fstrict-flex-arrays=1",
+            // Mixed with already-allowed flags to confirm no cross-
+            // contamination from the additions.
+            "-Wall",
+            "-Wno-unused-parameter",
+            "-DMOZILLA_INTERNAL_API=1",
+            "-I/some/include",
+        ]);
+        assert!(
+            descs.is_empty(),
+            "realistic Firefox compile should be fully cacheable, got: {descs:?}"
+        );
+    }
+
+    /// Pin the boundary: variants OUTSIDE the listed set must still
+    /// passthrough — we are not opening `-fno-*` / `-fstack-protector*`
+    /// as wildcards.
+    #[test]
+    fn allow_list_does_not_overreach_gecko_darwin_family() {
+        for flag in &[
+            // Inverse forms not listed in #114
+            "-fmath-errno",
+            "-fstrict-aliasing",
+            "-fomit-frame-pointer",
+            "-fno-unwind-tables",
+            // Adjacent stack-protector variants not on the list
+            "-fstack-protector",
+            "-fstack-protector-all",
+            // Lookalike that isn't the macOS deployment-target flag
+            "-mmacosx-min-version=10.15",
+        ] {
+            let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
+            assert!(
+                descs.iter().any(|d| d.contains("unsupported flag")),
+                "{flag} is NOT on the #114 list and must still refuse, got: {descs:?}"
             );
         }
     }


### PR DESCRIPTION
Closes #114.

## Summary

Firefox on macOS aarch64 triggered ~4,476 single-source C/C++ passthroughs per build because nine common Gecko/Darwin baseline flags weren't on the cc allow-list. Adds them to a new section of \`flag_is_cache_safe\` for flags whose effect is captured by the resolved \`cc -###\` invocation that the cache key already hashes.

## Why no cache-key changes are needed

The key composition at \`src/compiler/cc.rs::cache_key\` already hashes the resolved \`cc -###\` \`-cc1\` token list in order (see the comment block at lines 822-848). Clang expands every user-facing flag into the \`-cc1\` form, so:

- \`-mmacosx-version-min=10.15\` → \`-target arm64-apple-macos10.15\` in the resolved tokens
- \`-ffp-contract=off\` → \`-ffp-contract=off\` directly in \`-cc1\`
- \`-fstack-protector-strong\` → \`-stack-protector 2\` in \`-cc1\`
- \`-pthread\` → \`-D_REENTRANT\` (also captured by the preprocessor expansion hash)
- …and so on

Identical user flags produce identical resolved tokens → same key. Different flag values produce different resolved tokens → different keys. No miscache risk; the probe is the single source of truth.

## Flags allow-listed

From the #114 evidence list (Firefox build/configure log on macOS):

| Flag | Approx. blocked compiles per build |
|---|---|
| \`-mmacosx-version-min=*\` | 4406 |
| \`-fno-strict-aliasing\` | 4292 |
| \`-pthread\` | 4227 |
| \`-fno-math-errno\` | 4227 |
| \`-funwind-tables\` | 4226 |
| \`-fstrict-flex-arrays=*\` | 4226 |
| \`-fstack-protector-strong\` | 4226 |
| \`-fno-omit-frame-pointer\` | 4226 |
| \`-ffp-contract=*\` | 4226 |

These don't all stack independently — most invocations carried several at once, so unblocking them collectively reduces passthrough on ~4,476 distinct compiles (the union, per the issue).

## Conservative scoping

Only the exact strings in #114 are accepted. Adjacent variants intentionally still refuse:

- \`-fmath-errno\`, \`-fstrict-aliasing\`, \`-fomit-frame-pointer\`, \`-fno-unwind-tables\` — the inverses weren't in the Firefox evidence and adding them risks under-keying a flag whose \`-cc1\` form we haven't verified.
- \`-fstack-protector\`, \`-fstack-protector-all\` — neighbors of \`-fstack-protector-strong\` but distinct codegen modes.
- Lookalikes (\`-mmacosx-min-version=10.15\` — note the word order) refuse so a typo doesn't silently miscache.

Follow-ups (#115, #116, #117) extend the allow-list for other workloads.

## Test plan

- [x] \`allow_list_accepts_gecko_darwin_baseline_flags\` — every flag from #114 plus alternate values for the wildcard forms
- [x] \`allow_list_accepts_realistic_firefox_compile\` — the full bundle on one \`cc -c\` invocation produces zero refuse reasons (the headline contract)
- [x] \`allow_list_does_not_overreach_gecko_darwin_family\` — pins the boundary against the inverses and lookalikes
- [x] \`-mmacosx-version-min=14.0\` moved out of \`refuses_flags_outside_the_allow_list\` (it was previously asserted as refused)
- [x] \`just check\` clean (538 workspace tests, fmt, clippy)
- [x] \`just e2e\` clean (all 10 fixtures green)

## Out of scope

- Link-mode caching
- Response file expansion
- Preprocessor-mode (\`-E\`) caching
- gcc \`-###\` resolution — gcc currently returns \`None\` from the probe; the cache-key falls back to modeled flags only. Same gap exists for \`-O2\`, \`-fPIC\`, etc. via the same path. Adding a gcc prober is a separate, broader piece of work.