### PR TITLE
Document report cache outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
 | `kache stats [--since <dur>]` | Non-interactive cache stats summary |
 | `kache list [<crate>] [--sort name\|size\|hits\|age]` | List cached entries, or show details for a specific crate |
 | `kache why-miss <crate>` | Explain why a specific crate missed the cache |
-| `kache report [--format text\|json\|markdown\|github] [--since <dur>] [--output <path>]` | Generate a detailed build report |
+| `kache report [--format text\|json\|markdown\|github] [--since <dur>] [--output <path>]` | Generate a detailed hit/dup/miss build report |
 | `kache sync [--pull] [--push] [--all] [--dry-run]` | Synchronize local cache with S3 remote (pull + push) |
 | `kache save-manifest [--namespace <ns>]` | Save a build manifest for future prefetch warming |
 | `kache gc [--max-age <dur>]` | Garbage collect — LRU eviction or age-based cleanup |

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -103,7 +103,15 @@ kache list serde              # all entries for serde
 kache report [--format text|json|markdown|github] [--since <duration>] [--output <path>]
 ```
 
-Generates a detailed report of recent build activity: per-crate hit/miss counts, cumulative time saved, transfer activity, and store stats. Useful for sharing CI results in a PR comment or feeding the data into other tools.
+Generates a detailed report of recent build activity: per-crate hit/dup/miss counts, cumulative time saved, transfer activity, and store stats. Useful for sharing CI results in a PR comment or feeding the data into other tools.
+
+Reports keep cache outcomes separate:
+
+- `hit` means kache restored the artifact without running the compiler.
+- `dup` means the cache key missed, the compiler ran, and the compiled bytes already existed in the local store.
+- `miss` means the cache key missed, the compiler ran, and at least one output blob was new.
+
+Hit rate counts hits only. Compiled work is reported as `dups + misses`.
 
 ```sh
 kache report                                  # text to stdout

--- a/src/report.rs
+++ b/src/report.rs
@@ -945,10 +945,10 @@ fn generate_suggestions(
                 .map(|c| c.crate_name.as_str())
                 .collect();
             suggestions.push(format!(
-                "{:.0}% of compile time spent on cache misses/dups — improve hit rate for {}",
+                "{:.0}% of compile time spent on compiled cache-key misses — improve hit rate for {}",
                 miss_share,
                 if top_names.is_empty() {
-                    "top compiled misses".to_string()
+                    "top compiled cache-key misses".to_string()
                 } else {
                     top_names
                         .iter()
@@ -1442,9 +1442,9 @@ pub fn format_markdown(report: &BuildReport) -> String {
         lines.push(String::new());
     }
 
-    // Top compiled cache misses
+    // Top compiled cache-key misses (dups + misses)
     if !report.top_misses.is_empty() {
-        lines.push("#### Top Compiled Cache Misses".to_string());
+        lines.push("#### Top Compiled Cache-Key Misses".to_string());
         lines.push("| Crate | Compile time | Size | Key |".to_string());
         lines.push("|---|---|---|---|".to_string());
         for c in &report.top_misses {
@@ -1598,12 +1598,12 @@ pub fn format_github(report: &BuildReport) -> String {
         }
     }
 
-    // ── Top misses (collapsed) ──
+    // ── Top cache-key misses (collapsed) ──
     if !report.top_misses.is_empty() {
         lines.push(String::new());
         lines.push("<details>".to_string());
         lines.push(format!(
-            "<summary><strong>Top compiled cache misses</strong> ({} compiled)</summary>",
+            "<summary><strong>Top compiled cache-key misses</strong> ({} compiled)</summary>",
             total_compiled
         ));
         lines.push(String::new());
@@ -2166,9 +2166,9 @@ pub fn format_text(report: &BuildReport) -> String {
         lines.push(String::new());
     }
 
-    // Top compiled misses
+    // Top compiled cache-key misses
     if !report.top_misses.is_empty() {
-        lines.push("Top compiled misses:".to_string());
+        lines.push("Top compiled cache-key misses:".to_string());
         for c in &report.top_misses {
             lines.push(format!(
                 "  {} — {} ({})",
@@ -2505,7 +2505,7 @@ mod tests {
         assert!(md.contains("#### Network"));
         assert!(md.contains("#### Prefetch"));
         assert!(md.contains("#### Passthroughs & Skips"));
-        assert!(md.contains("#### Top Compiled Cache Misses"));
+        assert!(md.contains("#### Top Compiled Cache-Key Misses"));
         assert!(md.contains("#### Suggestions"));
     }
 
@@ -2582,7 +2582,7 @@ mod tests {
             report
                 .suggestions
                 .iter()
-                .any(|s| s.contains("compile time spent on cache misses/dups"))
+                .any(|s| s.contains("compile time spent on compiled cache-key misses"))
         );
     }
 
@@ -2604,7 +2604,7 @@ mod tests {
         assert!(gh.contains("**Passthroughs / skipped**"));
         // Details in collapsible sections
         assert!(gh.contains("<details>"));
-        assert!(gh.contains("<summary><strong>Top compiled cache misses</strong>"));
+        assert!(gh.contains("<summary><strong>Top compiled cache-key misses</strong>"));
         assert!(gh.contains("<summary><strong>Passthroughs & skips</strong>"));
         assert!(gh.contains("via fallback"));
         assert!(gh.contains("refused: unsupported rustc invocation"));


### PR DESCRIPTION
## Summary
- document that `kache report` shows hit/dup/miss outcomes separately
- clarify `hit`, `dup`, and `miss` semantics for reports
- note that hit rate counts hits only, while compiled work is `dups + misses`
- rename human-facing report sections from "compiled cache misses" to "compiled cache-key misses" so `dup + miss` output is not misleading

## Validation
- `cargo fmt --check`
- `cargo test report::tests`
- `git diff --check`

## Context
Follow-up to #267, which was already merged.