### PR TITLE
fix(wrapper): fall back to the real compiler on cache errors (#181)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+serde_json = "1"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -203,7 +203,23 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     // ── Local cache lookup ───────────────────────────────────────
     let lookup_start = std::time::Instant::now();
-    let lookup = store.get(&cache_key)?;
+    let lookup = match store.get(&cache_key) {
+        Ok(lookup) => lookup,
+        Err(e) => {
+            tracing::warn!(
+                "cc local store lookup failed for {}: {} — recompiling",
+                crate_name,
+                e
+            );
+            return cc_passthrough_with_event(
+                config,
+                &parsed,
+                &crate_name,
+                start,
+                format!("store lookup failed: {e}"),
+            );
+        }
+    };
     let lookup_ms = lookup_start.elapsed().as_millis() as u64;
     if let Some(meta) = lookup {
         if meta.files.is_empty() {
@@ -218,7 +234,20 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             let _ = store.remove_entry(&cache_key);
         } else {
             let restore_start = std::time::Instant::now();
-            restore_cc_from_cache(&store, &parsed, &meta)?;
+            if let Err(e) = restore_cc_from_cache(&store, &parsed, &meta) {
+                tracing::warn!(
+                    "restoring cc cache hit for {} failed: {} — recompiling",
+                    crate_name,
+                    e
+                );
+                return cc_passthrough_with_event(
+                    config,
+                    &parsed,
+                    &crate_name,
+                    start,
+                    format!("restore failed: {e}"),
+                );
+            }
             let restore_ms = restore_start.elapsed().as_millis() as u64;
             let elapsed = start.elapsed().as_millis() as u64;
             let size: u64 = meta.files.iter().map(|f| f.size).sum();
@@ -631,7 +660,23 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     // 1. Check local store
     let lookup_start = std::time::Instant::now();
-    let lookup_result = store.get(&cache_key)?;
+    let lookup_result = match store.get(&cache_key) {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::warn!(
+                "local store lookup failed for {}: {} — recompiling",
+                crate_name,
+                e
+            );
+            return passthrough_with_event(
+                config,
+                &args,
+                crate_name,
+                start,
+                format!("store lookup failed: {e}"),
+            );
+        }
+    };
     let lookup_ms = lookup_start.elapsed().as_millis() as u64;
     if let Some(meta) = lookup_result {
         // Safety: skip entries with no cached files (poisoned by earlier bugs)
@@ -644,7 +689,20 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         } else {
             tracing::debug!("local cache hit for {} ({})", crate_name, &cache_key[..16]);
             let restore_start = std::time::Instant::now();
-            restore_from_cache(config, &compiler, &store, &args, &meta)?;
+            if let Err(e) = restore_from_cache(config, &compiler, &store, &args, &meta) {
+                tracing::warn!(
+                    "restoring local cache hit for {} failed: {} — recompiling",
+                    crate_name,
+                    e
+                );
+                return passthrough_with_event(
+                    config,
+                    &args,
+                    crate_name,
+                    start,
+                    format!("restore failed: {e}"),
+                );
+            }
             let restore_ms = restore_start.elapsed().as_millis() as u64;
             let elapsed = start.elapsed().as_millis() as u64;
             let size: u64 = meta.files.iter().map(|f| f.size).sum();
@@ -685,7 +743,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         match crate::daemon::send_remote_check(config, &cache_key, &entry_dir, crate_name) {
             Some(result) if result.found => {
                 // Daemon downloaded it — now read from local store and restore
-                if let Some(meta) = store.get(&cache_key)? {
+                if let Ok(Some(meta)) = store.get(&cache_key) {
                     let event_result = if result.prefetched {
                         tracing::debug!(
                             "prefetch cache hit for {} ({})",
@@ -702,7 +760,20 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                         EventResult::RemoteHit
                     };
                     let restore_start = std::time::Instant::now();
-                    restore_from_cache(config, &compiler, &store, &args, &meta)?;
+                    if let Err(e) = restore_from_cache(config, &compiler, &store, &args, &meta) {
+                        tracing::warn!(
+                            "restoring cache hit for {} failed: {} — recompiling",
+                            crate_name,
+                            e
+                        );
+                        return passthrough_with_event(
+                            config,
+                            &args,
+                            crate_name,
+                            start,
+                            format!("restore failed: {e}"),
+                        );
+                    }
                     let restore_ms = restore_start.elapsed().as_millis() as u64;
                     let elapsed = start.elapsed().as_millis() as u64;
                     let size: u64 = meta.files.iter().map(|f| f.size).sum();
@@ -737,16 +808,43 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     }
 
     // 3. Cache miss — try to acquire build lock
-    let lock = match store.try_lock(&cache_key)? {
-        Some(lock) => lock,
-        None => {
+    let lock = match store.try_lock(&cache_key) {
+        Ok(Some(lock)) => lock,
+        Err(e) => {
+            tracing::warn!(
+                "acquiring build lock for {} failed: {} — recompiling",
+                crate_name,
+                e
+            );
+            return passthrough_with_event(
+                config,
+                &args,
+                crate_name,
+                start,
+                format!("build lock unavailable: {e}"),
+            );
+        }
+        Ok(None) => {
             // Another process is building this key — wait for it
             tracing::debug!("waiting for {} to be built by another process", crate_name);
-            if store.wait_for_committed(&cache_key)? {
+            if store.wait_for_committed(&cache_key).unwrap_or(false) {
                 // It's now available
-                if let Some(meta) = store.get(&cache_key)? {
+                if let Ok(Some(meta)) = store.get(&cache_key) {
                     let restore_start = std::time::Instant::now();
-                    restore_from_cache(config, &compiler, &store, &args, &meta)?;
+                    if let Err(e) = restore_from_cache(config, &compiler, &store, &args, &meta) {
+                        tracing::warn!(
+                            "restoring cache hit for {} failed: {} — recompiling",
+                            crate_name,
+                            e
+                        );
+                        return passthrough_with_event(
+                            config,
+                            &args,
+                            crate_name,
+                            start,
+                            format!("restore failed: {e}"),
+                        );
+                    }
                     let restore_ms = restore_start.elapsed().as_millis() as u64;
                     let elapsed = start.elapsed().as_millis() as u64;
                     let size: u64 = meta.files.iter().map(|f| f.size).sum();

--- a/tests/stale_artifact_test.rs
+++ b/tests/stale_artifact_test.rs
@@ -581,3 +581,100 @@ fn stale_invalidates_on_coverage_flag() {
         "coverage flag must produce new cache entry: before={count1}, after={count2}"
     );
 }
+
+/// Makes every cached dep-info (`.d`) blob unreadable, returning how many were
+/// touched. These blobs still pass `Store::get`'s checks (the file exists and
+/// has the recorded size — `get` only `stat`s them), but the restore path
+/// *reads* a `.d` blob to relativize it, so an unreadable one forces a restore
+/// failure. `.rlib`/`.rmeta` blobs are left readable so they restore normally
+/// (0444 hardlinks the recompile can overwrite), keeping the corruption scoped
+/// to the restore step we want to exercise.
+#[cfg(unix)]
+fn make_depinfo_blobs_unreadable(cache_dir: &Path) -> usize {
+    use std::os::unix::fs::PermissionsExt;
+
+    let store = cache_dir.join("store");
+    let blobs_dir = store.join("blobs");
+    let mut touched = 0;
+
+    for entry in std::fs::read_dir(&store).unwrap().filter_map(|e| e.ok()) {
+        let dir = entry.path();
+        if !dir.is_dir() || dir.file_name().is_some_and(|n| n == "blobs") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(dir.join("meta.json")) else {
+            continue;
+        };
+        let meta: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let Some(files) = meta["files"].as_array() else {
+            continue;
+        };
+        for file in files {
+            let name = file["name"].as_str().unwrap_or("");
+            if !name.ends_with(".d") {
+                continue;
+            }
+            let hash = file["hash"].as_str().unwrap();
+            let blob = blobs_dir.join(&hash[..2]).join(hash);
+            if blob.is_file() {
+                std::fs::set_permissions(&blob, std::fs::Permissions::from_mode(0o000)).unwrap();
+                touched += 1;
+            }
+        }
+    }
+    touched
+}
+
+/// A cache entry that survives `Store::get`'s validation but fails during
+/// restore must degrade to a transparent recompile, not abort the build.
+///
+/// We populate the cache, then make the dep-info blobs unreadable so the next
+/// build gets a local cache *hit* (metadata + size still check out) whose
+/// restore then fails on the unreadable `.d`. Before the fallback fix the
+/// wrapper propagated that error and `cargo build` failed; now it must
+/// recompile and produce identical output.
+#[cfg(unix)]
+#[test]
+fn unrestorable_cache_entry_falls_back_to_recompile() {
+    build_kache();
+    let project = copy_fixture();
+    let cache_dir = TempDir::new().unwrap();
+    let target_dir = TempDir::new().unwrap();
+
+    let out1 = build_and_run(
+        project.path(),
+        cache_dir.path(),
+        target_dir.path(),
+        &[],
+        &[],
+    );
+    assert_eq!(out1, "v1.helper-v1.default.debug.plain");
+
+    let broken = make_depinfo_blobs_unreadable(cache_dir.path());
+    assert!(
+        broken > 0,
+        "expected at least one cached dep-info blob to corrupt"
+    );
+
+    // Force cargo to re-invoke rustc through kache against the broken cache.
+    let _ = std::process::Command::new("cargo")
+        .args(["clean"])
+        .current_dir(project.path())
+        .env("CARGO_TARGET_DIR", target_dir.path())
+        .status();
+
+    // build_and_run asserts the build succeeds; without the fallback this
+    // would fail because the unreadable `.d` aborts restore.
+    let out2 = build_and_run(
+        project.path(),
+        cache_dir.path(),
+        target_dir.path(),
+        &[],
+        &[],
+    );
+    assert_eq!(out2, "v1.helper-v1.default.debug.plain");
+    assert_eq!(
+        out1, out2,
+        "fallback recompile must produce identical output"
+    );
+}


### PR DESCRIPTION
Closes #181.

## Problem
The wrapper's core invariant is **transparency**: on any cache problem it must run the real compiler with identical args/env/cwd and propagate the exact exit code/stdout/stderr. The miss path (`Ok(None)`) honored that, but **operational errors did not** — they propagated via `?` out of `wrapper::run` / `run_cc` and aborted a build that would otherwise compile fine:

- `store.get(&cache_key)?` — a locked/corrupt SQLite index
- `restore_from_cache(...)?` / `restore_cc_from_cache(...)?` — a missing/unreadable/truncated blob, a hardlink/copy failure
- `store.try_lock(...)?` / `store.wait_for_committed(...)?` — a lock-coordination error

Any of these surfaced to the user as a kache error on a green build.

## Fix
Route every cache-hit / lock / restore error to the existing passthrough/recompile path (`passthrough_with_event` / `cc_passthrough_with_event`) instead of `?`-propagating. The genuine post-compile "store the result" error handling is unchanged (it already only logs). Applied symmetrically to the rustc **and** cc wrappers.

This was a structural weakness — the invariant was enforced ad hoc at a dozen `?` sites, several of which violated it — so the fix makes the cache-error → recompile behavior consistent across all hit paths.

### High leverage
It also makes the store-integrity races degrade to a **transparent recompile** instead of a hard failure:
- #182 (GC deletes a blob mid-restore) → restore fails → recompile
- #180 (refcount drift → missing blob) → restore fails → recompile

## Testing
- New regression test `unrestorable_cache_entry_falls_back_to_recompile` (Unix): populates the cache, then makes the cached **dep-info** blobs unreadable. The entry still passes `Store::get`'s checks (it only `stat`s — file exists + size matches), but restore *reads* the `.d` to relativize it, so restore fails. The build must recompile to identical output. Before this fix it failed; now it passes. (Scoped to `.d` blobs so `rlib`/`rmeta` still restore as normal 0444 hardlinks the recompile overwrites — keeping the corruption on the exact path under test.)
- Full `stale_artifact_test` suite (12 tests, incl. the cache-hit/restore success paths) passes; clippy `-D warnings` clean.
- `serde_json` added to dev-dependencies for the test (it's already a runtime dep; integration tests can't reach the binary crate's internals).

## Notes
- Target: 0.4.0.
- First of the release-blocker series; #178 (import hash-verification) and #180 (atomic entry registration) follow as separate PRs.