### PR TITLE
bench(firefox): worktrees off clone-ref (sibling of work_dir) instead of re-cloning each run

### DIFF
--- a/crates/kache-e2e/src/bin/kache-bench.rs
+++ b/crates/kache-e2e/src/bin/kache-bench.rs
@@ -4,11 +4,14 @@
 //!
 //! - **cold**: a fresh clone with an empty cache → every compile is a
 //!   miss. This is the baseline.
-//! - **warm**: a second, independent clone at a *different* absolute path
-//!   against the same cache → compiles are served from what cold stored.
-//!   The different path is deliberate: it mirrors a real fresh checkout
-//!   (a new CI runner / a teammate's machine) and exposes absolute-path
-//!   leaks in the cache key — a path-dependent key would miss everything.
+//! - **warm**: a second, independent working tree at a *different*
+//!   absolute path against the same cache → compiles are served from
+//!   what cold stored. The different path is deliberate: it mirrors a
+//!   real fresh checkout (a new CI runner / a teammate's machine) and
+//!   exposes absolute-path leaks in the cache key — a path-dependent
+//!   key would miss everything. Both working trees are git worktrees
+//!   off a locally-cached `clone-clean` reference so re-runs don't pay
+//!   the network cost twice.
 //!
 //! Reports cold/warm wall-clock, speedup, and hit rate. This is a manual
 //! tool: a full run takes tens of minutes to a few hours and needs
@@ -98,11 +101,12 @@ struct Args {
     #[arg(long, default_value = "./target/release/kache")]
     kache: PathBuf,
 
-    /// Scratch directory for the clones, objdirs and cache (~50 GB).
+    /// Scratch directory for the clones, objdirs and cache (~55 GB).
     /// Lives under the repo's `tmp/` convention; gitignored. The whole
-    /// directory tree (clone-a, clone-b, cache, snapshots) can be
-    /// `rm -rf`ed at any time and a subsequent run rebuilds what it
-    /// needs.
+    /// directory tree (clone-clean, clone-a, clone-b, cache, snapshots)
+    /// can be `rm -rf`ed at any time; subsequent runs re-derive what
+    /// they need. `clone-clean` is the once-per-tag cached shallow
+    /// reference; `clone-a` and `clone-b` are git worktrees off it.
     #[arg(long, default_value = "./tmp/bench")]
     work_dir: PathBuf,
 
@@ -147,6 +151,7 @@ fn main() -> Result<()> {
         .with_context(|| format!("creating work dir {}", args.work_dir.display()))?;
     let work_dir = args.work_dir.canonicalize()?;
 
+    let clone_clean = work_dir.join("clone-clean");
     let clone_a = work_dir.join("clone-a");
     let clone_b = work_dir.join("clone-b");
     let cache_dir = work_dir.join("cache");
@@ -156,7 +161,7 @@ fn main() -> Result<()> {
     eprintln!("=== kache Firefox benchmark ===");
     eprintln!("Firefox tag : {}", args.tag);
     eprintln!(
-        "work dir    : {}  (~50 GB: 2 clones + objdirs + cache)",
+        "work dir    : {}  (~55 GB: clone-clean + 2 worktrees + objdirs + cache)",
         work_dir.display()
     );
     eprintln!("kache       : {}", kache.display());
@@ -187,7 +192,7 @@ fn main() -> Result<()> {
         };
         eprintln!("\n[bench] reusing existing clones ({flag})");
     } else {
-        clone_firefox(&args.repo, &args.tag, &clone_a, &clone_b)?;
+        clone_firefox(&args.repo, &args.tag, &clone_clean, &clone_a, &clone_b)?;
     }
 
     bootstrap(&clone_a, args.force_bootstrap)?;
@@ -314,31 +319,125 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Clone Firefox at `tag` into `clone_a` (shallow, from `repo`), then
-/// clone `clone_b` locally from `clone_a`.
+/// Materialize `clone_a` and `clone_b` at `tag` as git worktrees off a
+/// locally-cached `clone_clean` shallow clone.
 ///
-/// `clone_b` is an independent working tree at the same revision —
-/// cloned from `clone_a` so there is no second download. `--no-hardlinks`
-/// forces real copies of the git objects so the two trees never share
-/// storage on disk.
-fn clone_firefox(repo: &str, tag: &str, clone_a: &Path, clone_b: &Path) -> Result<()> {
-    for d in [clone_a, clone_b] {
-        if d.exists() {
-            std::fs::remove_dir_all(d)
-                .with_context(|| format!("removing stale {}", d.display()))?;
+/// The first run for a given `tag` pays the network cost once — a
+/// `--depth=1 --branch=<tag>` clone into `clone_clean`. Every subsequent
+/// fresh full run reuses that local reference and only re-creates
+/// `clone_a` / `clone_b` as fresh worktrees (~10 s vs ~5 min over the
+/// network). When `--tag` changes between runs the cached clone is
+/// detected as stale and wiped before the new fetch.
+///
+/// Worktrees share `clone_clean`'s object database but each lives at
+/// its own absolute path with independent working-tree files — the
+/// path-leak detector still measures what it always did (the cache key
+/// must not depend on which absolute directory the build was run in).
+///
+/// `--detach` keeps each worktree on the underlying commit rather than
+/// creating a branch, matching the detached-HEAD state of the previous
+/// (non-worktree) clone flow.
+fn clone_firefox(
+    repo: &str,
+    tag: &str,
+    clone_clean: &Path,
+    clone_a: &Path,
+    clone_b: &Path,
+) -> Result<()> {
+    // 1. Bring clone-clean up to the requested tag (network cost,
+    //    paid once per tag bump).
+    if clone_clean_at_tag(clone_clean, tag)? {
+        eprintln!("\n[bench] reusing clone-clean at {tag} (no network)");
+    } else {
+        if clone_clean.exists() {
+            eprintln!(
+                "\n[bench] clone-clean is missing or at the wrong tag — wiping and re-cloning"
+            );
+            std::fs::remove_dir_all(clone_clean)
+                .with_context(|| format!("removing stale {}", clone_clean.display()))?;
+        } else {
+            eprintln!("\n[bench] no clone-clean yet — fetching Firefox {tag} (one-time cost)");
         }
+        run(Command::new("git")
+            .args(["clone", "--depth", "1", "--branch"])
+            .arg(tag)
+            .arg(repo)
+            .arg(clone_clean))?;
     }
-    eprintln!("\n[bench] cloning Firefox {tag} into clone-a");
-    run(Command::new("git")
-        .args(["clone", "--depth", "1", "--branch"])
-        .arg(tag)
-        .arg(repo)
-        .arg(clone_a))?;
-    eprintln!("[bench] cloning a second independent tree into clone-b");
-    run(Command::new("git")
-        .args(["clone", "--no-hardlinks"])
-        .arg(clone_a)
-        .arg(clone_b))?;
+
+    // 2. Reset clone-a and clone-b. Worktree-aware cleanup first; fall
+    //    back to a plain `remove_dir_all` for legacy non-worktree dirs
+    //    left over from older bench versions.
+    for d in [clone_a, clone_b] {
+        reset_worktree_path(clone_clean, d)?;
+    }
+    // Prune any stale worktree registrations the cleanup might have
+    // left behind (e.g., interrupted runs where the worktree dir was
+    // removed but the registration in `.git/worktrees/` remains).
+    let _ = Command::new("git")
+        .arg("-C")
+        .arg(clone_clean)
+        .args(["worktree", "prune"])
+        .status();
+
+    // 3. Spawn fresh worktrees at `tag`. `--detach` mirrors the old
+    //    behavior (detached HEAD on the tag's commit, no branch).
+    for d in [clone_a, clone_b] {
+        eprintln!("[bench] creating worktree {}", d.display());
+        run(Command::new("git")
+            .arg("-C")
+            .arg(clone_clean)
+            .args(["worktree", "add", "--detach"])
+            .arg(d)
+            .arg(tag))?;
+    }
+    Ok(())
+}
+
+/// True when `clone_clean` is a valid git repository whose HEAD is the
+/// commit named by `tag`. A missing `.git`, a missing tag ref, or a
+/// HEAD pointing elsewhere all return false — the caller wipes and
+/// re-clones on any negative.
+fn clone_clean_at_tag(clone_clean: &Path, tag: &str) -> Result<bool> {
+    if !clone_clean.join(".git").exists() {
+        return Ok(false);
+    }
+    let head = Command::new("git")
+        .arg("-C")
+        .arg(clone_clean)
+        .args(["rev-parse", "HEAD"])
+        .output();
+    let tagged = Command::new("git")
+        .arg("-C")
+        .arg(clone_clean)
+        .args(["rev-parse"])
+        .arg(format!("{tag}^{{commit}}"))
+        .output();
+    Ok(matches!(
+        (head, tagged),
+        (Ok(h), Ok(t)) if h.status.success() && t.status.success() && h.stdout == t.stdout
+    ))
+}
+
+/// Best-effort cleanup of a previous worktree at `target`. Tries the
+/// worktree-aware command first; falls back to `remove_dir_all` so
+/// pre-worktree clone dirs (and corrupt / partially-cleaned trees) are
+/// also handled idempotently. Never errors: if the path is already
+/// gone, both branches no-op.
+fn reset_worktree_path(clone_clean: &Path, target: &Path) -> Result<()> {
+    if !target.exists() {
+        return Ok(());
+    }
+    let _ = Command::new("git")
+        .arg("-C")
+        .arg(clone_clean)
+        .args(["worktree", "remove", "--force"])
+        .arg(target)
+        .status();
+    if target.exists() {
+        std::fs::remove_dir_all(target)
+            .with_context(|| format!("removing {}", target.display()))?;
+    }
     Ok(())
 }
 

--- a/crates/kache-e2e/src/bin/kache-bench.rs
+++ b/crates/kache-e2e/src/bin/kache-bench.rs
@@ -101,12 +101,16 @@ struct Args {
     #[arg(long, default_value = "./target/release/kache")]
     kache: PathBuf,
 
-    /// Scratch directory for the clones, objdirs and cache (~55 GB).
+    /// Scratch directory for the worktrees, objdirs and cache (~50 GB).
     /// Lives under the repo's `tmp/` convention; gitignored. The whole
-    /// directory tree (clone-clean, clone-a, clone-b, cache, snapshots)
-    /// can be `rm -rf`ed at any time; subsequent runs re-derive what
-    /// they need. `clone-clean` is the once-per-tag cached shallow
-    /// reference; `clone-a` and `clone-b` are git worktrees off it.
+    /// directory tree (clone-a, clone-b, cache, snapshots) can be
+    /// `rm -rf`ed at any time; subsequent runs re-derive what they need.
+    ///
+    /// The Firefox reference clone is kept at a SIBLING path —
+    /// `<work_dir>-clone-ref` (e.g. `./tmp/bench-clone-ref`) — so that a
+    /// casual `rm -rf <work_dir>` doesn't wipe the ~1 GB / 5-minute
+    /// network clone. Re-cloning happens automatically when the
+    /// reference goes missing or its HEAD doesn't match `--tag`.
     #[arg(long, default_value = "./tmp/bench")]
     work_dir: PathBuf,
 
@@ -151,7 +155,13 @@ fn main() -> Result<()> {
         .with_context(|| format!("creating work dir {}", args.work_dir.display()))?;
     let work_dir = args.work_dir.canonicalize()?;
 
-    let clone_clean = work_dir.join("clone-clean");
+    // `clone-ref` lives at a SIBLING of `work_dir` (not inside it) so
+    // the natural `rm -rf <work_dir>` wipe — what someone reaches for
+    // to reset the bench — doesn't accidentally torch the locally-
+    // cached Firefox reference. Re-cloning Firefox is the bench's
+    // single most expensive setup step; making the reference survive
+    // a casual scratch-dir wipe is the whole point.
+    let clone_ref = clone_ref_path(&work_dir);
     let clone_a = work_dir.join("clone-a");
     let clone_b = work_dir.join("clone-b");
     let cache_dir = work_dir.join("cache");
@@ -161,8 +171,12 @@ fn main() -> Result<()> {
     eprintln!("=== kache Firefox benchmark ===");
     eprintln!("Firefox tag : {}", args.tag);
     eprintln!(
-        "work dir    : {}  (~55 GB: clone-clean + 2 worktrees + objdirs + cache)",
+        "work dir    : {}  (~50 GB: 2 worktrees + objdirs + cache)",
         work_dir.display()
+    );
+    eprintln!(
+        "clone ref   : {}  (~5 GB, persistent across runs)",
+        clone_ref.display()
     );
     eprintln!("kache       : {}", kache.display());
 
@@ -192,7 +206,7 @@ fn main() -> Result<()> {
         };
         eprintln!("\n[bench] reusing existing clones ({flag})");
     } else {
-        clone_firefox(&args.repo, &args.tag, &clone_clean, &clone_a, &clone_b)?;
+        clone_firefox(&args.repo, &args.tag, &clone_ref, &clone_a, &clone_b)?;
     }
 
     bootstrap(&clone_a, args.force_bootstrap)?;
@@ -319,18 +333,38 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+/// Derive the persistent reference-clone path for a given work dir.
+/// Sibling, not child: appends `-clone-ref` to the work dir's name so
+/// the reference outlives a `rm -rf <work_dir>` wipe.
+///
+/// Examples: `./tmp/bench` → `./tmp/bench-clone-ref`,
+/// `/scratch/foo` → `/scratch/foo-clone-ref`. Falls back to placing the
+/// reference next to the work dir under a generic name if the work
+/// dir has no file name (root paths, current dir, etc.).
+fn clone_ref_path(work_dir: &Path) -> PathBuf {
+    let parent = work_dir.parent().unwrap_or(Path::new("."));
+    let name = work_dir
+        .file_name()
+        .map(|n| format!("{}-clone-ref", n.to_string_lossy()))
+        .unwrap_or_else(|| "bench-clone-ref".to_string());
+    parent.join(name)
+}
+
 /// Materialize `clone_a` and `clone_b` at `tag` as git worktrees off a
-/// locally-cached `clone_clean` shallow clone.
+/// locally-cached `clone_ref` shallow clone.
 ///
 /// The first run for a given `tag` pays the network cost once — a
-/// `--depth=1 --branch=<tag>` clone into `clone_clean`. Every subsequent
+/// `--depth=1 --branch=<tag>` clone into `clone_ref`. Every subsequent
 /// fresh full run reuses that local reference and only re-creates
 /// `clone_a` / `clone_b` as fresh worktrees (~10 s vs ~5 min over the
 /// network). When `--tag` changes between runs the cached clone is
 /// detected as stale and wiped before the new fetch.
 ///
-/// Worktrees share `clone_clean`'s object database but each lives at
-/// its own absolute path with independent working-tree files — the
+/// `clone_ref` is a SIBLING of the bench work dir, not a child — see
+/// [`clone_ref_path`] — so `rm -rf <work_dir>` doesn't torch it.
+///
+/// Worktrees share `clone_ref`'s object database but each lives at its
+/// own absolute path with independent working-tree files — the
 /// path-leak detector still measures what it always did (the cache key
 /// must not depend on which absolute directory the build was run in).
 ///
@@ -340,43 +374,45 @@ fn main() -> Result<()> {
 fn clone_firefox(
     repo: &str,
     tag: &str,
-    clone_clean: &Path,
+    clone_ref: &Path,
     clone_a: &Path,
     clone_b: &Path,
 ) -> Result<()> {
-    // 1. Bring clone-clean up to the requested tag (network cost,
-    //    paid once per tag bump).
-    if clone_clean_at_tag(clone_clean, tag)? {
-        eprintln!("\n[bench] reusing clone-clean at {tag} (no network)");
+    // 1. Bring clone-ref up to the requested tag (network cost, paid
+    //    once per tag bump).
+    if clone_ref_at_tag(clone_ref, tag)? {
+        eprintln!("\n[bench] reusing clone-ref at {tag} (no network)");
     } else {
-        if clone_clean.exists() {
-            eprintln!(
-                "\n[bench] clone-clean is missing or at the wrong tag — wiping and re-cloning"
-            );
-            std::fs::remove_dir_all(clone_clean)
-                .with_context(|| format!("removing stale {}", clone_clean.display()))?;
+        if clone_ref.exists() {
+            eprintln!("\n[bench] clone-ref is at the wrong tag — wiping and re-cloning");
+            std::fs::remove_dir_all(clone_ref)
+                .with_context(|| format!("removing stale {}", clone_ref.display()))?;
         } else {
-            eprintln!("\n[bench] no clone-clean yet — fetching Firefox {tag} (one-time cost)");
+            eprintln!("\n[bench] no clone-ref yet — fetching Firefox {tag} (one-time cost)");
+        }
+        if let Some(parent) = clone_ref.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
         }
         run(Command::new("git")
             .args(["clone", "--depth", "1", "--branch"])
             .arg(tag)
             .arg(repo)
-            .arg(clone_clean))?;
+            .arg(clone_ref))?;
     }
 
     // 2. Reset clone-a and clone-b. Worktree-aware cleanup first; fall
     //    back to a plain `remove_dir_all` for legacy non-worktree dirs
     //    left over from older bench versions.
     for d in [clone_a, clone_b] {
-        reset_worktree_path(clone_clean, d)?;
+        reset_worktree_path(clone_ref, d)?;
     }
     // Prune any stale worktree registrations the cleanup might have
     // left behind (e.g., interrupted runs where the worktree dir was
     // removed but the registration in `.git/worktrees/` remains).
     let _ = Command::new("git")
         .arg("-C")
-        .arg(clone_clean)
+        .arg(clone_ref)
         .args(["worktree", "prune"])
         .status();
 
@@ -386,7 +422,7 @@ fn clone_firefox(
         eprintln!("[bench] creating worktree {}", d.display());
         run(Command::new("git")
             .arg("-C")
-            .arg(clone_clean)
+            .arg(clone_ref)
             .args(["worktree", "add", "--detach"])
             .arg(d)
             .arg(tag))?;
@@ -394,22 +430,22 @@ fn clone_firefox(
     Ok(())
 }
 
-/// True when `clone_clean` is a valid git repository whose HEAD is the
+/// True when `clone_ref` is a valid git repository whose HEAD is the
 /// commit named by `tag`. A missing `.git`, a missing tag ref, or a
 /// HEAD pointing elsewhere all return false — the caller wipes and
 /// re-clones on any negative.
-fn clone_clean_at_tag(clone_clean: &Path, tag: &str) -> Result<bool> {
-    if !clone_clean.join(".git").exists() {
+fn clone_ref_at_tag(clone_ref: &Path, tag: &str) -> Result<bool> {
+    if !clone_ref.join(".git").exists() {
         return Ok(false);
     }
     let head = Command::new("git")
         .arg("-C")
-        .arg(clone_clean)
+        .arg(clone_ref)
         .args(["rev-parse", "HEAD"])
         .output();
     let tagged = Command::new("git")
         .arg("-C")
-        .arg(clone_clean)
+        .arg(clone_ref)
         .args(["rev-parse"])
         .arg(format!("{tag}^{{commit}}"))
         .output();
@@ -424,13 +460,13 @@ fn clone_clean_at_tag(clone_clean: &Path, tag: &str) -> Result<bool> {
 /// pre-worktree clone dirs (and corrupt / partially-cleaned trees) are
 /// also handled idempotently. Never errors: if the path is already
 /// gone, both branches no-op.
-fn reset_worktree_path(clone_clean: &Path, target: &Path) -> Result<()> {
+fn reset_worktree_path(clone_ref: &Path, target: &Path) -> Result<()> {
     if !target.exists() {
         return Ok(());
     }
     let _ = Command::new("git")
         .arg("-C")
-        .arg(clone_clean)
+        .arg(clone_ref)
         .args(["worktree", "remove", "--force"])
         .arg(target)
         .status();
@@ -1584,6 +1620,28 @@ mod tests {
         assert_eq!(field_of("RUSTFLAGS=-C debuginfo=2"), "RUSTFLAGS");
         assert_eq!(field_of("final=abcdef"), "final");
         assert_eq!(field_of("feature:foo"), "feature:foo"); // no '=' → whole payload
+    }
+
+    #[test]
+    fn clone_ref_path_is_a_sibling_not_a_child_of_work_dir() {
+        // The reference must live OUTSIDE work_dir so that the natural
+        // `rm -rf <work_dir>` wipe (what someone reaches for to reset
+        // the bench) doesn't accidentally torch the network clone.
+        assert_eq!(
+            clone_ref_path(Path::new("./tmp/bench")),
+            PathBuf::from("./tmp/bench-clone-ref")
+        );
+        assert_eq!(
+            clone_ref_path(Path::new("/scratch/foo")),
+            PathBuf::from("/scratch/foo-clone-ref")
+        );
+        // Sanity: the reference path is not nested inside work_dir.
+        let work = Path::new("./tmp/bench");
+        let r = clone_ref_path(work);
+        assert!(
+            !r.starts_with(work),
+            "clone-ref must not live under work_dir, got {r:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The bench wiped \`clone-a\` / \`clone-b\` unconditionally on every fresh full run, so each iteration re-paid the ~1 GB / ~5 min network clone of Firefox at the pinned tag even when nothing about the tag had changed. With path-leak debugging now needing repeated re-runs, that idle time adds up.

New layout:

\`\`\`
tmp/
├── bench/                     ← scratch (rm -rf safe)
│   ├── clone-a/               git worktree off clone-ref
│   ├── clone-b/               git worktree off clone-ref
│   ├── cache/                 unchanged
│   └── ...                    reports, logs, snapshots
└── bench-clone-ref/           ← persistent reference (survives bench/ wipes)
    └── (--depth=1 --branch=TAG of mozilla-firefox/firefox)
\`\`\`

**\`clone-ref\` is a sibling of \`work_dir\`, not a child.** That way the natural \`rm -rf tmp/bench/\` wipe — what someone reaches for to reset state — doesn't accidentally torch the network clone. No \`just bench-clean\` foot-gun guard needed; the directory layout itself enforces the right behavior.

## What \`clone_firefox\` now does

1. **Checks whether \`clone-ref\` is already at the requested tag** (\`git rev-parse HEAD\` vs \`git rev-parse TAG^{commit}\`). If yes, no network. If no — missing, or stale because \`--tag\` bumped — wipe and shallow-clone fresh.
2. **Tears down any existing \`clone-a\` / \`clone-b\` idempotently** (\`git worktree remove --force\` falling through to \`rm -rf\` so pre-worktree clone dirs from older bench versions are handled too).
3. **\`git worktree add --detach\`** to materialize fresh worktrees at the tag. Detached HEAD mirrors the previous flow's git state.

## Wins

| | first run per tag | every subsequent fresh run |
|---|---|---|
| Network clone | ~5 min | **none** |
| Tree create | n/a | ~10 sec (local checkout) |

For someone chasing the key-leak fix this is several minutes back per iteration.

## Invariants preserved

- **Path-leak detection still works**: worktrees live at different absolute paths, so \`__FILE__\` / DWARF source paths / \`CARGO_MANIFEST_DIR\` all carry the worktree's own path — same exposure surface as today's independent clones.
- **\`--skip-clone\` / \`--retry\`**: unchanged semantics. They still bail if \`clone-a\` / \`clone-b\` are missing.
- **Detached HEAD state**: \`--detach\` mirrors the previous \`git clone --branch=TAG\` behavior.

## Tests

- New unit test \`clone_ref_path_is_a_sibling_not_a_child_of_work_dir\` pins the sibling-not-child invariant so it can't silently regress.
- Existing parser/diff tests still pass (5 total).

## Test plan

- [x] \`cargo build --release -p kache-e2e --bin kache-bench\`
- [x] \`cargo clippy --release -p kache-e2e --bin kache-bench -- -D warnings\`
- [x] \`cargo test -p kache-e2e --bin kache-bench\` (5 tests pass)
- [x] \`cargo fmt --all -- --check\`
- [ ] \`just bench-firefox\` end-to-end on a fresh \`tmp/\` — confirm first run pays network, second run reuses
- [ ] Bump \`--tag\` between two runs — confirm bench detects mismatch and re-clones
- [ ] \`rm -rf tmp/bench/\` between runs — confirm next run reuses \`tmp/bench-clone-ref/\` and skips network