### PR TITLE
deps: drop aws-lc-sys (use ring) — unblocks aarch64-pc-windows-msvc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,7 +480,7 @@ jobs:
     # disagrees with the manifest BEFORE any binary builds; `e2e` includes the
     # (blocking) Windows arm, so a tag won't release unless Windows e2e is green.
     needs: [check, nix-package, e2e, test-macos, version-consistency]
-    uses: zondax/_workflows/.github/workflows/_release-rust.yml@v9
+    uses: zondax/_workflows/.github/workflows/_release-rust.yml@v10
     with:
       binary_name: kache
       # Both Windows targets (x64 + arm64) ship as `-pc-windows-msvc`, cross-built
@@ -493,7 +493,7 @@ jobs:
       # the e2e job above.
       #
       # `aarch64-pc-windows-msvc` requires the cargo-xwin clang shim added in
-      # _workflows@v9 (rewrites ring's `.S` asm `/imsvc` flags → `-isystem` so the
+      # _workflows@v10 (rewrites ring's `.S` asm `/imsvc` flags → `-isystem` so the
       # GNU clang driver accepts them). Without that shim the arm64 build fails at
       # ring's asm step. blake3 also uses its `pure` feature on Windows (see
       # Cargo.toml) since its arm64 NEON C doesn't cross-compile.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,13 +193,15 @@ jobs:
       # the cargo build or a fixture's `make`. Mirrors the verification step in
       # ans-runners/tasks/setup_windows.yml — keep the two tool lists in sync.
       #   cc/c++/make  -> C/C++ fixtures (harness sets CC="$KACHE cc")
-      #   nasm/perl/cmake -> kache build (ring + aws-lc-sys); MSVC link.exe
-      #   presence is proven by a successful `cargo build`.
+      #   nasm         -> ring's x86_64 `.asm` (the rustls crypto provider).
+      #                   perl/cmake are no longer needed: they were aws-lc-sys
+      #                   build deps, and aws-lc-sys was dropped in favour of ring.
+      #   MSVC link.exe presence is proven by a successful `cargo build`.
       - name: Verify Windows build toolchain
         if: runner.os == 'Windows'
         run: |
           missing=
-          for t in cc c++ make nasm perl cmake; do
+          for t in cc c++ make nasm; do
             if ! command -v "$t" >/dev/null 2>&1; then
               echo "MISSING on runner PATH: $t — provision it (see ans-runners/tasks/setup_windows.yml)"
               missing=1
@@ -482,13 +484,19 @@ jobs:
     with:
       binary_name: kache
       # Both Windows targets (x64 + arm64) ship as `-pc-windows-msvc`, cross-built
-      # on the Linux runner via cargo-xwin: clang + lld-link against the MSVC CRT
-      # and Windows SDK that `xwin` downloads. The aws-lc TLS C deps that wouldn't
-      # cross to `-windows-gnu` compile cleanly for `-windows-msvc` under clang, so
-      # no native Windows runner is needed here — `runner_windows` is left unset.
-      # (The native kunobi-windows runner is still used by the e2e job above.)
-      # Requires _workflows@v9 (retagged), which routes `-pc-windows-msvc` through
-      # cargo-xwin on Linux.
+      # on the Linux runner via cargo-xwin: clang-cl + lld-link against the MSVC
+      # CRT and Windows SDK that `xwin` downloads. TLS uses the `ring` crypto
+      # provider (no aws-lc-sys — its cmake build hung cross-compiling to arm64),
+      # so the runner needs `nasm` to assemble ring's x86_64 `.asm` (provisioned
+      # by _release-rust.yml). No native Windows runner is needed here
+      # (`runner_windows` left unset); the kunobi-windows runner is still used by
+      # the e2e job above.
+      #
+      # `aarch64-pc-windows-msvc` requires the cargo-xwin clang shim added in
+      # _workflows@v9 (rewrites ring's `.S` asm `/imsvc` flags → `-isystem` so the
+      # GNU clang driver accepts them). Without that shim the arm64 build fails at
+      # ring's asm step. blake3 also uses its `pure` feature on Windows (see
+      # Cargo.toml) since its arm64 NEON C doesn't cross-compile.
       targets: '["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc"]'
       runner_macos: '["self-hosted", "macOS", "ARM64"]'
       extra_build_env: |

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -19,7 +19,7 @@ jobs:
     # (tag == manifest) and require-ci-green below are the fail-closed
     # protections; the GitHub `prerelease` flag does not gate THIS publish.
     # That flag is NOT cosmetic for the binary path, though: the release builder
-    # (zondax/_workflows/_release-rust.yml@v9) marks rc/alpha/beta/pre/dev tags
+    # (zondax/_workflows/_release-rust.yml@v10) marks rc/alpha/beta/pre/dev tags
     # `--prerelease --latest=false`, so an RC never becomes the GitHub "Latest"
     # release that `@latest` installers / the README badge resolve to — Policy B
     # depends on that boundary behavior. (Drafts never reach here:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,6 @@ checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -1072,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -3211,6 +3210,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.3",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
  "tar",
@@ -5700,9 +5700,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sif-itree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,31 @@ resolver = "3"
 
 [dependencies]
 blake3 = "1"
-# `default-features = false` + explicit list to drop aws-sdk-s3's
-# default `rustls` feature, which transitively enables
-# `aws-smithy-runtime/tls-rustls` → `aws-smithy-http-client/legacy-rustls-ring`,
-# pulling vulnerable rustls 0.21 (RUSTSEC-2026-0098/0099/0104). The
-# modern TLS path is the `default-https-client` feature, kept below
-# alongside the other defaults we want (sigv4a, http-1x, rt-tokio).
-aws-sdk-s3 = { version = "1", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
-aws-config = "1"
-aws-smithy-http-client = { version = "1", features = ["rustls-aws-lc"] }
+# TLS provider: `ring`, NOT aws-lc-rs. We avoid `aws-lc-sys` entirely
+# because its cmake/NASM C build hangs when cross-compiling to
+# `aarch64-pc-windows-msvc` under cargo-xwin; `ring` ships prebuilt asm
+# for that target and cross-compiles cleanly.
+#
+# `aws-lc-sys` enters ONLY as the rustls crypto provider — `sigv4a` uses
+# pure-Rust `p256`/`crypto-bigint`, not aws-lc. To force `ring`, every
+# rustls consumer must opt out of aws-lc AND avoid re-enabling it via
+# additive features:
+#   - aws-sdk-s3: drop `default-https-client` (it hard-wires
+#     `aws-smithy-http-client/rustls-aws-lc` on aws-smithy-runtime).
+#     We inject our own ring-backed Smithy client in `src/remote.rs`.
+#   - aws-config: `default-features = false` for the same reason — its
+#     default pulls `default-https-client`. We inject the client there too.
+#   - aws-smithy-http-client: `rustls-ring` (modern rustls 0.23 + ring).
+#     NOT `legacy-rustls-ring`, which pins vulnerable rustls 0.21
+#     (RUSTSEC-2026-0098/0099/0104).
+#   - reqwest: `rustls-no-provider` + a process-default ring CryptoProvider
+#     installed at startup (see `src/main.rs`).
+aws-sdk-s3 = { version = "1", default-features = false, features = ["sigv4a", "http-1x", "rt-tokio"] }
+aws-config = { version = "1", default-features = false, features = ["rt-tokio", "credentials-process", "sso"] }
+aws-smithy-http-client = { version = "1", features = ["rustls-ring"] }
+# Direct dep so we can install ring as the process-wide rustls crypto
+# provider (reqwest uses `rustls-no-provider`, so one must be installed).
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 kache-core = { version = "0.5.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
@@ -52,7 +68,7 @@ futures = "0.3"
 glob = "0.3"
 libc = "0.2"
 tempfile = "3"
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider"] }
 interprocess = { version = "2.4.2", features = ["tokio"] }
 unicode-normalization = "0.1"
 # Used by `src/compiler/flags.rs` (the cc / future Swift / future MSVC
@@ -63,6 +79,10 @@ unicode-normalization = "0.1"
 regex = { version = "1", default-features = false, features = ["std", "perf"] }
 
 [target.'cfg(windows)'.dependencies]
+# `pure` drops blake3's C SIMD (`c/blake3_neon.c` / SSE intrinsics), whose
+# arm64 NEON path doesn't cross-compile under cargo-xwin's clang + MSVC
+# sysroot. Windows-only so native/Linux/macOS keep the fast C SIMD backend.
+blake3 = { version = "1", features = ["pure"] }
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_System_Threading",

--- a/src/planner_client.rs
+++ b/src/planner_client.rs
@@ -19,10 +19,22 @@ pub async fn resolve_prefetch_plan(req: &BuildIntent) -> Result<Option<PrefetchP
     Ok(Some(plan))
 }
 
+/// Install ring as the process-wide rustls crypto provider. `reqwest` is built
+/// with `rustls-no-provider` (to keep `aws-lc-sys` out of the tree — see
+/// Cargo.toml), so it needs a default provider installed before it builds a TLS
+/// client. Idempotent across threads; the already-installed error is expected.
+fn ensure_crypto_provider() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 pub async fn resolve_prefetch_plan_with_config(
     config: &PlannerConfig,
     req: &BuildIntent,
 ) -> Result<PrefetchPlan> {
+    ensure_crypto_provider();
     let client = reqwest::Client::builder()
         .timeout(Duration::from_millis(config.timeout_ms))
         .build()

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -55,7 +55,18 @@ pub async fn create_s3_client(
     remote: &RemoteConfig,
     pool_idle_secs: u64,
 ) -> Result<aws_sdk_s3::Client> {
+    // Build one ring-backed HTTPS client and share it across both the
+    // aws-config credential-resolution path and the S3 client. Injecting it
+    // is what lets us drop `default-https-client` (which would otherwise
+    // force the aws-lc-rs crypto provider, pulling `aws-lc-sys`). See the TLS
+    // note in Cargo.toml.
+    let http_client = SmithyHttpClientBuilder::new()
+        .tls_provider(tls::Provider::Rustls(CryptoMode::Ring))
+        .pool_idle_timeout(Duration::from_secs(pool_idle_secs))
+        .build_https();
+
     let mut config_builder = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .http_client(http_client.clone())
         .region(aws_config::Region::new(remote.region.clone()));
 
     if let Some(profile) = &remote.profile {
@@ -91,10 +102,6 @@ pub async fn create_s3_client(
     let sdk_config = config_builder.load().await;
     let mut s3_config = aws_sdk_s3::config::Builder::from(&sdk_config).force_path_style(true);
 
-    let http_client = SmithyHttpClientBuilder::new()
-        .tls_provider(tls::Provider::Rustls(CryptoMode::AwsLc))
-        .pool_idle_timeout(Duration::from_secs(pool_idle_secs))
-        .build_https();
     s3_config = s3_config.http_client(http_client);
     tracing::debug!(pool_idle_secs, "S3 HTTP client configured");
 


### PR DESCRIPTION
## Why

CI run [27030028383](https://github.com/kunobi-ninja/kache/actions/runs/27030028383) had the `aarch64-pc-windows-msvc` release build **hang 44 min** then cancel. Root cause: `aws-lc-sys`'s cmake/NASM C build stalls cross-compiling to arm64-Windows under cargo-xwin. arm64-Windows had **never** produced an artifact.

`aws-lc-sys` entered the tree through exactly **one** door — the rustls crypto provider (`aws-lc-rs`). `sigv4a` uses pure-Rust `p256`/`crypto-bigint`, not aws-lc. So switching every rustls consumer to **`ring`** removes `aws-lc-sys` entirely, and ring cross-compiles cleanly.

## What changed

- **aws-sdk-s3**: drop `default-https-client` (it hard-wires `rustls-aws-lc` on `aws-smithy-runtime`); inject our own client instead.
- **aws-config**: `default-features = false` (same reason); inject the ring-backed client into the credential path.
- **aws-smithy-http-client**: `rustls-aws-lc` → `rustls-ring` (modern rustls 0.23 + ring). **Not** `legacy-rustls-ring` (vulnerable rustls 0.21, RUSTSEC-2026-0098/0099/0104).
- **reqwest**: `rustls` → `rustls-no-provider` + a process-default ring `CryptoProvider` installed in `planner_client`.
- **remote.rs**: one ring-backed Smithy client shared across S3 + aws-config.
- **blake3**: `pure` feature on Windows (its arm64 NEON C doesn't cross-compile); native/Linux/macOS keep the C SIMD backend.
- **CI**: re-enable `aarch64-pc-windows-msvc`; Windows build now needs only `nasm` (perl/cmake were aws-lc-sys-only).

## Validation — both Windows targets cross-compiled from macOS via cargo-xwin

| Target | Result |
|---|---|
| `aws-lc-sys` in dependency tree | **gone** |
| **`x86_64-pc-windows-msvc`** | ✅ ~1m12s (was 26 min w/ aws-lc) |
| **`aarch64-pc-windows-msvc`** | ✅ ~1m11s — real ARM64 PE (was: 44-min hang) |
| Native build + 657 unit tests | ✅ pass |
| `cargo fmt --check` + `clippy` | ✅ clean |

## ⚠️ Depends on a `_workflows` change

arm64-Windows also needs a cargo-xwin **clang shim** (rewrites ring's `.S` asm `/imsvc` flags → `-isystem`, which the GNU clang driver requires): **zondax/_workflows#98**. That must merge and **`v9` be retagged** before this PR's arm64 release build will pass. x86_64-Windows + all other targets work with the current `@v9`.

## Tradeoffs

- Lose `prefer-post-quantum` (X25519MLKEM768 hybrid KEM, aws-lc-only) and FIPS — neither matters for an S3 build-cache client.
- Removes a cmake/C build-time dependency across all targets.