### PR TITLE
fix(cc): path-normalize resolved `-###` tokens so the cc key is build-path-portable

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -69,12 +69,20 @@ use std::path::{Path, PathBuf};
 /// CONTENTS of a custom `--target` JSON spec. Also unifies the cc recipe
 /// onto this same constant (was a separate `CC_CACHE_KEY_VERSION`).
 ///
+/// v12: cc resolved `-###` tokens are path-normalized through the same
+/// prefix maps as the preprocessor stdout before hashing (were hashed
+/// raw). Absolute build paths in those tokens — `-I` dirs, `-D` defines
+/// like `FIREFOX_ICO="/abs/.../firefox.ico"`, input/`-o` paths — made the
+/// cc key path-dependent, so two builds of the same TU at different paths
+/// missed cross-machine / cross-clone (Firefox bench: `resolved_token`
+/// was a top cross-clone divergence).
+///
 /// Single source of truth for both the rustc recipe (this module) and
 /// the cc recipe ([`crate::compiler::cc`]). The two hash distinct labels
 /// (`key_version:` vs `cc_key_version:`) and disjoint field layouts, so
 /// their entries never collide regardless of this number — the version
 /// only controls *invalidation*. One constant, one bump.
-pub(crate) const CACHE_KEY_VERSION: u32 = 11;
+pub(crate) const CACHE_KEY_VERSION: u32 = 12;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
 /// Collapse runs of ASCII whitespace into single spaces and trim

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2040,13 +2040,25 @@ impl Compiler for CcCompiler {
         if let Some(tokens) = &resolved.resolved_tokens {
             hasher.update(b"resolved:");
             for tok in tokens {
-                hasher.update(tok.as_bytes());
+                // Resolved `cc -###` tokens carry absolute build paths —
+                // `-I` dirs, `-D NAME="/abs/.../foo.ico"` defines, input /
+                // `-o` paths — that embed the build directory. Hashing them
+                // raw makes the key path-dependent, so two builds of the
+                // same TU at different paths (a teammate's checkout, a CI
+                // runner, the bench's cross-clone warm phase) miss. Run them
+                // through the SAME prefix maps as the preprocessor stdout so
+                // the build root collapses to `<CC_ROOT>`/`<CC_BUILD>` and
+                // the key is path-portable. Mapping only ever merges keys
+                // that differ solely in build path (same object, remapped at
+                // compile time via `-ffile-prefix-map`) — never a miscache.
+                let mapped = apply_cc_prefix_maps_to_bytes(tok.clone().into_bytes(), &prefix_maps);
+                hasher.update(&mapped);
                 hasher.update(b"\x1f");
                 tracing::trace!(
                     target: "kache::cache_key",
                     "[key:{}] resolved_token={}",
                     trace_name,
-                    tok
+                    String::from_utf8_lossy(&mapped)
                 );
             }
             hasher.update(b"\n");
@@ -3783,6 +3795,38 @@ mod tests {
         assert_eq!(
             std::str::from_utf8(&normalized).unwrap(),
             r#"assert_fail("<CC_ROOT>/obj/dist/include/fmt/format.h")"#
+        );
+    }
+
+    /// Resolved `-###` tokens carry absolute build paths (here a `-D`
+    /// define pointing at a branding asset, like Firefox's `FIREFOX_ICO`).
+    /// The cc key now normalizes them through the per-build prefix maps, so
+    /// the SAME token built at two different paths hashes identically —
+    /// the cross-clone / cross-machine portability fix (v12). Previously
+    /// the tokens were hashed raw and diverged with the build directory.
+    #[test]
+    fn resolved_tokens_normalize_identically_across_build_paths() {
+        let tok = |clone: &str| {
+            format!(r#"FIREFOX_ICO="/Users/me/work/{clone}/browser/branding/firefox.ico""#)
+                .into_bytes()
+        };
+        let maps_for = |clone: &str| {
+            vec![CcPrefixMap {
+                from: format!("/Users/me/work/{clone}"),
+                to: CC_ROOT_SENTINEL,
+            }]
+        };
+
+        let a = apply_cc_prefix_maps_to_bytes(tok("clone-a"), &maps_for("clone-a"));
+        let b = apply_cc_prefix_maps_to_bytes(tok("clone-b"), &maps_for("clone-b"));
+
+        assert_eq!(
+            a, b,
+            "the same resolved token at different build paths must normalize identically"
+        );
+        assert_eq!(
+            std::str::from_utf8(&a).unwrap(),
+            r#"FIREFOX_ICO="<CC_ROOT>/browser/branding/firefox.ico""#
         );
     }
 


### PR DESCRIPTION
## What

The cc cache key hashed the resolved compiler-invocation tokens (the `cc -###` `-cc1` line) **raw**, while the preprocessor stdout was already normalized through the build-path prefix maps. Those tokens carry **absolute build paths** — `-I` dirs, input/`-o` paths, and `-D NAME="/abs/.../foo"` defines — so the cc key was **path-dependent**: the same translation unit built at a different directory got a different key and missed.

Fix: run each resolved token through the same `apply_cc_prefix_maps_to_bytes` maps as the preprocessor stdout before hashing, collapsing the build root to `<CC_ROOT>`/`<CC_BUILD>`. Bumps `CACHE_KEY_VERSION` → 12.

Mapping only ever merges keys that differ **solely** in build path (the same object, already remapped at compile time via `-ffile-prefix-map`) — never a miscache.

## How it was found (concrete evidence)

The Firefox cross-clone benchmark with `--trace-keys` flagged `resolved_token` as a top diverging key input. The trace logs show the exact leak — the same TU, two build paths:

```
cold:  resolved_token=FIREFOX_ICO="…/clone-a/browser/branding/unofficial/firefox.ico"
warm:  resolved_token=FIREFOX_ICO="…/clone-b/browser/branding/unofficial/firefox.ico"
```

These two compute different cc keys today → cross-clone (and cross-machine) miss. After this change both normalize to `FIREFOX_ICO="<CC_ROOT>/browser/branding/unofficial/firefox.ico"` → same key → hit.

## Tests

- New `resolved_tokens_normalize_identically_across_build_paths` — the same token at two build paths normalizes to one value.
- Full suite: `cargo clippy --workspace --all-targets` clean, `cargo fmt` clean, **617 bin tests pass**.

## Scope / not in this PR

This fixes the **`resolved_token`** cross-clone divergence. The larger **`preprocessed`-field** divergence (1046 units — the preprocessor stdout *is* prefix-mapped, yet a residual leak remains) and the **`mozbuild`-keystone Rust cascade** (generated source / path-valued env-deps like `BUILDCONFIG_RS` propagating up to `gkrust`) are distinct, still-open investigations from the same bench run — they'll get their own issues/PRs.