### PR TITLE
feat(windows): ship aarch64-pc-windows-msvc, cross-build both Windows targets on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,13 +459,16 @@ jobs:
     uses: zondax/_workflows/.github/workflows/_release-rust.yml@v9
     with:
       binary_name: kache
-      # Windows ships x86_64-pc-windows-msvc, built NATIVELY on the
-      # kunobi-windows runner via `runner_windows` (cross/MinGW can't build
-      # msvc, and kache's aws-lc TLS doesn't cross-compile to windows-gnu).
-      # Pinned to _workflows@v9, which carries the `runner_windows` input (#93).
-      targets: '["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-pc-windows-msvc"]'
+      # Both Windows targets (x64 + arm64) ship as `-pc-windows-msvc`, cross-built
+      # on the Linux runner via cargo-xwin: clang + lld-link against the MSVC CRT
+      # and Windows SDK that `xwin` downloads. The aws-lc TLS C deps that wouldn't
+      # cross to `-windows-gnu` compile cleanly for `-windows-msvc` under clang, so
+      # no native Windows runner is needed here — `runner_windows` is left unset.
+      # (The native kunobi-windows runner is still used by the e2e job above.)
+      # Requires _workflows@v9 (retagged), which routes `-pc-windows-msvc` through
+      # cargo-xwin on Linux.
+      targets: '["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc"]'
       runner_macos: '["self-hosted", "macOS", "ARM64"]'
-      runner_windows: '["self-hosted", "Windows", "X64", "kunobi-windows"]'
       extra_build_env: |
         KACHE_VERSION=${{ github.ref_name }}
     permissions:


### PR DESCRIPTION
## What

Adds a **Windows-on-ARM** release binary (`aarch64-pc-windows-msvc`) and moves
the existing **x64** Windows build off the native `kunobi-windows` runner onto
the Linux runner — both cross-built via `cargo-xwin` (real MSVC ABI).

## Why

We had no Windows/arm64 binary, and there's no arm64 Windows hardware in the
fleet. `cargo-xwin` cross-compiles `-pc-windows-msvc` from Linux: the `aws-lc`
TLS C deps that wouldn't cross to `-windows-gnu` compile cleanly for
`-windows-msvc` under clang. Verified locally — both `x86_64-` and
`aarch64-pc-windows-msvc` produce real `PE32+` executables.

So no native Windows runner is needed for **releases**; `runner_windows` is
dropped and both Windows targets cross-compile on Linux.

## Changes

- `targets`: add `aarch64-pc-windows-msvc`.
- Remove `runner_windows` → both `-msvc` targets build via `cargo-xwin` on Linux.

## Note: still uses the native Windows runner for testing

The `e2e` job is **unchanged** — it still builds + runs the e2e suite natively
on `kunobi-windows`, so Windows functional coverage is intact. Only the shipped
release artifact is now cross-built.

## Depends on

`Zondax/_workflows#94` (cargo-xwin routing). That PR's `v9` tag must be retagged
to its merge commit before this lands — `_release-rust.yml@v9` is referenced here.