### PR TITLE
Refuse to cache rustc @argfile invocations (false-hit fix)

### DIFF
--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -162,6 +162,17 @@ fn rustc_refuse_reasons(
             "rustc build-script probe (not yet supported)",
         ));
     }
+    // Response files: any arg starting with `@` (a path to a file containing
+    // additional flags). cargo emits these to dodge command-line length limits
+    // (large workspaces, Windows). The flags inside aren't visible to our parser
+    // without recursive expansion + path normalization, so codegen/cfg flags in
+    // an argfile would otherwise bypass the cache key and cause a false hit.
+    // Refuse to cache until expansion is supported. Mirrors the cc adapter guard.
+    if parsed.all_args.iter().any(|a| a.starts_with('@')) {
+        reasons.push(RefuseReason::Unsupported(
+            "rustc: response file @file (expansion not yet supported)",
+        ));
+    }
     reasons
 }
 
@@ -225,6 +236,30 @@ mod tests {
         assert!(parsed.is_primary);
         let reasons = RustcCompiler::new().refuse_reasons(&parsed);
         assert!(reasons.is_empty());
+    }
+
+    #[test]
+    fn refuse_reasons_refuses_response_file_argfile() {
+        // A primary-looking compilation that also passes an `@argfile`. Codegen
+        // flags could live inside the unexpanded argfile and bypass the cache
+        // key, so we must refuse rather than risk a false hit.
+        let parsed = RustcCompiler::new()
+            .parse(&s(&[
+                "rustc",
+                "--crate-name",
+                "foo",
+                "src/lib.rs",
+                "@/tmp/cargo/argfile.txt",
+            ]))
+            .unwrap();
+        let reasons = RustcCompiler::new().refuse_reasons(&parsed);
+        assert!(
+            reasons.iter().any(|r| matches!(
+                r,
+                RefuseReason::Unsupported(d) if d.contains("response file")
+            )),
+            "expected a response-file refusal, got {reasons:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Refuse to cache rustc invocations that pass a response file (`@argfile`).

## Why

An `@file` token is not `-`-prefixed and not a `.rs` source, so it fell through the
silent catch-all `_ => {}` in `RustcArgs::parse` and never reached the cache key.
`compute_cache_key` hashes only the structured parsed fields, so codegen/cfg flags
living **inside** an unexpanded argfile (`-C opt-level=3`, `--cfg feature="X"`) were
invisible — two invocations differing only in argfile contents computed the **same
key**, a false cache hit (the cardinal sin for a build cache). cargo emits these to
dodge command-line length limits (large workspaces, Windows).

The cc adapter already refuses this exact case (`cc.rs:607`); this mirrors that guard
on the rustc side. `RefuseReason`'s own doc comment already lists "response files" as
an intended `Unsupported` case.

## How

`rustc_refuse_reasons` pushes `Unsupported("rustc: response file @file …")` when any
`parsed.all_args` element starts with `@`, so the invocation transparently passes
through uncached until argfile expansion is implemented.

## Tests

New `refuse_reasons_refuses_response_file_argfile`; all existing rustc adapter tests
pass.

Closes #274
