### PR TITLE
fix(cc): allow C++ ABI, RTTI, and exception flags (#116)

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -767,6 +767,56 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         class: FlagClass::CapturedByProbe,
         source: "Issue #117 — LLVM debug-info abstraction (Firefox baseline). Listed by exact value rather than `-mllvm=*` wildcard so unmodeled LLVM flags still refuse.",
     },
+    // C++ ABI, RTTI, and exception flags (kunobi-ninja/kache#116).
+    // Each row affects the resulting object materially — `-fno-rtti`
+    // omits RTTI tables, `-fno-exceptions` skips exception-handling
+    // tables, `-stdlib=libc++` vs `libstdc++` selects a different C++
+    // standard library with different ABI defaults. Clang's `-###`
+    // captures all of them in the resolved `-cc1` invocation, so the
+    // cache key differentiates per-value via the resolved-tokens hash.
+    //
+    // Both the positive and negative forms are listed (`-frtti` /
+    // `-fno-rtti`, `-fexceptions` / `-fno-exceptions`) because a build
+    // may explicitly request either mode — they're conflicting and the
+    // cache must distinguish them, which is automatic via the probe.
+    FlagSpec {
+        // `-stdlib=libc++` (clang default on macOS), `-stdlib=libstdc++`
+        // (typical on Linux). Values are a small fixed set; the probe
+        // resolves each into a distinct `-cc1` form.
+        matcher: Matcher::Prefix("-stdlib="),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #116 — C++ standard-library selector (libc++ / libstdc++).",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fno-exceptions"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #116 — C++ exception mode (off).",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fexceptions"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #116 — C++ exception mode (on).",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fno-rtti"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #116 — C++ RTTI mode (off).",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-frtti"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #116 — C++ RTTI mode (on).",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fno-sized-deallocation"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #116 — C++ sized-deallocation (disabled).",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fno-aligned-new"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #116 — C++ aligned new/delete (disabled).",
+    },
     // ── PreprocessorCaptured: cc -E -P expansion hash subsumes effect ──
     FlagSpec {
         matcher: Matcher::Prefix("-D"),
@@ -1658,7 +1708,6 @@ mod tests {
             "-ffast-math",
             "-fsanitize=address",
             "-funroll-loops",
-            "-fno-rtti",
             "-fno-pic",
             "-fvisibility=hidden",
             "-ffunction-sections",
@@ -1894,6 +1943,97 @@ mod tests {
             assert!(
                 descs.iter().any(|d| d.contains("unsupported flag")),
                 "{flag} is NOT on the #117 list and must still refuse, got: {descs:?}"
+            );
+        }
+    }
+
+    /// C++ ABI / RTTI / exception flags (kunobi-ninja/kache#116).
+    /// Each row affects the resulting object materially, and clang's
+    /// `cc -###` resolved tokens differentiate them — RTTI on vs off,
+    /// exceptions on vs off, and `-stdlib=libc++` vs `libstdc++` all
+    /// produce distinct keys via the probe.
+    #[test]
+    fn classifier_accepts_cpp_abi_rtti_exception_flags() {
+        for flag in &[
+            "-stdlib=libc++",
+            "-stdlib=libstdc++",
+            "-fno-exceptions",
+            "-fexceptions",
+            "-fno-rtti",
+            "-frtti",
+            "-fno-sized-deallocation",
+            "-fno-aligned-new",
+        ] {
+            let descs = refuse_descriptions(&["cc", "-c", "foo.cpp", "-o", "foo.o", flag]);
+            assert!(
+                !descs.iter().any(|d| d.contains("unsupported flag")),
+                "{flag} should be classified (#116 baseline), got: {descs:?}"
+            );
+        }
+    }
+
+    /// A realistic Firefox-style C++ compile: pile the full #116
+    /// baseline plus already-allowed flags onto one `cc -c` invocation
+    /// and assert the classifier accepts it as fully cacheable.
+    #[test]
+    fn classifier_accepts_realistic_firefox_cpp_compile() {
+        let descs = refuse_descriptions(&[
+            "cc",
+            "-c",
+            "foo.cpp",
+            "-o",
+            "foo.o",
+            "-O2",
+            "-g",
+            "-std=gnu++17",
+            "-stdlib=libc++",
+            "-fno-exceptions",
+            "-fno-rtti",
+            "-fno-sized-deallocation",
+            "-fno-aligned-new",
+            // Mixed with previously-allowed Gecko/Darwin baseline flags
+            // (#114) to confirm no cross-contamination between
+            // additions.
+            "-mmacosx-version-min=10.15",
+            "-fno-strict-aliasing",
+            "-fstack-protector-strong",
+            "-Wall",
+            "-DMOZILLA_INTERNAL_API=1",
+        ]);
+        assert!(
+            descs.is_empty(),
+            "realistic Firefox C++ compile should be fully cacheable, got: {descs:?}"
+        );
+    }
+
+    /// Pin the boundary on #116: adjacent forms / lookalikes must
+    /// still refuse so unmodeled codegen flags don't slip past via
+    /// the new rows.
+    #[test]
+    fn classifier_does_not_overreach_116_additions() {
+        for flag in &[
+            // Visibility / sections / sanitizers aren't on #116's list
+            // — they remained refused before and must stay refused.
+            "-fvisibility=hidden",
+            "-fvisibility-inlines-hidden",
+            "-fsanitize=undefined",
+            // Aligned-new POSITIVE form not on the list. The negative
+            // form (`-fno-aligned-new`) is what Firefox uses; if a
+            // workload needs `-faligned-new`, file a follow-up.
+            "-faligned-new",
+            "-fsized-deallocation",
+            // `-stdlib=` lookalike that isn't actually the C++ stdlib
+            // selector.
+            "-fstdlib=libc++",
+            // `-fno-rt*`/`-fno-ex*` near-matches that aren't on the list.
+            "-fno-rt",
+            "-fno-rttis",
+            "-fexception",
+        ] {
+            let descs = refuse_descriptions(&["cc", "-c", "foo.cpp", "-o", "foo.o", flag]);
+            assert!(
+                descs.iter().any(|d| d.contains("unsupported flag")),
+                "{flag} is NOT on the #116 list and must still refuse, got: {descs:?}"
             );
         }
     }


### PR DESCRIPTION
Closes #116. Third PR in the cc allow-list cluster after #137 / #140. Same shape: 7 rows + 3 tests, no architectural touching.

## Summary

Firefox on macOS aarch64 triggered ~2,800 single-source C++ passthroughs per build because seven C++ ABI / RTTI / exception flags weren't classified in \`CC_FLAGS\`.

| Flag | Approx. passthroughs unblocked |
|---|---|
| \`-stdlib=libc++\` | 2,809 |
| \`-fno-exceptions\` | 2,779 |
| \`-fno-sized-deallocation\` | 2,713 |
| \`-fno-rtti\` | 2,713 |
| \`-fno-aligned-new\` | 2,713 |
| \`-frtti\` | 369 |
| \`-fexceptions\` | 1 |

(Overlapping invocations — union is ~2,800 distinct compiles, not the sum.)

## Why no cache-key changes

All seven flags classify as \`FlagClass::CapturedByProbe\`. Clang's \`cc -###\` resolves each into a distinct \`-cc1\` invocation, so the resolved-tokens hash already differentiates them per-value. This is exactly the acceptance criterion the issue calls out for "conflicting modes":

- \`-fno-rtti\` produces a \`-cc1 -fno-rtti\` invocation; \`-frtti\` produces \`-cc1\` without it. Different tokens, different key, different cached object.
- \`-fno-exceptions\` / \`-fexceptions\` same story.
- \`-stdlib=libc++\` vs \`-stdlib=libstdc++\` resolve into \`-cc1 -stdlib=…\` with distinct values *and* potentially different \`-isysroot\` / include search paths. Both effects show in the resolved tokens.

## Scoping (consistent with #137 / #140)

| Decision | Why |
|---|---|
| **Both positive and negative forms listed** (\`-frtti\` / \`-fno-rtti\`, \`-fexceptions\` / \`-fno-exceptions\`) | Either mode can be requested explicitly; the probe captures the difference. Without explicit rows, the inverse forms would refuse and break workloads that toggle these. |
| **\`-stdlib=\` is a \`Prefix\`, not multiple \`Exact\` rows** | Small fixed value set (\`libc++\`, \`libstdc++\`, \`platform\`); the probe resolves each to a distinct \`-cc1\` form. Same pattern as \`-mmacosx-version-min=\` from #114. |
| **\`-faligned-new\` (positive form) is NOT included** | Firefox uses \`-fno-aligned-new\`; the positive form isn't on #116's evidence. Adding it via a wildcard \`-f(no-)?aligned-new\` would silently accept the inverse without explicit review. Easy follow-up if a workload needs it. |

## Test plan

- [x] \`classifier_accepts_cpp_abi_rtti_exception_flags\` — every #116 flag, both \`-stdlib=*\` values.
- [x] \`classifier_accepts_realistic_firefox_cpp_compile\` — full #116 baseline + #114 baseline + already-allowed flags on one \`cc -c foo.cpp\`, asserting zero refuse reasons. This is the canonical Firefox-on-macOS C++ shape.
- [x] \`classifier_does_not_overreach_116_additions\` — pins boundary against \`-faligned-new\`, \`-fsized-deallocation\`, \`-fvisibility=hidden\`, \`-fsanitize=undefined\`, \`-fstdlib=libc++\` (lookalike), and near-misses like \`-fno-rt\` / \`-fno-rttis\` / \`-fexception\`.
- [x] \`just check\` clean — 552 workspace tests (+3 new from this PR).
- [x] \`just e2e\` clean — all 10 fixtures green.

## Refuse-list test cleanup

\`-fno-rtti\` was in \`refuses_flags_unclassified_in_cc_flags_table\` (it had been refused before #116). Removed — it's now in \`CC_FLAGS\` and would no longer refuse, which is the whole point.

## Combined passthrough-unblocking progress

Per the Firefox bench evidence:

| | Passthroughs unblocked | Status |
|---|---|---|
| #137 (Gecko/Darwin baseline) | ~4,476 | merged |
| #140 (debug-info + wrappers) | ~4,275 | merged |
| **#116 (this PR — C++ ABI/RTTI/exceptions)** | **~2,800** | in CI |
| #115 (target/arch/WASM/ObjC) | smaller | next |

These overlap substantially. Once #116 lands, only the residual #115 cluster remains; the next Firefox bench run should show a meaningfully different passthrough rate.

## Out of scope

- Link-mode caching
- The positive forms (\`-faligned-new\`, \`-fsized-deallocation\`) — Firefox uses the negatives; positives are explicit follow-ups.
- Sanitizer / coverage / module flags (separately refused; tracked elsewhere).