### PR TITLE
fix(disabled): pre-clean read-only restores before direct-exec passthrough

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -363,7 +363,11 @@ fn discover_output_files(
 /// target directory. If a subsequent build is a cache miss for the same crate,
 /// rustc tries to overwrite these paths but fails because the hardlinked files
 /// are read-only. This function removes them so rustc can create fresh files.
-fn pre_clean_outputs(
+///
+/// Also reused by the direct-exec passthrough (`KACHE_DISABLED`, nested
+/// re-entrancy) so a non-kache compile over a warm, restored target dir
+/// does not hit EACCES — see `run_compiler_directly` in `main.rs`.
+pub(crate) fn pre_clean_outputs(
     output_path: Option<&Path>,
     out_dir: Option<&Path>,
     crate_name: Option<&str>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -498,6 +498,28 @@ const KACHE_ACTIVE_ENV: &str = "KACHE_ACTIVE";
 /// prevent APFS-related corruption in git worktrees on macOS. Returns
 /// the child's exit code.
 fn run_compiler_directly(args: &[String]) -> Result<i32> {
+    // A previous cache-on build may have restored this crate's outputs
+    // as read-only hardlinks into the store (0o444, shared inode).
+    // Running the real compiler over them in place would fail with
+    // EACCES — and a chmod could not help, since the inode is shared
+    // with the store blob (truncating it would poison future restores).
+    // Unlink them first: a plain remove breaks the hardlink and leaves
+    // the store blob intact, exactly as the enabled cache-miss path does
+    // before recompiling. Without this, `KACHE_DISABLED=1` (or a nested
+    // re-entrant compile) over a warm target dir breaks the build.
+    //
+    // Best-effort and rustc-shaped: the arg parser is lenient, so a cc
+    // argv yields just its `-o` target (also a read-only restore) and an
+    // unparseable argv cleans nothing.
+    if let Ok(parsed) = args::RustcArgs::parse(args) {
+        compile::pre_clean_outputs(
+            parsed.output.as_deref(),
+            parsed.out_dir.as_deref(),
+            parsed.crate_name.as_deref(),
+            parsed.extra_filename.as_deref(),
+        );
+    }
+
     let filtered = compile::strip_incremental_flags(&args[1..]);
     let status = std::process::Command::new(&args[0])
         .args(&filtered)
@@ -595,6 +617,44 @@ mod tests {
         // compiler: they exit 0 / 1 and ignore their arguments.
         assert_eq!(run_compiler_directly(&["true".to_string()]).unwrap(), 0);
         assert_eq!(run_compiler_directly(&["false".to_string()]).unwrap(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_compiler_directly_pre_cleans_readonly_restores() {
+        // Regression for #238: a direct-exec passthrough (KACHE_DISABLED
+        // / nested re-entrancy) over a target dir that still holds
+        // read-only hardlinked restores must unlink them first, or the
+        // real compiler hits EACCES overwriting them in place.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let restored = dir.path().join("libfoo.rlib");
+        std::fs::write(&restored, b"cached").unwrap();
+        std::fs::set_permissions(&restored, std::fs::Permissions::from_mode(0o444)).unwrap();
+        assert!(
+            std::fs::metadata(&restored)
+                .unwrap()
+                .permissions()
+                .readonly()
+        );
+
+        // `true` stands in for the compiler (ignores args, exits 0); the
+        // rustc-shaped flags drive the pre-clean's out-dir branch.
+        let code = run_compiler_directly(&[
+            "true".to_string(),
+            "--crate-name".to_string(),
+            "foo".to_string(),
+            "--out-dir".to_string(),
+            dir.path().to_string_lossy().into_owned(),
+        ])
+        .unwrap();
+
+        assert_eq!(code, 0);
+        assert!(
+            !restored.exists(),
+            "read-only restore should have been unlinked before exec"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes an **EACCES** that the rio-build integration (lovesegfault/rio-build#51) hit: the first `KACHE_DISABLED=1` build over a warm target dir fails because the real compiler can't overwrite kache's read-only restores.

When kache restores a cache hit it hardlinks store blobs (0o444, shared inode) into `target/`. The **enabled** cache-miss path already unlinks those before recompiling (`compile::pre_clean_outputs`), but the **direct-exec passthrough** — `run_compiler_directly`, used by both the `KACHE_DISABLED` branch and the nested re-entrancy guard — skipped it. So the real compiler tried to overwrite a read-only file in place → `EACCES`.

A `chmod` can't fix it: the inode is shared with the store blob, so truncating in place would poison every future restore. **Unlinking** breaks the hardlink and leaves the blob intact.

`KACHE_DISABLED` is the recommended opt-out precisely because toggling it doesn't perturb cargo's fingerprints — so it's exactly the path that runs over a warm, kache-populated target dir.

Closes #238.

## Fix

Route `run_compiler_directly` (the single direct-exec chokepoint) through the same `pre_clean_outputs` the enabled path already uses — now `pub(crate)`. Best-effort and rustc-shaped: the lenient arg parser yields just a cc `-o` target (also a read-only restore) and cleans nothing for an unparseable argv. The existing `remove_if_readonly` does a plain `remove_file` on Unix (a true unlink), so the store blob is untouched.

The lifecycle stays symmetric: on the next caching-on build, the restore path re-establishes the hardlink (it removes the destination before linking), so the disabled build's private writable copy is replaced by a fresh read-only hardlink.

## Tests

- New `run_compiler_directly_pre_cleans_readonly_restores`: a 0o444 restore in an out-dir is unlinked before a stand-in compiler exec (regression for #238).
- Existing `pre_clean_outputs` unit tests (siblings, dep-info, writable-skipped) still cover the cleaning logic.
- Full suite green (627), `cargo fmt --check` + `clippy --all-targets` clean.