### PR TITLE
fix(cc): allow Firefox target/arch/WASM/ObjC flags (#115)

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -817,6 +817,97 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         class: FlagClass::CapturedByProbe,
         source: "Issue #116 — C++ aligned new/delete (disabled).",
     },
+    // Target / arch / WASM / ObjC / section flags
+    // (kunobi-ninja/kache#115). Each row affects the resulting object
+    // materially — `--target=` changes the entire output architecture,
+    // `-march=` picks a CPU baseline, `-msimd128` enables WASM SIMD,
+    // section flags reshape the object layout. Clang's `cc -###`
+    // resolves each into the `-cc1` token stream (target triple,
+    // target-cpu, target-feature list, language mode, section options),
+    // so the resolved-tokens hash differentiates per-value and a
+    // cross-target hit can't serve a foreign object.
+    //
+    // These flags were previously in the refuse-list (catch-all "would
+    // serve a foreign object" guard); the explicit classification
+    // makes them safe via the probe, with the boundary tests pinning
+    // adjacent / unmodeled cases.
+    FlagSpec {
+        // Sticky `--target=arm64-apple-macosx` / `--target=wasm32-wasi`
+        // / `--target=aarch64-linux-gnu`. The probe resolves the
+        // triple into a `-cc1 -triple <value>` token, so different
+        // targets produce different keys.
+        matcher: Matcher::Prefix("--target="),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #115 — cross-compilation target triple (sticky form).",
+    },
+    FlagSpec {
+        // Separate-arg form: `-target <triple>`. The value classifies
+        // as a positional (no leading `-`), so this row only needs to
+        // accept the flag itself.
+        matcher: Matcher::Exact("-target"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #115 — cross-compilation target triple (separate-arg form).",
+    },
+    FlagSpec {
+        // `-march=` family: `native`, `armv8-a`, `armv8.2-a+dotprod`,
+        // `armv8.2-a+i8mm`, etc. The probe captures the resolved
+        // `-target-cpu` and `-target-feature` list, so `native` on
+        // host A vs host B produces different keys (correct: they're
+        // different objects).
+        matcher: Matcher::Prefix("-march="),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #115 — architecture selection. `Prefix` is safe because the probe resolves the value into target-cpu/target-feature tokens.",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-msimd128"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #115 — WASM SIMD128 enable.",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-ffunction-sections"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #115 — function-per-section object layout.",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fdata-sections"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #115 — data-per-section object layout.",
+    },
+    FlagSpec {
+        // `-Wa,*` passes through to the assembler. Different `-Wa,*`
+        // values do arbitrary assembler things — listed as `Exact` for
+        // the specific Firefox value (per #115's evidence) so a wildcard
+        // `Prefix("-Wa,")` doesn't silently accept unmodeled assembler
+        // flags. `--noexecstack` sets a section flag on the object.
+        matcher: Matcher::Exact("-Wa,--noexecstack"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #115 — assembler: non-executable stack section flag. Listed by exact value rather than `-Wa,*` wildcard so unmodeled assembler flags still refuse.",
+    },
+    FlagSpec {
+        // Separate-arg form: `-x <lang>`. Value is positional. The
+        // probe resolves the language mode into the `-cc1` invocation.
+        matcher: Matcher::Exact("-x"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #115 — language override (separate-arg form).",
+    },
+    FlagSpec {
+        // Sticky form. `-xobjective-c++` is the one #115 lists; other
+        // sticky forms (`-xc`, `-xc++`, `-xobjective-c`) would need
+        // explicit rows when they show up in a real workload.
+        matcher: Matcher::Exact("-xobjective-c++"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #115 — Objective-C++ language override (sticky form).",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fobjc-exceptions"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #115 — Objective-C exception model.",
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fobjc-arc"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #115 — Objective-C ARC mode.",
+    },
     // ── PreprocessorCaptured: cc -E -P expansion hash subsumes effect ──
     FlagSpec {
         matcher: Matcher::Prefix("-D"),
@@ -1710,8 +1801,6 @@ mod tests {
             "-funroll-loops",
             "-fno-pic",
             "-fvisibility=hidden",
-            "-ffunction-sections",
-            "-march=native",
             "-mtune=skylake",
             "-mavx2",
             // unmodeled optimization / debug variants
@@ -1719,13 +1808,8 @@ mod tests {
             "-gdwarf-5",
             "-ggdb",
             "-gline-tables-only",
-            // cross-compilation target (would serve a foreign object)
-            "-target",
-            "--target=aarch64-linux-gnu",
             // profiling instrumentation
             "-pg",
-            // language override — not modeled in the key
-            "-x",
         ] {
             let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
             assert!(
@@ -2038,6 +2122,142 @@ mod tests {
         }
     }
 
+    /// Target / arch / WASM / ObjC / section flags
+    /// (kunobi-ninja/kache#115). Each row affects the resulting object
+    /// materially; clang's `cc -###` resolves each into the `-cc1`
+    /// token stream so the cache key differentiates per-value.
+    #[test]
+    fn classifier_accepts_target_arch_objc_flags() {
+        for flag in &[
+            // Sticky --target= for several real triples Firefox uses
+            "--target=arm64-apple-macosx",
+            "--target=wasm32-wasi",
+            "--target=aarch64-linux-gnu",
+            // Separate-arg form
+            "-target",
+            // -march= family — native + specific microarchs
+            "-march=native",
+            "-march=armv8-a",
+            "-march=armv8.2-a+dotprod",
+            "-march=armv8.2-a+i8mm",
+            // WASM SIMD
+            "-msimd128",
+            // Section layout
+            "-ffunction-sections",
+            "-fdata-sections",
+            // Assembler passthrough (specific value, not wildcard)
+            "-Wa,--noexecstack",
+            // Language override forms
+            "-x",
+            "-xobjective-c++",
+            // ObjC codegen modes
+            "-fobjc-exceptions",
+            "-fobjc-arc",
+        ] {
+            let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
+            assert!(
+                !descs.iter().any(|d| d.contains("unsupported flag")),
+                "{flag} should be classified (#115 baseline), got: {descs:?}"
+            );
+        }
+    }
+
+    /// A realistic Firefox-style cross-compile invocation:
+    /// `cc -c foo.c -O2 -g --target=wasm32-wasi -msimd128 …` (the
+    /// WASM bundling pipeline) plus previously-allowed flags.
+    /// Headline contract from #115's acceptance criteria — "tests
+    /// cover wasm target flags".
+    #[test]
+    fn classifier_accepts_realistic_firefox_wasm_compile() {
+        let descs = refuse_descriptions(&[
+            "cc",
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o",
+            "-O2",
+            "-g",
+            "-std=gnu11",
+            "--target=wasm32-wasi",
+            "-msimd128",
+            "-ffunction-sections",
+            "-fdata-sections",
+            "-fno-strict-aliasing",
+            "-Wa,--noexecstack",
+            "-Wall",
+            "-DMOZILLA_BUILD=1",
+        ]);
+        assert!(
+            descs.is_empty(),
+            "realistic Firefox WASM compile should be fully cacheable, got: {descs:?}"
+        );
+    }
+
+    /// Realistic ObjC++ Firefox compile — the language override goes
+    /// through, the ObjC-specific codegen flags go through. Pins
+    /// #115's third acceptance criterion ("ObjC/ObjC++ language mode
+    /// flags").
+    #[test]
+    fn classifier_accepts_realistic_firefox_objc_compile() {
+        let descs = refuse_descriptions(&[
+            "cc",
+            "-c",
+            "foo.mm",
+            "-o",
+            "foo.o",
+            "-O2",
+            "-g",
+            "-xobjective-c++",
+            "-fobjc-arc",
+            "-fobjc-exceptions",
+            "-fno-exceptions",
+            "-fno-rtti",
+            "-stdlib=libc++",
+            "-mmacosx-version-min=11.0",
+            "-march=armv8-a",
+        ]);
+        assert!(
+            descs.is_empty(),
+            "realistic Firefox ObjC++ compile should be fully cacheable, got: {descs:?}"
+        );
+    }
+
+    /// Pin the boundary on #115: adjacent / unmodeled forms must
+    /// still refuse so wildcards stay scoped to what #115 actually
+    /// covers.
+    #[test]
+    fn classifier_does_not_overreach_115_additions() {
+        for flag in &[
+            // `-Wa,*` wildcard is NOT opened — only the specific
+            // `--noexecstack` value is. Other assembler passthroughs
+            // refuse.
+            "-Wa,-mfp",
+            "-Wa,--something-else",
+            // `-x` sticky-form variants not on the list. The list
+            // names `-xobjective-c++` explicitly; other languages
+            // refuse until their workload appears.
+            "-xc",
+            "-xc++",
+            "-xobjective-c",
+            // ObjC variants not on the list
+            "-fno-objc-arc",
+            "-fobjc-weak",
+            // Section flags not on the list (similar shape, distinct
+            // codegen)
+            "-fno-function-sections",
+            "-fno-data-sections",
+            // SIMD adjacent — not `-msimd128`
+            "-msse4.2",
+            "-mavx512f",
+        ] {
+            let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
+            assert!(
+                descs.iter().any(|d| d.contains("unsupported flag")),
+                "{flag} is NOT on the #115 list and must still refuse, got: {descs:?}"
+            );
+        }
+    }
+
     #[test]
     fn refuse_reason_names_the_rejected_flags() {
         // The refusal must report *which* flags blocked caching — that
@@ -2049,7 +2269,7 @@ mod tests {
             "-o",
             "foo.o",
             "-ffast-math",
-            "--target=aarch64-linux-gnu",
+            "-fvisibility=hidden",
         ]);
         let detail = descs
             .iter()
@@ -2060,7 +2280,7 @@ mod tests {
             "reason should name the flag: {detail}"
         );
         assert!(
-            detail.contains("--target=aarch64-linux-gnu"),
+            detail.contains("-fvisibility=hidden"),
             "reason should name every rejected flag: {detail}"
         );
     }

--- a/test-projects/c-passthrough/Makefile
+++ b/test-projects/c-passthrough/Makefile
@@ -1,20 +1,21 @@
 # kache-e2e fixture: a C build kache must NOT cache.
 #
-# The `-c` compile passes `-march=native` — a flag whose result
-# depends on the BUILD HOST's CPU. kache is a cross-machine,
-# content-addressed cache, so it can never safely cache a
-# host-specific object; `-march=native` is permanently uncacheable by
-# design. kache detects it as an unmodeled `-m...` codegen flag and
-# passes the compile through to the real compiler, caching nothing.
+# The `-c` compile passes `-ffast-math` — an unmodeled codegen flag
+# that kache's classifier does not recognize. The compile passes
+# through to the real compiler, caching nothing.
 #
-# `-march=native` is chosen deliberately over a flag like
-# `-funroll-loops`: that one will eventually be classified as
-# cacheable (hashed into the key), which would silently break this
-# fixture's "caches nothing" contract. `-march=native` never will —
-# so the fixture stays valid as the support matrix grows.
+# Choice of flag: this needs an "unmodeled codegen flag that won't
+# get classified later". `-march=native` was originally used for this
+# but #115 added `Prefix("-march=")` to the cc table (the resolved
+# `cc -###` tokens differentiate the per-host target-cpu / target-
+# feature set, so `-march=*` is cacheable per-machine). `-ffast-math`
+# changes float semantics in ways the modeled cache-key inputs don't
+# capture today; if a future PR teaches the cache key about float
+# modes, that PR should pick a different fixture flag — the docstring
+# in the corresponding row of `CC_FLAGS` should mention this one.
 
 CC      ?= cc
-CFLAGS  ?= -O2 -march=native
+CFLAGS  ?= -O2 -ffast-math
 SRC     := src/main.c
 BUILD   := build
 OBJ     := $(BUILD)/main.o

--- a/test-projects/c-passthrough/kache-fixture.toml
+++ b/test-projects/c-passthrough/kache-fixture.toml
@@ -1,21 +1,23 @@
 # kache-e2e fixture: a build kache must NOT cache.
 #
-# The inverse of c-hello. The `-c` compile passes `-march=native`, an
-# unmodeled `-m...` codegen flag. kache refuses it — the compile
-# passes through to the real compiler, uncached — and every phase
-# lands ZERO cache entries.
+# The inverse of c-hello. The `-c` compile passes `-ffast-math`, an
+# unmodeled codegen flag. kache's classifier refuses it (no row in
+# `CC_FLAGS` matches), the compile passes through to the real
+# compiler uncached, and every phase lands ZERO cache entries.
 #
-# `-march=native` is chosen so this fixture stays valid forever. Its
-# result depends on the build host's CPU; kache is a cross-machine
-# content-addressed cache, so caching a host-specific object is
-# something it can never do — `-march=native` is permanently
-# uncacheable by design. A flag like `-funroll-loops` would instead
-# eventually be classified as cacheable (hashed into the key), which
-# would silently break this fixture's "caches nothing" contract.
+# Choice of flag: this fixture needs "an unmodeled codegen flag the
+# classifier will refuse". `-march=native` was originally used because
+# its host-specific output was thought to be permanently uncacheable;
+# #115 disproved that (the probe captures host-resolved cpu/features,
+# so `-march=*` caches correctly per-machine). `-ffast-math` is the
+# current pick — its float-semantics changes aren't captured by the
+# modeled key inputs today, and adding it to `CC_FLAGS` is genuinely
+# unsafe without explicit modeling. If a future PR DOES model
+# `-ffast-math`, the same PR should pick a new unmodeled flag here.
 #
 # This is the e2e cell for the unmodeled-codegen-flag passthrough
-# behavior (the `is_unmodeled_codegen_flag` refuse rule). c-hello
-# proves a clean compile caches; this proves an unsafe one does not.
+# behavior. c-hello proves a clean compile caches; this proves an
+# unsafe one does not.
 
 name = "c-passthrough"
 


### PR DESCRIPTION
Closes #115. Final PR in the cc allow-list cluster (#114 / #117 / #116 / #115).

## Summary

Adds 11 rows to \`CC_FLAGS\` for the target / arch / WASM / ObjC / section flags Firefox uses but the classifier didn't recognize yet. All classify as \`CapturedByProbe\` — clang's \`cc -###\` resolves each into the \`-cc1\` token stream that the cache key already hashes.

Also migrates the \`c-passthrough\` e2e fixture from \`-march=native\` (which is now cacheable per the probe) to \`-ffast-math\` (still unmodeled).

## Flags

| Flag | Approx. passthroughs per Firefox build |
|---|---|
| \`-ffunction-sections\` | 133 |
| \`-fdata-sections\` | 133 |
| \`--target=arm64-apple-macosx\` | 133 |
| \`-mmacosx-version-min=26.5\` | 133 (already covered by #137) |
| \`-x\` | 84 |
| \`-fobjc-exceptions\` | 83 |
| \`--target=wasm32-wasi\` | 70 |
| \`-msimd128\` | 58 |
| \`-Wa,--noexecstack\` | 50 |
| \`-march=armv8.2-a+dotprod\` | 22 |
| \`-march=armv8-a\` | 18 |
| \`-fobjc-arc\` | 14 |
| \`-march=armv8.2-a+i8mm\` | 10 |
| \`-xobjective-c++\` | 8 |

(Counts mostly overlap on the same invocations — union is smaller than the sum.)

## Five flags moved out of the refuse-list test

\`-target\`, \`--target=aarch64-linux-gnu\`, \`-march=native\`, \`-ffunction-sections\`, and \`-x\` were previously asserted-refused; they're now classified.

## Fixture migration: c-passthrough

The \`c-passthrough\` fixture used \`-march=native\` to verify "kache refuses unmodeled codegen flags". The fixture's docstring claimed \`-march=native\` was "permanently uncacheable" because the output is host-specific. **The probe disproves that**: different hosts resolve to different target-cpu / target-feature tokens, so cross-host sharing is correctly disabled, but same-host caching works.

Migrated to \`-ffast-math\` — currently unmodeled, genuinely unsafe to cache without explicit float-semantics modeling. Makefile + fixture TOML docstrings both updated with a forward note for whoever models float semantics next.

## Scoping (consistent with #137 / #140 / #141)

| Decision | Why |
|---|---|
| \`-Wa,--noexecstack\` is \`Exact\`, not \`Prefix("-Wa,")\` | Different \`-Wa,*\` values do arbitrary assembler things; a wildcard would silently accept unmodeled assembler flags. |
| \`-xobjective-c++\` is \`Exact\`, not \`Prefix("-x")\` | Other sticky-form language overrides aren't on #115's evidence; specific values now, more rows when a workload appears. |
| \`--target=\` and \`-march=\` ARE prefix-wildcarded | The probe resolves every value into distinct \`-cc1\` tokens; the cache key correctly differentiates without explicit modeling. |

## Test plan

- [x] \`classifier_accepts_target_arch_objc_flags\` — every #115 flag, including all four sample \`-march=\` values and three sample \`--target=\` values.
- [x] \`classifier_accepts_realistic_firefox_wasm_compile\` — full WASM pipeline shape. Headline acceptance criterion ("tests cover wasm target flags").
- [x] \`classifier_accepts_realistic_firefox_objc_compile\` — ObjC++ shape combined with #137's Gecko baseline and #141's C++ ABI flags. Headline acceptance criterion ("tests cover ObjC/ObjC++ language mode flags").
- [x] \`classifier_does_not_overreach_115_additions\` — pins boundary against \`-Wa,*\` non-noexecstack values, sticky-form \`-xc\` / \`-xc++\` / \`-xobjective-c\`, \`-fno-objc-arc\`, \`-fobjc-weak\`, \`-fno-function-sections\`, SIMD adjacents like \`-msse4.2\` / \`-mavx512f\`.
- [x] \`refuse_reason_names_the_rejected_flags\` updated — \`--target=…\` was its second-rejected example; swapped for \`-fvisibility=hidden\` (still unmodeled).
- [x] \`just check\` clean — 556 workspace tests (+4 new from this PR).
- [x] \`just e2e\` clean — all 10 fixtures green, including the migrated \`c-passthrough\`.

## Cluster status after merge

| Issue | PR | Status |
|---|---|---|
| #114 (Gecko/Darwin baseline) | #137 | merged |
| #117 (debug-info + wrappers) | #140 | merged |
| #116 (C++ ABI/RTTI/exceptions) | #141 | merged |
| **#115 (target/arch/WASM/ObjC)** | **this PR** | in CI |

A fresh Firefox bench run after this merges should show the C/C++ passthrough rate drop materially from the prior ~85% in the bench measurements pre-#137 — these four PRs combined classify ~11.5K previously-refused single-source C/C++ compiles per Firefox build.

## Out of scope (separate issues)

- Link-mode caching
- Response file expansion
- Full \`-mllvm=*\` wildcard support
- Full \`-Wa,*\` wildcard support
- Sticky-form \`-x<lang>\` variants other than \`-xobjective-c++\`
- C/C++ float-semantics modeling (would let \`-ffast-math\` join the table; for now it stays in the c-passthrough fixture)