### PR TITLE
feat(release): publish release-candidates to crates.io (Policy B)

### DIFF
--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -11,10 +11,19 @@ jobs:
   publish:
     name: Publish crates.io packages
     runs-on: ubuntu-latest
-    # Pre-release tags (rc/alpha/beta) are release rehearsals and must never
-    # publish to crates.io. This is the safety floor; a full dry-run rehearsal
-    # on pre-releases is added by the release-flow redesign.
-    if: github.event.release.prerelease == false
+    # Every published GitHub Release publishes to crates.io, release-candidates
+    # included (Policy B): the manifest carries the prerelease version (e.g.
+    # 0.5.0-rc.4), so `cargo publish` uploads it, and Cargo serves a prerelease
+    # only on an explicit `--version`/prerelease requirement — a normal `cargo
+    # add`/`cargo install kache` never picks it. The version-consistency gate
+    # (tag == manifest) and require-ci-green below are the fail-closed
+    # protections; the GitHub `prerelease` flag does not gate THIS publish.
+    # That flag is NOT cosmetic for the binary path, though: the release builder
+    # (zondax/_workflows/_release-rust.yml@v9) marks rc/alpha/beta/pre/dev tags
+    # `--prerelease --latest=false`, so an RC never becomes the GitHub "Latest"
+    # release that `@latest` installers / the README badge resolve to — Policy B
+    # depends on that boundary behavior. (Drafts never reach here:
+    # `release: published` excludes them.)
     # If the crates.io Trusted Publisher config includes a GitHub
     # Environment, add the same `environment: <name>` here. The
     # workflow file name and environment must stay in sync with
@@ -35,25 +44,14 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Refuse to publish a prerelease-shaped tag
-        # This job only runs when the GitHub Release is NOT marked prerelease
-        # (job-level `if: prerelease == false`). The `prerelease` flag is set by
-        # a human / the release workflow, NOT derived from the tag — so an RC
-        # tag mistakenly marked as a full release would reach here and publish
-        # an RC to crates.io (irreversible). Refuse any prerelease-shaped tag.
-        run: |
-          case "$RELEASE_TAG" in
-            *-rc.*|*-rc[0-9]*|*-alpha.*|*-alpha[0-9]*|*-beta.*|*-beta[0-9]*)
-              echo "tag $RELEASE_TAG is prerelease-shaped but the Release is not marked prerelease — refusing to publish to crates.io" >&2
-              exit 1 ;;
-          esac
-
       - name: Check release tag matches Cargo manifests (and dep-pin)
-        # The version gate: tag base == kache == kache-core == kache-core
-        # dep-pin (run directly here rather than polling for the CI job, so the
-        # manual-UI-release path is gated too without the tag-gated-job /
-        # same-SHA run ambiguity that `require-ci-green` would hit). Hermetic
-        # (pure manifest reads), so no nix/installer surface before the publish.
+        # The version gate: tag version (prerelease suffix included) == kache ==
+        # kache-core == kache-core dep-pin (run directly here rather than polling
+        # for the CI job, so the manual-UI-release path is gated too without the
+        # tag-gated-job / same-SHA run ambiguity that `require-ci-green` would
+        # hit). Hermetic (pure manifest reads), so no nix/installer surface
+        # before the publish. This is what makes publishing an RC safe: crates.io
+        # gets exactly the manifest version the tag was checked against.
         run: ./scripts/check-version-consistency.sh "$RELEASE_TAG"
 
       - name: Check release tag matches Nix package

--- a/Justfile
+++ b/Justfile
@@ -170,16 +170,31 @@ monitor *ARGS:
 # the kache-core dep-pin, and Cargo.lock — via `cargo set-version` (NOT a broad
 # `cargo update`, so the pinned kunobi-* git deps and the hand-maintained nix
 # `outputHashes` stay valid; the flake derives `version` from Cargo.toml, so no
-# hash change is needed). Then commit, open a PR, and merge; the tag is cut
-# later from the merged commit by `just release` / `just rc` (never re-typed).
-# Auto-installs `cargo-edit` (provides `cargo set-version`) on first use — it is
-# not pinned in mise.toml because that compiles it in every CI run, and it is a
-# maintainer-only tool CI never needs.
-# Usage: `just bump 0.5.0`
+# hash change is needed). The VERSION is the full version, prerelease included:
+# `just bump 0.5.0` for a final, `just bump 0.5.0-rc.4` for a candidate — both
+# publish to crates.io (a prerelease is only served on an explicit --version).
+# Then commit, open a PR, and merge; cut the tag from the merged commit with
+# `just release` (never re-typed). Auto-installs `cargo-edit` on first use — it
+# is not pinned in mise.toml because that compiles it in every CI run.
+#
+# Use a DOTTED-numeric prerelease (`-rc.4`, not `-rc4`): crates.io is permanent
+# and semver orders the no-dot form lexically (`rc.2` would sort after `rc.10`).
+# And don't bump back into an `-rc` for a version whose final already shipped
+# (e.g. a `0.5.0-rc.5` after `0.5.0` is published) — the version gate checks
+# tag==manifest, not crates.io monotonicity, so that would publish a permanent
+# "prerelease of an already-released version".
+# Usage: `just bump 0.5.0`  /  `just bump 0.5.0-rc.4`
 [group('release')]
 bump VERSION:
   #!/usr/bin/env bash
   set -euo pipefail
+  # Reject the no-dot prerelease form (-rc4): it sorts lexically on crates.io,
+  # which is permanent. Require -rc.4 / -alpha.2 / -beta.1 (dotted numeric).
+  case "{{VERSION}}" in
+    *-rc[0-9]*|*-alpha[0-9]*|*-beta[0-9]*)
+      echo "use a dotted prerelease (e.g. 0.5.0-rc.4), not the no-dot form — semver sorts no-dot lexically on crates.io" >&2
+      exit 1 ;;
+  esac
   if ! command -v cargo-set-version >/dev/null 2>&1; then
     echo "cargo-edit (cargo set-version) not found — installing it…"
     if command -v cargo-binstall >/dev/null 2>&1; then
@@ -194,27 +209,16 @@ bump VERSION:
   # local crates only (it does not advance kunobi-* / registry deps).
   cargo check --workspace
   ./scripts/check-version-consistency.sh
-  echo "Bumped to {{VERSION}}. Commit + open a PR; after merge, cut the tag with 'just release' (or 'just rc' for a candidate)."
+  echo "Bumped to {{VERSION}}. Commit + open a PR; after merge, cut the tag with 'just release'."
 
-# Derived from the merged manifest version so it can't drift (never re-typed).
-# Cut a FINAL release tag from the merged manifest version. Usage: `just release`
+# Refuses unless the tree is releasable (clean, on `main`, in sync with
+# origin/main, so a tag is never cut from a dirty / off-main / un-pulled
+# commit), runs the consistency gate, then pushes the tag → gated pipeline →
+# crates.io. The version (final OR prerelease, e.g. 0.5.0-rc.4) comes from the
+# merged manifest — never re-typed.
+# Cut the release tag for the merged manifest version. Usage: `just release`
 [group('release')]
-release: (_tag-and-push "final")
-
-# N is derived from existing tags; the base comes from the manifest.
-# Cut the next release-candidate tag v<base>-rc.N. Usage: `just rc`
-[group('release')]
-rc: (_tag-and-push "rc")
-
-# Shared release cutter. Refuses unless the tree is releasable — clean, on
-# `main`, and in sync with origin/main — so a tag can never be cut from a
-# dirty, off-main, or un-pulled commit (the CI gate checks tag==manifest, but
-# not tag-commit==main). Derives the version from the manifest, runs the
-# consistency gate locally, then pushes the tag (which triggers the gated
-# release pipeline). KIND = "final" or "rc".
-[group('release')]
-[private]
-_tag-and-push KIND:
+release:
   #!/usr/bin/env bash
   set -euo pipefail
   [ -z "$(git status --porcelain)" ] || { echo "working tree is dirty — commit or stash first" >&2; exit 1; }
@@ -222,15 +226,9 @@ _tag-and-push KIND:
   [ "$branch" = "main" ] || { echo "not on main (on '$branch') — releases are cut from main" >&2; exit 1; }
   git fetch --quiet origin main
   [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] || { echo "local main is not in sync with origin/main — pull/push first" >&2; exit 1; }
-  base="$(cargo metadata --no-deps --format-version 1 \
+  version="$(cargo metadata --no-deps --format-version 1 \
     | python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"]=="kache"))')"
-  if [ "{{KIND}}" = "rc" ]; then
-    # Next N across BOTH historical suffix forms (v<base>-rcN and v<base>-rc.N).
-    last="$(git tag --list "v${base}-rc*" | sed -E "s/^v${base}-rc\.?//" | grep -E '^[0-9]+$' | sort -n | tail -1 || true)"
-    tag="v${base}-rc.$(( ${last:-0} + 1 ))"
-  else
-    tag="v${base}"
-  fi
+  tag="v${version}"
   ./scripts/check-version-consistency.sh "$tag"
   git rev-parse -q --verify "refs/tags/$tag" >/dev/null && { echo "tag $tag already exists" >&2; exit 1; } || true
   git tag -a "$tag" -m "$tag"

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -48,6 +48,12 @@ kache requires Rust 1.95 or later (it uses `let ... && let` chains and other rec
   </Tab>
 </Tabs>
 
+<Callout type="info">
+  The methods above install the latest **stable** release. Release-candidates are
+  published but never resolve as "latest", so request one explicitly:
+  `cargo install kache --version 0.5.0-rc.4` (or `cargo binstall kache@0.5.0-rc.4`).
+</Callout>
+
 ## Supported platforms
 
 Pre-built binaries are available for:

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -7,6 +7,12 @@
 # Single source of truth = Cargo.toml; the git tag is a *checked mirror* of it
 # (the binary's --version comes from KACHE_VERSION=<tag>, see src/main.rs).
 #
+# Release-candidates publish to crates.io (Policy B), so the prerelease lives in
+# the manifest: a `0.5.0-rc.4` release means Cargo.toml says `0.5.0-rc.4` and the
+# tag is `v0.5.0-rc.4`. The full version (suffix included) must match — there is
+# NO suffix stripping. (Cargo serves prereleases only on an explicit `--version`
+# request, so this never affects a normal `cargo add`/`cargo install`.)
+#
 # Scope = what actually ships:
 #   - `kache`        crate (crates.io) + binary
 #   - `kache-core`   crate (crates.io)
@@ -22,34 +28,32 @@
 # failure surface.
 #
 # Usage:
-#   check-version-consistency.sh            # internal mode: the 3 values agree
-#   check-version-consistency.sh vX.Y.Z     # tag mode: the 3 values == tag base
-#   check-version-consistency.sh vX.Y.Z-rc.N  # RC: compared against the BASE (X.Y.Z)
+#   check-version-consistency.sh                # internal mode: the 3 values agree
+#   check-version-consistency.sh v0.5.0         # tag mode: the 3 values == 0.5.0
+#   check-version-consistency.sh v0.5.0-rc.4    # tag mode: the 3 values == 0.5.0-rc.4
 #
 # Exit: 0 consistent; 1 on a mismatch / malformed tag; fail-closed.
 set -euo pipefail
 
 tag="${1:-}"
 
-base=""
+tag_version=""
 if [ -n "$tag" ]; then
   case "$tag" in
     v*) : ;;
-    *) echo "release tag must look like vX.Y.Z, got: $tag" >&2; exit 1 ;;
+    *) echo "release tag must look like vX.Y.Z[-rc.N], got: $tag" >&2; exit 1 ;;
   esac
-  # base = tag without the leading 'v' and without a prerelease suffix:
-  # -rc.N / -rcN / -alpha.N / -beta.N — both the dotted (v0.5.0-rc.1) and the
-  # historical no-dot (v0.3.0-rc2) forms.
-  base="${tag#v}"
-  base="$(printf '%s' "$base" | sed -E 's/-(rc|alpha|beta)\.?[0-9]+$//')"
+  # The full version, prerelease suffix included — must equal the manifest
+  # exactly (no stripping; the manifest carries the prerelease under Policy B).
+  tag_version="${tag#v}"
 fi
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-BASE="$base" ROOT="$root" python3 - <<'PY'
-import os, sys, tomllib, pathlib
+TAG_VERSION="$tag_version" ROOT="$root" python3 - <<'PY'
+import os, re, sys, tomllib, pathlib
 
-base = os.environ["BASE"]
+tag_version = os.environ["TAG_VERSION"]
 root = pathlib.Path(os.environ["ROOT"])
 
 
@@ -78,8 +82,22 @@ if dep_pin is None:
 
 errors = []
 
+# (0) Reject a no-dot prerelease identifier in the version that will publish
+# (e.g. 0.5.0-rc4). crates.io is permanent and semver orders the no-dot form
+# LEXICALLY (rc.2 would sort after rc.10). Require the dotted form (-rc.N). This
+# runs in CI (version-consistency job) and at the publish floor, so it is
+# enforced even for a hand-pushed tag — not only the `just bump` local guard.
+m = re.search(r"-(rc|alpha|beta)[0-9]", kache_version)
+if m:
+    errors.append(
+        f"version {kache_version!r} uses a no-dot prerelease ({m.group(0)[1:]}…); "
+        "use the dotted form (e.g. -rc.4) — the no-dot form sorts lexically on crates.io"
+    )
+
 # (1) Internal consistency — always enforced. A half-applied bump (the crate
-# bumped but the dep-pin forgotten, or vice-versa) fails here on every PR.
+# bumped but the dep-pin forgotten, or vice-versa) fails here on every PR. The
+# dep-pin must be the EXACT version string (which `cargo set-version` writes),
+# prerelease included — a hand-edited caret/range would fail closed here.
 if core_version != dep_pin:
     errors.append(
         f"kache-core crate version {core_version!r} != kache-core dependency pin "
@@ -91,24 +109,25 @@ if kache_version != core_version:
         "(the workspace is bumped in lockstep)"
     )
 
-# (2) Tag agreement — only when a tag is supplied (tag pushes / publish).
-if base:
-    if kache_version != base:
-        errors.append(f"kache version {kache_version!r} != tag base {base!r}")
-    if core_version != base:
-        errors.append(f"kache-core version {core_version!r} != tag base {base!r}")
+# (2) Tag agreement — only when a tag is supplied (tag pushes / publish). The
+# full version must match, prerelease suffix included.
+if tag_version:
+    if kache_version != tag_version:
+        errors.append(f"kache version {kache_version!r} != tag version {tag_version!r}")
+    if core_version != tag_version:
+        errors.append(f"kache-core version {core_version!r} != tag version {tag_version!r}")
 
 if errors:
-    scope = f"tag base {base}" if base else "the workspace manifests"
+    scope = f"tag {tag_version}" if tag_version else "the workspace manifests"
     print(f"version consistency FAILED for {scope}:", file=sys.stderr)
     for e in errors:
         print("  - " + e, file=sys.stderr)
-    fix = base or kache_version
+    fix = tag_version or kache_version
     print(f"Fix: run `just bump {fix}` so the manifests agree, then re-tag if needed.", file=sys.stderr)
     sys.exit(1)
 
-if base:
-    print(f"version consistency OK: tag base {base} == kache == kache-core == kache-core dep-pin")
+if tag_version:
+    print(f"version consistency OK: tag {tag_version} == kache == kache-core == kache-core dep-pin")
 else:
     print(f"version consistency OK: kache == kache-core == kache-core dep-pin == {kache_version}")
 PY

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,10 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
-/// Build version: CI sets KACHE_VERSION from the git tag (e.g. "v0.1.0"), local builds
-/// use Cargo.toml. The leading 'v' is stripped if present.
+/// Build version: CI sets KACHE_VERSION from the git tag, local builds use
+/// Cargo.toml. Only the leading 'v' is stripped, so a prerelease suffix flows
+/// through verbatim (release-candidates publish to crates.io, so the tag — and
+/// thus --version — carries the full version, e.g. "v0.5.0-rc.4" -> "0.5.0-rc.4").
 pub const VERSION: &str = {
     const RAW: &str = match option_env!("KACHE_VERSION") {
         Some(v) => v,


### PR DESCRIPTION
## Summary

Makes release-candidates **first-class crates.io releases** instead of binary-only rehearsals (Policy B). The manifest carries the full prerelease version (e.g. `0.5.0-rc.4`), so `cargo publish` uploads it — and Cargo serves a prerelease **only on an explicit `--version`/prerelease requirement**, so a normal `cargo add`/`cargo install kache` never picks one.

So `cargo install kache --version 0.5.0-rc.4` now works.

## Changes
- **`check-version-consistency.sh`**: stop stripping the `-rc/-alpha/-beta` suffix — the tag version (suffix included) must equal the manifest exactly. A `v0.5.0-rc.4` tag now requires `Cargo.toml` to say `0.5.0-rc.4`.
- **`publish-crates.yaml`**: drop the `if: prerelease == false` skip and the Policy-A "refuse a prerelease-shaped tag" guard. Every published Release publishes; the version-consistency gate (tag == manifest) + `require-ci-green` + OIDC + idempotency remain the fail-closed protections.
- **`Justfile`**: `bump <version>` takes the full version incl. prerelease (`just bump 0.5.0-rc.4`, your instinct); the `rc` recipe is removed (an RC is just a normal bump+release); `release` tags whatever the manifest says.

## Adversarial review hardening (3 lenses; cargo mechanics verified empirically)
- **GitHub "Latest" / `@latest` path is safe**: the release builder (`zondax/_workflows/_release-rust.yml@v9`) already marks `*-rc*|*-alpha*|*-beta*|*-pre*|*-dev*` tags `--prerelease --latest=false`, so an RC never becomes "Latest". Corrected the publish-crates comment that wrongly called the flag "cosmetic" and documented the boundary dependency.
- **`bump` rejects the no-dot form** (`-rc4`): it sorts lexically on crates.io (`rc.2` after `rc.10`) — permanent. Require dotted `-rc.4`.
- **Documented the monotonicity caveat** (don't bump back into an `-rc` after the final shipped — the gate checks tag==manifest, not crates.io ordering).
- `src/main.rs` VERSION comment + installation docs updated (RCs install via explicit `--version`).

## Tradeoffs vs Policy A
Each RC is its own bump+PR+publish, and `Cargo.lock`/nix churn per RC — in exchange for source-installable RCs from crates.io.

## Flow
```
just bump 0.5.0-rc.4   # → PR → merge
just release           # tags v0.5.0-rc.4 → gated pipeline → crates.io (opt-in via --version)
```