### PR TITLE
fix(store): open blobs writable for fsync on Windows (#196)

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -12,10 +12,21 @@ use crate::config::Config;
 static BLOB_TMP_NONCE: AtomicU64 = AtomicU64::new(0);
 
 /// fsync a file so its bytes are durable on disk before we rename it into the
-/// content-addressed store or reference it from a committed entry. Opening
-/// read-only is sufficient for `fsync(2)`.
+/// content-addressed store or reference it from a committed entry.
+///
+/// On Unix, `fsync(2)` works on a read-only fd, so we keep opening read-only —
+/// byte-identical to before, and it even flushes files that are already
+/// read-only. On Windows, `sync_all` maps to `FlushFileBuffers`, which requires
+/// a handle with *write* access and fails with `ERROR_ACCESS_DENIED` on a
+/// read-only handle (#196) — so open writable there. Every caller fsyncs
+/// *before* `set_blob_readonly`, so the file is writable on Windows;
+/// `write(true)` does not truncate.
 fn fsync_file(path: &Path) -> std::io::Result<()> {
-    fs::File::open(path)?.sync_all()
+    #[cfg(windows)]
+    let file = fs::OpenOptions::new().write(true).open(path)?;
+    #[cfg(not(windows))]
+    let file = fs::File::open(path)?;
+    file.sync_all()
 }
 
 /// A unique temp path beside the destination blob. Concurrent writers of the
@@ -1300,6 +1311,20 @@ pub struct EntryInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Regression guard for #196: `fsync_file` must durably flush a freshly
+    // written (writable) file. The bug was a read-only handle — fine for Unix
+    // `fsync(2)`, but Windows `FlushFileBuffers` rejects it with
+    // ERROR_ACCESS_DENIED, so every blob store failed ("flushing blob to disk").
+    // Passes on Unix before and after; the real failing→passing signal is on
+    // Windows, where the old read-only-handle form errored here.
+    #[test]
+    fn fsync_file_flushes_a_writable_blob() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob = dir.path().join("blob.bin");
+        fs::write(&blob, b"some bytes").unwrap();
+        fsync_file(&blob).expect("fsync of a writable file must succeed on all platforms");
+    }
 
     fn test_config(dir: &Path) -> Config {
         Config {


### PR DESCRIPTION
Rebased onto `main` after #194 — now contains **only** the #196 cache-store fix.

## Root cause
`src/store.rs` `fsync_file` opened blobs **read-only** (`fs::File::open`) before `sync_all`. Unix `fsync(2)` is fine with a read-only fd, but on Windows `sync_all` maps to `FlushFileBuffers`, which needs a handle with **write** access and fails `ERROR_ACCESS_DENIED` on a read-only one — so every blob flush failed (`flushing blob to disk`), nothing was stored, and the Windows e2e saw **0 warm-cache hits** across ~9 fixtures.

## Fix
Open writable on **Windows only**; keep the read-only open on Unix (byte-identical, and still flushes already-read-only files). Every caller fsyncs before `set_blob_readonly`, so the file is writable on Windows. `write(true)` does not truncate. Adds a cross-platform regression test.

## Validation
The Windows e2e arm (in `main` since #194, non-blocking) should flip the store-dependent fixtures fail→pass: `c-hello`, `cpp-hello`, `c-depinfo`, `multi-dep`, `rust-check`, `rust-debug`, `rust-workspace`, `manifest-dir-runtime-workspace`, `out-dir-runtime`. `rust-fallback`/`rust-sccache`/`rust-c-ffi` still fail (#197/#198, next).

Fixes #196.