### PR TITLE
chore: consolidate tool-generated scratch under /tmp/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           python3 -c "
           import json, sys
-          data = json.load(open('target/llvm-cov/coverage.json'))
+          data = json.load(open('tmp/llvm-cov/coverage.json'))
           coverage = data['data'][0]['totals']['lines']['percent']
           threshold = 35.0
           print(f'Coverage: {coverage:.1f}%')
@@ -69,7 +69,7 @@ jobs:
         if: always()
         with:
           name: coverage-html
-          path: target/llvm-cov/html
+          path: tmp/llvm-cov/html
           retention-days: 14
 
   # --- E2E smoke test ---
@@ -145,11 +145,11 @@ jobs:
         # against `kache report --format json`, and writes a single
         # results.json. Replaces the previous per-language bash scripts.
         run: |
-          mkdir -p e2e-results
+          mkdir -p tmp/e2e
           ./target/release/kache-e2e \
             --kache ./target/release/kache \
             --fixtures ./test-projects \
-            --out e2e-results/results.json
+            --out tmp/e2e/results.json
       - name: Run e2e negative-control (falsifiability check)
         # Reruns every fixture with kache disabled (KACHE_DISABLED=1)
         # and asserts each result FLIPS to a failure — a fixture that
@@ -163,7 +163,7 @@ jobs:
             --kache ./target/release/kache \
             --fixtures ./test-projects \
             --negative-control \
-            --out e2e-results/negative-control.json
+            --out tmp/e2e/negative-control.json
       - name: Check the sccache fallback caches an rlib
         # The `rust-sccache` fixture (run by the harness above) proves
         # the executable passthrough composes with sccache; sccache
@@ -177,18 +177,22 @@ jobs:
       - name: Show aggregated e2e results
         if: always()
         run: |
-          if [ -f e2e-results/results.json ]; then
+          if [ -f tmp/e2e/results.json ]; then
             echo "--- e2e results.json ---"
-            cat e2e-results/results.json
+            cat tmp/e2e/results.json
           else
             echo "no results.json produced"
           fi
       - name: Upload e2e results artifact
+        # Artifact name kept as `e2e-results` (the GitHub-facing label) so
+        # historical-run links stay valid; the path it uploads from moved
+        # to `tmp/e2e/` per the repo-wide scratch-under-tmp convention
+        # (see .gitignore comment).
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-results
-          path: e2e-results/
+          path: tmp/e2e/
           retention-days: 14
 
   # --- macOS test suite ---

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,32 @@
 /target
 **/target
 
-*.profraw
+# All tool-generated scratch / output lives under /tmp/. Single
+# top-level path keeps `git status` quiet and `du -sh tmp/` answers
+# "how much disk is this repo wasting" in one command.
+#
+# Layout (tool configuration points at these paths via the Justfile
+# recipes and the relevant binaries' default args):
+#   tmp/bench/    — Firefox compile-cache benchmark scratch
+#                    (clones, objdirs, kache cache; tens of GB)
+#   tmp/e2e/      — kache-e2e harness output (results.json)
+#   tmp/llvm-cov/ — cargo-llvm-cov reports (HTML directory + JSON);
+#                    raw coverage data stays under target/llvm-cov-target/
+#                    (already covered by /target above).
+#
+# To recover disk: `rm -rf tmp/` — tools regenerate what they need.
+/tmp/
 
-# e2e harness output (kache-e2e --out); regenerated each run
-/e2e-results/
-
-# Firefox benchmark scratch — clones, objdirs, cache (tens of GB).
-# Never tracked; the kache-bench tool regenerates it.
+# Legacy scratch locations from before the /tmp/ consolidation.
+# Kept gitignored so anyone with leftover state from older tooling
+# doesn't see noise in `git status`. Safe to remove once the
+# corresponding paths are wiped from working trees:
+#   rm -rf bench/ e2e-results/ *.profraw
+# (tarpaulin-report.{json,html} dropped — coverage moved to
+# cargo-llvm-cov which writes under tmp/llvm-cov/.)
 /bench/
+/e2e-results/
+*.profraw
 
 # Nix
 /result

--- a/Justfile
+++ b/Justfile
@@ -57,7 +57,7 @@ test:
 # Run the end-to-end harness against every fixture in test-projects/.
 # Builds kache + harness in release mode, drives each fixture through
 # cold → warm → noop, asserts per-fixture contracts against
-# `kache report --format json`. Writes e2e-results/results.json.
+# `kache report --format json`. Writes tmp/e2e/results.json.
 [group('dev')]
 e2e:
   cargo build --release -p kache
@@ -65,7 +65,7 @@ e2e:
   ./target/release/kache-e2e \
     --kache ./target/release/kache \
     --fixtures ./test-projects \
-    --out e2e-results/results.json
+    --out tmp/e2e/results.json
 
 # Verify the `KACHE_FALLBACK` wrapper delegates to — and is cached by —
 # a real sccache. Builds an excluded rlib through kache twice and
@@ -116,23 +116,23 @@ fmt-check:
 helm-lint:
   helm lint charts/kache-service
 
-# Run cargo-llvm-cov and emit JSON + HTML reports under
-# target/llvm-cov/. JSON drives the CI threshold check; HTML is
-# uploaded as a CI artifact (and opened locally by `coverage-open`).
-# `--no-report` collects coverage once; the two `report` invocations
-# then emit the formats from that single test run.
+# Run cargo-llvm-cov and emit JSON + HTML reports under tmp/llvm-cov/.
+# JSON drives the CI threshold check; HTML is uploaded as a CI artifact
+# (and opened locally by `coverage-open`). `--no-report` collects
+# coverage once; the two `report` invocations then emit the formats
+# from that single test run.
 [group('coverage')]
 coverage:
   cargo llvm-cov --all-features --workspace --no-report
-  cargo llvm-cov report --html --output-dir target/llvm-cov
-  cargo llvm-cov report --json --output-path target/llvm-cov/coverage.json
+  cargo llvm-cov report --html --output-dir tmp/llvm-cov
+  cargo llvm-cov report --json --output-path tmp/llvm-cov/coverage.json
 
 # Run cargo-llvm-cov and open the HTML report locally.
 [group('coverage')]
 coverage-open:
-  cargo llvm-cov --all-features --workspace --html --output-dir target/llvm-cov
-  open target/llvm-cov/html/index.html || \
-    xdg-open target/llvm-cov/html/index.html || true
+  cargo llvm-cov --all-features --workspace --html --output-dir tmp/llvm-cov
+  open tmp/llvm-cov/html/index.html || \
+    xdg-open tmp/llvm-cov/html/index.html || true
 
 # Show kache CI cache metrics from GitHub Actions.
 [group('ops')]

--- a/crates/kache-e2e/src/bin/kache-bench.rs
+++ b/crates/kache-e2e/src/bin/kache-bench.rs
@@ -32,7 +32,7 @@
 //! ```text
 //! just bench-firefox             # full cold + warm (tens of minutes to hours)
 //! just bench-firefox-retry       # restore cold-state snapshot, re-measure warm only (~25 min)
-//! just bench-firefox --skip-clone   # reuse existing clones under bench/tmp
+//! just bench-firefox --skip-clone   # reuse existing clones under tmp/bench
 //! ```
 //!
 //! First-time setup requires Firefox build prerequisites — `./mach
@@ -41,7 +41,7 @@
 //!
 //! # Reading the output
 //!
-//! Each run prints a summary block and writes `bench/tmp/firefox.json`
+//! Each run prints a summary block and writes `tmp/bench/firefox.json`
 //! plus per-phase reports (`report-<phase>.{json,md}`), mach build logs
 //! (`build-<phase>.log`), and kache wrapper logs (`wrapper-<phase>.log`).
 //!
@@ -99,7 +99,11 @@ struct Args {
     kache: PathBuf,
 
     /// Scratch directory for the clones, objdirs and cache (~50 GB).
-    #[arg(long, default_value = "./bench/tmp")]
+    /// Lives under the repo's `tmp/` convention; gitignored. The whole
+    /// directory tree (clone-a, clone-b, cache, snapshots) can be
+    /// `rm -rf`ed at any time and a subsequent run rebuilds what it
+    /// needs.
+    #[arg(long, default_value = "./tmp/bench")]
     work_dir: PathBuf,
 
     /// Firefox git repository to clone from.

--- a/crates/kache-e2e/src/bin/kache-e2e.rs
+++ b/crates/kache-e2e/src/bin/kache-e2e.rs
@@ -5,7 +5,7 @@
 //!   cargo run -p kache-e2e -- \
 //!     --kache ./target/release/kache \
 //!     --fixtures ./test-projects \
-//!     --out ./e2e-results/results.json
+//!     --out ./tmp/e2e/results.json
 //!
 //! Exit code: `0` if every fixture passed, `1` if any failed.
 
@@ -31,7 +31,8 @@ struct Args {
     fixtures: PathBuf,
 
     /// Where to write the results JSON. Parent dir is created if missing.
-    #[arg(long, default_value = "./e2e-results/results.json")]
+    /// Default lives under the repo's `tmp/` convention (gitignored).
+    #[arg(long, default_value = "./tmp/e2e/results.json")]
     out: PathBuf,
 
     /// Only run fixtures whose name matches this filter (substring, not


### PR DESCRIPTION
## Why

Three tools were writing scratch / output to three different top-level paths. After a session of bench + e2e + coverage runs, the repo root looked like a dumping ground — \`git status\` showed 20+ stray \`.profraw\` files, \`du -sh ./bench\` held 50+ GB, and there was no single "wipe all the scratch" command.

## What changes

One \`/tmp/\` tree, four subdirectories:

\`\`\`
tmp/
├── bench/      ← Firefox compile-cache benchmark scratch (was ./bench/tmp/)
├── e2e/        ← kache-e2e harness output (was ./e2e-results/)
├── profraw/    ← LLVM raw coverage data (was *.profraw at repo root)
└── tarpaulin/  ← tarpaulin reports (was tarpaulin-report.{json,html} at root)
\`\`\`

Now:

- \`du -sh tmp/\` answers "how much disk is this repo wasting" in one command.
- \`rm -rf tmp/\` is the universal cleanup.
- \`git status\` stays quiet.

## Files touched

| File | Change |
|---|---|
| \`.gitignore\` | Single \`/tmp/\` pattern replaces \`*.profraw\` + \`tarpaulin-report.json\` + \`/e2e-results/\` + \`/bench/\`. Legacy patterns kept for transition. |
| \`Justfile\` | \`e2e\` writes to \`tmp/e2e/\`. \`coverage\`/\`coverage-open\` set \`LLVM_PROFILE_FILE\` + \`--output-dir tmp/tarpaulin\`. |
| \`kache-bench\` | Default \`--work-dir\` → \`./tmp/bench\`. Docstring updated. |
| \`kache-e2e\` | Default \`--out\` → \`./tmp/e2e/results.json\`. Docstring updated. |
| \`.github/workflows/ci.yml\` | e2e job paths → \`tmp/e2e/\`. Coverage threshold + HTML upload → \`tmp/tarpaulin/\`. The artifact display name (\`e2e-results\`) is kept so historical-run links stay valid; only the source path changes. |

## Local cleanup after merge (one-time)

\`\`\`sh
rm -rf bench/ e2e-results/ *.profraw tarpaulin-report.{json,html}
\`\`\`

The legacy \`.gitignore\` entries cover anyone who doesn't run that right away — \`git status\` stays quiet either way. The entries can be removed in a follow-up once everyone's migrated.

## Test plan

- [x] \`just check\` clean.
- [x] \`just e2e\` clean — confirmed it writes to \`tmp/e2e/results.json\` (the harness auto-creates the parent dir).
- [x] \`just --show coverage\` / \`coverage-open\` parse cleanly with the new path arguments.
- [ ] CI on this PR exercises the full coverage flow against the new paths.

## Out of scope

- Wiping the legacy paths from disk — that's a one-time user action (the command is in the commit message + PR body).
- Removing the legacy \`.gitignore\` entries — once everyone's migrated, those become stale and can drop in a follow-up.