### PR TITLE
fix(probe): exclude volatile env pseudo-vars from probe key (#201)

### DIFF
--- a/src/probe/cache.rs
+++ b/src/probe/cache.rs
@@ -50,8 +50,7 @@ pub fn probe_key(prober_id: &str, req: &ProbeRequest<'_>) -> Option<String> {
     Some(h.finalize().to_hex().to_string())
 }
 
-/// Hash of the process environment — every `VAR=value` pair, sorted
-/// for determinism.
+/// Hash of the process environment — see [`fingerprint_env`].
 ///
 /// `cc -###` inherits this environment, so a change to it (a different
 /// `SDKROOT`, `CPATH`, …) can change the resolved invocation. Hashing
@@ -59,7 +58,15 @@ pub fn probe_key(prober_id: &str, req: &ProbeRequest<'_>) -> Option<String> {
 /// change at worst forces one extra, cheap re-probe, while a relevant
 /// one can never be served a stale record.
 fn env_fingerprint() -> String {
-    let mut vars: Vec<(String, String)> = std::env::vars().collect();
+    fingerprint_env(std::env::vars())
+}
+
+/// Hash every `VAR=value` pair in `vars`, sorted for determinism, after
+/// dropping the volatile pseudo-variables [`is_volatile_env_name`]
+/// rejects. Split from [`env_fingerprint`] so the filtering is testable
+/// without mutating the real process environment.
+fn fingerprint_env(vars: impl Iterator<Item = (String, String)>) -> String {
+    let mut vars: Vec<(String, String)> = vars.filter(|(k, _)| !is_volatile_env_name(k)).collect();
     vars.sort();
     let mut h = blake3::Hasher::new();
     for (k, v) in vars {
@@ -69,6 +76,21 @@ fn env_fingerprint() -> String {
         h.update(b"\n");
     }
     h.finalize().to_hex().to_string()
+}
+
+/// True for environment-variable names that vary between otherwise
+/// identical build invocations and so must stay out of the probe key.
+///
+/// Windows' process environment carries hidden cmd.exe bookkeeping
+/// variables whose names begin with `=`: the per-drive working directory
+/// (`=C:`, `=D:`, …) and the previous child's exit status (`=ExitCode`).
+/// `std::env::vars()` surfaces them, yet they are never inputs to
+/// `cc -###` and they shift between the cold and warm builds — which made
+/// the on-disk probe memo miss on the warm build, re-running the probe
+/// (#201). A Unix variable name cannot contain `=`, so this never fires
+/// there.
+fn is_volatile_env_name(name: &str) -> bool {
+    name.starts_with('=')
 }
 
 /// Load a probe record by key, or `None` on any miss: file absent,
@@ -166,6 +188,54 @@ mod tests {
             args: &[],
             key_args: &[],
         }
+    }
+
+    #[test]
+    fn fingerprint_env_ignores_windows_hidden_pseudo_vars() {
+        // The #201 root cause: on Windows `std::env::vars()` yields
+        // cmd.exe's volatile `=`-prefixed vars (per-drive CWD `=C:`, last
+        // child's `=ExitCode`). They differ between the cold and warm
+        // builds, so including them made the probe key — and thus the
+        // memo — unstable. Adding them must not change the fingerprint.
+        let real = [
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            ("SDKROOT".to_string(), "/sdk".to_string()),
+        ];
+        let with_hidden = [
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            ("SDKROOT".to_string(), "/sdk".to_string()),
+            ("=C:".to_string(), r"C:\work\cold".to_string()),
+            ("=ExitCode".to_string(), "00000000".to_string()),
+        ];
+        assert_eq!(
+            fingerprint_env(real.iter().cloned()),
+            fingerprint_env(with_hidden.iter().cloned()),
+            "`=`-prefixed Windows pseudo-vars must not affect the probe key"
+        );
+    }
+
+    #[test]
+    fn fingerprint_env_still_reflects_real_vars() {
+        // The filter must not blunt the key: a genuine env change (a
+        // different SDKROOT, which `cc -###` honors) must still move it.
+        let a = [("SDKROOT".to_string(), "/sdk/a".to_string())];
+        let b = [("SDKROOT".to_string(), "/sdk/b".to_string())];
+        assert_ne!(
+            fingerprint_env(a.iter().cloned()),
+            fingerprint_env(b.iter().cloned()),
+            "a real env change must still change the fingerprint"
+        );
+    }
+
+    #[test]
+    fn is_volatile_env_name_flags_only_equals_prefixed() {
+        assert!(is_volatile_env_name("=C:"));
+        assert!(is_volatile_env_name("=ExitCode"));
+        assert!(!is_volatile_env_name("PATH"));
+        assert!(!is_volatile_env_name("SDKROOT"));
+        // A normal name that merely contains `=` later cannot occur, but
+        // guard the boundary: only a leading `=` is volatile.
+        assert!(!is_volatile_env_name("A=B"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #201.

## Problem
On the Windows e2e arm (#82) the compiler-probe memo missed on the **warm** build, re-running the probe — `probe_runs = 1` where `c-hello` / `c-depinfo` assert `max_probe_runs = 0`:

```
{"name": "max_probe_runs", "expected": "<= 0", "actual": "1", "passed": false}
```

Everything else on that phase passed (compile `local_hit`, `compiler_runs: 0`, diff byte-identical, verify ok) — only the probe memo failed to hit. Not a #196 regression.

## Root cause
The probe key (`src/probe/cache.rs::probe_key`) mixes in `env_fingerprint()`, which hashes the **entire** process environment. On Windows `std::env::vars()` surfaces cmd.exe's hidden `=`-prefixed pseudo-variables:
- `=C:`, `=D:`, … — the per-drive current working directory
- `=ExitCode` — the previous child process's exit status

These shift between the cold and warm `make` invocations, so the probe key differed across builds and the warm `load()` looked up a `{key}.json` that cold never wrote → miss → re-probe.

This is Windows-only because Unix variable names cannot contain `=`. It breaks *only* the probe memo (not the compile cache) because the main cache key (`cache_key.rs`) hashes only a curated env subset (`RUSTFLAGS`, `CARGO_ENCODED_RUSTFLAGS`, `CARGO_CFG_*`) — which stays stable — exactly matching the observed "compile hits, probe re-runs".

## Fix
Filter `=`-prefixed names out of the env fingerprint. Refactored the hashing into a pure `fingerprint_env` core (+ `is_volatile_env_name` predicate) so the filtering is unit-testable without mutating the real environment. No-op on Unix.

## Tests
Added 3 regression tests (`fingerprint_env_ignores_windows_hidden_pseudo_vars`, `fingerprint_env_still_reflects_real_vars`, `is_volatile_env_name_flags_only_equals_prefixed`). `cargo fmt`, `cargo clippy --all-targets`, and `cargo test -p kache` (626 passed) all green locally.

Validation: the Windows e2e arm (non-blocking, self-hosted `kunobi-windows` runner) on this PR's CI run should now show `c-hello` / `c-depinfo` warm with `probe_runs = 0`.