### PR TITLE
diag: complete the key-input trace + fix bench parser path-display noise

### DIFF
--- a/crates/kache-e2e/src/bin/kache-bench.rs
+++ b/crates/kache-e2e/src/bin/kache-bench.rs
@@ -717,13 +717,37 @@ fn parse_key_line(line: &str) -> Option<(String, String)> {
     if payload.is_empty() {
         return None;
     }
-    Some((crate_name, payload))
+    Some((crate_name, normalize_payload(&payload)))
+}
+
+/// Strip display-only path noise out of a trace payload so cross-clone
+/// set-diffing reflects real key-input divergence — not chatty trace
+/// formatting.
+///
+/// `cache_key.rs` emits `source:PATH=hash` for human readability, but
+/// the hasher only consumes the content hash. Two clones at different
+/// absolute paths that share identical source content emit different
+/// trace lines for the same key input. Without normalization the diff
+/// counts them as diverging when the cache key is actually stable —
+/// observed as 475 false positives in the first trace bench (the bug
+/// that made `final` appear as the top diverging field with only 77
+/// crates, despite the diff helper claiming 552 diverging crates).
+///
+/// Normalize to `source:hash` so the comparison reflects what the
+/// hasher actually consumes.
+fn normalize_payload(payload: &str) -> String {
+    if let Some(rest) = payload.strip_prefix("source:")
+        && let Some(eq) = rest.rfind('=')
+    {
+        return format!("source:{}", &rest[eq + 1..]);
+    }
+    payload.to_string()
 }
 
 /// Strip a key-input payload down to its "field name" — the part
 /// before the first `=`. Used to bucket diverging payloads so the
-/// report can say "1612 crates differ on `env_dep:CARGO_MANIFEST_DIR`"
-/// rather than dumping 1612 individual lines.
+/// report can say "12 crates differ on `extern:mozbuild`" rather than
+/// dumping individual lines.
 fn field_of(payload: &str) -> String {
     let eq = payload.find('=').unwrap_or(payload.len());
     payload[..eq].to_string()
@@ -1473,6 +1497,34 @@ mod tests {
                 "line should not parse: {line:?}"
             );
         }
+    }
+
+    #[test]
+    fn normalize_payload_strips_display_only_source_path() {
+        // `source:PATH=hash` is display-only path noise; the hasher
+        // consumes only the right-hand content hash. Normalizing to
+        // `source:hash` makes cross-clone set-diffing reflect what's
+        // actually in the cache key.
+        assert_eq!(
+            normalize_payload("source:/Users/a/clone-a/foo.rs=254dfb8084fc2e3f"),
+            "source:254dfb8084fc2e3f"
+        );
+        assert_eq!(
+            normalize_payload("source:/Users/b/clone-b/foo.rs=254dfb8084fc2e3f"),
+            "source:254dfb8084fc2e3f",
+        );
+        // Sanity: two clone paths with identical content collapse to
+        // the same normalized payload.
+        assert_eq!(
+            normalize_payload("source:/clone-a/x.rs=H"),
+            normalize_payload("source:/clone-b/x.rs=H"),
+        );
+        // Non-source payloads pass through untouched.
+        assert_eq!(
+            normalize_payload("env_dep:CARGO_MANIFEST_DIR=/p"),
+            "env_dep:CARGO_MANIFEST_DIR=/p"
+        );
+        assert_eq!(normalize_payload("final=abcdef"), "final=abcdef");
     }
 
     #[test]

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -93,12 +93,14 @@ pub fn compute_cache_key(
     hasher.update(b"target:");
     hasher.update(target.as_bytes());
     hasher.update(b"\n");
+    tracing::trace!("[key:{}] target={}", crate_name, target);
 
     // crate identity
     if let Some(name) = &args.crate_name {
         hasher.update(b"crate_name:");
         hasher.update(name.as_bytes());
         hasher.update(b"\n");
+        tracing::trace!("[key:{}] crate_name={}", crate_name, name);
     }
 
     // crate types
@@ -106,6 +108,7 @@ pub fn compute_cache_key(
         hasher.update(b"crate_type:");
         hasher.update(ct.as_bytes());
         hasher.update(b"\n");
+        tracing::trace!("[key:{}] crate_type={}", crate_name, ct);
     }
 
     // edition
@@ -113,6 +116,7 @@ pub fn compute_cache_key(
         hasher.update(b"edition:");
         hasher.update(edition.as_bytes());
         hasher.update(b"\n");
+        tracing::trace!("[key:{}] edition={}", crate_name, edition);
     }
 
     // emit kinds (sorted for determinism)
@@ -172,6 +176,7 @@ pub fn compute_cache_key(
         hasher.update(b"feature:");
         hasher.update(feat.as_bytes());
         hasher.update(b"\n");
+        tracing::trace!("[key:{}] feature:{}", crate_name, feat);
     }
 
     // cfg flags (non-feature, sorted)
@@ -189,6 +194,7 @@ pub fn compute_cache_key(
         hasher.update(b"cfg:");
         hasher.update(cfg.as_bytes());
         hasher.update(b"\n");
+        tracing::trace!("[key:{}] cfg:{}", crate_name, cfg);
     }
 
     let dep_info = args.source_file.as_ref().map(|source| {


### PR DESCRIPTION
## Summary

First `bench-firefox-trace` run revealed two issues that together prevented the diagnostic from pointing at the actual leak source. This PR fixes both so the next run names the real culprit.

### Issue 1 — bench parser over-counted divergence

The diff helper was set-comparing raw trace lines, but `cache_key.rs` emits `source:PATH=hash` for human readability — the hasher only consumes the right-hand content hash. Two clones at different absolute paths with identical source content produce *different trace lines* for the *same key input*. The parser counted all of those as divergences.

First trace bench: **552 "diverging" crates** of which **475 were pure path-display false positives** (the only differences were `source:/clone-a/...=H` vs `source:/clone-b/...=H` with identical hashes on the right). The actual real-input divergence is **77 crates**, dominated by `extern:X` cascading from a small set of workspace-local Mozilla crates (nserror, xpcom, mozbuild, ...).

Fix: `normalize_payload()` strips `source:PATH=` down to `source:hash` before set-diff. New unit test pins the invariant.

### Issue 2 — `cache_key.rs` doesn't trace every input it hashes

For the 77 truly diverging crates, the diff showed `final=…` changing without any traced input changing — classic "key changed but I can't see why".

`compute_cache_key` hashes:
- ✅ Traced: `key_version`, `rustc_version`, `emit`, `codegen`, `env_dep`, `extern`, `RUSTFLAGS`, `remap`, `final`, `source:PATH=hash` (display-only path)
- ❌ **NOT traced**: `target`, `crate_name`, `crate_type`, `edition`, **`feature:X`**, **`cfg:X`**

That last category is the prime suspect. There's even a comment at line 186:

> *"Build-script `cargo:rustc-cfg=…` lines reach us as raw strings; mozbuild / embedded crates sometimes emit cfgs that embed generated paths."*

Fix: one `tracing::trace!` per currently-untraced input. **Pure observability — does NOT change anything the hasher consumes**, so no `CACHE_KEY_VERSION` bump needed.

## What this is NOT

This is the diagnostic that pinpoints the kache fix — not the fix itself. After this lands (and #149), the next `just bench-firefox-trace` will produce trace lines like:

```
[key:mozbuild] cfg:foo=/Users/lenij/...
```

naming the path-leaky cfg directly, and *then* we know exactly what to normalize in kache.

## Tests

- `normalize_payload_strips_display_only_source_path` — pins the path-stripping invariant for the bench parser
- All existing tests still pass (558 workspace + 5 in kache-bench)

## Test plan

- [x] `cargo build --release -p kache`
- [x] `cargo test --workspace` — full green
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] After merge, run `just bench-firefox-trace --skip-clone` and confirm: (a) divergence count drops to ~77, (b) cfg/feature trace lines appear, (c) the real leak source is named