### PR TITLE
Separate hit, dup, and miss cache outcomes

### DIFF
--- a/crates/kache-e2e/src/assertions.rs
+++ b/crates/kache-e2e/src/assertions.rs
@@ -353,6 +353,7 @@ mod tests {
             local_hits: hits,
             prefetch_hits: 0,
             remote_hits: 0,
+            dups: 0,
             misses,
         }
     }

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -1224,8 +1224,8 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
     );
     eprintln!("  speedup    : {:.2}x", r.speedup);
     eprintln!(
-        "  warm cache : {} hits / {} misses   {:.1}% hit rate ({:.1}% weighted)",
-        r.warm.hits, r.warm.misses, r.warm.hit_rate_pct, r.warm.weighted_hit_rate_pct
+        "  warm cache : {} hits / {} dups / {} misses   {:.1}% hit rate ({:.1}% weighted)",
+        r.warm.hits, r.warm.dups, r.warm.misses, r.warm.hit_rate_pct, r.warm.weighted_hit_rate_pct
     );
     let el = &r.warm.event_log;
     let cacheable = el.hit_bytes.saturating_add(el.miss_bytes);
@@ -1411,6 +1411,7 @@ struct PhaseMetrics {
     wall_s: u64,
     total_crates: u64,
     hits: u64,
+    dups: u64,
     misses: u64,
     /// Cache errors recorded this phase (e.g. store/restore failures).
     errors: u64,
@@ -1459,6 +1460,7 @@ impl PhaseMetrics {
             wall_s,
             total_crates: s.total_crates,
             hits: s.total_hits(),
+            dups: s.dups,
             misses: s.misses,
             errors: sum["errors"].as_u64().unwrap_or(0),
             hit_rate_pct: round1(s.hit_rate_pct),
@@ -1967,6 +1969,7 @@ mod tests {
             wall_s: 1,
             total_crates: 10,
             hits: 6,
+            dups: 0,
             misses: 4,
             errors,
             hit_rate_pct: 60.0,

--- a/crates/kache-e2e/src/report.rs
+++ b/crates/kache-e2e/src/report.rs
@@ -61,6 +61,8 @@ pub struct ReportSummary {
     pub local_hits: u64,
     pub prefetch_hits: u64,
     pub remote_hits: u64,
+    #[serde(default)]
+    pub dups: u64,
     pub misses: u64,
 }
 
@@ -68,6 +70,11 @@ impl ReportSummary {
     /// Aggregate hits across all sources (local + prefetch + remote).
     pub fn total_hits(&self) -> u64 {
         self.local_hits + self.prefetch_hits + self.remote_hits
+    }
+
+    /// Entries where the compiler ran because the cache key missed.
+    pub fn total_compiled(&self) -> u64 {
+        self.dups + self.misses
     }
 
     /// Compute `self - earlier` for per-phase delta semantics.
@@ -78,7 +85,7 @@ impl ReportSummary {
     /// each phase and subtracting gives the per-phase signal that
     /// per-phase assertions want.
     ///
-    /// `hit_rate_pct` is recomputed from the delta hits/misses (NOT
+    /// `hit_rate_pct` is recomputed from the delta hits/dups/misses (NOT
     /// subtracted, since rates don't subtract meaningfully). Returns
     /// `0.0` when the delta `total_crates` is zero — a phase that
     /// did nothing is `0%`, not `NaN`.
@@ -86,13 +93,14 @@ impl ReportSummary {
         let local_hits = self.local_hits.saturating_sub(earlier.local_hits);
         let prefetch_hits = self.prefetch_hits.saturating_sub(earlier.prefetch_hits);
         let remote_hits = self.remote_hits.saturating_sub(earlier.remote_hits);
+        let dups = self.dups.saturating_sub(earlier.dups);
         let misses = self.misses.saturating_sub(earlier.misses);
-        let total_crates = self.total_crates.saturating_sub(earlier.total_crates);
         let hits = local_hits + prefetch_hits + remote_hits;
-        let hit_rate_pct = if hits + misses == 0 {
+        let total_crates = hits + dups + misses;
+        let hit_rate_pct = if total_crates == 0 {
             0.0
         } else {
-            (hits as f64 / (hits + misses) as f64) * 100.0
+            (hits as f64 / total_crates as f64) * 100.0
         };
         ReportSummary {
             hit_rate_pct,
@@ -100,6 +108,7 @@ impl ReportSummary {
             local_hits,
             prefetch_hits,
             remote_hits,
+            dups,
             misses,
         }
     }
@@ -115,7 +124,43 @@ pub fn empty_summary() -> ReportSummary {
         local_hits: 0,
         prefetch_hits: 0,
         remote_hits: 0,
+        dups: 0,
         misses: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delta_since_keeps_hits_dups_and_misses_separate() {
+        let earlier = ReportSummary {
+            hit_rate_pct: 0.0,
+            total_crates: 3,
+            local_hits: 1,
+            prefetch_hits: 0,
+            remote_hits: 0,
+            dups: 1,
+            misses: 1,
+        };
+        let later = ReportSummary {
+            hit_rate_pct: 50.0,
+            total_crates: 7,
+            local_hits: 3,
+            prefetch_hits: 1,
+            remote_hits: 0,
+            dups: 2,
+            misses: 1,
+        };
+
+        let delta = later.delta_since(&earlier);
+
+        assert_eq!(delta.total_hits(), 3);
+        assert_eq!(delta.dups, 1);
+        assert_eq!(delta.misses, 0);
+        assert_eq!(delta.total_crates, 4);
+        assert_eq!(delta.hit_rate_pct, 75.0);
     }
 }
 

--- a/crates/kache-e2e/src/report.rs
+++ b/crates/kache-e2e/src/report.rs
@@ -129,41 +129,6 @@ pub fn empty_summary() -> ReportSummary {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn delta_since_keeps_hits_dups_and_misses_separate() {
-        let earlier = ReportSummary {
-            hit_rate_pct: 0.0,
-            total_crates: 3,
-            local_hits: 1,
-            prefetch_hits: 0,
-            remote_hits: 0,
-            dups: 1,
-            misses: 1,
-        };
-        let later = ReportSummary {
-            hit_rate_pct: 50.0,
-            total_crates: 7,
-            local_hits: 3,
-            prefetch_hits: 1,
-            remote_hits: 0,
-            dups: 2,
-            misses: 1,
-        };
-
-        let delta = later.delta_since(&earlier);
-
-        assert_eq!(delta.total_hits(), 3);
-        assert_eq!(delta.dups, 1);
-        assert_eq!(delta.misses, 0);
-        assert_eq!(delta.total_crates, 4);
-        assert_eq!(delta.hit_rate_pct, 75.0);
-    }
-}
-
 /// Invoke `<kache> report --format json --since 1h` against `cache_dir`.
 ///
 /// Thin wrapper over [`fetch_since`] with the 1-hour window the e2e
@@ -206,4 +171,39 @@ pub fn fetch_since(
     let typed: KacheReport =
         serde_json::from_value(raw.clone()).context("extracting summary from kache report")?;
     Ok((typed, raw))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delta_since_keeps_hits_dups_and_misses_separate() {
+        let earlier = ReportSummary {
+            hit_rate_pct: 0.0,
+            total_crates: 3,
+            local_hits: 1,
+            prefetch_hits: 0,
+            remote_hits: 0,
+            dups: 1,
+            misses: 1,
+        };
+        let later = ReportSummary {
+            hit_rate_pct: 50.0,
+            total_crates: 7,
+            local_hits: 3,
+            prefetch_hits: 1,
+            remote_hits: 0,
+            dups: 2,
+            misses: 1,
+        };
+
+        let delta = later.delta_since(&earlier);
+
+        assert_eq!(delta.total_hits(), 3);
+        assert_eq!(delta.dups, 1);
+        assert_eq!(delta.misses, 0);
+        assert_eq!(delta.total_crates, 4);
+        assert_eq!(delta.hit_rate_pct, 75.0);
+    }
 }

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -727,6 +727,7 @@ fn phase_measurements(
         Measurement::number("wall_s", build_wall_s, Some("s")).with_warning(wall_warning),
         Measurement::number("total_crates", summary.total_crates, None),
         Measurement::number("hits", summary.total_hits(), None),
+        Measurement::number("dups", summary.dups, None),
         Measurement::number("misses", summary.misses, None),
         Measurement::number("hit_rate_pct", round1(summary.hit_rate_pct), Some("%"))
             .with_warning(hit_rate_warning),

--- a/docs/deduplication.mdx
+++ b/docs/deduplication.mdx
@@ -46,3 +46,11 @@ The value is computed periodically, not per-write. `Dedup: active` means the sca
 The estimate can be conservative. The scan only sees blobs in kache's store, not all hardlinks on the filesystem.
 
 The metric is informational — it doesn't affect behavior and doesn't need to reach any particular value to confirm kache is working correctly.
+
+## `dup` events are different
+
+The monitor's `dup` outcome is not the same thing as the `Deduplicated` storage
+metric. A `dup` event means a cache key missed, the compiler ran, and the
+compiled output hashes were already present before storing. That usually points
+to equivalent builds under different keys, such as over-specific arguments,
+paths, or environment inputs. It still counts as compiled work.

--- a/docs/how-it-works/architecture.mdx
+++ b/docs/how-it-works/architecture.mdx
@@ -37,6 +37,18 @@ release lock
 
 The lock prevents duplicate compilation when cargo spawns multiple parallel rustc processes for the same crate (which can happen in certain workspace configurations). A process that loses the lock waits for the winner's result and restores from the cache instead of compiling.
 
+Build outcomes are separated into three cacheable cases:
+
+| Outcome | Cache key | Compiler ran? | Blob content | Meaning |
+|---|---|---:|---|---|
+| `hit` | Found | No | Already known | kache restored from an existing entry |
+| `dup` | Missed | Yes | Already known | a new key produced bytes kache already had |
+| `miss` | Missed | Yes | New | a new key produced at least one new blob |
+
+`dup` is a cache-key/content outcome, not the same thing as the storage
+deduplication metric. A high `dup` count can point to over-specific cache keys
+or noisy inputs, because different keys are compiling to identical bytes.
+
 Non-primary invocations — rustc calls with no source file, like dependency probing — pass straight through without touching the cache.
 
 ## The local store

--- a/docs/monitor.mdx
+++ b/docs/monitor.mdx
@@ -54,7 +54,7 @@ The header line at the top of the monitor shows the current state of your local 
 | Field | What it means |
 |---|---|
 | `Store` | Bytes used vs. the configured maximum (`KACHE_MAX_SIZE`) |
-| `Hit rate` | Breakdown of cache outcomes over the displayed window: local / prefetch / remote / miss |
+| `Hit rate` | Breakdown of cache outcomes over the displayed window: local / prefetch / remote / dup / miss |
 | `Dedup` | Logical bytes saved by storing shared blobs once |
 | `Blobs` | Physical bytes used by blob files in the local store |
 | `Hardlinks` | Estimated bytes saved by hardlink sharing across project `target/` directories |
@@ -66,6 +66,15 @@ The header line at the top of the monitor shows the current state of your local 
 ### 1 — Build
 
 A live event stream showing every rustc invocation kache handled, with outcome, crate name, elapsed time, and artifact size. New events appear at the bottom.
+
+`dup` means the cache key missed and the compiler ran, but every unique output
+blob already existed in the local store before the store step. It is a
+diagnostic signal for over-specific keys or noisy inputs, but it still counts as
+compiled work rather than a cache hit.
+
+This is separate from the `Dedup` storage metric. `Dedup` estimates hardlink and
+content-addressed storage savings; `dup` identifies compiles that produced
+already-known bytes under a different cache key.
 
 The `--since` flag controls how far back the event log is read when the monitor opens:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,7 @@ impl Default for StatsSnapshot {
                 local_hits: 0,
                 prefetch_hits: 0,
                 remote_hits: 0,
+                dups: 0,
                 misses: 0,
                 errors: 0,
                 total_elapsed_ms: 0,
@@ -54,6 +55,9 @@ impl Default for StatsSnapshot {
                 miss_elapsed_ms: 0,
                 hit_compile_time_ms: 0,
                 miss_compile_time_ms: 0,
+                store_output_blobs: 0,
+                store_duplicate_blobs: 0,
+                store_new_blobs: 0,
             },
             daemon_connected: false,
             daemon_version: String::new(),
@@ -76,7 +80,7 @@ impl Default for StatsSnapshot {
 }
 
 pub fn count_hit_rate(es: &daemon::EventStatsResponse) -> f64 {
-    let total = es.local_hits + es.prefetch_hits + es.remote_hits + es.misses;
+    let total = es.local_hits + es.prefetch_hits + es.remote_hits + es.dups + es.misses;
     if total > 0 {
         ((es.local_hits + es.prefetch_hits + es.remote_hits) as f64 / total as f64) * 100.0
     } else {
@@ -214,6 +218,7 @@ pub(crate) fn fetch_stats_snapshot(
             local_hits: es.local_hits,
             prefetch_hits: es.prefetch_hits,
             remote_hits: es.remote_hits,
+            dups: es.dups,
             misses: es.misses,
             errors: es.errors,
             total_elapsed_ms: es.total_elapsed_ms,
@@ -221,6 +226,9 @@ pub(crate) fn fetch_stats_snapshot(
             miss_elapsed_ms: es.miss_elapsed_ms,
             hit_compile_time_ms: es.hit_compile_time_ms,
             miss_compile_time_ms: es.miss_compile_time_ms,
+            store_output_blobs: es.store_output_blobs,
+            store_duplicate_blobs: es.store_duplicate_blobs,
+            store_new_blobs: es.store_new_blobs,
         },
         daemon_connected: false,
         daemon_version: String::new(),
@@ -283,8 +291,8 @@ pub fn stats(config: &Config, hours: Option<u64>) -> Result<()> {
     let es = &snap.event_stats;
     let hit_rate = count_hit_rate(es);
     println!(
-        "Hit rate:   {hit_rate:.1}% (local: {}, prefetch: {}, remote: {}, miss: {})",
-        es.local_hits, es.prefetch_hits, es.remote_hits, es.misses,
+        "Hit rate:   {hit_rate:.1}% (local: {}, prefetch: {}, remote: {}, dup: {}, miss: {})",
+        es.local_hits, es.prefetch_hits, es.remote_hits, es.dups, es.misses,
     );
     if let Some(weighted) = compile_weighted_hit_rate(es) {
         println!("Weighted:   {weighted:.1}% by compile cost");
@@ -415,14 +423,16 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
         return Ok(());
     }
 
-    // ── Find last miss ─────────────────────────────────────────────────
-    let last_miss = crate_events
-        .iter()
-        .rev()
-        .find(|e| matches!(e.result, events::EventResult::Miss));
+    // ── Find last entry miss ───────────────────────────────────────────
+    let last_miss = crate_events.iter().rev().find(|e| {
+        matches!(
+            e.result,
+            events::EventResult::Dup | events::EventResult::Miss
+        )
+    });
 
     if last_miss.is_none() {
-        println!("No misses found for `{crate_name}` -- all events are hits!");
+        println!("No misses or dups found for `{crate_name}` -- all events are hits!");
         println!("\nRecent events:");
         for event in crate_events.iter().rev().take(5).rev() {
             let time = event.ts.format("%Y-%m-%dT%H:%M:%S");
@@ -443,7 +453,10 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
 
     let miss_time = miss.ts.format("%Y-%m-%dT%H:%M:%S");
     let miss_key_display = key_short(&miss.cache_key);
-    println!("  Last miss: {miss_time} (key: {miss_key_display})");
+    println!(
+        "  Last {}: {miss_time} (key: {miss_key_display})",
+        miss.result
+    );
 
     // Show miss metadata if it was subsequently stored
     if !miss.cache_key.is_empty() {
@@ -501,7 +514,7 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
                 format!(", type: {}", entry.crate_type)
             };
             let match_indicator = if entry.cache_key == miss.cache_key {
-                " <-- miss key (stored after compile)"
+                " <-- entry-miss key (stored after compile)"
             } else {
                 ""
             };
@@ -598,9 +611,10 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
         && miss_ev.ts > hit.ts
     {
         println!(
-            "\n  Key changed: {} (last hit) -> {} (miss)",
+            "\n  Key changed: {} (last hit) -> {} ({})",
             key_short(&hit.cache_key),
             key_short(&miss_ev.cache_key),
+            miss_ev.result,
         );
     }
 
@@ -2527,6 +2541,7 @@ pub fn save_manifest(
             crate::events::EventResult::LocalHit
             | crate::events::EventResult::PrefetchHit
             | crate::events::EventResult::RemoteHit
+            | crate::events::EventResult::Dup
             | crate::events::EventResult::Miss => {}
             _ => continue,
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -470,6 +470,8 @@ pub struct EventStatsResponse {
     #[serde(default)]
     pub prefetch_hits: usize,
     pub remote_hits: usize,
+    #[serde(default)]
+    pub dups: usize,
     pub misses: usize,
     pub errors: usize,
     pub total_elapsed_ms: u64,
@@ -481,6 +483,12 @@ pub struct EventStatsResponse {
     pub hit_compile_time_ms: u64,
     #[serde(default)]
     pub miss_compile_time_ms: u64,
+    #[serde(default)]
+    pub store_output_blobs: u32,
+    #[serde(default)]
+    pub store_duplicate_blobs: u32,
+    #[serde(default)]
+    pub store_new_blobs: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1059,6 +1067,7 @@ impl Daemon {
                 local_hits: es.local_hits,
                 prefetch_hits: es.prefetch_hits,
                 remote_hits: es.remote_hits,
+                dups: es.dups,
                 misses: es.misses,
                 errors: es.errors,
                 total_elapsed_ms: es.total_elapsed_ms,
@@ -1066,6 +1075,9 @@ impl Daemon {
                 miss_elapsed_ms: es.miss_elapsed_ms,
                 hit_compile_time_ms: es.hit_compile_time_ms,
                 miss_compile_time_ms: es.miss_compile_time_ms,
+                store_output_blobs: es.store_output_blobs,
+                store_duplicate_blobs: es.store_duplicate_blobs,
+                store_new_blobs: es.store_new_blobs,
             },
             version: self.version.clone(),
             build_epoch: self.build_epoch,
@@ -4450,6 +4462,7 @@ mod tests {
                 local_hits: 10,
                 prefetch_hits: 0,
                 remote_hits: 2,
+                dups: 1,
                 misses: 3,
                 errors: 1,
                 total_elapsed_ms: 5000,
@@ -4457,6 +4470,9 @@ mod tests {
                 miss_elapsed_ms: 4880,
                 hit_compile_time_ms: 22000,
                 miss_compile_time_ms: 9000,
+                store_output_blobs: 4,
+                store_duplicate_blobs: 1,
+                store_new_blobs: 3,
             },
             version: String::new(),
             build_epoch: 0,
@@ -4516,6 +4532,7 @@ mod tests {
                 local_hits: 0,
                 prefetch_hits: 0,
                 remote_hits: 0,
+                dups: 0,
                 misses: 0,
                 errors: 0,
                 total_elapsed_ms: 0,
@@ -4523,6 +4540,9 @@ mod tests {
                 miss_elapsed_ms: 0,
                 hit_compile_time_ms: 0,
                 miss_compile_time_ms: 0,
+                store_output_blobs: 0,
+                store_duplicate_blobs: 0,
+                store_new_blobs: 0,
             },
             version: String::new(),
             build_epoch: 0,

--- a/src/events.rs
+++ b/src/events.rs
@@ -146,20 +146,24 @@ pub struct BuildSummaryEvent {
 }
 
 /// Append a build event to the event log file.
-/// Uses O_APPEND for atomic writes on POSIX (safe for concurrent writers).
+/// Uses an exclusive file lock so concurrent wrapper processes cannot
+/// interleave JSON lines.
 pub fn log_event(event_log_path: &Path, event: &BuildEvent) -> Result<()> {
     if let Some(parent) = event_log_path.parent() {
         fs::create_dir_all(parent)?;
     }
 
-    let mut file = OpenOptions::new()
+    let file = OpenOptions::new()
         .create(true)
         .append(true)
         .open(event_log_path)
         .context("opening event log")?;
+    file.lock().context("locking event log")?;
 
     let line = serde_json::to_string(event).context("serializing event")?;
+    let mut file = file;
     writeln!(file, "{line}").context("writing event to log")?;
+    file.unlock().context("unlocking event log")?;
 
     Ok(())
 }
@@ -171,7 +175,8 @@ pub fn read_events(event_log_path: &Path) -> Result<Vec<BuildEvent>> {
     }
 
     let file = File::open(event_log_path).context("opening event log")?;
-    let reader = BufReader::new(file);
+    file.lock_shared().context("locking event log for read")?;
+    let reader = BufReader::new(&file);
     let mut events = Vec::new();
 
     for line in reader.lines() {
@@ -187,6 +192,7 @@ pub fn read_events(event_log_path: &Path) -> Result<Vec<BuildEvent>> {
         }
     }
 
+    file.unlock().context("unlocking event log")?;
     Ok(events)
 }
 
@@ -306,13 +312,16 @@ pub fn log_transfer(transfer_log_path: &Path, event: &TransferEvent) -> Result<(
     if let Some(parent) = transfer_log_path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let mut file = OpenOptions::new()
+    let file = OpenOptions::new()
         .create(true)
         .append(true)
         .open(transfer_log_path)
         .context("opening transfer log")?;
+    file.lock().context("locking transfer log")?;
     let line = serde_json::to_string(event).context("serializing transfer event")?;
+    let mut file = file;
     writeln!(file, "{line}").context("writing transfer event to log")?;
+    file.unlock().context("unlocking transfer log")?;
     Ok(())
 }
 
@@ -322,7 +331,9 @@ pub fn read_transfers(transfer_log_path: &Path) -> Result<Vec<TransferEvent>> {
         return Ok(Vec::new());
     }
     let file = File::open(transfer_log_path).context("opening transfer log")?;
-    let reader = BufReader::new(file);
+    file.lock_shared()
+        .context("locking transfer log for read")?;
+    let reader = BufReader::new(&file);
     let mut events = Vec::new();
     for line in reader.lines() {
         let line = line?;
@@ -336,6 +347,7 @@ pub fn read_transfers(transfer_log_path: &Path) -> Result<Vec<TransferEvent>> {
             }
         }
     }
+    file.unlock().context("unlocking transfer log")?;
     Ok(events)
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -26,7 +26,7 @@ pub struct BuildEvent {
     /// Event schema version: 0 = legacy, 1 = prefetch-aware,
     /// 2 = compile-cost-aware, 3 = op-count-aware, 4 = probe-count-aware,
     /// 5 = passthrough details, 6 = file-hash cache metrics,
-    /// 7 = restore-method bytes.
+    /// 7 = restore-method bytes, 8 = dup outcome + store blob counters.
     #[serde(default)]
     pub schema: u32,
     /// Cache key computation time (ms).
@@ -47,11 +47,20 @@ pub struct BuildEvent {
     /// Restore from cache time — blob link/copy + mtime + depinfo + codesign (hits only, ms).
     #[serde(default)]
     pub restore_ms: u64,
-    /// Store put time — tar + compress + dedup + SQLite (misses only, ms).
+    /// Store put time — tar + compress + dedup + SQLite (dup/miss only, ms).
     #[serde(default)]
     pub store_ms: u64,
+    /// Unique output blobs handled by store put (compiled outcomes only).
+    #[serde(default)]
+    pub store_output_blobs: u32,
+    /// Output blobs whose content hash already existed before store put.
+    #[serde(default)]
+    pub store_duplicate_blobs: u32,
+    /// Output blobs whose content hash was new before store put.
+    #[serde(default)]
+    pub store_new_blobs: u32,
     /// Times kache spawned the underlying compiler for this build.
-    /// 0 on a cache hit, 1 on a miss. Deterministic — independent of
+    /// 0 on a cache hit, 1 on a dup/miss. Deterministic — independent of
     /// machine speed — so the e2e harness can assert on it.
     #[serde(default)]
     pub compiler_runs: u32,
@@ -99,6 +108,8 @@ pub enum EventResult {
     /// Local hit on an artifact that was downloaded by the manifest prefetch.
     PrefetchHit,
     RemoteHit,
+    /// Entry miss; compiler ran; all output blobs already existed.
+    Dup,
     Miss,
     Error,
     Passthrough,
@@ -111,6 +122,7 @@ impl std::fmt::Display for EventResult {
             EventResult::LocalHit => write!(f, "local_hit"),
             EventResult::PrefetchHit => write!(f, "prefetch_hit"),
             EventResult::RemoteHit => write!(f, "remote_hit"),
+            EventResult::Dup => write!(f, "dup"),
             EventResult::Miss => write!(f, "miss"),
             EventResult::Error => write!(f, "error"),
             EventResult::Passthrough => write!(f, "passthrough"),
@@ -382,6 +394,7 @@ pub struct EventStats {
     pub local_hits: usize,
     pub prefetch_hits: usize,
     pub remote_hits: usize,
+    pub dups: usize,
     pub misses: usize,
     pub errors: usize,
     pub total_size: u64,
@@ -394,6 +407,9 @@ pub struct EventStats {
     pub total_lookup_ms: u64,
     pub total_restore_ms: u64,
     pub total_store_ms: u64,
+    pub store_output_blobs: u32,
+    pub store_duplicate_blobs: u32,
+    pub store_new_blobs: u32,
     /// Bytes restored from cache by CoW reflink (physically zero-copy).
     pub reflinked_bytes: u64,
     /// Bytes restored by hardlink (zero-copy via a shared inode).
@@ -408,6 +424,7 @@ pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
         local_hits: 0,
         prefetch_hits: 0,
         remote_hits: 0,
+        dups: 0,
         misses: 0,
         errors: 0,
         total_size: 0,
@@ -420,6 +437,9 @@ pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
         total_lookup_ms: 0,
         total_restore_ms: 0,
         total_store_ms: 0,
+        store_output_blobs: 0,
+        store_duplicate_blobs: 0,
+        store_new_blobs: 0,
         reflinked_bytes: 0,
         hardlinked_bytes: 0,
         copied_bytes: 0,
@@ -442,6 +462,15 @@ pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
                 stats.hit_elapsed_ms += event.elapsed_ms;
                 stats.hit_compile_time_ms += event.compile_time_ms;
             }
+            EventResult::Dup => {
+                stats.dups += 1;
+                stats.miss_elapsed_ms += event.elapsed_ms;
+                stats.miss_compile_time_ms += if event.compile_time_ms > 0 {
+                    event.compile_time_ms
+                } else {
+                    event.elapsed_ms
+                };
+            }
             EventResult::Miss => {
                 stats.misses += 1;
                 stats.miss_elapsed_ms += event.elapsed_ms;
@@ -460,6 +489,9 @@ pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
         stats.total_lookup_ms += event.lookup_ms;
         stats.total_restore_ms += event.restore_ms;
         stats.total_store_ms += event.store_ms;
+        stats.store_output_blobs += event.store_output_blobs;
+        stats.store_duplicate_blobs += event.store_duplicate_blobs;
+        stats.store_new_blobs += event.store_new_blobs;
         stats.reflinked_bytes += event.reflinked_bytes;
         stats.hardlinked_bytes += event.hardlinked_bytes;
         stats.copied_bytes += event.copied_bytes;
@@ -489,7 +521,7 @@ mod tests {
             compile_time_ms,
             size,
             cache_key: cache_key.to_string(),
-            schema: 7,
+            schema: 8,
             key_ms: 0,
             key_hash_hits: 0,
             key_hash_misses: 0,
@@ -497,6 +529,9 @@ mod tests {
             lookup_ms: 0,
             restore_ms: 0,
             store_ms: 0,
+            store_output_blobs: 0,
+            store_duplicate_blobs: 0,
+            store_new_blobs: 0,
             compiler_runs: 0,
             preprocessor_runs: 0,
             probe_runs: 0,
@@ -523,7 +558,7 @@ mod tests {
             compile_time_ms: 250,
             size: 3145728,
             cache_key: "abc123".to_string(),
-            schema: 7,
+            schema: 8,
             key_ms: 0,
             key_hash_hits: 0,
             key_hash_misses: 0,
@@ -531,6 +566,9 @@ mod tests {
             lookup_ms: 0,
             restore_ms: 0,
             store_ms: 0,
+            store_output_blobs: 0,
+            store_duplicate_blobs: 0,
+            store_new_blobs: 0,
             compiler_runs: 0,
             preprocessor_runs: 0,
             probe_runs: 0,
@@ -610,6 +648,7 @@ mod tests {
         assert_eq!(EventResult::LocalHit.to_string(), "local_hit");
         assert_eq!(EventResult::PrefetchHit.to_string(), "prefetch_hit");
         assert_eq!(EventResult::RemoteHit.to_string(), "remote_hit");
+        assert_eq!(EventResult::Dup.to_string(), "dup");
         assert_eq!(EventResult::Miss.to_string(), "miss");
         assert_eq!(EventResult::Error.to_string(), "error");
         assert_eq!(EventResult::Passthrough.to_string(), "passthrough");
@@ -666,6 +705,7 @@ mod tests {
             test_event("a", EventResult::LocalHit, 10, 300, 100, "k1"),
             test_event("b", EventResult::PrefetchHit, 5, 250, 150, "k1b"),
             test_event("c", EventResult::RemoteHit, 50, 900, 200, "k2"),
+            test_event("dup", EventResult::Dup, 700, 650, 400, "kdup"),
             test_event("d", EventResult::Miss, 1000, 950, 500, "k3"),
             test_event("e", EventResult::Error, 5, 0, 0, "k4"),
             test_event("f", EventResult::Skipped, 0, 0, 0, "k5"),
@@ -673,18 +713,19 @@ mod tests {
         ];
 
         let stats = compute_stats(&events);
-        assert_eq!(stats.total, 7);
+        assert_eq!(stats.total, 8);
         assert_eq!(stats.local_hits, 1);
         assert_eq!(stats.prefetch_hits, 1);
         assert_eq!(stats.remote_hits, 1);
+        assert_eq!(stats.dups, 1);
         assert_eq!(stats.misses, 1);
         assert_eq!(stats.errors, 1);
-        assert_eq!(stats.total_size, 950);
-        assert_eq!(stats.total_elapsed_ms, 1070);
+        assert_eq!(stats.total_size, 1350);
+        assert_eq!(stats.total_elapsed_ms, 1770);
         assert_eq!(stats.hit_elapsed_ms, 65);
-        assert_eq!(stats.miss_elapsed_ms, 1000);
+        assert_eq!(stats.miss_elapsed_ms, 1700);
         assert_eq!(stats.hit_compile_time_ms, 1450);
-        assert_eq!(stats.miss_compile_time_ms, 950);
+        assert_eq!(stats.miss_compile_time_ms, 1600);
     }
 
     #[test]

--- a/src/events.rs
+++ b/src/events.rs
@@ -146,24 +146,27 @@ pub struct BuildSummaryEvent {
 }
 
 /// Append a build event to the event log file.
-/// Uses an exclusive file lock so concurrent wrapper processes cannot
+/// Uses an exclusive sidecar file lock so concurrent wrapper processes cannot
 /// interleave JSON lines.
 pub fn log_event(event_log_path: &Path, event: &BuildEvent) -> Result<()> {
     if let Some(parent) = event_log_path.parent() {
         fs::create_dir_all(parent)?;
     }
 
-    let file = OpenOptions::new()
+    let lock = open_log_lock(event_log_path).context("opening event log lock")?;
+    lock.lock().context("locking event log")?;
+
+    let mut file = OpenOptions::new()
         .create(true)
         .append(true)
         .open(event_log_path)
         .context("opening event log")?;
-    file.lock().context("locking event log")?;
 
     let line = serde_json::to_string(event).context("serializing event")?;
-    let mut file = file;
-    writeln!(file, "{line}").context("writing event to log")?;
-    file.unlock().context("unlocking event log")?;
+    let mut bytes = line.into_bytes();
+    bytes.push(b'\n');
+    file.write_all(&bytes).context("writing event to log")?;
+    lock.unlock().context("unlocking event log")?;
 
     Ok(())
 }
@@ -174,8 +177,10 @@ pub fn read_events(event_log_path: &Path) -> Result<Vec<BuildEvent>> {
         return Ok(Vec::new());
     }
 
+    let lock = open_log_lock(event_log_path).context("opening event log lock")?;
+    lock.lock_shared().context("locking event log for read")?;
+
     let file = File::open(event_log_path).context("opening event log")?;
-    file.lock_shared().context("locking event log for read")?;
     let reader = BufReader::new(&file);
     let mut events = Vec::new();
 
@@ -192,7 +197,7 @@ pub fn read_events(event_log_path: &Path) -> Result<Vec<BuildEvent>> {
         }
     }
 
-    file.unlock().context("unlocking event log")?;
+    lock.unlock().context("unlocking event log")?;
     Ok(events)
 }
 
@@ -312,16 +317,20 @@ pub fn log_transfer(transfer_log_path: &Path, event: &TransferEvent) -> Result<(
     if let Some(parent) = transfer_log_path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let file = OpenOptions::new()
+    let lock = open_log_lock(transfer_log_path).context("opening transfer log lock")?;
+    lock.lock().context("locking transfer log")?;
+
+    let mut file = OpenOptions::new()
         .create(true)
         .append(true)
         .open(transfer_log_path)
         .context("opening transfer log")?;
-    file.lock().context("locking transfer log")?;
     let line = serde_json::to_string(event).context("serializing transfer event")?;
-    let mut file = file;
-    writeln!(file, "{line}").context("writing transfer event to log")?;
-    file.unlock().context("unlocking transfer log")?;
+    let mut bytes = line.into_bytes();
+    bytes.push(b'\n');
+    file.write_all(&bytes)
+        .context("writing transfer event to log")?;
+    lock.unlock().context("unlocking transfer log")?;
     Ok(())
 }
 
@@ -330,9 +339,11 @@ pub fn read_transfers(transfer_log_path: &Path) -> Result<Vec<TransferEvent>> {
     if !transfer_log_path.exists() {
         return Ok(Vec::new());
     }
-    let file = File::open(transfer_log_path).context("opening transfer log")?;
-    file.lock_shared()
+    let lock = open_log_lock(transfer_log_path).context("opening transfer log lock")?;
+    lock.lock_shared()
         .context("locking transfer log for read")?;
+
+    let file = File::open(transfer_log_path).context("opening transfer log")?;
     let reader = BufReader::new(&file);
     let mut events = Vec::new();
     for line in reader.lines() {
@@ -347,8 +358,24 @@ pub fn read_transfers(transfer_log_path: &Path) -> Result<Vec<TransferEvent>> {
             }
         }
     }
-    file.unlock().context("unlocking transfer log")?;
+    lock.unlock().context("unlocking transfer log")?;
     Ok(events)
+}
+
+fn open_log_lock(log_path: &Path) -> Result<File> {
+    OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(sidecar_lock_path(log_path))
+        .context("opening log lock")
+}
+
+fn sidecar_lock_path(log_path: &Path) -> PathBuf {
+    let mut path = log_path.as_os_str().to_owned();
+    path.push(".lock");
+    PathBuf::from(path)
 }
 
 /// Read transfer events since a given unix timestamp (seconds).

--- a/src/report.rs
+++ b/src/report.rs
@@ -63,6 +63,8 @@ pub struct ReportSummary {
     pub local_hits: usize,
     pub prefetch_hits: usize,
     pub remote_hits: usize,
+    #[serde(default)]
+    pub dups: usize,
     pub misses: usize,
     pub errors: usize,
     #[serde(default)]
@@ -256,8 +258,14 @@ pub struct CrateDetail {
     pub overhead_ms: u64,
     pub size: u64,
     pub cache_key: String,
+    #[serde(default)]
+    pub store_output_blobs: u32,
+    #[serde(default)]
+    pub store_duplicate_blobs: u32,
+    #[serde(default)]
+    pub store_new_blobs: u32,
     /// Times kache spawned the underlying compiler (0 on a hit, 1 on a
-    /// miss). Deterministic; the e2e harness asserts on it.
+    /// dup/miss). Deterministic; the e2e harness asserts on it.
     #[serde(default)]
     pub compiler_runs: u32,
     /// Times kache spawned the preprocessor (`cc -E`) — once per C/C++
@@ -327,7 +335,9 @@ pub fn generate_report(config: &Config, hours: u64, top: usize) -> Result<BuildR
         events::read_transfers_since(&config.transfer_log_path(), since_ts).unwrap_or_default();
 
     let stats = events::compute_stats(&build_events);
-    let total_cacheable = stats.local_hits + stats.prefetch_hits + stats.remote_hits + stats.misses;
+    let total_compiled = stats.dups + stats.misses;
+    let total_cacheable =
+        stats.local_hits + stats.prefetch_hits + stats.remote_hits + total_compiled;
     let total_hits = stats.local_hits + stats.prefetch_hits + stats.remote_hits;
     let bypass = build_bypass_analysis(&build_events, top);
 
@@ -353,7 +363,7 @@ pub fn generate_report(config: &Config, hours: u64, top: usize) -> Result<BuildR
 
     let mut misses: Vec<CrateDetail> = build_events
         .iter()
-        .filter(|e| matches!(e.result, EventResult::Miss))
+        .filter(|e| matches!(e.result, EventResult::Dup | EventResult::Miss))
         .map(to_crate_detail)
         .collect();
     misses.sort_by_key(|entry| std::cmp::Reverse(entry.compile_time_ms));
@@ -386,8 +396,8 @@ pub fn generate_report(config: &Config, hours: u64, top: usize) -> Result<BuildR
     } else {
         0.0
     };
-    let avg_miss_ms = if stats.misses > 0 {
-        stats.miss_elapsed_ms as f64 / stats.misses as f64
+    let avg_miss_ms = if total_compiled > 0 {
+        stats.miss_elapsed_ms as f64 / total_compiled as f64
     } else {
         0.0
     };
@@ -467,6 +477,7 @@ pub fn generate_report(config: &Config, hours: u64, top: usize) -> Result<BuildR
             local_hits: stats.local_hits,
             prefetch_hits: stats.prefetch_hits,
             remote_hits: stats.remote_hits,
+            dups: stats.dups,
             misses: stats.misses,
             errors: stats.errors,
             passthroughs: bypass.passthroughs,
@@ -505,8 +516,8 @@ pub fn generate_report(config: &Config, hours: u64, top: usize) -> Result<BuildR
             } else {
                 0.0
             },
-            avg_store_ms: if stats.misses > 0 {
-                (stats.total_store_ms as f64 / stats.misses as f64 * 10.0).round() / 10.0
+            avg_store_ms: if total_compiled > 0 {
+                (stats.total_store_ms as f64 / total_compiled as f64 * 10.0).round() / 10.0
             } else {
                 0.0
             },
@@ -566,6 +577,9 @@ fn to_crate_detail(e: &BuildEvent) -> CrateDetail {
         overhead_ms: overhead,
         size: e.size,
         cache_key: e.cache_key.clone(),
+        store_output_blobs: e.store_output_blobs,
+        store_duplicate_blobs: e.store_duplicate_blobs,
+        store_new_blobs: e.store_new_blobs,
         compiler_runs: e.compiler_runs,
         preprocessor_runs: e.preprocessor_runs,
         probe_runs: e.probe_runs,
@@ -919,21 +933,22 @@ fn generate_suggestions(
     let mut suggestions = Vec::new();
 
     // High miss share
+    let total_compiled = stats.dups + stats.misses;
     if total_cacheable > 0 && stats.miss_compile_time_ms > 0 {
         let miss_share = stats.miss_compile_time_ms as f64
             / (stats.miss_compile_time_ms + stats.hit_compile_time_ms) as f64
             * 100.0;
-        if miss_share > 80.0 && stats.misses > 3 {
+        if miss_share > 80.0 && total_compiled > 3 {
             let top_names: Vec<&str> = top_misses
                 .iter()
                 .take(3)
                 .map(|c| c.crate_name.as_str())
                 .collect();
             suggestions.push(format!(
-                "{:.0}% of compile time spent on misses — improve hit rate for {}",
+                "{:.0}% of compile time spent on cache misses/dups — improve hit rate for {}",
                 miss_share,
                 if top_names.is_empty() {
-                    "top misses".to_string()
+                    "top compiled misses".to_string()
                 } else {
                     top_names
                         .iter()
@@ -1178,6 +1193,7 @@ pub fn format_markdown(report: &BuildReport) -> String {
     let t = &report.timing;
 
     let total_hits = s.local_hits + s.prefetch_hits + s.remote_hits;
+    let total_compiled = s.dups + s.misses;
     lines.push("### kache build report".to_string());
     lines.push(String::new());
     lines.push(format!(
@@ -1185,7 +1201,7 @@ pub fn format_markdown(report: &BuildReport) -> String {
         s.hit_rate_pct,
         total_hits,
         s.total_crates,
-        s.misses,
+        total_compiled,
         format_duration_ms(s.time_saved_ms),
     ));
     lines.push(String::new());
@@ -1223,6 +1239,9 @@ pub fn format_markdown(report: &BuildReport) -> String {
         "| Hits | {} (local: {}, prefetch: {}, remote: {}) |",
         total_hits, s.local_hits, s.prefetch_hits, s.remote_hits
     ));
+    if s.dups > 0 {
+        lines.push(format!("| Dups | {} |", s.dups));
+    }
     lines.push(format!("| Misses | {} |", s.misses));
     if s.errors > 0 {
         lines.push(format!("| Errors | {} |", s.errors));
@@ -1256,7 +1275,7 @@ pub fn format_markdown(report: &BuildReport) -> String {
         hit_pct
     ));
     lines.push(format!(
-        "| Misses (wrapper total) | {} | {:.1}% |",
+        "| Compiles (wrapper total) | {} | {:.1}% |",
         format_duration_ms(t.miss_time_ms),
         miss_pct
     ));
@@ -1423,9 +1442,9 @@ pub fn format_markdown(report: &BuildReport) -> String {
         lines.push(String::new());
     }
 
-    // Top cache misses
+    // Top compiled cache misses
     if !report.top_misses.is_empty() {
-        lines.push("#### Top Cache Misses".to_string());
+        lines.push("#### Top Compiled Cache Misses".to_string());
         lines.push("| Crate | Compile time | Size | Key |".to_string());
         lines.push("|---|---|---|---|".to_string());
         for c in &report.top_misses {
@@ -1503,6 +1522,7 @@ pub fn format_github(report: &BuildReport) -> String {
     let s = &report.summary;
     let t = &report.timing;
     let total_hits = s.local_hits + s.prefetch_hits + s.remote_hits;
+    let total_compiled = s.dups + s.misses;
 
     // Header
     lines.push("### kache build cache".to_string());
@@ -1512,7 +1532,7 @@ pub fn format_github(report: &BuildReport) -> String {
         s.hit_rate_pct,
         total_hits,
         s.total_crates,
-        s.misses,
+        total_compiled,
         format_duration_ms(s.time_saved_ms),
     ));
     lines.push(String::new());
@@ -1526,8 +1546,14 @@ pub fn format_github(report: &BuildReport) -> String {
     ));
     lines.push(format!(
         "| **Crates** | {} cached / {} compiled / {} total |",
-        total_hits, s.misses, s.total_crates
+        total_hits, total_compiled, s.total_crates
     ));
+    if s.dups > 0 {
+        lines.push(format!(
+            "| **Dups** | {} storage duplicates after compile |",
+            s.dups
+        ));
+    }
     lines.push(format!(
         "| **Hit rate** | {:.1}% count{} |",
         s.hit_rate_pct,
@@ -1577,8 +1603,8 @@ pub fn format_github(report: &BuildReport) -> String {
         lines.push(String::new());
         lines.push("<details>".to_string());
         lines.push(format!(
-            "<summary><strong>Top cache misses</strong> ({} compiled)</summary>",
-            s.misses
+            "<summary><strong>Top compiled cache misses</strong> ({} compiled)</summary>",
+            total_compiled
         ));
         lines.push(String::new());
         lines.push("| Crate | Compile time | Size |".to_string());
@@ -1591,8 +1617,8 @@ pub fn format_github(report: &BuildReport) -> String {
                 format_bytes(c.size),
             ));
         }
-        if s.misses > 10 {
-            lines.push(format!("| *... {} more* | | |", s.misses - 10));
+        if total_compiled > 10 {
+            lines.push(format!("| *... {} more* | | |", total_compiled - 10));
         }
         lines.push(String::new());
         lines.push("</details>".to_string());
@@ -1869,7 +1895,7 @@ pub fn format_github(report: &BuildReport) -> String {
                 hit_pct
             ));
             lines.push(format!(
-                "| Misses (wrapper total) | {} | {:.1}% |",
+                "| Compiles (wrapper total) | {} | {:.1}% |",
                 format_duration_ms(t.miss_time_ms),
                 miss_pct
             ));
@@ -1938,6 +1964,7 @@ pub fn format_text(report: &BuildReport) -> String {
     let s = &report.summary;
     let t = &report.timing;
     let total_hits = s.local_hits + s.prefetch_hits + s.remote_hits;
+    let total_compiled = s.dups + s.misses;
 
     lines.push(format!(
         "kache build report (last {}h)",
@@ -1945,8 +1972,14 @@ pub fn format_text(report: &BuildReport) -> String {
     ));
     lines.push(format!(
         "  {:.1}% hit rate — {}/{} cacheable crates cached, {} compiled",
-        s.hit_rate_pct, total_hits, s.total_crates, s.misses,
+        s.hit_rate_pct, total_hits, s.total_crates, total_compiled,
     ));
+    if s.dups > 0 {
+        lines.push(format!(
+            "  Dups: {} storage duplicates after compile",
+            s.dups
+        ));
+    }
     if let Some(w) = s.weighted_hit_rate_pct {
         lines.push(format!("  {:.1}% by compile cost", w));
     }
@@ -1988,7 +2021,7 @@ pub fn format_text(report: &BuildReport) -> String {
         t.avg_hit_ms
     ));
     lines.push(format!(
-        "  Misses: {} (avg {:.0}ms/crate)",
+        "  Compiles: {} (avg {:.0}ms/crate)",
         format_duration_ms(t.miss_time_ms),
         t.avg_miss_ms
     ));
@@ -2133,9 +2166,9 @@ pub fn format_text(report: &BuildReport) -> String {
         lines.push(String::new());
     }
 
-    // Top misses
+    // Top compiled misses
     if !report.top_misses.is_empty() {
-        lines.push("Top misses:".to_string());
+        lines.push("Top compiled misses:".to_string());
         for c in &report.top_misses {
             lines.push(format!(
                 "  {} — {} ({})",
@@ -2227,7 +2260,7 @@ mod tests {
             compile_time_ms,
             size,
             cache_key: cache_key.to_string(),
-            schema: 7,
+            schema: 8,
             key_ms: 0,
             key_hash_hits: 0,
             key_hash_misses: 0,
@@ -2235,6 +2268,9 @@ mod tests {
             lookup_ms: 0,
             restore_ms: 0,
             store_ms: 0,
+            store_output_blobs: 0,
+            store_duplicate_blobs: 0,
+            store_new_blobs: 0,
             compiler_runs: 0,
             preprocessor_runs: 0,
             probe_runs: 0,
@@ -2313,6 +2349,17 @@ mod tests {
         let mut skipped = test_event("doc-test", EventResult::Skipped, 0, 0, 0, "");
         skipped.passthrough_reason = "explicitly skipped".to_string();
 
+        let mut dup = test_event(
+            "my_lib",
+            EventResult::Dup,
+            5000,
+            4800,
+            3 * 1024 * 1024,
+            "def456789012",
+        );
+        dup.store_output_blobs = 1;
+        dup.store_duplicate_blobs = 1;
+
         let events = vec![
             test_event(
                 "serde",
@@ -2338,14 +2385,7 @@ mod tests {
                 512 * 1024,
                 "cde345",
             ),
-            test_event(
-                "my_lib",
-                EventResult::Miss,
-                5000,
-                4800,
-                3 * 1024 * 1024,
-                "def456789012",
-            ),
+            dup,
             test_event(
                 "my_app",
                 EventResult::Miss,
@@ -2423,7 +2463,8 @@ mod tests {
         assert_eq!(report.summary.local_hits, 1);
         assert_eq!(report.summary.prefetch_hits, 1);
         assert_eq!(report.summary.remote_hits, 1);
-        assert_eq!(report.summary.misses, 2);
+        assert_eq!(report.summary.dups, 1);
+        assert_eq!(report.summary.misses, 1);
         assert_eq!(report.summary.errors, 1);
         assert_eq!(report.summary.passthroughs, 1);
         assert_eq!(report.summary.skipped, 1);
@@ -2464,7 +2505,7 @@ mod tests {
         assert!(md.contains("#### Network"));
         assert!(md.contains("#### Prefetch"));
         assert!(md.contains("#### Passthroughs & Skips"));
-        assert!(md.contains("#### Top Cache Misses"));
+        assert!(md.contains("#### Top Compiled Cache Misses"));
         assert!(md.contains("#### Suggestions"));
     }
 
@@ -2541,7 +2582,7 @@ mod tests {
             report
                 .suggestions
                 .iter()
-                .any(|s| s.contains("compile time spent on misses"))
+                .any(|s| s.contains("compile time spent on cache misses/dups"))
         );
     }
 
@@ -2563,7 +2604,7 @@ mod tests {
         assert!(gh.contains("**Passthroughs / skipped**"));
         // Details in collapsible sections
         assert!(gh.contains("<details>"));
-        assert!(gh.contains("<summary><strong>Top cache misses</strong>"));
+        assert!(gh.contains("<summary><strong>Top compiled cache misses</strong>"));
         assert!(gh.contains("<summary><strong>Passthroughs & skips</strong>"));
         assert!(gh.contains("via fallback"));
         assert!(gh.contains("refused: unsupported rustc invocation"));

--- a/src/store.rs
+++ b/src/store.rs
@@ -11,6 +11,19 @@ use crate::config::Config;
 /// Process-local counter for unique blob temp-file names.
 static BLOB_TMP_NONCE: AtomicU64 = AtomicU64::new(0);
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StorePutResult {
+    pub output_blobs: u32,
+    pub duplicate_blobs: u32,
+    pub new_blobs: u32,
+}
+
+impl StorePutResult {
+    pub fn is_full_dup(self) -> bool {
+        self.output_blobs > 0 && self.duplicate_blobs == self.output_blobs
+    }
+}
+
 /// fsync a file so its bytes are durable on disk before we rename it into the
 /// content-addressed store or reference it from a committed entry.
 ///
@@ -78,6 +91,11 @@ fn materialize_blob(source: &Path, blob: &Path, hash: &str) -> Result<()> {
     fs::rename(&tmp, blob).context("atomic rename of blob")?;
     set_blob_readonly(blob);
     Ok(())
+}
+
+fn blob_path_in_store_dir(store_dir: &Path, hash: &str) -> PathBuf {
+    let prefix = &hash[..2];
+    store_dir.join("blobs").join(prefix).join(hash)
 }
 
 /// Exclude a directory from Time Machine backups and Spotlight indexing.
@@ -446,7 +464,7 @@ impl Store {
         output_files: &[(PathBuf, String)], // (source_path, filename_in_store)
         stdout: &str,
         stderr: &str,
-    ) -> Result<()> {
+    ) -> Result<StorePutResult> {
         self.put_with_compile_time(
             cache_key,
             crate_name,
@@ -473,7 +491,7 @@ impl Store {
         stdout: &str,
         stderr: &str,
         compile_time_ms: u64,
-    ) -> Result<()> {
+    ) -> Result<StorePutResult> {
         let entry_dir = self.entry_dir(cache_key);
         fs::create_dir_all(&entry_dir).context("creating entry directory")?;
 
@@ -484,6 +502,8 @@ impl Store {
         // re-materialize a blob if a concurrent remove unlinks it.
         let mut cached_files = Vec::new();
         let mut sources: Vec<PathBuf> = Vec::new();
+        let mut seen_output_blobs = std::collections::HashSet::new();
+        let mut put_result = StorePutResult::default();
         let mut total_size = 0u64;
         for (source_path, store_name) in output_files {
             let hash = crate::cache_key::hash_file(source_path)?;
@@ -492,6 +512,15 @@ impl Store {
                 anyhow::bail!("refusing to cache zero-byte artifact: {}", store_name);
             }
             total_size += size;
+
+            if seen_output_blobs.insert(hash.clone()) {
+                put_result.output_blobs += 1;
+                if self.blob_path(&hash).is_file() {
+                    put_result.duplicate_blobs += 1;
+                } else {
+                    put_result.new_blobs += 1;
+                }
+            }
 
             materialize_blob(source_path, &self.blob_path(&hash), &hash)?;
 
@@ -560,7 +589,7 @@ impl Store {
         )?;
         tx.commit()?;
 
-        Ok(())
+        Ok(put_result)
     }
 
     /// Import a remotely downloaded entry into the database.
@@ -733,12 +762,7 @@ impl Store {
     /// Resolve the filesystem path for a content-addressed blob.
     /// Layout: store/blobs/{first 2 hex chars}/{full hash}
     pub fn blob_path(&self, hash: &str) -> PathBuf {
-        let prefix = &hash[..2];
-        self.config
-            .store_dir()
-            .join("blobs")
-            .join(prefix)
-            .join(hash)
+        blob_path_in_store_dir(&self.config.store_dir(), hash)
     }
 
     /// Directory containing all blobs.
@@ -1376,6 +1400,63 @@ mod tests {
         assert_eq!(meta.crate_name, "mylib");
         assert_eq!(meta.files.len(), 1);
         assert_eq!(meta.files[0].name, "libmylib.rlib");
+    }
+
+    #[test]
+    fn test_store_put_reports_full_dup_for_existing_blob() {
+        let cache_dir = tempfile::tempdir().unwrap();
+        let config = test_config(cache_dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let output_file = cache_dir.path().join("output.rlib");
+        std::fs::write(&output_file, b"fake rlib content").unwrap();
+
+        let put_result = store
+            .put(
+                "first_key",
+                "mylib",
+                &["lib".to_string()],
+                &[],
+                "host",
+                "dev",
+                &[(output_file.clone(), "libmylib.rlib".to_string())],
+                "",
+                "",
+            )
+            .unwrap();
+        assert_eq!(put_result.output_blobs, 1);
+        assert_eq!(put_result.duplicate_blobs, 0);
+        assert_eq!(put_result.new_blobs, 1);
+        assert!(!put_result.is_full_dup());
+
+        let meta = store.get("first_key").unwrap().unwrap();
+        let hash = meta.files[0].hash.clone();
+        assert!(store.blob_path(&hash).is_file());
+
+        let duplicate_output = cache_dir.path().join("duplicate-output.rlib");
+        std::fs::write(&duplicate_output, b"fake rlib content").unwrap();
+        let second_put = store
+            .put(
+                "second_key",
+                "mylib",
+                &["lib".to_string()],
+                &[],
+                "host",
+                "dev",
+                &[(duplicate_output, "libmylib.rlib".to_string())],
+                "",
+                "",
+            )
+            .unwrap();
+        assert_eq!(second_put.output_blobs, 1);
+        assert_eq!(second_put.duplicate_blobs, 1);
+        assert_eq!(second_put.new_blobs, 0);
+        assert!(second_put.is_full_dup());
+
+        store.remove_entry("first_key").unwrap();
+        assert!(store.blob_path(&hash).exists());
+        store.remove_entry("second_key").unwrap();
+        assert!(!store.blob_path(&hash).exists());
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -546,13 +546,14 @@ fn draw_stats_bar(frame: &mut Frame, state: &AppState, area: Rect) {
     let total = snap.event_stats.local_hits
         + snap.event_stats.prefetch_hits
         + snap.event_stats.remote_hits
+        + snap.event_stats.dups
         + snap.event_stats.misses;
     let (local_pct, remote_pct, miss_pct) = if total > 0 {
         (
             ((snap.event_stats.local_hits + snap.event_stats.prefetch_hits) as f64 / total as f64)
                 * 100.0,
             (snap.event_stats.remote_hits as f64 / total as f64) * 100.0,
-            (snap.event_stats.misses as f64 / total as f64) * 100.0,
+            ((snap.event_stats.dups + snap.event_stats.misses) as f64 / total as f64) * 100.0,
         )
     } else {
         (0.0, 0.0, 0.0)
@@ -740,6 +741,7 @@ fn draw_live_build(frame: &mut Frame, state: &AppState, area: Rect) {
                 EventResult::LocalHit => ("✓", Style::default().fg(Color::Green)),
                 EventResult::PrefetchHit => ("⇣", Style::default().fg(Color::Cyan)),
                 EventResult::RemoteHit => ("↓", Style::default().fg(Color::Blue)),
+                EventResult::Dup => ("=", Style::default().fg(Color::Yellow)),
                 EventResult::Miss => ("✗", Style::default().fg(Color::Yellow)),
                 EventResult::Error => ("!", Style::default().fg(Color::Red)),
                 EventResult::Passthrough => ("→", Style::default().fg(Color::Magenta)),
@@ -1104,11 +1106,12 @@ fn draw_projects_overview(frame: &mut Frame, state: &AppState, area: Rect) {
         Line::from(vec![
             Span::styled("  Hit rate: ", Style::default().fg(Color::Cyan)),
             Span::raw(format!(
-                "{hit_rate:.0}% count{} (24h: {} hits, {} misses)",
+                "{hit_rate:.0}% count{} (24h: {} hits, {} dups, {} misses)",
                 weighted_hit_rate
                     .map(|v| format!(" | {v:.0}% weighted"))
                     .unwrap_or_default(),
                 es.local_hits + es.prefetch_hits + es.remote_hits,
+                es.dups,
                 es.misses
             )),
             Span::raw(format!("    Time saved: {time_saved}")),

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -14,13 +14,13 @@ use crate::compiler::{
 use crate::config::Config;
 use crate::events::{self, BuildEvent, EventResult};
 use crate::link;
-use crate::store::Store;
+use crate::store::{Store, StorePutResult};
 
 /// Check whether progress lines should be printed to stderr.
 ///
 /// Controlled by `KACHE_PROGRESS` env var (off by default):
 /// - `1` / `hits`    — print hits only
-/// - `verbose` / `all` — print hits and misses
+/// - `verbose` / `all` — print hits, dups, and misses
 /// - anything else / unset — silent
 fn progress_level() -> u8 {
     match std::env::var("KACHE_PROGRESS").as_deref() {
@@ -41,6 +41,8 @@ fn print_progress(crate_name: &str, result: EventResult, elapsed_ms: u64, size: 
         EventResult::LocalHit => "local hit",
         EventResult::PrefetchHit => "prefetch hit",
         EventResult::RemoteHit => "remote hit",
+        EventResult::Dup if level < 2 => return,
+        EventResult::Dup => "dup",
         EventResult::Miss if level < 2 => return,
         EventResult::Miss => "miss",
         EventResult::Error => "error",
@@ -61,6 +63,14 @@ fn print_progress(crate_name: &str, result: EventResult, elapsed_ms: u64, size: 
     };
 
     eprintln!("[kache] {crate_name}: {label} ({elapsed_str}{size_str})");
+}
+
+fn event_result_for_store_put(put: StorePutResult) -> EventResult {
+    if put.is_full_dup() {
+        EventResult::Dup
+    } else {
+        EventResult::Miss
+    }
 }
 
 /// Forward a `cc`-crate compiler-family probe (`kache -E <file>`) to
@@ -98,7 +108,7 @@ pub fn run_cc_probe(args: &[String]) -> Result<i32> {
 ///
 /// Caches the single-source `-c` object compile: parse → refuse-check
 /// → cache key (preprocessor hash) → local store lookup → restore the
-/// `.o` on hit, or compile + store on miss. Everything else (link
+/// `.o` on hit, or compile + store on dup/miss. Everything else (link
 /// mode, multi-source, unsafe flags) routes through [`cc_passthrough`].
 ///
 /// This is the local-cache path. Remote cache + build-lock
@@ -300,6 +310,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // discovery came up empty is not cacheable — return the exit
     // code and let cargo see the failure.
     let store_start = std::time::Instant::now();
+    let mut store_put = StorePutResult::default();
     if result.exit_code == 0 && !result.artifacts.is_empty() {
         let depinfo_anchor = cc_depinfo_rewrite_root(&parsed);
         if let Some(anchor) = depinfo_anchor.as_deref() {
@@ -308,7 +319,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
         let target = parsed.cache_target_arch();
         let store_files = result.artifacts.store_files();
-        if let Err(e) = store.put_with_compile_time(
+        match store.put_with_compile_time(
             &cache_key,
             &crate_name,
             &[], // crate_types: n/a for cc objects
@@ -320,7 +331,8 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             &result.stderr,
             compile_time_ms,
         ) {
-            tracing::warn!("failed to store cc cache entry for {}: {}", crate_name, e);
+            Ok(result) => store_put = result,
+            Err(e) => tracing::warn!("failed to store cc cache entry for {}: {}", crate_name, e),
         }
 
         if let Some(anchor) = depinfo_anchor.as_deref() {
@@ -331,20 +343,23 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     let elapsed = start.elapsed().as_millis() as u64;
     let size = result.artifacts.total_size();
-    log_event(
+    let event_result = event_result_for_store_put(store_put);
+    log_event_with_store_stats(
         config,
         &crate_name,
-        EventResult::Miss,
+        event_result,
         elapsed,
         compile_time_ms,
         size,
         &cache_key,
         key_ms,
+        FileHashStats::default(),
         lookup_ms,
         0,
         store_ms,
+        store_put,
     );
-    print_progress(&crate_name, EventResult::Miss, elapsed, size);
+    print_progress(&crate_name, event_result, elapsed, size);
     Ok(result.exit_code)
 }
 
@@ -956,7 +971,8 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     let store_start = std::time::Instant::now();
     let store_files = result.artifacts.store_files();
-    if let Err(e) = store.put_with_compile_time(
+    let mut store_put = StorePutResult::default();
+    match store.put_with_compile_time(
         &cache_key,
         crate_name,
         &args.crate_types,
@@ -968,7 +984,8 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         &result.stderr,
         compile_time_ms,
     ) {
-        tracing::warn!("failed to store cache entry: {}", e);
+        Ok(result) => store_put = result,
+        Err(e) => tracing::warn!("failed to store cache entry: {}", e),
     }
     let store_ms = store_start.elapsed().as_millis() as u64;
 
@@ -992,10 +1009,11 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     let elapsed = start.elapsed().as_millis() as u64;
     let size = result.artifacts.total_size();
-    log_event_with_hash_stats(
+    let event_result = event_result_for_store_put(store_put);
+    log_event_with_store_stats(
         config,
         crate_name,
-        EventResult::Miss,
+        event_result,
         elapsed,
         compile_time_ms,
         size,
@@ -1005,8 +1023,9 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         lookup_ms,
         0,
         store_ms,
+        store_put,
     );
-    print_progress(crate_name, EventResult::Miss, elapsed, size);
+    print_progress(crate_name, event_result, elapsed, size);
 
     drop(lock);
     Ok(result.exit_code)
@@ -1353,6 +1372,39 @@ fn log_event_with_hash_stats(
     restore_ms: u64,
     store_ms: u64,
 ) {
+    log_event_with_store_stats(
+        config,
+        crate_name,
+        result,
+        elapsed_ms,
+        compile_time_ms,
+        size,
+        cache_key,
+        key_ms,
+        key_hash_stats,
+        lookup_ms,
+        restore_ms,
+        store_ms,
+        StorePutResult::default(),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn log_event_with_store_stats(
+    config: &Config,
+    crate_name: &str,
+    result: EventResult,
+    elapsed_ms: u64,
+    compile_time_ms: u64,
+    size: u64,
+    cache_key: &str,
+    key_ms: u64,
+    key_hash_stats: FileHashStats,
+    lookup_ms: u64,
+    restore_ms: u64,
+    store_ms: u64,
+    store_put: StorePutResult,
+) {
     log_event_details(
         config,
         crate_name,
@@ -1366,6 +1418,7 @@ fn log_event_with_hash_stats(
         lookup_ms,
         restore_ms,
         store_ms,
+        store_put,
         String::new(),
         false,
         None,
@@ -1392,6 +1445,7 @@ fn log_passthrough_event(
         0,
         0,
         0,
+        StorePutResult::default(),
         reason,
         output.fallback,
         Some(output.exit_code),
@@ -1412,6 +1466,7 @@ fn log_event_details(
     lookup_ms: u64,
     restore_ms: u64,
     store_ms: u64,
+    store_put: StorePutResult,
     passthrough_reason: String,
     fallback: bool,
     exit_code: Option<i32>,
@@ -1425,7 +1480,7 @@ fn log_event_details(
         compile_time_ms,
         size,
         cache_key: cache_key.to_string(),
-        schema: 7,
+        schema: 8,
         key_ms,
         key_hash_hits: key_hash_stats.cache_hits,
         key_hash_misses: key_hash_stats.cache_misses,
@@ -1433,6 +1488,9 @@ fn log_event_details(
         lookup_ms,
         restore_ms,
         store_ms,
+        store_output_blobs: store_put.output_blobs,
+        store_duplicate_blobs: store_put.duplicate_blobs,
+        store_new_blobs: store_put.new_blobs,
         // Read the process-global op-counters: this `kache` process
         // handled exactly this one compile, so the counts are its own.
         compiler_runs: crate::opcounts::compiler_runs(),

--- a/tests/cache_key_underkeying_test.rs
+++ b/tests/cache_key_underkeying_test.rs
@@ -25,9 +25,13 @@
 //! faithful e2e needs a nightly toolchain / `-Zbuild-std`.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Once, OnceLock};
 use tempfile::TempDir;
 
 fn kache_binary() -> PathBuf {
+    if let Some(path) = KACHE_BIN.get() {
+        return path.clone();
+    }
     let mut path = std::env::current_exe().unwrap();
     path.pop(); // test binary name
     path.pop(); // deps/
@@ -35,16 +39,37 @@ fn kache_binary() -> PathBuf {
     path
 }
 
+static KACHE_BIN: OnceLock<PathBuf> = OnceLock::new();
+
 fn build_kache() {
-    // Bootstrap the binary under test with no configured wrapper; the
-    // wrapper behavior is exercised by invoking it directly below.
-    let status = std::process::Command::new("cargo")
-        .args(["build", "--config", "build.rustc-wrapper=\"\""])
-        .env_remove("RUSTC_WRAPPER")
-        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
-        .status()
-        .expect("failed to build kache");
-    assert!(status.success(), "kache build failed");
+    static BUILD: Once = Once::new();
+    BUILD.call_once(|| {
+        // Bootstrap the binary under test with no configured wrapper; the
+        // wrapper behavior is exercised by invoking it directly below.
+        let target_dir =
+            std::env::temp_dir().join(format!("kache-underkeying-target-{}", std::process::id()));
+        let status = std::process::Command::new("cargo")
+            .args([
+                "build",
+                "--bin",
+                "kache",
+                "--target-dir",
+                target_dir.to_str().unwrap(),
+                "--config",
+                "build.rustc-wrapper=\"\"",
+            ])
+            .env_remove("RUSTC_WRAPPER")
+            .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+            .status()
+            .expect("failed to build kache");
+        assert!(status.success(), "kache build failed");
+
+        let mut bin = target_dir.join("debug").join("kache");
+        if cfg!(windows) {
+            bin.set_extension("exe");
+        }
+        KACHE_BIN.set(bin).ok();
+    });
 }
 
 fn isolated_config_path(cache_dir: &Path) -> PathBuf {
@@ -101,8 +126,12 @@ fn run_kache_rustc(cache_dir: &Path, out_dir: &Path, src: &Path, extra: &[&str])
     );
 }
 
-/// `(misses, local_hits)` from `kache report` over this isolated cache dir.
-fn miss_hit_counts(cache_dir: &Path) -> (u64, u64) {
+/// `(compiled, local_hits)` from `kache report` over this isolated cache dir.
+///
+/// `dup` is still a compiler run: the entry missed, but the output blob was
+/// already present. These tests are about key divergence, so they count
+/// `dups + misses`.
+fn compiled_hit_counts(cache_dir: &Path) -> (u64, u64) {
     let output = std::process::Command::new(kache_binary())
         .args(["report", "--format", "json", "--since", "1h"])
         .env("KACHE_CACHE_DIR", cache_dir)
@@ -113,10 +142,8 @@ fn miss_hit_counts(cache_dir: &Path) -> (u64, u64) {
     let report: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("report should be valid json");
     let s = &report["summary"];
-    (
-        s["misses"].as_u64().unwrap_or(0),
-        s["local_hits"].as_u64().unwrap_or(0),
-    )
+    let compiled = s["dups"].as_u64().unwrap_or(0) + s["misses"].as_u64().unwrap_or(0);
+    (compiled, s["local_hits"].as_u64().unwrap_or(0))
 }
 
 fn fresh_src() -> (TempDir, PathBuf) {
@@ -139,12 +166,12 @@ fn link_lib_value_changes_cache_key() {
     run_kache_rustc(cache_dir.path(), out.path(), &src, &["-l", "ssl"]); // hit (same key)
     run_kache_rustc(cache_dir.path(), out.path(), &src, &["-l", "crypto"]); // miss (diverged)
 
-    let (misses, hits) = miss_hit_counts(cache_dir.path());
+    let (compiled, hits) = compiled_hit_counts(cache_dir.path());
     assert_eq!(
-        (misses, hits),
+        (compiled, hits),
         (2, 1),
         "expected -l ssl→miss, -l ssl→hit, -l crypto→miss; a false hit on the \
-         differing -l would show misses=1, hits=2"
+         differing -l would show compiled=1, hits=2"
     );
 }
 
@@ -164,13 +191,13 @@ fn link_search_native_keys_but_dependency_is_skipped() {
     run_kache_rustc(cache_dir.path(), out.path(), &src, &["-L", "dependency=/x"]); // miss (new)
     run_kache_rustc(cache_dir.path(), out.path(), &src, &["-L", "dependency=/y"]); // HIT (dependency= skipped)
 
-    let (misses, hits) = miss_hit_counts(cache_dir.path());
+    let (compiled, hits) = compiled_hit_counts(cache_dir.path());
     assert_eq!(
-        (misses, hits),
+        (compiled, hits),
         (3, 2),
         "native= must diverge (native=/b→miss) while dependency= must be \
          ignored (dependency=/y→hit). A regression keying dependency= would \
-         show misses=4; one not keying native= would show misses=2"
+         show compiled=4; one not keying native= would show compiled=2"
     );
 }
 
@@ -189,12 +216,12 @@ fn sysroot_changes_cache_key() {
     run_kache_rustc(cache_dir.path(), out.path(), &src, &[]); // hit
     run_kache_rustc(cache_dir.path(), out.path(), &src, &["--sysroot", &sysroot]); // miss (diverged)
 
-    let (misses, hits) = miss_hit_counts(cache_dir.path());
+    let (compiled, hits) = compiled_hit_counts(cache_dir.path());
     assert_eq!(
-        (misses, hits),
+        (compiled, hits),
         (2, 1),
         "adding --sysroot must diverge the key; an ignored --sysroot (the bug) \
-         would falsely hit the no-sysroot entry → misses=1, hits=2"
+         would falsely hit the no-sysroot entry → compiled=1, hits=2"
     );
 }
 
@@ -233,11 +260,11 @@ fn colocated_extra_input_changes_cache_key() {
     std::fs::write(&query, "v2").unwrap();
     run_kache_rustc(cache_dir.path(), out.path(), &src, &[]); // miss (declared input changed)
 
-    let (misses, hits) = miss_hit_counts(cache_dir.path());
+    let (compiled, hits) = compiled_hit_counts(cache_dir.path());
     assert_eq!(
-        (misses, hits),
+        (compiled, hits),
         (2, 1),
         "editing a declared extra input must diverge the key; the pre-feature \
-         behavior (ignoring it) would falsely hit and show misses=1, hits=2"
+         behavior (ignoring it) would falsely hit and show compiled=1, hits=2"
     );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,8 +1,12 @@
 use assert_cmd::Command;
 use std::path::{Path, PathBuf};
+use std::sync::{Once, OnceLock};
 use tempfile::TempDir;
 
 fn kache_binary() -> PathBuf {
+    if let Some(path) = KACHE_BIN.get() {
+        return path.clone();
+    }
     let mut path = std::env::current_exe().unwrap();
     path.pop(); // remove test binary name
     path.pop(); // remove deps/
@@ -10,16 +14,37 @@ fn kache_binary() -> PathBuf {
     path
 }
 
+static KACHE_BIN: OnceLock<PathBuf> = OnceLock::new();
+
 fn build_kache() {
-    // Bootstrap the binary under test without any configured wrapper. The wrapper
-    // behavior is exercised below by setting RUSTC_WRAPPER to this fresh binary.
-    let status = std::process::Command::new("cargo")
-        .args(["build", "--config", "build.rustc-wrapper=\"\""])
-        .env_remove("RUSTC_WRAPPER")
-        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
-        .status()
-        .expect("failed to build kache");
-    assert!(status.success(), "kache build failed");
+    static BUILD: Once = Once::new();
+    BUILD.call_once(|| {
+        // Bootstrap the binary under test without any configured wrapper. The wrapper
+        // behavior is exercised below by setting RUSTC_WRAPPER to this fresh binary.
+        let target_dir =
+            std::env::temp_dir().join(format!("kache-integration-target-{}", std::process::id()));
+        let status = std::process::Command::new("cargo")
+            .args([
+                "build",
+                "--bin",
+                "kache",
+                "--target-dir",
+                target_dir.to_str().unwrap(),
+                "--config",
+                "build.rustc-wrapper=\"\"",
+            ])
+            .env_remove("RUSTC_WRAPPER")
+            .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+            .status()
+            .expect("failed to build kache");
+        assert!(status.success(), "kache build failed");
+
+        let mut bin = target_dir.join("debug").join("kache");
+        if cfg!(windows) {
+            bin.set_extension("exe");
+        }
+        KACHE_BIN.set(bin).ok();
+    });
 }
 
 fn isolated_config_path(cache_dir: &Path) -> PathBuf {

--- a/tests/stale_artifact_test.rs
+++ b/tests/stale_artifact_test.rs
@@ -1,8 +1,12 @@
 use std::path::{Path, PathBuf};
+use std::sync::{Once, OnceLock};
 use tempfile::TempDir;
 
 /// Finds the kache binary in the test output directory.
 fn kache_binary() -> PathBuf {
+    if let Some(path) = KACHE_BIN.get() {
+        return path.clone();
+    }
     let mut path = std::env::current_exe().unwrap();
     path.pop(); // remove test binary name
     path.pop(); // remove deps/
@@ -10,13 +14,36 @@ fn kache_binary() -> PathBuf {
     path
 }
 
+static KACHE_BIN: OnceLock<PathBuf> = OnceLock::new();
+
 /// Runs `cargo build` to ensure kache is built.
 fn build_kache() {
-    let status = std::process::Command::new("cargo")
-        .args(["build"])
-        .status()
-        .expect("failed to build kache");
-    assert!(status.success(), "kache build failed");
+    static BUILD: Once = Once::new();
+    BUILD.call_once(|| {
+        let target_dir =
+            std::env::temp_dir().join(format!("kache-stale-target-{}", std::process::id()));
+        let status = std::process::Command::new("cargo")
+            .args([
+                "build",
+                "--bin",
+                "kache",
+                "--target-dir",
+                target_dir.to_str().unwrap(),
+                "--config",
+                "build.rustc-wrapper=\"\"",
+            ])
+            .env_remove("RUSTC_WRAPPER")
+            .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+            .status()
+            .expect("failed to build kache");
+        assert!(status.success(), "kache build failed");
+
+        let mut bin = target_dir.join("debug").join("kache");
+        if cfg!(windows) {
+            bin.set_extension("exe");
+        }
+        KACHE_BIN.set(bin).ok();
+    });
 }
 
 fn isolated_config_path(cache_dir: &Path) -> PathBuf {


### PR DESCRIPTION
## Summary
- add `dup` as a separate cacheable outcome for key misses whose compiled output matches already-known blobs
- keep `dup` counted as compiled work, not as a cache hit; `miss` remains new compiled blob content
- surface `dup` in event stats, daemon/TUI/CLI stats, `kache report` JSON/markdown/GitHub/text output, `why-miss`, e2e reports, benchmark summaries, and docs
- keep report math explicit: hit rate counts hits only; compiled work is `dups + misses`

## Not included
- no multiple local stores
- no cross-drive locality behavior
- no mirror or peer-store behavior

## Validation
- `cargo fmt --check`
- `cargo test events::tests`
- `cargo test -p kache-e2e report::tests::delta_since_keeps_hits_dups_and_misses_separate`
- `cargo clippy --workspace --all-targets -- -D warnings`
- local `e2e-rust-workspace` scenario
- PR CI green: Linux check, Linux/macOS/Windows e2e, macOS tests, Nix package, version consistency