### PR TITLE
Reclaim orphaned blob files via a GC + doctor sweep

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2980,6 +2980,21 @@ pub fn verify(config: &Config, checksums: bool, repair: bool) -> Result<()> {
         }
     }
 
+    // Repair: reclaim orphaned blob files (counted above). These are never
+    // reclaimed by normal GC, so without this they leak invisibly to
+    // size-based eviction. A small grace leaves any blob a concurrent build
+    // is materializing untouched.
+    if repair && orphaned_blobs > 0 {
+        match store.sweep_orphan_blobs(std::time::Duration::from_secs(60)) {
+            Ok(swept) => println!(
+                "Repairing: reclaimed {} orphan blobs ({})",
+                swept.removed,
+                ByteSize(swept.bytes_reclaimed)
+            ),
+            Err(e) => tracing::warn!("orphan-blob sweep failed: {e}"),
+        }
+    }
+
     // Compute store size
     let store_size = store.total_size().unwrap_or(0);
 
@@ -2995,9 +3010,11 @@ pub fn verify(config: &Config, checksums: bool, repair: bool) -> Result<()> {
     );
     println!("  Store size: {}", ByteSize(store_size));
 
-    if corrupted_entries > 0 && !repair {
+    if (corrupted_entries > 0 || orphaned_blobs > 0) && !repair {
         println!();
-        println!("Tip: run `kache doctor --repair` to remove corrupted entries.");
+        println!(
+            "Tip: run `kache doctor --repair` to remove corrupted entries and reclaim orphaned blobs."
+        );
     }
 
     Ok(())

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2012,33 +2012,50 @@ impl Daemon {
     /// Returns aggregated GcStats and persists them to `gc_stats.json` in the cache dir.
     pub fn run_gc(&self, max_age_hours: Option<u64>) -> Result<crate::store::GcStats> {
         let start = Instant::now();
-        let (dedup_stats, evict_stats, incremental_cleaned) = self.with_store(|store| {
-            // Backfill content_hash for legacy entries
-            let backfilled = store.backfill_content_hashes().unwrap_or(0);
-            if backfilled > 0 {
-                tracing::info!("backfilled {backfilled} content hashes");
-            }
+        let (dedup_stats, evict_stats, incremental_cleaned, orphan_stats) =
+            self.with_store(|store| {
+                // Backfill content_hash for legacy entries
+                let backfilled = store.backfill_content_hashes().unwrap_or(0);
+                if backfilled > 0 {
+                    tracing::info!("backfilled {backfilled} content hashes");
+                }
 
-            // Evict duplicate entries (same content, different cache keys)
-            let dedup_stats = store.evict_duplicate_entries().unwrap_or_default();
-            if dedup_stats.entries_evicted > 0 {
-                tracing::info!("evicted {} duplicate entries", dedup_stats.entries_evicted);
-            }
+                // Evict duplicate entries (same content, different cache keys)
+                let dedup_stats = store.evict_duplicate_entries().unwrap_or_default();
+                if dedup_stats.entries_evicted > 0 {
+                    tracing::info!("evicted {} duplicate entries", dedup_stats.entries_evicted);
+                }
 
-            let evict_stats = if let Some(hours) = max_age_hours {
-                store.evict_older_than(hours)?
-            } else {
-                store.evict()?
-            };
+                let evict_stats = if let Some(hours) = max_age_hours {
+                    store.evict_older_than(hours)?
+                } else {
+                    store.evict()?
+                };
 
-            let incremental_cleaned = if self.config.clean_incremental {
-                store.clean_registered_incremental_dirs().unwrap_or(0)
-            } else {
-                0
-            };
+                let incremental_cleaned = if self.config.clean_incremental {
+                    store.clean_registered_incremental_dirs().unwrap_or(0)
+                } else {
+                    0
+                };
 
-            Ok((dedup_stats, evict_stats, incremental_cleaned))
-        })?;
+                // Reclaim orphaned blob files (crash mid-put, or a meta-less
+                // remove_entry that couldn't decrement refcounts). A 1h grace
+                // leaves blobs a concurrent build is materializing untouched; they
+                // get reclaimed on a later pass once settled.
+                let orphan_stats = store
+                    .sweep_orphan_blobs(std::time::Duration::from_secs(3600))
+                    .unwrap_or_default();
+                if orphan_stats.removed > 0 {
+                    tracing::info!(
+                        "swept {} of {} blobs as orphans ({} reclaimed)",
+                        orphan_stats.removed,
+                        orphan_stats.scanned,
+                        crate::report::format_bytes(orphan_stats.bytes_reclaimed)
+                    );
+                }
+
+                Ok((dedup_stats, evict_stats, incremental_cleaned, orphan_stats))
+            })?;
 
         // Clean up stale tool-version cache files (rustc-ver-*.txt, linker-ver-*.txt).
         // Each toolchain update leaves behind orphaned files keyed by the old binary mtime.
@@ -2051,8 +2068,12 @@ impl Daemon {
         // Aggregate stats
         let stats = crate::store::GcStats {
             entries_evicted: dedup_stats.entries_evicted + evict_stats.entries_evicted,
-            bytes_freed: dedup_stats.bytes_freed + evict_stats.bytes_freed,
-            blobs_removed: dedup_stats.blobs_removed + evict_stats.blobs_removed,
+            bytes_freed: dedup_stats.bytes_freed
+                + evict_stats.bytes_freed
+                + orphan_stats.bytes_reclaimed,
+            blobs_removed: dedup_stats.blobs_removed
+                + evict_stats.blobs_removed
+                + orphan_stats.removed,
             duration_ms: start.elapsed().as_millis() as u64,
         };
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -61,6 +61,17 @@ fn set_blob_readonly(blob: &Path) {
     }
 }
 
+/// Is `name` exactly a content-blob filename: 64 lowercase hex chars (a
+/// blake3 digest)? Used by the orphan sweep so it only ever unlinks files
+/// that look like a blob — never an in-progress temp (`.{hash}.{pid}.{n}.tmp`)
+/// or any stray file.
+fn is_blob_hash_name(name: &str) -> bool {
+    name.len() == 64
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_digit() || matches!(b, b'a'..=b'f'))
+}
+
 /// Best-effort unlink of a blob file (clears read-only first).
 fn unlink_blob(blob: &Path) {
     if blob.exists() {
@@ -149,6 +160,17 @@ pub struct GcStats {
     pub bytes_freed: u64,
     pub blobs_removed: usize,
     pub duration_ms: u64,
+}
+
+/// Statistics returned by [`Store::sweep_orphan_blobs`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OrphanSweepStats {
+    /// Blob-shaped files inspected on disk.
+    pub scanned: usize,
+    /// Orphan blobs (no `blobs` row) unlinked.
+    pub removed: usize,
+    /// Bytes reclaimed by the sweep.
+    pub bytes_reclaimed: u64,
 }
 
 /// The local content-addressed store.
@@ -497,8 +519,9 @@ impl Store {
 
         // Phase 1: hash every output and durably materialize its blob on disk
         // *before* any committed entry can reference it. No DB writes happen
-        // here, so a crash leaves at most orphan blob files (reclaimed by GC),
-        // never a half-registered entry. `sources` is kept so Phase 2 can
+        // here, so a crash leaves at most orphan blob files (reclaimed by
+        // `sweep_orphan_blobs`, run from GC and `doctor --repair`), never a
+        // half-registered entry. `sources` is kept so Phase 2 can
         // re-materialize a blob if a concurrent remove unlinks it.
         let mut cached_files = Vec::new();
         let mut sources: Vec<PathBuf> = Vec::new();
@@ -973,6 +996,107 @@ impl Store {
         Ok(stats)
     }
 
+    /// Reclaim orphaned blob files — content-addressed files on disk with no
+    /// row in the `blobs` table. They accumulate when a crash interrupts a
+    /// `put`/import between materialize (Phase 1) and the commit transaction
+    /// (Phase 2), or when `remove_entry` runs against an entry whose
+    /// `meta.json` is gone (so its blob hashes can't be decremented). Nothing
+    /// else reclaims them: `evict*`/`remove_entry` only touch blobs reachable
+    /// from an entry, and `total_size()` doesn't count them — so they leak
+    /// invisibly to size-based eviction.
+    ///
+    /// Only blobs whose file mtime is older than `min_age` are swept, so a blob
+    /// a concurrent `put` is materializing (it renames the file into place just
+    /// before inserting its row) is never reclaimed out from under it. Unlinks
+    /// run while holding the SQLite write lock (`BEGIN IMMEDIATE`), upholding
+    /// the store invariant that a blob is only ever removed under that lock —
+    /// so even if this races a `put` adopting a long-lived orphan, that put's
+    /// Phase 2 re-materializes the blob before committing a reference to it.
+    pub fn sweep_orphan_blobs(&self, min_age: Duration) -> Result<OrphanSweepStats> {
+        let blobs_dir = self.config.store_dir().join("blobs");
+        if !blobs_dir.exists() {
+            return Ok(OrphanSweepStats::default());
+        }
+
+        // Phase A (no lock): enumerate blob-shaped files old enough to sweep.
+        // The directory walk is the slow part and holds no lock.
+        let now = std::time::SystemTime::now();
+        let mut candidates: Vec<(String, PathBuf, u64)> = Vec::new();
+        let mut scanned = 0usize;
+        for shard in fs::read_dir(&blobs_dir)?.flatten() {
+            if !shard.path().is_dir() {
+                continue;
+            }
+            let Ok(files) = fs::read_dir(shard.path()) else {
+                continue;
+            };
+            for file in files.flatten() {
+                let path = file.path();
+                let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+                if !is_blob_hash_name(name) {
+                    continue;
+                }
+                let Ok(meta) = file.metadata() else { continue };
+                if !meta.is_file() {
+                    continue;
+                }
+                scanned += 1;
+                let old_enough = meta
+                    .modified()
+                    .ok()
+                    .and_then(|m| now.duration_since(m).ok())
+                    .map(|age| age >= min_age)
+                    .unwrap_or(false);
+                if old_enough {
+                    candidates.push((name.to_string(), path, meta.len()));
+                }
+            }
+        }
+
+        let mut stats = OrphanSweepStats {
+            scanned,
+            ..Default::default()
+        };
+        if candidates.is_empty() {
+            return Ok(stats);
+        }
+
+        // Phase B (write lock held): re-check each candidate against the live
+        // `blobs` table and unlink the unreferenced ones. `BEGIN IMMEDIATE`
+        // takes the write lock up front so the unlinks serialize with any
+        // `put`/`remove_entry` mutating the same blob.
+        self.db.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> Result<()> {
+            let referenced: std::collections::HashSet<String> = {
+                let mut stmt = self.db.prepare("SELECT hash FROM blobs")?;
+                stmt.query_map([], |row| row.get::<_, String>(0))?
+                    .filter_map(|r| r.ok())
+                    .collect()
+            };
+            for (hash, path, size) in &candidates {
+                if referenced.contains(hash) {
+                    continue;
+                }
+                unlink_blob(path);
+                stats.removed += 1;
+                stats.bytes_reclaimed += *size;
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                self.db.execute_batch("COMMIT")?;
+                Ok(stats)
+            }
+            Err(e) => {
+                let _ = self.db.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
     /// Backfill content_hash for entries that don't have one.
     /// Reads meta.json from each entry to get file hashes.
     /// Returns the number of entries updated.
@@ -1400,6 +1524,72 @@ mod tests {
         assert_eq!(meta.crate_name, "mylib");
         assert_eq!(meta.files.len(), 1);
         assert_eq!(meta.files[0].name, "libmylib.rlib");
+    }
+
+    #[test]
+    fn sweep_orphan_blobs_removes_unreferenced_files_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        // A real entry → its blob is referenced (has a `blobs` row).
+        let output_file = dir.path().join("output.rlib");
+        std::fs::write(&output_file, b"real rlib content").unwrap();
+        store
+            .put(
+                "abc123",
+                "mylib",
+                &["lib".to_string()],
+                &["std".to_string()],
+                "x86_64-unknown-linux-gnu",
+                "dev",
+                &[(output_file, "libmylib.rlib".to_string())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // An orphan blob: a 64-hex file on disk with no `blobs` row, as a
+        // crash mid-put would leave behind.
+        let orphan_hash = "f".repeat(64);
+        let orphan_path = store.blob_path(&orphan_hash);
+        std::fs::create_dir_all(orphan_path.parent().unwrap()).unwrap();
+        std::fs::write(&orphan_path, b"orphaned bytes").unwrap();
+        // A `.tmp` in-progress file must never be touched by the sweep.
+        let tmp_path = orphan_path.with_file_name(format!(".{orphan_hash}.123.0.tmp"));
+        std::fs::write(&tmp_path, b"in-progress").unwrap();
+
+        // min_age 0 → sweep the freshly-created orphan immediately.
+        let stats = store.sweep_orphan_blobs(std::time::Duration::ZERO).unwrap();
+
+        assert_eq!(stats.removed, 1, "only the orphan should be removed");
+        // The put blob + the orphan are blob-shaped; the `.tmp` is excluded.
+        assert_eq!(stats.scanned, 2);
+        assert_eq!(stats.bytes_reclaimed, b"orphaned bytes".len() as u64);
+        assert!(!orphan_path.exists(), "orphan blob must be unlinked");
+        assert!(tmp_path.exists(), "in-progress .tmp must be left alone");
+        // The referenced entry's blob survived: get() still restores it.
+        assert!(store.get("abc123").unwrap().is_some());
+    }
+
+    #[test]
+    fn sweep_orphan_blobs_respects_min_age() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let orphan_hash = "a".repeat(64);
+        let orphan_path = store.blob_path(&orphan_hash);
+        std::fs::create_dir_all(orphan_path.parent().unwrap()).unwrap();
+        std::fs::write(&orphan_path, b"fresh orphan").unwrap();
+
+        // A freshly written orphan is younger than the grace period, so a
+        // concurrent put materializing it would be protected: not swept.
+        let stats = store
+            .sweep_orphan_blobs(std::time::Duration::from_secs(3600))
+            .unwrap();
+        assert_eq!(stats.removed, 0);
+        assert!(orphan_path.exists());
     }
 
     #[test]


### PR DESCRIPTION
## What

Reclaim orphaned blob files — content-addressed files on disk with no row in the
`blobs` table.

## Why

`put` materializes blobs (Phase 1) before the commit transaction (Phase 2), so a crash
between the two leaves a rows-less file. Nothing reclaimed these: `remove_entry` only
unlinks at refcount ≤ 0, `doctor --repair` only removed entries, and `total_size()`
counts only the `entries` table — so the leak was **invisible to size-based eviction**.
On churny CI this silently fills the disk. (The Phase-1 comment even promised GC
reclaimed them; it didn't.)

## How

`Store::sweep_orphan_blobs(min_age)`:

1. Walks `store/blobs` **lock-free** collecting blob-shaped files (64-hex names, so
   in-progress `.{hash}.{pid}.{n}.tmp` temps are skipped) older than `min_age`.
2. Under `BEGIN IMMEDIATE`, unlinks those with no `blobs` row.

Unlinking under the write lock upholds the existing invariant that a blob is only ever
removed under that lock (`store.rs:584`), so a racing `put` re-materializes anything
removed before committing a reference to it; the mtime grace additionally protects a
blob a concurrent `put` is materializing. The directory walk (the slow part) holds no
lock — only the fast unlink pass does.

Wired into the daemon GC (1h grace) and `doctor --repair` (60s grace). The stale
Phase-1 comment is corrected and the `doctor` tip now mentions orphan reclamation.

## Tests

`sweep_orphan_blobs_removes_unreferenced_files_only` (removes the orphan, keeps the
referenced blob, leaves the `.tmp` alone) and `sweep_orphan_blobs_respects_min_age`
(a fresh orphan inside the grace window is not swept).

Complements #176. Closes #275
