### PR TITLE
ci: isolate tool state on the Windows e2e arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,16 +179,14 @@ jobs:
           done
           [ -z "$missing" ] || exit 1
           echo "all build/fixture tools present"
-      # Point tool state at the per-run temp dir before installing.
-      # The self-hosted macOS runners are persistent; shared ~/.rustup and
-      # ~/.local/share/mise state has gone stale before and made mise try to
-      # uninstall a missing rustup toolchain. Keep Rust and mise installs
-      # disposable per job so runner drift cannot poison future runs.
-      # Windows-only skip: this is a macOS-runner workaround (corrupted
-      # ~/.rustup / stale Homebrew Rust) and relies on bash globbing of Windows
-      # paths; the fresh Windows runners let mise manage state directly.
+      # Point tool state at the per-run temp dir before installing. All the
+      # self-hosted runners (macOS AND Windows) are persistent: shared rustup /
+      # mise state goes stale and makes `mise --force rust` try to remove a
+      # locked toolchain dir (`Access is denied (os error 5)` on Windows), and
+      # `rustup target add` against a shared toolchain poisons every later job.
+      # Keep Rust + mise installs disposable per job so one run can't break the
+      # next. Runs everywhere via `shell: bash` (Git Bash on Windows).
       - name: Isolate tool state
-        if: runner.os != 'Windows'
         run: |
           mkdir -p \
             "$RUNNER_TEMP/rustup" \


### PR DESCRIPTION
Small, standalone fix to unbreak Windows CI.

The Windows self-hosted runner is persistent, like the macOS ones, but the e2e arm wasn't isolating tool state on Windows (only macOS). Without it:
- `mise --force rust` tries to remove the shared toolchain dir and fails — `could not remove '…\.rustup\toolchains\1.96.0-x86_64-pc-windows-msvc': Access is denied (os error 5)`;
- and `rustup target add` against the shared toolchain poisons the host build for every later job (`can't find crate for std`).

This runs the existing tool-state isolation (`RUSTUP_HOME`/`CARGO_HOME`/`MISE_*` → `RUNNER_TEMP`) on **all** OSes, not just macOS — so every Windows run uses a disposable per-run toolchain and can't corrupt the shared runner. The macOS-only `Put the Rust toolchain first on PATH` step stays Windows-skipped (mise shims provide cargo there).

One-line `if:` removal + comment. No behaviour change on Linux/macOS (they already ran this step). Merging this heals the shared Windows runner for all open PRs.

Relates to #82 / #45.