### PR TITLE
ci: gate publishes on green CI; pin floating tool versions

### DIFF
--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      actions: read # read CI job conclusions for the release commit (gate below)
     env:
       CARGO_TERM_COLOR: always
       RELEASE_TAG: ${{ github.event.release.tag_name }}
@@ -51,6 +52,17 @@ jobs:
             echo "Nix package version $nix_version does not match release tag $RELEASE_TAG" >&2
             exit 1
           fi
+
+      - name: Require CI green for this release commit
+        # Don't publish to crates.io unless the full CI suite passed for this
+        # exact commit. `release: published` can fire from a hand-drafted UI
+        # release before/independent of CI; the tag-push path is already gated
+        # by the release job's `needs`, but this closes the manual-release hole.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./scripts/require-ci-green.sh "$(git rev-parse HEAD)" \
+            "Check (Linux)" "Nix package" "E2E smoke (Linux)" "E2E smoke (macOS)" "Test (macOS)"
 
       - name: Package kache-core
         run: cargo package -p kache-core --locked

--- a/.github/workflows/service-image.yml
+++ b/.github/workflows/service-image.yml
@@ -42,8 +42,19 @@ jobs:
     if: github.event_name != 'pull_request'
     name: Build Service Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # read CI job conclusions for the pushed commit (gate below)
     steps:
       - uses: actions/checkout@v6
+
+      - name: Require CI green for this commit
+        # Don't push an image built from a commit whose CI hasn't passed. The
+        # `Check (Linux)` job runs the full `just ci` (which compiles
+        # kache-service), so it's the relevant gate for the image.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/require-ci-green.sh "$(git rev-parse HEAD)" "Check (Linux)"
 
       - uses: jdx/mise-action@v4
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,17 +96,25 @@ no `dev` branch.
 # 1. Bump the workspace version in a PR: edit Cargo.toml + crates/*/Cargo.toml
 #    version = "X.Y.Z", refresh Cargo.lock, `just check`. Merge it into main.
 
-# 2. Draft a GitHub Release: tag = vX.Y.Z targeting main, write the changelog,
-#    Publish. Creating the release creates the tag and triggers:
-#      - tag CI: scripts/check-release-tag-version.sh enforces tag == manifest
-#        version, builds the release binaries, and uploads them to the release.
-#      - the crates.io workflow (.github/workflows/publish-crates.yaml), which
-#        publishes kache-core then kache in dependency order.
+# 2. Push the tag — let CI create the release. Do NOT draft the release by
+#    hand in the UI (see note below).
+git tag vX.Y.Z && git push origin vX.Y.Z
+#    The tag triggers CI; once check + nix + e2e + macOS tests pass, the
+#    release job builds the binaries and creates the GitHub Release. Publishing
+#    the release then triggers the crates.io workflow
+#    (.github/workflows/publish-crates.yaml), which publishes kache-core then
+#    kache in dependency order.
 ```
 
 The version is bumped *in* the release PR, so `main` advertises a number only
-once the commit that carries it is on the trunk. Tag CI re-validates the exact
-tagged commit before any binaries or crates go out.
+once the commit that carries it is on the trunk.
+
+**Why push the tag instead of drafting in the UI:** the release job only runs
+after the full CI suite passes, so a CI-created release is gated on green CI. A
+hand-drafted release fires `release: published` immediately, racing CI. As a
+safety net the publish job re-checks (`scripts/require-ci-green.sh`) that CI
+passed for the tagged commit and refuses to publish otherwise — but pushing the
+tag is the intended, friction-free path.
 
 ### Publishing to crates.io
 

--- a/mise.toml
+++ b/mise.toml
@@ -6,13 +6,16 @@ idiomatic_version_file_enable_tools = ["rust"]
 [tools]
 rust = { version = "latest", components = "rustfmt,clippy" }
 "github:casey/just" = "1.43.1"
-helm = "latest"
+# Versions are pinned (not `latest`) so a tool release can't break CI with no
+# code change. Bump deliberately. (rust is intentionally left to
+# rust-toolchain.toml via idiomatic_version_file_enable_tools above.)
+helm = "4.2.0"
 # Test-coverage + sccache fallback. Listed here (not as separate
 # CI install actions) so the same `mise install` populates every
 # tool the repo needs.
-"github:taiki-e/cargo-llvm-cov" = "latest"
-"github:mozilla/sccache" = "latest"
+"github:taiki-e/cargo-llvm-cov" = "0.8.7"
+"github:mozilla/sccache" = "0.15.0"
 # Dependency vulnerability auditing — `just audit`. The `cargo:`
 # backend compiles from source (no prebuilt GitHub release matches
 # cargo-audit cleanly because rustsec/rustsec is a monorepo).
-"cargo:cargo-audit" = "latest"
+"cargo:cargo-audit" = "0.22.1"

--- a/scripts/require-ci-green.sh
+++ b/scripts/require-ci-green.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Require that the named CI jobs concluded `success` for a given commit before
+# proceeding. Used to gate irreversible publishes (crates.io, container image)
+# on the CI suite, regardless of how the release/tag/push was created — e.g. a
+# release drafted by hand in the UI fires `release: published` immediately and
+# would otherwise publish in parallel with (or ahead of) CI.
+#
+# Usage: require-ci-green.sh <commit-sha> <job-name>...
+# Env:   GH_TOKEN, GITHUB_REPOSITORY (both set automatically in Actions).
+#
+# Exit: 0 when every named job is completed+success; 1 if any failed or on
+# timeout; 2 on usage error. Fails closed on purpose — a publish must not
+# proceed on an indeterminate CI state.
+set -euo pipefail
+
+sha="${1:-}"
+[ -n "$sha" ] || { echo "usage: require-ci-green.sh <sha> <job>..." >&2; exit 2; }
+shift
+[ "$#" -ge 1 ] || { echo "at least one required job name needed" >&2; exit 2; }
+required=("$@")
+: "${GH_TOKEN:?GH_TOKEN required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
+repo="$GITHUB_REPOSITORY"
+
+interval="${CI_GREEN_INTERVAL:-30}"
+max_attempts="${CI_GREEN_MAX_ATTEMPTS:-80}" # ~40 min ceiling; `Check` is ~15 min
+
+echo "Gating on CI for $sha — required jobs: ${required[*]}"
+
+for attempt in $(seq 1 "$max_attempts"); do
+  run_id="$(gh run list --repo "$repo" --commit "$sha" --workflow CI \
+              --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
+  if [ -z "${run_id:-}" ] || [ "$run_id" = "null" ]; then
+    echo "[$attempt/$max_attempts] no CI run for $sha yet; waiting ${interval}s"
+    sleep "$interval"; continue
+  fi
+
+  jobs="$(gh api "repos/$repo/actions/runs/$run_id/jobs?per_page=100")"
+
+  failed=(); pending=(); ok=()
+  for name in "${required[@]}"; do
+    obj="$(jq -c --arg n "$name" '.jobs[] | select(.name == $n)' <<<"$jobs" | head -1)"
+    if [ -z "$obj" ]; then pending+=("$name (not started)"); continue; fi
+    status="$(jq -r '.status' <<<"$obj")"
+    concl="$(jq -r '.conclusion' <<<"$obj")"
+    if [ "$status" != "completed" ]; then pending+=("$name ($status)"); continue; fi
+    if [ "$concl" = "success" ]; then ok+=("$name"); else failed+=("$name ($concl)"); fi
+  done
+
+  if [ "${#failed[@]}" -gt 0 ]; then
+    echo "required CI job(s) did not pass for $sha: ${failed[*]}" >&2
+    exit 1
+  fi
+  if [ "${#pending[@]}" -eq 0 ]; then
+    echo "all required CI jobs green for $sha: ${ok[*]}"
+    exit 0
+  fi
+  echo "[$attempt/$max_attempts] waiting on: ${pending[*]}"
+  sleep "$interval"
+done
+
+echo "timed out after $((max_attempts * interval))s waiting for CI green on $sha" >&2
+exit 1


### PR DESCRIPTION
Closes the three remaining items from the CI review.

## 1. crates.io publish was bypassable by a hand-drafted release
`publish-crates.yaml` fires on `release: published`. A release drafted in the UI fires that event immediately, racing (or skipping) CI — the tag-push path is gated by the release job's `needs`, but the manual path wasn't.

- New **`scripts/require-ci-green.sh`**: polls the CI run for the release commit and exits non-zero unless every required job (`Check (Linux)`, `Nix package`, `E2E smoke (Linux)`, `E2E smoke (macOS)`, `Test (macOS)`) concluded `success`. **Fails closed.**
- `publish-crates` calls it before packaging/publishing. In the canonical push-the-tag flow those jobs are already green (the release job needed them), so it passes immediately; in the UI-draft flow it waits for / enforces CI.
- **CONTRIBUTING** now documents *push the tag → CI creates the release* as the canonical flow, instead of the UI-draft flow that races CI.

## 2. service-image Docker push was ungated on CI
Same guard on the `release` job, requiring `Check (Linux)` (which runs the full `just ci` that compiles `kache-service`) before pushing the image.

## 3. mise.toml tools floated on `latest`
`helm`, `cargo-llvm-cov`, `sccache`, `cargo-audit` were `latest` — a tool release could break CI with zero code change. Pinned to current versions (freezes today's resolution; no behavior change). `rust` stays sourced from `rust-toolchain.toml`.

Both workflows gain `actions: read` to query CI job conclusions.

### Note on the gate's first run
`require-ci-green.sh` resolves job names against `ci.yml`; if those display names change, update the call sites. The guard adds a short poll to the publish/image paths (immediate when CI is already green).