### PR TITLE
ci: CI review fixes + trunk-based docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -38,7 +38,7 @@ jobs:
       - uses: jdx/mise-action@v4
         with:
           cache: false
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
       - uses: kunobi-ninja/kache-action@v1
         with:
           github-cache: "true"
@@ -54,15 +54,18 @@ jobs:
         run: |
           version="$(cargo pkgid -p kache-core | sed 's/.*#//')"
           cargo package -p kache-core --locked
-          if cargo search kache-core --limit 1 | grep -q "^kache-core = \"$version\""; then
+          # Poll the sparse index (index.crates.io), not `cargo search`: the
+          # search index is eventually-consistent and lagged on the 0.4.0 cut.
+          if curl -sf -A kache-ci-metadata-check "https://index.crates.io/ka/ch/kache-core" | grep -q "\"vers\":\"$version\""; then
             cargo package -p kache --locked
           else
             echo "kache-core $version is not on crates.io yet; skipping kache package verification"
           fi
         env:
           RUSTC_WRAPPER: ""
-      - name: Check coverage threshold (35%, push only)
-        if: github.event_name == 'push'
+      - name: Check coverage threshold (35%)
+        # Enforced on PRs too, not just push: in a trunk-based model a PR that
+        # drops coverage must fail before merge, not after on the main push.
         run: |
           python3 -c "
           import json, sys
@@ -76,7 +79,7 @@ jobs:
           print(f'OK: >= {threshold}%')
           "
       - name: Upload HTML coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         # Skip on tag/release runs: the shared release workflow downloads *all*
         # run artifacts and `gh release upload artifacts/*` chokes on directory
         # artifacts like this one. Coverage HTML is only useful on PR/branch runs.
@@ -251,7 +254,7 @@ jobs:
         # artifact: the shared release workflow's `gh release upload
         # artifacts/*` would try to upload this directory as a release asset.
         if: always() && github.ref_type != 'tag'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-results
           path: tmp/e2e/
@@ -343,7 +346,10 @@ jobs:
   # --- Release (only on v* tags) ---
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [check]
+    # Gate the release (and, transitively, the crates publish it triggers) on
+    # the full validation suite — not just `check`. windows-check is omitted on
+    # purpose: it is exploratory (continue-on-error) and must not block a release.
+    needs: [check, nix-package, e2e, test-macos]
     uses: zondax/_workflows/.github/workflows/_release-rust.yml@main
     with:
       binary_name: kache

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -11,6 +11,10 @@ jobs:
   publish:
     name: Publish crates.io packages
     runs-on: ubuntu-latest
+    # Pre-release tags (rc/alpha/beta) are release rehearsals and must never
+    # publish to crates.io. This is the safety floor; a full dry-run rehearsal
+    # on pre-releases is added by the release-flow redesign.
+    if: github.event.release.prerelease == false
     # If the crates.io Trusted Publisher config includes a GitHub
     # Environment, add the same `environment: <name>` here. The
     # workflow file name and environment must stay in sync with
@@ -53,7 +57,9 @@ jobs:
 
       - name: Authenticate to crates.io
         id: auth
-        uses: rust-lang/crates-io-auth-action@v1
+        # Pinned to v1.0.4: the floating @v1 tag still runs on the deprecated
+        # Node 20 runtime; v1.0.4 is the first node24 release.
+        uses: rust-lang/crates-io-auth-action@v1.0.4
 
       - name: Publish kache-core
         env:

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -34,6 +34,12 @@ jobs:
         run: ./scripts/check-release-tag-version.sh "$RELEASE_TAG"
 
       - name: Check release tag matches Nix package
+        # Cheap consistency gate (<5s): the full `nix build .#kache` is the
+        # CI `nix-package` job's responsibility and already runs on the tagged
+        # commit. Rebuilding it here only duplicated ~8min of work and pulled
+        # in the Determinate/FlakeHub installer as an extra failure surface
+        # before the irreversible crates.io publish. The version-match check
+        # is what actually guards against tag/manifest drift, so it stays.
         run: |
           version="${RELEASE_TAG#v}"
           nix_version="$(nix eval --raw .#kache.version)"
@@ -41,9 +47,6 @@ jobs:
             echo "Nix package version $nix_version does not match release tag $RELEASE_TAG" >&2
             exit 1
           fi
-
-      - name: Build Nix package from release source
-        run: nix build .#kache --no-link --print-build-logs
 
       - name: Package kache-core
         run: cargo package -p kache-core --locked

--- a/.github/workflows/service-image.yml
+++ b/.github/workflows/service-image.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
       - name: Build image (dry-run, no cache)
         run: docker buildx bake -f docker-bake.hcl --set '*.cache-from=' service
 
@@ -45,15 +45,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -67,7 +67,9 @@ jobs:
             BUILD_VERSION="${GITHUB_REF_NAME}"
           else
             VERSION="0.0.0"
-            IMAGE_TAG="dev"
+            # Non-tag main builds: `edge` (the dev branch is gone under the
+            # trunk-based model, so a `dev` image tag no longer maps to anything).
+            IMAGE_TAG="edge"
             BUILD_VERSION="${GITHUB_REF_NAME}"
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,10 +66,10 @@ just check
 
 ## Pull request process
 
-1. **Fork** the repository and create a feature branch from `dev`
+1. **Fork** the repository and create a feature branch from `main`
 2. Make your changes — keep commits focused and use [conventional commit](https://www.conventionalcommits.org/) messages (e.g., `feat:`, `fix:`, `test:`, `docs:`)
 3. Run `just check` and ensure it passes
-4. Open a pull request against `dev` (not `main` — see [Branching and releases](#branching-and-releases))
+4. Open a pull request against `main` (see [Branching and releases](#branching-and-releases))
 5. Describe what the PR does and why — link related issues if any
 
 ### PR guidelines
@@ -81,47 +81,32 @@ just check
 
 ## Branching and releases
 
-kache uses an integration branch plus a release-staging branch. Tags and the
-published version live on `main`; day-to-day work flows through `dev`.
+kache is trunk-based: `main` is the single long-lived branch. All work lands on
+`main` through reviewed PRs, and releases are tagged directly on `main`. There is
+no `dev` branch.
 
-| Branch | Role | Version it carries |
-|---|---|---|
-| `main` | Published, tagged history. Each release tag `vX.Y.Z` points here. | The last released version |
-| `dev` | Integration line. All feature/fix PRs land here. | The last released version (bumped only *after* a release) |
-| `release/X.Y.Z` | Short-lived staging branch cut from `dev` to prepare a release. | The version being released (`X.Y.Z`) |
-
-**Why `dev` keeps the last-released version:** `dev` is usually well ahead of
-`main` in *code* but not in *version number*. The bump is deferred to release
-time so `dev` never advertises a version that hasn't shipped, and so the
-`Cargo.toml` version line doesn't conflict across the many in-flight PRs.
+| Branch | Role |
+|---|---|
+| `main` | The trunk. All feature/fix PRs land here and CI runs on every PR. Release tags `vX.Y.Z` point at commits on `main`. |
+| `release/X.Y` | *(rare, short-lived)* Cut from a release tag only to back-port fixes to an already-shipped line after `main` has moved past it. |
 
 ### Cutting a release (maintainers)
 
 ```sh
-# 1. Branch from dev and bump the workspace version to X.Y.Z
-git switch -c release/X.Y.Z origin/dev
-#    edit Cargo.toml + crates/*/Cargo.toml version = "X.Y.Z", refresh Cargo.lock
-just check
+# 1. Bump the workspace version in a PR: edit Cargo.toml + crates/*/Cargo.toml
+#    version = "X.Y.Z", refresh Cargo.lock, `just check`. Merge it into main.
 
-# 2. Merge the release branch into main
-#    (PR release/X.Y.Z -> main, or fast-forward)
-
-# 3. Publish the release on main via the GitHub UI: Draft a new release,
-#    tag = vX.Y.Z (target main), write the changelog, Publish.
-#    - Creating the release creates the tag and triggers tag CI
-#      (scripts/check-release-tag-version.sh enforces tag == version) and,
-#      on publish, the crates.io workflow (.github/workflows/publish-crates.yaml).
-
-# 4. Fast-forward dev onto main, then bump dev to the next dev version.
-git switch dev && git merge --ff-only main
-#    edit versions to the next target (e.g. X.Y.(Z+1)) and commit + push
+# 2. Draft a GitHub Release: tag = vX.Y.Z targeting main, write the changelog,
+#    Publish. Creating the release creates the tag and triggers:
+#      - tag CI: scripts/check-release-tag-version.sh enforces tag == manifest
+#        version, builds the release binaries, and uploads them to the release.
+#      - the crates.io workflow (.github/workflows/publish-crates.yaml), which
+#        publishes kache-core then kache in dependency order.
 ```
 
-The fast-forward in step 4 matters: it makes `main` an ancestor of `dev`, so the
-next `dev → main` promotion is a clean fast-forward instead of conflicting.
-
-Invariant: **`main` reads the last released number (tagged); `dev` always reads
-a number *higher* than the last release (untagged).**
+The version is bumped *in* the release PR, so `main` advertises a number only
+once the commit that carries it is on the trunk. Tag CI re-validates the exact
+tagged commit before any binaries or crates go out.
 
 ### Publishing to crates.io
 


### PR DESCRIPTION
First follow-up after moving to the trunk-based (Plan A) model. Two focused changes:

## `ci`: drop redundant nix build from the crates publish job
`publish-crates.yaml` rebuilt `nix build .#kache` right before publishing — but the CI `nix-package` job already runs that exact build on the tagged commit. It only added ~8 min and an extra dependency on the Determinate/FlakeHub installer (the source of the `FlakeHub Login failure` warning in the 0.4.0 cut) ahead of the irreversible crates.io publish. Keeps the cheap `nix eval` version-match gate, which is what actually guards against tag/manifest drift.

## `docs(contributing)`: switch to trunk-based model
PRs now target `main`; releases are tagged directly on `main`. Replaces the `dev` / `main` / `release-branch` GitFlow section and the `ff-dev-onto-main` + version-invariant dance with a single-trunk flow, matching the now-retired `dev` branch.

## Not in this PR (deliberate)
The RC / dry-run release rehearsal — that lands in its own change so the CONTRIBUTING release section never documents CI that doesn't exist yet.