### PR TITLE
fix(rustc): recognize clippy-driver.exe under cargo clippy on Windows

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -848,6 +848,44 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_double_wrapper_windows_exe() {
+        // Regression for issue #287: the double-wrapper split keys off
+        // `RustcCompiler::recognizes(&args[1..])`, so it must also fire when
+        // the inner rustc is a Windows `.exe` path. Before the `.exe`/backslash
+        // fix, `clippy-driver.exe` was not recognized at all — and here the
+        // inner `rustc.exe` would likewise have been missed, mis-parsing the
+        // inner compiler as a positional source file. Holds on every host OS.
+        let args: Vec<String> = vec![
+            r"G:\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\bin\clippy-driver.exe",
+            r"C:\Program Files\Rust\bin\rustc.exe",
+            "--crate-name",
+            "foo",
+            "src/lib.rs",
+            "--crate-type",
+            "lib",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let parsed = RustcArgs::parse(&args).unwrap();
+        assert_eq!(
+            parsed.rustc,
+            PathBuf::from(
+                r"G:\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\bin\clippy-driver.exe"
+            )
+        );
+        assert_eq!(
+            parsed.inner_rustc,
+            Some(PathBuf::from(r"C:\Program Files\Rust\bin\rustc.exe"))
+        );
+        assert_eq!(parsed.crate_name.as_deref(), Some("foo"));
+        // The inner rustc.exe must be consumed by the split, not left in
+        // all_args where it could be mistaken for a source positional.
+        assert!(!parsed.all_args.iter().any(|a| a.contains("rustc.exe")));
+    }
+
+    #[test]
     fn test_parse_single_wrapper_unchanged() {
         // Normal case: kache /path/to/rustc --crate-name foo src/lib.rs
         // After main.rs strips argv[0], parse receives: [/path/to/rustc, ...]

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2058,10 +2058,10 @@ impl CcCompiler {
         let Some(arg0) = args.first() else {
             return false;
         };
-        let Some(name) = cc_command_name(arg0) else {
+        let Some(name) = super::command_basename(arg0) else {
             return false;
         };
-        let name = strip_windows_exe_suffix(name);
+        let name = super::strip_windows_exe_suffix(name);
 
         // Exact matches for the canonical command names.
         if matches!(name, "cc" | "c++" | "gcc" | "g++" | "clang" | "clang++") {
@@ -2098,21 +2098,6 @@ impl CcCompiler {
     /// `run_wrapper_mode` checks this *before* the compiler match.
     pub fn recognizes_family_probe(args: &[String]) -> bool {
         args.len() >= 2 && args[0] == "-E"
-    }
-}
-
-fn cc_command_name(arg0: &str) -> Option<&str> {
-    arg0.rsplit(['/', '\\'])
-        .next()
-        .filter(|name| !name.is_empty())
-}
-
-fn strip_windows_exe_suffix(name: &str) -> &str {
-    let bytes = name.as_bytes();
-    if bytes.len() >= 4 && bytes[bytes.len() - 4..].eq_ignore_ascii_case(b".exe") {
-        &name[..bytes.len() - 4]
-    } else {
-        name
     }
 }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -529,6 +529,32 @@ pub fn detect_compiler(args: &[String]) -> Option<&'static CompilerAdapter> {
         .find(|adapter| adapter.recognizes(args))
 }
 
+/// Extract the bare command name from an `argv[0]`, splitting on both Unix
+/// (`/`) and Windows (`\`) separators regardless of host OS.
+///
+/// [`std::path::Path::file_name`] is deliberately avoided: off-Windows it does
+/// not treat `\` as a separator, so a Windows path like
+/// `G:\…\bin\clippy-driver.exe` would come back whole. Every compiler adapter's
+/// `recognizes` rule must see the same basename whether it runs on the target
+/// platform or in a cross-platform test, so detection of e.g. `clippy-driver`
+/// holds for both. Returns `None` when the trailing component is empty.
+pub(crate) fn command_basename(arg0: &str) -> Option<&str> {
+    arg0.rsplit(['/', '\\'])
+        .next()
+        .filter(|name| !name.is_empty())
+}
+
+/// Strip a trailing, case-insensitive `.exe` suffix (Windows executables) so
+/// `rustc.exe` / `clippy-driver.exe` compare equal to their bare names.
+pub(crate) fn strip_windows_exe_suffix(name: &str) -> &str {
+    let bytes = name.as_bytes();
+    if bytes.len() >= 4 && bytes[bytes.len() - 4..].eq_ignore_ascii_case(b".exe") {
+        &name[..bytes.len() - 4]
+    } else {
+        name
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -554,6 +580,19 @@ mod tests {
         );
         assert_eq!(
             detect_compiler(&s(&["clippy-driver"])).map(|adapter| adapter.id()),
+            Some(rustc::RUSTC_ID)
+        );
+        // Regression for issue #287: the exact argv cargo passes for
+        // `cargo clippy` on Windows. Detection must route this to the rustc
+        // adapter (wrapper mode) rather than fall through to clap subcommand
+        // parsing, which is what surfaced as "unrecognized subcommand".
+        assert_eq!(
+            detect_compiler(&s(&[
+                r"G:\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\bin\clippy-driver.exe",
+                "rustc",
+                "-vV",
+            ]))
+            .map(|adapter| adapter.id()),
             Some(rustc::RUSTC_ID)
         );
     }
@@ -596,6 +635,38 @@ mod tests {
         assert!(detect_compiler(&s(&["make"])).is_none());
         assert!(detect_compiler(&s(&["ld"])).is_none());
         assert!(detect_compiler(&s(&["--crate-name"])).is_none());
+    }
+
+    #[test]
+    fn command_basename_splits_both_separators() {
+        assert_eq!(command_basename("rustc"), Some("rustc"));
+        assert_eq!(command_basename("/usr/bin/rustc"), Some("rustc"));
+        // Windows backslash paths resolve identically on every host OS —
+        // std::path::Path::file_name would not split these off-Windows.
+        assert_eq!(
+            command_basename(r"G:\bin\clippy-driver.exe"),
+            Some("clippy-driver.exe")
+        );
+        assert_eq!(command_basename(r"C:\a/b\c.exe"), Some("c.exe"));
+        // A trailing separator leaves no command name.
+        assert_eq!(command_basename("/usr/bin/"), None);
+        assert_eq!(command_basename(r"C:\bin\"), None);
+        assert_eq!(command_basename(""), None);
+    }
+
+    #[test]
+    fn strip_windows_exe_suffix_is_case_insensitive_and_optional() {
+        assert_eq!(strip_windows_exe_suffix("rustc.exe"), "rustc");
+        assert_eq!(
+            strip_windows_exe_suffix("clippy-driver.EXE"),
+            "clippy-driver"
+        );
+        // No suffix: returned unchanged.
+        assert_eq!(strip_windows_exe_suffix("rustc"), "rustc");
+        // `.exe` is only stripped from the end, never mid-name.
+        assert_eq!(strip_windows_exe_suffix("a.exe.b"), "a.exe.b");
+        // Too short to carry a `.exe` suffix.
+        assert_eq!(strip_windows_exe_suffix(".ex"), ".ex");
     }
 
     #[test]

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -6,7 +6,6 @@
 //! callers a stable shape that other compiler adapters can match.
 
 use anyhow::Result;
-use std::path::Path;
 
 use crate::args::RustcArgs;
 use crate::cache_key::compute_cache_key;
@@ -55,20 +54,21 @@ impl RustcCompiler {
     /// Owns its own detection rule; `super::detect_compiler` reaches it
     /// through this module's [`ADAPTER`] descriptor.
     ///
-    /// Inspects only `argv[0]`. Path-prefixed forms (`/usr/bin/rustc`)
-    /// work via [`Path::file_name`].
+    /// Inspects only `argv[0]`. Path-prefixed forms (`/usr/bin/rustc`,
+    /// `C:\…\bin\rustc.exe`) and Windows `.exe` suffixes are accepted —
+    /// cargo passes `clippy-driver.exe` here under `cargo clippy` on Windows
+    /// (issue #287), which must be recognized as a rustc invocation. Basename
+    /// extraction and `.exe` stripping are shared with the cc adapter so both
+    /// stay consistent across host platforms.
     pub fn recognizes(args: &[String]) -> bool {
         let Some(arg0) = args.first() else {
             return false;
         };
-        let path = Path::new(arg0);
-        match path.file_name() {
-            Some(name) => {
-                let name = name.to_string_lossy();
-                name == "rustc" || name.starts_with("rustc") || name == "clippy-driver"
-            }
-            None => false,
-        }
+        let Some(name) = super::command_basename(arg0) else {
+            return false;
+        };
+        let name = super::strip_windows_exe_suffix(name);
+        name == "rustc" || name.starts_with("rustc") || name == "clippy-driver"
     }
 }
 
@@ -195,8 +195,42 @@ mod tests {
         assert!(RustcCompiler::recognizes(&s(&[
             "/path/to/bin/clippy-driver"
         ])));
+
+        // Regression for issue #287: on Windows `cargo clippy` invokes the
+        // wrapper as `kache <…>\clippy-driver.exe rustc -vV`. The `.exe`
+        // suffix and backslash separators must not defeat detection — this
+        // case ran as a clap subcommand before the fix ("unrecognized
+        // subcommand"). These assertions hold on every host OS, so the
+        // regression is caught without a Windows runner.
+        assert!(RustcCompiler::recognizes(&s(&["rustc.exe"])));
+        assert!(RustcCompiler::recognizes(&s(&["clippy-driver.exe"])));
+        assert!(RustcCompiler::recognizes(&s(&[
+            r"C:\Program Files\Rust\bin\rustc.exe"
+        ])));
+        assert!(RustcCompiler::recognizes(&s(&[
+            r"G:\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\bin\clippy-driver.exe"
+        ])));
+        // Detection is architecture-independent: the binary is named
+        // `clippy-driver.exe` / `rustc.exe` identically on ARM64 (aarch64),
+        // i686, and the gnu toolchain. The arch substring in the toolchain
+        // dir is incidental — only the `.exe` basename matters.
+        assert!(RustcCompiler::recognizes(&s(&[
+            r"C:\Users\dev\.rustup\toolchains\stable-aarch64-pc-windows-msvc\bin\clippy-driver.exe"
+        ])));
+        assert!(RustcCompiler::recognizes(&s(&[
+            r"C:\.rustup\toolchains\stable-x86_64-pc-windows-gnu\bin\rustc.exe"
+        ])));
+        // `.exe` matching is case-insensitive (Windows filesystems).
+        assert!(RustcCompiler::recognizes(&s(&["clippy-driver.EXE"])));
+
         assert!(!RustcCompiler::recognizes(&s(&["gcc"])));
         assert!(!RustcCompiler::recognizes(&s(&["--crate-name"])));
+        // C-family compilers (incl. their Windows `.exe` forms) belong to the
+        // cc adapter, not rustc.
+        assert!(!RustcCompiler::recognizes(&s(&["gcc.exe"])));
+        assert!(!RustcCompiler::recognizes(&s(&[
+            r"C:\msys64\bin\clang.exe"
+        ])));
         // Empty argv: there is nothing to recognize.
         assert!(!RustcCompiler::recognizes(&[]));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -688,5 +688,29 @@ mod tests {
             ]),
             LogMode::Wrapper
         );
+        // Regression for issue #287: `cargo clippy` on Windows invokes the
+        // wrapper as `kache <…>\clippy-driver.exe rustc -vV`. The whole
+        // dispatch (not just recognizes()) must select Wrapper mode — before
+        // the fix this fell through to Cli and clap-errored with
+        // "unrecognized subcommand". The backslash basename + `.exe` suffix
+        // resolve identically on every host OS.
+        assert_eq!(
+            detect_log_mode(&[
+                "kache".into(),
+                r"G:\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\bin\clippy-driver.exe"
+                    .into(),
+                "rustc".into(),
+                "-vV".into(),
+            ]),
+            LogMode::Wrapper
+        );
+        assert_eq!(
+            detect_log_mode(&[
+                "kache".into(),
+                r"C:\Program Files\Rust\bin\rustc.exe".into(),
+                "--crate-name".into(),
+            ]),
+            LogMode::Wrapper
+        );
     }
 }


### PR DESCRIPTION
## Problem

Under `cargo clippy` on **Windows**, cargo invokes the `RUSTC_WRAPPER` as:

```
kache G:\...\bin\clippy-driver.exe rustc -vV
```

`RustcCompiler::recognizes()` compared the basename against the literal `"clippy-driver"` using `Path::file_name()` with **no `.exe` stripping**, so `clippy-driver.exe` was not recognized as a rustc invocation. kache then fell through to clap subcommand parsing and exited with `unrecognized subcommand`, which clippy/flycheck surfaces as "Cargo watcher failed". This broke `cargo clippy` for every Windows user with `RUSTC_WRAPPER=kache`.

Closes #287

## Root cause

`src/compiler/rustc.rs` used `Path::file_name()` + an exact `== "clippy-driver"` check. Two latent defects, both about Windows argv shapes:

1. **No `.exe` stripping** → `clippy-driver.exe != "clippy-driver"`. (`rustc.exe` survived only via `starts_with("rustc")`, masking the gap.)
2. `Path::file_name()` doesn't split backslashes off-Windows, which is what blocked writing a cross-platform regression test.

The **cc adapter already solved this exact class** (`src/compiler/cc.rs`) via two private helpers. The rustc adapter simply never adopted them.

## Fix (durable, DRY)

- Promote the two cc helpers — `command_basename` (splits on `/` **and** `\`) and `strip_windows_exe_suffix` (case-insensitive `.exe` trim) — to shared `pub(crate)` fns in `src/compiler/mod.rs`.
- Both adapters now use them. rustc gains `.exe`/backslash handling; cc drops its private duplicates (pure refactor, no behavior change).
- `RustcCompiler::recognizes` is the single chokepoint reused by wrapper-vs-CLI dispatch (`main.rs`), adapter routing (`compiler::mod`), and the double-wrapper inner-rustc split (`args.rs`) — so one change fixes all paths.

**Architecture-independent:** `rustc.exe` / `clippy-driver.exe` are named identically across x86_64, aarch64 (ARM64), i686 and the msvc/gnu toolchains. The `x86_64` substring in the issue's path is just the rustup toolchain dir name and plays no role in detection.

## Tests

Regression tests are co-located with the bug and pure string-logic, so they run on **every** host — macOS, Linux, and Windows of any arch — without needing a Windows runner:

- `rustc.rs`: literal issue-#287 path, bare `clippy-driver.exe`/`rustc.exe`, **aarch64 + gnu-toolchain** paths (explicitly asserting arch-independence), case-insensitive `.EXE`, and negative `gcc.exe`/`clang.exe` cases.
- `mod.rs`: dispatch-level `detect_compiler([clippy-driver.exe, rustc, -vV])` + unit tests for both shared helpers.

**Red-green verified:** against the pre-fix logic, exactly the two new assertions fail (`rustc.rs` `clippy-driver.exe`, `mod.rs` dispatch); with the fix, all green.

## Verification

- `cargo test -p kache compiler::` → 145 passed
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean