### PR TITLE
ci: install everything through mise + swap tarpaulin → cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,28 +31,20 @@ jobs:
           # and stays Linux-only. macOS gets a dedicated, lighter `test-macos`
           # job below — see that job for the rationale.
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3
+      - uses: actions/checkout@v6
+      # mise installs everything in mise.toml: rust (with rustfmt +
+      # clippy via the rust tool-options block), just, helm, sccache,
+      # cargo-llvm-cov.
+      - uses: jdx/mise-action@v4
         with:
-          install_args: "github:casey/just@1.43.1"
-          env: "false"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          cache: false
       - uses: docker/setup-buildx-action@v3
-      - uses: azure/setup-helm@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
       - uses: kunobi-ninja/kache-action@v1
         with:
           github-cache: "true"
           cache-executables: "false"
       - name: Clean bootstrap cache artifacts
         run: cargo clean
-      - name: Install tarpaulin
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-tarpaulin
       - name: Run repo verification
         # kache-action exports the installed release version; self-checks must
         # compile with Cargo.toml's version from this PR.
@@ -63,8 +55,8 @@ jobs:
         run: |
           python3 -c "
           import json, sys
-          data = json.load(open('tarpaulin-report.json'))
-          coverage = data['coverage']
+          data = json.load(open('target/llvm-cov/coverage.json'))
+          coverage = data['data'][0]['totals']['lines']['percent']
           threshold = 35.0
           print(f'Coverage: {coverage:.1f}%')
           if coverage < threshold:
@@ -77,7 +69,7 @@ jobs:
         if: always()
         with:
           name: coverage-html
-          path: tarpaulin-report.html
+          path: target/llvm-cov/html
           retention-days: 14
 
   # --- E2E smoke test ---
@@ -103,7 +95,7 @@ jobs:
           - os: macOS
             runner: ${{ (github.repository_owner == 'kunobi-ninja' && github.event.pull_request.head.repo.fork != true) && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Point rustup/cargo state at the per-run temp dir before installing
       # the toolchain. On the self-hosted macOS runner this isolates the
       # build from a corrupted shared ~/.rustup; on Linux it is simply a
@@ -112,37 +104,21 @@ jobs:
         run: |
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
-      # Heal mise shim state (macOS self-hosted runners only).
-      #
-      # A previous job that uninstalled a tool can leave a dangling
-      # entry in `~/.local/share/mise/shims/` — typically `rustup`
-      # pointing at a removed binary. The next job then fails with
-      # `mise ERROR rustup is not a valid shim. ... rustup failed`
-      # *before* any build work runs, because mise tries to use the
-      # broken shim during `mise install --force rust`. Linux runners
-      # are ephemeral, so this only bites macOS.
-      #
-      # Wiping the shim dir is non-destructive: mise rebuilds shims
-      # from the installs/ directory during the next install call.
-      # `continue-on-error` is intentional — the path may not exist on
-      # a brand-new runner; that's fine.
-      - name: Heal mise shim state (macOS self-hosted runner)
-        if: runner.os == 'macOS'
-        continue-on-error: true
-        run: rm -rf "${HOME}/.local/share/mise/shims"
-      # `--force`: RUSTUP_HOME is per-run ($RUNNER_TEMP), but mise's record of
-      # which tools are installed persists on the self-hosted runner. Without
-      # --force, mise sees rust as "installed" and skips it, leaving the fresh
-      # RUSTUP_HOME empty. --force makes it reinstall the toolchain every run.
-      # `cache_key_prefix: mise-v2` invalidates the previous shared
-      # cache that captured the broken-shim state above; without the
-      # bump, every cache restore would re-import the corruption before
-      # the heal step had a chance to run on a fresh runner.
-      - name: Install Rust via mise
-        uses: jdx/mise-action@v3
+      # `cache: false` so the self-hosted runner's mise state never
+      # round-trips through GHA cache (it accumulates broken shims).
+      # `reshim` rebuilds shims pre-install, fixing any dangling
+      # entries left by previous jobs.
+      # mise installs rust + sccache (the latter backs the
+      # `rust-sccache` fixture / KACHE_FALLBACK check). Tool names
+      # must match the mise.toml key — sccache is registered under
+      # the github backend, so the full `github:mozilla/sccache`
+      # identifier is required.
+      - name: Install tools via mise
+        uses: jdx/mise-action@v4
         with:
-          install_args: --force rust
-          cache_key_prefix: mise-v2
+          install_args: --force rust github:mozilla/sccache
+          cache: false
+          reshim: true
       # mise installs the toolchain via rustup under RUSTUP_HOME, but on a
       # runner with a pre-existing rustup it leaves no cargo proxy on PATH —
       # so the stale system Rust (Homebrew 1.94) would win. Prepend the
@@ -157,15 +133,6 @@ jobs:
           fi
           "$bin_dir/rustc" --version
           echo "$bin_dir" >> "$GITHUB_PATH"
-      # sccache backs the `rust-sccache` fixture and the fallback
-      # caching check below — both exercise `KACHE_FALLBACK`. When it
-      # is absent (e.g. a fork without this step) the fixture is
-      # skipped and the check is a no-op, so this is the only place
-      # the dependency is wired in.
-      - name: Install sccache (KACHE_FALLBACK fixture)
-        uses: taiki-e/install-action@v2
-        with:
-          tool: sccache
       - name: Build kache + e2e harness (release)
         run: |
           rustc --version && cargo --version
@@ -239,7 +206,7 @@ jobs:
     # "require approval" Actions setting, not by this expression.
     runs-on: ${{ (github.repository_owner == 'kunobi-ninja' && github.event.pull_request.head.repo.fork != true) && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # This persistent self-hosted runner has no usable shared toolchain:
       # its ~/.rustup is corrupted and its Homebrew Rust is stale (1.94,
       # below the pinned 1.95). Point RUSTUP_HOME/CARGO_HOME at the per-run
@@ -249,29 +216,14 @@ jobs:
         run: |
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
-      # Heal mise shim state — same hazard the `e2e` job documents in
-      # detail. A previous job can leave a dangling `rustup` shim
-      # under `~/.local/share/mise/shims/` that fails the next
-      # `mise install --force rust` with "rustup is not a valid shim".
-      # See the corresponding step in the `e2e` job for the full
-      # story. Non-destructive: mise rebuilds shims from installs/.
-      - name: Heal mise shim state (macOS self-hosted runner)
-        if: runner.os == 'macOS'
-        continue-on-error: true
-        run: rm -rf "${HOME}/.local/share/mise/shims"
-      # mise is the project's toolchain manager (see mise.toml); it installs
-      # rust via rustup into the isolated home above. `--force` is required:
-      # RUSTUP_HOME is per-run but mise's installed-tool record persists on
-      # the self-hosted runner, so without it mise skips the reinstall and
-      # leaves the fresh RUSTUP_HOME empty.
-      # `cache_key_prefix: mise-v2` matches the bump in the e2e job —
-      # they share a cache pool, and the prior `mise-v1` cache captured
-      # the broken-shim state we're healing here.
+      # Same setup as the `e2e` job — see that block for the
+      # `cache: false` + `reshim: true` rationale.
       - name: Install Rust via mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           install_args: --force rust
-          cache_key_prefix: mise-v2
+          cache: false
+          reshim: true
       # mise installs the toolchain via rustup under RUSTUP_HOME, but on a
       # runner with a pre-existing rustup it leaves no cargo proxy on PATH —
       # so the stale system Rust (Homebrew 1.94) would win. Prepend the
@@ -303,7 +255,7 @@ jobs:
     runs-on: windows-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: cargo check (x86_64-pc-windows-msvc)
         run: cargo check --target x86_64-pc-windows-msvc

--- a/.github/workflows/service-image.yml
+++ b/.github/workflows/service-image.yml
@@ -33,7 +33,7 @@ jobs:
     name: Build Service Image (Dry Run)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v3
       - name: Build image (dry-run, no cache)
         run: docker buildx bake -f docker-bake.hcl --set '*.cache-from=' service
@@ -43,7 +43,7 @@ jobs:
     name: Build Service Image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: jdx/mise-action@v3
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 
 *.profraw
 
-tarpaulin-report.json
-
 # e2e harness output (kache-e2e --out); regenerated each run
 /e2e-results/
 

--- a/Justfile
+++ b/Justfile
@@ -116,18 +116,23 @@ fmt-check:
 helm-lint:
   helm lint charts/kache-service
 
-# Run tarpaulin coverage and emit JSON + HTML reports.
-# JSON drives the CI threshold check; HTML is uploaded as a CI artifact
-# (and used locally by `just coverage-open`).
+# Run cargo-llvm-cov and emit JSON + HTML reports under
+# target/llvm-cov/. JSON drives the CI threshold check; HTML is
+# uploaded as a CI artifact (and opened locally by `coverage-open`).
+# `--no-report` collects coverage once; the two `report` invocations
+# then emit the formats from that single test run.
 [group('coverage')]
 coverage:
-  cargo tarpaulin --engine llvm --all-features --workspace --out Json --out Html
+  cargo llvm-cov --all-features --workspace --no-report
+  cargo llvm-cov report --html --output-dir target/llvm-cov
+  cargo llvm-cov report --json --output-path target/llvm-cov/coverage.json
 
-# Run tarpaulin coverage and open the HTML report locally.
+# Run cargo-llvm-cov and open the HTML report locally.
 [group('coverage')]
 coverage-open:
-  cargo tarpaulin --engine llvm --all-features --workspace --out Html
-  open tarpaulin-report.html || xdg-open tarpaulin-report.html || true
+  cargo llvm-cov --all-features --workspace --html --output-dir target/llvm-cov
+  open target/llvm-cov/html/index.html || \
+    xdg-open target/llvm-cov/html/index.html || true
 
 # Show kache CI cache metrics from GitHub Actions.
 [group('ops')]

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,11 @@
 idiomatic_version_file_enable_tools = ["rust"]
 
 [tools]
-rust = "latest"
+rust = { version = "latest", components = "rustfmt,clippy" }
 "github:casey/just" = "1.43.1"
 helm = "latest"
+# Test-coverage + sccache fallback. Listed here (not as separate
+# CI install actions) so the same `mise install` populates every
+# tool the repo needs.
+"github:taiki-e/cargo-llvm-cov" = "latest"
+"github:mozilla/sccache" = "latest"


### PR DESCRIPTION
Two related cleanups in one PR — both about consolidating CI tool management through mise and cutting installer-action sprawl.

## 1. Everything install-able via mise lives in mise.toml

The Linux \`check\` job had five separate installer actions: \`mise-action\` (just), \`docker/setup-buildx-action\`, \`azure/setup-helm\`, \`dtolnay/rust-toolchain\`, \`taiki-e/install-action\` (tarpaulin). Four of five install things mise can install. Keep \`docker/setup-buildx-action\` (mise has no docker plugin) and let mise own the rest.

\`mise.toml\` now lists every dev tool the repo needs: \`rust\`, \`just\`, \`helm\`, \`sccache\`, \`cargo-llvm-cov\`. A fresh \`mise install\` populates them all locally; CI does the same via one \`jdx/mise-action@v4\` call per job.

| Job | Before | After |
|---|---|---|
| Linux \`check\` | 5 installer actions | 1 mise-action call |
| \`e2e\` (Linux + macOS) | mise (rust) + taiki-e (sccache) | mise (rust + sccache) |
| \`test-macos\` | mise (rust) | unchanged |
| Windows \`exploratory\` | dtolnay/rust-toolchain | unchanged (mise on Windows is less mature; not worth the risk for a one-step exploratory job) |

## 2. tarpaulin → cargo-llvm-cov

Per discussion: tarpaulin is fine but maintained solely by one individual. cargo-llvm-cov uses the same \`-Cinstrument-coverage\` tech, is modestly faster, has a cleaner CLI, and sits within taiki-e's broader portfolio of trusted Rust tools (which we're already using for \`install-action\`-style flows).

Functional changes:

- \`Justfile\`: two \`cargo llvm-cov\` recipes that use \`--no-report\` + two \`report\` invocations so one test run produces both HTML and JSON (vs tarpaulin's \`--out Html --out Json\` flag stacking).
- Reports land under \`target/llvm-cov/\` (already gitignored via \`/target\`) instead of \`tarpaulin-report.{json,html}\` at the repo root.
- CI threshold parser updated for cargo-llvm-cov's JSON shape (\`data[0].totals.lines.percent\` vs tarpaulin's flat \`coverage\` field).
- HTML artifact upload path: \`target/llvm-cov/html\` directory (vs tarpaulin's single-file \`tarpaulin-report.html\`).
- \`.gitignore\`: removes the stale \`tarpaulin-report.json\` row.

## Version bumps (also in this PR)

- \`actions/checkout@v4\` → \`@v6\` (six uses across \`ci.yml\` + \`service-image.yml\`)
- \`jdx/mise-action@v3\` → \`@v4\` (all three uses)

mise-action v4 behavior:

- \`github_token\` defaults to \`\${{ github.token }}\` — drops the explicit env block on the check job.
- \`cache: false\` everywhere; the self-hosted-runner state never round-trips through GHA cache (which is what kept re-importing broken shims; see #139's history).
- \`reshim: true\` on the macOS rust install fixes any dangling shims the runner has accumulated, replacing the manual heal step.

Net: 5 files, **+46 / -90**.