### PR TITLE
Use guppy crate order for prefetch planning

### DIFF
--- a/crates/kache-core/src/lib.rs
+++ b/crates/kache-core/src/lib.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "planning")]
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 #[cfg(feature = "planning")]
 use anyhow::Result;
@@ -73,25 +73,30 @@ where
             .await
         {
             Ok(candidates) if !candidates.is_empty() => {
-                return Ok(execute_plan(planner_name, candidates));
+                return Ok(execute_plan(
+                    planner_name,
+                    order_candidates_by_crate_order(candidates, intent),
+                ));
             }
             Ok(_) | Err(_) => {}
         }
     }
 
+    let crate_order = crate_query_order(intent);
     let mut seen = HashSet::new();
     let mut resolved_crates = HashSet::new();
     let mut candidates = Vec::new();
 
-    for candidate in source.history_candidates(&intent.crate_names).await? {
+    for candidate in
+        order_candidates_by_crate_order(source.history_candidates(&crate_order).await?, intent)
+    {
         resolved_crates.insert(candidate.crate_name.clone());
         if seen.insert(candidate.cache_key.clone()) {
             candidates.push(candidate);
         }
     }
 
-    for crate_name in intent
-        .crate_names
+    for crate_name in crate_order
         .iter()
         .filter(|name| !resolved_crates.contains(*name))
     {
@@ -123,6 +128,47 @@ fn execute_plan(planner_name: &str, candidates: Vec<PrefetchCandidate>) -> Prefe
     }
 }
 
+#[cfg(feature = "planning")]
+fn crate_query_order(intent: &BuildIntent) -> Vec<String> {
+    let mut seen = HashSet::new();
+    intent
+        .crate_names
+        .iter()
+        .filter(|crate_name| seen.insert((*crate_name).clone()))
+        .cloned()
+        .collect()
+}
+
+#[cfg(feature = "planning")]
+fn order_candidates_by_crate_order(
+    mut candidates: Vec<PrefetchCandidate>,
+    intent: &BuildIntent,
+) -> Vec<PrefetchCandidate> {
+    if intent.crate_names.is_empty() {
+        return candidates;
+    }
+
+    let mut priority = HashMap::new();
+    for (index, crate_name) in crate_query_order(intent).iter().enumerate() {
+        priority.entry(crate_name.clone()).or_insert(index);
+    }
+
+    let mut indexed_candidates = candidates.drain(..).enumerate().collect::<Vec<_>>();
+    indexed_candidates.sort_by_key(|(index, candidate)| {
+        (
+            priority
+                .get(&candidate.crate_name)
+                .copied()
+                .unwrap_or(usize::MAX),
+            *index,
+        )
+    });
+    indexed_candidates
+        .into_iter()
+        .map(|(_, candidate)| candidate)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,6 +185,7 @@ mod tests {
         shard_candidates: Vec<PrefetchCandidate>,
         shard_error: bool,
         history_candidates: Vec<PrefetchCandidate>,
+        history_by_crate: HashMap<String, String>,
         key_cache: HashMap<String, Vec<String>>,
     }
 
@@ -159,9 +206,23 @@ mod tests {
 
         async fn history_candidates(
             &self,
-            _crate_names: &[String],
+            crate_names: &[String],
         ) -> Result<Vec<PrefetchCandidate>> {
-            Ok(self.history_candidates.clone())
+            if !self.history_candidates.is_empty() {
+                return Ok(self.history_candidates.clone());
+            }
+
+            Ok(crate_names
+                .iter()
+                .filter_map(|crate_name| {
+                    self.history_by_crate
+                        .get(crate_name)
+                        .map(|cache_key| PrefetchCandidate {
+                            cache_key: cache_key.clone(),
+                            crate_name: crate_name.clone(),
+                        })
+                })
+                .collect())
         }
 
         async fn key_cache_keys_for_crate(&self, crate_name: &str) -> Result<Vec<String>> {
@@ -180,6 +241,14 @@ mod tests {
         let json = serde_json::to_string(&intent).unwrap();
         let parsed: BuildIntent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, intent);
+    }
+
+    #[test]
+    fn test_build_intent_defaults_missing_fields() {
+        let parsed: BuildIntent = serde_json::from_str(r#"{"crate_names":["serde"]}"#).unwrap();
+        assert_eq!(parsed.crate_names, vec!["serde"]);
+        assert!(parsed.namespace.is_none());
+        assert!(parsed.cargo_lock_deps.is_empty());
     }
 
     #[test]
@@ -278,5 +347,72 @@ mod tests {
         assert_eq!(plan.candidates.len(), 2);
         assert_eq!(plan.candidates[0].cache_key, "history-key");
         assert_eq!(plan.candidates[1].cache_key, "tokio-key");
+    }
+
+    #[cfg(feature = "planning")]
+    #[tokio::test]
+    async fn test_build_prefetch_plan_orders_shard_candidates_by_crate_order() {
+        let source = FakePlannerDataSource {
+            shard_candidates: vec![
+                PrefetchCandidate {
+                    cache_key: "app-key".into(),
+                    crate_name: "app".into(),
+                },
+                PrefetchCandidate {
+                    cache_key: "dep-key".into(),
+                    crate_name: "dep".into(),
+                },
+                PrefetchCandidate {
+                    cache_key: "middle-key".into(),
+                    crate_name: "middle".into(),
+                },
+            ],
+            ..Default::default()
+        };
+        let intent = BuildIntent {
+            crate_names: vec!["dep".into(), "middle".into(), "app".into()],
+            namespace: Some("linux/hash/debug".into()),
+            cargo_lock_deps: vec![("dep".into(), "1.0.0".into())],
+        };
+
+        let plan = build_prefetch_plan(&source, &intent, "fallback")
+            .await
+            .unwrap();
+
+        let keys = plan
+            .candidates
+            .iter()
+            .map(|candidate| candidate.cache_key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec!["dep-key", "middle-key", "app-key"]);
+    }
+
+    #[cfg(feature = "planning")]
+    #[tokio::test]
+    async fn test_build_prefetch_plan_queries_history_by_crate_order() {
+        let source = FakePlannerDataSource {
+            history_by_crate: HashMap::from([
+                ("app".into(), "app-key".into()),
+                ("dep".into(), "dep-key".into()),
+                ("middle".into(), "middle-key".into()),
+            ]),
+            ..Default::default()
+        };
+        let intent = BuildIntent {
+            crate_names: vec!["dep".into(), "middle".into(), "app".into()],
+            namespace: None,
+            cargo_lock_deps: vec![],
+        };
+
+        let plan = build_prefetch_plan(&source, &intent, "fallback")
+            .await
+            .unwrap();
+
+        let keys = plan
+            .candidates
+            .iter()
+            .map(|candidate| candidate.cache_key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec!["dep-key", "middle-key", "app-key"]);
     }
 }

--- a/src/build_intent.rs
+++ b/src/build_intent.rs
@@ -1,8 +1,8 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use crate::args::RustcArgs;
-use guppy::graph::PackageGraph;
+use guppy::graph::{DependencyDirection, PackageGraph};
 use kache_core::BuildIntent;
 
 struct MetadataDiscovery {
@@ -120,12 +120,15 @@ fn run_cargo_metadata(manifest_path: Option<&Path>) -> Option<MetadataDiscovery>
         return None;
     }
 
-    parse_metadata_graph(&output.stdout)
+    parse_metadata_graph(&output.stdout, manifest_path)
 }
 
-fn parse_metadata_graph(metadata_json: &[u8]) -> Option<MetadataDiscovery> {
+fn parse_metadata_graph(
+    metadata_json: &[u8],
+    manifest_path: Option<&Path>,
+) -> Option<MetadataDiscovery> {
     let graph = PackageGraph::from_json(std::str::from_utf8(metadata_json).ok()?).ok()?;
-    let crate_names = graph_crate_names_bfs(&graph);
+    let crate_names = graph_crate_order(&graph, manifest_path)?;
     let workspace_root = Some(graph.workspace().root().as_std_path().to_path_buf());
 
     Some(MetadataDiscovery {
@@ -134,112 +137,49 @@ fn parse_metadata_graph(metadata_json: &[u8]) -> Option<MetadataDiscovery> {
     })
 }
 
-fn graph_crate_names_bfs(graph: &PackageGraph) -> Vec<String> {
-    let packages = graph
-        .packages()
-        .map(|package| {
-            let dependencies = package
-                .direct_links()
-                .map(|link| link.to().id().to_string())
-                .collect::<HashSet<_>>()
-                .into_iter()
-                .collect();
+fn graph_crate_order(graph: &PackageGraph, manifest_path: Option<&Path>) -> Option<Vec<String>> {
+    let package_ids = if let Some(manifest_path) = manifest_path
+        && let Some(package) = graph
+            .packages()
+            .find(|package| paths_match(package.manifest_path().as_std_path(), manifest_path))
+    {
+        vec![package.id().clone()]
+    } else {
+        graph
+            .workspace()
+            .iter()
+            .map(|package| package.id().clone())
+            .collect::<Vec<_>>()
+    };
 
-            (
-                package.id().to_string(),
-                package.name().to_string(),
-                dependencies,
-            )
-        })
-        .collect::<Vec<_>>();
+    let package_set = graph.query_forward(package_ids.iter()).ok()?.resolve();
+    let mut seen = HashSet::new();
+    let mut ordered = Vec::new();
 
-    crate_names_bfs_from_edges(packages)
+    for package in package_set.packages(DependencyDirection::Reverse) {
+        let name = package.name().to_string();
+        if seen.insert(name.clone()) {
+            ordered.push(name);
+        }
+    }
+
+    Some(ordered)
 }
 
-fn crate_names_bfs_from_edges(
-    packages: impl IntoIterator<Item = (String, String, Vec<String>)>,
-) -> Vec<String> {
-    let mut id_to_name: HashMap<String, String> = HashMap::new();
-    let mut dep_count: HashMap<String, usize> = HashMap::new();
-    let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
-
-    for (id, name, dependencies) in packages {
-        id_to_name.insert(id.clone(), name);
-        dep_count.insert(id.clone(), dependencies.len());
-
-        for dep_id in dependencies {
-            dep_count.entry(dep_id.clone()).or_insert(0);
-            dependents.entry(dep_id).or_default().push(id.clone());
-        }
+fn paths_match(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
     }
 
-    for reverse_edges in dependents.values_mut() {
-        reverse_edges.sort();
+    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
     }
-
-    let mut zero_deps: Vec<String> = dep_count
-        .iter()
-        .filter(|&(_, &count)| count == 0)
-        .map(|(id, _)| id.clone())
-        .collect();
-    zero_deps.sort();
-    let mut queue: VecDeque<String> = zero_deps.into();
-
-    let mut seen = HashSet::new();
-    let mut ordered_names = Vec::new();
-
-    while let Some(id) = queue.pop_front() {
-        if let Some(name) = id_to_name.get(&id)
-            && seen.insert(name.clone())
-        {
-            ordered_names.push(name.clone());
-        }
-        if let Some(reverse_edges) = dependents.get(&id) {
-            for dependent in reverse_edges {
-                if let Some(count) = dep_count.get_mut(dependent) {
-                    *count = count.saturating_sub(1);
-                    if *count == 0 {
-                        queue.push_back(dependent.clone());
-                    }
-                }
-            }
-        }
-    }
-
-    ordered_names
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_crate_names_bfs_orders_leaves_first() {
-        let names = crate_names_bfs_from_edges(vec![
-            ("serde 1.0.0 (registry)".into(), "serde".into(), vec![]),
-            ("tokio 1.0.0 (registry)".into(), "tokio".into(), vec![]),
-            (
-                "app 0.1.0 (path)".into(),
-                "app".into(),
-                vec![
-                    "serde 1.0.0 (registry)".into(),
-                    "tokio 1.0.0 (registry)".into(),
-                ],
-            ),
-        ]);
-
-        assert_eq!(names, vec!["serde", "tokio", "app"]);
-    }
-
-    #[test]
-    fn test_crate_names_bfs_deduplicates_names() {
-        let names = crate_names_bfs_from_edges(vec![
-            ("serde 1.0.0 (registry)".into(), "serde".into(), vec![]),
-            ("serde 1.0.1 (registry)".into(), "serde".into(), vec![]),
-        ]);
-
-        assert_eq!(names, vec!["serde"]);
-    }
 
     #[test]
     fn test_run_cargo_metadata_uses_guppy_graph_and_workspace_root() {
@@ -249,7 +189,7 @@ mod tests {
         std::fs::write(
             root.join("Cargo.toml"),
             r#"[workspace]
-members = ["app", "dep"]
+members = ["app", "dep", "unrelated"]
 resolver = "2"
 "#,
         )
@@ -281,6 +221,18 @@ edition = "2021"
         )
         .unwrap();
         std::fs::write(root.join("dep/src/lib.rs"), "").unwrap();
+
+        std::fs::create_dir_all(root.join("unrelated/src")).unwrap();
+        std::fs::write(
+            root.join("unrelated/Cargo.toml"),
+            r#"[package]
+name = "unrelated"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .unwrap();
+        std::fs::write(root.join("unrelated/src/lib.rs"), "").unwrap();
 
         let discovery = run_cargo_metadata(Some(&root.join("app/Cargo.toml"))).unwrap();
         assert_eq!(discovery.crate_names, vec!["dep", "app"]);


### PR DESCRIPTION
## Summary

- Derive crate_names directly from guppy dependency order: query_forward(...).resolve().packages(DependencyDirection::Reverse).
- Focus that order to the current package dependency closure when a manifest is known.
- Use the existing crate_names order to prioritize shard/history/key-cache candidates.
- Keep BuildIntent schema unchanged so root package verification can compile against published kache-core v0.5.0.

## Validation

- cargo fmt --check
- cargo test build_intent
- cargo test -p kache-core
- cargo test planner_client
- cargo test -p kache-service prefetch_plan
- cargo clippy --workspace --all-targets -- -D warnings
- cargo package --allow-dirty
