### PR TITLE
chore(just): add bump / release recipes for the workspace version

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -166,6 +166,33 @@ coverage-open:
 monitor *ARGS:
   ./scripts/ci-monitor.sh {{ARGS}}
 
+# Uses `cargo set-version` (NOT a broad `cargo update`), so pinned git deps
+# (kunobi-*) don't drift and the Nix `outputHashes` stay valid — a
+# version-only bump needs no hash change (the flake derives `version` from
+# Cargo.toml). Requires cargo-edit (`cargo install cargo-edit`).
+#
+# Set the version everywhere — all 4 manifests + inter-crate pin + lock. Usage: `just bump 0.5.0`
+[group('release')]
+bump VERSION:
+  @command -v cargo-set-version >/dev/null 2>&1 || { echo "needs cargo-edit: cargo install cargo-edit" >&2; exit 1; }
+  cargo set-version --workspace {{VERSION}}
+  cargo check --workspace --locked
+  @echo "Set version to {{VERSION}}. No Nix hash change needed for a version-only bump."
+
+# Bumps the version, then runs `nix build .#kache` locally — a fast pre-flight
+# that mirrors CI's `nix-package` job (which builds the flake and enforces that
+# the Nix-derived version matches Cargo), so a bad bump is caught here instead
+# of in CI. Prints the commit + tag steps on success.
+#
+# Bump + validate (cargo & nix) for a release cut. Usage: `just release 0.5.0`
+[group('release')]
+release VERSION: (bump VERSION)
+  nix build .#kache
+  @echo ""
+  @echo "Validated (cargo + nix). Next:"
+  @echo "  git commit -am 'chore(release): v{{VERSION}}'"
+  @echo "  git tag v{{VERSION}} && git push origin main v{{VERSION}}"
+
 # Remove build artifacts.
 clean:
   cargo clean


### PR DESCRIPTION
## Summary

There was no recipe for cutting a release — bumping the version meant hand-editing four manifests (`kache` + `kache-core`/`-e2e`/`-service`), the inter-crate `version =` pin, and `Cargo.lock`. Adds a `[release]` group:

- **`just bump <ver>`** wraps `cargo set-version --workspace` (updates all of the above in one shot), then `cargo check --workspace --locked` to validate consistency. It self-guards a stale inter-crate pin: if the pin weren't updated, the path-dep version requirement wouldn't be satisfied and `check` fails.

  It deliberately does **not** run a broad `cargo update`, so the pinned git deps (`kunobi-auth` tag, `kunobi-ha` branch) don't drift — a version-only bump leaves the Nix `outputHashes` valid and needs no Nix hash change (the flake derives `version` from `Cargo.toml`).

- **`just release <ver>`** adds `nix build .#kache` as a fast local pre-flight that mirrors CI's existing `nix-package` job (which builds the flake and enforces `nix eval .#kache.version == Cargo version`), so a bad bump fails locally instead of in CI. Prints the commit + tag steps.

Requires `cargo-edit`; the recipe errors with an install hint if absent.

## Relationship to CI

This is local convenience, not a new gate — CI already enforces the same things:
- `ci.yml` → `nix-package` job: `nix flake check`, **version-match check**, `nix build .#kache`.
- `publish-crates.yaml` publishes on a **GitHub Release** (`release: published`, prereleases skipped) — so after `just release` + tag, you still create the Release to trigger crates.io publishing.

The recipe just moves the version-consistency + Nix-build feedback left, to before the push.

## Not included

Tagging/releasing itself stays manual (the recipe prints the steps) and the `kunobi-*` dep upgrades are deliberately out of scope (separate PR, after the 0.5.0 cut).