### PR TITLE
fix(key): key previously-unkeyed codegen inputs (--sysroot, -L/-l/-Z, --target spec); unify cache-key version; + config/robustness fixes

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -36,6 +36,22 @@ pub struct RustcArgs {
     pub extra_filename: Option<String>,
     /// Whether incremental compilation is enabled (-C incremental=...)
     pub incremental: Option<PathBuf>,
+    /// Sysroot override (`--sysroot <path>`). Selects which std/core/
+    /// proc-macro libs rustc links against, so it is codegen-relevant
+    /// and must be part of the key (normalized at key time).
+    pub sysroot: Option<PathBuf>,
+    /// Native library search paths (`-L [KIND=]PATH`). Stored raw (kind
+    /// prefix preserved); `compute_cache_key` path-normalizes the path
+    /// and skips cargo's redundant `dependency=`/`crate=` entries.
+    pub link_search: Vec<String>,
+    /// Native libraries to link (`-l [KIND[:MODIFIERS]=]NAME`). Build
+    /// scripts emit these via `cargo:rustc-link-lib`; they change a
+    /// linked artifact without going through RUSTFLAGS, so they must be
+    /// keyed. Machine-independent — hashed raw.
+    pub link_libs: Vec<String>,
+    /// Unstable `-Z` flags. Can change codegen (e.g. `-Zsanitizer`,
+    /// `-Zshare-generics`) and arrive on argv outside RUSTFLAGS.
+    pub unstable_flags: Vec<String>,
     /// Inner rustc path for double-wrapper case (RUSTC_WRAPPER + RUSTC_WORKSPACE_WRAPPER).
     /// When both wrappers are active, cargo passes: wrapper workspace_wrapper rustc <args>.
     /// This field holds the rustc path that the workspace wrapper expects as its first arg.
@@ -90,6 +106,10 @@ impl RustcArgs {
             cfgs: Vec::new(),
             extra_filename: None,
             incremental: None,
+            sysroot: None,
+            link_search: Vec::new(),
+            link_libs: Vec::new(),
+            unstable_flags: Vec::new(),
             inner_rustc,
             all_args: rustc_args.to_vec(),
             is_test: false,
@@ -211,6 +231,45 @@ impl RustcArgs {
                         parsed.incremental = value.as_ref().map(PathBuf::from);
                     }
                     parsed.codegen_opts.push((key, value));
+                }
+                "--sysroot" => {
+                    i += 1;
+                    parsed.sysroot = rustc_args.get(i).map(PathBuf::from);
+                }
+                _ if arg.starts_with("--sysroot=") => {
+                    parsed.sysroot = Some(PathBuf::from(&arg["--sysroot=".len()..]));
+                }
+                // Native link search paths / libraries. cargo passes
+                // `-L dependency=…` / `--extern` for rlib resolution (the
+                // latter already content-hashed); build scripts add
+                // `-L native=…` / `-l name` that change a linked artifact.
+                // Both separate (`-L val`) and attached (`-Lval`) forms.
+                "-L" => {
+                    i += 1;
+                    if let Some(val) = rustc_args.get(i) {
+                        parsed.link_search.push(val.clone());
+                    }
+                }
+                _ if arg.starts_with("-L") && arg.len() > 2 => {
+                    parsed.link_search.push(arg["-L".len()..].to_string());
+                }
+                "-l" => {
+                    i += 1;
+                    if let Some(val) = rustc_args.get(i) {
+                        parsed.link_libs.push(val.clone());
+                    }
+                }
+                _ if arg.starts_with("-l") && arg.len() > 2 => {
+                    parsed.link_libs.push(arg["-l".len()..].to_string());
+                }
+                "-Z" => {
+                    i += 1;
+                    if let Some(val) = rustc_args.get(i) {
+                        parsed.unstable_flags.push(val.clone());
+                    }
+                }
+                _ if arg.starts_with("-Z") && arg.len() > 2 => {
+                    parsed.unstable_flags.push(arg["-Z".len()..].to_string());
                 }
                 // Positional argument: source file (doesn't start with -)
                 _ if !arg.starts_with('-')

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -63,7 +63,18 @@ use std::path::{Path, PathBuf};
 /// to a different key; bump to invalidate v9 entries cleanly rather than
 /// leave a silent partial invalidation. (Env-dep values are also now
 /// un-escaped, which can change Windows OUT_DIR keys.)
-const CACHE_KEY_VERSION: u32 = 10;
+///
+/// v11: previously-unkeyed codegen-affecting inputs are now folded in —
+/// `--sysroot`, native link flags (`-L`/`-l`), `-Z` flags, and the
+/// CONTENTS of a custom `--target` JSON spec. Also unifies the cc recipe
+/// onto this same constant (was a separate `CC_CACHE_KEY_VERSION`).
+///
+/// Single source of truth for both the rustc recipe (this module) and
+/// the cc recipe ([`crate::compiler::cc`]). The two hash distinct labels
+/// (`key_version:` vs `cc_key_version:`) and disjoint field layouts, so
+/// their entries never collide regardless of this number — the version
+/// only controls *invalidation*. One constant, one bump.
+pub(crate) const CACHE_KEY_VERSION: u32 = 11;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
 /// Collapse runs of ASCII whitespace into single spaces and trim
@@ -136,6 +147,34 @@ pub fn compute_cache_key(
     hasher.update(target.as_bytes());
     hasher.update(b"\n");
     tracing::trace!("[key:{}] target={}", crate_name, target);
+
+    // A `--target` value can be a path to a custom target JSON spec
+    // (Firefox / embedded toolchains). That spec encodes data-layout,
+    // target-cpu/features, linker, panic strategy, code-model — all
+    // codegen-affecting — yet the dep-info pass never lists it, so only
+    // the path string above would distinguish two builds. Hash the file
+    // CONTENTS too, so editing the spec in place (or a different spec at
+    // the same path on another machine) diverges the key. Built-in
+    // triples aren't files, so they're unaffected.
+    let target_path = Path::new(target);
+    if target_path.is_file() {
+        match hash_file(target_path) {
+            Ok(spec_hash) => {
+                hasher.update(b"target_spec:");
+                hasher.update(spec_hash.as_bytes());
+                hasher.update(b"\n");
+                tracing::trace!("[key:{}] target_spec={}", crate_name, &spec_hash[..16]);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[key:{}] failed to hash target spec {}: {}",
+                    crate_name,
+                    target,
+                    e
+                );
+            }
+        }
+    }
 
     // crate identity
     if let Some(name) = &args.crate_name {
@@ -376,6 +415,68 @@ pub fn compute_cache_key(
             crate_name,
             normalized
         );
+    }
+
+    // Sysroot override (`--sysroot`). Selects which std/core/proc-macro
+    // libs rustc links against, so two builds of the same rustc binary
+    // with different sysroots (custom-built std, `-Zbuild-std`) must not
+    // collide. Normalized so a standard rustup layout still shares
+    // across machines while a genuinely different path diverges.
+    if let Some(sysroot) = &args.sysroot {
+        let normalized = path_normalizer.normalize(sysroot.to_string_lossy());
+        hasher.update(b"sysroot:");
+        hasher.update(normalized.as_bytes());
+        hasher.update(b"\n");
+        tracing::trace!("[key:{}] sysroot={}", crate_name, normalized);
+    }
+
+    // Native link search paths (`-L [KIND=]PATH`). cargo's own
+    // `dependency=`/`crate=` entries are redundant with the
+    // content-hashed `--extern` rlibs and are machine-local, so they're
+    // skipped; build-script-supplied `native=`/`framework=`/bare paths
+    // DO change a linked artifact and are kept (path-normalized for
+    // cross-machine stability). Order is preserved — link order is
+    // significant, and a stable argv from cargo keeps the key stable.
+    const KNOWN_L_KINDS: [&str; 5] = ["dependency", "crate", "native", "framework", "all"];
+    for spec in &args.link_search {
+        // Only split on a *recognized* kind so a path containing '='
+        // isn't mis-parsed (matches rustc's own `-L` parsing).
+        let (kind, path) = match spec.split_once('=') {
+            Some((k, p)) if KNOWN_L_KINDS.contains(&k) => (Some(k), p),
+            _ => (None, spec.as_str()),
+        };
+        if matches!(kind, Some("dependency") | Some("crate")) {
+            continue;
+        }
+        let normalized = path_normalizer.normalize(path);
+        hasher.update(b"link_search:");
+        if let Some(k) = kind {
+            hasher.update(k.as_bytes());
+            hasher.update(b"=");
+        }
+        hasher.update(normalized.as_bytes());
+        hasher.update(b"\n");
+        tracing::trace!("[key:{}] link_search:{}", crate_name, normalized);
+    }
+
+    // Native libraries to link (`-l`). Machine-independent names; a
+    // build script repointing these (e.g. linking a different `libfoo`)
+    // changes the linked binary without touching RUSTFLAGS. Hashed raw,
+    // order preserved (static link order is significant).
+    for lib in &args.link_libs {
+        hasher.update(b"link_lib:");
+        hasher.update(lib.as_bytes());
+        hasher.update(b"\n");
+        tracing::trace!("[key:{}] link_lib:{}", crate_name, lib);
+    }
+
+    // Unstable `-Z` flags arriving on argv outside RUSTFLAGS. Can change
+    // codegen (`-Zsanitizer`, `-Zshare-generics`, …); hashed raw.
+    for z in &args.unstable_flags {
+        hasher.update(b"unstable:");
+        hasher.update(z.as_bytes());
+        hasher.update(b"\n");
+        tracing::trace!("[key:{}] unstable:{}", crate_name, z);
     }
 
     // Relevant CARGO_CFG_* env vars (sorted for determinism —
@@ -1399,6 +1500,122 @@ mod tests {
         )
         .unwrap();
         assert_eq!(a, b, "linker path must not affect the cache key");
+    }
+
+    /// Shared base argv for the flag-keying regression tests below.
+    fn flag_base(source: &Path, extra: &[&str]) -> Vec<String> {
+        let mut v = vec![
+            "rustc".to_string(),
+            "--crate-name".to_string(),
+            "mylib".to_string(),
+            source.to_string_lossy().to_string(),
+            "--crate-type".to_string(),
+            "cdylib".to_string(),
+        ];
+        v.extend(extra.iter().map(|s| s.to_string()));
+        v
+    }
+
+    fn key_of(args: &[String]) -> String {
+        let fh = FileHasher::new();
+        let pn = PathNormalizer::empty();
+        compute_cache_key(&RustcArgs::parse(args).unwrap(), &fh, &pn).unwrap()
+    }
+
+    /// H1: build-script `-l` link libs reach rustc on argv (not via
+    /// RUSTFLAGS); a different native lib must diverge the key.
+    #[test]
+    fn link_lib_changes_key() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+
+        let none = key_of(&flag_base(&source, &[]));
+        let ssl = key_of(&flag_base(&source, &["-l", "ssl"]));
+        let crypto = key_of(&flag_base(&source, &["-l", "crypto"]));
+        assert_ne!(none, ssl, "adding -l must change the key");
+        assert_ne!(ssl, crypto, "a different -l lib must change the key");
+        // Attached form parses identically to the separate form.
+        assert_eq!(ssl, key_of(&flag_base(&source, &["-lssl"])));
+    }
+
+    /// H1: a build-script native search path must diverge the key, but
+    /// cargo's redundant `-L dependency=` (covered by content-hashed
+    /// `--extern`) must NOT — else every target-dir move busts the cache.
+    #[test]
+    fn link_search_native_keys_but_dependency_does_not() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+
+        let a = key_of(&flag_base(&source, &["-L", "native=/opt/a/lib"]));
+        let b = key_of(&flag_base(&source, &["-L", "native=/opt/b/lib"]));
+        assert_ne!(a, b, "a different native -L must change the key");
+
+        let dep_x = key_of(&flag_base(&source, &["-L", "dependency=/x/deps"]));
+        let dep_y = key_of(&flag_base(&source, &["-L", "dependency=/y/deps"]));
+        assert_eq!(
+            dep_x, dep_y,
+            "cargo's -L dependency= must not affect the key"
+        );
+    }
+
+    /// H1: `-Z` codegen flags arriving on argv must be keyed.
+    #[test]
+    fn unstable_flag_changes_key() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+
+        let none = key_of(&flag_base(&source, &[]));
+        let san = key_of(&flag_base(&source, &["-Z", "sanitizer=address"]));
+        assert_ne!(none, san, "a -Z codegen flag must change the key");
+        assert_eq!(san, key_of(&flag_base(&source, &["-Zsanitizer=address"])));
+    }
+
+    /// H2: `--sysroot` selects which std rustc links against; with the
+    /// same rustc version, a different sysroot must diverge the key.
+    #[test]
+    fn sysroot_changes_key() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+
+        let a = key_of(&flag_base(&source, &["--sysroot", "/opt/std-a"]));
+        let b = key_of(&flag_base(&source, &["--sysroot", "/opt/std-b"]));
+        let none = key_of(&flag_base(&source, &[]));
+        assert_ne!(a, b, "a different --sysroot must change the key");
+        assert_ne!(none, a, "adding --sysroot must change the key");
+        assert_eq!(a, key_of(&flag_base(&source, &["--sysroot=/opt/std-a"])));
+    }
+
+    /// H3: a `--target` custom JSON spec must be keyed by its CONTENTS,
+    /// so editing the spec in place diverges the key (path string alone
+    /// would not).
+    #[test]
+    fn target_spec_contents_change_key() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+        let spec = dir.path().join("custom.json");
+
+        std::fs::write(&spec, br#"{"llvm-target":"x86_64","data-layout":"e-m:e"}"#).unwrap();
+        let args = flag_base(&source, &["--target", &spec.to_string_lossy()]);
+        let before = key_of(&args);
+
+        // Edit the spec in place — same path, different codegen contract.
+        std::fs::write(
+            &spec,
+            br#"{"llvm-target":"x86_64","data-layout":"DIFFERENT"}"#,
+        )
+        .unwrap();
+        let after = key_of(&args);
+        assert_ne!(before, after, "editing the target spec must change the key");
     }
 
     #[test]

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -937,8 +937,11 @@ fn apply_cc_arg(parsed: &mut CcArgs, depinfo: &mut Option<DepInfoSpec>, arg: &Pa
 /// stdout is normalized with the same maps before hashing. Older
 /// entries may embed clone-local paths in `__FILE__`, debug info, or
 /// preprocessor-expanded string literals.
-const CC_CACHE_KEY_VERSION: u32 = 6;
-
+///
+/// The cc recipe now shares [`crate::cache_key::CACHE_KEY_VERSION`] with
+/// the rustc recipe (one number to bump). The `cc_key_version:` label
+/// plus disjoint fields keep cc and rustc entries from ever colliding;
+/// the shared number just means one bump invalidates both recipes.
 const CC_ROOT_SENTINEL: &str = "<CC_ROOT>";
 const CC_BUILD_SENTINEL: &str = "<CC_BUILD>";
 const CC_SOURCE_SENTINEL: &str = "<CC_SOURCE>";
@@ -1944,13 +1947,13 @@ impl Compiler for CcCompiler {
         let prefix_maps = cc_prefix_maps(parsed);
 
         hasher.update(b"cc_key_version:");
-        hasher.update(CC_CACHE_KEY_VERSION.to_string().as_bytes());
+        hasher.update(crate::cache_key::CACHE_KEY_VERSION.to_string().as_bytes());
         hasher.update(b"\n");
         tracing::trace!(
             target: "kache::cache_key",
             "[key:{}] cc_key_version={}",
             trace_name,
-            CC_CACHE_KEY_VERSION
+            crate::cache_key::CACHE_KEY_VERSION
         );
 
         let mut prefix_sentinels: Vec<&str> = Vec::new();

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -11,8 +11,8 @@ use std::ops::Range;
 use std::time::Duration;
 
 use crate::config::{
-    CacheFileConfig, Config, EnvOverrides, FileConfig, RemoteFileConfig, default_cache_dir,
-    parse_size, resolve_config_path,
+    CacheFileConfig, Config, EnvOverrides, FileConfig, PlannerFileConfig, RemoteFileConfig,
+    default_cache_dir, parse_size, resolve_config_path,
 };
 
 // ── Field definitions ─────────────────────────────────────────────────────
@@ -79,6 +79,11 @@ struct EditorState {
     file_had_content: bool,
     has_saved_once: bool,
     scroll_offset: u16,
+    /// `[cache.planner]` section as loaded from disk. The editor has no
+    /// form fields for it (endpoint + bearer token), so it is carried
+    /// through verbatim on save — otherwise saving would silently drop
+    /// the planner config, including its credential.
+    preserved_planner: Option<PlannerFileConfig>,
 }
 
 // ── Build form fields from FileConfig ─────────────────────────────────────
@@ -364,7 +369,10 @@ fn run_all_validation(fields: &mut [FormField]) {
 
 // ── Extract FileConfig from fields ────────────────────────────────────────
 
-fn fields_to_file_config(fields: &[FormField]) -> FileConfig {
+fn fields_to_file_config(
+    fields: &[FormField],
+    preserved_planner: Option<PlannerFileConfig>,
+) -> FileConfig {
     let get = |key: &str| -> Option<String> {
         fields.iter().find(|f| f.key == key).and_then(|f| {
             if f.value.is_empty() {
@@ -435,7 +443,9 @@ fn fields_to_file_config(fields: &[FormField]) -> FileConfig {
         cache: Some(CacheFileConfig {
             local_store: get("cache_dir"),
             local_max_size: get("max_size"),
-            planner: None,
+            // The editor exposes no planner fields; preserve the loaded
+            // section verbatim so a save never drops it (or its token).
+            planner: preserved_planner,
             cache_executables: get_bool("cache_executables"),
             clean_incremental: get_bool("clean_incremental"),
             exclude: get_list("exclude"),
@@ -476,6 +486,7 @@ pub fn run_config_editor() -> Result<()> {
         file_had_content: file_existed,
         has_saved_once: false,
         scroll_offset: 0,
+        preserved_planner: file_config.cache.as_ref().and_then(|c| c.planner.clone()),
     };
 
     // Run initial validation
@@ -648,7 +659,7 @@ fn try_save(state: &mut EditorState) {
 }
 
 fn do_save(state: &mut EditorState) {
-    let config = fields_to_file_config(&state.fields);
+    let config = fields_to_file_config(&state.fields, state.preserved_planner.clone());
     match Config::save_file_config(&config) {
         Ok(()) => {
             state.dirty = false;
@@ -1085,7 +1096,11 @@ mod tests {
                 fallback: None,
                 local_store: Some("~/cache".to_string()),
                 local_max_size: Some("50GiB".to_string()),
-                planner: None,
+                planner: Some(PlannerFileConfig {
+                    endpoint: Some("https://planner.example.com".to_string()),
+                    timeout_ms: Some(2000),
+                    token: Some("secret-token".to_string()),
+                }),
                 cache_executables: Some(true),
                 clean_incremental: Some(false),
                 exclude: Some(vec![
@@ -1110,10 +1125,20 @@ mod tests {
         };
 
         let fields = build_fields(&original, &empty_env());
-        let reconstructed = fields_to_file_config(&fields);
+        let preserved = original.cache.as_ref().and_then(|c| c.planner.clone());
+        let reconstructed = fields_to_file_config(&fields, preserved);
 
         let cache = reconstructed.cache.as_ref().unwrap();
         assert_eq!(cache.local_store.as_deref(), Some("~/cache"));
+        // The editor has no planner fields, but a save must preserve the
+        // loaded `[cache.planner]` section verbatim (endpoint + token).
+        let planner = cache.planner.as_ref().expect("planner preserved on save");
+        assert_eq!(
+            planner.endpoint.as_deref(),
+            Some("https://planner.example.com")
+        );
+        assert_eq!(planner.token.as_deref(), Some("secret-token"));
+        assert_eq!(planner.timeout_ms, Some(2000));
         assert_eq!(
             cache.exclude.as_deref(),
             Some(&["src/generated/**".to_string(), "vendor/**".to_string()][..])
@@ -1134,7 +1159,7 @@ mod tests {
     fn test_fields_to_file_config_empty_omits_remote() {
         let config = FileConfig::default();
         let fields = build_fields(&config, &empty_env());
-        let result = fields_to_file_config(&fields);
+        let result = fields_to_file_config(&fields, None);
         assert!(result.cache.as_ref().unwrap().remote.is_none());
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1233,7 +1233,7 @@ impl Daemon {
 
     /// Execute an upload directly (used by upload queue workers).
     pub async fn do_upload(&self, job: &UploadJob) -> Response {
-        let key_short = &job.key[..job.key.len().min(16)];
+        let key_short = key_prefix(&job.key);
         let Some(remote) = &self.config.remote else {
             return Response::err("no remote configured");
         };
@@ -1825,8 +1825,21 @@ impl Daemon {
                                     .unwrap_or_default()
                                     .as_secs(),
                             });
-                            // Track as prefetched for PrefetchHit attribution
-                            d.prefetched_keys.write().await.insert(key.clone());
+                            // Track as prefetched for PrefetchHit attribution.
+                            // Bound the set: a long-lived daemon that
+                            // prefetches many distinct keys would otherwise
+                            // grow it without limit. The attribution memory
+                            // is purely cosmetic (PrefetchHit vs LocalHit
+                            // event labelling), so clearing on overflow is
+                            // harmless.
+                            {
+                                const MAX_PREFETCHED_KEYS: usize = 50_000;
+                                let mut pf = d.prefetched_keys.write().await;
+                                if pf.len() >= MAX_PREFETCHED_KEYS {
+                                    pf.clear();
+                                }
+                                pf.insert(key.clone());
+                            }
                         }
                         Err(e) => {
                             let elapsed_ms = start.elapsed().as_millis() as u64;
@@ -2702,7 +2715,7 @@ async fn handle_connection(
             Ok(Request::Upload(ref job)) => {
                 tracing::debug!(
                     crate_name = job.crate_name,
-                    key = &job.key[..job.key.len().min(16)],
+                    key = key_prefix(&job.key),
                     "handling upload request"
                 );
                 daemon.handle_upload(job).await
@@ -2770,6 +2783,18 @@ fn is_client_disconnect(e: &std::io::Error) -> bool {
     ) || e.raw_os_error() == Some(32) // EPIPE on macOS may report as ErrorKind::Other
 }
 
+/// First (up to) 16 bytes of a key for log display, never panicking on a
+/// non-char-boundary. A legitimate wrapper sends 64-char ASCII hex, but a
+/// crafted client on the local socket could send arbitrary bytes, and
+/// `&key[..16]` would panic mid-multibyte-char and kill the connection task.
+fn key_prefix(key: &str) -> &str {
+    let mut end = key.len().min(16);
+    while end > 0 && !key.is_char_boundary(end) {
+        end -= 1;
+    }
+    &key[..end]
+}
+
 use crate::platform::wait_for_shutdown as shutdown_signal;
 
 // ── Client ───────────────────────────────────────────────────────
@@ -2796,7 +2821,7 @@ pub fn send_upload_job(
         client_epoch: build_epoch(),
     });
 
-    let key_short = if key.len() > 16 { &key[..16] } else { key };
+    let key_short = key_prefix(key);
 
     let try_send = |path: &Path| -> Result<()> { send_request_fire_and_forget(path, &req) };
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -862,6 +862,16 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                         restore_ms,
                         0,
                     );
+                    // Replay the original compiler diagnostics, exactly as
+                    // the other hit sites do — otherwise the process that
+                    // loses the build-lock race silently swallows the
+                    // cached warnings/notes.
+                    if !meta.stdout.is_empty() {
+                        print!("{}", meta.stdout);
+                    }
+                    if !meta.stderr.is_empty() {
+                        eprint!("{}", meta.stderr);
+                    }
                     clean_incremental_dir(config, &args);
                     return Ok(0);
                 }

--- a/tests/cache_key_underkeying_test.rs
+++ b/tests/cache_key_underkeying_test.rs
@@ -1,0 +1,199 @@
+//! End-to-end regression tests for cache-key under-keying.
+//!
+//! Each test drives the real `kache` binary as a `RUSTC_WRAPPER` on a
+//! controlled `rustc` invocation (a trivial rlib compile), varying ONE
+//! codegen-affecting input that was previously absent from the cache key,
+//! and asserts via `kache report` that:
+//!
+//!   - an identical re-invocation HITS (the invocation is cacheable and the
+//!     key is deterministic — so the test can't pass vacuously), and
+//!   - changing the input MISSES (the key diverged — no false hit).
+//!
+//! Before the fixes these guard, the changed-input build would have HIT the
+//! original entry and silently restored a wrong artifact:
+//!   - `-l` / `-L native=` — build-script `cargo:rustc-link-lib` /
+//!     `cargo:rustc-link-search` reach rustc on argv, not via RUSTFLAGS.
+//!   - `--sysroot` — selects which std rustc links against.
+//!
+//! `-L dependency=` (cargo's rlib search, redundant with the content-hashed
+//! `--extern`) must NOT affect the key, or every target-dir move would bust
+//! the cache; that invariant is asserted too.
+//!
+//! `-Z` flags and custom `--target` JSON specs are also keyed (see the
+//! `cache_key` unit tests `unstable_flag_changes_key` /
+//! `target_spec_contents_change_key`); they are not exercised here because a
+//! faithful e2e needs a nightly toolchain / `-Zbuild-std`.
+
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn kache_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // test binary name
+    path.pop(); // deps/
+    path.push("kache");
+    path
+}
+
+fn build_kache() {
+    // Bootstrap the binary under test with no configured wrapper; the
+    // wrapper behavior is exercised by invoking it directly below.
+    let status = std::process::Command::new("cargo")
+        .args(["build", "--config", "build.rustc-wrapper=\"\""])
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+        .status()
+        .expect("failed to build kache");
+    assert!(status.success(), "kache build failed");
+}
+
+fn isolated_config_path(cache_dir: &Path) -> PathBuf {
+    cache_dir.join("config.toml")
+}
+
+fn rustc_path() -> String {
+    // cargo sets RUSTC to the absolute path when running tests; fall back
+    // to PATH resolution otherwise.
+    std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string())
+}
+
+fn rustc_sysroot() -> String {
+    let out = std::process::Command::new(rustc_path())
+        .args(["--print", "sysroot"])
+        .output()
+        .expect("run rustc --print sysroot");
+    assert!(out.status.success(), "rustc --print sysroot failed");
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+/// Compile a trivial rlib through kache-as-RUSTC_WRAPPER with `extra` flags
+/// appended to the rustc argv. Asserts the compile succeeds.
+fn run_kache_rustc(cache_dir: &Path, out_dir: &Path, src: &Path, extra: &[&str]) {
+    let mut args: Vec<String> = vec![
+        rustc_path(),
+        "--crate-name".into(),
+        "kt".into(),
+        "--crate-type".into(),
+        "lib".into(),
+        "--edition".into(),
+        "2021".into(),
+        "--emit=link".into(),
+        "--out-dir".into(),
+        out_dir.display().to_string(),
+        src.display().to_string(),
+    ];
+    args.extend(extra.iter().map(|s| s.to_string()));
+
+    let output = std::process::Command::new(kache_binary())
+        .args(&args)
+        .env("KACHE_CACHE_DIR", cache_dir)
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
+        .env("KACHE_LOG", "kache=info")
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+        .output()
+        .expect("failed to run kache rustc");
+
+    assert!(
+        output.status.success(),
+        "kache rustc failed.\nargs: {args:?}\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// `(misses, local_hits)` from `kache report` over this isolated cache dir.
+fn miss_hit_counts(cache_dir: &Path) -> (u64, u64) {
+    let output = std::process::Command::new(kache_binary())
+        .args(["report", "--format", "json", "--since", "1h"])
+        .env("KACHE_CACHE_DIR", cache_dir)
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
+        .output()
+        .expect("failed to run kache report");
+    assert!(output.status.success(), "kache report failed");
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("report should be valid json");
+    let s = &report["summary"];
+    (
+        s["misses"].as_u64().unwrap_or(0),
+        s["local_hits"].as_u64().unwrap_or(0),
+    )
+}
+
+fn fresh_src() -> (TempDir, PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("lib.rs");
+    std::fs::write(&src, b"pub fn f() -> u32 { 42 }\n").unwrap();
+    (dir, src)
+}
+
+/// H1: a build-script `-l <lib>` reaches rustc on argv. A different native
+/// lib must diverge the key; an identical one must hit.
+#[test]
+fn link_lib_value_changes_cache_key() {
+    build_kache();
+    let cache_dir = TempDir::new().unwrap();
+    let out = TempDir::new().unwrap();
+    let (_src_dir, src) = fresh_src();
+
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &["-l", "ssl"]); // miss
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &["-l", "ssl"]); // hit (same key)
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &["-l", "crypto"]); // miss (diverged)
+
+    let (misses, hits) = miss_hit_counts(cache_dir.path());
+    assert_eq!(
+        (misses, hits),
+        (2, 1),
+        "expected -l ssl→miss, -l ssl→hit, -l crypto→miss; a false hit on the \
+         differing -l would show misses=1, hits=2"
+    );
+}
+
+/// H1: a build-script `-L native=<path>` must diverge the key, but cargo's
+/// redundant `-L dependency=<path>` (covered by the content-hashed
+/// `--extern`) must NOT — otherwise every target-dir move busts the cache.
+#[test]
+fn link_search_native_keys_but_dependency_is_skipped() {
+    build_kache();
+    let cache_dir = TempDir::new().unwrap();
+    let out = TempDir::new().unwrap();
+    let (_src_dir, src) = fresh_src();
+
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &["-L", "native=/opt/a"]); // miss
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &["-L", "native=/opt/a"]); // hit
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &["-L", "native=/opt/b"]); // miss (diverged)
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &["-L", "dependency=/x"]); // miss (new)
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &["-L", "dependency=/y"]); // HIT (dependency= skipped)
+
+    let (misses, hits) = miss_hit_counts(cache_dir.path());
+    assert_eq!(
+        (misses, hits),
+        (3, 2),
+        "native= must diverge (native=/b→miss) while dependency= must be \
+         ignored (dependency=/y→hit). A regression keying dependency= would \
+         show misses=4; one not keying native= would show misses=2"
+    );
+}
+
+/// H2: `--sysroot` selects which std rustc links against. Adding it (or
+/// changing it) must diverge the key — before the fix it was ignored, so an
+/// explicit `--sysroot` would have falsely hit the no-sysroot entry.
+#[test]
+fn sysroot_changes_cache_key() {
+    build_kache();
+    let cache_dir = TempDir::new().unwrap();
+    let out = TempDir::new().unwrap();
+    let (_src_dir, src) = fresh_src();
+    let sysroot = rustc_sysroot();
+
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &[]); // miss
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &[]); // hit
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &["--sysroot", &sysroot]); // miss (diverged)
+
+    let (misses, hits) = miss_hit_counts(cache_dir.path());
+    assert_eq!(
+        (misses, hits),
+        (2, 1),
+        "adding --sysroot must diverge the key; an ignored --sysroot (the bug) \
+         would falsely hit the no-sysroot entry → misses=1, hits=2"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes from a correctness/robustness audit of the cache. Three focused commits:

1. **`fix(key)` — fold previously-unkeyed codegen inputs into the cache key.** Several rustc inputs that change compiled output were absent from the key, so two genuinely-different invocations could collide and a stale/wrong artifact be restored:
   - `--sysroot` (which std rustc links against) — unkeyed.
   - native link flags `-L` / `-l` — build scripts emit `cargo:rustc-link-search` / `cargo:rustc-link-lib` straight onto argv (not via `RUSTFLAGS`), so a `*-sys` crate relinked against a different native lib kept the same key. cargo's redundant `-L dependency=`/`crate=` (already covered by content-hashed `--extern`) is **skipped** to preserve cross-machine / target-dir hit rates; link order preserved.
   - `-Z` flags arriving on argv outside `RUSTFLAGS`.
   - custom `--target` JSON spec — was keyed by path string only; now hashes the spec file **contents** (editing it in place was a false hit for embedded/cross builds).
   - Also **unifies `CC_CACHE_KEY_VERSION` into the single `CACHE_KEY_VERSION`** (the `cc_key_version:` label + disjoint fields already prevent rustc/cc collisions; the number only controls invalidation). Bumped to **10** — this invalidates existing entries once, the safe direction.

2. **`fix(config)` — preserve `[cache.planner]` through the config editor.** `kache config` loaded the planner section (endpoint + bearer token) but `fields_to_file_config` hardcoded `planner: None`, so one save silently dropped it, **including the credential**.

3. **`fix(wrapper,daemon)` — robustness.** Replay cached compiler diagnostics in the build-lock-race-loser branch (the only hit site that swallowed them under parallel cargo); a char-boundary-safe `key_prefix()` for daemon key-display slices (`&key[..16]` panicked on a crafted non-hex key); cap the unbounded `prefetched_keys` attribution set.

## Validation
- `cargo clippy --all-targets` clean (under `warnings = deny`), `cargo test --bin kache` → **606 passed / 0 failed**, including 5 new cache-key regression tests (`link_lib_changes_key`, `link_search_native_keys_but_dependency_does_not`, `unstable_flag_changes_key`, `sysroot_changes_key`, `target_spec_contents_change_key`) and a strengthened config roundtrip test asserting planner survival.

## Scope notes
- The audit's headline **critical finding (cc/gcc probe-contract under-keying) was already fixed on `main`** (`cc_flags_need_resolved_invocation` + bail), so it is **not** in this PR. Same for the cc `__FILE__` portability item (preprocessor prefix-map normalization already on main).
- Partially addresses #128 (`-L native=` keying) and #183 (key unmodeled rustc flags).

## Companion issues (separate findings, not in this PR)
Remote/trust-boundary and platform/DoS findings filed separately: **#211** (remote import: re-hash blobs + validate `meta.json` name/hash — re-validated against main), **#212** (zstd/tar decompression-bomb cap), **#213** (daemon remote-path races), **#214** (OUT_DIR dual-pattern false hit — tradeoff), **#215** (Windows IPC read timeout), **#216** (unbounded daemon line read).
