### PR TITLE
Bypass rustc build-script probes

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -335,6 +335,32 @@ impl RustcArgs {
         None
     }
 
+    /// Whether this rustc invocation looks like a build-script feature probe.
+    ///
+    /// Crates such as `proc-macro2`, `thiserror`, and `anyhow` run small rustc
+    /// probes from their build scripts to detect compiler features. Those
+    /// commands intentionally may fail, usually emit metadata only, and write
+    /// under the build script's `OUT_DIR`. They are not useful cache entries:
+    /// pass them through so expected probe failures do not appear as kache
+    /// cache errors.
+    pub fn is_build_script_probe(&self, build_script_out_dir: Option<&Path>) -> bool {
+        let Some(build_script_out_dir) = build_script_out_dir else {
+            return false;
+        };
+        let metadata_only = !self.emit.is_empty() && !self.emit.iter().any(|e| e == "link");
+        if !metadata_only {
+            return false;
+        }
+
+        self.out_dir
+            .as_deref()
+            .is_some_and(|out_dir| out_dir.starts_with(build_script_out_dir))
+            || self
+                .source_file
+                .as_deref()
+                .is_some_and(|source| source.starts_with(build_script_out_dir))
+    }
+
     /// Get the output filename stem (crate name + extra filename).
     #[allow(dead_code)]
     pub fn output_stem(&self) -> Option<String> {
@@ -889,6 +915,71 @@ mod tests {
     #[test]
     fn test_target_dir_none_when_no_paths() {
         assert_eq!(RustcArgs::default().target_dir(), None);
+    }
+
+    #[test]
+    fn test_build_script_probe_detected_from_probe_out_dir() {
+        let args: Vec<String> = vec![
+            "rustc",
+            "--edition=2021",
+            "--crate-name=proc_macro2",
+            "--crate-type=lib",
+            "--emit=dep-info,metadata",
+            "--out-dir",
+            "/work/proj/target/release/build/proc-macro2-abc/out/probe",
+            "src/probe/proc_macro_span.rs",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        let parsed = RustcArgs::parse(&args).unwrap();
+
+        assert!(parsed.is_build_script_probe(Some(Path::new(
+            "/work/proj/target/release/build/proc-macro2-abc/out"
+        ))));
+    }
+
+    #[test]
+    fn test_build_script_probe_detected_from_source_in_out_dir() {
+        let args: Vec<String> = vec![
+            "rustc",
+            "--edition=2018",
+            "--crate-name=anyhow_build",
+            "--crate-type=lib",
+            "--emit=metadata",
+            "--out-dir",
+            "/work/proj/target/release/build/anyhow-abc/out",
+            "/work/proj/target/release/build/anyhow-abc/out/probe.rs",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        let parsed = RustcArgs::parse(&args).unwrap();
+
+        assert!(parsed.is_build_script_probe(Some(Path::new(
+            "/work/proj/target/release/build/anyhow-abc/out"
+        ))));
+    }
+
+    #[test]
+    fn test_normal_cargo_compile_is_not_build_script_probe() {
+        let args: Vec<String> = vec![
+            "rustc",
+            "--crate-name=foo",
+            "--crate-type=lib",
+            "--emit=dep-info,metadata,link",
+            "--out-dir",
+            "/work/proj/target/release/deps",
+            "src/lib.rs",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        let parsed = RustcArgs::parse(&args).unwrap();
+
+        assert!(!parsed.is_build_script_probe(Some(Path::new(
+            "/work/proj/target/release/build/foo-abc/out"
+        ))));
     }
 
     #[test]

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -84,11 +84,8 @@ impl Compiler for RustcCompiler {
     }
 
     fn refuse_reasons(&self, parsed: &RustcArgs) -> Vec<RefuseReason> {
-        let mut reasons = Vec::new();
-        if !parsed.is_primary {
-            reasons.push(RefuseReason::NotPrimary);
-        }
-        reasons
+        let build_script_out_dir = std::env::var_os("OUT_DIR").map(std::path::PathBuf::from);
+        rustc_refuse_reasons(parsed, build_script_out_dir.as_deref())
     }
 
     fn cache_key(&self, parsed: &RustcArgs, ctx: &KeyCtx<'_, '_>) -> Result<String> {
@@ -142,6 +139,22 @@ impl Compiler for RustcCompiler {
             kind => kind,
         }
     }
+}
+
+fn rustc_refuse_reasons(
+    parsed: &RustcArgs,
+    build_script_out_dir: Option<&std::path::Path>,
+) -> Vec<RefuseReason> {
+    let mut reasons = Vec::new();
+    if !parsed.is_primary {
+        reasons.push(RefuseReason::NotPrimary);
+    }
+    if parsed.is_build_script_probe(build_script_out_dir) {
+        reasons.push(RefuseReason::Unsupported(
+            "rustc build-script probe (not yet supported)",
+        ));
+    }
+    reasons
 }
 
 #[cfg(test)]
@@ -204,6 +217,34 @@ mod tests {
         assert!(parsed.is_primary);
         let reasons = RustcCompiler::new().refuse_reasons(&parsed);
         assert!(reasons.is_empty());
+    }
+
+    #[test]
+    fn refuse_reasons_identifies_build_script_probe() {
+        let parsed = RustcCompiler::new()
+            .parse(&s(&[
+                "rustc",
+                "--edition=2018",
+                "--crate-name=thiserror",
+                "--crate-type=lib",
+                "--emit=dep-info,metadata",
+                "--out-dir",
+                "/work/proj/target/release/build/thiserror-abc/out/probe",
+                "build/probe.rs",
+            ]))
+            .unwrap();
+
+        let reasons = rustc_refuse_reasons(
+            &parsed,
+            Some(std::path::Path::new(
+                "/work/proj/target/release/build/thiserror-abc/out",
+            )),
+        );
+        assert_eq!(reasons.len(), 1);
+        assert_eq!(
+            reasons[0].description(),
+            "rustc build-script probe (not yet supported)"
+        );
     }
 
     fn lib_args() -> RustcArgs {


### PR DESCRIPTION
## Summary

Treat Rust build-script feature probes as passthroughs instead of cache attempts.

Build scripts from crates like proc-macro2, thiserror, and anyhow invoke RUSTC_WRAPPER directly to compile small metadata-only probe crates under OUT_DIR. These probes intentionally may fail. Kache currently treats them as normal primary rustc compilations, so expected probe failures are logged as cache errors and make the Firefox benchmark report DEGRADED RUN.

Changes:
- detect metadata-only rustc invocations whose source or out-dir lives under the build script OUT_DIR
- refuse those as rustc build-script probes, causing normal passthrough execution
- keep normal cargo crate compiles cacheable, even when OUT_DIR is present for env!("OUT_DIR") use
- add parser/refusal tests for proc-macro2, anyhow, and normal cargo compile shapes

## Validation

- cargo test build_script_probe
- cargo test refuse_reasons_identifies_build_script_probe
- git diff --check

Full cargo test was intentionally skipped while the Firefox benchmark was running.