### PR TITLE
Validate untrusted cache_key/crate_name before path/key interpolation

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -220,6 +220,37 @@ pub(crate) fn fold_labeled(base: String, label: &str, value: &str) -> String {
     hasher.finalize().to_hex().to_string()
 }
 
+/// Is `s` a well-formed cache key: exactly 64 lowercase hex chars, matching
+/// the `blake3::Hash::to_hex()` output that every key path produces
+/// ([`compute_cache_key`], [`fold_labeled`])?
+///
+/// Cache keys that arrive from an untrusted source — a prefetch planner
+/// response or an S3 bucket listing — get interpolated into local filesystem
+/// paths (`store_dir().join(cache_key)`) and S3 object keys. An unvalidated
+/// value like `../../../home/user/.config` is a path-traversal / prefix-escape
+/// primitive (`PathBuf::join` walks up on `..` and resets on an absolute
+/// component). Callers must **reject** such keys, never sanitize them.
+pub(crate) fn is_valid_cache_key(s: &str) -> bool {
+    s.len() == 64
+        && s.bytes()
+            .all(|b| b.is_ascii_digit() || matches!(b, b'a'..=b'f'))
+}
+
+/// Is `s` a crate name safe to use as an S3 object-key path component?
+///
+/// Permissive enough for real crate names and cc source basenames
+/// (`[A-Za-z0-9_.-]`) but rejects anything that could escape a path or key
+/// prefix: separators, `..` traversal, NUL/control chars, the empty string,
+/// or an absurd length. Like [`is_valid_cache_key`], this guards values that
+/// cross the untrusted-remote boundary; reject, do not sanitize.
+pub(crate) fn is_valid_crate_name(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 128
+        && !s.contains("..")
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.'))
+}
+
 /// Compute the blake3 cache key for a rustc invocation.
 ///
 /// The key captures everything that affects compilation output:
@@ -1739,6 +1770,59 @@ fn resolve_in_path(name: &str) -> Option<std::path::PathBuf> {
 mod tests {
     use super::*;
     use crate::args::RustcArgs;
+
+    #[test]
+    fn is_valid_cache_key_accepts_real_blake3_hex() {
+        // A real key is 64 lowercase hex chars (blake3 to_hex).
+        let key = fold_labeled("seed".into(), "label", "value");
+        assert_eq!(key.len(), 64);
+        assert!(is_valid_cache_key(&key));
+        assert!(is_valid_cache_key(&"a".repeat(64)));
+        assert!(is_valid_cache_key(&"0123456789abcdef".repeat(4)));
+    }
+
+    #[test]
+    fn is_valid_cache_key_rejects_traversal_and_malformed() {
+        assert!(!is_valid_cache_key(""));
+        assert!(!is_valid_cache_key("abc123")); // too short
+        assert!(!is_valid_cache_key(&"a".repeat(63)));
+        assert!(!is_valid_cache_key(&"a".repeat(65)));
+        assert!(!is_valid_cache_key(&"A".repeat(64))); // uppercase not produced by to_hex
+        assert!(!is_valid_cache_key(&"g".repeat(64))); // non-hex
+        // Path-traversal / prefix-escape attempts, padded to 64 chars.
+        assert!(!is_valid_cache_key(&format!(
+            "{:/<64}",
+            "../../../etc/passwd"
+        )));
+        assert!(!is_valid_cache_key(&format!("{:0<64}", "/abs/path")));
+        assert!(!is_valid_cache_key(&format!("{:0<63}\n", "x"))); // newline
+    }
+
+    #[test]
+    fn is_valid_crate_name_accepts_real_names() {
+        for name in [
+            "serde",
+            "tokio_stream",
+            "foo-bar",
+            "build_script_build",
+            "a.out",
+            "x",
+        ] {
+            assert!(is_valid_crate_name(name), "{name} should be valid");
+        }
+    }
+
+    #[test]
+    fn is_valid_crate_name_rejects_path_escapes() {
+        assert!(!is_valid_crate_name(""));
+        assert!(!is_valid_crate_name("../evil"));
+        assert!(!is_valid_crate_name("a/b"));
+        assert!(!is_valid_crate_name("a\\b"));
+        assert!(!is_valid_crate_name("a..b")); // traversal substring
+        assert!(!is_valid_crate_name("nul\0byte"));
+        assert!(!is_valid_crate_name("tab\there"));
+        assert!(!is_valid_crate_name(&"a".repeat(129))); // too long
+    }
 
     #[test]
     fn apply_key_salt_no_salt_is_identity() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -386,6 +386,23 @@ impl PrefetchRequest {
             keys: plan
                 .candidates
                 .into_iter()
+                // The planner is an untrusted boundary (a distinct endpoint
+                // from S3). cache_key/crate_name flow into local path joins and
+                // S3 object keys, so drop any candidate that isn't a well-formed
+                // key + safe crate name before it can become a traversal /
+                // prefix-escape primitive. Reject, don't sanitize.
+                .filter(|c| {
+                    let ok = crate::cache_key::is_valid_cache_key(&c.cache_key)
+                        && crate::cache_key::is_valid_crate_name(&c.crate_name);
+                    if !ok {
+                        tracing::warn!(
+                            cache_key = key_prefix(&c.cache_key),
+                            cache_key_len = c.cache_key.len(),
+                            "prefetch: dropping planner candidate with invalid cache_key/crate_name"
+                        );
+                    }
+                    ok
+                })
                 .map(|candidate| (candidate.cache_key, candidate.crate_name))
                 .collect(),
         }
@@ -906,6 +923,14 @@ impl Daemon {
     }
 
     pub(crate) fn entry_dir_for(&self, cache_key: &str) -> PathBuf {
+        // Defense-in-depth: every caller must validate untrusted keys before
+        // reaching here (see `is_valid_cache_key`), so a malformed key getting
+        // this far is a programming error. A 64-char hex key can never contain
+        // a path separator or `..`, so the join stays inside the store.
+        debug_assert!(
+            crate::cache_key::is_valid_cache_key(cache_key),
+            "entry_dir_for called with unvalidated cache_key"
+        );
         self.config.store_dir().join(cache_key)
     }
 
@@ -1673,6 +1698,15 @@ impl Daemon {
         let mut keys_to_fetch: Vec<(String, String, PathBuf)> = Vec::new();
         let downloading_guard = self.downloading.read().await;
         for (key, crate_name) in &req.keys {
+            if !crate::cache_key::is_valid_cache_key(key)
+                || !crate::cache_key::is_valid_crate_name(crate_name)
+            {
+                tracing::warn!(
+                    key = key_prefix(key),
+                    "prefetch: skipping request key with invalid cache_key/crate_name"
+                );
+                continue;
+            }
             let entry_dir = self.entry_dir_for(key);
             if entry_dir.exists() {
                 continue;
@@ -1697,6 +1731,15 @@ impl Daemon {
                 .await
         {
             for (key, crate_name) in s3_keys {
+                if !crate::cache_key::is_valid_cache_key(&key)
+                    || !crate::cache_key::is_valid_crate_name(&crate_name)
+                {
+                    tracing::warn!(
+                        key = key_prefix(&key),
+                        "prefetch: skipping listing key with invalid cache_key/crate_name"
+                    );
+                    continue;
+                }
                 let entry_dir = self.entry_dir_for(&key);
                 if !entry_dir.exists() {
                     keys_to_fetch.push((key, crate_name, entry_dir));
@@ -4936,18 +4979,31 @@ mod tests {
 
     #[test]
     fn test_prefetch_request_from_plan() {
+        let valid_key = "a".repeat(64);
         let plan = PrefetchPlan {
             plan_id: Some("plan-1".into()),
             planner: Some("fallback".into()),
             disposition: PrefetchDisposition::Execute,
-            candidates: vec![kache_core::PrefetchCandidate {
-                cache_key: "abc123".into(),
-                crate_name: "serde".into(),
-            }],
+            candidates: vec![
+                kache_core::PrefetchCandidate {
+                    cache_key: valid_key.clone(),
+                    crate_name: "serde".into(),
+                },
+                // Malformed key from an untrusted planner: must be dropped.
+                kache_core::PrefetchCandidate {
+                    cache_key: "../../../etc/passwd".into(),
+                    crate_name: "serde".into(),
+                },
+                // Valid key but path-escaping crate name: must be dropped.
+                kache_core::PrefetchCandidate {
+                    cache_key: valid_key.clone(),
+                    crate_name: "../evil".into(),
+                },
+            ],
         };
 
         let req = PrefetchRequest::from_plan(plan);
-        assert_eq!(req.keys, vec![("abc123".into(), "serde".into())]);
+        assert_eq!(req.keys, vec![(valid_key, "serde".into())]);
     }
 
     #[test]


### PR DESCRIPTION
## What

Validate untrusted `cache_key` / `crate_name` before they are interpolated into local
filesystem paths and S3 object keys.

## Why

Planner- and S3-listing-supplied strings flowed unvalidated into
`store_dir().join(cache_key)` (`entry_dir_for`) and into the S3 key builders. The
prefetch planner is a **distinct trust boundary** from S3 (deserialized straight from
an HTTP response), and the empty-keys discovery path ingests a raw bucket listing.
Because `PathBuf::join` walks up on `..` and resets on an absolute component, a
`cache_key` like `../../../home/user/.config/evil` is an arbitrary-write primitive
(the extracted archive is `rename`d into that path), and a crafted `crate_name`
escapes the S3 prefix.

## How

Add fail-closed `is_valid_cache_key` (exactly 64 lowercase hex, matching `to_hex()`)
and `is_valid_crate_name` (`[A-Za-z0-9_.-]`, no `..`, bounded). **Reject, don't
sanitize**, at every boundary crossing:

- `PrefetchRequest::from_plan` drops bad planner candidates.
- both `handle_prefetch` loops (request keys + S3-listing keys) skip bad keys.
- `entry_dir_for` carries a `debug_assert!` as defense-in-depth.

## Tests

4 new validator unit tests (accepts real blake3 hex / real crate names; rejects
traversal, absolute, non-hex, wrong-length, separators, `..`, NUL, over-length);
`test_prefetch_request_from_plan` updated to assert malformed candidates are dropped.
All prefetch tests pass.

Adjacent to #211 / #179 (the untrusted-remote boundary). Closes #273
