### PR TITLE
Add Nix package CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,19 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v22
       - name: Check flake evaluation
         run: nix flake check --no-build
+      - name: Check Nix package version matches Cargo
+        run: |
+          cargo_version="$(python3 - <<'PY'
+          import tomllib
+          with open("Cargo.toml", "rb") as f:
+              print(tomllib.load(f)["package"]["version"])
+          PY
+          )"
+          nix_version="$(nix eval --raw .#kache.version)"
+          if [ "$nix_version" != "$cargo_version" ]; then
+            echo "Nix package version $nix_version does not match Cargo version $cargo_version" >&2
+            exit 1
+          fi
       - name: Build flake package
         run: nix build .#kache --no-link --print-build-logs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,17 @@ jobs:
           path: tmp/llvm-cov/html
           retention-days: 14
 
+  nix-package:
+    name: Nix package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - name: Check flake evaluation
+        run: nix flake check --no-build
+      - name: Build flake package
+        run: nix build .#kache --no-link --print-build-logs
+
   # --- E2E smoke test ---
   # Builds kache, configures as RUSTC_WRAPPER, cold-builds a fixture project,
   # cleans, warm-builds, and verifies cache hits work end-to-end.

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -28,8 +28,22 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - uses: DeterminateSystems/nix-installer-action@v22
+
       - name: Check release tag matches Cargo manifests
         run: ./scripts/check-release-tag-version.sh "$RELEASE_TAG"
+
+      - name: Check release tag matches Nix package
+        run: |
+          version="${RELEASE_TAG#v}"
+          nix_version="$(nix eval --raw .#kache.version)"
+          if [ "$nix_version" != "$version" ]; then
+            echo "Nix package version $nix_version does not match release tag $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+      - name: Build Nix package from release source
+        run: nix build .#kache --no-link --print-build-logs
 
       - name: Package kache-core
         run: cargo package -p kache-core --locked

--- a/flake.lock
+++ b/flake.lock
@@ -37,7 +37,28 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779992051,
+        "narHash": "sha256-4YWGv/0NkAdtTW1MXfaLYpfC9BhpCy9k1pWkR0xI9uw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e93ad0df1073b2c969a8f0c1f10b84e870469d40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,13 +4,32 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
     self,
     nixpkgs,
     flake-utils,
+    rust-overlay,
   }:
+    let
+      kacheOverlay = final: _prev: let
+        rustToolchain = final.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        rustPlatform = final.makeRustPlatform {
+          cargo = rustToolchain;
+          rustc = rustToolchain;
+        };
+      in
+        {
+          kache = final.callPackage ./nix/package.nix {
+            inherit rustPlatform;
+          };
+        };
+    in
     {
       nixosModules = {
         kache = import ./nix/module.nix;
@@ -23,8 +42,12 @@
         default = self.darwinModules.kache;
       };
 
-      overlays.default = _final: prev: {
-        kache = prev.callPackage ./nix/package.nix {};
+      overlays = {
+        kache = kacheOverlay;
+        default = nixpkgs.lib.composeManyExtensions [
+          rust-overlay.overlays.default
+          kacheOverlay
+        ];
       };
     }
     // flake-utils.lib.eachDefaultSystem (system: let

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchurl,
   apple-sdk_15,
+  cacert,
   stdenv,
 }:
 let
@@ -56,6 +57,11 @@ buildRustPackage {
 
   # Avoid bootstrapping loop: don't let kache wrap itself during build
   env.RUSTC_WRAPPER = "";
+
+  # reqwest (rustls) loads system CA certs when building a client, even for the
+  # plain-HTTP localhost planner tests. The sandbox has no trust store, so point
+  # it at the cacert bundle to keep client construction from failing.
+  env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   meta = {
     description = "Zero-copy, content-addressed Rust build cache";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,6 +6,8 @@
   stdenv,
 }:
 let
+  cargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+
   fetchurlWithCratesUserAgent = args:
     fetchurl (args
       // {
@@ -20,7 +22,7 @@ let
 in
 buildRustPackage {
   pname = "kache";
-  version = "0-unstable";
+  version = cargoToml.package.version;
 
   src = lib.fileset.toSource {
     root = ../.;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,10 +1,24 @@
 {
   lib,
   rustPlatform,
+  fetchurl,
   apple-sdk_15,
   stdenv,
 }:
-rustPlatform.buildRustPackage {
+let
+  fetchurlWithCratesUserAgent = args:
+    fetchurl (args
+      // {
+        curlOptsList = (args.curlOptsList or []) ++ ["-A" "kache-nix"];
+      });
+
+  buildRustPackage = rustPlatform.buildRustPackage.override {
+    importCargoLock = rustPlatform.importCargoLock.override {
+      fetchurl = fetchurlWithCratesUserAgent;
+    };
+  };
+in
+buildRustPackage {
   pname = "kache";
   version = "0-unstable";
 
@@ -13,11 +27,21 @@ rustPlatform.buildRustPackage {
     fileset = lib.fileset.unions [
       ../Cargo.toml
       ../Cargo.lock
+      ../crates
       ../src
     ];
   };
 
-  cargoHash = "sha256-sKGGDkVAt9vn8t5O0b419/REE89M5hrwyZ8erld7mcc=";
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+    outputHashes = {
+      "kunobi-auth-0.2.0" = "sha256-5qwhst8gt6KY9A37j0loEHBICzIAaVuyvtdOjTjRbdk=";
+      "kunobi-ha-0.5.0" = "sha256-y1Kye3/WfnnkcuThOr8AzvlQIkvKVMCOrT5cOohMKE4=";
+    };
+  };
+
+  cargoBuildFlags = ["-p" "kache"];
+  cargoTestFlags = ["-p" "kache"];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     apple-sdk_15

--- a/src/compiler/platform.rs
+++ b/src/compiler/platform.rs
@@ -37,7 +37,7 @@
 //! - `probe_compiler(path) -> CompilerInfo` — for cc cache keys to
 //!   know gcc-vs-clang-vs-MSVC.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::path::Path;
 use std::process::Command;
 
@@ -123,11 +123,20 @@ impl Platform for MacOsPlatform {
         // verify-then-sign: skip mutation when ld64's signature is
         // still valid. `codesign --verify --strict` exits 0 iff a
         // structurally-valid signature is already present.
-        let verify = Command::new("codesign")
+        let verify = match Command::new("codesign")
             .args(["--verify", "--strict"])
             .arg(path)
             .status()
-            .context("running codesign --verify")?;
+        {
+            Ok(status) => status,
+            Err(err) => {
+                tracing::warn!(
+                    "unable to run codesign --verify for {}: {err}",
+                    path.display()
+                );
+                return Ok(());
+            }
+        };
 
         if verify.success() {
             tracing::debug!(
@@ -141,11 +150,20 @@ impl Platform for MacOsPlatform {
             "ad-hoc signature missing or invalid for {}, re-applying",
             path.display()
         );
-        let status = Command::new("codesign")
+        let status = match Command::new("codesign")
             .args(["--sign", "-", "--force"])
             .arg(path)
             .status()
-            .context("running codesign --sign")?;
+        {
+            Ok(status) => status,
+            Err(err) => {
+                tracing::warn!(
+                    "unable to run codesign --sign for {}: {err}",
+                    path.display()
+                );
+                return Ok(());
+            }
+        };
 
         if !status.success() {
             tracing::warn!("ad-hoc codesign failed for {}", path.display());


### PR DESCRIPTION
Summary:
- add a Linux CI job that evaluates the flake and builds .#kache
- make the Nix package use the repo Rust toolchain via rust-overlay
- switch Nix vendoring to Cargo.lock with explicit git dependency hashes
- derive the Nix package version from root Cargo.toml
- verify in CI that Nix package version matches Cargo
- verify in publish workflow that release tag, Cargo manifests, and Nix package version match before crates.io publish
- build the Nix package from the release source before publishing crates
- include local workspace crates in the Nix source and scope package build/test to -p kache
- make macOS codesign invocation best-effort when the tool is unavailable

Validation:
- git diff --check
- bash -n scripts/check-release-tag-version.sh
- ./scripts/check-release-tag-version.sh v0.3.1
- nix eval --raw .#kache.version
- nix flake check --no-build
- nix build .#kache --no-link --print-build-logs
- env -u RUSTC_WRAPPER cargo fmt --check
- env -u RUSTC_WRAPPER cargo test -p kache compiler::platform::tests::macos_ensure_binary_loadable_does_not_propagate_errors