### PR TITLE
ci: harden the release pipeline for 0.4.1 (0.4.0 postmortem)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,10 @@ jobs:
           "
       - name: Upload HTML coverage report
         uses: actions/upload-artifact@v4
-        if: always()
+        # Skip on tag/release runs: the shared release workflow downloads *all*
+        # run artifacts and `gh release upload artifacts/*` chokes on directory
+        # artifacts like this one. Coverage HTML is only useful on PR/branch runs.
+        if: always() && github.ref_type != 'tag'
         with:
           name: coverage-html
           path: tmp/llvm-cov/html
@@ -243,7 +246,11 @@ jobs:
         # historical-run links stay valid; the path it uploads from moved
         # to `tmp/e2e/` per the repo-wide scratch-under-tmp convention
         # (see .gitignore comment).
-        if: always()
+        #
+        # Skipped on tag/release runs for the same reason as the coverage
+        # artifact: the shared release workflow's `gh release upload
+        # artifacts/*` would try to upload this directory as a release asset.
+        if: always() && github.ref_type != 'tag'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-results

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -69,10 +69,16 @@ jobs:
           cargo publish -p kache-core --locked
 
       - name: Wait for kache-core in crates.io index
+        # Poll the sparse index (index.crates.io) — the source `cargo publish`
+        # resolves dependencies against, updated within seconds of a publish.
+        # The old `cargo search` check hit the crates.io *search* index, which
+        # is eventually-consistent and lagged past this loop on the 0.4.0 cut.
         run: |
           version="${RELEASE_TAG#v}"
           for attempt in {1..30}; do
-            if cargo search kache-core --limit 1 | grep -q "^kache-core = \"$version\""; then
+            if curl -sf -A kache-publish-workflow \
+                 "https://index.crates.io/ka/ch/kache-core" | grep -q "\"vers\":\"$version\""; then
+              echo "kache-core $version visible in crates.io sparse index"
               exit 0
             fi
             echo "kache-core $version not visible yet; retry $attempt/30"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,17 +106,45 @@ just check
 # 2. Merge the release branch into main
 #    (PR release/X.Y.Z -> main, or fast-forward)
 
-# 3. Tag the release on main — the tag MUST match the workspace version
-git tag vX.Y.Z            # scripts/check-release-tag-version.sh enforces tag == version
-git push origin vX.Y.Z
+# 3. Publish the release on main via the GitHub UI: Draft a new release,
+#    tag = vX.Y.Z (target main), write the changelog, Publish.
+#    - Creating the release creates the tag and triggers tag CI
+#      (scripts/check-release-tag-version.sh enforces tag == version) and,
+#      on publish, the crates.io workflow (.github/workflows/publish-crates.yaml).
 
-# 4. Bring main back into dev, then bump dev to the next dev version
-git switch dev && git merge main
-#    edit versions to the next target (e.g. X.Y.(Z+1)) and commit
+# 4. Fast-forward dev onto main, then bump dev to the next dev version.
+git switch dev && git merge --ff-only main
+#    edit versions to the next target (e.g. X.Y.(Z+1)) and commit + push
 ```
+
+The fast-forward in step 4 matters: it makes `main` an ancestor of `dev`, so the
+next `dev → main` promotion is a clean fast-forward instead of conflicting.
 
 Invariant: **`main` reads the last released number (tagged); `dev` always reads
 a number *higher* than the last release (untagged).**
+
+### Publishing to crates.io
+
+Publishing is automated by `.github/workflows/publish-crates.yaml`, triggered when
+a GitHub **Release** is published. It uses crates.io **Trusted Publishing** (OIDC,
+no stored token), publishes `kache-core` then `kache` (in dependency order), and
+is idempotent (skips versions already on crates.io).
+
+**First publish of a *new* crate is manual.** Trusted Publishing tokens **cannot
+create a new crate** — crates.io requires the first publish to claim ownership with
+a personal token. When adding a crate, bootstrap it once:
+
+```sh
+git checkout vX.Y.Z              # publish from the tag, never a moving branch
+cargo login                      # personal token from crates.io → Account → API Tokens
+cargo publish -p <new-crate> --locked
+```
+
+Then configure Trusted Publishing for that crate on crates.io (repo +
+`publish-crates.yaml` workflow, matching any Environment the others use) so all
+later releases publish automatically. Crates are published **individually** in
+dependency order — publishing `kache` does **not** publish `kache-core`; the
+dependency must already be on crates.io first.
 
 ## Project structure
 


### PR DESCRIPTION
Fixes the three things that bit the 0.4.0 release, so 0.4.1 cuts cleanly. All kache-side; none affect the already-cut 0.4.0.

## 1. `publish-crates.yaml` — `Wait for kache-core in crates.io index`
Polled `cargo search`, which hits the crates.io **search index** (eventually-consistent). It lagged **>5 min** on 0.4.0 and failed the job *even though kache-core was published* — so `Publish kache` was skipped and `kache 0.4.0` never went out.

→ Poll the **sparse index** (`https://index.crates.io/ka/ch/kache-core`) instead — the source `cargo publish` actually resolves against, updated within seconds of publish. Validated locally (correct VISIBLE for a real version, not-yet for a bogus one).

## 2. `ci.yml` — stop release runs from producing directory artifacts
The shared release workflow downloads **all** run artifacts and runs `gh release upload artifacts/* --clobber`, which **chokes on directory artifacts**. On 0.4.0 that left the release with only **2 of 4 binaries** plus stray coverage files (`control.js`, `index.html`).

→ Gate `Upload HTML coverage report` and `Upload e2e results artifact` with `if: always() && github.ref_type != 'tag'`. The jobs still run on tag pushes (validation); they just don't upload the directory artifacts that pollute the release upload. (The *root* fix belongs in the shared `zondax/_workflows/_release-rust.yml` — restrict its download to `<binary_name>-*` — but this kache-side gate fixes our releases regardless.)

## 3. `CONTRIBUTING.md` — publishing docs
Documents what we learned the hard way:
- crates.io **Trusted Publishing can't create a new crate** → first publish of a new crate is manual (claims ownership), then configure Trusted Publishing.
- Crates publish **individually in dependency order** — publishing `kache` does *not* publish `kache-core`; the dep must already be on crates.io.
- The release step fast-forwards `dev` onto `main` (keeps `main` an ancestor of `dev` so the next promotion doesn't conflict).

## Not in scope (tracked separately)
- Root fix in the shared `zondax/_workflows` release workflow (different repo).
- One-time: add the `kache-core` Trusted-Publishing config on crates.io so 0.4.1 publishes fully automatically.