### PR TITLE
build(just): set windows-shell to Git bash so recipes run on Windows

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,13 @@
 # Don't use kache to build kache (bootstrapping problem).
 export RUSTC_WRAPPER := ""
 
+# On Windows, `just` runs each recipe line via `sh`, which Git for Windows
+# provides but does not put on PATH — so recipes (e.g. `just bench`) fail with
+# "could not find the shell". Point it at Git bash at its default install path.
+# Unix is unaffected: `windows-shell` only applies on Windows. If Git is
+# installed elsewhere, override this path (or put Git's `usr\bin` on PATH).
+set windows-shell := ["C:/Program Files/Git/usr/bin/sh.exe", "-cu"]
+
 default:
   @just --list
 


### PR DESCRIPTION
## Summary

`just` runs each recipe line via a POSIX shell. On Windows it looks for `sh` on PATH; Git for Windows provides one but doesn't put it on PATH, so `just <recipe>` (e.g. `just bench`) fails with **"could not find the shell: program not found"**. This points `just` at Git bash on Windows.

```just
set windows-shell := ["C:/Program Files/Git/usr/bin/sh.exe", "-cu"]
```

- **Windows-only** — `windows-shell` does not apply on Unix, so macOS/Linux are unaffected (default `sh` still used).
- Git bash is required (not cmd/PowerShell): several recipes use POSIX features — `sccache-check`/`monitor` run `.sh` scripts, `coverage-open` uses `||`.
- The path is the exact `usr/bin/sh.exe` the `kache-bench` engine already resolves and drives builds through on a real Windows 11 box (validated in #232). `-cu` matches `just`'s default `sh` flags.
- Static path because `just`'s `set windows-shell` can't dynamically locate Git (unlike the engine's `git --exec-path` derivation). A comment documents overriding it if Git is installed elsewhere.

Follow-up to #232 (which made the `kache-bench` engine platform-independent); this is the dev-workflow half so `just bench` itself works on Windows.

## Test Plan
- [x] macOS: `just --list` parses; `just fmt-check` runs normally (directive is a no-op on Unix — no regression)
- [ ] **Windows: `just fmt-check` finds Git bash and runs** (instead of "could not find the shell") — *pending the test box coming back online; the `sh.exe` path is already confirmed present + working on it via #232's engine run*

🤖 Generated with [Claude Code](https://claude.com/claude-code)