### PR TITLE
Use guppy for build intent discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1112,16 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1578,6 +1621,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "debug-ignore"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,6 +2030,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flatbuffers"
 version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +2386,39 @@ name = "guardian"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
+
+[[package]]
+name = "guppy"
+version = "0.17.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb611f63088c20f3f7252d896f0beaa176a9628da8c21cdf258fe9ae179bebda"
+dependencies = [
+ "ahash 0.8.12",
+ "camino",
+ "cargo_metadata",
+ "cfg-if",
+ "debug-ignore",
+ "fixedbitset 0.5.7",
+ "guppy-workspace-hack",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "nested",
+ "once_cell",
+ "pathdiff",
+ "petgraph",
+ "semver",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "static_assertions",
+ "target-spec",
+]
+
+[[package]]
+name = "guppy-workspace-hack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
@@ -3202,6 +3290,7 @@ dependencies = [
  "filetime",
  "futures",
  "glob",
+ "guppy",
  "interprocess",
  "kache-core",
  "libc",
@@ -3691,6 +3780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nested"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4101,6 +4196,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+dependencies = [
+ "camino",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4184,6 +4288,17 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -6303,6 +6418,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "target-spec"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00e973676af5497c2a69cc9787e2205c00f3b6f4f70e7d7b0112e28aa84b501"
+dependencies = [
+ "cfg-expr",
+ "guppy-workspace-hack",
+ "target-lexicon",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6365,7 +6497,7 @@ dependencies = [
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "hex",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ dirs = "6"
 tar = "0.4"
 futures = "0.3"
 glob = "0.3"
+guppy = "0.17"
 libc = "0.2"
 tempfile = "3"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider"] }

--- a/src/build_intent.rs
+++ b/src/build_intent.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 
 use crate::args::RustcArgs;
+use guppy::graph::PackageGraph;
 use kache_core::BuildIntent;
 
 struct MetadataDiscovery {
@@ -119,17 +120,13 @@ fn run_cargo_metadata(manifest_path: Option<&Path>) -> Option<MetadataDiscovery>
         return None;
     }
 
-    parse_metadata(&output.stdout)
+    parse_metadata_graph(&output.stdout)
 }
 
-fn parse_metadata(metadata_json: &[u8]) -> Option<MetadataDiscovery> {
-    let value: serde_json::Value = serde_json::from_slice(metadata_json).ok()?;
-    let crate_names = parse_metadata_value_crate_names_bfs(&value)?;
-    let workspace_root = value
-        .get("workspace_root")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from);
+fn parse_metadata_graph(metadata_json: &[u8]) -> Option<MetadataDiscovery> {
+    let graph = PackageGraph::from_json(std::str::from_utf8(metadata_json).ok()?).ok()?;
+    let crate_names = graph_crate_names_bfs(&graph);
+    let workspace_root = Some(graph.workspace().root().as_std_path().to_path_buf());
 
     Some(MetadataDiscovery {
         crate_names,
@@ -137,46 +134,40 @@ fn parse_metadata(metadata_json: &[u8]) -> Option<MetadataDiscovery> {
     })
 }
 
-#[cfg(test)]
-fn parse_metadata_crate_names_bfs(metadata_json: &[u8]) -> Option<Vec<String>> {
-    let value: serde_json::Value = serde_json::from_slice(metadata_json).ok()?;
-    parse_metadata_value_crate_names_bfs(&value)
+fn graph_crate_names_bfs(graph: &PackageGraph) -> Vec<String> {
+    let packages = graph
+        .packages()
+        .map(|package| {
+            let dependencies = package
+                .direct_links()
+                .map(|link| link.to().id().to_string())
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect();
+
+            (
+                package.id().to_string(),
+                package.name().to_string(),
+                dependencies,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    crate_names_bfs_from_edges(packages)
 }
 
-fn parse_metadata_value_crate_names_bfs(value: &serde_json::Value) -> Option<Vec<String>> {
-    let packages = value.get("packages")?.as_array()?;
+fn crate_names_bfs_from_edges(
+    packages: impl IntoIterator<Item = (String, String, Vec<String>)>,
+) -> Vec<String> {
     let mut id_to_name: HashMap<String, String> = HashMap::new();
-    for pkg in packages {
-        if let (Some(id), Some(name)) = (
-            pkg.get("id").and_then(|v| v.as_str()),
-            pkg.get("name").and_then(|v| v.as_str()),
-        ) {
-            id_to_name.insert(id.to_string(), name.to_string());
-        }
-    }
-
-    let nodes = value.get("resolve")?.get("nodes")?.as_array()?;
     let mut dep_count: HashMap<String, usize> = HashMap::new();
     let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
 
-    for node in nodes {
-        let Some(id) = node.get("id").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        let id = id.to_string();
-        let deps = node
-            .get("deps")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|d| d.get("pkg").and_then(|v| v.as_str()).map(String::from))
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
+    for (id, name, dependencies) in packages {
+        id_to_name.insert(id.clone(), name);
+        dep_count.insert(id.clone(), dependencies.len());
 
-        dep_count.insert(id.clone(), deps.len());
-
-        for dep_id in deps {
+        for dep_id in dependencies {
             dep_count.entry(dep_id.clone()).or_insert(0);
             dependents.entry(dep_id).or_default().push(id.clone());
         }
@@ -215,7 +206,7 @@ fn parse_metadata_value_crate_names_bfs(value: &serde_json::Value) -> Option<Vec
         }
     }
 
-    Some(ordered_names)
+    ordered_names
 }
 
 #[cfg(test)]
@@ -223,72 +214,77 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_metadata_crate_names_bfs_orders_leaves_first() {
-        let metadata = r#"{
-          "packages": [
-            {"id": "serde 1.0.0 (registry)", "name": "serde"},
-            {"id": "tokio 1.0.0 (registry)", "name": "tokio"},
-            {"id": "app 0.1.0 (path)", "name": "app"}
-          ],
-          "resolve": {
-            "nodes": [
-              {"id": "app 0.1.0 (path)", "deps": [
-                {"pkg": "serde 1.0.0 (registry)"},
-                {"pkg": "tokio 1.0.0 (registry)"}
-              ]},
-              {"id": "serde 1.0.0 (registry)", "deps": []},
-              {"id": "tokio 1.0.0 (registry)", "deps": []}
-            ]
-          }
-        }"#;
+    fn test_crate_names_bfs_orders_leaves_first() {
+        let names = crate_names_bfs_from_edges(vec![
+            ("serde 1.0.0 (registry)".into(), "serde".into(), vec![]),
+            ("tokio 1.0.0 (registry)".into(), "tokio".into(), vec![]),
+            (
+                "app 0.1.0 (path)".into(),
+                "app".into(),
+                vec![
+                    "serde 1.0.0 (registry)".into(),
+                    "tokio 1.0.0 (registry)".into(),
+                ],
+            ),
+        ]);
 
-        let names = parse_metadata_crate_names_bfs(metadata.as_bytes()).unwrap();
         assert_eq!(names, vec!["serde", "tokio", "app"]);
     }
 
     #[test]
-    fn test_parse_metadata_crate_names_bfs_deduplicates_names() {
-        let metadata = r#"{
-          "packages": [
-            {"id": "serde 1.0.0 (registry)", "name": "serde"},
-            {"id": "serde 1.0.1 (registry)", "name": "serde"}
-          ],
-          "resolve": {
-            "nodes": [
-              {"id": "serde 1.0.0 (registry)", "deps": []},
-              {"id": "serde 1.0.1 (registry)", "deps": []}
-            ]
-          }
-        }"#;
+    fn test_crate_names_bfs_deduplicates_names() {
+        let names = crate_names_bfs_from_edges(vec![
+            ("serde 1.0.0 (registry)".into(), "serde".into(), vec![]),
+            ("serde 1.0.1 (registry)".into(), "serde".into(), vec![]),
+        ]);
 
-        let names = parse_metadata_crate_names_bfs(metadata.as_bytes()).unwrap();
         assert_eq!(names, vec!["serde"]);
     }
 
     #[test]
-    fn test_parse_metadata_preserves_workspace_root() {
-        let metadata = r#"{
-          "workspace_root": "/repo/apps/tauri/src-tauri",
-          "packages": [
-            {"id": "serde 1.0.0 (registry)", "name": "serde"},
-            {"id": "app 0.1.0 (path)", "name": "app"}
-          ],
-          "resolve": {
-            "nodes": [
-              {"id": "app 0.1.0 (path)", "deps": [
-                {"pkg": "serde 1.0.0 (registry)"}
-              ]},
-              {"id": "serde 1.0.0 (registry)", "deps": []}
-            ]
-          }
-        }"#;
+    fn test_run_cargo_metadata_uses_guppy_graph_and_workspace_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
 
-        let discovery = parse_metadata(metadata.as_bytes()).unwrap();
-        assert_eq!(discovery.crate_names, vec!["serde", "app"]);
-        assert_eq!(
-            discovery.workspace_root.as_deref(),
-            Some(Path::new("/repo/apps/tauri/src-tauri"))
-        );
+        std::fs::write(
+            root.join("Cargo.toml"),
+            r#"[workspace]
+members = ["app", "dep"]
+resolver = "2"
+"#,
+        )
+        .unwrap();
+
+        std::fs::create_dir_all(root.join("app/src")).unwrap();
+        std::fs::write(
+            root.join("app/Cargo.toml"),
+            r#"[package]
+name = "app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+dep = { path = "../dep" }
+"#,
+        )
+        .unwrap();
+        std::fs::write(root.join("app/src/lib.rs"), "").unwrap();
+
+        std::fs::create_dir_all(root.join("dep/src")).unwrap();
+        std::fs::write(
+            root.join("dep/Cargo.toml"),
+            r#"[package]
+name = "dep"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .unwrap();
+        std::fs::write(root.join("dep/src/lib.rs"), "").unwrap();
+
+        let discovery = run_cargo_metadata(Some(&root.join("app/Cargo.toml"))).unwrap();
+        assert_eq!(discovery.crate_names, vec!["dep", "app"]);
+        assert_eq!(discovery.workspace_root.as_deref(), Some(root));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add guppy as the Cargo graph parser for build-intent discovery.
- Replace manual cargo metadata JSON graph walking with guppy PackageGraph traversal.
- Keep BuildIntent wire format and existing prefetch inputs unchanged.

## Validation

- cargo fmt --check
- cargo test build_intent
- cargo clippy --bin kache -- -D warnings
