### PR TITLE
ci: run e2e on self-hosted Windows runners (#77)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,12 +141,13 @@ jobs:
           - os: macOS
             runner: ${{ (github.repository_owner == 'kunobi-ninja' && github.event.pull_request.head.repo.fork != true) && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
             exe_suffix: ""
-          # Self-hosted Windows runners (org-level, group `zondax`). No
-          # fork-fallback expression like macOS: these are internal runners and
-          # the Windows e2e is internal (#77); a fork PR simply can't reach them.
-          # Blocking — Windows is a supported platform once green.
+          # Self-hosted Windows runner shared with this repo (kunobi org,
+          # group `kunobi`, label `kunobi-windows`). No fork-fallback expression
+          # like macOS: it's an internal runner and the Windows e2e is internal
+          # (#77); a fork PR simply can't reach it. Blocking — Windows is a
+          # supported platform once green.
           - os: Windows
-            runner: ${{ fromJSON('["self-hosted", "Windows", "X64", "zondax-windows"]') }}
+            runner: ${{ fromJSON('["self-hosted", "Windows", "X64", "kunobi-windows"]') }}
             exe_suffix: ".exe"
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,12 +116,20 @@ jobs:
   e2e:
     name: E2E smoke (${{ matrix.os }})
     runs-on: ${{ matrix.runner }}
+    # Run every step through bash on all three OSes. On Windows the bash comes
+    # from Git for Windows (already present — checkout needs git), so the shared
+    # step bodies below run identically everywhere. `exe_suffix` (matrix) is the
+    # only build-output difference: Windows binaries are `.exe`.
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: Linux
             runner: ubuntu-latest
+            exe_suffix: ""
           # Use the self-hosted Apple Silicon runners only inside
           # kunobi-ninja and not for fork PRs; otherwise fall back to a
           # GitHub-hosted runner (a fork cannot reach our runners, so a
@@ -132,14 +140,45 @@ jobs:
           # setting, which is the actual boundary.
           - os: macOS
             runner: ${{ (github.repository_owner == 'kunobi-ninja' && github.event.pull_request.head.repo.fork != true) && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
+            exe_suffix: ""
+          # Self-hosted Windows runners (org-level, group `zondax`). No
+          # fork-fallback expression like macOS: these are internal runners and
+          # the Windows e2e is internal (#77); a fork PR simply can't reach them.
+          # Blocking — Windows is a supported platform once green.
+          - os: Windows
+            runner: ${{ fromJSON('["self-hosted", "Windows", "X64", "zondax-windows"]') }}
+            exe_suffix: ".exe"
     steps:
       - uses: actions/checkout@v6
+      # Fail fast with an explicit checklist if the self-hosted Windows runner
+      # is missing a build/fixture tool, instead of an opaque failure deep in
+      # the cargo build or a fixture's `make`. Mirrors the verification step in
+      # ans-runners/tasks/setup_windows.yml — keep the two tool lists in sync.
+      #   cc/c++/make  -> C/C++ fixtures (harness sets CC="$KACHE cc")
+      #   nasm/perl/cmake -> kache build (ring + aws-lc-sys); MSVC link.exe
+      #   presence is proven by a successful `cargo build`.
+      - name: Verify Windows build toolchain
+        if: runner.os == 'Windows'
+        run: |
+          missing=
+          for t in cc c++ make nasm perl cmake; do
+            if ! command -v "$t" >/dev/null 2>&1; then
+              echo "MISSING on runner PATH: $t — provision it (see ans-runners/tasks/setup_windows.yml)"
+              missing=1
+            fi
+          done
+          [ -z "$missing" ] || exit 1
+          echo "all build/fixture tools present"
       # Point tool state at the per-run temp dir before installing.
       # The self-hosted macOS runners are persistent; shared ~/.rustup and
       # ~/.local/share/mise state has gone stale before and made mise try to
       # uninstall a missing rustup toolchain. Keep Rust and mise installs
       # disposable per job so runner drift cannot poison future runs.
+      # Windows-only skip: this is a macOS-runner workaround (corrupted
+      # ~/.rustup / stale Homebrew Rust) and relies on bash globbing of Windows
+      # paths; the fresh Windows runners let mise manage state directly.
       - name: Isolate tool state
+        if: runner.os != 'Windows'
         run: |
           mkdir -p \
             "$RUNNER_TEMP/rustup" \
@@ -181,7 +220,11 @@ jobs:
       # runner with a pre-existing rustup it leaves no cargo proxy on PATH —
       # so the stale system Rust (Homebrew 1.94) would win. Prepend the
       # toolchain's own bin dir (the real 1.95 binaries) to PATH instead.
+      # macOS-runner workaround (see "Isolate tool state"): skipped on Windows,
+      # where mise-action puts cargo on PATH directly and there is no competing
+      # system Rust to shadow it.
       - name: Put the Rust toolchain first on PATH
+        if: runner.os != 'Windows'
         run: |
           bin_dir=$(echo "$RUSTUP_HOME"/toolchains/*/bin)
           if [ ! -x "$bin_dir/cargo" ]; then
@@ -204,8 +247,8 @@ jobs:
         # results.json. Replaces the previous per-language bash scripts.
         run: |
           mkdir -p tmp/e2e
-          ./target/release/kache-e2e \
-            --kache ./target/release/kache \
+          ./target/release/kache-e2e${{ matrix.exe_suffix }} \
+            --kache ./target/release/kache${{ matrix.exe_suffix }} \
             --fixtures ./test-projects \
             --out tmp/e2e/results.json
       - name: Run e2e negative-control (falsifiability check)
@@ -215,10 +258,10 @@ jobs:
         # actually exercise caching. Independent signal; `always()` so
         # it runs even when the harness run above failed, as long as
         # the build produced the binaries.
-        if: always() && hashFiles('target/release/kache-e2e') != ''
+        if: always() && hashFiles(format('target/release/kache-e2e{0}', matrix.exe_suffix)) != ''
         run: |
-          ./target/release/kache-e2e \
-            --kache ./target/release/kache \
+          ./target/release/kache-e2e${{ matrix.exe_suffix }} \
+            --kache ./target/release/kache${{ matrix.exe_suffix }} \
             --fixtures ./test-projects \
             --negative-control \
             --out tmp/e2e/negative-control.json
@@ -230,8 +273,8 @@ jobs:
         # sccache, asserting the rebuild is an sccache cache hit.
         # Independent signal; `always()` so it runs even if the
         # harness step above failed.
-        if: always() && hashFiles('target/release/kache') != ''
-        run: ./scripts/sccache-fallback-check.sh ./target/release/kache
+        if: always() && hashFiles(format('target/release/kache{0}', matrix.exe_suffix)) != ''
+        run: ./scripts/sccache-fallback-check.sh ./target/release/kache${{ matrix.exe_suffix }}
       - name: Show aggregated e2e results
         if: always()
         run: |
@@ -325,20 +368,6 @@ jobs:
         timeout-minutes: 30
         env:
           RUSTC_WRAPPER: ""
-
-  # --- Windows exploratory check (non-blocking) ---
-  # Surfaces remaining Windows porting work for issue #45. Allowed to fail
-  # until the daemon (UnixStream/UnixListener), wrapper flock, and other
-  # unix-only paths get Windows arms. Remove `continue-on-error` once green.
-  windows-check:
-    name: Windows check (exploratory)
-    runs-on: windows-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - name: cargo check (x86_64-pc-windows-msvc)
-        run: cargo check --target x86_64-pc-windows-msvc
 
   # --- Release (only on v* tags) ---
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,12 @@ jobs:
   e2e:
     name: E2E smoke (${{ matrix.os }})
     runs-on: ${{ matrix.runner }}
+    # Windows is non-blocking for now: the runner + harness work, but kache's
+    # Windows port is incomplete, so most fixtures still fail — the cache store
+    # ("flushing blob to disk", #196), the `.sh` fallback wrappers (#197), and
+    # the rust-c-ffi cc-rs path (#198). Keep it running for signal; flip to
+    # blocking once those land. Linux/macOS stay blocking.
+    continue-on-error: ${{ matrix.os == 'Windows' }}
     # Run every step through bash on all three OSes. On Windows the bash comes
     # from Git for Windows (already present — checkout needs git), so the shared
     # step bodies below run identically everywhere. `exe_suffix` (matrix) is the
@@ -144,8 +150,8 @@ jobs:
           # Self-hosted Windows runner shared with this repo (kunobi org,
           # group `kunobi`, label `kunobi-windows`). No fork-fallback expression
           # like macOS: it's an internal runner and the Windows e2e is internal
-          # (#77); a fork PR simply can't reach it. Blocking — Windows is a
-          # supported platform once green.
+          # (#77); a fork PR simply can't reach it. Non-blocking for now (see the
+          # job-level continue-on-error note).
           - os: Windows
             runner: ${{ fromJSON('["self-hosted", "Windows", "X64", "kunobi-windows"]') }}
             exe_suffix: ".exe"

--- a/crates/kache-e2e/src/bin/kache-e2e.rs
+++ b/crates/kache-e2e/src/bin/kache-e2e.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use kache_e2e::fixture;
+use kache_e2e::portable_path;
 use kache_e2e::result::{FixtureResult, RunResults};
 use kache_e2e::runner;
 
@@ -54,10 +55,16 @@ struct Args {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    let kache_path = args
-        .kache
-        .canonicalize()
-        .with_context(|| format!("kache binary not found at {}", args.kache.display()))?;
+    // Normalize so the path is safe both to invoke directly and to embed in
+    // the fixtures' shell-driven `$KACHE` commands (see `portable_path`): on
+    // Windows `canonicalize` yields a `\\?\` verbatim, backslash path that
+    // make's `sh` mangles.
+    let kache_path = portable_path(
+        &args
+            .kache
+            .canonicalize()
+            .with_context(|| format!("kache binary not found at {}", args.kache.display()))?,
+    );
 
     let kache_version_out = Command::new(&kache_path)
         .arg("--version")
@@ -71,10 +78,12 @@ fn main() -> Result<()> {
     eprintln!("Binary:  {}", kache_path.display());
     eprintln!("Version: {kache_version}");
 
-    let fixtures_dir = args
-        .fixtures
-        .canonicalize()
-        .with_context(|| format!("fixtures dir not found at {}", args.fixtures.display()))?;
+    let fixtures_dir = portable_path(
+        &args
+            .fixtures
+            .canonicalize()
+            .with_context(|| format!("fixtures dir not found at {}", args.fixtures.display()))?,
+    );
     let mut fixtures = fixture::discover(&fixtures_dir, &kache_path)?;
 
     if let Some(filter) = &args.only {

--- a/crates/kache-e2e/src/fixture.rs
+++ b/crates/kache-e2e/src/fixture.rs
@@ -330,9 +330,13 @@ impl Fixture {
             *value = expand_kache(value, kache_path);
         }
 
-        fixture.dir = dir
-            .canonicalize()
-            .with_context(|| format!("canonicalize {}", dir.display()))?;
+        // Normalize so the dir is safe as a `cp -R <dir>/.` source (MSYS
+        // coreutils) and as a working directory on Windows — see
+        // `crate::portable_path`.
+        fixture.dir = crate::portable_path(
+            &dir.canonicalize()
+                .with_context(|| format!("canonicalize {}", dir.display()))?,
+        );
         Ok(fixture)
     }
 }

--- a/crates/kache-e2e/src/lib.rs
+++ b/crates/kache-e2e/src/lib.rs
@@ -17,3 +17,58 @@ pub mod fixture;
 pub mod report;
 pub mod result;
 pub mod runner;
+
+use std::path::{Path, PathBuf};
+
+/// Make a canonicalized path safe to embed in the shell commands the harness
+/// drives (fixture `make` recipes via `/usr/bin/sh`, `cp -R` via MSYS
+/// coreutils) and to invoke directly as a program.
+///
+/// On Windows, [`std::fs::canonicalize`] returns an extended-length *verbatim*
+/// path (`\\?\C:\...`) with backslash separators. Backslashes are escape
+/// characters to a POSIX `sh`, so `\\?\C:\foo\kache.exe` reaching make's shell
+/// collapses to `?C:fookache.exe` ("command not found"). Stripping the `\\?\`
+/// prefix and switching to forward slashes yields a form that Windows APIs and
+/// `sh`/MSYS tools both accept.
+///
+/// No-op on Unix, where `\` is a legal byte in a filename and must be preserved.
+pub fn portable_path(p: &Path) -> PathBuf {
+    if cfg!(windows) {
+        PathBuf::from(to_portable_str(&p.to_string_lossy()))
+    } else {
+        p.to_path_buf()
+    }
+}
+
+/// String core of [`portable_path`]: drop a leading `\\?\` and replace `\`
+/// with `/`. Kept separate so it is testable on any host.
+fn to_portable_str(s: &str) -> String {
+    let s = s.strip_prefix(r"\\?\").unwrap_or(s);
+    s.replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_portable_str;
+
+    #[test]
+    fn strips_verbatim_prefix_and_flips_separators() {
+        assert_eq!(
+            to_portable_str(r"\\?\C:\actions-runner\_work\kache\target\release\kache.exe"),
+            "C:/actions-runner/_work/kache/target/release/kache.exe"
+        );
+    }
+
+    #[test]
+    fn flips_separators_without_verbatim_prefix() {
+        assert_eq!(to_portable_str(r"C:\tmp\fixture"), "C:/tmp/fixture");
+    }
+
+    #[test]
+    fn leaves_unix_style_paths_untouched() {
+        assert_eq!(
+            to_portable_str("/usr/local/bin/kache"),
+            "/usr/local/bin/kache"
+        );
+    }
+}


### PR DESCRIPTION
## What

Stands up the Windows half of #77: runs the e2e harness on the self-hosted `kunobi-windows` runner, and fixes the harness so it works on Windows. The PathNormalizer half of #77 already landed via #84.

**Windows is non-blocking for now** (`continue-on-error` on the Windows matrix arm) — the runner + harness work, but kache's Windows *port* is incomplete, so most fixtures still fail. The arm runs for signal; flip to blocking once the core gaps land. Linux/macOS stay blocking.

## Changes

**`.github/workflows/ci.yml`**
- Windows arm on the `e2e` matrix → `["self-hosted","Windows","X64","kunobi-windows"]`, `continue-on-error` only on Windows.
- Job-level `shell: bash`; `exe_suffix` matrix var threads `.exe` through the harness call, negative-control (+ `hashFiles` guards), and sccache-fallback.
- Windows toolchain preflight (`cc/c++/make/nasm/perl/cmake`), kept in sync with `ans-runners/tasks/setup_windows.yml`.
- macOS-runner tool-state/PATH workarounds gated off Windows (mise manages state there).
- Removed the redundant exploratory `windows-check` job.

**`crates/kache-e2e` — `portable_path()`**
- `std::fs::canonicalize` yields `\\?\C:\...` verbatim/backslash paths on Windows; embedded in `$KACHE` (the fixtures' `CC`) and `cp -R`, they get mangled by make's `sh`/MSYS coreutils (`?C:...: command not found`, `cp: cannot stat`). `portable_path` strips `\\?\` and uses forward slashes (no-op on Unix). Applied to the kache binary, fixtures root, and each fixture dir. +3 unit tests.

## Status on the runner (validated)
- ✅ Provisioning preflight, mise, full `kache` source build (ring/aws-lc), and path handling all work on Windows.
- ✅ `c-passthrough`, `exclude-c`, `exclude-rust` pass.
- ❌ Remaining failures are kache's incomplete Windows port, now tracked:
  - **#196** — cache store fails (`flushing blob to disk`) → blocks every warm-hit fixture (dominant).
  - **#197** — `.sh` `KACHE_FALLBACK` wrappers can't exec (`rust-fallback`, `rust-sccache`).
  - **#198** — `rust-c-ffi` cc-rs on windows-msvc.

Relates to #77; surfaces #196, #197, #198.

**Closes #82** (run kache-e2e harness on Windows in CI — delivered here, non-blocking).