### PR TITLE
Introduce compiler artifact sets

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -2,14 +2,15 @@ use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::compiler::{ArtifactSet, classify_by_filename};
+
 /// Result of running rustc.
 pub struct CompileResult {
     pub exit_code: i32,
     pub stdout: String,
     pub stderr: String,
-    /// All output files produced by this compilation.
-    /// Each entry is (absolute_path, filename_for_store).
-    pub output_files: Vec<(PathBuf, String)>,
+    /// Full artifact set produced by this compilation.
+    pub artifacts: ArtifactSet,
 }
 
 /// Run rustc with the given arguments, capturing all outputs.
@@ -115,31 +116,34 @@ pub fn run_rustc(
     // for invocations that don't emit those messages (a bare `rustc`
     // without `--json=artifacts`), where filename guessing is the best
     // available signal.
-    let output_files = if exit_code == 0 {
+    let artifacts = if exit_code == 0 {
         let from_json = resolve_artifacts(&parse_rustc_artifacts(&stderr));
         if from_json.is_empty() {
             tracing::debug!(
                 "[kache] no rustc artifact notifications for {}; falling back to directory scan",
                 crate_name.unwrap_or("unknown")
             );
-            discover_output_files(output_path, out_dir, crate_name, extra_filename)?
+            ArtifactSet::from_output_files(
+                discover_output_files(output_path, out_dir, crate_name, extra_filename)?,
+                classify_by_filename,
+            )
         } else {
             tracing::debug!(
                 "[kache] discovered {} output file(s) for {} from rustc artifact notifications",
                 from_json.len(),
                 crate_name.unwrap_or("unknown")
             );
-            from_json
+            ArtifactSet::from_output_files(from_json, classify_by_filename)
         }
     } else {
-        Vec::new()
+        ArtifactSet::empty()
     };
 
     Ok(CompileResult {
         exit_code,
         stdout,
         stderr,
-        output_files,
+        artifacts,
     })
 }
 

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -44,7 +44,8 @@ use std::sync::OnceLock;
 
 use super::flags::{FlagClass, FlagSpec, Matcher};
 use super::{
-    ArtifactKind, CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason, classify_by_filename,
+    ArtifactKind, ArtifactSet, CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason,
+    classify_by_filename,
 };
 
 /// What stage the compiler is being asked to produce.
@@ -1821,26 +1822,26 @@ impl Compiler for CcCompiler {
         // cache) or non-Compile mode (refused upstream anyway). The
         // store name is the bare filename so restore can place it at
         // whatever `-o` path the warm invocation requests.
-        let output_files = if exit_code == 0 && parsed.mode == CompileMode::Compile {
+        let artifacts = if exit_code == 0 && parsed.mode == CompileMode::Compile {
             match parsed.object_output_path() {
                 Some(obj) if obj.exists() => {
                     let name = obj
                         .file_name()
                         .map(|n| n.to_string_lossy().into_owned())
                         .unwrap_or_default();
-                    vec![(obj, name)]
+                    ArtifactSet::from_output_files(vec![(obj, name)], classify_by_filename)
                 }
-                _ => Vec::new(),
+                _ => ArtifactSet::empty(),
             }
         } else {
-            Vec::new()
+            ArtifactSet::empty()
         };
 
         Ok(CompileResult {
             exit_code,
             stdout: String::from_utf8_lossy(&output.stdout).to_string(),
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-            output_files,
+            artifacts,
         })
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -164,12 +164,85 @@ impl ArtifactKind {
     }
 }
 
-/// A compiler output file with its [`ArtifactKind`] for dispatch purposes.
-#[allow(dead_code)] // produced by future Compiler::outputs(), not yet wired
-#[derive(Debug, Clone)]
-pub struct OutputArtifact {
+/// One compiler output artifact.
+///
+/// `store_name` is the stable filename used inside a cache entry. It is
+/// usually the basename of `path`, but it is explicit so adapters can
+/// later represent directory/discovered outputs without making the store
+/// infer names from paths.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Artifact {
     pub path: PathBuf,
+    pub store_name: String,
     pub kind: ArtifactKind,
+    pub required: bool,
+}
+
+/// Full output set produced by one compiler invocation.
+///
+/// Today the store still persists files as `(source_path, store_name)`
+/// pairs. Keeping the richer artifact set at the compiler boundary lets
+/// C/C++ and Rust grow side-output modeling without changing the cache
+/// format in the same PR.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ArtifactSet {
+    outputs: Vec<Artifact>,
+}
+
+impl ArtifactSet {
+    pub fn new(outputs: Vec<Artifact>) -> Self {
+        Self { outputs }
+    }
+
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn from_output_files(
+        output_files: Vec<(PathBuf, String)>,
+        classify: impl Fn(&str) -> ArtifactKind,
+    ) -> Self {
+        Self::new(
+            output_files
+                .into_iter()
+                .map(|(path, store_name)| {
+                    let kind = classify(&store_name);
+                    Artifact {
+                        path,
+                        store_name,
+                        kind,
+                        required: true,
+                    }
+                })
+                .collect(),
+        )
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.outputs.is_empty()
+    }
+
+    pub fn outputs(&self) -> &[Artifact] {
+        &self.outputs
+    }
+
+    pub fn store_files(&self) -> Vec<(PathBuf, String)> {
+        self.outputs
+            .iter()
+            .map(|artifact| (artifact.path.clone(), artifact.store_name.clone()))
+            .collect()
+    }
+
+    pub fn total_size(&self) -> u64 {
+        self.outputs
+            .iter()
+            .map(|artifact| {
+                std::fs::metadata(&artifact.path)
+                    .map(|m| m.len())
+                    .unwrap_or(0)
+            })
+            .sum()
+    }
 }
 
 /// Best-guess classification from filename alone, no compile-context.

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -9,7 +9,7 @@ use crate::compile;
 use crate::compiler::cc::CcCompiler;
 use crate::compiler::rustc::RustcCompiler;
 use crate::compiler::{
-    ArtifactKind, Compiler, KeyCtx, classify_by_filename, plan_post_restore, platform,
+    ArtifactKind, ArtifactSet, Compiler, KeyCtx, classify_by_filename, plan_post_restore, platform,
 };
 use crate::config::Config;
 use crate::events::{self, BuildEvent, EventResult};
@@ -264,8 +264,9 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // discovery came up empty is not cacheable — return the exit
     // code and let cargo see the failure.
     let store_start = std::time::Instant::now();
-    if result.exit_code == 0 && !result.output_files.is_empty() {
+    if result.exit_code == 0 && !result.artifacts.is_empty() {
         let target = parsed.cache_target_arch();
+        let store_files = result.artifacts.store_files();
         if let Err(e) = store.put_with_compile_time(
             &cache_key,
             &crate_name,
@@ -273,7 +274,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             &[], // features: n/a
             &target,
             "", // profile: n/a (opt level is in the key)
-            &result.output_files,
+            &store_files,
             &result.stdout,
             &result.stderr,
             compile_time_ms,
@@ -284,11 +285,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let store_ms = store_start.elapsed().as_millis() as u64;
 
     let elapsed = start.elapsed().as_millis() as u64;
-    let size: u64 = result
-        .output_files
-        .iter()
-        .map(|(p, _)| std::fs::metadata(p).map(|m| m.len()).unwrap_or(0))
-        .sum();
+    let size = result.artifacts.total_size();
     log_event(
         config,
         &crate_name,
@@ -372,7 +369,7 @@ fn restore_cc_from_cache(
         std::fs::create_dir_all(parent)
             .with_context(|| format!("cc restore: creating {}", parent.display()))?;
     }
-    let kind = crate::compiler::classify_by_filename(&cached.name);
+    let kind = classify_by_filename(&cached.name);
     link::link_to_target(&blob, &target, kind.link_strategy()).with_context(|| {
         format!(
             "cc restore: linking {} -> {}",
@@ -735,10 +732,11 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // absolute paths the *current* build's cargo still needs to see.
     let depinfo_anchor = args.target_dir();
     if let Some(anchor) = depinfo_anchor.as_deref() {
-        rewrite_depinfo_outputs(&result.output_files, anchor, link::DepInfoMode::Relativize);
+        rewrite_depinfo_outputs(&result.artifacts, anchor, link::DepInfoMode::Relativize);
     }
 
     let store_start = std::time::Instant::now();
+    let store_files = result.artifacts.store_files();
     if let Err(e) = store.put_with_compile_time(
         &cache_key,
         crate_name,
@@ -746,7 +744,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         &args.features,
         target,
         profile,
-        &result.output_files,
+        &store_files,
         &result.stdout,
         &result.stderr,
         compile_time_ms,
@@ -759,7 +757,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // already captured the relativized form above; this leaves the
     // current build's `.d` valid for cargo's own freshness checks.
     if let Some(anchor) = depinfo_anchor.as_deref() {
-        rewrite_depinfo_outputs(&result.output_files, anchor, link::DepInfoMode::Expand);
+        rewrite_depinfo_outputs(&result.artifacts, anchor, link::DepInfoMode::Expand);
     }
 
     // 6. Async upload to remote (if configured) — sends job to the daemon
@@ -774,11 +772,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     clean_incremental_dir(config, &args);
 
     let elapsed = start.elapsed().as_millis() as u64;
-    let size: u64 = result
-        .output_files
-        .iter()
-        .map(|(p, _)| std::fs::metadata(p).map(|m| m.len()).unwrap_or(0))
-        .sum();
+    let size = result.artifacts.total_size();
     log_event_with_hash_stats(
         config,
         crate_name,
@@ -799,30 +793,24 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     Ok(result.exit_code)
 }
 
-/// Rewrite every dep-info (`.d`) file in a set of compiler output files,
-/// in place, against `anchor`.
+/// Rewrite every dep-info (`.d`) file in a compiler artifact set, in place,
+/// against `anchor`.
 ///
-/// `output_files` is `(source_path, store_name)` pairs as handed to
-/// `Store::put*`. Dep-info files are identified structurally via
-/// [`ArtifactKind::DepInfo`] — the same classification the restore loop
-/// uses — rather than by an ad-hoc `.d` suffix check, so the store and
-/// restore sides stay in lock-step on what counts as a `.d`.
+/// Dep-info files are identified by the adapter-provided artifact kind,
+/// so the store and restore sides stay in lock-step on what counts as a
+/// `.d`.
 ///
 /// Rewrite failures are logged and skipped, not propagated: a malformed
 /// `.d` must not abort an otherwise-successful cache store.
-fn rewrite_depinfo_outputs(
-    output_files: &[(std::path::PathBuf, String)],
-    anchor: &Path,
-    mode: link::DepInfoMode,
-) {
-    for (source_path, store_name) in output_files {
-        if classify_by_filename(store_name) != ArtifactKind::DepInfo {
+fn rewrite_depinfo_outputs(artifacts: &ArtifactSet, anchor: &Path, mode: link::DepInfoMode) {
+    for artifact in artifacts.outputs() {
+        if artifact.kind != ArtifactKind::DepInfo {
             continue;
         }
-        if let Err(e) = link::rewrite_depinfo(source_path, anchor, mode) {
+        if let Err(e) = link::rewrite_depinfo(&artifact.path, anchor, mode) {
             tracing::warn!(
                 "failed to rewrite dep-info {} ({:?}): {}",
-                source_path.display(),
+                artifact.path.display(),
                 mode,
                 e
             );
@@ -1376,7 +1364,10 @@ mod tests {
         )
         .unwrap();
 
-        let outputs = vec![(depfile.clone(), "foo-abc.d".to_string())];
+        let outputs = ArtifactSet::from_output_files(
+            vec![(depfile.clone(), "foo-abc.d".to_string())],
+            classify_by_filename,
+        );
 
         // Store side: relativize against the producing build's target dir.
         rewrite_depinfo_outputs(&outputs, producing_target, link::DepInfoMode::Relativize);
@@ -1414,7 +1405,10 @@ mod tests {
         let original = "/build/worktree-a/target/release/deps/x";
         std::fs::write(&rlib, original).unwrap();
 
-        let outputs = vec![(rlib.clone(), "libfoo-abc.rlib".to_string())];
+        let outputs = ArtifactSet::from_output_files(
+            vec![(rlib.clone(), "libfoo-abc.rlib".to_string())],
+            classify_by_filename,
+        );
         rewrite_depinfo_outputs(
             &outputs,
             std::path::Path::new("/build/worktree-a/target"),
@@ -1432,7 +1426,10 @@ mod tests {
     /// malformed output set must never abort an otherwise-good store.
     #[test]
     fn rewrite_depinfo_outputs_is_silent_on_missing_file() {
-        let outputs = vec![(PathBuf::from("/nonexistent/foo.d"), "foo.d".to_string())];
+        let outputs = ArtifactSet::from_output_files(
+            vec![(PathBuf::from("/nonexistent/foo.d"), "foo.d".to_string())],
+            classify_by_filename,
+        );
         // Must not panic.
         rewrite_depinfo_outputs(
             &outputs,


### PR DESCRIPTION
## Summary
- introduce Artifact and ArtifactSet at the compiler boundary
- return ArtifactSet from Rust and C/C++ compile execution while preserving the store tuple format
- route dep-info rewrite and miss-size accounting through artifact metadata

## Validation
- env -u RUSTC_WRAPPER just lint
- env -u RUSTC_WRAPPER cargo test
- git diff --check