### PR TITLE
fix(bench): start the kache daemon during cold + warm phases

### DIFF
--- a/crates/kache-e2e/src/bin/kache-bench.rs
+++ b/crates/kache-e2e/src/bin/kache-bench.rs
@@ -286,7 +286,10 @@ fn main() -> Result<()> {
     }
 
     // warm: same cache, fresh clone at a different path → served from
-    // what cold populated.
+    // what cold populated. Bring the daemon up first so the restore uses the
+    // async file-hash prefetch path instead of hashing every input inline
+    // (cold's daemon was stopped before its report capture).
+    daemon_start(&kache, &cache_dir, &kache_config);
     let warm_s = build(
         &profile,
         &clone_b,
@@ -849,6 +852,7 @@ fn run_cold_phase(
         std::fs::remove_dir_all(cache_dir).context("clearing cache dir")?;
     }
     std::fs::create_dir_all(cache_dir)?;
+    daemon_start(kache, cache_dir, kache_config);
     let cold_s = build(
         profile,
         clone_a,
@@ -1298,6 +1302,29 @@ fn daemon_stop(kache: &Path, cache_dir: &Path) {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
+}
+
+/// Start a background `kache daemon` against the bench cache dir. The kache
+/// wrapper never auto-starts one (so builds never break if it is down), so
+/// without this the warm phase hits the "daemon socket does not exist"
+/// fallback and hashes every input file synchronously — inflating wall-time
+/// and reporting zero prefetch hits. Must point at the SAME
+/// `KACHE_CACHE_DIR`/`KACHE_CONFIG` the build uses so the socket path
+/// (`cache_dir/daemon.sock`) matches what the wrapper probes. Best-effort: a
+/// failure degrades to the no-daemon path rather than breaking the bench.
+fn daemon_start(kache: &Path, cache_dir: &Path, kache_config: &Path) {
+    match Command::new(kache)
+        .args(["daemon", "start"])
+        .env("KACHE_CACHE_DIR", cache_dir)
+        .env("KACHE_CONFIG", kache_config)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+    {
+        Ok(s) if s.success() => eprintln!("[bench] daemon started"),
+        Ok(s) => eprintln!("[bench] WARN: daemon start exited {s} (running w/o daemon)"),
+        Err(e) => eprintln!("[bench] WARN: daemon start failed ({e}) (running w/o daemon)"),
+    }
 }
 
 /// Run a command with inherited stdio, failing on a non-zero exit.


### PR DESCRIPTION
## Problem

The kache wrapper deliberately **never auto-starts a daemon** (so a build never breaks if one is down), and the bench harness only ever **stopped** one (`daemon_stop`) — it never started one. So across an entire bench run **no daemon ever existed**:

- every wrapper invocation hit the `daemon socket does not exist` fallback (~600× on the Firefox bench),
- file hashing ran **synchronously** in-process,
- `prefetch_hits = 0`,

which inflated the **warm** wall-time the bench reports — i.e. the harness was measuring a degraded path, not the one a real user with a daemon gets.

## Fix

Add a `daemon_start` helper (symmetric to the existing `daemon_stop`) and bring the daemon up at the top of each build phase — in `run_cold_phase` (after the cache dir is (re)created) and right before the warm `build(...)`. It points at the **same** `KACHE_CACHE_DIR`/`KACHE_CONFIG` the build uses, so the socket path (`cache_dir/daemon.sock`) matches what the wrapper probes.

Best-effort: if `kache daemon start` fails, it logs a warning and the bench continues on the no-daemon path (same behavior as before this change) rather than breaking.

## Notes
- Helps **every** bench profile, not just Firefox.
- fmt + clippy clean; `kache-bench` unit tests (13) pass.