### PR TITLE
ci: e2e reliability — per-arm artifact names (#203) + job timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,10 +313,14 @@ jobs:
             echo "no results.json produced"
           fi
       - name: Upload e2e results artifact
-        # Artifact name kept as `e2e-results` (the GitHub-facing label) so
-        # historical-run links stay valid; the path it uploads from moved
-        # to `tmp/e2e/` per the repo-wide scratch-under-tmp convention
-        # (see .gitignore comment).
+        # Per-arm artifact name (#203): with upload-artifact@v4+ an artifact
+        # name is unique per run, so all three matrix arms uploading the same
+        # `e2e-results` collide — `gh run download -n e2e-results` then returns
+        # an arbitrary arm's results and the others are lost (this masked the
+        # real Windows results.json while debugging #196). `${{ matrix.os }}`
+        # keeps each arm's results.json + negative-control.json separate.
+        # The path moved to `tmp/e2e/` per the repo-wide scratch-under-tmp
+        # convention (see .gitignore comment).
         #
         # Skipped on tag/release runs for the same reason as the coverage
         # artifact: the shared release workflow's `gh release upload
@@ -324,7 +328,7 @@ jobs:
         if: always() && github.ref_type != 'tag'
         uses: actions/upload-artifact@v7
         with:
-          name: e2e-results
+          name: e2e-results-${{ matrix.os }}
           path: tmp/e2e/
           retention-days: 14
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
   check:
     name: Check (${{ matrix.os }})
     runs-on: ${{ matrix.runner }}
+    # Job-level cap so a hang in checkout/mise/build is killed in minutes, not
+    # the 6h GitHub default — the step-level timeouts below only guard their own
+    # steps. (`just ci` itself is additionally capped at 30m.)
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -92,6 +96,7 @@ jobs:
   nix-package:
     name: Nix package
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v22
@@ -119,6 +124,10 @@ jobs:
   e2e:
     name: E2E smoke (${{ matrix.os }})
     runs-on: ${{ matrix.runner }}
+    # Per-arm cap. The self-hosted macOS/Windows runners are persistent and have
+    # hung in `checkout` on stale git refs (#208 run hung ~51m before manual
+    # cancel); without a job timeout the default is 6h. Normal runs are <10m.
+    timeout-minutes: 30
     # Windows is non-blocking for now: the runner + harness work, but kache's
     # Windows port is incomplete, so most fixtures still fail — the cache store
     # ("flushing blob to disk", #196), the `.sh` fallback wrappers (#197), and
@@ -160,6 +169,10 @@ jobs:
             exe_suffix: ".exe"
     steps:
       - uses: actions/checkout@v6
+        # Checkout has hung on the persistent self-hosted runners' stale git
+        # state (#208); a checkout never legitimately runs this long, so fail
+        # fast rather than waiting out the whole job timeout.
+        timeout-minutes: 10
       # Fail fast with an explicit checklist if the self-hosted Windows runner
       # is missing a build/fixture tool, instead of an opaque failure deep in
       # the cargo build or a fixture's `make`. Mirrors the verification step in
@@ -346,8 +359,14 @@ jobs:
     # matching note on the `e2e` job; fork PRs are gated by the repo's
     # "require approval" Actions setting, not by this expression.
     runs-on: ${{ (github.repository_owner == 'kunobi-ninja' && github.event.pull_request.head.repo.fork != true) && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
+    # Job-level cap on the persistent self-hosted macOS runner (cargo test is
+    # additionally capped at 30m); catches checkout/mise hangs.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v6
+        # See the e2e job: checkout can hang on this persistent runner's stale
+        # git state, so cap it well under the job timeout.
+        timeout-minutes: 10
       # This persistent self-hosted runner has no usable shared toolchain:
       # its ~/.rustup is corrupted and its Homebrew Rust is stale (1.94,
       # below the pinned 1.95). Keep Rust and mise install/cache/state under


### PR DESCRIPTION
Fixes #203.

The `e2e` matrix's three arms (Linux/macOS/Windows) all uploaded their results under the same artifact name `e2e-results`. With `upload-artifact@v4+` an artifact name is unique per run, so the arms collide — `gh run download -n e2e-results` returns an arbitrary arm's results and the rest are lost. This masked the real Windows `results.json` while debugging #196.

**Fix:** name the artifact `e2e-results-${{ matrix.os }}` (as suggested in the issue), keeping each arm's `results.json` + `negative-control.json` separate.

No consumers reference the old name (only the upload step itself), so nothing downstream breaks.