### PR TITLE
feat(cc): auto-derive repo root from -I includes for objdir TUs (+ KACHE_BASE_DIR / kill-switch)

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -77,12 +77,22 @@ use std::path::{Path, PathBuf};
 /// missed cross-machine / cross-clone (Firefox bench: `resolved_token`
 /// was a top cross-clone divergence).
 ///
+/// v13: cc prefix-map roots now also derive from the `-I` include dirs,
+/// not just (cwd, source-dir). Objdir-generated TUs (`Unified_cpp_*`)
+/// compile a source that lives IN the build dir, so the old derivation
+/// collapsed to a narrow objdir subdir and leaked `__FILE__` paths into
+/// `dist/include` + the source tree (Firefox bench: `preprocessed` was the
+/// top cross-clone divergence, ~1000 TUs). The include dirs span the repo,
+/// so their common ancestor with cwd reaches the repo root, making
+/// cross-checkout cc caching work automatically. (`KACHE_BASE_DIR` is an
+/// explicit override; `KACHE_CC_PATH_NORMALIZE=0` disables it all.)
+///
 /// Single source of truth for both the rustc recipe (this module) and
 /// the cc recipe ([`crate::compiler::cc`]). The two hash distinct labels
 /// (`key_version:` vs `cc_key_version:`) and disjoint field layouts, so
 /// their entries never collide regardless of this number — the version
 /// only controls *invalidation*. One constant, one bump.
-pub(crate) const CACHE_KEY_VERSION: u32 = 12;
+pub(crate) const CACHE_KEY_VERSION: u32 = 13;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
 /// Collapse runs of ASCII whitespace into single spaces and trim

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -945,6 +945,10 @@ fn apply_cc_arg(parsed: &mut CcArgs, depinfo: &mut Option<DepInfoSpec>, arg: &Pa
 const CC_ROOT_SENTINEL: &str = "<CC_ROOT>";
 const CC_BUILD_SENTINEL: &str = "<CC_BUILD>";
 const CC_SOURCE_SENTINEL: &str = "<CC_SOURCE>";
+/// Sentinel for a user-declared `KACHE_BASE_DIR` (ccache `CCACHE_BASEDIR`
+/// analog). Distinct from the derived roots so an explicit base dir can't
+/// collide with a `<CC_ROOT>` subtree.
+const CC_BASE_SENTINEL: &str = "<CC_BASE>";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CcPrefixMap {
@@ -1699,11 +1703,63 @@ fn cc_flags_need_resolved_invocation(parsed: &CcArgs) -> bool {
 /// object directories do not share a useful project root. Distinct
 /// sentinels avoid collapsing unrelated paths to the same spelling.
 fn cc_prefix_maps(parsed: &CcArgs) -> Vec<CcPrefixMap> {
+    // `KACHE_CC_PATH_NORMALIZE=0` disables cc path normalization entirely:
+    // no maps → the key hashes raw paths AND `execute` injects no
+    // `-ffile-prefix-map`. The conservative escape hatch — cc keys become
+    // path-literal (no cross-machine cc sharing, but zero normalization
+    // miscache risk). Default on.
+    if !cc_path_normalize_enabled() {
+        return Vec::new();
+    }
     let cwd = match std::env::current_dir() {
         Ok(cwd) => cwd,
         Err(_) => return Vec::new(),
     };
-    cc_prefix_maps_for(parsed, &cwd)
+    let base = std::env::var_os("KACHE_BASE_DIR").filter(|v| !v.is_empty());
+    cc_prefix_maps_cfg(parsed, &cwd, base.as_deref().map(Path::new))
+}
+
+/// Deterministic core of [`cc_prefix_maps`] (reads no env) — the derived
+/// roots plus an optional user `base_dir` (`KACHE_BASE_DIR`).
+fn cc_prefix_maps_cfg(parsed: &CcArgs, cwd: &Path, base_dir: Option<&Path>) -> Vec<CcPrefixMap> {
+    let mut maps = cc_prefix_maps_for(parsed, cwd);
+
+    // User-declared base dir (ccache `CCACHE_BASEDIR` analog). An explicit
+    // root stripped to `<CC_BASE>` — covers paths the derived roots miss,
+    // e.g. objdir-built TUs whose `__FILE__` points into the source tree
+    // *above* the (narrow) derived root. A distinct sentinel so it can't
+    // collide with a derived `<CC_ROOT>` subtree.
+    if let Some(base) = base_dir {
+        let base_abs = absolutize_path(cwd, base);
+        for root in [base_abs.clone(), canonicalize_or_self(&base_abs)] {
+            let from = root.to_string_lossy().to_string();
+            if !from.is_empty() && !maps.iter().any(|m| m.from == from) {
+                maps.push(CcPrefixMap {
+                    from,
+                    to: CC_BASE_SENTINEL,
+                });
+            }
+        }
+        // Re-sort longest-first so the most specific prefix still wins.
+        maps.sort_by_key(|m| std::cmp::Reverse(m.from.len()));
+    }
+    maps
+}
+
+/// Whether cc path normalization is active. `KACHE_CC_PATH_NORMALIZE` set
+/// to `0` / `false` / `off` / `no` disables it; default on.
+fn cc_path_normalize_enabled() -> bool {
+    parse_cc_normalize_toggle(std::env::var("KACHE_CC_PATH_NORMALIZE").ok().as_deref())
+}
+
+fn parse_cc_normalize_toggle(value: Option<&str>) -> bool {
+    match value {
+        Some(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        ),
+        None => true,
+    }
 }
 
 fn cc_prefix_maps_for(parsed: &CcArgs, cwd: &Path) -> Vec<CcPrefixMap> {
@@ -1737,6 +1793,30 @@ fn cc_prefix_maps_for(parsed: &CcArgs, cwd: &Path) -> Vec<CcPrefixMap> {
         && stable_cc_common_root(&common, &cwd_canon, &source_canon_parent)
     {
         roots.push((common, CC_ROOT_SENTINEL));
+    }
+
+    // Objdir-generated TUs (`Unified_cpp_*`, generated `.cpp`) live in the
+    // build dir, so cwd ≈ source-dir and the roots above collapse to a
+    // narrow objdir subdir — missing `__FILE__` paths into `dist/include`
+    // and the source tree. The `-I` dirs span the repo, so fold them in:
+    // the common ancestor of cwd and each include reaches the repo root.
+    // `stable_cc_common_root`/`useful_cc_prefix` already drop the out-of-
+    // tree ones — a system `-I` gives `/` (0 components) and `$HOME`-rooted
+    // toolchain dirs give a 2-component ancestor, both below the ≥3 bound —
+    // so only genuine in-tree roots survive. This is what makes
+    // cross-checkout cc caching work automatically (no `KACHE_BASE_DIR`).
+    for include in &parsed.includes {
+        let include_abs = absolutize_path(cwd, include);
+        for (a, b) in [
+            (&cwd_abs, include_abs.clone()),
+            (&cwd_canon, canonicalize_or_self(&include_abs)),
+        ] {
+            if let Some(common) = common_ancestor(a, &b)
+                && stable_cc_common_root(&common, a, &b)
+            {
+                roots.push((common, CC_ROOT_SENTINEL));
+            }
+        }
     }
 
     prefix_maps_from_roots(roots)
@@ -3828,6 +3908,99 @@ mod tests {
             std::str::from_utf8(&a).unwrap(),
             r#"FIREFOX_ICO="<CC_ROOT>/browser/branding/firefox.ico""#
         );
+    }
+
+    /// The objdir cross-checkout fix (v13). An objdir-generated TU compiles
+    /// a source that lives IN the build dir, so cwd == source-dir and the
+    /// (cwd, source) derivation collapses to a narrow objdir subdir. The
+    /// `-I` include dirs span the repo, so folding them in lifts the root
+    /// back to the project root — which is what `__FILE__` / preprocessor
+    /// paths into `dist/include` and the source tree need to normalize.
+    #[test]
+    fn cc_prefix_maps_broaden_to_repo_root_via_includes_for_objdir_tus() {
+        let root = tempfile::TempDir::new().unwrap();
+        let obj_dir = root.path().join("obj-kache-bench/xpcom/components");
+        let inc_dir = root.path().join("xpcom/components");
+        std::fs::create_dir_all(&obj_dir).unwrap();
+        std::fs::create_dir_all(&inc_dir).unwrap();
+        // The generated TU lives in the objdir, so cwd ≈ its own dir.
+        let source = obj_dir.join("StaticComponents.cpp");
+        std::fs::write(&source, "int x;\n").unwrap();
+
+        let parsed = CcArgs::parse(&s(&[
+            "cc",
+            "-c",
+            source.to_str().unwrap(),
+            "-I",
+            inc_dir.to_str().unwrap(), // in-tree → lifts the root to the repo
+            "-I",
+            "/usr/include", // out-of-tree → common ancestor is `/` → dropped
+            "-o",
+            "StaticComponents.o",
+        ]))
+        .unwrap();
+
+        let maps = cc_prefix_maps_for(&parsed, &obj_dir);
+        let canonical_root = root
+            .path()
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        assert!(
+            maps.iter()
+                .any(|m| m.from == canonical_root && m.to == CC_ROOT_SENTINEL),
+            "include-folding must derive the repo root for objdir TUs, got {maps:?}"
+        );
+        // A system `-I` must never widen the root to the filesystem root.
+        assert!(
+            !maps.iter().any(|m| m.from == "/"),
+            "out-of-tree includes must not add a `/` root, got {maps:?}"
+        );
+    }
+
+    /// `KACHE_BASE_DIR` (the ccache `CCACHE_BASEDIR` analog) is an explicit
+    /// override: whatever path the user names is stripped to `<CC_BASE>`,
+    /// independent of the auto-derived roots.
+    #[test]
+    fn cc_prefix_maps_cfg_maps_explicit_base_dir_to_base_sentinel() {
+        let parsed =
+            CcArgs::parse(&s(&["cc", "-c", "/work/checkout/src/foo.c", "-o", "foo.o"])).unwrap();
+        let cwd = Path::new("/work/checkout");
+        // `/work` is the common parent of many checkouts (the canonical
+        // CCACHE_BASEDIR shape), above what the auto-derivation would pick.
+        let maps = cc_prefix_maps_cfg(&parsed, cwd, Some(Path::new("/work")));
+        assert!(
+            maps.iter()
+                .any(|m| m.from == "/work" && m.to == CC_BASE_SENTINEL),
+            "explicit KACHE_BASE_DIR must map to the base sentinel, got {maps:?}"
+        );
+    }
+
+    /// The kill-switch: any explicit off-value disables cc path
+    /// normalization; everything else (including unset and empty) leaves it
+    /// on — normalization is the default, opt-out only.
+    #[test]
+    fn parse_cc_normalize_toggle_defaults_on_opts_out_explicitly() {
+        for on in [
+            None,
+            Some("1"),
+            Some("yes"),
+            Some("on"),
+            Some(""),
+            Some("garbage"),
+        ] {
+            assert!(parse_cc_normalize_toggle(on), "{on:?} should keep it on");
+        }
+        for off in [
+            Some("0"),
+            Some("false"),
+            Some("off"),
+            Some("no"),
+            Some("  OFF "),
+        ] {
+            assert!(!parse_cc_normalize_toggle(off), "{off:?} should disable it");
+        }
     }
 
     #[cfg(unix)]

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -160,6 +160,20 @@ impl PathNormalizer {
     pub fn from_env(workspace_root: Option<&Path>) -> Self {
         let mut rules = Vec::new();
 
+        // User-declared base dir (`KACHE_BASE_DIR`, the analog of ccache's
+        // `CCACHE_BASEDIR`). Highest priority — an explicit prefix the
+        // user knows should be stripped so the key is independent of the
+        // checkout location. Covers paths the auto-derived rules below
+        // can't see (container mounts, generated-file env-deps that point
+        // outside the workspace, etc.).
+        push_rule_with_variants(
+            &mut rules,
+            std::env::var_os("KACHE_BASE_DIR")
+                .filter(|v| !v.is_empty())
+                .and_then(|v| canonical_string(Path::new(&v))),
+            "<BASE_DIR>",
+        );
+
         push_rule_with_variants(
             &mut rules,
             std::env::current_dir()


### PR DESCRIPTION
## What

Makes cross-checkout **cc** caching work automatically for objdir-generated translation units, and adds two manual controls for parity with ccache.

### The bug (residual half of #217)

Objdir-generated TUs (`Unified_cpp_*`, generated `.cpp`) compile a source that lives **in** the build dir. So the prefix-map root derivation — which used only `(cwd, source-dir)` — collapsed to a narrow objdir subdir (e.g. `obj-kache-bench/media/libdav1d`) and never reached the repo root. Absolute `__FILE__` / preprocessor paths into `dist/include` and the source tree then leaked into the cc key, making it path-dependent.

This was the **top cross-clone divergence** in the Firefox bench — the `preprocessed` class, ~1000 TUs missing on a warm cross-checkout restore.

### The fix (automatic)

Fold the `-I` include dirs into the root derivation: the common ancestor of `cwd` and each include reaches the repo root. The existing `stable_cc_common_root` / `useful_cc_prefix` guards already drop the out-of-tree ones:

- a system `-I` (`/usr/include`) → common ancestor `/` (0 components) → rejected
- a `$HOME`-rooted toolchain dir → 2-component ancestor → below the ≥3 bound → rejected

…so only genuine in-tree roots survive. No new heuristics, no over-broadening.

**Verified on the live Firefox clones** (`compile_commands.json`, 716 objdir TUs):

| derivation | root == repo root |
|---|---|
| old `(cwd, source-dir)` | 0 / 716 (all narrow, leaking) |
| new (folds `-I`) | **716 / 716** |

Combined with the earlier empirical result that `clone-X → <CC_ROOT>` replacement drops the preprocessed diff from 80 lines to 0, this closes the `preprocessed` divergence class.

### Manual controls (ccache parity)

- **`KACHE_BASE_DIR`** — explicit base dir (the `CCACHE_BASEDIR` analog), stripped to `<CC_BASE>` in the cc key and `<BASE_DIR>` in the rustc key. For paths the auto-derivation can't see (container mounts, generated-file env-deps above the workspace). Typically set to the common parent of your checkouts.
- **`KACHE_CC_PATH_NORMALIZE=0`** — kill-switch. Emits no prefix maps, so the cc key hashes raw paths and no `-ffile-prefix-map` is injected. Conservative escape hatch: no cross-machine cc sharing, but zero normalization-miscache surface. Default on; accepts `0`/`false`/`off`/`no`.

### Key version

Bumps `CACHE_KEY_VERSION` 12 → 13 — the include-folding changes default cc keys. (`KACHE_BASE_DIR` / the toggle are opt-in and wouldn't need a bump on their own.)

## Tests

- `cc_prefix_maps_broaden_to_repo_root_via_includes_for_objdir_tus` — objdir TU + in-tree `-I` derives the repo root; a system `-I` adds no `/` root.
- `cc_prefix_maps_cfg_maps_explicit_base_dir_to_base_sentinel` — `KACHE_BASE_DIR` → `<CC_BASE>`.
- `parse_cc_normalize_toggle_defaults_on_opts_out_explicitly` — toggle parsing (default-on, explicit opt-out).
- Full suite: 620 passing, clippy clean, fmt clean.

Refs #217.