### PR TITLE
fix(monitor): reduce file syscall churn

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,7 @@ pub(crate) struct StatsSnapshot {
     pub bytes_uploaded: u64,
     pub bytes_downloaded: u64,
     pub recent_transfers: Vec<daemon::TransferEvent>,
+    pub blob_stats: Option<crate::store::BlobStats>,
 }
 
 impl Default for StatsSnapshot {
@@ -69,6 +70,7 @@ impl Default for StatsSnapshot {
             bytes_uploaded: 0,
             bytes_downloaded: 0,
             recent_transfers: Vec::new(),
+            blob_stats: None,
         }
     }
 }
@@ -99,6 +101,11 @@ pub(crate) fn fetch_stats_snapshot(
     hours: Option<u64>,
 ) -> StatsSnapshot {
     let event_hours = hours.or(Some(24));
+    let blob_stats = || {
+        Store::open(config)
+            .ok()
+            .and_then(|store| store.blob_stats().ok())
+    };
 
     // Try daemon
     if let Ok(resp) =
@@ -125,6 +132,7 @@ pub(crate) fn fetch_stats_snapshot(
             bytes_uploaded: resp.bytes_uploaded,
             bytes_downloaded: resp.bytes_downloaded,
             recent_transfers: resp.recent_transfers,
+            blob_stats: blob_stats(),
         };
     }
 
@@ -155,6 +163,7 @@ pub(crate) fn fetch_stats_snapshot(
             bytes_uploaded: resp.bytes_uploaded,
             bytes_downloaded: resp.bytes_downloaded,
             recent_transfers: resp.recent_transfers,
+            blob_stats: blob_stats(),
         };
     }
 
@@ -228,6 +237,7 @@ pub(crate) fn fetch_stats_snapshot(
         bytes_uploaded: 0,
         bytes_downloaded: 0,
         recent_transfers: Vec::new(),
+        blob_stats: store.as_ref().and_then(|s| s.blob_stats().ok()),
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -938,24 +938,24 @@ pub(crate) fn compute_link_stats(store_dir: &std::path::Path) -> LinkStats {
     };
 
     for shard in shards.flatten() {
-        let shard_path = shard.path();
-        if !shard_path.is_dir() {
+        let Ok(file_type) = shard.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
             continue;
         }
 
-        let Ok(blobs) = std::fs::read_dir(&shard_path) else {
+        let Ok(blobs) = std::fs::read_dir(shard.path()) else {
             continue;
         };
 
         for blob in blobs.flatten() {
-            let fpath = blob.path();
-            if !fpath.is_file() {
-                continue;
-            }
-
-            let Ok(meta) = std::fs::metadata(&fpath) else {
+            let Ok(meta) = blob.metadata() else {
                 continue;
             };
+            if !meta.is_file() {
+                continue;
+            }
 
             let size = meta.len();
             stats.store_bytes += size;
@@ -1515,11 +1515,14 @@ pub(crate) fn find_target_dirs(dir: &std::path::Path, results: &mut Vec<TargetEn
             continue;
         }
 
-        if name_str == "Cargo.toml" && entry.path().is_file() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if name_str == "Cargo.toml" && file_type.is_file() {
             has_cargo_toml = true;
         }
 
-        if entry.path().is_dir() {
+        if file_type.is_dir() {
             subdirs.push((name_str.to_string(), entry.path()));
         }
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -31,13 +31,17 @@ const FILE_HASH_MEMORY_CACHE_CAP: usize = 4096;
 /// This changes every time `cargo build` produces a new binary,
 /// giving us a cheap way to detect when the daemon is running stale code.
 pub fn build_epoch() -> u64 {
-    std::env::current_exe()
-        .and_then(std::fs::metadata)
-        .and_then(|m| m.modified())
-        .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+    static BUILD_EPOCH: OnceLock<u64> = OnceLock::new();
+
+    *BUILD_EPOCH.get_or_init(|| {
+        std::env::current_exe()
+            .and_then(std::fs::metadata)
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/events.rs
+++ b/src/events.rs
@@ -175,26 +175,45 @@ pub fn read_events_since(event_log_path: &Path, since: DateTime<Utc>) -> Result<
 pub struct EventTailer {
     path: PathBuf,
     position: u64,
+    file: Option<File>,
 }
 
 impl EventTailer {
     pub fn new(path: PathBuf) -> Self {
-        let position = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
-        EventTailer { path, position }
+        let file = File::open(&path).ok();
+        let position = file
+            .as_ref()
+            .and_then(|file| file.metadata().ok())
+            .map(|m| m.len())
+            .unwrap_or(0);
+        EventTailer {
+            path,
+            position,
+            file,
+        }
     }
 
     /// Start from the beginning.
     pub fn from_start(path: PathBuf) -> Self {
-        EventTailer { path, position: 0 }
+        let file = File::open(&path).ok();
+        EventTailer {
+            path,
+            position: 0,
+            file,
+        }
     }
 
     /// Read new events since last poll.
     pub fn poll(&mut self) -> Result<Vec<BuildEvent>> {
-        if !self.path.exists() {
-            return Ok(Vec::new());
+        if self.file.is_none() {
+            match File::open(&self.path) {
+                Ok(file) => self.file = Some(file),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+                Err(e) => return Err(e.into()),
+            }
         }
 
-        let mut file = File::open(&self.path)?;
+        let file = self.file.as_mut().unwrap();
         let file_len = file.metadata()?.len();
 
         if file_len < self.position {
@@ -207,7 +226,7 @@ impl EventTailer {
         }
 
         file.seek(SeekFrom::Start(self.position))?;
-        let reader = BufReader::new(&file);
+        let reader = BufReader::new(file);
         let mut events = Vec::new();
         let mut bytes_read = 0u64;
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1171,7 +1171,7 @@ impl Store {
 }
 
 /// Content-dedup statistics.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default)]
 pub struct BlobStats {
     pub total_blobs: usize,
     pub total_blob_size: u64,

--- a/src/store.rs
+++ b/src/store.rs
@@ -1171,7 +1171,7 @@ impl Store {
 }
 
 /// Content-dedup statistics.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct BlobStats {
     pub total_blobs: usize,
     pub total_blob_size: u64,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -145,6 +145,7 @@ struct AppState {
 
     should_quit: bool,
     rustc_version: String,
+    wrapper_status: String,
     service_installed: bool,
 }
 
@@ -231,6 +232,7 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
         stats_fetch_requested_entries: false,
         should_quit: false,
         rustc_version: "\u{2026}".to_string(), // placeholder until background thread completes
+        wrapper_status: crate::wrapper_config::wrapper_status_line(),
         service_installed,
     };
 
@@ -565,7 +567,7 @@ fn draw_stats_bar(frame: &mut Frame, state: &AppState, area: Rect) {
         "not configured"
     };
 
-    let wrapper_status = crate::wrapper_config::wrapper_status_line();
+    let wrapper_status = &state.wrapper_status;
 
     let kache_version = crate::VERSION;
 
@@ -589,12 +591,8 @@ fn draw_stats_bar(frame: &mut Frame, state: &AppState, area: Rect) {
     let my_epoch = crate::daemon::build_epoch();
 
     let dedup_line = {
-        // Blob-level savings from the DB (logical size - physical blob size)
-        let blob_savings = if let Ok(store) = crate::store::Store::open(&state.config) {
-            store.blob_stats().ok()
-        } else {
-            None
-        };
+        // Blob-level savings from the latest periodic stats refresh.
+        let blob_savings = state.stats_snapshot.blob_stats;
 
         let scan_part = if let Ok(scan_stats) = state.project_scan.lock() {
             let ls = &scan_stats.link_stats;
@@ -834,22 +832,18 @@ fn draw_store_tab(frame: &mut Frame, state: &AppState, area: Rect) {
 }
 
 fn draw_store_table(frame: &mut Frame, state: &AppState, area: Rect) {
-    let dedup_info = if let Ok(store) = crate::store::Store::open(&state.config) {
-        if let Ok(bs) = store.blob_stats() {
-            if bs.total_blobs > 0 {
-                let pct = if bs.total_logical_size > 0 {
-                    bs.savings as f64 / bs.total_logical_size as f64 * 100.0
-                } else {
-                    0.0
-                };
-                format!(
-                    " | dedup: {} physical, {:.1}% saved",
-                    ByteSize(bs.total_blob_size),
-                    pct,
-                )
+    let dedup_info = if let Some(bs) = state.stats_snapshot.blob_stats {
+        if bs.total_blobs > 0 {
+            let pct = if bs.total_logical_size > 0 {
+                bs.savings as f64 / bs.total_logical_size as f64 * 100.0
             } else {
-                String::new()
-            }
+                0.0
+            };
+            format!(
+                " | dedup: {} physical, {:.1}% saved",
+                ByteSize(bs.total_blob_size),
+                pct,
+            )
         } else {
             String::new()
         }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -153,7 +153,6 @@ struct AppState {
 
 const PROJECT_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 const SNAPSHOT_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
-const INPUT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 // ── Entry point ────────────────────────────────────────────────────────────
 
@@ -315,7 +314,7 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
 
         terminal.draw(|frame| draw_ui(frame, &state))?;
 
-        if event::poll(INPUT_POLL_INTERVAL)?
+        if event::poll(Duration::from_millis(100))?
             && let Event::Key(key) = event::read()?
             && key.kind == KeyEventKind::Press
         {
@@ -596,7 +595,7 @@ fn draw_stats_bar(frame: &mut Frame, state: &AppState, area: Rect) {
 
     let dedup_line = {
         // Blob-level savings from the latest periodic stats refresh.
-        let blob_savings = state.stats_snapshot.blob_stats;
+        let blob_savings = state.stats_snapshot.blob_stats.as_ref();
 
         let scan_part = if let Ok(scan_stats) = state.project_scan.lock() {
             let ls = &scan_stats.link_stats;
@@ -838,7 +837,7 @@ fn draw_store_tab(frame: &mut Frame, state: &AppState, area: Rect) {
 }
 
 fn draw_store_table(frame: &mut Frame, state: &AppState, area: Rect) {
-    let dedup_info = if let Some(bs) = state.stats_snapshot.blob_stats {
+    let dedup_info = if let Some(bs) = state.stats_snapshot.blob_stats.as_ref() {
         if bs.total_blobs > 0 {
             let pct = if bs.total_logical_size > 0 {
                 bs.savings as f64 / bs.total_logical_size as f64 * 100.0

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -88,6 +88,7 @@ struct ProjectScanData {
     project_targets: Vec<cli::TargetEntry>,
     link_stats: cli::LinkStats,
     scanning: bool,
+    scanned: bool,
 }
 
 impl Default for ProjectScanData {
@@ -100,6 +101,7 @@ impl Default for ProjectScanData {
                 saved_bytes: 0,
             },
             scanning: false,
+            scanned: false,
         }
     }
 }
@@ -194,8 +196,8 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
 
     let project_scan = Arc::new(Mutex::new(ProjectScanData::default()));
 
-    // Kick off initial background scan
-    spawn_project_scan(Arc::clone(&project_scan), config.store_dir());
+    // Project scans are expensive on large caches/workspaces, so defer them until the
+    // Projects tab is shown.
 
     // Stats start empty; the first periodic refresh fires immediately (see last_stats_fetch below).
     let stats_snapshot = StatsSnapshot::default();
@@ -372,6 +374,7 @@ fn spawn_project_scan(stats: Arc<Mutex<ProjectScanData>>, store_dir: std::path::
             // Remove entries that are still stale (no longer exist on disk)
             s.project_targets.retain(|t| !t.stale);
             s.scanning = false;
+            s.scanned = true;
         }
     });
 }
@@ -599,8 +602,10 @@ fn draw_stats_bar(frame: &mut Frame, state: &AppState, area: Rect) {
             let ls = &scan_stats.link_stats;
             let dedup_status = if !state.stats_loaded || scan_stats.scanning {
                 "calculating"
-            } else {
+            } else if scan_stats.scanned {
                 "idle"
+            } else {
+                "not scanned"
             };
             if ls.saved_bytes > 0 {
                 format!(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -151,6 +151,7 @@ struct AppState {
 
 const PROJECT_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 const SNAPSHOT_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+const INPUT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 // ── Entry point ────────────────────────────────────────────────────────────
 
@@ -312,7 +313,7 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
 
         terminal.draw(|frame| draw_ui(frame, &state))?;
 
-        if event::poll(Duration::from_millis(100))?
+        if event::poll(INPUT_POLL_INTERVAL)?
             && let Event::Key(key) = event::read()?
             && key.kind == KeyEventKind::Press
         {


### PR DESCRIPTION
`kache monitor` currently spams syscalls, using like 80% single CPU time when idling:

| Syscall/path | Rate | Origin |
|---|---:|---|
| `stat ~/.cache/kache/index.db` | ~37/s | `draw_stats_bar` / `draw_store_table` → `Store::open()` / `blob_stats()` |
| `stat ~/.cargo/config.toml`, `stat ~/.cargo/config`, ancestor `.cargo/config*` | ~130/s combined | `draw_stats_bar` → `wrapper_status_line()` → `resolve_wrapper_setting()` |
| `stat ~/.cargo/bin/kache`, `stat /proc/self/exe` | ~19/s | `draw_stats_bar` → `daemon::build_epoch()` |
| `stat ~/.cache/kache/events.jsonl` + `openat ~/.cache/kache/events.jsonl` | ~9/s each | monitor loop → `EventTailer::poll()` |
| `stat ~/.cache/kache`, `stat ~/.cache/kache/store`, `lstat /home`, `lstat /home/doni`, `lstat ~/.cache` | ~9/s each | periodic stats/store path handling, mainly `Store::open()` |
| `openat /dev/tty` + anonymous `statx` | ~10/s | monitor loop → `crossterm::event::poll(100ms)` |

This PR cuts all except the event::poll, cutting this to near 0% CPU usage.

- cache monitor values that were recomputed during every render
- move blob stats into the periodic stats snapshot and keep the event log open while tailing
- defer project scanning until the Projects tab is opened