### PR TITLE
fix(ci): heal macOS mise shim corruption blocking PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,14 +112,37 @@ jobs:
         run: |
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
+      # Heal mise shim state (macOS self-hosted runners only).
+      #
+      # A previous job that uninstalled a tool can leave a dangling
+      # entry in `~/.local/share/mise/shims/` — typically `rustup`
+      # pointing at a removed binary. The next job then fails with
+      # `mise ERROR rustup is not a valid shim. ... rustup failed`
+      # *before* any build work runs, because mise tries to use the
+      # broken shim during `mise install --force rust`. Linux runners
+      # are ephemeral, so this only bites macOS.
+      #
+      # Wiping the shim dir is non-destructive: mise rebuilds shims
+      # from the installs/ directory during the next install call.
+      # `continue-on-error` is intentional — the path may not exist on
+      # a brand-new runner; that's fine.
+      - name: Heal mise shim state (macOS self-hosted runner)
+        if: runner.os == 'macOS'
+        continue-on-error: true
+        run: rm -rf "${HOME}/.local/share/mise/shims"
       # `--force`: RUSTUP_HOME is per-run ($RUNNER_TEMP), but mise's record of
       # which tools are installed persists on the self-hosted runner. Without
       # --force, mise sees rust as "installed" and skips it, leaving the fresh
       # RUSTUP_HOME empty. --force makes it reinstall the toolchain every run.
+      # `cache_key_prefix: mise-v2` invalidates the previous shared
+      # cache that captured the broken-shim state above; without the
+      # bump, every cache restore would re-import the corruption before
+      # the heal step had a chance to run on a fresh runner.
       - name: Install Rust via mise
         uses: jdx/mise-action@v3
         with:
           install_args: --force rust
+          cache_key_prefix: mise-v2
       # mise installs the toolchain via rustup under RUSTUP_HOME, but on a
       # runner with a pre-existing rustup it leaves no cargo proxy on PATH —
       # so the stale system Rust (Homebrew 1.94) would win. Prepend the
@@ -226,15 +249,29 @@ jobs:
         run: |
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
+      # Heal mise shim state — same hazard the `e2e` job documents in
+      # detail. A previous job can leave a dangling `rustup` shim
+      # under `~/.local/share/mise/shims/` that fails the next
+      # `mise install --force rust` with "rustup is not a valid shim".
+      # See the corresponding step in the `e2e` job for the full
+      # story. Non-destructive: mise rebuilds shims from installs/.
+      - name: Heal mise shim state (macOS self-hosted runner)
+        if: runner.os == 'macOS'
+        continue-on-error: true
+        run: rm -rf "${HOME}/.local/share/mise/shims"
       # mise is the project's toolchain manager (see mise.toml); it installs
       # rust via rustup into the isolated home above. `--force` is required:
       # RUSTUP_HOME is per-run but mise's installed-tool record persists on
       # the self-hosted runner, so without it mise skips the reinstall and
       # leaves the fresh RUSTUP_HOME empty.
+      # `cache_key_prefix: mise-v2` matches the bump in the e2e job —
+      # they share a cache pool, and the prior `mise-v1` cache captured
+      # the broken-shim state we're healing here.
       - name: Install Rust via mise
         uses: jdx/mise-action@v3
         with:
           install_args: --force rust
+          cache_key_prefix: mise-v2
       # mise installs the toolchain via rustup under RUSTUP_HOME, but on a
       # runner with a pre-existing rustup it leaves no cargo proxy on PATH —
       # so the stale system Rust (Homebrew 1.94) would win. Prepend the


### PR DESCRIPTION
A previous self-hosted-runner job can leave a dangling \`rustup\` entry in \`~/.local/share/mise/shims/\` — typically because a tool was uninstalled but its shim was not removed. The next macOS job then fails at \`mise install --force rust\` with:

\`\`\`
mise rust@1.95.0               uninstall
mise ERROR rustup is not a valid shim. This likely means you uninstalled a
       tool and the shim does not point to anything.
mise ERROR rustup failed
mise ERROR Failed to install core:rust@latest: rustup exited with non-zero status: exit code 1
\`\`\`

…before any build work runs.

The corruption is then captured by the cache mise-action saves at job-end, so subsequent jobs restoring the same key (\`mise-v1-macos-arm64-...\`) re-import the bad state and inherit the failure. PRs #136 and #138 both hit this; #134 escaped via runner-pool luck (different runner). Linux is unaffected — its ephemeral runners can't accumulate state.

## Two-part fix

**1. Heal step** before each macOS \`mise install --force rust\`:

\`\`\`yaml
- name: Heal mise shim state (macOS self-hosted runner)
  if: runner.os == 'macOS'
  continue-on-error: true
  run: rm -rf "\${HOME}/.local/share/mise/shims"
\`\`\`

Non-destructive — mise rebuilds shims from \`installs/\` during the next install call. Defensive forever: if the corruption recurs from a future tool uninstall, the next run heals automatically. \`continue-on-error\` so a brand-new runner without the path doesn't fail the job.

**2. \`cache_key_prefix: mise-v2\`** on the two affected mise-action calls (the \`e2e\` and \`test-macos\` jobs, both on the same self-hosted Apple Silicon pool). Without the bump the corrupted \`mise-v1-...\` cache would keep being restored *before* the heal step ran on a fresh runner, regenerating the bad state on every job. The \`Check (Linux)\` job's mise-action stays at the default \`mise-v1\` — its cache key already differs by OS/arch and isn't affected by this bug.

## Why both fixes

| Fix alone | Failure mode |
|---|---|
| Cache bump only | Works once. The next bad-state-leaving job re-poisons the new cache; we'd need a v3 bump, then v4, … |
| Heal step only | Works on every run *after* the first one with the broken cache key. But the cache hit on the first restore brings back the broken state — the heal step has to run before \`mise install\` can succeed, which is the order I've placed it in. |

Combined: the bump breaks the current cycle, the heal step prevents future cycles.

## Test plan

- [x] YAML validates (\`python3 -c 'import yaml; yaml.safe_load(...)'\`).
- [x] The heal step is gated \`if: runner.os == 'macOS'\` so Linux runs are no-op.
- [x] \`continue-on-error\` means the step won't fail on a runner that doesn't have the path yet.
- [ ] CI run on this PR will exercise the new path. If it passes on both self-hosted macOS runners (\`kunobi-1\` and \`kunobi-2\`), the fix works.

## Notes

- This fixes the *symptom* on kache's CI. The underlying mise/mise-action behavior — leaving dangling shims after an uninstall — is upstream; the workaround is the most we can do without filing against the upstream.
- The \`Linux Check\` job's \`jdx/mise-action@v3\` call (line 35) is untouched — it installs \`just\`, not rust, and its cache is already separate by OS/arch.
- The third mise-action call in \`.github/workflows/service-image.yml\` is untouched for now; the bug hasn't been observed there. Can be patched if it surfaces.