### PR TITLE
chore(release): bump workspace version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 description = "Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — just hardlinks locally and S3 for sharing."
 license = "Apache-2.0"
@@ -29,7 +29,7 @@ blake3 = "1"
 aws-sdk-s3 = { version = "1", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
 aws-config = "1"
 aws-smithy-http-client = { version = "1", features = ["rustls-aws-lc"] }
-kache-core = { version = "0.4.1", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.5.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
## What

Bumps the workspace version from `0.4.1` → `0.5.0` across all crates (`kache`, `kache-core`, `kache-e2e`, `kache-service`) plus the `kache-core` dep-pin and `Cargo.lock`.

Produced by `just bump 0.5.0` (the recipe added in #252–#255).

## Why

The manifest was still at `0.4.1` even though a `v0.5.0` tag already exists — the manifest never got bumped to match the release. This aligns the workspace manifests with the `v0.5.0` release tag and satisfies the version-consistency gate.

## Verification

- `./scripts/check-version-consistency.sh` → `version consistency OK: kache == kache-core == kache-core dep-pin == 0.5.0`
- `cargo check --workspace` passed (run by `just bump`)

## Next

After merge, cut the tag with `just release`. Note: `v0.5.0` already exists as a tag, so a fresh tag may need a higher version if v0.5.0 is considered already released.