### PR TITLE
Release 0.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,10 @@ jobs:
           "
       - name: Upload HTML coverage report
         uses: actions/upload-artifact@v4
-        if: always()
+        # Skip on tag/release runs: the shared release workflow downloads *all*
+        # run artifacts and `gh release upload artifacts/*` chokes on directory
+        # artifacts like this one. Coverage HTML is only useful on PR/branch runs.
+        if: always() && github.ref_type != 'tag'
         with:
           name: coverage-html
           path: tmp/llvm-cov/html
@@ -243,7 +246,11 @@ jobs:
         # historical-run links stay valid; the path it uploads from moved
         # to `tmp/e2e/` per the repo-wide scratch-under-tmp convention
         # (see .gitignore comment).
-        if: always()
+        #
+        # Skipped on tag/release runs for the same reason as the coverage
+        # artifact: the shared release workflow's `gh release upload
+        # artifacts/*` would try to upload this directory as a release asset.
+        if: always() && github.ref_type != 'tag'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-results

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -69,10 +69,16 @@ jobs:
           cargo publish -p kache-core --locked
 
       - name: Wait for kache-core in crates.io index
+        # Poll the sparse index (index.crates.io) — the source `cargo publish`
+        # resolves dependencies against, updated within seconds of a publish.
+        # The old `cargo search` check hit the crates.io *search* index, which
+        # is eventually-consistent and lagged past this loop on the 0.4.0 cut.
         run: |
           version="${RELEASE_TAG#v}"
           for attempt in {1..30}; do
-            if cargo search kache-core --limit 1 | grep -q "^kache-core = \"$version\""; then
+            if curl -sf -A kache-publish-workflow \
+                 "https://index.crates.io/ka/ch/kache-core" | grep -q "\"vers\":\"$version\""; then
+              echo "kache-core $version visible in crates.io sparse index"
               exit 0
             fi
             echo "kache-core $version not visible yet; retry $attempt/30"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,17 +106,45 @@ just check
 # 2. Merge the release branch into main
 #    (PR release/X.Y.Z -> main, or fast-forward)
 
-# 3. Tag the release on main — the tag MUST match the workspace version
-git tag vX.Y.Z            # scripts/check-release-tag-version.sh enforces tag == version
-git push origin vX.Y.Z
+# 3. Publish the release on main via the GitHub UI: Draft a new release,
+#    tag = vX.Y.Z (target main), write the changelog, Publish.
+#    - Creating the release creates the tag and triggers tag CI
+#      (scripts/check-release-tag-version.sh enforces tag == version) and,
+#      on publish, the crates.io workflow (.github/workflows/publish-crates.yaml).
 
-# 4. Bring main back into dev, then bump dev to the next dev version
-git switch dev && git merge main
-#    edit versions to the next target (e.g. X.Y.(Z+1)) and commit
+# 4. Fast-forward dev onto main, then bump dev to the next dev version.
+git switch dev && git merge --ff-only main
+#    edit versions to the next target (e.g. X.Y.(Z+1)) and commit + push
 ```
+
+The fast-forward in step 4 matters: it makes `main` an ancestor of `dev`, so the
+next `dev → main` promotion is a clean fast-forward instead of conflicting.
 
 Invariant: **`main` reads the last released number (tagged); `dev` always reads
 a number *higher* than the last release (untagged).**
+
+### Publishing to crates.io
+
+Publishing is automated by `.github/workflows/publish-crates.yaml`, triggered when
+a GitHub **Release** is published. It uses crates.io **Trusted Publishing** (OIDC,
+no stored token), publishes `kache-core` then `kache` (in dependency order), and
+is idempotent (skips versions already on crates.io).
+
+**First publish of a *new* crate is manual.** Trusted Publishing tokens **cannot
+create a new crate** — crates.io requires the first publish to claim ownership with
+a personal token. When adding a crate, bootstrap it once:
+
+```sh
+git checkout vX.Y.Z              # publish from the tag, never a moving branch
+cargo login                      # personal token from crates.io → Account → API Tokens
+cargo publish -p <new-crate> --locked
+```
+
+Then configure Trusted Publishing for that crate on crates.io (repo +
+`publish-crates.yaml` workflow, matching any Environment the others use) so all
+later releases publish automatically. Crates are published **individually** in
+dependency order — publishing `kache` does **not** publish `kache-core`; the
+dependency must already be on crates.io first.
 
 ## Project structure
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — just hardlinks locally and S3 for sharing."
 license = "Apache-2.0"
@@ -29,7 +29,7 @@ blake3 = "1"
 aws-sdk-s3 = { version = "1", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
 aws-config = "1"
 aws-smithy-http-client = { version = "1", features = ["rustls-aws-lc"] }
-kache-core = { version = "0.4.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.4.1", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ kache doctor
 
 That uses GitHub Actions cache by default. For S3-backed caching shared across repos or runners, pass `s3-bucket` plus credentials — see the action's README for the full input list.
 
+## C/C++ caching (experimental)
+
+Alongside the rustc wrapper, kache can cache **C/C++ object compiles** as a `cc` / `c++` wrapper. It recognizes `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++` on POSIX:
+
+```sh
+export CC="kache cc"
+export CXX="kache c++"
+```
+
+**What's cached today:** single-source `-c` object compiles (e.g. `cc -c foo.c -o foo.o`). The cache key is the preprocessor expansion (`cc -E -P`, with `SOURCE_DATE_EPOCH` pinned) plus compiler identity, target arch, and codegen flags — so any header change invalidates it, and the key is portable across machines and worktrees. On a hit the `.o` (and its `.d` dep-info) restore without re-running the compiler. Any flag kache hasn't classified is **refused** — the invocation passes through to the real compiler rather than risk a silently-wrong object.
+
+**Not cached yet** (these pass through): link / whole-program steps, multi-source and multi-arch invocations, precompiled headers, modules, coverage, and split-DWARF. C/C++ caching is also **local-only** for now — the Rust path's S3 sharing doesn't extend to `cc` artifacts yet.
+
+It's experimental and conservative by design: when in doubt, kache misses rather than serve a wrong artifact. Scope and remaining work are tracked in [#49](https://github.com/kunobi-ninja/kache/issues/49).
+
 ## Development
 
 ```sh
@@ -95,7 +110,7 @@ It is intentionally a hard scenario. Firefox combines a large Rust workspace wit
 
 So the current bench measures progress against that long-term objective rather than a finished product. The verdict reliably reports `ok` for cache-key portability on the Rust side after v7 (88% cross-clone stability), but two known limitations keep the weighted speedup modest:
 
-1. **C/C++ passthrough** — ~85% of Firefox compiles refuse caching because kache's `cc` arg allow-list rejects several Firefox-specific clang flags (`-mmacosx-version-min=…`, `-stdlib=libc++`, etc.). This is the bottleneck. Fixing it is the multi-step C/C++ caching maturity work.
+1. **C/C++ caching maturity** — C/C++ dominates the Firefox build (~85% of compiles), and so far only single-source `-c` object compiles are cached (see [C/C++ caching](#cc-caching-experimental)). Link/whole-program steps, multi-source units, and any still-unmodeled flag pass through, and `cc` caching is local-only — so most of Firefox's C/C++ work isn't warm-cached yet. (0.4.0 broadened the `cc` flag coverage considerably — Gecko/Darwin/clang and C++ ABI flags — but the bottleneck is now the broader scope above, not a single rejected flag.) This is the bottleneck; closing it is the multi-step C/C++ maturity work.
 2. **Workspace-local Rust crate instability** — a handful of Mozilla-local crates (`gkrust_shared`, `style`, `webrender`, …) still miss across clones for a non-path-leak reason, separate from the v7 linker fix.
 
 Treat the benchmark as a diagnostic platform first and a headline-number tool second — the structural improvements come out of running it, not today's speedup figure.

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
Promotes `dev` to `main` to cut the **0.4.1** release.

## What's in it
- **ci: harden the release pipeline** (#188) — fixes both failures from the 0.4.0 cut:
  - publish-crates now polls the sparse index (`index.crates.io`) instead of the lagging `cargo search`.
  - skips directory-artifact uploads on tag runs so `gh release upload artifacts/*` no longer chokes (0.4.0 shipped only 2 of 4 binaries).
- **docs(readme): document experimental C/C++ caching** (#190 / #49)
- **Bump dev to 0.4.1**

## Why a PR (not a fast-forward)
First promotion under the trunk-based model: `main` becomes the protected single trunk, so promotions go through a reviewed PR. `dev` will be retired after this merges.

## After merge
1. Tag `v0.4.1` → release (hardened pipeline).
2. Delete `dev`, set `main` branch protection.
3. Follow-up PR: drop redundant publish-job nix build + add RC/dry-run release rehearsal.