### PR TITLE
feat(key): user-configurable cache-key salt

### DIFF
--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -58,6 +58,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `16` | Max concurrent S3 operations |
 | `KACHE_S3_POOL_IDLE_SECS` | `cache.s3_pool_idle_secs` | `300` | How long an idle S3 connection is kept in the HTTP pool. Higher values reuse warm TLS sessions across build phases; lower this if you sit behind a load balancer that drops idle connections aggressively |
 | `KACHE_DAEMON_IDLE_TIMEOUT` | `cache.daemon_idle_timeout_secs` | `600` | Idle daemon shutdown timeout in seconds (`0` disables auto-shutdown) |
+| `KACHE_KEY_SALT` | `cache.key_salt` | — | Opaque string folded into every cache key. Change it to force a cold cache on a toolchain change kache cannot otherwise see (see [Cache-key salt](#cache-key-salt)) |
 | `KACHE_DISABLED` | — | `0` | Disable caching entirely (pass-through to rustc) |
 | `KACHE_LOG` | — | `kache=warn` | Log level for stderr output |
 | `KACHE_LOG_FILE` | — | `kache=info` | Log level for the file log |
@@ -81,6 +82,27 @@ exclude = [
 Patterns are globs matched against the compiler's primary source path. Relative patterns are matched relative to the current build directory and, when kache can infer it, the Cargo workspace root. Excluded invocations bypass local lookup, remote lookup, store, and upload.
 
 Exclude patterns support `~`, `$VAR`, and `${VAR}` expansion. `$CARGO_HOME` falls back to Cargo's default `~/.cargo` when the environment variable is not set, so registry-source exclusions work on default Cargo installs.
+
+## Cache-key salt
+
+kache's cache key captures everything it can *observe* about a compile: the rustc version, the target, flags, source and dependency hashes, and the linker's `--version` banner. That set is complete for divergences a tool reports in its version output. It is **not** complete for toolchain changes that alter compiled output while leaving every banner unchanged — most commonly a `glibc`, `mold`, or linker bump, or a Nix store rebuild that swaps the ELF interpreter baked into a binary.
+
+When that happens, the key does not move, so a stale artifact can be restored. On Nix in particular, a `nixpkgs` bump followed by `nix store gc` can leave a restored executable pointing at a garbage-collected interpreter — an error no `cargo clean` can fix, because the key never changed.
+
+`key_salt` is an opaque string folded into every cache key. Set it to a value that *does* change when your toolchain changes — a hash of the toolchain closure, a store-path digest, a date, a CI build id — and that change re-keys the cache (a cold miss) instead of serving a stale hit:
+
+```toml title=".kache.toml"
+[cache]
+key_salt = "nixpkgs-a1b2c3d-mold-2.40"
+```
+
+Or compute it from the toolchain itself:
+
+```sh
+export KACHE_KEY_SALT="$(nix eval --raw .#devShells.default.outPath | sha256sum | cut -c1-16)"
+```
+
+The salt is hashed raw; its meaning is entirely yours. An unset or empty value has **no effect** — keys are byte-identical to not setting it — so it is safe to leave off until you need it. A misconfigured salt can only cost hit rate (an extra miss), never cause a wrong artifact to be restored.
 
 ## Credential resolution order
 

--- a/docs/how-it-works/cache-key.mdx
+++ b/docs/how-it-works/cache-key.mdx
@@ -41,6 +41,8 @@ Sysroot crates (std, core, alloc) can't be read from their installed path on oth
 
 **Remap status.** kache adds `--remap-path-prefix` to normalize source paths in debug info, making artifacts portable. But when coverage instrumentation is active (`-C instrument-coverage`), path remapping is skipped so that coverage tools can map profiling data back to source files. The key reflects this decision.
 
+**Key salt (optional).** If `KACHE_KEY_SALT` / `cache.key_salt` is set, its value is folded into the key. This is an escape hatch for toolchain divergence the key cannot otherwise observe — e.g. a `glibc`/`mold`/linker bump or a Nix store rebuild that changes compiled output without changing any tool's `--version` banner. Unset (the default) has no effect. See [Configuration → Cache-key salt](/getting-started/configuration#cache-key-salt).
+
 ## Cross-machine portability
 
 The key is designed to be the same on any machine that has the same:

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -183,6 +183,34 @@ fn scrub_remap_value(value: &str) -> String {
     }
 }
 
+/// Fold a user-declared salt into an already-computed cache key.
+///
+/// The salt captures toolchain divergence kache cannot observe from the
+/// invocation itself — a glibc/mold/linker bump, a Nix store rebuild,
+/// anything that changes compiled output without changing a tool's
+/// `--version` banner (which is all the linker identity the key sees,
+/// see [`get_linker_identity`]). Hashing the base key together with the
+/// salt yields a distinct key per salt value while leaving the unsalted
+/// case **byte-identical** to today: `None`/empty returns `base`
+/// untouched, so no `CACHE_KEY_VERSION` bump is needed and a project
+/// that never sets it is unaffected.
+///
+/// Shared by every compiler family (rustc and cc) so the salt applies
+/// uniformly regardless of which adapter produced `base`.
+pub(crate) fn apply_key_salt(base: String, salt: Option<&str>) -> String {
+    match salt {
+        Some(salt) if !salt.is_empty() => {
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(b"key_salt:");
+            hasher.update(salt.as_bytes());
+            hasher.update(b"\x1f");
+            hasher.update(base.as_bytes());
+            hasher.finalize().to_hex().to_string()
+        }
+        _ => base,
+    }
+}
+
 /// Compute the blake3 cache key for a rustc invocation.
 ///
 /// The key captures everything that affects compilation output:
@@ -1476,6 +1504,40 @@ fn resolve_in_path(name: &str) -> Option<std::path::PathBuf> {
 mod tests {
     use super::*;
     use crate::args::RustcArgs;
+
+    #[test]
+    fn apply_key_salt_no_salt_is_identity() {
+        let base = "deadbeef".to_string();
+        // None and empty/whitespace are both treated as "unsalted" and
+        // must return the base key byte-for-byte (no CACHE_KEY_VERSION
+        // bump, no effect for projects that never set it).
+        assert_eq!(apply_key_salt(base.clone(), None), base);
+        assert_eq!(apply_key_salt(base.clone(), Some("")), base);
+    }
+
+    #[test]
+    fn apply_key_salt_changes_key_and_is_salt_specific() {
+        let base = "deadbeef".to_string();
+        let a = apply_key_salt(base.clone(), Some("toolchain-A"));
+        let b = apply_key_salt(base.clone(), Some("toolchain-B"));
+        // A salt re-keys, and distinct salts produce distinct keys.
+        assert_ne!(a, base);
+        assert_ne!(b, base);
+        assert_ne!(a, b);
+        // Deterministic: same (base, salt) → same key.
+        assert_eq!(a, apply_key_salt(base, Some("toolchain-A")));
+    }
+
+    #[test]
+    fn apply_key_salt_distinguishes_base_keys() {
+        // The same salt over different base keys stays distinct (the
+        // base is mixed into the hash, not just the salt).
+        let salt = Some("nix-rev-abc");
+        assert_ne!(
+            apply_key_salt("aaaa".to_string(), salt),
+            apply_key_salt("bbbb".to_string(), salt),
+        );
+    }
 
     #[test]
     fn unescape_env_dep_value_undoes_rustc_escaping() {

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2249,6 +2249,7 @@ impl Compiler for CcCompiler {
         );
 
         let key = hasher.finalize().to_hex().to_string();
+        let key = crate::cache_key::apply_key_salt(key, ctx.key_salt);
         tracing::trace!(
             target: "kache::cache_key",
             "[key:{}] final={}",
@@ -3492,6 +3493,7 @@ mod tests {
             file_hasher: &file_hasher,
             path_normalizer: &path_normalizer,
             cache_dir: cache.path(),
+            key_salt: None,
         };
 
         let err = compiler.cache_key(&parsed, &ctx).unwrap_err().to_string();

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -153,6 +153,10 @@ pub struct KeyCtx<'a, 'db> {
     /// runs once per build instead of once per translation unit — see
     /// [`crate::probe`].
     pub cache_dir: &'a Path,
+    /// Opaque user-declared salt folded into the final key by every
+    /// compiler family (see [`crate::cache_key::apply_key_salt`]).
+    /// `None` leaves the key byte-identical to the unsalted case.
+    pub key_salt: Option<&'a str>,
 }
 
 /// Categorization of a compiler output file.

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -89,7 +89,8 @@ impl Compiler for RustcCompiler {
     }
 
     fn cache_key(&self, parsed: &RustcArgs, ctx: &KeyCtx<'_, '_>) -> Result<String> {
-        compute_cache_key(parsed, ctx.file_hasher, ctx.path_normalizer)
+        let key = compute_cache_key(parsed, ctx.file_hasher, ctx.path_normalizer)?;
+        Ok(crate::cache_key::apply_key_salt(key, ctx.key_salt))
     }
 
     fn execute(&self, parsed: &RustcArgs) -> Result<CompileResult> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,15 @@ pub struct Config {
     /// doesn't. `None` = plain passthrough. Set via `KACHE_FALLBACK`
     /// or `[cache] fallback` in the config file.
     pub fallback: Option<String>,
+    /// An opaque string folded into every cache key. Lets a project
+    /// force a cold cache on a change kache cannot otherwise observe —
+    /// e.g. a toolchain-closure bump (glibc/mold/linker, a Nix store
+    /// rebuild) that alters compiled output but leaves every tool's
+    /// `--version` banner unchanged. Set it to a hash of the toolchain
+    /// (or any sentinel) and a change re-keys instead of serving a
+    /// stale hit. `None`/empty = no effect (keys are byte-identical to
+    /// not setting it). Set via `KACHE_KEY_SALT` or `[cache] key_salt`.
+    pub key_salt: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -80,6 +89,8 @@ pub(crate) struct CacheFileConfig {
     /// Secondary compiler-wrapper for passed-through compiles.
     /// See [`Config::fallback`].
     pub(crate) fallback: Option<String>,
+    /// Opaque cache-key salt. See [`Config::key_salt`].
+    pub(crate) key_salt: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
@@ -122,6 +133,7 @@ pub(crate) struct EnvOverrides {
     pub(crate) s3_prefix: bool,
     pub(crate) s3_profile: bool,
     pub(crate) fallback: bool,
+    pub(crate) key_salt: bool,
 }
 
 impl EnvOverrides {
@@ -138,6 +150,7 @@ impl EnvOverrides {
             s3_prefix: std::env::var("KACHE_S3_PREFIX").is_ok(),
             s3_profile: std::env::var("KACHE_S3_PROFILE").is_ok(),
             fallback: std::env::var("KACHE_FALLBACK").is_ok(),
+            key_salt: std::env::var("KACHE_KEY_SALT").is_ok(),
         }
     }
 }
@@ -278,6 +291,20 @@ impl Config {
                 !s.is_empty() && !s.eq_ignore_ascii_case("off") && !s.eq_ignore_ascii_case("none")
             });
 
+        // Cache-key salt. Env wins over the file; an empty / whitespace
+        // value is treated as unset so it never silently shifts the key.
+        let key_salt = std::env::var("KACHE_KEY_SALT")
+            .ok()
+            .or_else(|| {
+                file_config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.cache.as_ref())
+                    .and_then(|c| c.key_salt.clone())
+            })
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
         let remote = Self::load_remote_config(&file_config);
 
         Ok(Config {
@@ -294,6 +321,7 @@ impl Config {
             daemon_idle_timeout_secs,
             s3_pool_idle_secs,
             fallback,
+            key_salt,
         })
     }
 
@@ -761,6 +789,7 @@ mod tests {
         let config = FileConfig {
             cache: Some(CacheFileConfig {
                 fallback: None,
+                key_salt: None,
                 local_store: Some("~/my/cache".to_string()),
                 local_max_size: Some("50GiB".to_string()),
                 planner: None,
@@ -824,6 +853,47 @@ mod tests {
     }
 
     #[test]
+    fn test_key_salt_file_env_precedence() {
+        let _guard = config_path_lock();
+
+        // Save/clear the process-global salt env so the test is
+        // deterministic, and restore it on the way out.
+        let prev_salt = std::env::var_os("KACHE_KEY_SALT");
+        let restore_salt = |v: &Option<OsString>| unsafe {
+            match v {
+                Some(val) => std::env::set_var("KACHE_KEY_SALT", val),
+                None => std::env::remove_var("KACHE_KEY_SALT"),
+            }
+        };
+        restore_salt(&None);
+
+        let dir = tempfile::tempdir().unwrap();
+        let cfg_path = dir.path().join("config.toml");
+        std::fs::write(&cfg_path, "[cache]\nkey_salt = \"from-file\"\n").unwrap();
+        let _cfg_guard = set_kache_config_for_test(&cfg_path);
+
+        // File value is picked up.
+        assert_eq!(
+            Config::load().unwrap().key_salt.as_deref(),
+            Some("from-file")
+        );
+
+        // Env wins over the file.
+        unsafe { std::env::set_var("KACHE_KEY_SALT", "from-env") };
+        assert_eq!(
+            Config::load().unwrap().key_salt.as_deref(),
+            Some("from-env")
+        );
+
+        // A whitespace-only value is treated as unset (never silently
+        // shifts the key).
+        unsafe { std::env::set_var("KACHE_KEY_SALT", "   ") };
+        assert_eq!(Config::load().unwrap().key_salt, None);
+
+        restore_salt(&prev_salt);
+    }
+
+    #[test]
     fn test_env_overrides_detect() {
         // Just verify it doesn't panic — actual env var presence is environment-dependent
         let overrides = EnvOverrides::detect();
@@ -836,6 +906,7 @@ mod tests {
     fn test_config_store_dir() {
         let config = Config {
             fallback: None,
+            key_salt: None,
             cache_dir: PathBuf::from("/tmp/kache"),
             max_size: 1024,
             remote: None,
@@ -856,6 +927,7 @@ mod tests {
     fn test_config_index_db_path() {
         let config = Config {
             fallback: None,
+            key_salt: None,
             cache_dir: PathBuf::from("/tmp/kache"),
             max_size: 1024,
             remote: None,
@@ -876,6 +948,7 @@ mod tests {
     fn test_config_event_log_path() {
         let config = Config {
             fallback: None,
+            key_salt: None,
             cache_dir: PathBuf::from("/tmp/kache"),
             max_size: 1024,
             remote: None,
@@ -899,6 +972,7 @@ mod tests {
     fn test_config_socket_path() {
         let config = Config {
             fallback: None,
+            key_salt: None,
             cache_dir: PathBuf::from("/tmp/kache"),
             max_size: 1024,
             remote: None,
@@ -1056,6 +1130,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
         let config = FileConfig {
             cache: Some(CacheFileConfig {
                 fallback: None,
+                key_salt: None,
                 local_store: Some("/tmp/my-cache".to_string()),
                 local_max_size: Some("10GiB".to_string()),
                 planner: None,

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -179,6 +179,17 @@ fn build_fields(file_config: &FileConfig, env: &EnvOverrides) -> Vec<FormField> 
             env_locked: env.fallback,
         },
         FormField {
+            key: "key_salt",
+            label: "Cache-key salt",
+            kind: FieldKind::Text,
+            value: cache.and_then(|c| c.key_salt.clone()).unwrap_or_default(),
+            env_var: "KACHE_KEY_SALT",
+            env_value: env_val("KACHE_KEY_SALT"),
+            default_hint: "(none)",
+            validation_error: None,
+            env_locked: env.key_salt,
+        },
+        FormField {
             key: "exclude",
             label: "Exclude paths",
             kind: FieldKind::Text,
@@ -457,6 +468,7 @@ fn fields_to_file_config(
                 .and_then(|s| s.parse::<u64>().ok()),
             s3_pool_idle_secs: get("s3_pool_idle_secs").and_then(|s| s.parse::<u64>().ok()),
             fallback: get("fallback"),
+            key_salt: get("key_salt"),
             remote,
         }),
     }
@@ -980,6 +992,7 @@ mod tests {
     fn empty_env() -> EnvOverrides {
         EnvOverrides {
             fallback: false,
+            key_salt: false,
             disabled: false,
             cache_dir: false,
             max_size: false,
@@ -997,7 +1010,7 @@ mod tests {
     fn test_build_fields_count() {
         let config = FileConfig::default();
         let fields = build_fields(&config, &empty_env());
-        assert_eq!(fields.len(), 14);
+        assert_eq!(fields.len(), 15);
     }
 
     #[test]
@@ -1094,6 +1107,7 @@ mod tests {
         let original = FileConfig {
             cache: Some(CacheFileConfig {
                 fallback: None,
+                key_salt: None,
                 local_store: Some("~/cache".to_string()),
                 local_max_size: Some("50GiB".to_string()),
                 planner: Some(PlannerFileConfig {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3757,6 +3757,7 @@ mod tests {
     fn test_config(dir: &Path) -> Config {
         Config {
             fallback: None,
+            key_salt: None,
             cache_dir: dir.to_path_buf(),
             max_size: 50 * 1024 * 1024, // 50 MiB
             remote: None,

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -495,6 +495,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let config = Config {
             fallback: None,
+            key_salt: None,
             cache_dir: tmp.path().join("cache"),
             max_size: 1024 * 1024,
             remote: None,
@@ -552,6 +553,7 @@ mod tests {
         let restore_cache_dir = tmp.path().join("restore-cache");
         let restore_config = Config {
             fallback: None,
+            key_salt: None,
             cache_dir: restore_cache_dir,
             max_size: 1024 * 1024,
             remote: None,
@@ -589,6 +591,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let config = Config {
             fallback: None,
+            key_salt: None,
             cache_dir: tmp.path().join("cache"),
             max_size: 1024 * 1024,
             remote: None,

--- a/src/remote_plan.rs
+++ b/src/remote_plan.rs
@@ -78,6 +78,7 @@ mod tests {
     fn test_config() -> Config {
         Config {
             fallback: None,
+            key_salt: None,
             cache_dir: PathBuf::from("/tmp/kache-test"),
             max_size: 1024,
             remote: None,

--- a/src/report.rs
+++ b/src/report.rs
@@ -1760,6 +1760,7 @@ mod tests {
     fn write_test_events(dir: &std::path::Path) -> Config {
         let config = Config {
             fallback: None,
+            key_salt: None,
             cache_dir: dir.to_path_buf(),
             max_size: 1024,
             remote: None,
@@ -1928,6 +1929,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = Config {
             fallback: None,
+            key_salt: None,
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,
@@ -1956,6 +1958,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = Config {
             fallback: None,
+            key_salt: None,
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,
@@ -2037,6 +2040,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = Config {
             fallback: None,
+            key_salt: None,
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,

--- a/src/store.rs
+++ b/src/store.rs
@@ -1329,6 +1329,7 @@ mod tests {
     fn test_config(dir: &Path) -> Config {
         Config {
             fallback: None,
+            key_salt: None,
             cache_dir: dir.to_path_buf(),
             max_size: 1024 * 1024, // 1 MiB
             remote: None,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -180,6 +180,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         file_hasher: &file_hasher,
         path_normalizer: &path_normalizer,
         cache_dir: &config.cache_dir,
+        key_salt: config.key_salt.as_deref(),
     };
     let cache_key = match compiler.cache_key(&parsed, &key_ctx) {
         Ok(k) => k,
@@ -639,6 +640,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         file_hasher: &file_hasher,
         path_normalizer: &path_normalizer,
         cache_dir: &config.cache_dir,
+        key_salt: config.key_salt.as_deref(),
     };
     let cache_key = match compiler.cache_key(&args, &key_ctx) {
         Ok(key) => key,


### PR DESCRIPTION
## Summary

Adds an opaque, user-declared **cache-key salt** — `KACHE_KEY_SALT` env or `[cache] key_salt` in config — folded into every cache key.

It's an escape hatch for toolchain divergence kache **cannot observe** from the invocation itself: the key captures the linker only by its `--version` banner (`cache_key.rs:get_linker_identity`), so a `glibc`/`mold`/linker bump or a Nix store rebuild that changes compiled output without changing any banner is invisible. On Nix this bites hard — a `nixpkgs` bump + `nix store gc` can leave a restored binary pointing at a GC'd ELF interpreter (`ENOENT` no `cargo clean` fixes). Set the salt to something that *does* move with the toolchain and that change re-keys (cold miss) instead of serving a stale hit.

This is the upstream version of what the rio-build integration (lovesegfault/rio-build#51) hand-rolled as an environment-salted store directory.

Closes #237.

## Design

- `cache_key::apply_key_salt(base, salt)` hashes the salt together with the already-computed key. Threaded through `KeyCtx`, so **both** the rustc and cc adapters apply it uniformly.
- **Unset/empty = no-op**: returns the base key byte-for-byte → no `CACHE_KEY_VERSION` bump, zero impact for projects that never set it.
- Resolved in `Config::load` (env wins over file; whitespace-only trimmed to unset so it can't silently shift the key).
- Surfaced in the `kache config` TUI and documented.
- **Fail-toward-miss**: a misconfigured salt can only cost hit rate, never restore a wrong artifact — same bias as the rest of the keying layer.

## Config

```toml title=".kache.toml"
[cache]
key_salt = "nixpkgs-a1b2c3d-mold-2.40"
```

```sh
export KACHE_KEY_SALT="$(nix eval --raw .#devShells.default.outPath | sha256sum | cut -c1-16)"
```

## Tests

- `apply_key_salt`: unset/empty is identity; a salt re-keys; distinct salts differ; same base+salt is deterministic; same salt over different bases stays distinct.
- `Config` load: file value picked up, env wins over file, whitespace-only treated as unset.
- Full suite green (626 tests), `cargo fmt --check` + `clippy --all-targets` clean.

## Docs

- `docs/getting-started/configuration.mdx`: new `KACHE_KEY_SALT` row + a **Cache-key salt** section (with the Nix rationale).
- `docs/how-it-works/cache-key.mdx`: a **Key salt** entry in the key-inputs list.