### PR TITLE
refactor(cc): every limitation reads as a deferral, not 'impossible'

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -340,6 +340,66 @@ impl CcArgs {
     pub fn refuse_reasons(&self) -> Vec<RefuseReason> {
         let mut reasons = Vec::new();
 
+        // ── Structural refusals ──
+        //
+        // These determine whether the invocation is even the kind of work
+        // kache caches — a single-source `-c` object compile. If not, the
+        // invocation is doing something else entirely (preprocess, link,
+        // assembly, multi-source, output-to-stdout) and no follow-up work
+        // could convert it into a cache hit. Reported as `NotACompile` so
+        // the bench's passthrough breakdown can separate them from
+        // classifier gaps; collected first so we can short-circuit before
+        // the flag classifier — its "unsupported flag(s): -E" output for
+        // a preprocessor invocation would falsely suggest modeling `-E`
+        // could unlock caching.
+
+        // Mode gate: kache caches only the `-c` object-compile step.
+        //   - Link: whole-program caching (depends on every input .o,
+        //     linker version, link order) — a much harder problem,
+        //     deferred. The default mode, so this refusal is common.
+        //   - Preprocess (-E) / Assemble (-S): developer-facing output,
+        //     rarely worth caching, and -E tangles with the cc-crate
+        //     family probe.
+        match self.mode {
+            CompileMode::Compile => {}
+            CompileMode::Link => reasons.push(RefuseReason::NotACompile(
+                "cc: link mode (whole-program caching not yet supported)",
+            )),
+            CompileMode::Preprocess => {
+                reasons.push(RefuseReason::NotACompile("cc: preprocessor mode (-E)"))
+            }
+            CompileMode::Assemble => {
+                reasons.push(RefuseReason::NotACompile("cc: assembly mode (-S)"))
+            }
+        }
+
+        // Output to stdout — `-o -` is unambiguous; an `-o` followed
+        // by a literal `-` arg. Structurally not a cacheable artifact.
+        if let Some(output) = &self.output
+            && output.as_os_str() == "-"
+        {
+            reasons.push(RefuseReason::NotACompile("cc: output to stdout"));
+        }
+
+        // If a truly structural refusal accumulated (mode or output-to-
+        // stdout), return early — running the flag classifier or feature
+        // checks would add misleading noise ("unsupported flag(s): -E"
+        // when the real cause is "this is preprocessor mode, not a
+        // compile"). The single-source check is NOT short-circuited here:
+        // a feature like a response file (`@foo.opts`) appears to the
+        // parser as zero sources, and the feature explanation is more
+        // useful than the bare structural symptom.
+        if !reasons.is_empty() {
+            return reasons;
+        }
+
+        // ── Feature refusals ──
+        //
+        // The invocation IS a single-source object compile, but uses a
+        // feature kache doesn't model yet. These are the actionable
+        // refusals: adding support would convert future invocations
+        // into hits.
+
         // Response files: any arg starting with `@` (typically a
         // path to a file containing additional flags). The flags
         // inside aren't visible to our parser without recursive
@@ -432,41 +492,14 @@ impl CcArgs {
             reasons.push(RefuseReason::Unsupported(detail));
         }
 
-        // Output to stdout — `-o -` is unambiguous; an `-o` followed
-        // by a literal `-` arg.
-        if let Some(output) = &self.output
-            && output.as_os_str() == "-"
-        {
-            reasons.push(RefuseReason::Unsupported("cc: output to stdout"));
-        }
-
-        // Mode gate: kache caches only the `-c` object-compile step.
-        //   - Link: whole-program caching (depends on every input .o,
-        //     linker version, link order) — a much harder problem,
-        //     deferred. The default mode, so this refusal is common.
-        //   - Preprocess (-E) / Assemble (-S): developer-facing output,
-        //     rarely worth caching, and -E tangles with the cc-crate
-        //     family probe.
-        match self.mode {
-            CompileMode::Compile => {}
-            CompileMode::Link => reasons.push(RefuseReason::Unsupported(
-                "cc: link mode (whole-program caching not yet supported)",
-            )),
-            CompileMode::Preprocess => {
-                reasons.push(RefuseReason::Unsupported("cc: preprocessor mode (-E)"))
-            }
-            CompileMode::Assemble => {
-                reasons.push(RefuseReason::Unsupported("cc: assembly mode (-S)"))
-            }
-        }
-
-        // Single-source contract: kache caches exactly one source per
-        // invocation (one .o out). Multi-source `-c a.c b.c` produces
-        // several .o files — uncommon (cargo's `cc` crate does one
-        // source per invocation); zero sources is a link-only / probe
-        // step. Both fall outside the per-translation-unit cache model.
+        // Single-source contract — last, so feature refusals
+        // (response file, PCH-as-input, ...) get a chance to explain
+        // *why* there's no parseable single source. Without that
+        // ordering, `cc @foo.opts` would land here as "not a single-
+        // source compile" instead of the more specific "response file
+        // (@file)" reason.
         if self.sources.len() != 1 {
-            reasons.push(RefuseReason::Unsupported("cc: not a single-source compile"));
+            reasons.push(RefuseReason::NotACompile("cc: not a single-source compile"));
         }
 
         reasons
@@ -2358,6 +2391,54 @@ mod tests {
         assert!(
             assemble.iter().any(|d| d.contains("assembly")),
             "expected assembly-mode refuse, got: {assemble:?}"
+        );
+    }
+
+    /// Structural refusals (preprocessor mode, link mode, assembly mode,
+    /// output-to-stdout) must NOT also carry "unsupported flag(s)" noise.
+    /// Mixing them mis-categorizes a correctly-refused non-compile as
+    /// a kache classifier gap. The bench's passthrough breakdown
+    /// depends on this split — see `RefuseReason::NotACompile` doc.
+    #[test]
+    fn structural_refusal_does_not_carry_unsupported_flag_noise() {
+        // The realistic shape: `cc -xc -P -E -` style preprocessor
+        // probe Firefox's build system runs. Pre-refactor this returned
+        // BOTH "unsupported flag(s): -xc -P -E" AND "preprocessor mode
+        // (-E)", inflating the "classifier gap" bucket in the bench's
+        // top-passthrough report. Post-refactor only the structural
+        // reason fires.
+        let descs = refuse_descriptions(&["cc", "-xc", "-P", "-E", "foo.c"]);
+        assert!(
+            descs.iter().any(|d| d.contains("preprocessor mode")),
+            "preprocessor mode must be reported, got: {descs:?}"
+        );
+        assert!(
+            !descs.iter().any(|d| d.contains("unsupported flag")),
+            "structural refusal must not carry 'unsupported flag' noise, got: {descs:?}"
+        );
+
+        // Same property for link mode + an unmodeled flag.
+        let descs = refuse_descriptions(&["cc", "foo.o", "-fuse-ld=lld", "-o", "out"]);
+        assert!(
+            descs.iter().any(|d| d.contains("link mode")),
+            "link mode must be reported, got: {descs:?}"
+        );
+        assert!(
+            !descs.iter().any(|d| d.contains("unsupported flag")),
+            "link-mode refusal must not carry 'unsupported flag' noise, got: {descs:?}"
+        );
+    }
+
+    /// The complement: a real single-source compile with a single
+    /// unmodeled flag MUST still report "unsupported flag(s)" — that
+    /// case is exactly what the bench's "classifier gap" bucket is
+    /// for, and what the next CC_FLAGS row would fix.
+    #[test]
+    fn compile_mode_unmodeled_flag_still_reports_unsupported_flag() {
+        let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", "-Ofast"]);
+        assert!(
+            descs.iter().any(|d| d.contains("unsupported flag")),
+            "compile-mode unmodeled flag must still report 'unsupported flag', got: {descs:?}"
         );
     }
 

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -340,29 +340,30 @@ impl CcArgs {
     pub fn refuse_reasons(&self) -> Vec<RefuseReason> {
         let mut reasons = Vec::new();
 
-        // ── Structural refusals ──
+        // ── Non-compile-mode refusals (short-circuit) ──
         //
-        // These determine whether the invocation is even the kind of work
-        // kache caches — a single-source `-c` object compile. If not, the
-        // invocation is doing something else entirely (preprocess, link,
-        // assembly, multi-source, output-to-stdout) and no follow-up work
-        // could convert it into a cache hit. Reported as `NotACompile` so
-        // the bench's passthrough breakdown can separate them from
-        // classifier gaps; collected first so we can short-circuit before
-        // the flag classifier — its "unsupported flag(s): -E" output for
-        // a preprocessor invocation would falsely suggest modeling `-E`
-        // could unlock caching.
-
-        // Mode gate: kache caches only the `-c` object-compile step.
-        //   - Link: whole-program caching (depends on every input .o,
-        //     linker version, link order) — a much harder problem,
-        //     deferred. The default mode, so this refusal is common.
-        //   - Preprocess (-E) / Assemble (-S): developer-facing output,
-        //     rarely worth caching, and -E tangles with the cc-crate
-        //     family probe.
+        // First, check whether the invocation is the kind of work the
+        // flag classifier was designed to reason about: a `-c` object
+        // compile that produces a file. If not, the flag-classifier
+        // output that would otherwise run below ("unsupported flag(s):
+        // -E") is misleading — those flags aren't blocking caching of
+        // a compile, they belong to a different invocation pattern.
+        // Short-circuit to keep the reason list focused.
+        //
+        // The variant split here is deliberate:
+        //
+        //   - `NotACompile` for preprocessor / assembly / output-to-
+        //     stdout: kache's cache model is per-object-file; these
+        //     invocations don't fit that model regardless of roadmap.
+        //
+        //   - `Unsupported` for link mode: whole-program link caching
+        //     IS on the roadmap (depends on every input .o, linker
+        //     version, link order, native search paths — hard but
+        //     solvable). Message includes "not yet supported" so the
+        //     bench's reporting can treat this as a fixable category.
         match self.mode {
             CompileMode::Compile => {}
-            CompileMode::Link => reasons.push(RefuseReason::NotACompile(
+            CompileMode::Link => reasons.push(RefuseReason::Unsupported(
                 "cc: link mode (whole-program caching not yet supported)",
             )),
             CompileMode::Preprocess => {
@@ -374,21 +375,20 @@ impl CcArgs {
         }
 
         // Output to stdout — `-o -` is unambiguous; an `-o` followed
-        // by a literal `-` arg. Structurally not a cacheable artifact.
+        // by a literal `-` arg. No file artifact to cache.
         if let Some(output) = &self.output
             && output.as_os_str() == "-"
         {
             reasons.push(RefuseReason::NotACompile("cc: output to stdout"));
         }
 
-        // If a truly structural refusal accumulated (mode or output-to-
-        // stdout), return early — running the flag classifier or feature
-        // checks would add misleading noise ("unsupported flag(s): -E"
-        // when the real cause is "this is preprocessor mode, not a
-        // compile"). The single-source check is NOT short-circuited here:
-        // a feature like a response file (`@foo.opts`) appears to the
-        // parser as zero sources, and the feature explanation is more
-        // useful than the bare structural symptom.
+        // If a non-compile-mode refusal accumulated, return early —
+        // running the flag classifier or feature checks would add
+        // misleading noise ("unsupported flag(s): -E" when the real
+        // cause is "this is preprocessor mode"). The single-source
+        // check is NOT short-circuited here: a feature like a response
+        // file (`@foo.opts`) appears to the parser as zero sources, and
+        // the feature explanation is more useful than the bare symptom.
         if !reasons.is_empty() {
             return reasons;
         }
@@ -495,11 +495,24 @@ impl CcArgs {
         // Single-source contract — last, so feature refusals
         // (response file, PCH-as-input, ...) get a chance to explain
         // *why* there's no parseable single source. Without that
-        // ordering, `cc @foo.opts` would land here as "not a single-
-        // source compile" instead of the more specific "response file
-        // (@file)" reason.
-        if self.sources.len() != 1 {
-            reasons.push(RefuseReason::NotACompile("cc: not a single-source compile"));
+        // ordering, `cc @foo.opts` would land here instead of getting
+        // the more specific "response file (@file)" reason.
+        //
+        // Reported as `Unsupported`, NOT `NotACompile`: a multi-source
+        // `cc -c a.c b.c` is conceptually N independent single-source
+        // compiles bundled into one invocation — per-source caching is
+        // on the roadmap, just unimplemented. Zero-source falls under
+        // the same "kache doesn't yet handle this invocation pattern"
+        // bucket; a future expansion of response files or improved
+        // probe-vs-compile detection would convert most of these.
+        if self.sources.len() > 1 {
+            reasons.push(RefuseReason::Unsupported(
+                "cc: multi-source compile (per-source split not yet supported)",
+            ));
+        } else if self.sources.is_empty() {
+            reasons.push(RefuseReason::Unsupported(
+                "cc: no source file (not yet supported)",
+            ));
         }
 
         reasons
@@ -2394,31 +2407,51 @@ mod tests {
         );
     }
 
-    /// Structural refusals (preprocessor mode, link mode, assembly mode,
-    /// output-to-stdout) must NOT also carry "unsupported flag(s)" noise.
-    /// Mixing them mis-categorizes a correctly-refused non-compile as
-    /// a kache classifier gap. The bench's passthrough breakdown
-    /// depends on this split — see `RefuseReason::NotACompile` doc.
+    /// Non-compile-mode refusals (preprocessor, assembly, link,
+    /// output-to-stdout) must NOT carry "unsupported flag(s)" noise.
+    /// Mixing them mis-categorizes a correctly-refused non-compile
+    /// as a kache classifier gap. Variant split is also pinned so
+    /// the bench's reporting can distinguish "won't ever cache"
+    /// (NotACompile: preprocessor / assembly / output-to-stdout)
+    /// from "doesn't cache yet, but roadmap" (Unsupported: link).
     #[test]
-    fn structural_refusal_does_not_carry_unsupported_flag_noise() {
-        // The realistic shape: `cc -xc -P -E -` style preprocessor
-        // probe Firefox's build system runs. Pre-refactor this returned
-        // BOTH "unsupported flag(s): -xc -P -E" AND "preprocessor mode
-        // (-E)", inflating the "classifier gap" bucket in the bench's
-        // top-passthrough report. Post-refactor only the structural
-        // reason fires.
-        let descs = refuse_descriptions(&["cc", "-xc", "-P", "-E", "foo.c"]);
+    fn non_compile_refusal_does_not_carry_unsupported_flag_noise() {
+        let compiler = CcCompiler::new();
+
+        // Preprocessor mode → NotACompile (text out, not a compile we'd
+        // ever cache). Pre-refactor this returned BOTH "unsupported
+        // flag(s): -xc -P -E" AND "preprocessor mode (-E)", inflating
+        // the "classifier gap" bucket. Post-refactor only the
+        // structural reason fires.
+        let parsed = compiler
+            .parse(&s(&["cc", "-xc", "-P", "-E", "foo.c"]))
+            .unwrap();
+        let reasons = compiler.refuse_reasons(&parsed);
+        let descs: Vec<_> = reasons.iter().map(|r| r.description()).collect();
         assert!(
             descs.iter().any(|d| d.contains("preprocessor mode")),
             "preprocessor mode must be reported, got: {descs:?}"
         );
         assert!(
             !descs.iter().any(|d| d.contains("unsupported flag")),
-            "structural refusal must not carry 'unsupported flag' noise, got: {descs:?}"
+            "preprocessor-mode refusal must not carry 'unsupported flag' noise, got: {descs:?}"
+        );
+        assert!(
+            reasons
+                .iter()
+                .any(|r| matches!(r, RefuseReason::NotACompile(_))),
+            "preprocessor mode must classify as NotACompile (won't ever cache), got: {reasons:?}"
         );
 
-        // Same property for link mode + an unmodeled flag.
-        let descs = refuse_descriptions(&["cc", "foo.o", "-fuse-ld=lld", "-o", "out"]);
+        // Link mode → Unsupported (whole-program caching IS on the
+        // roadmap, just not implemented). Same short-circuit behavior:
+        // the flag classifier's complaint about `-fuse-ld=lld` would be
+        // misleading because the issue is "link mode", not the flag.
+        let parsed = compiler
+            .parse(&s(&["cc", "foo.o", "-fuse-ld=lld", "-o", "out"]))
+            .unwrap();
+        let reasons = compiler.refuse_reasons(&parsed);
+        let descs: Vec<_> = reasons.iter().map(|r| r.description()).collect();
         assert!(
             descs.iter().any(|d| d.contains("link mode")),
             "link mode must be reported, got: {descs:?}"
@@ -2426,6 +2459,12 @@ mod tests {
         assert!(
             !descs.iter().any(|d| d.contains("unsupported flag")),
             "link-mode refusal must not carry 'unsupported flag' noise, got: {descs:?}"
+        );
+        assert!(
+            reasons
+                .iter()
+                .any(|r| matches!(r, RefuseReason::Unsupported(d) if d.contains("link mode"))),
+            "link mode must classify as Unsupported (roadmap), got: {reasons:?}"
         );
     }
 
@@ -2512,17 +2551,25 @@ mod tests {
     #[test]
     fn refuse_reasons_refuses_multi_source_compile() {
         // `-c a.c b.c` produces two .o files — outside the
-        // single-translation-unit cache model.
+        // single-translation-unit cache model. Reported as
+        // `Unsupported` (not `NotACompile`) because per-source
+        // caching is on the roadmap, just not implemented yet.
         let compiler = CcCompiler::new();
         let parsed = compiler.parse(&s(&["cc", "-c", "a.c", "b.c"])).unwrap();
-        let descs: Vec<_> = compiler
-            .refuse_reasons(&parsed)
-            .iter()
-            .map(|r| r.description())
-            .collect();
+        let reasons = compiler.refuse_reasons(&parsed);
+        let descs: Vec<_> = reasons.iter().map(|r| r.description()).collect();
         assert!(
-            descs.iter().any(|d| d.contains("single-source")),
+            descs.iter().any(|d| d.contains("multi-source")),
             "multi-source compile must be refused, got: {descs:?}"
+        );
+        // Pin the variant: must be Unsupported (roadmap), NOT
+        // NotACompile (conceptually impossible) — multi-source IS
+        // cacheable in principle, just not yet.
+        assert!(
+            reasons
+                .iter()
+                .any(|r| matches!(r, RefuseReason::Unsupported(d) if d.contains("multi-source"))),
+            "multi-source must classify as Unsupported (roadmap), got: {reasons:?}"
         );
     }
 

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -340,55 +340,53 @@ impl CcArgs {
     pub fn refuse_reasons(&self) -> Vec<RefuseReason> {
         let mut reasons = Vec::new();
 
-        // ── Non-compile-mode refusals (short-circuit) ──
+        // ── Non-`-c` mode refusals (short-circuit) ──
         //
-        // First, check whether the invocation is the kind of work the
-        // flag classifier was designed to reason about: a `-c` object
-        // compile that produces a file. If not, the flag-classifier
-        // output that would otherwise run below ("unsupported flag(s):
-        // -E") is misleading — those flags aren't blocking caching of
-        // a compile, they belong to a different invocation pattern.
+        // First, check whether the invocation is the `-c` object
+        // compile shape the flag classifier was designed for. If not,
+        // the flag-classifier output below ("unsupported flag(s): -E")
+        // is misleading — those flags aren't blocking caching of a
+        // compile, they belong to a different invocation pattern.
         // Short-circuit to keep the reason list focused.
         //
-        // The variant split here is deliberate:
-        //
-        //   - `NotACompile` for preprocessor / assembly / output-to-
-        //     stdout: kache's cache model is per-object-file; these
-        //     invocations don't fit that model regardless of roadmap.
-        //
-        //   - `Unsupported` for link mode: whole-program link caching
-        //     IS on the roadmap (depends on every input .o, linker
-        //     version, link order, native search paths — hard but
-        //     solvable). Message includes "not yet supported" so the
-        //     bench's reporting can treat this as a fixable category.
+        // All variants here are `Unsupported` — none of them are
+        // conceptually uncacheable. `-E` / `-S` / link / output-to-
+        // stdout are all deterministic input-to-output functions; the
+        // reason kache doesn't cache them today is engineering
+        // priority, not feasibility. Messages include "(not yet
+        // supported)" so this is explicit in the bench output and
+        // anyone reading `kache report`.
         match self.mode {
             CompileMode::Compile => {}
             CompileMode::Link => reasons.push(RefuseReason::Unsupported(
                 "cc: link mode (whole-program caching not yet supported)",
             )),
-            CompileMode::Preprocess => {
-                reasons.push(RefuseReason::NotACompile("cc: preprocessor mode (-E)"))
-            }
-            CompileMode::Assemble => {
-                reasons.push(RefuseReason::NotACompile("cc: assembly mode (-S)"))
-            }
+            CompileMode::Preprocess => reasons.push(RefuseReason::Unsupported(
+                "cc: preprocessor mode -E (not yet supported)",
+            )),
+            CompileMode::Assemble => reasons.push(RefuseReason::Unsupported(
+                "cc: assembly mode -S (not yet supported)",
+            )),
         }
 
         // Output to stdout — `-o -` is unambiguous; an `-o` followed
-        // by a literal `-` arg. No file artifact to cache.
+        // by a literal `-` arg. Cacheable in principle (cache the
+        // stdout bytes); not yet implemented.
         if let Some(output) = &self.output
             && output.as_os_str() == "-"
         {
-            reasons.push(RefuseReason::NotACompile("cc: output to stdout"));
+            reasons.push(RefuseReason::Unsupported(
+                "cc: output to stdout (not yet supported)",
+            ));
         }
 
-        // If a non-compile-mode refusal accumulated, return early —
-        // running the flag classifier or feature checks would add
-        // misleading noise ("unsupported flag(s): -E" when the real
-        // cause is "this is preprocessor mode"). The single-source
-        // check is NOT short-circuited here: a feature like a response
-        // file (`@foo.opts`) appears to the parser as zero sources, and
-        // the feature explanation is more useful than the bare symptom.
+        // If a non-`-c` refusal accumulated, return early — running
+        // the flag classifier or feature checks would add misleading
+        // noise ("unsupported flag(s): -E" when the real cause is
+        // "this is preprocessor mode"). The single-source check is NOT
+        // short-circuited here: a feature like a response file
+        // (`@foo.opts`) appears to the parser as zero sources, and the
+        // feature explanation is more useful than the bare symptom.
         if !reasons.is_empty() {
             return reasons;
         }
@@ -405,7 +403,9 @@ impl CcArgs {
         // inside aren't visible to our parser without recursive
         // expansion + path normalization.
         if self.rest.iter().any(|a| a.starts_with('@')) {
-            reasons.push(RefuseReason::Unsupported("cc: response file (@file)"));
+            reasons.push(RefuseReason::Unsupported(
+                "cc: response file @file (expansion not yet supported)",
+            ));
         }
 
         // Multi-arch (`-arch X -arch Y` produces a fat binary).
@@ -413,27 +413,33 @@ impl CcArgs {
         let arch_count = self.rest.windows(2).filter(|w| w[0] == "-arch").count();
         if arch_count > 1 {
             reasons.push(RefuseReason::Unsupported(
-                "cc: multi-arch (-arch X -arch Y)",
+                "cc: multi-arch -arch X -arch Y (fat-binary caching not yet supported)",
             ));
         }
 
         // Coverage instrumentation.
         for flag in &["--coverage", "-fprofile-arcs", "-ftest-coverage"] {
             if self.rest.iter().any(|a| a == flag) {
-                reasons.push(RefuseReason::Unsupported("cc: coverage instrumentation"));
+                reasons.push(RefuseReason::Unsupported(
+                    "cc: coverage instrumentation (not yet supported)",
+                ));
                 break;
             }
         }
 
         // Split DWARF (separate .dwo file alongside .o).
         if self.rest.iter().any(|a| a == "-gsplit-dwarf") {
-            reasons.push(RefuseReason::Unsupported("cc: -gsplit-dwarf"));
+            reasons.push(RefuseReason::Unsupported(
+                "cc: -gsplit-dwarf (not yet supported)",
+            ));
         }
 
         // Precompiled headers.
         for flag in &["-include-pch", "-emit-pch"] {
             if self.rest.iter().any(|a| a == flag) {
-                reasons.push(RefuseReason::Unsupported("cc: precompiled headers"));
+                reasons.push(RefuseReason::Unsupported(
+                    "cc: precompiled headers (not yet supported)",
+                ));
                 break;
             }
         }
@@ -444,7 +450,9 @@ impl CcArgs {
                 && let Some(next) = iter.peek()
                 && (next.ends_with(".pch") || next.ends_with(".gch"))
             {
-                reasons.push(RefuseReason::Unsupported("cc: precompiled headers"));
+                reasons.push(RefuseReason::Unsupported(
+                    "cc: precompiled headers (not yet supported)",
+                ));
                 break;
             }
         }
@@ -452,7 +460,7 @@ impl CcArgs {
         // Modules (clang/gcc).
         for flag in &["-fmodules", "-fcxx-modules"] {
             if self.rest.iter().any(|a| a == flag) {
-                reasons.push(RefuseReason::Unsupported("cc: modules"));
+                reasons.push(RefuseReason::Unsupported("cc: modules (not yet supported)"));
                 break;
             }
         }
@@ -498,13 +506,14 @@ impl CcArgs {
         // ordering, `cc @foo.opts` would land here instead of getting
         // the more specific "response file (@file)" reason.
         //
-        // Reported as `Unsupported`, NOT `NotACompile`: a multi-source
-        // `cc -c a.c b.c` is conceptually N independent single-source
-        // compiles bundled into one invocation — per-source caching is
-        // on the roadmap, just unimplemented. Zero-source falls under
-        // the same "kache doesn't yet handle this invocation pattern"
-        // bucket; a future expansion of response files or improved
-        // probe-vs-compile detection would convert most of these.
+        // Reported as `Unsupported` with "(not yet supported)" wording:
+        // multi-source `cc -c a.c b.c` is conceptually N independent
+        // single-source compiles bundled into one invocation —
+        // per-source caching is on the roadmap, just unimplemented.
+        // Zero-source falls under the same "kache doesn't yet handle
+        // this invocation pattern" bucket; a future expansion of
+        // response files or improved probe-vs-compile detection would
+        // convert most of these.
         if self.sources.len() > 1 {
             reasons.push(RefuseReason::Unsupported(
                 "cc: multi-source compile (per-source split not yet supported)",
@@ -2407,22 +2416,20 @@ mod tests {
         );
     }
 
-    /// Non-compile-mode refusals (preprocessor, assembly, link,
+    /// Non-`-c` mode refusals (preprocessor, assembly, link,
     /// output-to-stdout) must NOT carry "unsupported flag(s)" noise.
     /// Mixing them mis-categorizes a correctly-refused non-compile
-    /// as a kache classifier gap. Variant split is also pinned so
-    /// the bench's reporting can distinguish "won't ever cache"
-    /// (NotACompile: preprocessor / assembly / output-to-stdout)
-    /// from "doesn't cache yet, but roadmap" (Unsupported: link).
+    /// as a kache classifier gap. Each refusal is `Unsupported` with
+    /// "(not yet supported)" in the message — none of these are
+    /// conceptually uncacheable, just deferred.
     #[test]
     fn non_compile_refusal_does_not_carry_unsupported_flag_noise() {
         let compiler = CcCompiler::new();
 
-        // Preprocessor mode → NotACompile (text out, not a compile we'd
-        // ever cache). Pre-refactor this returned BOTH "unsupported
-        // flag(s): -xc -P -E" AND "preprocessor mode (-E)", inflating
-        // the "classifier gap" bucket. Post-refactor only the
-        // structural reason fires.
+        // Preprocessor mode. Pre-refactor this returned BOTH
+        // "unsupported flag(s): -xc -P -E" AND "preprocessor mode
+        // (-E)", inflating the "classifier gap" bucket. Post-refactor
+        // only the mode refusal fires.
         let parsed = compiler
             .parse(&s(&["cc", "-xc", "-P", "-E", "foo.c"]))
             .unwrap();
@@ -2436,17 +2443,16 @@ mod tests {
             !descs.iter().any(|d| d.contains("unsupported flag")),
             "preprocessor-mode refusal must not carry 'unsupported flag' noise, got: {descs:?}"
         );
+        // Must read as a deferral, not a permanent limitation.
         assert!(
-            reasons
-                .iter()
-                .any(|r| matches!(r, RefuseReason::NotACompile(_))),
-            "preprocessor mode must classify as NotACompile (won't ever cache), got: {reasons:?}"
+            descs.iter().any(|d| d.contains("not yet supported")),
+            "preprocessor mode message must read as deferral ('not yet supported'), got: {descs:?}"
         );
 
-        // Link mode → Unsupported (whole-program caching IS on the
-        // roadmap, just not implemented). Same short-circuit behavior:
-        // the flag classifier's complaint about `-fuse-ld=lld` would be
-        // misleading because the issue is "link mode", not the flag.
+        // Link mode — also `Unsupported` with "(not yet supported)".
+        // Same short-circuit: the flag classifier's complaint about
+        // `-fuse-ld=lld` would be misleading because the issue is
+        // "link mode", not the flag.
         let parsed = compiler
             .parse(&s(&["cc", "foo.o", "-fuse-ld=lld", "-o", "out"]))
             .unwrap();
@@ -2551,9 +2557,8 @@ mod tests {
     #[test]
     fn refuse_reasons_refuses_multi_source_compile() {
         // `-c a.c b.c` produces two .o files — outside the
-        // single-translation-unit cache model. Reported as
-        // `Unsupported` (not `NotACompile`) because per-source
-        // caching is on the roadmap, just not implemented yet.
+        // single-translation-unit cache model. Per-source caching is
+        // on the roadmap, message reads as deferral.
         let compiler = CcCompiler::new();
         let parsed = compiler.parse(&s(&["cc", "-c", "a.c", "b.c"])).unwrap();
         let reasons = compiler.refuse_reasons(&parsed);
@@ -2562,14 +2567,9 @@ mod tests {
             descs.iter().any(|d| d.contains("multi-source")),
             "multi-source compile must be refused, got: {descs:?}"
         );
-        // Pin the variant: must be Unsupported (roadmap), NOT
-        // NotACompile (conceptually impossible) — multi-source IS
-        // cacheable in principle, just not yet.
         assert!(
-            reasons
-                .iter()
-                .any(|r| matches!(r, RefuseReason::Unsupported(d) if d.contains("multi-source"))),
-            "multi-source must classify as Unsupported (roadmap), got: {reasons:?}"
+            descs.iter().any(|d| d.contains("not yet supported")),
+            "multi-source message must read as deferral, got: {descs:?}"
         );
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -50,42 +50,39 @@ pub enum CompilerKind {
 
 /// Reason an invocation cannot be cached. Empty list = cacheable.
 ///
-/// The variants encode the categorical distinction between "kache
-/// could solve this someday" and "kache's cache model doesn't apply":
+/// Two variants:
 ///
-/// - `NotPrimary` / `NotACompile`: the invocation is conceptually
-///   outside what a single-translation-unit object cache covers.
-///   Preprocessor mode (`-E`) and assembly mode (`-S`) emit text, not
-///   objects — a different operation entirely. Output to stdout has
-///   no file artifact. Refusing these is *correct*, not a kache
-///   limitation, and no roadmap work would convert them into hits.
-/// - `Unsupported`: kache *will* cache this in principle but the
-///   relevant feature / flag / mode isn't modeled yet. The message
-///   should make the "not yet" character explicit so users know it's
-///   on the roadmap. Includes link-mode caching, multi-source split,
-///   response-file expansion, PCH / modules, and the long tail of
-///   unmodeled flags surfaced by the classifier table. These are the
-///   actionable cases — implementing one converts future invocations
-///   into hits.
+/// - `NotPrimary`: the invocation is a query / probe (`--print`,
+///   `-vV`) that exists to provide information to the caller, not to
+///   produce a build artifact for downstream consumption. Caching is
+///   meaningless — the call is one-shot informational.
+/// - `Unsupported`: kache could in principle cache this, but the
+///   feature / flag / mode isn't modeled yet. EVERYTHING that's
+///   technically cacheable-with-engineering-effort lands here:
+///   link-mode caching, multi-source per-source split, preprocessor /
+///   assembly variant outputs, output-to-stdout, response-file
+///   expansion, PCH / modules, classifier gaps. Message MUST include
+///   "(not yet supported)" or equivalent so users reading the bench
+///   output can tell it's a deferral, not a permanent limitation.
 ///
-/// The bench's passthrough breakdown uses this split to separate
-/// "won't ever cache (structural)" from "doesn't cache yet (roadmap)".
+/// There is deliberately no third "won't ever cache" variant. For cc
+/// (and rustc) every deterministic input-to-output function IS
+/// cacheable in principle — even `-E` preprocessor output, even `-S`
+/// assembly output, even stdout bytes. What separates them from `-c`
+/// today is engineering priority, not categorical impossibility. The
+/// taxonomy reflects that honestly so future work to support any of
+/// them can drop a row to `Unsupported` and find this comment
+/// describing the deferral, rather than running into a "NotACompile"
+/// variant whose name lies about feasibility.
 #[derive(Debug, Clone)]
 pub enum RefuseReason {
     /// Not a primary compilation (e.g. `--print`, `-vV`, query mode).
     NotPrimary,
-    /// Conceptually not a single-translation-unit object compile —
-    /// preprocessor mode (`-E`), assembly mode (`-S`), output-to-stdout
-    /// (`-o -`). No object file out; caching isn't applicable to the
-    /// operation itself, regardless of what flags kache models. Distinct
-    /// from `Unsupported` because no roadmap work would change this.
-    NotACompile(&'static str),
-    /// Roadmap: kache could cache this but doesn't model the feature
-    /// yet. Examples: link-mode caching (whole-program), multi-source
-    /// per-source split, response-file expansion, PCH / modules, and
-    /// the long tail of flags missing from the classifier table.
-    /// Message should include language like "(not yet supported)" so
-    /// it's clear this is a deferral, not a permanent limit.
+    /// Kache could cache this with engineering effort but doesn't yet.
+    /// Message should include "(not yet supported)" so the deferral
+    /// nature is explicit. Examples: link mode, multi-source compile,
+    /// preprocessor / assembly variant outputs, output-to-stdout,
+    /// response files, PCH, modules, unmodeled classifier flags.
     Unsupported(&'static str),
 }
 
@@ -96,7 +93,6 @@ impl RefuseReason {
     pub fn description(&self) -> &'static str {
         match self {
             RefuseReason::NotPrimary => "not a primary compilation",
-            RefuseReason::NotACompile(detail) => detail,
             RefuseReason::Unsupported(detail) => detail,
         }
     }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -50,37 +50,42 @@ pub enum CompilerKind {
 
 /// Reason an invocation cannot be cached. Empty list = cacheable.
 ///
-/// The variants encode an important categorical distinction the
-/// passthrough-reporting downstream uses to set expectations:
+/// The variants encode the categorical distinction between "kache
+/// could solve this someday" and "kache's cache model doesn't apply":
 ///
-/// - `NotPrimary` / `NotACompile`: the invocation isn't the kind of
-///   work kache caches at all. Refusing is *correct*, not a kache
-///   limitation. No follow-up work could turn this into a cache hit.
-/// - `Unsupported`: kache *could* cache this in principle but the
-///   relevant feature / flag / mode isn't modeled yet. These are the
-///   actionable cases — adding a row to `CC_FLAGS` (or implementing
-///   PCH / modules / link caching / …) would convert future
-///   invocations into hits.
+/// - `NotPrimary` / `NotACompile`: the invocation is conceptually
+///   outside what a single-translation-unit object cache covers.
+///   Preprocessor mode (`-E`) and assembly mode (`-S`) emit text, not
+///   objects — a different operation entirely. Output to stdout has
+///   no file artifact. Refusing these is *correct*, not a kache
+///   limitation, and no roadmap work would convert them into hits.
+/// - `Unsupported`: kache *will* cache this in principle but the
+///   relevant feature / flag / mode isn't modeled yet. The message
+///   should make the "not yet" character explicit so users know it's
+///   on the roadmap. Includes link-mode caching, multi-source split,
+///   response-file expansion, PCH / modules, and the long tail of
+///   unmodeled flags surfaced by the classifier table. These are the
+///   actionable cases — implementing one converts future invocations
+///   into hits.
 ///
 /// The bench's passthrough breakdown uses this split to separate
-/// "structural refusals" (a baseline the user can't push lower) from
-/// "classifier gaps" (the actual fix queue).
+/// "won't ever cache (structural)" from "doesn't cache yet (roadmap)".
 #[derive(Debug, Clone)]
 pub enum RefuseReason {
     /// Not a primary compilation (e.g. `--print`, `-vV`, query mode).
     NotPrimary,
-    /// Structurally not a single-source object compile — preprocessor mode
-    /// (`-E`), assembly mode (`-S`), link mode (no `-c`), output-to-stdout
-    /// (`-o -`), zero-source or multi-source invocation. No object file in,
-    /// no object file out; caching the result isn't applicable regardless of
-    /// what flags kache models. Static string is a stable identifier
-    /// suitable for logging / metrics.
+    /// Conceptually not a single-translation-unit object compile —
+    /// preprocessor mode (`-E`), assembly mode (`-S`), output-to-stdout
+    /// (`-o -`). No object file out; caching isn't applicable to the
+    /// operation itself, regardless of what flags kache models. Distinct
+    /// from `Unsupported` because no roadmap work would change this.
     NotACompile(&'static str),
-    /// Compiler-specific feature not yet supported by kache. Static string
-    /// is a stable identifier suitable for logging / metrics. Used today
-    /// by the C-family skeleton (refuses everything until real caching
-    /// lands) and reserved for future per-compiler "we know this flag
-    /// exists but can't safely cache it" cases.
+    /// Roadmap: kache could cache this but doesn't model the feature
+    /// yet. Examples: link-mode caching (whole-program), multi-source
+    /// per-source split, response-file expansion, PCH / modules, and
+    /// the long tail of flags missing from the classifier table.
+    /// Message should include language like "(not yet supported)" so
+    /// it's clear this is a deferral, not a permanent limit.
     Unsupported(&'static str),
 }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -49,10 +49,33 @@ pub enum CompilerKind {
 }
 
 /// Reason an invocation cannot be cached. Empty list = cacheable.
+///
+/// The variants encode an important categorical distinction the
+/// passthrough-reporting downstream uses to set expectations:
+///
+/// - `NotPrimary` / `NotACompile`: the invocation isn't the kind of
+///   work kache caches at all. Refusing is *correct*, not a kache
+///   limitation. No follow-up work could turn this into a cache hit.
+/// - `Unsupported`: kache *could* cache this in principle but the
+///   relevant feature / flag / mode isn't modeled yet. These are the
+///   actionable cases — adding a row to `CC_FLAGS` (or implementing
+///   PCH / modules / link caching / …) would convert future
+///   invocations into hits.
+///
+/// The bench's passthrough breakdown uses this split to separate
+/// "structural refusals" (a baseline the user can't push lower) from
+/// "classifier gaps" (the actual fix queue).
 #[derive(Debug, Clone)]
 pub enum RefuseReason {
     /// Not a primary compilation (e.g. `--print`, `-vV`, query mode).
     NotPrimary,
+    /// Structurally not a single-source object compile — preprocessor mode
+    /// (`-E`), assembly mode (`-S`), link mode (no `-c`), output-to-stdout
+    /// (`-o -`), zero-source or multi-source invocation. No object file in,
+    /// no object file out; caching the result isn't applicable regardless of
+    /// what flags kache models. Static string is a stable identifier
+    /// suitable for logging / metrics.
+    NotACompile(&'static str),
     /// Compiler-specific feature not yet supported by kache. Static string
     /// is a stable identifier suitable for logging / metrics. Used today
     /// by the C-family skeleton (refuses everything until real caching
@@ -68,6 +91,7 @@ impl RefuseReason {
     pub fn description(&self) -> &'static str {
         match self {
             RefuseReason::NotPrimary => "not a primary compilation",
+            RefuseReason::NotACompile(detail) => detail,
             RefuseReason::Unsupported(detail) => detail,
         }
     }


### PR DESCRIPTION
## Summary

The bench's passthrough breakdown was mixing categorically different refusals in the same "unsupported flag(s)" bucket:

\`\`\`
154x  refused: cc: unsupported flag(s): -xc -P -E; cc: preprocessor mode (-E)
\`\`\`

The user couldn't tell whether the cause was "kache will never cache this" or "kache hasn't gotten to this yet."

## What this PR does

Two intertwined cleanups:

### 1. Restructure \`cc::refuse_reasons\`

Check non-\`-c\` mode refusals (preprocessor / assembly / link / output-to-stdout) FIRST and short-circuit before running the flag classifier. The classifier's "unsupported flag(s): -E" output for a preprocessor invocation falsely suggested modeling a flag would unlock caching — when the real cause was "this isn't a compile."

\`\`\`
Before: ["cc: unsupported flag(s): -xc -P -E", "cc: preprocessor mode (-E)"]
After:  ["cc: preprocessor mode -E (not yet supported)"]
\`\`\`

The single-source/multi-source check moves to LAST so feature refusals (response file, PCH-as-input) name the actual cause before falling through to the bare symptom.

### 2. Every limitation reads as a deferral

The PR went through two design iterations based on review feedback. The journey, since the commit history shows it:

- **Commit 1**: Split into three variants — \`NotPrimary\` / \`NotACompile\` (won't ever cache) / \`Unsupported\` (roadmap). Categorized preprocessor / assembly / link / multi-source as "won't ever cache."

- **Commit 2** (after "I will eventually solve linker... and we may want to solve multi-source too — when possible I want the limitations to be clear so we can later cover them!"): Move link mode and multi-source from \`NotACompile\` to \`Unsupported\` — they're on the roadmap, not impossible.

- **Commit 3** (after "why is assembly mode not possible?"): Realize there is no honest "won't ever cache" category for cc. \`cc -S\` IS cacheable in principle (same input + flags → same \`.s\` output). Same for \`cc -E\` (cache the preprocessed file) and stdout output. **Drop the \`NotACompile\` variant entirely.** Every refusal except \`NotPrimary\` now lands in \`Unsupported\` with "(not yet supported)" or equivalent wording in the message.

Final shape:

| Variant | Meaning |
|---|---|
| \`NotPrimary\` | Query / probe (\`--print\`, \`-vV\`). Caching is meaningless. |
| \`Unsupported\` | Kache could cache this with engineering effort but doesn't yet. Message must include "(not yet supported)" or equivalent. |

Every cc refusal message updated to convey deferral:

- \`cc: preprocessor mode -E (not yet supported)\`
- \`cc: assembly mode -S (not yet supported)\`
- \`cc: output to stdout (not yet supported)\`
- \`cc: link mode (whole-program caching not yet supported)\`
- \`cc: multi-source compile (per-source split not yet supported)\`
- \`cc: no source file (not yet supported)\`
- \`cc: response file @file (expansion not yet supported)\`
- \`cc: multi-arch -arch X -arch Y (fat-binary caching not yet supported)\`
- \`cc: coverage instrumentation (not yet supported)\`
- \`cc: -gsplit-dwarf (not yet supported)\`
- \`cc: precompiled headers (not yet supported)\`
- \`cc: modules (not yet supported)\`
- \`cc: unsupported flag(s): ...\` (classifier gaps — implicit deferral)

The doc comment on \`RefuseReason\` explicitly calls out the design choice:

> *There is deliberately no third "won't ever cache" variant. For cc (and rustc) every deterministic input-to-output function IS cacheable in principle — even \`-E\` preprocessor output, even \`-S\` assembly output, even stdout bytes. What separates them from \`-c\` today is engineering priority, not categorical impossibility.*

## Tests

- \`non_compile_refusal_does_not_carry_unsupported_flag_noise\` — pins short-circuit behavior AND that messages read as deferrals
- \`compile_mode_unmodeled_flag_still_reports_unsupported_flag\` — complement: real compile + unmodeled flag still surfaces "unsupported flag(s)" (the actionable classifier-gap signal)
- \`refuse_reasons_refuses_multi_source_compile\` pins the "not yet supported" deferral wording
- 112 cc/compiler tests pass

## Test plan
- [x] \`cargo test --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [ ] After merge: next \`just bench-firefox-trace --skip-clone\` should produce a cleaner passthrough breakdown — preprocessor / assembly / link refusals stand alone (no "-xc -P -E" mixed in), and every reason string reads as a deferral the project intends to revisit