### PR TITLE
Replace compiler kind with adapter descriptors

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -44,9 +44,13 @@ use std::sync::OnceLock;
 
 use super::flags::{FlagClass, FlagSpec, Matcher};
 use super::{
-    ArtifactKind, ArtifactSet, CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason,
-    classify_by_filename,
+    ArtifactKind, ArtifactSet, CompileResult, Compiler, CompilerAdapter, CompilerId, KeyCtx,
+    RefuseReason, classify_by_filename,
 };
+
+pub const CC_ID: CompilerId = CompilerId::new("cc");
+pub const ADAPTER: CompilerAdapter =
+    CompilerAdapter::new(CC_ID, "C-family compiler", CcCompiler::recognizes);
 
 /// What stage the compiler is being asked to produce.
 ///
@@ -1624,9 +1628,8 @@ impl CcCompiler {
     /// versioned variants (`gcc-13`, `clang++-17`). Path-prefixed
     /// forms (`/usr/bin/cc`) work via [`Path::file_name`].
     ///
-    /// Owns its own detection rule so `super::detect_compiler` is a
-    /// thin delegating dispatch rather than a central registry of
-    /// "what's a compiler" knowledge.
+    /// Owns its own detection rule; `super::detect_compiler` reaches it
+    /// through this module's [`ADAPTER`] descriptor.
     pub fn recognizes(args: &[String]) -> bool {
         let Some(arg0) = args.first() else {
             return false;
@@ -1666,7 +1669,7 @@ impl CcCompiler {
     /// land here when their absence becomes a real symptom —
     /// over-broad matching would mask legitimate CLI typos.
     ///
-    /// **Not a [`CompilerKind`].** A probe is a non-compiler invocation
+    /// **Not a compiler adapter.** A probe is a non-compiler invocation
     /// pattern that happens to need passthrough. The dispatch in
     /// `run_wrapper_mode` checks this *before* the compiler match.
     pub fn recognizes_family_probe(args: &[String]) -> bool {
@@ -1677,8 +1680,8 @@ impl CcCompiler {
 impl Compiler for CcCompiler {
     type Parsed = CcArgs;
 
-    fn kind(&self) -> CompilerKind {
-        CompilerKind::Cc
+    fn id(&self) -> CompilerId {
+        CC_ID
     }
 
     fn parse(&self, args: &[String]) -> Result<CcArgs> {
@@ -1883,6 +1886,13 @@ mod tests {
                 "should recognize {name}"
             );
         }
+    }
+
+    #[test]
+    fn adapter_descriptor_uses_cc_recognizer() {
+        assert_eq!(ADAPTER.id(), CC_ID);
+        assert!(ADAPTER.recognizes(&s(&["cc"])));
+        assert!(!ADAPTER.recognizes(&s(&["rustc"])));
     }
 
     #[test]

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,10 +1,10 @@
 //! Compiler abstraction.
 //!
-//! Each supported compiler (today: rustc; planned: gcc, clang, msvc) implements
-//! the [`Compiler`] trait. The wrapper picks an implementation based on argv[0]
-//! inspection ([`detect_compiler`]) and dispatches by static type — there is no
-//! `dyn Compiler`, intentionally, because each compiler keeps its native parsed
-//! representation as an associated type.
+//! Each supported compiler adapter (today: rustc and C-family compilers)
+//! implements the [`Compiler`] trait and exports a [`CompilerAdapter`]
+//! descriptor. Detection walks those descriptors instead of returning a closed
+//! enum, so adding an adapter is adding a module-owned descriptor plus wrapper
+//! dispatch, not growing a central taxonomy of future tool kinds.
 //!
 //! **Scope.** The trait covers the operations with a clean generic shape
 //! today: `parse`, `refuse_reasons`, `cache_key`, `execute`, and
@@ -30,22 +30,63 @@ pub use platform::Platform;
 
 pub use crate::compile::CompileResult;
 
-/// Identifies a compiler family.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CompilerKind {
-    Rustc,
-    /// C-family compiler (cc, gcc, g++, clang, clang++, c++ and version
-    /// suffixes). Single variant for now — sub-distinctions (real gcc vs
-    /// clang vs apple-clang vs MSVC) become relevant when arg parsing
-    /// lands and matter per-impl, not at the dispatch layer.
-    Cc,
-    // Future: Msvc (different argv shape, separate variant).
-    //
-    // Compiler-family *probes* (e.g. `kache -E <file>`) are NOT a
-    // compiler kind — they're a non-compiler invocation pattern that
-    // happens to need passthrough. Detected separately via
-    // `CcCompiler::recognizes_family_probe` and dispatched in
-    // `run_wrapper_mode` before the compiler match.
+/// Stable adapter identifier.
+///
+/// This is intentionally an open string newtype instead of a closed enum:
+/// adapter ids name concrete implementations that exist today, while future
+/// adapters bring their own ids without forcing kache to define an abstract
+/// "kind" hierarchy up front.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CompilerId(&'static str);
+
+impl CompilerId {
+    pub const fn new(id: &'static str) -> Self {
+        Self(id)
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+impl std::fmt::Display for CompilerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+/// Module-owned adapter descriptor used for argv detection.
+#[derive(Debug, Clone, Copy)]
+pub struct CompilerAdapter {
+    id: CompilerId,
+    display_name: &'static str,
+    recognizes: fn(&[String]) -> bool,
+}
+
+impl CompilerAdapter {
+    pub const fn new(
+        id: CompilerId,
+        display_name: &'static str,
+        recognizes: fn(&[String]) -> bool,
+    ) -> Self {
+        Self {
+            id,
+            display_name,
+            recognizes,
+        }
+    }
+
+    pub const fn id(self) -> CompilerId {
+        self.id
+    }
+
+    pub const fn display_name(self) -> &'static str {
+        self.display_name
+    }
+
+    pub fn recognizes(self, args: &[String]) -> bool {
+        (self.recognizes)(args)
+    }
 }
 
 /// Reason an invocation cannot be cached. Empty list = cacheable.
@@ -433,10 +474,10 @@ impl PostRestoreAction {
 pub trait Compiler {
     type Parsed;
 
-    fn kind(&self) -> CompilerKind;
+    fn id(&self) -> CompilerId;
 
     /// Parse raw argv into the compiler's native representation.
-    /// Caller has already established this is the right compiler kind via
+    /// Caller has already established this is the right compiler adapter via
     /// [`detect_compiler`].
     fn parse(&self, args: &[String]) -> Result<Self::Parsed>;
 
@@ -462,25 +503,26 @@ pub trait Compiler {
     fn classify_output(&self, parsed: &Self::Parsed, name: &str) -> ArtifactKind;
 }
 
-/// Detect which compiler family an argv vector is invoking.
+/// Adapter descriptors currently supported by kache.
 ///
-/// Each compiler impl owns its own `recognizes` rule; this function is
-/// just the dispatch table. Adding a new compiler family means adding
-/// a new `CompilerKind` variant + its impl + one arm here — no central
-/// "registry of recognizers" to keep in sync.
+/// Registration is deliberately concrete and local: adding an adapter means
+/// adding its module-owned descriptor here, with no broad enum of possible
+/// future tool kinds.
+pub const COMPILER_ADAPTERS: &[CompilerAdapter] = &[rustc::ADAPTER, cc::ADAPTER];
+
+/// Detect which compiler adapter an argv vector is invoking.
+///
+/// Each compiler impl owns its own `recognizes` rule; this function just walks
+/// the descriptor list.
 ///
 /// Returns `None` if no supported compiler matches — caller should
 /// fall through to direct execution (or to compiler-family probe
-/// handling via [`cc::CcCompiler::recognizes_family_probe`], which is
-/// its own concern, not a compiler kind).
-pub fn detect_compiler(args: &[String]) -> Option<CompilerKind> {
-    if rustc::RustcCompiler::recognizes(args) {
-        return Some(CompilerKind::Rustc);
-    }
-    if cc::CcCompiler::recognizes(args) {
-        return Some(CompilerKind::Cc);
-    }
-    None
+/// handling via [`cc::CcCompiler::recognizes_family_probe`], which is its own
+/// concern, not an adapter).
+pub fn detect_compiler(args: &[String]) -> Option<&'static CompilerAdapter> {
+    COMPILER_ADAPTERS
+        .iter()
+        .find(|adapter| adapter.recognizes(args))
 }
 
 #[cfg(test)]
@@ -493,54 +535,63 @@ mod tests {
 
     #[test]
     fn detect_compiler_returns_none_for_empty_argv() {
-        assert_eq!(detect_compiler(&[]), None);
+        assert!(detect_compiler(&[]).is_none());
     }
 
     #[test]
     fn detect_compiler_recognizes_rustc_paths() {
-        assert_eq!(detect_compiler(&s(&["rustc"])), Some(CompilerKind::Rustc));
         assert_eq!(
-            detect_compiler(&s(&["/usr/bin/rustc", "src/lib.rs"])),
-            Some(CompilerKind::Rustc)
+            detect_compiler(&s(&["rustc"])).map(|adapter| adapter.id()),
+            Some(rustc::RUSTC_ID)
         );
         assert_eq!(
-            detect_compiler(&s(&["clippy-driver"])),
-            Some(CompilerKind::Rustc)
+            detect_compiler(&s(&["/usr/bin/rustc", "src/lib.rs"])).map(|adapter| adapter.id()),
+            Some(rustc::RUSTC_ID)
+        );
+        assert_eq!(
+            detect_compiler(&s(&["clippy-driver"])).map(|adapter| adapter.id()),
+            Some(rustc::RUSTC_ID)
         );
     }
 
     #[test]
     fn detect_compiler_recognizes_cc_paths() {
-        assert_eq!(detect_compiler(&s(&["cc"])), Some(CompilerKind::Cc));
-        assert_eq!(detect_compiler(&s(&["gcc"])), Some(CompilerKind::Cc));
-        assert_eq!(detect_compiler(&s(&["clang++"])), Some(CompilerKind::Cc));
         assert_eq!(
-            detect_compiler(&s(&["/usr/bin/cc", "-c", "foo.c"])),
-            Some(CompilerKind::Cc)
+            detect_compiler(&s(&["cc"])).map(|adapter| adapter.id()),
+            Some(cc::CC_ID)
+        );
+        assert_eq!(
+            detect_compiler(&s(&["gcc"])).map(|adapter| adapter.id()),
+            Some(cc::CC_ID)
+        );
+        assert_eq!(
+            detect_compiler(&s(&["clang++"])).map(|adapter| adapter.id()),
+            Some(cc::CC_ID)
+        );
+        assert_eq!(
+            detect_compiler(&s(&["/usr/bin/cc", "-c", "foo.c"])).map(|adapter| adapter.id()),
+            Some(cc::CC_ID)
         );
     }
 
     #[test]
     fn detect_compiler_returns_none_for_cc_probe_shape() {
         // The cc-crate compiler-family probe (`kache -E <file>`) is
-        // intentionally NOT a CompilerKind — it's a non-compiler
+        // intentionally NOT a compiler adapter — it's a non-compiler
         // invocation pattern handled separately in run_wrapper_mode
         // via `CcCompiler::recognizes_family_probe`. Asserting None
         // here pins that boundary: detect_compiler must not grow into
         // a grab-bag of "anything kache should passthrough".
-        assert_eq!(detect_compiler(&s(&["-E", "/tmp/probe.c"])), None);
-        assert_eq!(
-            detect_compiler(&s(&["-E", "/tmp/detect_compiler_family.c"])),
-            None
-        );
+        assert!(detect_compiler(&s(&["-E", "/tmp/probe.c"])).is_none());
+        assert!(detect_compiler(&s(&["-E", "/tmp/detect_compiler_family.c"])).is_none());
     }
 
     #[test]
     fn detect_compiler_returns_none_for_unrelated_argv() {
-        assert_eq!(detect_compiler(&s(&["cargo", "build"])), None);
-        assert_eq!(detect_compiler(&s(&["make"])), None);
-        assert_eq!(detect_compiler(&s(&["ld"])), None);
-        assert_eq!(detect_compiler(&s(&["--crate-name"])), None);
+        assert!(detect_compiler(&s(&["cargo", "build"])).is_none());
+        assert!(detect_compiler(&s(&["make"])).is_none());
+        assert!(detect_compiler(&s(&["ld"])).is_none());
+        assert!(detect_compiler(&s(&["--crate-name"])).is_none());
     }
 
     #[test]

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -3,7 +3,7 @@
 //! Phase 0: a thin facade over the existing free functions in
 //! [`crate::args`], [`crate::cache_key`], and [`crate::compile`]. Those
 //! functions remain the canonical implementations; the trait simply gives
-//! callers a stable shape that future compilers (gcc, clang) will match.
+//! callers a stable shape that other compiler adapters can match.
 
 use anyhow::Result;
 use std::path::Path;
@@ -13,8 +13,13 @@ use crate::cache_key::compute_cache_key;
 use crate::compile;
 
 use super::{
-    ArtifactKind, CompileResult, Compiler, CompilerKind, KeyCtx, RefuseReason, classify_by_filename,
+    ArtifactKind, CompileResult, Compiler, CompilerAdapter, CompilerId, KeyCtx, RefuseReason,
+    classify_by_filename,
 };
+
+pub const RUSTC_ID: CompilerId = CompilerId::new("rustc");
+pub const ADAPTER: CompilerAdapter =
+    CompilerAdapter::new(RUSTC_ID, "Rust compiler", RustcCompiler::recognizes);
 
 /// Map a rustc `--crate-type` to the [`ArtifactKind`] of the artifact it
 /// produces.
@@ -47,12 +52,8 @@ impl RustcCompiler {
 
     /// Does this argv invoke rustc (or clippy-driver, which wraps it)?
     ///
-    /// Owns its own detection rule — `super::detect_compiler` delegates
-    /// here so a future Msvc / etc. compiler doesn't require editing a
-    /// central registry: it just adds its own `recognizes` and one new
-    /// arm in `detect_compiler`. The arm is forced by the compile
-    /// error on adding a `CompilerKind` variant, not by remembering to
-    /// update an opaque list.
+    /// Owns its own detection rule; `super::detect_compiler` reaches it
+    /// through this module's [`ADAPTER`] descriptor.
     ///
     /// Inspects only `argv[0]`. Path-prefixed forms (`/usr/bin/rustc`)
     /// work via [`Path::file_name`].
@@ -74,8 +75,8 @@ impl RustcCompiler {
 impl Compiler for RustcCompiler {
     type Parsed = RustcArgs;
 
-    fn kind(&self) -> CompilerKind {
-        CompilerKind::Rustc
+    fn id(&self) -> CompilerId {
+        RUSTC_ID
     }
 
     fn parse(&self, args: &[String]) -> Result<RustcArgs> {
@@ -169,8 +170,15 @@ mod tests {
     }
 
     #[test]
-    fn kind_is_rustc() {
-        assert_eq!(RustcCompiler::new().kind(), CompilerKind::Rustc);
+    fn id_is_rustc() {
+        assert_eq!(RustcCompiler::new().id(), RUSTC_ID);
+    }
+
+    #[test]
+    fn adapter_descriptor_uses_rustc_recognizer() {
+        assert_eq!(ADAPTER.id(), RUSTC_ID);
+        assert!(ADAPTER.recognizes(&s(&["rustc"])));
+        assert!(!ADAPTER.recognizes(&s(&["cc"])));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -535,24 +535,29 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
     // crate) — handled before compiler dispatch because it is NOT a
     // compiler invocation: it's a passthrough to the system default
     // `cc` so the cc crate sees the real underlying compiler's
-    // preprocessor output. Keeping this branch separate from the
-    // compiler match keeps `CompilerKind` semantically clean
-    // ("which compiler family is this?", not "which kind of thing
-    // should kache do?").
+    // preprocessor output.
     if compiler::cc::CcCompiler::recognizes_family_probe(args) {
         std::process::exit(wrapper::run_cc_probe(args)?);
     }
 
-    // Dispatch by detected compiler kind. detect_log_mode already verified
-    // there's a recognized compiler at args[0], so the None branch is just
-    // defensive (matches detect_compiler's contract).
-    let exit_code = match compiler::detect_compiler(args) {
-        Some(compiler::CompilerKind::Rustc) => wrapper::run(&config, args)?,
-        Some(compiler::CompilerKind::Cc) => wrapper::run_cc(&config, args)?,
-        None => anyhow::bail!(
-            "wrapper-mode dispatched but no compiler matched argv[0] = {:?}",
+    // Dispatch by detected adapter. detect_log_mode already verified there's
+    // a recognized compiler at args[0], so the None branch is defensive.
+    let Some(adapter) = compiler::detect_compiler(args) else {
+        anyhow::bail!(
+            "wrapper-mode dispatched but no compiler adapter matched argv[0] = {:?}",
             args.first()
-        ),
+        );
+    };
+    let exit_code = if adapter.id() == compiler::rustc::RUSTC_ID {
+        wrapper::run(&config, args)?
+    } else if adapter.id() == compiler::cc::CC_ID {
+        wrapper::run_cc(&config, args)?
+    } else {
+        anyhow::bail!(
+            "detected compiler adapter {} ({}) has no wrapper dispatch",
+            adapter.id(),
+            adapter.display_name()
+        );
     };
     std::process::exit(exit_code);
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -127,8 +127,8 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     if !refuse.is_empty() {
         let reasons: Vec<&str> = refuse.iter().map(|r| r.description()).collect();
         tracing::debug!(
-            "{:?}: passthrough ({})",
-            compiler.kind(),
+            "{}: passthrough ({})",
+            compiler.id().as_str(),
             reasons.join("; ")
         );
         return cc_passthrough_with_event(
@@ -429,8 +429,8 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     if !refuse.is_empty() {
         let reasons: Vec<&str> = refuse.iter().map(|r| r.description()).collect();
         tracing::debug!(
-            "{:?}: bypassing cache ({})",
-            compiler.kind(),
+            "{}: bypassing cache ({})",
+            compiler.id().as_str(),
             reasons.join("; ")
         );
         return passthrough_with_event(


### PR DESCRIPTION
## Summary
- replace the closed CompilerKind enum with open CompilerId values and CompilerAdapter descriptors
- let rustc and C/C++ modules own their adapter descriptors and recognition rules
- dispatch wrapper mode through detected adapter ids while keeping only rustc and C/C++ implementations

## Validation
- env -u RUSTC_WRAPPER just lint
- env -u RUSTC_WRAPPER cargo test compiler::
- env -u RUSTC_WRAPPER cargo test
- git diff --check