### PR TITLE
refactor(cc): declarative flag classification table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3357,6 +3357,7 @@ dependencies = [
  "libc",
  "predicates",
  "ratatui",
+ "regex",
  "reqwest 0.13.2",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,12 @@ tempfile = "3"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 interprocess = { version = "2.4.2", features = ["tokio"] }
 unicode-normalization = "0.1"
+# Used by `src/compiler/flags.rs` (the cc / future Swift / future MSVC
+# flag classifier). The `regex` crate is linear-time by construction
+# (no backtracking, no lookarounds) — matters because the wrapper runs
+# the classifier on every cc compile argument; bounded cost is a design
+# requirement.
+regex = { version = "1", default-features = false, features = ["std", "perf"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -21,10 +21,12 @@
 //! - Multi-source compiles, multi-arch fat binaries
 //! - Response files, coverage instrumentation, split DWARF,
 //!   precompiled headers, modules, output-to-stdout
-//! - Any flag outside the allow-list (`flag_is_cache_safe`) — an
-//!   unmodeled codegen flag, a cross-target, profiling, or simply a
-//!   flag kache has not classified. Refused so an unknown flag is
-//!   never silently cached.
+//! - Any flag not classified by [`CC_FLAGS`] (see [`classify_cc_flag`])
+//!   — an unmodeled codegen flag, a cross-target, profiling, or simply
+//!   a flag kache has not classified. Refused so an unknown flag is
+//!   never silently cached. The table is declarative; see
+//!   [`crate::compiler::flags`] for the matcher / classification
+//!   vocabulary it uses.
 //!
 //! Future work (separate PRs):
 //! - Link-mode / whole-executable caching
@@ -34,9 +36,13 @@
 //! - Dep-info (`.d`) file caching alongside the `.o`
 
 use anyhow::{Context, Result};
+use regex::Regex;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::OnceLock;
 
+use super::flags::{FlagClass, FlagSpec, Matcher};
 use super::{
     ArtifactKind, CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason, classify_by_filename,
 };
@@ -316,16 +322,17 @@ impl CcArgs {
     /// - **Modules** (`-fmodules`, `-fcxx-modules`): module
     ///   compilation has its own dependency model; doesn't fit the
     ///   per-TU cache model.
-    /// - **Any flag outside the allow-list**: the cache key captures
-    ///   the preprocessor expansion plus the codegen flags kache
-    ///   explicitly models (optimization / debug / `-std` / PIC /
-    ///   arch). A flag whose object-file effect is *not* captured —
-    ///   an unmodeled codegen flag (`-Ofast`, `-ffast-math`,
-    ///   `-march=…`, `-ffunction-sections`), a cross-target
-    ///   (`-target`, `--target=`), profiling (`-pg`), or a flag kache
-    ///   has never seen — would miscache. `flag_is_cache_safe` is the
-    ///   allow-list; anything it does not recognize is refused, with
-    ///   the offending flags named in the reason.
+    /// - **Any flag not classified by [`CC_FLAGS`]**: the cache key
+    ///   captures the preprocessor expansion plus the codegen flags
+    ///   kache explicitly models (`FlagClass::ModeledInKey`) plus the
+    ///   resolved `cc -###` tokens (`FlagClass::CapturedByProbe`). A
+    ///   flag whose object-file effect is in none of those — an
+    ///   unmodeled codegen flag (`-Ofast`, `-ffast-math`, `-march=…`,
+    ///   `-ffunction-sections`), a cross-target (`-target`,
+    ///   `--target=`), profiling (`-pg`), or a flag kache has never
+    ///   seen — would miscache. The table is the source of truth;
+    ///   anything it does not classify is refused with the offending
+    ///   flags named in the reason.
     /// - **Output to stdout** (`-o -`): not a cacheable artifact.
     /// - **Preprocess / Assemble mode**: `-E` and `-S` produce
     ///   developer-facing output that's rarely worth caching and
@@ -390,27 +397,28 @@ impl CcArgs {
             }
         }
 
-        // Allow-list gate — the structural safety net.
+        // Classifier gate — the structural safety net.
         //
         // kache's cc cache key captures the preprocessor expansion
         // plus the codegen flags it *explicitly* models (optimization,
-        // debug level, `-std`, PIC, target arch). A flag OUTSIDE that
-        // captured set would change the object file WITHOUT changing
+        // debug level, `-std`, PIC, target arch) plus the resolved
+        // `cc -###` token stream. A flag whose effect is captured by
+        // none of those would change the object file WITHOUT changing
         // the key — a silent miscache.
         //
-        // So this is an allow-list, not a deny-list: `flag_is_cache_safe`
-        // names the categories kache can account for, and ANYTHING
-        // else — an unmodeled codegen flag (`-Ofast`, `-ffast-math`,
-        // `-march=native`, `-ffunction-sections`), a cross-target
-        // (`-target`, `--target=`), profiling (`-pg`), or a flag kache
-        // has simply never seen — forces a passthrough. The rejected
-        // flags are named in the reason, so it is visible which flags
-        // blocked caching (and therefore which to add support for).
+        // [`CC_FLAGS`] declares which flags fall into which category;
+        // [`classify_cc_flag`] returns `None` for anything outside the
+        // table. Unclassified flags include the genuinely unsafe
+        // (`-Ofast`, `-march=native`), the cross-targets (`-target`,
+        // `--target=`), profiling (`-pg`), and any flag kache has not
+        // yet seen — all force a passthrough. The rejected flags are
+        // named in the reason so it is visible which flags blocked
+        // caching (and therefore which rows to add to `CC_FLAGS`).
         let rejected: Vec<&str> = self
             .rest
             .iter()
             .map(String::as_str)
-            .filter(|a| !flag_is_cache_safe(a))
+            .filter(|a| classify_cc_flag(a).is_none())
             .collect();
         if !rejected.is_empty() {
             // Leak a per-invocation summary so it can ride in
@@ -602,123 +610,283 @@ fn parse_define(s: &str) -> (String, Option<String>) {
     }
 }
 
-/// Optimization flags kache models in the cc cache key — the exact
-/// set `CcArgs::parse` extracts into `optimization`. A variant outside
-/// this set (`-Ofast`) is NOT modeled, so it is not cache-safe.
-const MODELED_OPT_FLAGS: &[&str] = &["-O", "-O0", "-O1", "-O2", "-O3", "-Os", "-Oz", "-Og"];
-
-/// Debug flags kache models — the exact set `CcArgs::parse` extracts
-/// into `debug_level`. A variant outside this set (`-gdwarf-5`,
-/// `-ggdb`, `-gline-tables-only`) changes the object's debug info but
-/// is not modeled, so it is not cache-safe.
-const MODELED_DEBUG_FLAGS: &[&str] = &["-g", "-g0", "-g1", "-g2", "-g3"];
-
-/// Whether a cc argument is safe to cache past — i.e. its effect on
-/// the object file is either fully captured by kache's cache key, or
-/// it has no effect on the object at all.
+/// Cc flag classification table — the declarative source of truth
+/// for "how does kache treat this argument?".
 ///
-/// This is the **allow-list**. An argument is safe only if it falls
-/// into one of the recognized categories below. ANYTHING else — an
-/// unmodeled codegen flag, a cross-target, a flag kache has simply
-/// never seen — is unsafe, and [`CcArgs::refuse_reasons`] forces a
-/// passthrough. Erring toward "unsafe" is deliberate: an over-refusal
-/// costs a cache miss; an under-refusal is a silent miscache.
-fn flag_is_cache_safe(arg: &str) -> bool {
-    // Non-flag positional — a source file, or the value of a
-    // separate-argument flag (`-I dir`, `-o file`). Sources are
-    // counted by the parser; flag values are harmless here.
-    if !arg.starts_with('-') {
-        return true;
-    }
-
-    // (1) Codegen flags kache models directly in the cache key.
-    if MODELED_OPT_FLAGS.contains(&arg)
-        || MODELED_DEBUG_FLAGS.contains(&arg)
-        || arg == "-fPIC"
-        || arg == "-fpic"
-        || arg.starts_with("-std=")
-        // Single `-arch` — the resolved target arch is hashed.
-        // Multi-`-arch` is refused separately in `refuse_reasons`.
-        || arg == "-arch"
-    {
-        return true;
-    }
-
-    // (2) Codegen flags whose effect is captured by the resolved
-    //     `cc -###` invocation that the cache key hashes (see
-    //     `cache_key` — the `resolved:` tokens). Clang expands every
-    //     user-facing flag here into `-cc1` arguments; identical user
-    //     flags produce identical resolved tokens and different flags
-    //     produce different ones, so the cache key distinguishes the
-    //     resulting objects without kache modeling each flag.
+/// Each row pairs a [`Matcher`] with a [`FlagClass`] and a `source`
+/// reference. See [`crate::compiler::flags`] for the matcher /
+/// classification vocabulary and for the audit / extensibility
+/// guarantees this shape delivers.
+///
+/// **Adding a flag**: drop a row in the appropriate `class`
+/// section, point `source` at the issue / PR that introduced it,
+/// and write a test for the new pattern. Done.
+///
+/// **Reading the table**: `class` answers "why is this safe?".
+/// `ModeledInKey` = the parser extracts it into a typed field.
+/// `CapturedByProbe` = `cc -###` resolves it into `-cc1` tokens
+/// the cache key already hashes. `PreprocessorCaptured` = the
+/// preprocessor expansion hash subsumes its effect.
+/// `NoObjectEffect` = it doesn't change the resulting object.
+///
+/// **Anything not in the table** is refused with `cc: unsupported
+/// flag(s): …` — see [`CcArgs::refuse_reasons`]. The omission is
+/// the safety signal: a flag kache has never seen could miscache,
+/// so the conservative default is to passthrough.
+pub static CC_FLAGS: &[FlagSpec] = &[
+    // ── ModeledInKey: parser extracts into a typed field ──
+    FlagSpec {
+        // `-O` family: bare, digit (`-O0`..`-O3`), `-Os`/`-Oz`, `-Og`.
+        // The regex names the family in one row; an out-of-set value
+        // (`-Ofast`) deliberately falls through to refusal because the
+        // parser doesn't model it. See `CcArgs::parse`.
+        matcher: Matcher::Regex(r"-O[0-3sz]?|-Og"),
+        class: FlagClass::ModeledInKey,
+        source: "PR #94 — opt level. Regex captures family; -Ofast/+others fall through to refuse.",
+    },
+    FlagSpec {
+        // `-g` family: bare or with a level digit (`-g0`..`-g3`). The
+        // parser extracts the level into `debug_level`. Variants like
+        // `-gdwarf-5` / `-ggdb` / `-gline-tables-only` change debug
+        // info but aren't modeled, so they're not on this row.
+        matcher: Matcher::Regex(r"-g[0-3]?"),
+        class: FlagClass::ModeledInKey,
+        source: "PR #94 — debug level. Regex captures `-g`/`-g0..3`; -gdwarf-* etc. refuse.",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fPIC"),
+        class: FlagClass::ModeledInKey,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fpic"),
+        class: FlagClass::ModeledInKey,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Prefix("-std="),
+        class: FlagClass::ModeledInKey,
+        source: "PR #94",
+    },
+    FlagSpec {
+        // Single `-arch <value>`. The parser sets `cache_target_arch`
+        // from the resolved arch; multi-`-arch X -arch Y` is refused
+        // separately in the procedural pass of `refuse_reasons`.
+        matcher: Matcher::Exact("-arch"),
+        class: FlagClass::ModeledInKey,
+        source: "PR #94",
+    },
+    // ── CapturedByProbe: `cc -###` resolved tokens differentiate ──
     //
-    //     This set was selected from the Firefox/Gecko Darwin baseline
-    //     (kunobi-ninja/kache#114) — they cover ~4,400 single-source
-    //     compiles that previously passed through unnecessarily. Each
-    //     flag is one of:
-    //       - target/version selectors (`-mmacosx-version-min=`)
-    //       - codegen knobs whose `-cc1` form is deterministic given
-    //         the user-facing form (frame-pointer, fp-contract, stack
-    //         protector, unwind tables, alias analysis, math errno,
-    //         strict flex array length)
-    //       - pthread feature switch (adds `_REENTRANT`, which the
-    //         preprocessor expansion already captures)
+    // Each row's effect on the resulting object is captured by the
+    // resolved `cc -###` `-cc1` token stream that the cache key
+    // already hashes (see `cache_key`'s `resolved:` tokens). Identical
+    // user-facing flags → identical resolved tokens → same key;
+    // different values → different tokens → different key. Safety holds
+    // when the probe resolves on the host compiler (clang today; gcc's
+    // `-###` is on the roadmap but currently returns `None`, in which
+    // case these flags would silently no-op for keying — the same
+    // gap that already exists for `-O2`/`-fPIC`/etc., not introduced
+    // by this row.
     //
-    //     If a future compiler returns `None` from the `-###` probe,
-    //     these flags would silently no-op for keying — but the same
-    //     would already be true for `-O2`/`-fPIC`/etc. via the same
-    //     path. The probe is the single source of truth.
-    if arg.starts_with("-mmacosx-version-min=")
-        || arg.starts_with("-fstrict-flex-arrays=")
-        || arg.starts_with("-ffp-contract=")
-        || matches!(
-            arg,
-            "-pthread"
-                | "-fstack-protector-strong"
-                | "-fno-math-errno"
-                | "-fno-strict-aliasing"
-                | "-fno-omit-frame-pointer"
-                | "-funwind-tables"
-        )
-    {
-        return true;
-    }
+    // Initial population sourced from the Firefox/Gecko Darwin
+    // baseline (kunobi-ninja/kache#114): ~4,476 single-source compiles
+    // per Firefox build that previously passed through unnecessarily.
+    FlagSpec {
+        matcher: Matcher::Prefix("-mmacosx-version-min="),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #114 — Darwin deployment target.",
+    },
+    FlagSpec {
+        matcher: Matcher::Prefix("-fstrict-flex-arrays="),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #114 — strict-flex-arrays codegen knob.",
+    },
+    FlagSpec {
+        matcher: Matcher::Prefix("-ffp-contract="),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #114 — fp-contract codegen knob.",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-pthread"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #114 — pthread feature switch (also visible via _REENTRANT in preprocessor).",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fstack-protector-strong"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #114 — stack-protector codegen mode.",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fno-math-errno"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #114 — math-errno codegen knob.",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fno-strict-aliasing"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #114 — alias-analysis codegen knob.",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fno-omit-frame-pointer"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #114 — frame-pointer codegen knob.",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-funwind-tables"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #114 — unwind-tables codegen knob.",
+    },
+    // ── PreprocessorCaptured: cc -E -P expansion hash subsumes effect ──
+    FlagSpec {
+        matcher: Matcher::Prefix("-D"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Prefix("-U"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Prefix("-I"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Prefix("--sysroot"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-include"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-imacros"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-isystem"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-iquote"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-idirafter"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-isysroot"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-nostdinc"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-nostdinc++"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-undef"),
+        class: FlagClass::PreprocessorCaptured,
+        source: "PR #94",
+    },
+    // ── NoObjectEffect: diagnostics / dep-info / build mechanics ──
+    FlagSpec {
+        // `-W*` warnings — `-Werror` is included (it changes success/
+        // failure of the compile, not the resulting object bytes).
+        // The regex EXCLUDES `-Wl,*` / `-Wa,*` / `-Wp,*` (linker /
+        // assembler / preprocessor passthrough forms that change the
+        // resulting object); they need separate handling and aren't
+        // covered here.
+        matcher: Matcher::Regex(r"-W[^,]*"),
+        class: FlagClass::NoObjectEffect,
+        source: "PR #94 — warnings. Regex excludes `-Wl,*`/`-Wa,*`/`-Wp,*` passthrough forms.",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-w"),
+        class: FlagClass::NoObjectEffect,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Prefix("-pedantic"),
+        class: FlagClass::NoObjectEffect,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Prefix("-fdiagnostics-"),
+        class: FlagClass::NoObjectEffect,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fcolor-diagnostics"),
+        class: FlagClass::NoObjectEffect,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fno-color-diagnostics"),
+        class: FlagClass::NoObjectEffect,
+        source: "PR #94",
+    },
+    FlagSpec {
+        // Dep-info generation: -MD, -MMD, -MF, -MT, -MQ, -MP, -MG.
+        // All write the `.d` sidecar; none affect the object. Regex
+        // captures the family; alternatives are equally tight in this
+        // table layout but the row stays declarative this way.
+        matcher: Matcher::Regex(r"-MM?D|-M[FTQPG]"),
+        class: FlagClass::NoObjectEffect,
+        source: "PR #94 — dep-info sidecar flags.",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-c"),
+        class: FlagClass::NoObjectEffect,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-o"),
+        class: FlagClass::NoObjectEffect,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-pipe"),
+        class: FlagClass::NoObjectEffect,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-v"),
+        class: FlagClass::NoObjectEffect,
+        source: "PR #94",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("--verbose"),
+        class: FlagClass::NoObjectEffect,
+        source: "PR #94",
+    },
+];
 
-    // (3) Preprocessor-captured: the flag's entire compile-time effect
-    //     is the header content / macros the `cc -E -P` expansion
-    //     sees, and the cache key hashes that expansion verbatim.
-    if arg.starts_with("-D")          // -DNAME      / -D NAME
-        || arg.starts_with("-U")      // -UNAME      / -U NAME
-        || arg.starts_with("-I")      // -Idir       / -I dir
-        || arg.starts_with("--sysroot")
-        || matches!(
-            arg,
-            "-include" | "-imacros" | "-isystem" | "-iquote" | "-idirafter"
-                | "-isysroot" | "-nostdinc" | "-nostdinc++" | "-undef"
-        )
-    {
-        return true;
-    }
-
-    // (4) No effect on the object of a successful compile: warnings
-    //     (incl. `-Werror` — changes success/failure, not the bytes),
-    //     dependency-file generation (writes a `.d` sidecar), and
-    //     build mechanics. `-W?,` passthrough forms (`-Wl,`, `-Wp,`,
-    //     `-Wa,`) carry a comma and are NOT treated as warnings —
-    //     they fall through to "unsafe".
-    if (arg.starts_with("-W") && !arg.contains(','))
-        || arg == "-w"
-        || arg.starts_with("-pedantic")
-        || arg.starts_with("-fdiagnostics-")
-        || matches!(arg, "-fcolor-diagnostics" | "-fno-color-diagnostics")
-        || matches!(arg, "-MD" | "-MMD" | "-MF" | "-MT" | "-MQ" | "-MP" | "-MG")
-        || matches!(arg, "-c" | "-o" | "-pipe" | "-v" | "--verbose")
-    {
-        return true;
-    }
-
-    // Everything else is unsafe — see `refuse_reasons`.
-    false
+/// Classify a cc argument. Wraps [`crate::compiler::flags::classify_against`]
+/// over [`CC_FLAGS`] with a lazy regex cache. Returns `None` for any
+/// argument no row matches — the caller treats that as "unsupported
+/// flag, refuse to cache".
+fn classify_cc_flag(arg: &str) -> Option<FlagClass> {
+    static CACHE: OnceLock<HashMap<&'static str, Regex>> = OnceLock::new();
+    crate::compiler::flags::classify_against(
+        arg,
+        CC_FLAGS,
+        CACHE.get_or_init(|| crate::compiler::flags::build_regex_cache(CC_FLAGS)),
+    )
 }
 
 /// The `-ffile-prefix-map` flag that rewrites the absolute build
@@ -1331,6 +1499,17 @@ mod tests {
         assert_eq!(parsed.language_override, Some("c++".to_string()));
     }
 
+    // ── classifier table validation ─────────────────────────────
+
+    /// Every `Matcher::Regex` row in [`CC_FLAGS`] must compile as a
+    /// valid anchored regex. CI safety: production lookups assume
+    /// pre-validated patterns; a typo in a row should fail here, not
+    /// at first use on a developer's machine.
+    #[test]
+    fn cc_flags_table_regexes_compile() {
+        crate::compiler::flags::assert_table_regexes_compile(CC_FLAGS);
+    }
+
     // ── refuse-to-cache: per-case ───────────────────────────────
 
     fn refuse_descriptions(args: &[&str]) -> Vec<&'static str> {
@@ -1422,11 +1601,12 @@ mod tests {
     }
 
     #[test]
-    fn refuses_flags_outside_the_allow_list() {
+    fn refuses_flags_unclassified_in_cc_flags_table() {
         // Flags whose object-file effect kache does not capture in the
-        // cache key. Each would miscache → must passthrough. Spans
-        // every shape, not just `-f…` / `-m…`: unmodeled optimization
-        // / debug variants, cross-targets, profiling.
+        // cache key — i.e. no row in `CC_FLAGS` matches them. Each
+        // would miscache → must passthrough. Spans every shape, not
+        // just `-f…` / `-m…`: unmodeled optimization / debug variants,
+        // cross-targets, profiling.
         for flag in &[
             // unmodeled -f… / -m… codegen flags
             "-ffast-math",
@@ -1455,17 +1635,17 @@ mod tests {
             let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
             assert!(
                 descs.iter().any(|d| d.contains("unsupported flag")),
-                "expected allow-list refuse for {flag}, got: {descs:?}"
+                "expected classifier refuse for {flag}, got: {descs:?}"
             );
         }
     }
 
     #[test]
-    fn allow_list_does_not_refuse_cache_safe_flags() {
+    fn cc_flags_table_classifies_known_cache_safe_flags() {
         // Flags kache fully accounts for: modeled codegen (opt / debug
         // / std / pic / arch), preprocessor-captured (defines /
         // includes / sysroot), and no-object-effect (warnings /
-        // dep-info / mechanics). None should trip the allow-list.
+        // dep-info / mechanics). None should trip the classifier.
         for flag in &[
             "-O2",
             "-O0",
@@ -1495,7 +1675,7 @@ mod tests {
             let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
             assert!(
                 !descs.iter().any(|d| d.contains("unsupported flag")),
-                "{flag} is cache-safe and must NOT trip the allow-list, got: {descs:?}"
+                "{flag} is cache-safe and must NOT trip the classifier, got: {descs:?}"
             );
         }
     }
@@ -1504,12 +1684,14 @@ mod tests {
     /// knobs whose effect is captured by clang's `cc -###` resolved
     /// invocation (which the cache key already hashes), so they're
     /// cache-safe even though kache doesn't model them explicitly.
+    /// These were the inaugural `FlagClass::CapturedByProbe` rows in
+    /// `CC_FLAGS` (#137).
     ///
     /// Each was previously refused as "unsupported flag" and forced
     /// passthrough on Firefox builds — over 4,400 single-source
     /// compiles per build, per the issue's evidence.
     #[test]
-    fn allow_list_accepts_gecko_darwin_baseline_flags() {
+    fn classifier_accepts_gecko_darwin_baseline_flags() {
         for flag in &[
             "-mmacosx-version-min=10.15",
             "-mmacosx-version-min=11.0",
@@ -1527,17 +1709,17 @@ mod tests {
             let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
             assert!(
                 !descs.iter().any(|d| d.contains("unsupported flag")),
-                "{flag} should be allow-listed (Gecko/Darwin baseline), got: {descs:?}"
+                "{flag} should be classified (Gecko/Darwin baseline), got: {descs:?}"
             );
         }
     }
 
     /// A representative Firefox-style C compile: pile the full
     /// Gecko/Darwin baseline onto one `cc -c` invocation and assert
-    /// the allow-list accepts it. This is the headline contract from
+    /// the classifier accepts it. This is the headline contract from
     /// #114: this exact shape should *cache*, not passthrough.
     #[test]
-    fn allow_list_accepts_realistic_firefox_compile() {
+    fn classifier_accepts_realistic_firefox_compile() {
         let descs = refuse_descriptions(&[
             "cc",
             "-c",
@@ -1573,7 +1755,7 @@ mod tests {
     /// passthrough — we are not opening `-fno-*` / `-fstack-protector*`
     /// as wildcards.
     #[test]
-    fn allow_list_does_not_overreach_gecko_darwin_family() {
+    fn classifier_does_not_overreach_gecko_darwin_family() {
         for flag in &[
             // Inverse forms not listed in #114
             "-fmath-errno",

--- a/src/compiler/flags.rs
+++ b/src/compiler/flags.rs
@@ -1,0 +1,351 @@
+//! Compiler-agnostic flag classification.
+//!
+//! Each compiler (cc, future swift, future MSVC, …) declares a static
+//! table of [`FlagSpec`] entries; the shared [`classify_against`] helper
+//! resolves any argument to one of the [`FlagClass`] categories. The
+//! result tells downstream code (refusal logic, cache-key composition,
+//! probe-availability gating) **why** a given argument is safe to cache
+//! past — not just whether it is.
+//!
+//! # Why a table, not a procedural classifier
+//!
+//! - **Auditable.** "What flags does kache support?" / "Did this PR
+//!   add X correctly?" / "Are cc and clang-cl consistent?" are all
+//!   answerable by reading or diffing the table. A procedural
+//!   classifier scattered across `if`/`match` arms forces every such
+//!   question to be answered by code reading.
+//! - **Extensible.** Adding a flag is a single row, justified by its
+//!   `source` field. A new compiler is its own table, same vocabulary
+//!   — no wrapper / cache-key churn.
+//! - **User-configurable.** A future config-layer (kunobi-ninja/kache#95)
+//!   reads user-defined rows and overlays them onto the shipped table
+//!   with explicit precedence rules.
+//! - **Documentable.** `kache list-flags --class captured-by-probe`
+//!   (future) is a one-line projection over the static data.
+//!
+//! # Matcher set
+//!
+//! Three variants, no carve-outs. Anything weirder than `Exact` /
+//! `Prefix` lives in a [`Matcher::Regex`] row that justifies its
+//! pattern in the row's `source`.
+//!
+//! # Regex safety
+//!
+//! [`Matcher::Regex`] uses the [`regex`] crate's default engine —
+//! linear-time RE2-style, no backreferences, no lookarounds, no
+//! catastrophic backtracking. Patterns are auto-anchored (`^...$`) so
+//! row authors cannot accidentally match a substring. All regex
+//! patterns in every shipped table are compiled at CI time by
+//! [`assert_table_regexes_compile`], so production lookups never panic.
+
+use regex::Regex;
+use std::collections::HashMap;
+
+/// How kache treats one compiler argument for caching purposes.
+///
+/// The classification tells the orchestration code *why* the
+/// argument is safe to cache past. Each variant has a different
+/// safety contract:
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlagClass {
+    /// The argument's effect is captured by a typed field the
+    /// per-compiler parser extracts (optimization, debug level,
+    /// `-std=`, PIC, target arch). The cache-key recipe for that
+    /// compiler hashes those fields directly — same flag → same
+    /// field value → same key.
+    ModeledInKey,
+
+    /// The argument's effect is captured by a probe that asks the
+    /// compiler to print its resolved invocation (`cc -###`,
+    /// `swiftc -print-target-info`, `cl /Bv`, …). The resolved
+    /// token stream is hashed into the cache key, so different
+    /// arguments produce different keys without kache modeling
+    /// each flag individually.
+    ///
+    /// **Safety contract**: holds only when the probe resolves on
+    /// the host compiler. If the probe returns `None` (e.g. gcc's
+    /// `-###` parsing currently incomplete), arguments classified
+    /// here MUST refuse to cache — otherwise the key falls back to
+    /// modeled-only and silently under-keys.
+    CapturedByProbe,
+
+    /// The argument changes *what the compiler sees*, not *how it
+    /// compiles*. The preprocessor expansion (or equivalent first
+    /// pass) is hashed into the cache key, so the effect lives in
+    /// the input bytes the key already covers. Examples: `-DFOO=1`,
+    /// `-Iinclude`, `-include header.h`.
+    PreprocessorCaptured,
+
+    /// The argument has no effect on the resulting object bytes —
+    /// only on diagnostics, the dep-info sidecar, build mechanics,
+    /// or color settings. Safe to ignore for keying.
+    NoObjectEffect,
+}
+
+/// How a [`FlagSpec`] matches an argument.
+///
+/// Three variants. `Exact` for one literal string. `Prefix` for an
+/// open-ended family with a shared head (`-D`, `-I`, …). `Regex` for
+/// everything else; auto-anchored so the pattern matches the entire
+/// argument or nothing.
+#[derive(Debug, Clone, Copy)]
+pub enum Matcher {
+    /// Single literal string. `arg == s`.
+    Exact(&'static str),
+
+    /// `arg.starts_with(s)`.
+    Prefix(&'static str),
+
+    /// Anchored, linear-time regex. The matcher implicitly wraps the
+    /// pattern as `^(?:pattern)$` so callers can't author a partial-
+    /// match regex by accident, and a top-level alternation
+    /// (`-foo|-bar`) inside the row pattern doesn't escape the anchors
+    /// via operator-precedence quirks. Each `Regex(...)` row must
+    /// justify in its owning [`FlagSpec::source`] why a simpler
+    /// variant doesn't suffice.
+    Regex(&'static str),
+}
+
+/// One row of a compiler's flag classification table.
+///
+/// `source` is mandatory and serves two purposes:
+/// - **Audit trail**: every row points at an issue / PR / spec that
+///   introduced it. `grep` on the table tells you when each flag
+///   was added and why.
+/// - **Rationale**: for [`Matcher::Regex`] rows, the source string
+///   also explains *why* the pattern can't be expressed with `Exact`
+///   or `Prefix` — review checks this.
+#[derive(Debug, Clone, Copy)]
+pub struct FlagSpec {
+    pub matcher: Matcher,
+    pub class: FlagClass,
+    pub source: &'static str,
+}
+
+/// Build a cache mapping each `Matcher::Regex` pattern in `table` to
+/// its compiled `^pattern$` form.
+///
+/// Called once per process per table via the caller's `OnceLock`. A
+/// malformed pattern panics with a diagnostic naming the row's
+/// `source`; the [`assert_table_regexes_compile`] test runs in CI to
+/// make production unwraps infallible.
+pub fn build_regex_cache(table: &'static [FlagSpec]) -> HashMap<&'static str, Regex> {
+    let mut map = HashMap::with_capacity(table.len());
+    for spec in table {
+        if let Matcher::Regex(pat) = spec.matcher {
+            // Wrap in `(?:…)` before anchoring so a top-level
+            // alternation in the row pattern (e.g. `-O[0-3sz]?|-Og`)
+            // doesn't bind looser than the anchors. Without the
+            // group, `^-O[0-3sz]?|-Og$` would parse as
+            // `(^-O[0-3sz]?) | (-Og$)`, accepting `-Ofast` via the
+            // first alternative. With it, both halves are anchored.
+            let anchored = format!("^(?:{pat})$");
+            let re = Regex::new(&anchored).unwrap_or_else(|e| {
+                panic!(
+                    "compiler/flags: invalid regex `{pat}` from {}: {e}",
+                    spec.source
+                )
+            });
+            map.insert(pat, re);
+        }
+    }
+    map
+}
+
+/// Classify `arg` against `table`. Returns `None` when no row matches
+/// — the caller treats that as "unsupported flag, refuse to cache".
+///
+/// Non-flag positional arguments (no leading `-`) are unconditionally
+/// safe — they're source files, output paths, or values consumed by a
+/// separate-argument flag (e.g. the `dir` in `-I dir`).
+pub fn classify_against(
+    arg: &str,
+    table: &'static [FlagSpec],
+    regex_cache: &HashMap<&'static str, Regex>,
+) -> Option<FlagClass> {
+    if !arg.starts_with('-') {
+        // Positional. The parser already counted sources; flag values
+        // are inert here.
+        return Some(FlagClass::NoObjectEffect);
+    }
+    for spec in table {
+        let matched = match &spec.matcher {
+            Matcher::Exact(s) => arg == *s,
+            Matcher::Prefix(s) => arg.starts_with(*s),
+            // The cache is populated lazily by `build_regex_cache`; a
+            // missing entry here means the table changed without
+            // refreshing the cache — debug-time bug, not a flag
+            // we should silently accept.
+            Matcher::Regex(pat) => regex_cache
+                .get(pat)
+                .map(|re| re.is_match(arg))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "compiler/flags: regex `{pat}` ({}) not in cache",
+                        spec.source
+                    )
+                }),
+        };
+        if matched {
+            return Some(spec.class);
+        }
+    }
+    None
+}
+
+/// CI helper: validate that every [`Matcher::Regex`] pattern in
+/// `table` compiles. Run from each compiler's unit-test module so
+/// shipped tables can't carry malformed regexes.
+#[cfg(test)]
+#[doc(hidden)]
+pub fn assert_table_regexes_compile(table: &'static [FlagSpec]) {
+    for spec in table {
+        if let Matcher::Regex(pat) = spec.matcher {
+            // Wrap in `(?:…)` before anchoring so a top-level
+            // alternation in the row pattern (e.g. `-O[0-3sz]?|-Og`)
+            // doesn't bind looser than the anchors. Without the
+            // group, `^-O[0-3sz]?|-Og$` would parse as
+            // `(^-O[0-3sz]?) | (-Og$)`, accepting `-Ofast` via the
+            // first alternative. With it, both halves are anchored.
+            let anchored = format!("^(?:{pat})$");
+            Regex::new(&anchored).unwrap_or_else(|e| {
+                panic!(
+                    "compiler/flags: invalid regex `{pat}` from {}: {e}",
+                    spec.source
+                )
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::OnceLock;
+
+    static TEST_TABLE: &[FlagSpec] = &[
+        FlagSpec {
+            matcher: Matcher::Exact("-fPIC"),
+            class: FlagClass::ModeledInKey,
+            source: "tests",
+        },
+        FlagSpec {
+            matcher: Matcher::Prefix("-D"),
+            class: FlagClass::PreprocessorCaptured,
+            source: "tests",
+        },
+        FlagSpec {
+            matcher: Matcher::Regex(r"-W[^,]*"),
+            class: FlagClass::NoObjectEffect,
+            source: "tests — warnings; excludes `-Wl,*`/`-Wa,*`/`-Wp,*` passthrough forms",
+        },
+    ];
+
+    fn cache() -> &'static HashMap<&'static str, Regex> {
+        static CACHE: OnceLock<HashMap<&'static str, Regex>> = OnceLock::new();
+        CACHE.get_or_init(|| build_regex_cache(TEST_TABLE))
+    }
+
+    #[test]
+    fn positional_arg_classifies_as_no_effect() {
+        // Source files, output paths, values consumed by separate-
+        // argument flags — never flags, always safe.
+        assert_eq!(
+            classify_against("foo.c", TEST_TABLE, cache()),
+            Some(FlagClass::NoObjectEffect)
+        );
+        assert_eq!(
+            classify_against("include", TEST_TABLE, cache()),
+            Some(FlagClass::NoObjectEffect)
+        );
+    }
+
+    #[test]
+    fn exact_matcher_matches_only_the_literal() {
+        assert_eq!(
+            classify_against("-fPIC", TEST_TABLE, cache()),
+            Some(FlagClass::ModeledInKey)
+        );
+        assert_eq!(classify_against("-fPIC=1", TEST_TABLE, cache()), None);
+        assert_eq!(classify_against("-fPI", TEST_TABLE, cache()), None);
+    }
+
+    #[test]
+    fn prefix_matcher_matches_the_family() {
+        assert_eq!(
+            classify_against("-DFOO=1", TEST_TABLE, cache()),
+            Some(FlagClass::PreprocessorCaptured)
+        );
+        assert_eq!(
+            classify_against("-D", TEST_TABLE, cache()),
+            Some(FlagClass::PreprocessorCaptured)
+        );
+        assert_eq!(classify_against("-d", TEST_TABLE, cache()), None);
+    }
+
+    #[test]
+    fn regex_matcher_is_anchored_and_excludes_by_pattern() {
+        // -W* warnings should match; -Wl,*  / -Wa,* / -Wp,* must NOT
+        // (they're passthrough forms with different semantics).
+        assert_eq!(
+            classify_against("-Wall", TEST_TABLE, cache()),
+            Some(FlagClass::NoObjectEffect)
+        );
+        assert_eq!(
+            classify_against("-Wno-unused", TEST_TABLE, cache()),
+            Some(FlagClass::NoObjectEffect)
+        );
+        assert_eq!(classify_against("-Wl,-no_pie", TEST_TABLE, cache()), None);
+        assert_eq!(classify_against("-Wa,--64", TEST_TABLE, cache()), None);
+        assert_eq!(classify_against("-Wp,-MD,foo.d", TEST_TABLE, cache()), None);
+    }
+
+    #[test]
+    fn unknown_flag_classifies_as_none() {
+        // An argument no row matches → caller refuses. This is the
+        // safety property: the table is an allow-list of *known*
+        // classifications.
+        assert_eq!(classify_against("-fmadeup", TEST_TABLE, cache()), None);
+        assert_eq!(classify_against("--unknown", TEST_TABLE, cache()), None);
+    }
+
+    #[test]
+    fn ci_validator_accepts_valid_table() {
+        assert_table_regexes_compile(TEST_TABLE);
+    }
+
+    /// Anchoring must survive top-level alternation in a row's regex.
+    /// Without the `(?:...)` wrap in `build_regex_cache`, a pattern
+    /// like `-foo|-bar` would parse as `(^-foo)|(-bar$)`: partial
+    /// matches succeed, and an unrelated argument like `-foozilla`
+    /// gets classified silently. This used to bite the cc table's
+    /// `-O[0-3sz]?|-Og` row.
+    #[test]
+    fn anchoring_survives_top_level_alternation_in_pattern() {
+        static ALT_TABLE: &[FlagSpec] = &[FlagSpec {
+            matcher: Matcher::Regex(r"-foo|-bar"),
+            class: FlagClass::NoObjectEffect,
+            source: "tests — alternation anchoring",
+        }];
+        let cache = build_regex_cache(ALT_TABLE);
+
+        // The legitimate matches.
+        assert_eq!(
+            classify_against("-foo", ALT_TABLE, &cache),
+            Some(FlagClass::NoObjectEffect)
+        );
+        assert_eq!(
+            classify_against("-bar", ALT_TABLE, &cache),
+            Some(FlagClass::NoObjectEffect)
+        );
+
+        // The traps a naive `^pat$` would let through. All start with
+        // `-` so the positional early-return doesn't short-circuit
+        // the actual regex check — we are genuinely exercising
+        // the matcher.
+        assert_eq!(classify_against("-foobar", ALT_TABLE, &cache), None);
+        assert_eq!(classify_against("-foozilla", ALT_TABLE, &cache), None);
+        assert_eq!(classify_against("-x-bar", ALT_TABLE, &cache), None);
+        assert_eq!(classify_against("--bar", ALT_TABLE, &cache), None);
+    }
+}

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -22,6 +22,7 @@ use std::path::{Path, PathBuf};
 use crate::link::LinkStrategy;
 
 pub mod cc;
+pub mod flags;
 pub mod platform;
 pub mod rustc;
 


### PR DESCRIPTION
Refactors the cc flag classifier from procedural (\`flag_is_cache_safe\`) to declarative (a static \`CC_FLAGS\` table backed by a shared vocabulary in the new \`src/compiler/flags.rs\` module). Pure structure change — every existing input gets the same verdict as before.

This is groundwork. It doesn't fix a bug or unblock a workload on its own. It makes the *next* batch of work tractable: extending the allow set for Firefox (#114, #115, #116, #117), exposing user-configurable rows (#95), and growing the same vocabulary to future Swift / MSVC / clang-cl compilers.

## Why a table

Auditability and extensibility. With the procedural classifier:

- "What flags does kache support?" → read code
- "Did this PR add X correctly?" → re-read code
- "Are cc and (future) clang-cl consistent?" → diff code
- "Can a user extend the set locally (#95)?" → either no, or invent a config-only side channel

With the table:

- Every supported flag is one row, sortable, diffable, listable
- Each row carries a \`source\` field (the issue/PR that added it) — the table **is** the audit log
- The future config-extension story (#95) becomes "load user rows, overlay onto the shipped table with explicit precedence"
- A future \`kache list-flags\` is a one-line projection over the static data

## The vocabulary

**Four classification categories** (\`FlagClass\`):

| Variant | Safety contract |
|---|---|
| \`ModeledInKey\` | Parser extracts the value into a typed field the cache key hashes (\`-O*\`, \`-g*\`, \`-std=\`, \`-fPIC\`, \`-arch\`). |
| \`CapturedByProbe\` | \`cc -###\` resolves the flag into \`-cc1\` tokens the cache key already hashes. **Safety holds only when the probe resolves** — flags in this class must refuse to cache when the probe returns \`None\` (gcc today). No rows on this branch; #114-style PRs will populate. |
| \`PreprocessorCaptured\` | The preprocessor expansion hash subsumes the effect (\`-D…\`, \`-I…\`, \`-include\`, …). The flag changes *what* the compiler sees, not *how* it compiles. |
| \`NoObjectEffect\` | Doesn't change the resulting object bytes — diagnostics, dep-info sidecar, build mechanics. |

**Three matcher variants** (\`Matcher\`):

| Variant | Job | Example |
|---|---|---|
| \`Exact(s)\` | Single literal string | \`-fPIC\` |
| \`Prefix(s)\` | Open-ended family with a shared head | \`-D\`, \`-I\`, \`-mmacosx-version-min=\` |
| \`Regex(pat)\` | Anything more structural | \`-W[^,]*\` (warnings minus \`-Wl,*\`/\`-Wa,*\`/\`-Wp,*\`) |

No ad-hoc carve-outs. The one tricky case (\`-W*\` with the comma-exclusion for passthrough forms) lives honestly as a \`Regex\` row with a one-line rationale.

## Regex safety

- **Engine**: \`regex\` crate default — RE2-style, **guaranteed linear time**, no backreferences, no lookarounds, no catastrophic backtracking.
- **Auto-anchored**: patterns are wrapped as \`^(?:pat)$\` so a row author can't author a partial-match by accident, and so a top-level alternation in a row pattern (\`-foo|-bar\`) doesn't escape the anchors via operator precedence. (I hit that trap while writing this — \`-O[0-3sz]?|-Og\` matched \`-Ofast\` before the \`(?:…)\` wrap landed. There's a dedicated regression test now.)
- **CI-validated**: \`cc_flags_table_regexes_compile\` compiles every regex in \`CC_FLAGS\` at CI time. A typo in a pattern fails review, not production.
- **Lazy + cached**: each table compiles its regex set once per process via \`OnceLock<HashMap>\`. Per-arg lookup is hash-map fast; the one-time compile is amortized across the wrapper lifetime.

## Migration

The existing call site:

\`\`\`rust
.filter(|a| !flag_is_cache_safe(a))
\`\`\`

became:

\`\`\`rust
.filter(|a| classify_cc_flag(a).is_none())
\`\`\`

Same refusal semantics, same \`"cc: unsupported flag(s): …"\` message. Two test names got updated (\`refuses_flags_unclassified_in_cc_flags_table\`, \`cc_flags_table_classifies_known_cache_safe_flags\`) but their inputs and assertions are identical.

\`CapturedByProbe\` is marked \`#[allow(dead_code)]\` on this branch — the cc table doesn't yet have rows that need probe resolution. Upcoming flag-extension PRs (starting with #114) will populate it; the variant is documented design surface kept inert with no runtime cost.

## Test plan

- [x] \`just check\` clean — 543 main-crate tests (was 535: +8 new), fmt, clippy.
- [x] \`just e2e\` clean — all 10 fixtures green.
- [x] New tests in \`compiler::flags\`: positional fallthrough, every matcher variant, unknown→None, CI regex validator, **anchoring-survives-alternation regression** (covers the exact trap I hit).
- [x] New test \`compiler::cc::tests::cc_flags_table_regexes_compile\` — validates every \`CC_FLAGS\` regex compiles.
- [x] Existing tests unchanged in intent: \`refuses_flags_unclassified_in_cc_flags_table\`, \`cc_flags_table_classifies_known_cache_safe_flags\`, \`refuse_reason_names_the_rejected_flags\`, etc.

## What this unlocks next

| Issue | What it becomes |
|---|---|
| #114 (Gecko/Darwin baseline) | ~9 rows in the \`CapturedByProbe\` section |
| #115 (target/arch/WASM/ObjC) | small cluster of new rows |
| #116 (C++ ABI/RTTI/exceptions) | new rows + probably some \`ModeledInKey\` for RTTI/exception modes that need explicit key sensitivity |
| #117 (debug-info / clang wrappers) | new \`CapturedByProbe\` rows |
| #95 (user-configurable extension) | a config-merge layer that overlays user rows onto \`CC_FLAGS\` |

Future compiler support (Swift, MSVC, clang-cl) is the same pattern: one new table file using the same vocabulary, one \`classify_*_flag\` function, no changes to the wrapper or to the shared types.

## Notes for the reviewer

- The cc \`CC_FLAGS\` table preserves the existing behavior precisely. The \`-O\` family is one \`Regex(r"-O[0-3sz]?|-Og")\` row (semantically equivalent to the old \`MODELED_OPT_FLAGS\` array); same for \`-g\`. The \`-W*\` warning family is the \`Regex(r"-W[^,]*")\` row that replaced \`arg.starts_with("-W") && !arg.contains(',')\`. The rest is straight \`Exact\` / \`Prefix\` rows.
- \`assert_table_regexes_compile\` is \`#[cfg(test)]\` — it's a CI helper, not a runtime API.
- The \`#[allow(dead_code)]\` on \`FlagClass\` is per-enum so all variants are preserved; documentation references and Swift/MSVC future use stay coherent.
