### PR TITLE
Forward cc-crate family probe to the real compiler (fixes #286)

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2101,6 +2101,91 @@ impl CcCompiler {
     }
 }
 
+/// Does `key` name a `CC`/`CXX` compiler variable the `cc` crate reads?
+///
+/// Mirrors the crate's `getenv_with_target_prefixes("CC"|"CXX")`: the
+/// bare name, a `<target>` suffix (`CC_aarch64_pc_windows_msvc`), or a
+/// `TARGET_`/`HOST_` prefix. Deliberately excludes neighbours like
+/// `CFLAGS`, `CXXFLAGS`, and `CCACHE_*` whose values are not
+/// `<wrapper> <compiler>` pairs.
+fn is_cc_family_env_key(key: &str) -> bool {
+    let base = key
+        .strip_prefix("TARGET_")
+        .or_else(|| key.strip_prefix("HOST_"))
+        .unwrap_or(key);
+    base == "CC" || base == "CXX" || base.starts_with("CC_") || base.starts_with("CXX_")
+}
+
+/// Is `key` a C++ (`CXX`) compiler variable, as opposed to C (`CC`)?
+fn is_cxx_env_key(key: &str) -> bool {
+    let base = key
+        .strip_prefix("TARGET_")
+        .or_else(|| key.strip_prefix("HOST_"))
+        .unwrap_or(key);
+    base == "CXX" || base.starts_with("CXX_")
+}
+
+/// Does `token` (a path or bare name) refer to the kache binary itself?
+fn probe_token_is_self(token: &str, self_stem: &str) -> bool {
+    super::command_basename(token)
+        .map(super::strip_windows_exe_suffix)
+        .is_some_and(|name| name.eq_ignore_ascii_case(self_stem))
+}
+
+/// Recover the real compiler the `cc` crate dropped from a family probe.
+///
+/// When `CC="kache <compiler>"` the cc crate mis-parses it — kache is
+/// not in the crate's hard-coded known-wrapper allowlist (`ccache`,
+/// `sccache`, `distcc`, …), so it treats kache as the *compiler* and
+/// `<compiler>` as a leading argument, then drops that argument when it
+/// runs the family probe (`Command::new(path).arg("-E").arg(file)`).
+/// kache therefore receives `kache -E <file>` with no compiler to
+/// forward to.
+///
+/// The compiler is still recoverable: the very `CC`/`CXX` variable the
+/// cc crate read still holds `kache <compiler>` in our environment.
+/// Scan those variables, find the one whose first whitespace token is
+/// us, and return `<compiler>` so the probe can forward to the real
+/// thing — yielding the genuine compiler family instead of a wrong
+/// default guess (issue #286: `cc` is absent on Windows MSVC, so the
+/// old hard-coded `cc` forward failed and the build fell back to an
+/// unsupported GNU family).
+///
+/// `CC` is preferred over `CXX` (the probe file is C), but both resolve
+/// to the same toolchain family in practice. Returns `None` when no
+/// kache-wrapped compiler variable is present.
+pub(crate) fn resolve_probe_compiler<I>(self_stem: &str, env_vars: I) -> Option<String>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    // A CXX match is held back as a fallback so a CC match always wins,
+    // regardless of environment iteration order.
+    let mut cxx_fallback: Option<String> = None;
+    for (key, value) in env_vars {
+        if !is_cc_family_env_key(&key) {
+            continue;
+        }
+        let mut tokens = value.split_whitespace();
+        let Some(first) = tokens.next() else { continue };
+        // The first token must be us; otherwise this is a plain
+        // compiler, not a kache-wrapped one.
+        if !probe_token_is_self(first, self_stem) {
+            continue;
+        }
+        let Some(real) = tokens.next() else { continue };
+        // Guard against a degenerate `CC="kache kache"`.
+        if probe_token_is_self(real, self_stem) {
+            continue;
+        }
+        if is_cxx_env_key(&key) {
+            cxx_fallback.get_or_insert_with(|| real.to_string());
+        } else {
+            return Some(real.to_string());
+        }
+    }
+    cxx_fallback
+}
+
 impl Compiler for CcCompiler {
     type Parsed = CcArgs;
 
@@ -2574,6 +2659,103 @@ mod tests {
                 "should NOT recognize {argv:?} as cc-probe"
             );
         }
+    }
+
+    // ── family-probe compiler recovery (issue #286) ──────────────
+
+    fn env(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn probe_compiler_recovers_real_compiler_from_target_cc_var() {
+        // The exact shape from issue #286: mozbuild sets the
+        // target-prefixed CC var to `kache <clang-cl>`, the cc crate
+        // drops clang-cl from the family probe, and kache must recover
+        // it from the environment.
+        let vars = env(&[(
+            "CC_aarch64_pc_windows_msvc",
+            "C:/Users/sasch/.cargo/bin/kache.exe C:/Users/sasch/.mozbuild/clang/bin/clang-cl.exe",
+        )]);
+        assert_eq!(
+            resolve_probe_compiler("kache", vars),
+            Some("C:/Users/sasch/.mozbuild/clang/bin/clang-cl.exe".to_string())
+        );
+    }
+
+    #[test]
+    fn probe_compiler_recovers_from_plain_cc() {
+        assert_eq!(
+            resolve_probe_compiler("kache", env(&[("CC", "kache cc")])),
+            Some("cc".to_string())
+        );
+    }
+
+    #[test]
+    fn probe_compiler_recovers_from_cxx_when_no_cc() {
+        assert_eq!(
+            resolve_probe_compiler("kache", env(&[("CXX", "kache clang++")])),
+            Some("clang++".to_string())
+        );
+    }
+
+    #[test]
+    fn probe_compiler_prefers_cc_over_cxx() {
+        // Both wrap kache; the C variable wins (the probe file is C).
+        let vars = env(&[("CXX", "kache clang++"), ("CC", "kache clang")]);
+        assert_eq!(
+            resolve_probe_compiler("kache", vars),
+            Some("clang".to_string())
+        );
+    }
+
+    #[test]
+    fn probe_compiler_matches_self_stem_case_insensitively() {
+        // Windows path with an upper-case .EXE and mixed-case stem.
+        let vars = env(&[("CC", r"C:\bin\KACHE.EXE clang-cl.exe")]);
+        assert_eq!(
+            resolve_probe_compiler("kache", vars),
+            Some("clang-cl.exe".to_string())
+        );
+    }
+
+    #[test]
+    fn probe_compiler_none_when_cc_is_not_kache_wrapped() {
+        // A plain compiler (no kache wrapper) is not ours to recover.
+        assert_eq!(
+            resolve_probe_compiler("kache", env(&[("CC", "clang -fPIC")])),
+            None
+        );
+    }
+
+    #[test]
+    fn probe_compiler_none_when_only_self_present() {
+        // `CC=kache` with no trailing compiler (and the RUSTC_WRAPPER
+        // shape) leaves nothing to forward to.
+        assert_eq!(
+            resolve_probe_compiler("kache", env(&[("CC", "kache")])),
+            None
+        );
+        assert_eq!(
+            resolve_probe_compiler("kache", env(&[("CC", "kache kache")])),
+            None
+        );
+    }
+
+    #[test]
+    fn probe_compiler_ignores_non_compiler_env_vars() {
+        // Flags and ccache-style vars must never be mistaken for a
+        // `<wrapper> <compiler>` pair even if they mention kache.
+        let vars = env(&[
+            ("CFLAGS", "kache -O2"),
+            ("CXXFLAGS", "kache -O2"),
+            ("CCACHE_DIR", "kache whatever"),
+            ("RUSTC_WRAPPER", "kache"),
+        ]);
+        assert_eq!(resolve_probe_compiler("kache", vars), None);
     }
 
     #[test]

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2151,16 +2151,36 @@ fn probe_token_is_self(token: &str, self_stem: &str) -> bool {
 /// old hard-coded `cc` forward failed and the build fell back to an
 /// unsupported GNU family).
 ///
-/// `CC` is preferred over `CXX` (the probe file is C), but both resolve
-/// to the same toolchain family in practice. Returns `None` when no
-/// kache-wrapped compiler variable is present.
-pub(crate) fn resolve_probe_compiler<I>(self_stem: &str, env_vars: I) -> Option<String>
+/// Selection mirrors the cc crate's own `getenv_with_target_prefixes`
+/// precedence so kache forwards to the exact variable the crate read
+/// when several are kache-wrapped (mozbuild sets a host *and* a target
+/// compiler): for a given `<name>` in `CC`, then `CXX`, the order is
+/// `<name>_<target>`, `<name>_<target-underscored>`, `TARGET_<name>`,
+/// `<name>`, `HOST_<name>`. `target` comes from cargo's `TARGET` env
+/// var (set for build scripts). When `target` is `None`, selection
+/// falls back to a deterministic order (CC before CXX, then the
+/// lexicographically smallest key) so it never depends on environment
+/// iteration order.
+///
+/// `CC` is preferred over `CXX` because the probe file is C and kache
+/// cannot tell from `-E <file>` alone whether the cc crate's probe
+/// belongs to a C or C++ `Build`. When `CC` and `CXX` are kache-wrapped
+/// with *different* compiler families this can mislabel a C++ probe —
+/// harmless in practice (the cc crate treats GNU and Clang identically;
+/// only MSVC diverges, and a kache-wrapped MSVC `CXX` paired with a
+/// non-MSVC `CC` does not occur in real toolchains).
+///
+/// Returns `None` when no kache-wrapped compiler variable is present.
+pub(crate) fn resolve_probe_compiler<I>(
+    self_stem: &str,
+    target: Option<&str>,
+    env_vars: I,
+) -> Option<String>
 where
     I: IntoIterator<Item = (String, String)>,
 {
-    // A CXX match is held back as a fallback so a CC match always wins,
-    // regardless of environment iteration order.
-    let mut cxx_fallback: Option<String> = None;
+    // Collect every kache-wrapped CC/CXX variable: key -> real compiler.
+    let mut wrapped: HashMap<String, String> = HashMap::new();
     for (key, value) in env_vars {
         if !is_cc_family_env_key(&key) {
             continue;
@@ -2177,13 +2197,46 @@ where
         if probe_token_is_self(real, self_stem) {
             continue;
         }
-        if is_cxx_env_key(&key) {
-            cxx_fallback.get_or_insert_with(|| real.to_string());
-        } else {
-            return Some(real.to_string());
+        wrapped.entry(key).or_insert_with(|| real.to_string());
+    }
+    if wrapped.is_empty() {
+        return None;
+    }
+
+    // cc-crate precedence: most-specific target var first, CC before CXX.
+    for name in ["CC", "CXX"] {
+        if let Some(t) = target {
+            if let Some(c) = wrapped.get(&format!("{name}_{t}")) {
+                return Some(c.clone());
+            }
+            let underscored = t.replace('-', "_");
+            if underscored != t
+                && let Some(c) = wrapped.get(&format!("{name}_{underscored}"))
+            {
+                return Some(c.clone());
+            }
+            if let Some(c) = wrapped.get(&format!("TARGET_{name}")) {
+                return Some(c.clone());
+            }
+        }
+        if let Some(c) = wrapped.get(name) {
+            return Some(c.clone());
+        }
+        if let Some(c) = wrapped.get(&format!("HOST_{name}")) {
+            return Some(c.clone());
         }
     }
-    cxx_fallback
+
+    // No precedence key matched (e.g. only a target-suffixed var for an
+    // unknown target): deterministic fallback — CC family before CXX,
+    // then the lexicographically smallest key.
+    let mut keys: Vec<&String> = wrapped.keys().collect();
+    keys.sort_by(|a, b| {
+        is_cxx_env_key(a)
+            .cmp(&is_cxx_env_key(b))
+            .then_with(|| a.cmp(b))
+    });
+    keys.first().map(|k| wrapped[*k].clone())
 }
 
 impl Compiler for CcCompiler {
@@ -2681,7 +2734,7 @@ mod tests {
             "C:/Users/sasch/.cargo/bin/kache.exe C:/Users/sasch/.mozbuild/clang/bin/clang-cl.exe",
         )]);
         assert_eq!(
-            resolve_probe_compiler("kache", vars),
+            resolve_probe_compiler("kache", None, vars),
             Some("C:/Users/sasch/.mozbuild/clang/bin/clang-cl.exe".to_string())
         );
     }
@@ -2689,7 +2742,7 @@ mod tests {
     #[test]
     fn probe_compiler_recovers_from_plain_cc() {
         assert_eq!(
-            resolve_probe_compiler("kache", env(&[("CC", "kache cc")])),
+            resolve_probe_compiler("kache", None, env(&[("CC", "kache cc")])),
             Some("cc".to_string())
         );
     }
@@ -2697,7 +2750,7 @@ mod tests {
     #[test]
     fn probe_compiler_recovers_from_cxx_when_no_cc() {
         assert_eq!(
-            resolve_probe_compiler("kache", env(&[("CXX", "kache clang++")])),
+            resolve_probe_compiler("kache", None, env(&[("CXX", "kache clang++")])),
             Some("clang++".to_string())
         );
     }
@@ -2707,7 +2760,7 @@ mod tests {
         // Both wrap kache; the C variable wins (the probe file is C).
         let vars = env(&[("CXX", "kache clang++"), ("CC", "kache clang")]);
         assert_eq!(
-            resolve_probe_compiler("kache", vars),
+            resolve_probe_compiler("kache", None, vars),
             Some("clang".to_string())
         );
     }
@@ -2717,7 +2770,7 @@ mod tests {
         // Windows path with an upper-case .EXE and mixed-case stem.
         let vars = env(&[("CC", r"C:\bin\KACHE.EXE clang-cl.exe")]);
         assert_eq!(
-            resolve_probe_compiler("kache", vars),
+            resolve_probe_compiler("kache", None, vars),
             Some("clang-cl.exe".to_string())
         );
     }
@@ -2726,7 +2779,7 @@ mod tests {
     fn probe_compiler_none_when_cc_is_not_kache_wrapped() {
         // A plain compiler (no kache wrapper) is not ours to recover.
         assert_eq!(
-            resolve_probe_compiler("kache", env(&[("CC", "clang -fPIC")])),
+            resolve_probe_compiler("kache", None, env(&[("CC", "clang -fPIC")])),
             None
         );
     }
@@ -2736,11 +2789,11 @@ mod tests {
         // `CC=kache` with no trailing compiler (and the RUSTC_WRAPPER
         // shape) leaves nothing to forward to.
         assert_eq!(
-            resolve_probe_compiler("kache", env(&[("CC", "kache")])),
+            resolve_probe_compiler("kache", None, env(&[("CC", "kache")])),
             None
         );
         assert_eq!(
-            resolve_probe_compiler("kache", env(&[("CC", "kache kache")])),
+            resolve_probe_compiler("kache", None, env(&[("CC", "kache kache")])),
             None
         );
     }
@@ -2755,7 +2808,60 @@ mod tests {
             ("CCACHE_DIR", "kache whatever"),
             ("RUSTC_WRAPPER", "kache"),
         ]);
-        assert_eq!(resolve_probe_compiler("kache", vars), None);
+        assert_eq!(resolve_probe_compiler("kache", None, vars), None);
+    }
+
+    #[test]
+    fn probe_compiler_prefers_target_specific_cc_var() {
+        // mozbuild sets both a host and a target compiler. With TARGET
+        // known, kache must pick the target-specific var the cc crate
+        // actually read — not whichever the environment lists first.
+        let vars = env(&[
+            ("HOST_CC", "kache gcc"),
+            ("CC_aarch64_pc_windows_msvc", "kache clang-cl.exe"),
+        ]);
+        assert_eq!(
+            resolve_probe_compiler("kache", Some("aarch64-pc-windows-msvc"), vars),
+            Some("clang-cl.exe".to_string())
+        );
+    }
+
+    #[test]
+    fn probe_compiler_matches_dashed_target_cc_var() {
+        // The cc crate also reads the un-underscored `CC_<triple>` form.
+        let vars = env(&[("CC_aarch64-pc-windows-msvc", "kache clang-cl.exe")]);
+        assert_eq!(
+            resolve_probe_compiler("kache", Some("aarch64-pc-windows-msvc"), vars),
+            Some("clang-cl.exe".to_string())
+        );
+    }
+
+    #[test]
+    fn probe_compiler_target_specific_beats_bare_cc() {
+        let vars = env(&[
+            ("CC", "kache gcc"),
+            ("CC_x86_64_unknown_linux_gnu", "kache clang"),
+        ]);
+        assert_eq!(
+            resolve_probe_compiler("kache", Some("x86_64-unknown-linux-gnu"), vars),
+            Some("clang".to_string())
+        );
+    }
+
+    #[test]
+    fn probe_compiler_deterministic_when_target_unknown() {
+        // Two target-suffixed vars and no TARGET to disambiguate: the pick
+        // must be stable across environment iteration order, not flaky.
+        let a = env(&[("CC_zzz", "kache zzz-cc"), ("CC_aaa", "kache aaa-cc")]);
+        let b = env(&[("CC_aaa", "kache aaa-cc"), ("CC_zzz", "kache zzz-cc")]);
+        assert_eq!(
+            resolve_probe_compiler("kache", None, a),
+            Some("aaa-cc".to_string())
+        );
+        assert_eq!(
+            resolve_probe_compiler("kache", None, b),
+            Some("aaa-cc".to_string())
+        );
     }
 
     #[test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -126,7 +126,12 @@ fn probe_forward_compiler() -> String {
     let env_vars = std::env::vars_os()
         .filter_map(|(k, v)| Some((k.into_string().ok()?, v.into_string().ok()?)));
 
-    crate::compiler::cc::resolve_probe_compiler(&self_stem, env_vars)
+    // Cargo sets `TARGET` for build scripts — the same triple the cc
+    // crate keys its `CC_<target>` lookup on — so kache can resolve the
+    // exact variable the cc crate read when several are kache-wrapped.
+    let target = std::env::var("TARGET").ok();
+
+    crate::compiler::cc::resolve_probe_compiler(&self_stem, target.as_deref(), env_vars)
         .unwrap_or_else(|| "cc".to_string())
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -74,33 +74,60 @@ fn event_result_for_store_put(put: StorePutResult) -> EventResult {
 }
 
 /// Forward a `cc`-crate compiler-family probe (`kache -E <file>`) to
-/// the system default `cc`.
+/// the real underlying compiler.
 ///
-/// **Why this exists.** When `CC="kache cc"`, the `cc` Rust crate
-/// detects compiler family by running `Command::new(program).arg("-E").
-/// arg(tmp.path())` — and `program` is just the first whitespace-split
-/// component (`kache`), with the trailing `cc` arg dropped. So kache
-/// gets called with argv that starts with a flag, not a recognized
-/// compiler. Without this passthrough, kache clap-errors and the cc
-/// crate falls back to a default family guess. That's a logged warning
-/// today; once C/C++ caching lands and family identifies the cache
-/// key, it becomes silent miscaching across machines.
+/// **Why this exists.** When `CC="kache <compiler>"`, the `cc` Rust
+/// crate detects compiler family by running `Command::new(program).
+/// arg("-E").arg(tmp.path())` — and `program` is just the first
+/// whitespace-split component (`kache`), with the trailing `<compiler>`
+/// arg dropped (kache is not in the crate's known-wrapper allowlist).
+/// So kache gets called with argv that starts with a flag, not a
+/// recognized compiler. Without this passthrough, kache clap-errors,
+/// the cc crate falls back to a default family guess — and on Windows
+/// MSVC that default is GNU, which is unsupported for the target, so
+/// the whole build aborts (issue #286).
 ///
-/// **Why we use system `cc`.** The probe is family-detection — the
-/// answer the cc crate wants is whatever the underlying compiler would
-/// say. Forwarding to `cc` from PATH gets the right answer on every
-/// unix host. If `cc` isn't on PATH, the spawn returns an error and
-/// the probe still fails — same end state as today, no regression.
+/// **Which compiler we forward to.** The answer the cc crate wants is
+/// whatever the *underlying* compiler would say. We recover it from the
+/// same `CC`/`CXX` environment variable the cc crate read — it still
+/// holds `kache <compiler>` — via
+/// [`resolve_probe_compiler`](crate::compiler::cc::resolve_probe_compiler).
+/// That gives the genuine family on every platform, including the
+/// Windows `clang-cl` case where no `cc` exists on PATH. Only when no
+/// kache-wrapped compiler variable is present do we fall back to the
+/// system `cc` (the original unix behaviour).
 ///
 /// stdout / stderr inherit so the cc crate reads the preprocessor
 /// output verbatim. Exit code propagates so a real probe failure
-/// (missing system cc, malformed probe file) still surfaces.
+/// (missing compiler, malformed probe file) still surfaces.
 pub fn run_cc_probe(args: &[String]) -> Result<i32> {
-    let status = std::process::Command::new("cc")
+    let program = probe_forward_compiler();
+    let status = std::process::Command::new(&program)
         .args(args)
         .status()
-        .context("spawning system `cc` to forward cc-crate compiler-family probe")?;
+        .with_context(|| {
+            format!("spawning `{program}` to forward cc-crate compiler-family probe")
+        })?;
     Ok(status.code().unwrap_or(1))
+}
+
+/// Resolve the compiler a cc-crate family probe should forward to: the
+/// real compiler recovered from `CC`/`CXX`, else the system `cc`.
+fn probe_forward_compiler() -> String {
+    let self_stem = std::env::current_exe()
+        .ok()
+        .as_deref()
+        .and_then(Path::file_stem)
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "kache".to_string());
+
+    // `vars_os` + lossy filter rather than `vars()`, which panics if
+    // *any* environment variable holds non-UTF-8 (plausible on Windows).
+    let env_vars = std::env::vars_os()
+        .filter_map(|(k, v)| Some((k.into_string().ok()?, v.into_string().ok()?)));
+
+    crate::compiler::cc::resolve_probe_compiler(&self_stem, env_vars)
+        .unwrap_or_else(|| "cc".to_string())
 }
 
 /// Run kache as a C-family compiler wrapper (`CC=kache cc`,

--- a/tests/cc_family_probe_test.rs
+++ b/tests/cc_family_probe_test.rs
@@ -1,0 +1,114 @@
+//! End-to-end regression test for the `cc`-crate compiler-family probe
+//! (issue #286: "Firefox fails to build swgl").
+//!
+//! When `CC="kache <compiler>"`, the `cc` crate mis-parses it (kache is
+//! not in the crate's known-wrapper allowlist), treats kache as the
+//! compiler, and runs the family probe as `kache -E <file>` — dropping
+//! `<compiler>`. kache must recover the real compiler from the
+//! environment and forward the probe to it. The old code hard-coded a
+//! spawn of the system `cc`, which does not exist on Windows MSVC
+//! toolchains, so the probe failed and the cc crate fell back to an
+//! unsupported GNU family, aborting the whole build.
+//!
+//! This drives the real `kache` binary as the probe with `CC` pointing
+//! at `kache <fake-compiler>`, and asserts the probe is forwarded to the
+//! fake compiler (whose marker shows up on stdout) rather than the
+//! system `cc`. Unix-only: it relies on a shell-script stand-in for the
+//! compiler. The Windows shapes are covered by the `resolve_probe_compiler`
+//! unit tests in `src/compiler/cc.rs`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Path to the kache binary under test (Cargo sets this for the
+/// integration-test harness).
+fn kache_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_kache")
+}
+
+/// The marker the fake compiler prints — proof the probe reached *it*
+/// and not the system `cc`.
+const FAKE_MARKER: &str = "__KACHE_FAKE_COMPILER_FAMILY_PROBE__";
+
+#[test]
+fn family_probe_forwards_to_real_compiler_recovered_from_cc_env() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // A fake compiler: ignores its args, prints a unique marker. Stands
+    // in for clang-cl on a host where `cc` may or may not exist.
+    let fake = dir.path().join("fake-cc.sh");
+    fs::write(&fake, format!("#!/bin/sh\necho '{FAKE_MARKER}'\nexit 0\n")).unwrap();
+    fs::set_permissions(&fake, fs::Permissions::from_mode(0o755)).unwrap();
+
+    // The probe file the cc crate would have created (contents irrelevant
+    // — the fake compiler ignores it).
+    let probe_file = dir.path().join("detect_compiler_family.c");
+    fs::write(&probe_file, b"int main(void){return 0;}\n").unwrap();
+
+    // Hermetic cache/config so the probe run touches nothing real.
+    let cache_dir = dir.path().join("cache");
+    let config = dir.path().join("kache.toml");
+
+    // Reproduce the cc crate's mis-parse: CC = "<kache> <real-compiler>".
+    // The cc crate would invoke `kache -E <probe_file>`, dropping the
+    // real compiler from argv — so kache must recover it from CC here.
+    let cc_value = format!("{} {}", kache_binary(), fake.display());
+
+    let output = Command::new(kache_binary())
+        .args(["-E", probe_file.to_str().unwrap()])
+        .env("CC", &cc_value)
+        .env("KACHE_CACHE_DIR", &cache_dir)
+        .env("KACHE_CONFIG", &config)
+        // Make sure a stray `cc` on PATH can't accidentally satisfy the
+        // probe and mask a regression: an empty PATH means the old
+        // hard-coded `cc` spawn fails outright.
+        .env("PATH", "")
+        .output()
+        .expect("failed to run kache as a cc-family probe");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "probe should succeed by forwarding to the recovered compiler; \
+         status={:?}\nstdout={stdout}\nstderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains(FAKE_MARKER),
+        "probe must forward to the CC-recovered compiler (marker missing). \
+         Got stdout: {stdout:?}"
+    );
+}
+
+/// Sanity: when no kache-wrapped CC variable exists, the probe falls
+/// back to the system `cc` (preserving the original unix behaviour).
+/// We only assert it does NOT pick up the fake compiler — proving the
+/// fallback path is distinct from the recovery path.
+#[test]
+fn family_probe_without_kache_cc_does_not_use_fake_compiler() {
+    let dir = tempfile::tempdir().unwrap();
+    let probe_file = dir.path().join("detect_compiler_family.c");
+    fs::write(&probe_file, b"int main(void){return 0;}\n").unwrap();
+
+    let _ = PathBuf::from(kache_binary());
+    let output = Command::new(kache_binary())
+        .args(["-E", probe_file.to_str().unwrap()])
+        // No CC var → nothing to recover → fall back to system `cc`.
+        .env_remove("CC")
+        .env_remove("CXX")
+        .env("KACHE_CACHE_DIR", dir.path().join("cache"))
+        .env("KACHE_CONFIG", dir.path().join("kache.toml"))
+        .output()
+        .expect("failed to run kache as a cc-family probe");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains(FAKE_MARKER),
+        "fallback path must not invent the fake compiler"
+    );
+}


### PR DESCRIPTION
## Problem

`kache` is used as both `RUSTC_WRAPPER` and a C-compiler wrapper. Firefox/mozbuild sets, e.g.:

```
CC_aarch64_pc_windows_msvc = "C:/Users/.../kache.exe C:/Users/.../clang-cl.exe"
```

But **`kache` is not in the `cc` crate's hard-coded known-wrapper allowlist** (`ccache`, `distcc`, `sccache`, `icecc`, `cachepot`, `buildcache`). So the cc crate mis-parses that value — it treats `kache` as the *compiler* and `clang-cl.exe` as a leading argument, then **drops that argument** during compiler-family detection, which runs:

```
kache.exe -E detect_compiler_family.c
```

kache routed this probe to `run_cc_probe`, which **hard-coded spawning `cc`**. On a Windows MSVC toolchain there is no `cc` on PATH → exit 1 → the cc crate falls back on the filename (`kache.exe`, no clang/cl marker) → **GNU** → *"GNU compiler is not supported for this target"* → `mozmake` Error 101. (issue #286)

## Fix

Instead of blindly spawning `cc`, recover the **real compiler from the environment**: the same `CC`/`CXX` variable the cc crate read still holds `kache <compiler>`. `resolve_probe_compiler` scans those variables, finds the one whose first token is kache itself, and returns `<compiler>`, so the probe forwards to the genuine compiler (`clang-cl.exe`) and reports the correct family on every platform. Falls back to system `cc` only when no kache-wrapped variable is present (preserving prior unix behavior).

This also closes the latent "silent miscaching across machines" concern the old code's own comment flagged — the family is now genuinely correct rather than "whatever `cc` happens to be".

## Tests

- **8 unit tests** (`src/compiler/cc.rs`) for `resolve_probe_compiler`: the exact `CC_aarch64_pc_windows_msvc = "kache.exe clang-cl.exe"` shape, `CXX`, case-insensitive `.EXE`, CC-over-CXX preference, and negatives (`CFLAGS`/`CXXFLAGS`/`CCACHE_*`/`RUSTC_WRAPPER` ignored, non-kache `CC`, self-only).
- **2 unix integration tests** (`tests/cc_family_probe_test.rs`) driving the real binary as a probe — verified to **fail** against the old hard-coded `cc` (reproduces the exact issue error) and pass with the fix.

The Windows-only bug now has cross-platform regression guards that run on macOS/Linux CI.

Fixes #286