### PR TITLE
Cache cc dep-info artifacts

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2,8 +2,8 @@
 //!
 //! **C/C++ caching is live for the single-source `-c` compile.**
 //! A `cc -c foo.c -o foo.o` invocation gets a content-addressed
-//! cache entry; an identical re-invocation restores the `.o` without
-//! running the compiler.
+//! cache entry; an identical re-invocation restores the `.o` and, when
+//! requested, its `.d` dep-info sidecar without running the compiler.
 //!
 //! What's cached:
 //! - **`-c` object compiles**, exactly one source per invocation.
@@ -33,7 +33,6 @@
 //! - `ar` archive caching
 //! - Cross-machine cache sharing for C/C++ artifacts: SDKROOT
 //!   sentinel + Mach-O OSO record stripping (issue #78)
-//! - Dep-info (`.d`) file caching alongside the `.o`
 
 use anyhow::{Context, Result};
 use regex::Regex;
@@ -106,9 +105,17 @@ pub enum OptLevel {
 /// the same path-normalization treatment as rustc's dep-info.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DepInfoSpec {
+    /// True when the invocation actually asks the compiler to emit dep-info
+    /// in compile mode (`-MD` / `-MMD`). Path/target modifiers alone do not
+    /// create a depfile.
+    pub emit: bool,
     /// `-MD` (true) or `-MMD` (false). True = include system headers
     /// in the dep-info output; false = user headers only.
     pub include_system: bool,
+    /// `-MP`: add phony targets for each dependency.
+    pub phony_targets: bool,
+    /// `-MG`: treat missing headers as generated files in dependency output.
+    pub missing_generated: bool,
     /// `-MF foo.d`: where to write the dep-info file. `None` means
     /// the compiler picks a default (typically next to the `.o`).
     pub output: Option<PathBuf>,
@@ -185,6 +192,8 @@ enum CcArgAction {
     SetOptimization(OptLevel),
     SetStd,
     DepIncludeSystem(bool),
+    DepPhonyTargets,
+    DepMissingGenerated,
     DepOutput,
     DepTarget,
     LanguageOverride,
@@ -380,6 +389,20 @@ static CC_ARG_SPECS: &[CcArgSpec] = &[
         action: CcArgAction::DepIncludeSystem(false),
         bucket: CcArgBucket::NoObjectEffect,
         source: "dependency sidecar",
+    },
+    CcArgSpec {
+        matcher: Matcher::Exact("-MP"),
+        value_form: CcArgValueForm::Flag,
+        action: CcArgAction::DepPhonyTargets,
+        bucket: CcArgBucket::NoObjectEffect,
+        source: "dependency sidecar phony targets",
+    },
+    CcArgSpec {
+        matcher: Matcher::Exact("-MG"),
+        value_form: CcArgValueForm::Flag,
+        action: CcArgAction::DepMissingGenerated,
+        bucket: CcArgBucket::NoObjectEffect,
+        source: "dependency sidecar generated headers",
     },
     CcArgSpec {
         matcher: Matcher::Exact("-MF"),
@@ -716,6 +739,36 @@ impl CcArgs {
         Some(PathBuf::from(format!("{}.o", stem.to_string_lossy())))
     }
 
+    /// The dep-info file a compile produces when `-MD` / `-MMD` is active.
+    ///
+    /// `-MF <path>` wins. Otherwise gcc/clang derive the depfile from the
+    /// object output by replacing its extension with `.d`.
+    pub fn depinfo_output_path(&self) -> Option<PathBuf> {
+        let depinfo = self.depinfo.as_ref()?;
+        if !depinfo.emit {
+            return None;
+        }
+        if let Some(output) = &depinfo.output {
+            return Some(output.clone());
+        }
+        let mut object = self.object_output_path()?;
+        object.set_extension("d");
+        Some(object)
+    }
+
+    /// Anchor used to relativize/expand C/C++ dep-info target paths.
+    pub fn depinfo_anchor(&self) -> Option<PathBuf> {
+        self.depinfo_output_path()?;
+        let object = self.object_output_path()?;
+        Some(
+            object
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| PathBuf::from(".")),
+        )
+    }
+
     /// Target architecture for cache-key / metadata purposes:
     /// an explicit `-arch X` if present, else the host arch.
     pub fn cache_target_arch(&self) -> String {
@@ -826,7 +879,16 @@ fn apply_cc_arg(parsed: &mut CcArgs, depinfo: &mut Option<DepInfoSpec>, arg: &Pa
         }
         CcArgAction::DepIncludeSystem(include_system) => {
             let d = depinfo.get_or_insert_with(DepInfoSpec::default);
+            d.emit = true;
             d.include_system = include_system;
+        }
+        CcArgAction::DepPhonyTargets => {
+            let d = depinfo.get_or_insert_with(DepInfoSpec::default);
+            d.phony_targets = true;
+        }
+        CcArgAction::DepMissingGenerated => {
+            let d = depinfo.get_or_insert_with(DepInfoSpec::default);
+            d.missing_generated = true;
         }
         CcArgAction::DepOutput => {
             if let Some(value) = &arg.value {
@@ -860,7 +922,7 @@ fn apply_cc_arg(parsed: &mut CcArgs, depinfo: &mut Option<DepInfoSpec>, arg: &Pa
 
 /// Cache key schema version for C-family compiles. Bump when the key
 /// composition changes in a way that could collide with old entries.
-const CC_CACHE_KEY_VERSION: u32 = 2;
+const CC_CACHE_KEY_VERSION: u32 = 3;
 
 /// Resolve the target architecture for the cache key: an explicit
 /// `-arch X` flag if present, else the host arch. (Multi-`-arch` is
@@ -1791,6 +1853,36 @@ impl Compiler for CcCompiler {
         hasher.update(&[parsed.pic as u8]);
         hasher.update(b"\n");
 
+        // The object bytes do not depend on dep-info flags, but the cached
+        // artifact set now can include a `.d` sidecar. Key the dep-info
+        // content shape so an object-only entry never satisfies an invocation
+        // that expects dependency output, and so flags like `-MD` vs `-MMD`
+        // or `-MT` do not share incompatible sidecars.
+        hasher.update(b"depinfo:");
+        if let Some(depinfo) = parsed.depinfo.as_ref().filter(|d| d.emit) {
+            hasher.update(b"1\n");
+            hasher.update(b"depinfo_include_system:");
+            hasher.update(&[depinfo.include_system as u8]);
+            hasher.update(b"\n");
+            hasher.update(b"depinfo_phony_targets:");
+            hasher.update(&[depinfo.phony_targets as u8]);
+            hasher.update(b"\n");
+            hasher.update(b"depinfo_missing_generated:");
+            hasher.update(&[depinfo.missing_generated as u8]);
+            hasher.update(b"\n");
+            hasher.update(b"depinfo_target:");
+            if let Some(target) = &depinfo.target {
+                hasher.update(target.as_bytes());
+            } else if let Some(object) = parsed.object_output_path()
+                && let Some(name) = object.file_name()
+            {
+                hasher.update(name.to_string_lossy().as_bytes());
+            }
+            hasher.update(b"\n");
+        } else {
+            hasher.update(b"0\n");
+        }
+
         // Preprocessor expansion — the load-bearing input. Captures
         // the source plus every transitively-included header plus
         // macro expansion. `-E -P` strips line markers so header
@@ -1832,7 +1924,17 @@ impl Compiler for CcCompiler {
                         .file_name()
                         .map(|n| n.to_string_lossy().into_owned())
                         .unwrap_or_default();
-                    ArtifactSet::from_output_files(vec![(obj, name)], classify_by_filename)
+                    let mut outputs = vec![(obj, name)];
+                    if let Some(depinfo) = parsed.depinfo_output_path()
+                        && depinfo.exists()
+                    {
+                        let name = depinfo
+                            .file_name()
+                            .map(|n| n.to_string_lossy().into_owned())
+                            .unwrap_or_default();
+                        outputs.push((depinfo, name));
+                    }
+                    ArtifactSet::from_output_files(outputs, classify_by_filename)
                 }
                 _ => ArtifactSet::empty(),
             }
@@ -2171,6 +2273,7 @@ mod tests {
     fn parse_depinfo_mmd_excludes_system_headers() {
         let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-MMD"])).unwrap();
         let d = parsed.depinfo.expect("dep-info should be set");
+        assert!(d.emit);
         assert!(!d.include_system);
         assert_eq!(d.output, None);
         assert_eq!(d.target, None);
@@ -2180,6 +2283,7 @@ mod tests {
     fn parse_depinfo_md_includes_system_headers() {
         let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-MD"])).unwrap();
         let d = parsed.depinfo.expect("dep-info should be set");
+        assert!(d.emit);
         assert!(d.include_system);
     }
 
@@ -2200,9 +2304,25 @@ mod tests {
     }
 
     #[test]
+    fn parse_depinfo_mp_and_mg_shape_flags() {
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-MMD", "-MP", "-MG"])).unwrap();
+        let d = parsed.depinfo.expect("dep-info should be set");
+        assert!(d.phony_targets);
+        assert!(d.missing_generated);
+    }
+
+    #[test]
     fn parse_no_depinfo_flags_means_no_depinfo_struct() {
         let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o"])).unwrap();
         assert!(parsed.depinfo.is_none());
+    }
+
+    #[test]
+    fn depinfo_path_modifiers_alone_do_not_emit_depinfo() {
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-MF", "deps/foo.d"])).unwrap();
+        assert!(parsed.depinfo.is_some());
+        assert_eq!(parsed.depinfo_output_path(), None);
+        assert_eq!(parsed.depinfo_anchor(), None);
     }
 
     // ── parser: language override ───────────────────────────────
@@ -3220,6 +3340,23 @@ mod tests {
         // source stem + `.o` in the current directory.
         let parsed = CcArgs::parse(&s(&["cc", "-c", "src/foo.c"])).unwrap();
         assert_eq!(parsed.object_output_path(), Some(PathBuf::from("foo.o")));
+    }
+
+    #[test]
+    fn depinfo_output_path_uses_mf_or_object_stem() {
+        let explicit =
+            CcArgs::parse(&s(&["cc", "-c", "foo.c", "-MMD", "-MF", "deps/foo.d"])).unwrap();
+        assert_eq!(
+            explicit.depinfo_output_path(),
+            Some(PathBuf::from("deps/foo.d"))
+        );
+
+        let derived = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "obj/foo.o", "-MMD"])).unwrap();
+        assert_eq!(
+            derived.depinfo_output_path(),
+            Some(PathBuf::from("obj/foo.d"))
+        );
+        assert_eq!(derived.depinfo_anchor(), Some(PathBuf::from("obj")));
     }
 
     // ── build_preprocess_args ───────────────────────────────────

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -210,6 +210,12 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             // Poisoned entry (earlier bug) — evict and recompile.
             tracing::warn!("cc cache entry for {} has no files, evicting", crate_name);
             let _ = store.remove_entry(&cache_key);
+        } else if !cc_cache_entry_satisfies_invocation(&parsed, &meta) {
+            tracing::warn!(
+                "cc cache entry for {} lacks artifacts required by this invocation, evicting",
+                crate_name
+            );
+            let _ = store.remove_entry(&cache_key);
         } else {
             let restore_start = std::time::Instant::now();
             restore_cc_from_cache(&store, &parsed, &meta)?;
@@ -265,6 +271,11 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // code and let cargo see the failure.
     let store_start = std::time::Instant::now();
     if result.exit_code == 0 && !result.artifacts.is_empty() {
+        let depinfo_anchor = parsed.depinfo_anchor();
+        if let Some(anchor) = depinfo_anchor.as_deref() {
+            rewrite_depinfo_outputs(&result.artifacts, anchor, link::DepInfoMode::Relativize);
+        }
+
         let target = parsed.cache_target_arch();
         let store_files = result.artifacts.store_files();
         if let Err(e) = store.put_with_compile_time(
@@ -280,6 +291,10 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             compile_time_ms,
         ) {
             tracing::warn!("failed to store cc cache entry for {}: {}", crate_name, e);
+        }
+
+        if let Some(anchor) = depinfo_anchor.as_deref() {
+            rewrite_depinfo_outputs(&result.artifacts, anchor, link::DepInfoMode::Expand);
         }
     }
     let store_ms = store_start.elapsed().as_millis() as u64;
@@ -336,48 +351,110 @@ fn cc_passthrough(
     })
 }
 
-/// Restore a cached cc object file to the invocation's `-o` target.
+fn cc_cache_entry_satisfies_invocation(
+    parsed: &crate::compiler::cc::CcArgs,
+    meta: &crate::store::EntryMeta,
+) -> bool {
+    let has_object = meta
+        .files
+        .iter()
+        .any(|file| classify_by_filename(&file.name) == ArtifactKind::Object);
+    let has_depinfo = meta
+        .files
+        .iter()
+        .any(|file| classify_by_filename(&file.name) == ArtifactKind::DepInfo);
+
+    has_object && (parsed.depinfo_output_path().is_none() || has_depinfo)
+}
+
+/// Restore cached cc artifacts to this invocation's output paths.
 ///
-/// A `-c` compile has exactly one cached artifact (the `.o`). The
-/// blob is content-addressed in the store; we link it to wherever
-/// the warm invocation's `-o` points. Object files need no
-/// post-restore processing (no codesign, no path rewriting) — they
-/// get linked into a final binary later, and that link step (or its
-/// own cache entry) handles loader concerns.
+/// Object files go to the current `-o` target. Dep-info sidecars go to the
+/// current `-MF` target, or the compiler's default `.d` next to the object.
 fn restore_cc_from_cache(
     store: &Store,
     parsed: &crate::compiler::cc::CcArgs,
     meta: &crate::store::EntryMeta,
 ) -> Result<()> {
-    let target = parsed
-        .object_output_path()
-        .context("cc restore: cannot determine object output path")?;
-    // Single-source `-c` ⇒ exactly one cached file. Take the first;
-    // the empty-files case was already filtered by the caller.
-    let cached = &meta.files[0];
-    let blob = store.blob_path(&cached.hash);
-    if !blob.exists() {
-        anyhow::bail!(
-            "cc restore: blob missing for {} (hash {})",
-            cached.name,
-            &cached.hash[..16.min(cached.hash.len())]
-        );
+    let depinfo_anchor = parsed
+        .depinfo_anchor()
+        .unwrap_or_else(|| Path::new(".").to_path_buf());
+
+    for cached in &meta.files {
+        let kind = classify_by_filename(&cached.name);
+        let target = match kind {
+            ArtifactKind::Object => parsed
+                .object_output_path()
+                .context("cc restore: cannot determine object output path")?,
+            ArtifactKind::DepInfo => match parsed.depinfo_output_path() {
+                Some(path) => path,
+                None => {
+                    tracing::debug!(
+                        "cc restore: cached dep-info {} not requested by invocation; skipping",
+                        cached.name
+                    );
+                    continue;
+                }
+            },
+            _ => {
+                tracing::debug!(
+                    "cc restore: cached artifact {} has unsupported kind {:?}; skipping",
+                    cached.name,
+                    kind
+                );
+                continue;
+            }
+        };
+
+        let blob = store.blob_path(&cached.hash);
+        if !blob.exists() {
+            anyhow::bail!(
+                "cc restore: blob missing for {} (hash {})",
+                cached.name,
+                &cached.hash[..16.min(cached.hash.len())]
+            );
+        }
+        if let Some(parent) = target.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("cc restore: creating {}", parent.display()))?;
+        }
+
+        let transforms: Vec<_> = plan_post_restore(kind)
+            .into_iter()
+            .filter(|a| a.is_content_transform())
+            .collect();
+        if transforms.is_empty() {
+            link::link_to_target(&blob, &target, kind.link_strategy()).with_context(|| {
+                format!(
+                    "cc restore: linking {} -> {}",
+                    blob.display(),
+                    target.display()
+                )
+            })?;
+        } else {
+            let original =
+                std::fs::read(&blob).with_context(|| format!("reading blob {}", blob.display()))?;
+            let mut content = original.clone();
+            for action in transforms {
+                content = action.transform(content, &depinfo_anchor);
+            }
+            if content == original {
+                link::link_to_target(&blob, &target, kind.link_strategy()).with_context(|| {
+                    format!(
+                        "cc restore: linking {} -> {}",
+                        blob.display(),
+                        target.display()
+                    )
+                })?;
+            } else {
+                link::write_restored(&target, &content)
+                    .with_context(|| format!("cc restore: writing {}", target.display()))?;
+            }
+        }
+        link::touch_mtime(&target)?;
     }
-    if let Some(parent) = target.parent()
-        && !parent.as_os_str().is_empty()
-    {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("cc restore: creating {}", parent.display()))?;
-    }
-    let kind = classify_by_filename(&cached.name);
-    link::link_to_target(&blob, &target, kind.link_strategy()).with_context(|| {
-        format!(
-            "cc restore: linking {} -> {}",
-            blob.display(),
-            target.display()
-        )
-    })?;
-    link::touch_mtime(&target)?;
     Ok(())
 }
 
@@ -1436,6 +1513,55 @@ mod tests {
             std::path::Path::new("/some/target"),
             link::DepInfoMode::Relativize,
         );
+    }
+
+    #[test]
+    fn cc_cache_entry_requires_depinfo_when_invocation_requests_it() {
+        fn meta(names: &[&str]) -> crate::store::EntryMeta {
+            crate::store::EntryMeta {
+                cache_key: "key".to_string(),
+                crate_name: "foo.c".to_string(),
+                crate_types: vec![],
+                files: names
+                    .iter()
+                    .map(|name| crate::store::CachedFile {
+                        name: (*name).to_string(),
+                        size: 1,
+                        hash: "0123456789abcdef".to_string(),
+                    })
+                    .collect(),
+                stdout: String::new(),
+                stderr: String::new(),
+                features: vec![],
+                target: String::new(),
+                profile: String::new(),
+                compile_time_ms: 0,
+            }
+        }
+
+        let with_depinfo_args: Vec<String> = ["cc", "-c", "foo.c", "-o", "foo.o", "-MMD"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let with_depinfo = CcCompiler::new().parse(&with_depinfo_args).unwrap();
+        assert!(!cc_cache_entry_satisfies_invocation(
+            &with_depinfo,
+            &meta(&["foo.o"])
+        ));
+        assert!(cc_cache_entry_satisfies_invocation(
+            &with_depinfo,
+            &meta(&["foo.o", "foo.d"])
+        ));
+
+        let object_only_args: Vec<String> = ["cc", "-c", "foo.c", "-o", "foo.o"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let object_only = CcCompiler::new().parse(&object_only_args).unwrap();
+        assert!(cc_cache_entry_satisfies_invocation(
+            &object_only,
+            &meta(&["foo.o", "foo.d"])
+        ));
     }
 
     // ── fallback wrapper ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- discover C/C++ dep-info sidecars in ArtifactSet alongside object outputs
- restore cached cc artifacts to the current object and dep-info output paths
- version and key dep-info sidecar shape so object-only and dep-info entries do not collide

## Validation
- env -u RUSTC_WRAPPER cargo test depinfo
- env -u RUSTC_WRAPPER just lint
- env -u RUSTC_WRAPPER cargo test
- git diff --check