### PR TITLE
feat(cc): user-configurable cc flag allow-list ([cc] extra_codegen_flags)

### DIFF
--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -59,6 +59,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_S3_POOL_IDLE_SECS` | `cache.s3_pool_idle_secs` | `300` | How long an idle S3 connection is kept in the HTTP pool. Higher values reuse warm TLS sessions across build phases; lower this if you sit behind a load balancer that drops idle connections aggressively |
 | `KACHE_DAEMON_IDLE_TIMEOUT` | `cache.daemon_idle_timeout_secs` | `600` | Idle daemon shutdown timeout in seconds (`0` disables auto-shutdown) |
 | `KACHE_KEY_SALT` | `cache.key_salt` | — | Opaque string folded into every cache key. Change it to force a cold cache on a toolchain change kache cannot otherwise see (see [Cache-key salt](#cache-key-salt)) |
+| `KACHE_CC_EXTRA_CODEGEN_FLAGS` | `cc.extra_codegen_flags` | `[]` | C/C++ flags to opt into caching that kache's built-in allow-list doesn't yet model (see [Extra cc codegen flags](#extra-cc-codegen-flags)). Env value is whitespace-separated |
 | `KACHE_DISABLED` | — | `0` | Disable caching entirely (pass-through to rustc) |
 | `KACHE_LOG` | — | `kache=warn` | Log level for stderr output |
 | `KACHE_LOG_FILE` | — | `kache=info` | Log level for the file log |
@@ -140,6 +141,36 @@ This is **opt-in and scoped per crate**: a crate with no `kache.toml` is unaffec
   `kache.toml` (no leading dot) is **only** for `extra_inputs`. It is distinct
   from the project config `.kache.toml`; any other key in it is a loud error.
 </Callout>
+
+## Extra cc codegen flags
+
+kache caches a C/C++ compile only when it recognizes every flag on the command line. Its cc flag classifier is an **allow-list**: each flag is one kache has reasoned about and knows how to key. Anything unrecognized is refused and the compile passes through uncached — the safe default, since a flag kache doesn't model could change the object file without changing the key.
+
+The cost is that a common-but-unlisted flag disables caching for that compile until kache ships a release adding it. `cc.extra_codegen_flags` lets you opt such a flag in locally, ahead of official support:
+
+```toml title=".kache.toml"
+[cc]
+extra_codegen_flags = ["-ffunction-sections", "-fdata-sections", "-fno-rtti"]
+```
+
+Or via the environment (whitespace-separated; overrides the file):
+
+```sh
+export KACHE_CC_EXTRA_CODEGEN_FLAGS="-ffunction-sections -fdata-sections"
+```
+
+Semantics:
+
+- **Exact match.** An entry matches a command-line token character-for-character — no prefixes or wildcards. List each value you use (e.g. `-march=armv8.2-a`, not `-march=`).
+- **Hashed verbatim.** A matched flag that's actually present is folded into the cache key as its literal string, so a different flag (or value) always produces a different key — it can never miscache *by value*.
+- **Add-only.** This can only make kache *stop refusing* a flag. It cannot override structural refusals — link mode, coverage instrumentation, multi-`-arch`, precompiled headers, modules, and the like still pass through.
+- **Off by default.** An empty list has no effect; keys are byte-identical to not setting it.
+
+<Callout type="warn">
+Avoid host-dependent flags like `-march=native`. The string is identical on every machine but compiles to different objects per CPU, so hashing it verbatim collides across hosts — a cache hit on one machine can restore an object built for another. List explicit architectures instead.
+</Callout>
+
+To confirm it took effect, run with `KACHE_LOG=kache=debug`: the cc flag-classify summary gains a `user-allowed` count, and the flag no longer appears in any `unsupported flag(s): … — passthrough` line. At `kache=trace` each accepted flag logs as `user-allowed (config)` and each one folded into the key logs as `cc_extra_flag=`.
 
 ## Credential resolution order
 

--- a/docs/how-it-works/cache-key.mdx
+++ b/docs/how-it-works/cache-key.mdx
@@ -45,6 +45,8 @@ Sysroot crates (std, core, alloc) can't be read from their installed path on oth
 
 **Extra cache-key inputs (optional).** A crate can declare files the compiler reads at compile time but never reports — sqlx's `.sqlx/query-*.json`, `migrations/`, `include!`'d data — in a co-located `kache.toml`. Each matched file is folded as its _crate-relative path_ plus _content hash_, so editing one (or swapping two files' contents, where the filename→content binding is load-bearing, like migration order) re-keys that crate, while a worktree move does not. The declared glob set is folded too, so editing `kache.toml` re-keys even at zero matches. Opt-in, per-crate, and union-only — a misdeclared glob can only cost an extra miss, never restore a wrong artifact. See [Configuration → Extra cache-key inputs](/getting-started/configuration#extra-cache-key-inputs).
 
+**Extra cc codegen flags (optional).** For C/C++ compiles, any flag listed in `cc.extra_codegen_flags` / `KACHE_CC_EXTRA_CODEGEN_FLAGS` that the built-in allow-list doesn't model is folded into the key *verbatim* when present on the command line, so a different flag or value always produces a different key. Unset (the default) has no effect. See [Configuration → Extra cc codegen flags](/getting-started/configuration#extra-cc-codegen-flags).
+
 ## Cross-machine portability
 
 The key is designed to be the same on any machine that has the same:

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -539,7 +539,7 @@ impl CcArgs {
     /// - **Preprocess / Assemble mode**: `-E` and `-S` produce
     ///   developer-facing output that's rarely worth caching and
     ///   tangles with the cc-crate probe pattern.
-    pub fn refuse_reasons(&self) -> Vec<RefuseReason> {
+    pub fn refuse_reasons(&self, extra_codegen_flags: &[String]) -> Vec<RefuseReason> {
         let mut reasons = Vec::new();
 
         // ── Non-`-c` mode refusals (short-circuit) ──
@@ -684,7 +684,7 @@ impl CcArgs {
         // yet seen — all force a passthrough. The rejected flags are
         // named in the reason so it is visible which flags blocked
         // caching (and therefore which rows to add to `CC_FLAGS`).
-        let rejected = classify_and_trace_cc_flags(self);
+        let rejected = classify_and_trace_cc_flags(self, extra_codegen_flags);
         if !rejected.is_empty() {
             // Leak a per-invocation summary so it can ride in
             // `RefuseReason::Unsupported(&'static str)`. The wrapper
@@ -1585,6 +1585,9 @@ struct FlagClassificationSummary {
     preprocessor_captured: usize,
     no_object_effect: usize,
     parser_handled: usize,
+    /// Unmodeled by the built-in table but opted into caching via the
+    /// user's `[cc] extra_codegen_flags` allow-list (issue #95).
+    user_allowed: usize,
     unmodeled: usize,
 }
 
@@ -1601,7 +1604,18 @@ impl FlagClassificationSummary {
     }
 }
 
-fn classify_and_trace_cc_flags(parsed: &CcArgs) -> Vec<&str> {
+/// Classify the parsed flags, emitting per-flag and per-compile traces,
+/// and return the tokens that should *refuse* (force passthrough).
+///
+/// `extra_codegen_flags` is the user's allow-list (issue #95): a flag the
+/// built-in table doesn't model is normally rejected, but if it exactly
+/// matches an allow-list entry it is accepted instead (logged as
+/// `user-allowed (config)`) and folded verbatim into the cache key by
+/// [`CcCompiler::cache_key`].
+fn classify_and_trace_cc_flags<'a>(
+    parsed: &'a CcArgs,
+    extra_codegen_flags: &[String],
+) -> Vec<&'a str> {
     let subject = parsed
         .sources
         .first()
@@ -1618,6 +1632,12 @@ fn classify_and_trace_cc_flags(parsed: &CcArgs) -> Vec<&str> {
                 "[cc:{subject}] flag {arg} -> {class:?} [{:?}]",
                 analysis.bucket
             ),
+            None if extra_codegen_flags.iter().any(|f| f == arg) => {
+                summary.user_allowed += 1;
+                tracing::trace!(
+                    "[cc:{subject}] flag {arg} -> user-allowed (config) [verbatim-keyed]"
+                );
+            }
             None => {
                 tracing::trace!(
                     "[cc:{subject}] flag {arg} -> unmodeled [{:?}]",
@@ -1630,17 +1650,41 @@ fn classify_and_trace_cc_flags(parsed: &CcArgs) -> Vec<&str> {
 
     if !parsed.rest.is_empty() {
         tracing::debug!(
-            "[cc:{subject}] flag classify: {} modeled / {} probe / {} preprocessor / {} no-effect / {} parser-handled / {} unmodeled",
+            "[cc:{subject}] flag classify: {} modeled / {} probe / {} preprocessor / {} no-effect / {} parser-handled / {} user-allowed / {} unmodeled",
             summary.modeled_in_key,
             summary.captured_by_probe,
             summary.preprocessor_captured,
             summary.no_object_effect,
             summary.parser_handled,
+            summary.user_allowed,
             summary.unmodeled
         );
     }
 
     rejected
+}
+
+/// Select the user-declared flags (issue #95) to fold verbatim into the
+/// cache key: the command-line tokens that (a) match an allow-list entry
+/// exactly and (b) the built-in table does NOT model — i.e. exactly the
+/// "user-allowed" set from [`classify_and_trace_cc_flags`]. Sorted +
+/// deduped so argv order and repeated flags never perturb the key, and a
+/// configured-but-absent flag is excluded (it has no codegen effect).
+fn cc_extra_flags_for_key<'a>(parsed: &'a CcArgs, extra_codegen_flags: &[String]) -> Vec<&'a str> {
+    if extra_codegen_flags.is_empty() {
+        return Vec::new();
+    }
+    let mut matched: Vec<&str> = parsed
+        .rest
+        .iter()
+        .map(String::as_str)
+        .filter(|arg| {
+            classify_cc_flag(arg).is_none() && extra_codegen_flags.iter().any(|f| f == arg)
+        })
+        .collect();
+    matched.sort_unstable();
+    matched.dedup();
+    matched
 }
 
 fn analyze_cc_arg(arg: &str) -> CcArgAnalysis<'_> {
@@ -1977,11 +2021,25 @@ fn cc_trace_name(parsed: &CcArgs) -> String {
 }
 
 #[derive(Default)]
-pub struct CcCompiler;
+pub struct CcCompiler {
+    /// User-declared flags (issue #95) that kache's built-in allow-list
+    /// doesn't model but the user opted into caching. A flag here stops
+    /// refusing and is folded verbatim into the cache key. Empty in the
+    /// common case (and for every existing `CcCompiler::new()` caller).
+    extra_codegen_flags: Vec<String>,
+}
 
 impl CcCompiler {
     pub fn new() -> Self {
-        Self
+        Self::default()
+    }
+
+    /// Construct with a user-declared cc flag allow-list (issue #95),
+    /// typically `config.cc_extra_codegen_flags`.
+    pub fn with_extra_codegen_flags(extra_codegen_flags: Vec<String>) -> Self {
+        Self {
+            extra_codegen_flags,
+        }
     }
 
     /// Does this argv invoke a C-family compiler?
@@ -2055,7 +2113,7 @@ impl Compiler for CcCompiler {
         // catch-all is gone — single-source `-c` compiles with no
         // unsafe flags now produce an EMPTY refuse list, which is the
         // signal to the wrapper that this invocation is cacheable.
-        parsed.refuse_reasons()
+        parsed.refuse_reasons(&self.extra_codegen_flags)
     }
 
     fn cache_key(&self, parsed: &CcArgs, ctx: &KeyCtx<'_, '_>) -> Result<String> {
@@ -2240,6 +2298,31 @@ impl Compiler for CcCompiler {
             trace_name,
             parsed.pic
         );
+
+        // User-declared cc flags (issue #95). The built-in table doesn't
+        // model these; the user opted them into caching via
+        // `[cc] extra_codegen_flags`. kache can't know how each affects
+        // codegen, so it folds the flag string *verbatim* — a different
+        // flag (or value) is a different string, hence a different key
+        // (never a miscache by value). Only flags actually present on the
+        // command line are folded (an unused allow-list entry has no
+        // codegen effect and must not move the key), sorted + deduped so
+        // argv order and repeats don't perturb the key.
+        let matched = cc_extra_flags_for_key(parsed, &self.extra_codegen_flags);
+        if !matched.is_empty() {
+            hasher.update(b"cc_extra_flags:");
+            for flag in matched {
+                hasher.update(flag.as_bytes());
+                hasher.update(b"\x1f");
+                tracing::trace!(
+                    target: "kache::cache_key",
+                    "[key:{}] cc_extra_flag={}",
+                    trace_name,
+                    flag
+                );
+            }
+            hasher.update(b"\n");
+        }
 
         // The object bytes do not depend on dep-info flags, but the cached
         // artifact set now can include a `.d` sidecar. Key the dep-info
@@ -2822,9 +2905,13 @@ mod tests {
     // ── refuse-to-cache: per-case ───────────────────────────────
 
     fn refuse_descriptions(args: &[&str]) -> Vec<&'static str> {
+        refuse_descriptions_with_flags(args, &[])
+    }
+
+    fn refuse_descriptions_with_flags(args: &[&str], extra: &[String]) -> Vec<&'static str> {
         let parsed = CcArgs::parse(&s(args)).unwrap();
         parsed
-            .refuse_reasons()
+            .refuse_reasons(extra)
             .iter()
             .map(|r| r.description())
             .collect()
@@ -3034,6 +3121,79 @@ mod tests {
             !descs.iter().any(|d| d.contains("unsupported flag")),
             "-fstack-clash-protection should be classified (issue #245), got: {descs:?}"
         );
+    }
+    // ── #95: user-configurable cc flag allow-list ──────────────────
+
+    fn flags(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// A flag the built-in table doesn't model normally refuses, but
+    /// listing it in `[cc] extra_codegen_flags` makes it cacheable.
+    #[test]
+    fn user_allowed_flag_stops_refusing() {
+        let args = &["cc", "-c", "foo.c", "-o", "foo.o", "-fsome-exotic-flag"];
+
+        // Control: unconfigured → still refused.
+        let refused = refuse_descriptions(args);
+        assert!(
+            refused.iter().any(|d| d.contains("unsupported flag")),
+            "unconfigured exotic flag should refuse, got: {refused:?}"
+        );
+
+        // Configured → accepted (no unsupported-flag refusal).
+        let allowed = refuse_descriptions_with_flags(args, &flags(&["-fsome-exotic-flag"]));
+        assert!(
+            !allowed.iter().any(|d| d.contains("unsupported flag")),
+            "allow-listed flag should not refuse, got: {allowed:?}"
+        );
+    }
+
+    /// The allow-list can only add to the hashable set — it must NOT
+    /// override a structural refusal like coverage instrumentation.
+    #[test]
+    fn user_allowed_flag_cannot_override_structural_refusal() {
+        let args = &["cc", "-c", "foo.c", "-o", "foo.o", "--coverage"];
+        let descs = refuse_descriptions_with_flags(args, &flags(&["--coverage"]));
+        assert!(
+            descs.iter().any(|d| d.contains("coverage")),
+            "coverage must still refuse even when allow-listed, got: {descs:?}"
+        );
+    }
+
+    /// Only flags actually present on the command line and unmodeled by
+    /// the built-in table are folded into the key (sorted + deduped).
+    #[test]
+    fn cc_extra_flags_for_key_selects_present_unmodeled_sorted() {
+        let extra = flags(&["-fbravo", "-falpha", "-fPIC"]);
+
+        // `-fbravo`/`-falpha` present + unmodeled → folded, sorted.
+        // `-fPIC` is modeled by the built-in table → NOT folded here.
+        // `-falpha` repeated → deduped. `-fcharlie` not configured → out.
+        let parsed = CcArgs::parse(&s(&[
+            "cc",
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o",
+            "-fbravo",
+            "-falpha",
+            "-falpha",
+            "-fPIC",
+            "-fcharlie",
+        ]))
+        .unwrap();
+        assert_eq!(
+            cc_extra_flags_for_key(&parsed, &extra),
+            vec!["-falpha", "-fbravo"]
+        );
+
+        // A configured-but-absent flag contributes nothing.
+        let absent = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o"])).unwrap();
+        assert!(cc_extra_flags_for_key(&absent, &extra).is_empty());
+
+        // No config → nothing folded (key byte-identical to today).
+        assert!(cc_extra_flags_for_key(&parsed, &[]).is_empty());
     }
 
     /// A representative Firefox-style C compile: pile the full
@@ -3722,9 +3882,9 @@ mod tests {
         ]))
         .unwrap();
         assert!(
-            parsed.refuse_reasons().is_empty(),
+            parsed.refuse_reasons(&[]).is_empty(),
             "clean compile invocation should have no parser-level refuse reasons; got: {:?}",
-            parsed.refuse_reasons()
+            parsed.refuse_reasons(&[])
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,23 @@ pub struct Config {
     /// stale hit. `None`/empty = no effect (keys are byte-identical to
     /// not setting it). Set via `KACHE_KEY_SALT` or `[cache] key_salt`.
     pub key_salt: Option<String>,
+    /// User-declared cc/c++ codegen flags to opt into caching ahead of
+    /// built-in support (issue #95). kache's cc allow-list refuses any
+    /// flag it doesn't model; listing one here makes kache *stop
+    /// refusing* it and fold the flag verbatim into the cache key, so a
+    /// different flag value still produces a different key (never a
+    /// miscache by value). Matched **exactly** against the command line;
+    /// only flags actually present are folded. This can only *add* to the
+    /// hashable set — it cannot override structural refusals (link mode,
+    /// coverage, multi-arch, PCH, modules, …). Empty = feature off (keys
+    /// byte-identical to not setting it). Set via
+    /// `KACHE_CC_EXTRA_CODEGEN_FLAGS` (whitespace-separated) or
+    /// `[cc] extra_codegen_flags`.
+    ///
+    /// Sharp edge: host-dependent flags like `-march=native` are a
+    /// constant string but compile to per-CPU objects; folded verbatim
+    /// they collide across machines. List explicit values, not `native`.
+    pub cc_extra_codegen_flags: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -69,6 +86,14 @@ pub struct RemoteConfig {
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub(crate) struct FileConfig {
     pub(crate) cache: Option<CacheFileConfig>,
+    pub(crate) cc: Option<CcFileConfig>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+pub(crate) struct CcFileConfig {
+    /// User-declared cc codegen flags to opt into caching.
+    /// See [`Config::cc_extra_codegen_flags`].
+    pub(crate) extra_codegen_flags: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
@@ -134,6 +159,7 @@ pub(crate) struct EnvOverrides {
     pub(crate) s3_profile: bool,
     pub(crate) fallback: bool,
     pub(crate) key_salt: bool,
+    pub(crate) cc_extra_codegen_flags: bool,
 }
 
 impl EnvOverrides {
@@ -151,8 +177,24 @@ impl EnvOverrides {
             s3_profile: std::env::var("KACHE_S3_PROFILE").is_ok(),
             fallback: std::env::var("KACHE_FALLBACK").is_ok(),
             key_salt: std::env::var("KACHE_KEY_SALT").is_ok(),
+            cc_extra_codegen_flags: std::env::var("KACHE_CC_EXTRA_CODEGEN_FLAGS").is_ok(),
         }
     }
+}
+
+/// Normalize a list of user-declared cc flags: trim each, drop empties,
+/// dedupe while preserving first-seen order. Keeps the cache-key fold
+/// deterministic and the allow-list free of accidental blanks.
+fn normalize_cc_flags(raw: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for flag in raw {
+        let trimmed = flag.trim();
+        if trimmed.is_empty() || out.iter().any(|f| f == trimmed) {
+            continue;
+        }
+        out.push(trimmed.to_string());
+    }
+    out
 }
 
 impl Config {
@@ -305,6 +347,21 @@ impl Config {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
+        // User-declared cc codegen flags (issue #95). Env wins over the
+        // file: a set `KACHE_CC_EXTRA_CODEGEN_FLAGS` (whitespace-separated,
+        // possibly empty → disables) replaces the file list entirely.
+        let cc_extra_codegen_flags = match std::env::var("KACHE_CC_EXTRA_CODEGEN_FLAGS") {
+            Ok(val) => normalize_cc_flags(val.split_whitespace().map(str::to_string)),
+            Err(_) => normalize_cc_flags(
+                file_config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.cc.as_ref())
+                    .and_then(|c| c.extra_codegen_flags.clone())
+                    .unwrap_or_default(),
+            ),
+        };
+
         let remote = Self::load_remote_config(&file_config);
 
         Ok(Config {
@@ -322,6 +379,7 @@ impl Config {
             s3_pool_idle_secs,
             fallback,
             key_salt,
+            cc_extra_codegen_flags,
         })
     }
 
@@ -787,6 +845,7 @@ mod tests {
     #[test]
     fn test_file_config_roundtrip() {
         let config = FileConfig {
+            cc: None,
             cache: Some(CacheFileConfig {
                 fallback: None,
                 key_salt: None,
@@ -839,6 +898,7 @@ mod tests {
     #[test]
     fn test_file_config_empty_remote_omitted() {
         let config = FileConfig {
+            cc: None,
             cache: Some(CacheFileConfig {
                 local_store: Some("~/cache".to_string()),
                 remote: Some(RemoteFileConfig::default()),
@@ -894,6 +954,57 @@ mod tests {
     }
 
     #[test]
+    fn test_cc_extra_codegen_flags_file_env_precedence() {
+        let _guard = config_path_lock();
+
+        let prev = std::env::var_os("KACHE_CC_EXTRA_CODEGEN_FLAGS");
+        let restore = |v: &Option<OsString>| unsafe {
+            match v {
+                Some(val) => std::env::set_var("KACHE_CC_EXTRA_CODEGEN_FLAGS", val),
+                None => std::env::remove_var("KACHE_CC_EXTRA_CODEGEN_FLAGS"),
+            }
+        };
+        restore(&None);
+
+        let dir = tempfile::tempdir().unwrap();
+        let cfg_path = dir.path().join("config.toml");
+        std::fs::write(
+            &cfg_path,
+            "[cc]\nextra_codegen_flags = [\"-ffunction-sections\", \"-fdata-sections\"]\n",
+        )
+        .unwrap();
+        let _cfg_guard = set_kache_config_for_test(&cfg_path);
+
+        // File list is picked up.
+        assert_eq!(
+            Config::load().unwrap().cc_extra_codegen_flags,
+            vec![
+                "-ffunction-sections".to_string(),
+                "-fdata-sections".to_string()
+            ]
+        );
+
+        // Env (whitespace-separated) wins over the file and is normalized:
+        // trimmed, empties dropped, deduped, first-seen order preserved.
+        unsafe {
+            std::env::set_var(
+                "KACHE_CC_EXTRA_CODEGEN_FLAGS",
+                "  -fno-rtti   -fno-rtti -fbravo ",
+            )
+        };
+        assert_eq!(
+            Config::load().unwrap().cc_extra_codegen_flags,
+            vec!["-fno-rtti".to_string(), "-fbravo".to_string()]
+        );
+
+        // An empty env value disables the feature (overrides the file).
+        unsafe { std::env::set_var("KACHE_CC_EXTRA_CODEGEN_FLAGS", "   ") };
+        assert!(Config::load().unwrap().cc_extra_codegen_flags.is_empty());
+
+        restore(&prev);
+    }
+
+    #[test]
     fn test_env_overrides_detect() {
         // Just verify it doesn't panic — actual env var presence is environment-dependent
         let overrides = EnvOverrides::detect();
@@ -907,6 +1018,7 @@ mod tests {
         let config = Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: PathBuf::from("/tmp/kache"),
             max_size: 1024,
             remote: None,
@@ -928,6 +1040,7 @@ mod tests {
         let config = Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: PathBuf::from("/tmp/kache"),
             max_size: 1024,
             remote: None,
@@ -949,6 +1062,7 @@ mod tests {
         let config = Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: PathBuf::from("/tmp/kache"),
             max_size: 1024,
             remote: None,
@@ -973,6 +1087,7 @@ mod tests {
         let config = Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: PathBuf::from("/tmp/kache"),
             max_size: 1024,
             remote: None,
@@ -1084,6 +1199,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
         let _env_guard = set_kache_config_for_test(&config_path);
 
         let config = FileConfig {
+            cc: None,
             cache: Some(CacheFileConfig {
                 local_store: Some("/tmp/managed-cache".to_string()),
                 ..Default::default()
@@ -1128,6 +1244,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
         let config_path = dir.path().join("kache/config.toml");
 
         let config = FileConfig {
+            cc: None,
             cache: Some(CacheFileConfig {
                 fallback: None,
                 key_salt: None,
@@ -1172,6 +1289,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
     #[test]
     fn test_remote_file_config_with_profile() {
         let config = FileConfig {
+            cc: None,
             cache: Some(CacheFileConfig {
                 planner: None,
                 remote: Some(RemoteFileConfig {
@@ -1210,6 +1328,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
         let _env_guard = set_kache_config_for_test(&config_path);
 
         let config = FileConfig {
+            cc: None,
             cache: Some(CacheFileConfig {
                 planner: Some(PlannerFileConfig {
                     endpoint: Some("https://planner.example.com".to_string()),
@@ -1237,6 +1356,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
         let _env_guard = set_kache_config_for_test(&config_path);
 
         let config = FileConfig {
+            cc: None,
             cache: Some(CacheFileConfig {
                 planner: Some(PlannerFileConfig {
                     endpoint: Some("https://planner.example.com".to_string()),

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -11,8 +11,8 @@ use std::ops::Range;
 use std::time::Duration;
 
 use crate::config::{
-    CacheFileConfig, Config, EnvOverrides, FileConfig, PlannerFileConfig, RemoteFileConfig,
-    default_cache_dir, parse_size, resolve_config_path,
+    CacheFileConfig, CcFileConfig, Config, EnvOverrides, FileConfig, PlannerFileConfig,
+    RemoteFileConfig, default_cache_dir, parse_size, resolve_config_path,
 };
 
 // ── Field definitions ─────────────────────────────────────────────────────
@@ -84,6 +84,11 @@ struct EditorState {
     /// through verbatim on save — otherwise saving would silently drop
     /// the planner config, including its credential.
     preserved_planner: Option<PlannerFileConfig>,
+    /// `[cc]` section as loaded from disk. The editor has no form fields
+    /// for it (the cc flag allow-list), so it is carried through verbatim
+    /// on save — otherwise saving would silently drop the user's
+    /// `extra_codegen_flags`.
+    preserved_cc: Option<CcFileConfig>,
 }
 
 // ── Build form fields from FileConfig ─────────────────────────────────────
@@ -383,6 +388,7 @@ fn run_all_validation(fields: &mut [FormField]) {
 fn fields_to_file_config(
     fields: &[FormField],
     preserved_planner: Option<PlannerFileConfig>,
+    preserved_cc: Option<CcFileConfig>,
 ) -> FileConfig {
     let get = |key: &str| -> Option<String> {
         fields.iter().find(|f| f.key == key).and_then(|f| {
@@ -451,6 +457,7 @@ fn fields_to_file_config(
     };
 
     FileConfig {
+        cc: preserved_cc,
         cache: Some(CacheFileConfig {
             local_store: get("cache_dir"),
             local_max_size: get("max_size"),
@@ -499,6 +506,7 @@ pub fn run_config_editor() -> Result<()> {
         has_saved_once: false,
         scroll_offset: 0,
         preserved_planner: file_config.cache.as_ref().and_then(|c| c.planner.clone()),
+        preserved_cc: file_config.cc.clone(),
     };
 
     // Run initial validation
@@ -671,7 +679,11 @@ fn try_save(state: &mut EditorState) {
 }
 
 fn do_save(state: &mut EditorState) {
-    let config = fields_to_file_config(&state.fields, state.preserved_planner.clone());
+    let config = fields_to_file_config(
+        &state.fields,
+        state.preserved_planner.clone(),
+        state.preserved_cc.clone(),
+    );
     match Config::save_file_config(&config) {
         Ok(()) => {
             state.dirty = false;
@@ -993,6 +1005,7 @@ mod tests {
         EnvOverrides {
             fallback: false,
             key_salt: false,
+            cc_extra_codegen_flags: false,
             disabled: false,
             cache_dir: false,
             max_size: false,
@@ -1016,6 +1029,7 @@ mod tests {
     #[test]
     fn test_build_fields_preserves_values() {
         let config = FileConfig {
+            cc: None,
             cache: Some(CacheFileConfig {
                 local_store: Some("~/my/cache".to_string()),
                 local_max_size: Some("100GiB".to_string()),
@@ -1105,6 +1119,7 @@ mod tests {
     #[test]
     fn test_fields_to_file_config_roundtrip() {
         let original = FileConfig {
+            cc: None,
             cache: Some(CacheFileConfig {
                 fallback: None,
                 key_salt: None,
@@ -1140,7 +1155,7 @@ mod tests {
 
         let fields = build_fields(&original, &empty_env());
         let preserved = original.cache.as_ref().and_then(|c| c.planner.clone());
-        let reconstructed = fields_to_file_config(&fields, preserved);
+        let reconstructed = fields_to_file_config(&fields, preserved, original.cc.clone());
 
         let cache = reconstructed.cache.as_ref().unwrap();
         assert_eq!(cache.local_store.as_deref(), Some("~/cache"));
@@ -1173,7 +1188,7 @@ mod tests {
     fn test_fields_to_file_config_empty_omits_remote() {
         let config = FileConfig::default();
         let fields = build_fields(&config, &empty_env());
-        let result = fields_to_file_config(&fields, None);
+        let result = fields_to_file_config(&fields, None, None);
         assert!(result.cache.as_ref().unwrap().remote.is_none());
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3758,6 +3758,7 @@ mod tests {
         Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: dir.to_path_buf(),
             max_size: 50 * 1024 * 1024, // 50 MiB
             remote: None,

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -496,6 +496,7 @@ mod tests {
         let config = Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: tmp.path().join("cache"),
             max_size: 1024 * 1024,
             remote: None,
@@ -554,6 +555,7 @@ mod tests {
         let restore_config = Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: restore_cache_dir,
             max_size: 1024 * 1024,
             remote: None,
@@ -592,6 +594,7 @@ mod tests {
         let config = Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: tmp.path().join("cache"),
             max_size: 1024 * 1024,
             remote: None,

--- a/src/remote_plan.rs
+++ b/src/remote_plan.rs
@@ -79,6 +79,7 @@ mod tests {
         Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: PathBuf::from("/tmp/kache-test"),
             max_size: 1024,
             remote: None,

--- a/src/report.rs
+++ b/src/report.rs
@@ -1761,6 +1761,7 @@ mod tests {
         let config = Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: dir.to_path_buf(),
             max_size: 1024,
             remote: None,
@@ -1930,6 +1931,7 @@ mod tests {
         let config = Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,
@@ -1959,6 +1961,7 @@ mod tests {
         let config = Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,
@@ -2041,6 +2044,7 @@ mod tests {
         let config = Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,

--- a/src/store.rs
+++ b/src/store.rs
@@ -1330,6 +1330,7 @@ mod tests {
         Config {
             fallback: None,
             key_salt: None,
+            cc_extra_codegen_flags: Vec::new(),
             cache_dir: dir.to_path_buf(),
             max_size: 1024 * 1024, // 1 MiB
             remote: None,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -106,7 +106,7 @@ pub fn run_cc_probe(args: &[String]) -> Result<i32> {
 /// follow-ups — single-machine caching is the shipped concept.
 pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let start = std::time::Instant::now();
-    let compiler = CcCompiler::new();
+    let compiler = CcCompiler::with_extra_codegen_flags(config.cc_extra_codegen_flags.clone());
     let parsed = compiler
         .parse(wrapper_args)
         .context("parsing cc-family arguments")?;


### PR DESCRIPTION
Closes #95.

## Problem
kache's cc cache key is an **allow-list**: only flags in the built-in `CC_FLAGS` table are recognized; anything else is refused (`cc: unsupported flag(s): …`) and the compile passes through uncached. That's the correct safety default — an unmodeled flag could change the object file without changing the key. But advanced users get zero caching for common-but-unlisted flags (`-ffunction-sections`, `-fno-rtti`, specific `-march=<v>`, …) until kache ships a release adding them.

## Solution
A config overlay to opt a flag into caching locally, ahead of official support:

```toml
[cc]
extra_codegen_flags = ["-ffunction-sections", "-fdata-sections", "-fno-rtti"]
```

or `KACHE_CC_EXTRA_CODEGEN_FLAGS` (whitespace-separated, env wins), mirroring the `key_salt` precedence.

## Design (per issue #95)
- **Exact match only.** A matched flag is folded into the key **verbatim**, so a different flag/value always yields a different key — never a miscache *by value*. Only flags actually present on the command line are folded; sorted + deduped.
- **Add-only.** Stops refusing an unmodeled flag, but **cannot override structural refusals** (link mode, coverage, multi-`-arch`, PCH, modules).
- **Off by default.** Empty list folds nothing → keys byte-identical to today → no `CACHE_KEY_VERSION` bump.
- **Sharp edge documented:** `-march=native` is host-dependent (constant string, per-CPU object) → loud doc warning to list explicit values.

## Observability
- `KACHE_LOG=kache=debug`: cc flag-classify summary gains a `user-allowed` count; the flag stops appearing in `unsupported flag(s): … — passthrough`.
- `kache=trace`: each accepted flag logs `user-allowed (config)`; each folded one logs `cc_extra_flag=`.

## Tests
- `user_allowed_flag_stops_refusing` (accept vs control-refuse)
- `user_allowed_flag_cannot_override_structural_refusal` (coverage still refuses)
- `cc_extra_flags_for_key_selects_present_unmodeled_sorted` (present-only, unmodeled-only, sorted, deduped, off-by-default)
- `test_cc_extra_codegen_flags_file_env_precedence` (file/env precedence, whitespace split, empty disables)

## Docs
- Configuration → **Extra cc codegen flags** (semantics + `-march=native` warning)
- Cache-key → note on verbatim folding

## Notes
- Builds on the same area as #247 (#245); independent change, branched off `main`.
- Prefix/regex matching and #222's broader bypass/refuse rules are deferred.