### PR TITLE
Add crates.io publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,17 @@ jobs:
         # compile with Cargo.toml's version from this PR.
         run: env -u KACHE_VERSION just ci
         timeout-minutes: 30
+      - name: Check crates.io package metadata
+        run: |
+          version="$(cargo pkgid -p kache-core | sed 's/.*#//')"
+          cargo package -p kache-core --locked
+          if cargo search kache-core --limit 1 | grep -q "^kache-core = \"$version\""; then
+            cargo package -p kache --locked
+          else
+            echo "kache-core $version is not on crates.io yet; skipping kache package verification"
+          fi
+        env:
+          RUSTC_WRAPPER: ""
       - name: Check coverage threshold (35%, push only)
         if: github.event_name == 'push'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,6 @@ jobs:
             "$RUNNER_TEMP/mise-cache" \
             "$RUNNER_TEMP/mise-state"
           rm -rf "$RUNNER_TEMP/mise"
-          echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
           echo "MISE_DATA_DIR=$RUNNER_TEMP/mise-data" >> "$GITHUB_ENV"
@@ -140,6 +139,13 @@ jobs:
       # identifier is required.
       - name: Install tools via mise
         uses: jdx/mise-action@v4
+        env:
+          # jdx/mise-action extracts into `$TMPDIR/mise` before moving
+          # the binary. On the shared macOS host, parallel runner
+          # instances share the default /var/folders/.../T path and can
+          # race each other. Scope TMPDIR to the action only so Cargo
+          # builds keep their normal environment.
+          TMPDIR: ${{ runner.temp }}
         with:
           install_args: --force rust github:mozilla/sccache
           cache: false
@@ -250,7 +256,6 @@ jobs:
             "$RUNNER_TEMP/mise-cache" \
             "$RUNNER_TEMP/mise-state"
           rm -rf "$RUNNER_TEMP/mise"
-          echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
           echo "MISE_DATA_DIR=$RUNNER_TEMP/mise-data" >> "$GITHUB_ENV"
@@ -260,6 +265,10 @@ jobs:
       # `cache: false` + `reshim: false` rationale.
       - name: Install Rust via mise
         uses: jdx/mise-action@v4
+        env:
+          # See the e2e job: isolate mise's download/extract scratch
+          # without changing TMPDIR for the later Cargo test process.
+          TMPDIR: ${{ runner.temp }}
         with:
           install_args: --force rust
           cache: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
             "$RUNNER_TEMP/mise-data/shims" \
             "$RUNNER_TEMP/mise-cache" \
             "$RUNNER_TEMP/mise-state"
+          rm -rf "$RUNNER_TEMP/mise"
+          echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
           echo "MISE_DATA_DIR=$RUNNER_TEMP/mise-data" >> "$GITHUB_ENV"
@@ -247,6 +249,8 @@ jobs:
             "$RUNNER_TEMP/mise-data/shims" \
             "$RUNNER_TEMP/mise-cache" \
             "$RUNNER_TEMP/mise-state"
+          rm -rf "$RUNNER_TEMP/mise"
+          echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
           echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
           echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
           echo "MISE_DATA_DIR=$RUNNER_TEMP/mise-data" >> "$GITHUB_ENV"

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -1,0 +1,87 @@
+name: Publish crates
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish crates.io packages
+    runs-on: ubuntu-latest
+    # If the crates.io Trusted Publisher config includes a GitHub
+    # Environment, add the same `environment: <name>` here. The
+    # workflow file name and environment must stay in sync with
+    # crates.io's trusted-publisher claims.
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CARGO_TERM_COLOR: always
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Check release tag matches Cargo manifests
+        run: ./scripts/check-release-tag-version.sh "$RELEASE_TAG"
+
+      - name: Package kache-core
+        run: cargo package -p kache-core --locked
+
+      - name: Authenticate to crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish kache-core
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          status="$(curl -sS -A kache-publish-workflow -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/kache-core/$version")"
+          if [ "$status" = "200" ]; then
+            echo "kache-core $version is already published"
+            exit 0
+          fi
+          if [ "$status" != "404" ]; then
+            echo "unexpected crates.io status while checking kache-core $version: $status" >&2
+            exit 1
+          fi
+          cargo publish -p kache-core --locked
+
+      - name: Wait for kache-core in crates.io index
+        run: |
+          version="${RELEASE_TAG#v}"
+          for attempt in {1..30}; do
+            if cargo search kache-core --limit 1 | grep -q "^kache-core = \"$version\""; then
+              exit 0
+            fi
+            echo "kache-core $version not visible yet; retry $attempt/30"
+            sleep 10
+          done
+          echo "kache-core $version did not become visible in crates.io index" >&2
+          exit 1
+
+      - name: Package kache
+        run: cargo package -p kache --locked
+
+      - name: Publish kache
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          status="$(curl -sS -A kache-publish-workflow -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/kache/$version")"
+          if [ "$status" = "200" ]; then
+            echo "kache $version is already published"
+            exit 0
+          fi
+          if [ "$status" != "404" ]; then
+            echo "unexpected crates.io status while checking kache $version: $status" >&2
+            exit 1
+          fi
+          cargo publish -p kache --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ blake3 = "1"
 aws-sdk-s3 = { version = "1", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
 aws-config = "1"
 aws-smithy-http-client = { version = "1", features = ["rustls-aws-lc"] }
-kache-core = { path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.3.1", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ kache is useful even before remote cache is configured:
 mise use -g github:kunobi-ninja/kache@latest
 
 # cargo (build from source)
-cargo install --git https://github.com/kunobi-ninja/kache kache
+cargo install kache
 
 # cargo-binstall (downloads pre-built binary, requires cargo-binstall)
-cargo binstall --git https://github.com/kunobi-ninja/kache kache
+cargo binstall kache
 ```
 
 ## Quick start

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -2,9 +2,12 @@
 name = "kache-core"
 version = "0.3.1"
 edition = "2024"
+description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"
 rust-version = "1.95"
+keywords = ["build-cache", "planner", "cache"]
+categories = ["development-tools::build-utils", "caching"]
 
 [features]
 default = ["planning"]

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -6,6 +6,7 @@ description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"
 rust-version = "1.95"
+publish = false
 
 [dependencies]
 anyhow = "1"

--- a/scripts/check-release-tag-version.sh
+++ b/scripts/check-release-tag-version.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:-}"
+
+if [[ -z "$tag" ]]; then
+  echo "usage: $0 vX.Y.Z" >&2
+  exit 2
+fi
+
+if [[ "$tag" != v* || "$tag" == "v" ]]; then
+  echo "release tag must look like vX.Y.Z, got: $tag" >&2
+  exit 1
+fi
+
+version="${tag#v}"
+metadata="$(cargo metadata --no-deps --format-version 1)"
+
+package_version() {
+  local package="$1"
+  METADATA="$metadata" python3 - "$package" <<'PY'
+import json
+import os
+import sys
+
+package = sys.argv[1]
+metadata = json.loads(os.environ["METADATA"])
+versions = [p["version"] for p in metadata["packages"] if p["name"] == package]
+if len(versions) != 1:
+    raise SystemExit(f"expected exactly one package named {package}, found {len(versions)}")
+print(versions[0])
+PY
+}
+
+root_version="$(package_version kache)"
+core_version="$(package_version kache-core)"
+
+if [[ "$root_version" != "$version" ]]; then
+  echo "kache version $root_version does not match release tag $tag" >&2
+  exit 1
+fi
+
+if [[ "$core_version" != "$version" ]]; then
+  echo "kache-core version $core_version does not match release tag $tag" >&2
+  exit 1
+fi
+
+echo "release tag $tag matches kache and kache-core version $version"


### PR DESCRIPTION
## Summary
- add release.published crates.io workflow using rust-lang/crates-io-auth-action OIDC
- fail before auth/publish unless release tag vX.Y.Z matches kache and kache-core Cargo versions
- make kache depend on a versioned kache-core path dependency so Cargo can publish it
- mark non-publishable service crate as publish = false and update install docs

## Validation
- ./scripts/check-release-tag-version.sh v0.3.1
- ./scripts/check-release-tag-version.sh v0.3.2 fails as expected
- Ruby YAML parse for ci.yml and publish-crates.yaml
- git diff --check
- cargo metadata --no-deps --format-version 1
- cargo publish -p kache-core --locked --dry-run --allow-dirty

## Release note
crates.io Trusted Publishing can only be configured after a crate exists. kache-core is not on crates.io yet, so the first kache-core publish still needs a one-time manual bootstrap; after that, configure the same trusted publisher for kache-core and this workflow can publish future releases.