### PR TITLE
report: show kache version in github report footer

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -1485,9 +1485,10 @@ pub fn format_github(report: &BuildReport) -> String {
     }
 
     lines.push(String::new());
-    lines.push(
-        "*Posted by [kache-action](https://github.com/kunobi-ninja/kache-action)*".to_string(),
-    );
+    lines.push(format!(
+        "*Posted by [kache-action](https://github.com/kunobi-ninja/kache-action) · kache v{}*",
+        report.meta.kache_version,
+    ));
 
     lines.join("\n")
 }


### PR DESCRIPTION
## What

Surface the kache version in the `kache report --format github` output. It was already collected in `ReportMeta.kache_version` but only appeared in JSON, never in the rendered job summary / PR comment.

The footer now reads:

> *Posted by [kache-action](…) · kache v0.4.1*

## Why

Makes it clear which kache binary produced a given report — useful when diagnosing report/format changes across versions.

## Notes

- Single-line change in `format_github()` ([src/report.rs](../blob/c/amazing-driscoll-a4d3e8/src/report.rs)). `cargo build` passes; no tests asserted on the footer string.
- Pairs with kunobi-ninja/kache-action PR that removes the duplicate "Kache Build Cache" heading in the job summary.