### PR TITLE
fix(bench): drop bogus firefox `requires`; progress line for worktree reset

### DIFF
--- a/bench-profiles/firefox.toml
+++ b/bench-profiles/firefox.toml
@@ -3,8 +3,11 @@
 name     = "firefox"
 repo     = "https://github.com/mozilla-firefox/firefox.git"
 ref      = "FIREFOX_151_0_RELEASE"
-requires = ["mach", "python3"]
 objdir   = "obj-kache-bench"
+# No `requires`: it's a PATH check for external tools the harness needs
+# around the checkout (cf. substrate's cargo/rustc). Firefox's build
+# driver is `./mach` IN the source tree, and `./mach bootstrap`
+# provisions its own toolchain — so there's nothing to pre-check on PATH.
 
 # One-time toolchain setup. Skipped when ~/.mozbuild already exists
 # (--force-setup overrides); the toolchain it installs is shared across runs.

--- a/crates/kache-e2e/src/bin/kache-bench.rs
+++ b/crates/kache-e2e/src/bin/kache-bench.rs
@@ -430,6 +430,15 @@ fn clone_worktrees(
     //    back to a plain `remove_dir_all` for legacy non-worktree dirs
     //    left over from older bench versions.
     for d in [clone_a, clone_b] {
+        if d.exists() {
+            // Removing a previous worktree (full source + objdir, often
+            // several GB / 100k+ files) is slow and silent — say so, so a
+            // re-run doesn't look hung after "reusing clone-ref".
+            eprintln!(
+                "[bench] removing previous worktree {} (can take a few minutes, no progress output)…",
+                d.display()
+            );
+        }
         reset_worktree_path(clone_ref, d)?;
     }
     // Prune any stale worktree registrations the cleanup might have


### PR DESCRIPTION
Two small fixes to the just-merged bench-profiles harness (#224), surfaced running `just bench firefox`:

1. **`firefox.toml` always SKIPped.** It listed `requires = ["mach", "python3"]`, but `requires` is a **PATH** check and `mach` is `./mach` shipped *in the Firefox source tree* — never on PATH — so `just bench firefox` always printed `SKIP profile firefox: missing required tool(s) on PATH: mach` and did nothing. Firefox needs no PATH guard (its build driver is in-tree, and `./mach bootstrap` provisions its own toolchain), so `requires` is removed. (`requires` stays correct for substrate: `cargo`/`rustc` are genuine PATH tools.)

2. **Re-runs looked hung after "reusing clone-ref".** The harness removes the previous `clone-a`/`clone-b` worktrees (a full Firefox checkout + objdir, often several GB / 100k+ files) before recreating them; `git worktree remove --force` is slow and **silent**. Added a `[bench] removing previous worktree … (can take a few minutes, no progress output)…` line so it's obviously working.

Verified: compiles, `cargo fmt` clean, the firefox mozconfig parity test still passes.