### PR TITLE
Fix dep-info restore sentinel

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -309,11 +309,11 @@ impl RustcArgs {
     ///   to the ancestor named `deps` or `build`, then take its grandparent.
     ///
     /// Store and restore must agree on this anchor: the store side
-    /// relativizes the `.d` against it (`<target>/...` → `./...`) and the
-    /// restore side expands `./...` back against *this* invocation's target
-    /// dir. Because the `.d`'s paths are all rooted under `<target>`, the
-    /// relativize→expand round-trip yields paths valid at whatever location
-    /// the restoring build runs from.
+    /// relativizes the `.d` against it (`<target>/...` → kache's dep-info
+    /// sentinel) and the restore side expands that sentinel back against
+    /// *this* invocation's target dir. Because the `.d`'s paths are all
+    /// rooted under `<target>`, the relativize→expand round-trip yields paths
+    /// valid at whatever location the restoring build runs from.
     ///
     /// Returns `None` for invocations outside cargo's layout (e.g. ad-hoc
     /// `rustc -o /tmp/prog`), so dep-info rewriting is skipped rather than

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -48,7 +48,13 @@ use std::path::{Path, PathBuf};
 /// semantically-identical flag sets. Observed on the Firefox bench as
 /// the dominant source of "leaf" cache-key divergence — fixing it
 /// stabilizes ~18 leaf crates and their non-mozbuild dependents.
-const CACHE_KEY_VERSION: u32 = 8;
+///
+/// v9: dep-info blobs use an explicit kache sentinel instead of `./`
+/// for stored project-root paths. The old marker was ambiguous with
+/// ordinary make depfile paths such as `../foo.h`, whose second dot
+/// contains a `./` substring and could be expanded incorrectly on
+/// restore.
+const CACHE_KEY_VERSION: u32 = 9;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
 /// Collapse runs of ASCII whitespace into single spaces and trim

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -927,7 +927,11 @@ fn apply_cc_arg(parsed: &mut CcArgs, depinfo: &mut Option<DepInfoSpec>, arg: &Pa
 /// v4: `.pp` dependency sidecars are restored as dep-info and C/C++
 /// dep-info path rewriting uses the common source/object root. Older
 /// entries may contain machine-local source paths in `.pp` blobs.
-const CC_CACHE_KEY_VERSION: u32 = 4;
+///
+/// v5: dep-info blobs use an explicit kache sentinel instead of `./`
+/// for stored project-root paths. The old marker collided with ordinary
+/// make depfile parent paths such as `../foo.h` during restore.
+const CC_CACHE_KEY_VERSION: u32 = 5;
 
 /// Resolve the target architecture for the cache key: an explicit
 /// `-arch X` flag if present, else the host arch. (Multi-`-arch` is

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -662,11 +662,11 @@ mod tests {
 
     #[test]
     fn transform_expand_dep_info_paths_roots_relative_paths_at_anchor() {
-        // The relative-paths shape `rewrite_depinfo_content`'s Relativize
+        // The sentinel-path shape `rewrite_depinfo_content`'s Relativize
         // mode produces; Expand (the restore-side transform) reverses it.
         // The anchor is the restoring build's target dir — NOT the
         // process cwd.
-        let blob = b"./target/debug/foo: ./src/lib.rs".to_vec();
+        let blob = b"__kache_root__/target/debug/foo: __kache_root__/src/lib.rs".to_vec();
         let anchor = std::path::Path::new("/restored/worktree");
 
         let out = PostRestoreAction::ExpandDepInfoPaths.transform(blob, anchor);
@@ -681,8 +681,31 @@ mod tests {
             "expected anchor-rooted source path, got: {content}"
         );
         assert!(
-            !content.contains("./"),
-            "no relative `./` markers should remain, got: {content}"
+            !content.contains("__kache_root__/"),
+            "no kache dep-info markers should remain, got: {content}"
+        );
+    }
+
+    #[test]
+    fn transform_expand_dep_info_paths_preserves_parent_relative_deps() {
+        let blob =
+            b"foo.o: ../../src/foo.cc ../include/foo.h __kache_root__/generated/header.h".to_vec();
+        let anchor = std::path::Path::new("/restored/worktree/obj");
+
+        let out = PostRestoreAction::ExpandDepInfoPaths.transform(blob, anchor);
+        let content = String::from_utf8(out).unwrap();
+
+        assert!(
+            content.contains("../../src/foo.cc"),
+            "compiler-emitted parent-relative source paths must survive: {content}"
+        );
+        assert!(
+            content.contains("../include/foo.h"),
+            "compiler-emitted parent-relative header paths must survive: {content}"
+        );
+        assert!(
+            content.contains("/restored/worktree/obj/generated/header.h"),
+            "kache sentinel paths should still expand: {content}"
         );
     }
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -512,6 +512,49 @@ foo.o: ../../src/foo.cc ../include/foo.h __kache_root__/generated.h foo/./bar.h
         );
     }
 
+    #[test]
+    fn test_depinfo_expand_preserves_firefox_parent_relative_depfile_paths() {
+        let input = "\
+Unified_mm_ettings-WrongChannel0.o: Unified_mm_ettings-WrongChannel0.mm \\
+  ../../../../../../../toolkit/mozapps/update/updater/macos-frameworks/UpdateSettings/UpdateSettings.mm \\
+  ../../../../../../../toolkit/mozapps/update/updater/macos-frameworks/UpdateSettings/UpdateSettings.h \\
+  __kache_root__/mozilla-config.h
+";
+        let anchor = Path::new(
+            "/Users/lenij/work/kache/tmp/bench/clone-a/obj-kache-bench\
+             /toolkit/mozapps/update/updater/macos-frameworks/UpdateSettings-WrongChannel",
+        );
+
+        let rewritten = rewrite_depinfo_content(input, anchor, DepInfoMode::Expand);
+
+        assert!(
+            rewritten.contains(
+                "../../../../../../../toolkit/mozapps/update/updater/macos-frameworks\
+                 /UpdateSettings/UpdateSettings.mm"
+            ),
+            "Firefox-style parent-relative source path must survive restore: {rewritten}"
+        );
+        assert!(
+            rewritten.contains(
+                "../../../../../../../toolkit/mozapps/update/updater/macos-frameworks\
+                 /UpdateSettings/UpdateSettings.h"
+            ),
+            "Firefox-style parent-relative header path must survive restore: {rewritten}"
+        );
+        assert!(
+            !rewritten.contains("/./Users/") && !rewritten.contains("WrongChannel/./"),
+            "restore must not inject the anchor into ../ paths: {rewritten}"
+        );
+        assert!(
+            rewritten.contains(
+                "/Users/lenij/work/kache/tmp/bench/clone-a/obj-kache-bench\
+                 /toolkit/mozapps/update/updater/macos-frameworks\
+                 /UpdateSettings-WrongChannel/mozilla-config.h"
+            ),
+            "sentinel paths should still expand at the restore anchor: {rewritten}"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn test_copy_executable_gets_execute_permission() {

--- a/src/link.rs
+++ b/src/link.rs
@@ -268,8 +268,11 @@ pub fn touch_mtime(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Pure dep-info path rewrite: relativize absolute project paths to `./`,
-/// or expand `./` back to absolute. No I/O.
+const DEPINFO_ROOT_SENTINEL: &str = "__kache_root__/";
+
+/// Pure dep-info path rewrite: relativize absolute project paths to a
+/// kache-only sentinel, or expand that sentinel back to absolute paths.
+/// No I/O.
 ///
 /// This is the in-memory half of the transform. The restore side calls
 /// it directly — it computes the final `.d` content from the store blob
@@ -279,8 +282,8 @@ pub fn touch_mtime(path: &Path) -> Result<()> {
 pub fn rewrite_depinfo_content(content: &str, project_dir: &Path, mode: DepInfoMode) -> String {
     let project_prefix = format!("{}/", project_dir.display());
     match mode {
-        DepInfoMode::Relativize => content.replace(&project_prefix, "./"),
-        DepInfoMode::Expand => content.replace("./", &project_prefix),
+        DepInfoMode::Relativize => content.replace(&project_prefix, DEPINFO_ROOT_SENTINEL),
+        DepInfoMode::Expand => content.replace(DEPINFO_ROOT_SENTINEL, &project_prefix),
     }
 }
 
@@ -322,9 +325,9 @@ pub fn rewrite_depinfo(depinfo_path: &Path, project_dir: &Path, mode: DepInfoMod
 
 #[derive(Debug, Clone, Copy)]
 pub enum DepInfoMode {
-    /// Replace absolute project paths with "./" for cross-project cache sharing
+    /// Replace absolute project paths with a kache sentinel for cross-project cache sharing.
     Relativize,
-    /// Expand "./" back to absolute project paths after restoring
+    /// Expand the kache sentinel back to absolute project paths after restoring.
     Expand,
 }
 
@@ -465,8 +468,9 @@ mod tests {
         .unwrap();
 
         let content = fs::read_to_string(&depfile).unwrap();
-        assert!(content.contains("./target/debug"));
-        assert!(content.contains("./src/lib.rs"));
+        assert!(content.contains("target/debug"));
+        assert!(content.contains("src/lib.rs"));
+        assert!(content.contains(DEPINFO_ROOT_SENTINEL));
         assert!(!content.contains("/home/user/project/"));
 
         // Now expand back
@@ -479,6 +483,33 @@ mod tests {
 
         let content = fs::read_to_string(&depfile).unwrap();
         assert!(content.contains("/home/user/project/"));
+    }
+
+    #[test]
+    fn test_depinfo_expand_preserves_parent_relative_paths() {
+        let input = "\
+foo.o: ../../src/foo.cc ../include/foo.h __kache_root__/generated.h foo/./bar.h
+";
+
+        let rewritten =
+            rewrite_depinfo_content(input, Path::new("/build/worktree/obj"), DepInfoMode::Expand);
+
+        assert!(
+            rewritten.contains("../../src/foo.cc"),
+            "parent-relative deps must not be expanded: {rewritten}"
+        );
+        assert!(
+            rewritten.contains("../include/foo.h"),
+            "single parent-relative deps must not be expanded: {rewritten}"
+        );
+        assert!(
+            rewritten.contains("/build/worktree/obj/generated.h"),
+            "sentinel paths must expand: {rewritten}"
+        );
+        assert!(
+            rewritten.contains("foo/./bar.h"),
+            "embedded ./ segments are compiler-owned paths: {rewritten}"
+        );
     }
 
     #[cfg(unix)]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1512,7 +1512,7 @@ mod tests {
         rewrite_depinfo_outputs(&outputs, producing_target, link::DepInfoMode::Relativize);
         let stored = std::fs::read_to_string(&depfile).unwrap();
         assert!(
-            stored.starts_with("./release/deps/libfoo-abc.rlib:"),
+            stored.starts_with("__kache_root__/release/deps/libfoo-abc.rlib:"),
             "stored `.d` must be relativized, got: {stored}"
         );
         assert!(
@@ -1521,7 +1521,9 @@ mod tests {
         );
         let stored_mozilla = std::fs::read_to_string(&mozilla_depfile).unwrap();
         assert!(
-            stored_mozilla.starts_with("./config/host_pathsub.o: ./config/pathsub.c"),
+            stored_mozilla.starts_with(
+                "__kache_root__/config/host_pathsub.o: __kache_root__/config/pathsub.c"
+            ),
             "stored `.pp` must be relativized, got: {stored_mozilla}"
         );
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1025,10 +1025,11 @@ fn restore_from_cache(
 
     // Anchor for dep-info (`.d`) path expansion. Cached `.d` blobs hold
     // paths relativized against the *producing* build's target dir
-    // (`<target>/...` → `./...`); on restore they must be re-rooted at
-    // *this* invocation's target dir so cargo's freshness `stat()`s find
-    // them. `args.target_dir()` derives that from `--out-dir` / `-o` —
-    // cargo's cwd is the package source dir, so it cannot be used.
+    // (`<target>/...` → kache's dep-info sentinel); on restore they must
+    // be re-rooted at *this* invocation's target dir so cargo's freshness
+    // `stat()`s find them. `args.target_dir()` derives that from
+    // `--out-dir` / `-o` — cargo's cwd is the package source dir, so it
+    // cannot be used.
     // Falls back to cwd only for ad-hoc invocations outside cargo's
     // layout, where there is no cached `.d` to rewrite anyway.
     let depinfo_anchor = args

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -28,9 +28,13 @@ fn isolated_config_path(cache_dir: &Path) -> PathBuf {
 }
 
 fn run_kache_cc(project: &Path, cache_dir: &Path, args: &[&str]) {
+    run_kache_cc_from(project, cache_dir, args);
+}
+
+fn run_kache_cc_from(cwd: &Path, cache_dir: &Path, args: &[&str]) {
     let output = std::process::Command::new(kache_binary())
         .args(args)
-        .current_dir(project)
+        .current_dir(cwd)
         .env("KACHE_CACHE_DIR", cache_dir)
         .env("KACHE_CONFIG", isolated_config_path(cache_dir))
         .env("KACHE_LOG", "kache=debug")
@@ -337,4 +341,72 @@ fn test_cc_depinfo_sidecar_restores_on_hit_and_new_mf_path() {
     let report = kache_report(pp_cache_dir.path());
     assert_cc_report_counts(&report, 1, 1);
     assert_last_cc_event(&report, "local_hit", 0);
+}
+
+#[test]
+fn test_cc_depinfo_restore_preserves_parent_relative_deps() {
+    build_kache();
+
+    let project = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    let source_dir = project.path().join("src");
+    let object_dir = project.path().join("obj/a/b/c");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::create_dir_all(object_dir.join(".deps")).unwrap();
+    std::fs::write(source_dir.join("bar.h"), "#define VALUE 42\n").unwrap();
+    std::fs::write(
+        source_dir.join("foo.c"),
+        "#include \"bar.h\"\nint answer(void) { return VALUE; }\n",
+    )
+    .unwrap();
+
+    let args = [
+        "cc",
+        "-O0",
+        "-g0",
+        "-MMD",
+        "-MP",
+        "-MF",
+        ".deps/foo.o.pp",
+        "-I../../../../src",
+        "-c",
+        "../../../../src/foo.c",
+        "-o",
+        "foo.o",
+    ];
+
+    run_kache_cc_from(&object_dir, cache_dir.path(), &args);
+    let cold_depinfo = std::fs::read_to_string(object_dir.join(".deps/foo.o.pp")).unwrap();
+    assert!(object_dir.join("foo.o").exists());
+    assert!(
+        cold_depinfo.contains("../../../../src/foo.c"),
+        "cold depfile should preserve compiler parent-relative source path: {cold_depinfo}"
+    );
+    assert!(
+        cold_depinfo.contains("../../../../src/bar.h"),
+        "cold depfile should preserve compiler parent-relative header path: {cold_depinfo}"
+    );
+    assert!(
+        !cold_depinfo.contains("__kache_root__/"),
+        "restored-facing depfiles must not expose kache sentinels: {cold_depinfo}"
+    );
+
+    std::fs::remove_file(object_dir.join("foo.o")).unwrap();
+    std::fs::remove_dir_all(object_dir.join(".deps")).unwrap();
+    std::fs::create_dir_all(object_dir.join(".deps")).unwrap();
+
+    run_kache_cc_from(&object_dir, cache_dir.path(), &args);
+    let warm_depinfo = std::fs::read_to_string(object_dir.join(".deps/foo.o.pp")).unwrap();
+    assert!(object_dir.join("foo.o").exists());
+    assert_eq!(
+        warm_depinfo, cold_depinfo,
+        "cache-hit restore must reproduce parent-relative depfiles byte-for-byte"
+    );
+    assert!(
+        !warm_depinfo.contains(&object_dir.to_string_lossy().to_string()),
+        "restore must not inject the object dir into parent-relative paths: {warm_depinfo}"
+    );
+
+    let report = kache_report(cache_dir.path());
+    assert_cc_report_counts(&report, 1, 1);
 }


### PR DESCRIPTION
## Summary
- use a dedicated __kache_root__/ marker for stored dep-info paths
- preserve compiler-emitted ../ paths when restoring depfiles
- bump rustc and cc cache key versions to avoid old ambiguous blobs

## Root cause
The old restore path expanded every ./ substring. In make depfiles, ../ contains ./ at the second dot, so parent-relative deps were rewritten into repeated objdir paths and could break dependency ordering.

## Validation
- cargo test depinfo