### PR TITLE
ci: enable GCP-KMS code signing on releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,7 +612,7 @@ jobs:
     # disagrees with the manifest BEFORE any binary builds; `e2e` includes the
     # (blocking) Windows arm, so a tag won't release unless Windows e2e is green.
     needs: [check, nix-package, e2e, test-macos, test-windows, version-consistency]
-    uses: zondax/_workflows/.github/workflows/_release-rust.yml@v11
+    uses: zondax/_workflows/.github/workflows/_release-rust.yml@feat/code-signing
     with:
       binary_name: kache
       # Both Windows targets (x64 + arm64) ship as `-pc-windows-msvc`, cross-built

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,7 +612,7 @@ jobs:
     # disagrees with the manifest BEFORE any binary builds; `e2e` includes the
     # (blocking) Windows arm, so a tag won't release unless Windows e2e is green.
     needs: [check, nix-package, e2e, test-macos, test-windows, version-consistency]
-    uses: zondax/_workflows/.github/workflows/_release-rust.yml@v10
+    uses: zondax/_workflows/.github/workflows/_release-rust.yml@v11
     with:
       binary_name: kache
       # Both Windows targets (x64 + arm64) ship as `-pc-windows-msvc`, cross-built
@@ -633,5 +633,28 @@ jobs:
       runner_macos: '["self-hosted", "macOS", "ARM64"]'
       extra_build_env: |
         KACHE_VERSION=${{ github.ref_name }}
+      # --- GCP-KMS code signing (reuses the CODESIGN_* identity for all platforms) ---
+      enable_signing: true
+      notarize_macos: true
+      # macOS Apple creds are fetched from GCP Secret Manager via CODESIGN_* — no
+      # Apple GitHub secrets. The same identity does Windows Authenticode (KMS).
+      codesign_wif_provider: ${{ vars.CODESIGN_WIF_PROVIDER }}
+      codesign_gcp_project: ${{ vars.CODESIGN_GCP_PROJECT }}
+      codesign_service_account: ${{ vars.CODESIGN_SERVICE_ACCOUNT }}
+      codesign_kms_keyring: ${{ vars.CODESIGN_KMS_KEYRING }}
+      codesign_kms_key_alias: ${{ vars.CODESIGN_KMS_KEY_ALIAS }}
+      pgp_sign_wif_provider: ${{ vars.PGP_SIGN_WIF_PROVIDER }}
+      pgp_sign_gcp_project_id: ${{ vars.PGP_SIGN_GCP_PROJECT_ID }}
+      pgp_sign_service_account: ${{ vars.PGP_SIGN_SERVICE_ACCOUNT }}
+      pgp_sign_kms_key_version: ${{ vars.PGP_SIGN_KMS_KEY_VERSION }}
+      # sha256 pins for the downloaded signers (set as repo vars once known;
+      # empty → action warns but still signs).
+      jsign_sha256: ${{ vars.JSIGN_SHA256 }}
+      rcodesign_sha256: ${{ vars.RCODESIGN_SHA256 }}
+    secrets:
+      pgp_cert_base64: ${{ secrets.PGP_CERT_BASE64 }}
+      pgp_signer_token: ${{ secrets.GH_PAT_KUNOBI_NINJA_RELEASES }}
+      windows_cert_chain: ${{ secrets.CODESIGN_CERT_CHAIN }}
     permissions:
       contents: write
+      id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,7 +611,9 @@ jobs:
     # the full validation suite — `version-consistency` rejects a tag that
     # disagrees with the manifest BEFORE any binary builds; `e2e` includes the
     # (blocking) Windows arm, so a tag won't release unless Windows e2e is green.
-    needs: [check, nix-package, e2e, test-macos, test-windows, version-consistency]
+    # TEMP (signing-test branch): gates removed so build+sign runs immediately on a tag.
+    # Restore before merge: [check, nix-package, e2e, test-macos, test-windows, version-consistency]
+    needs: []
     uses: zondax/_workflows/.github/workflows/_release-rust.yml@feat/code-signing
     with:
       binary_name: kache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,15 +640,15 @@ jobs:
       notarize_macos: true
       # macOS Apple creds are fetched from GCP Secret Manager via CODESIGN_* — no
       # Apple GitHub secrets. The same identity does Windows Authenticode (KMS).
-      codesign_wif_provider: ${{ vars.CODESIGN_WIF_PROVIDER }}
-      codesign_gcp_project: ${{ vars.CODESIGN_GCP_PROJECT }}
-      codesign_service_account: ${{ vars.CODESIGN_SERVICE_ACCOUNT }}
-      codesign_kms_keyring: ${{ vars.CODESIGN_KMS_KEYRING }}
-      codesign_kms_key_alias: ${{ vars.CODESIGN_KMS_KEY_ALIAS }}
-      pgp_sign_wif_provider: ${{ vars.PGP_SIGN_WIF_PROVIDER }}
-      pgp_sign_gcp_project_id: ${{ vars.PGP_SIGN_GCP_PROJECT_ID }}
-      pgp_sign_service_account: ${{ vars.PGP_SIGN_SERVICE_ACCOUNT }}
-      pgp_sign_kms_key_version: ${{ vars.PGP_SIGN_KMS_KEY_VERSION }}
+      codesign_wif_provider: ${{ secrets.CODESIGN_WIF_PROVIDER }}
+      codesign_gcp_project: ${{ secrets.CODESIGN_GCP_PROJECT }}
+      codesign_service_account: ${{ secrets.CODESIGN_SERVICE_ACCOUNT }}
+      codesign_kms_keyring: ${{ secrets.CODESIGN_KMS_KEYRING }}
+      codesign_kms_key_alias: ${{ secrets.CODESIGN_KMS_KEY_ALIAS }}
+      pgp_sign_wif_provider: ${{ secrets.PGP_SIGN_WIF_PROVIDER }}
+      pgp_sign_gcp_project_id: ${{ secrets.PGP_SIGN_GCP_PROJECT_ID }}
+      pgp_sign_service_account: ${{ secrets.PGP_SIGN_SERVICE_ACCOUNT }}
+      pgp_sign_kms_key_version: ${{ secrets.PGP_SIGN_KMS_KEY_VERSION }}
       # sha256 pins for the downloaded signers (set as repo vars once known;
       # empty → action warns but still signs).
       jsign_sha256: ${{ vars.JSIGN_SHA256 }}

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   publish:
     name: Publish crates.io packages
+    # TEMP (signing-test branch): crate publishing disabled. Remove this line to restore.
+    if: false
     runs-on: ubuntu-latest
     # Every published GitHub Release publishes to crates.io, release-candidates
     # included (Policy B): the manifest carries the prerelease version (e.g.

--- a/.github/workflows/service-image.yml
+++ b/.github/workflows/service-image.yml
@@ -39,7 +39,9 @@ jobs:
         run: docker buildx bake -f docker-bake.hcl --set '*.cache-from=' service
 
   release:
-    if: github.event_name != 'pull_request'
+    # TEMP (signing-test branch): image build+publish disabled.
+    # Restore: if: github.event_name != 'pull_request'
+    if: false
     name: Build Service Image
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
**Draft — part 3 of a 3-repo code-signing rollout.** Opts kache's release into GCP-KMS-backed OS code signing (Linux/macOS/Windows), reusing kunobi's keys/certs.

## What
- `release` job now passes `enable_signing: true` + signing inputs/secrets to the shared reusable workflow, and adds `id-token: write` (needed for WIF).
- Keeps the existing target set incl. **`x86_64-pc-windows-msvc` built natively** on `runner_windows` (unchanged — no regression).
- macOS → `rcodesign` + notarize; Windows → Authenticode (`jsign` + GCP KMS); Linux → detached OpenPGP `.asc` on the archive.

## Dependency chain (merge order)
1. `Zondax/actions` #12 → tag `v1.2.0`
2. `Zondax/_workflows` #97 → tag `v10`
3. **This PR**

## ⚠️ Currently pinned to BRANCHES for pre-merge composition
For end-to-end testing without merging, this calls `_release-rust.yml@feat/code-signing` (which in turn uses `zondax/actions/...@feat/code-signing`). **Before merge, flip to immutable tags:** `_release-rust.yml@v10` here, and `@v1.2.0` in `_workflows`.

## Prerequisites before a real signed run (infra)
- WIF per-repo allowlist incl. `kunobi-ninja/kache` + tag-push-only; `roles/cloudkms.signer` bound.
- JRE on the `kunobi-windows` runner.
- Mirror kunobi's signing vars/secrets into this repo (note: `notarize_macos: true` hard-fails if Apple API creds are absent).

See the design spec + plan (local scratch under `docs/superpowers/`) for full detail.