### PR TITLE
Robustness quick wins: list_keys loop, blob dir fsync, RUSTC_BOOTSTRAP key, spawn-failure fallback

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -581,6 +581,23 @@ pub fn compute_cache_key(
         );
     }
 
+    // RUSTC_BOOTSTRAP changes what rustc accepts — nightly-only
+    // `#![feature(...)]` and unstable `-Z` flags on a stable/beta toolchain —
+    // so byte-identical source can compile differently (or succeed vs fail)
+    // purely because this var is set. It's consumed by the driver and never
+    // surfaces as a source env-dep, so the `-Z`/`#![feature]` bytes are keyed
+    // but the var's presence was not. Fold it in only when set, so the key is
+    // byte-identical for the common case (var unset): no CACHE_KEY_VERSION bump
+    // and no cache invalidation for existing users.
+    if let Ok(bootstrap) = std::env::var("RUSTC_BOOTSTRAP")
+        && !bootstrap.is_empty()
+    {
+        hasher.update(b"RUSTC_BOOTSTRAP:");
+        hasher.update(bootstrap.as_bytes());
+        hasher.update(b"\n");
+        tracing::trace!("[key:{}] RUSTC_BOOTSTRAP={}", crate_name, bootstrap);
+    }
+
     // Sysroot override (`--sysroot`). Selects which std/core/proc-macro
     // libs rustc links against, so two builds of the same rustc binary
     // with different sysroots (custom-built std, `-Zbuild-std`) must not
@@ -3079,6 +3096,54 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             Some(value) => unsafe { std::env::set_var(key, value) },
             None => unsafe { std::env::remove_var(key) },
         }
+    }
+
+    #[test]
+    fn key_rustc_bootstrap_presence_changes_key_but_empty_is_identity() {
+        let _lock = key_test_lock();
+        if !rustc_available() {
+            return;
+        }
+        let old = std::env::var_os("RUSTC_BOOTSTRAP");
+
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("lib.rs");
+        std::fs::write(&src, "pub fn f() {}\n").unwrap();
+        let args = base_args(&src);
+
+        unsafe {
+            std::env::remove_var("RUSTC_BOOTSTRAP");
+        }
+        let key_unset = key_for(&args);
+
+        // Empty must hash identically to unset: that is what keeps existing
+        // caches valid (no CACHE_KEY_VERSION bump for the common case).
+        unsafe {
+            std::env::set_var("RUSTC_BOOTSTRAP", "");
+        }
+        let key_empty = key_for(&args);
+
+        unsafe {
+            std::env::set_var("RUSTC_BOOTSTRAP", "1");
+        }
+        let key_set = key_for(&args);
+
+        unsafe {
+            std::env::set_var("RUSTC_BOOTSTRAP", "some_crate");
+        }
+        let key_other = key_for(&args);
+
+        restore_env_var("RUSTC_BOOTSTRAP", old);
+
+        assert_eq!(
+            key_unset, key_empty,
+            "empty RUSTC_BOOTSTRAP must equal unset"
+        );
+        assert_ne!(key_unset, key_set, "RUSTC_BOOTSTRAP=1 must change the key");
+        assert_ne!(
+            key_set, key_other,
+            "different RUSTC_BOOTSTRAP values must differ"
+        );
     }
 
     // ── "should change" cases — varying a codegen-affecting input ──

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -230,10 +230,15 @@ impl<'a> RemoteLayout<'a> {
                 }
             }
 
-            if resp.is_truncated == Some(true) {
-                continuation_token = resp.next_continuation_token().map(|s| s.to_string());
-            } else {
-                break;
+            // A truncated response must carry a continuation token. Some
+            // non-AWS S3 implementations (MinIO/Ceph RGW/R2/proxies) have
+            // emitted is_truncated=true with a missing/empty token; treat that
+            // as end-of-pagination rather than looping forever re-listing page 1.
+            match resp.next_continuation_token() {
+                Some(token) if resp.is_truncated == Some(true) && !token.is_empty() => {
+                    continuation_token = Some(token.to_string());
+                }
+                _ => break,
             }
         }
 
@@ -278,10 +283,14 @@ impl<'a> RemoteLayout<'a> {
                     }
                 }
 
-                if resp.is_truncated == Some(true) {
-                    continuation_token = resp.next_continuation_token().map(|s| s.to_string());
-                } else {
-                    break;
+                // See list_keys: guard against a truncated response with no
+                // usable continuation token (non-AWS S3) to avoid an infinite
+                // re-list of page 1.
+                match resp.next_continuation_token() {
+                    Some(token) if resp.is_truncated == Some(true) && !token.is_empty() => {
+                        continuation_token = Some(token.to_string());
+                    }
+                    _ => break,
                 }
             }
         }

--- a/src/store.rs
+++ b/src/store.rs
@@ -42,6 +42,19 @@ fn fsync_file(path: &Path) -> std::io::Result<()> {
     file.sync_all()
 }
 
+/// fsync a directory so a rename/create into it survives a crash. Without it,
+/// a blob's contents can be durable while its directory entry is not, leaving a
+/// committed entry pointing at a phantom-missing blob. No-op on non-Unix:
+/// Windows has no directory-handle fsync and `File::open` on a directory fails.
+#[cfg(unix)]
+fn fsync_dir(dir: &Path) -> std::io::Result<()> {
+    fs::File::open(dir)?.sync_all()
+}
+#[cfg(not(unix))]
+fn fsync_dir(_dir: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
 /// A unique temp path beside the destination blob. Concurrent writers of the
 /// same hash must not share a temp file (a fixed `<hash>.tmp` lets one truncate
 /// the other mid-copy), so we disambiguate by pid + a process-local counter.
@@ -101,6 +114,12 @@ fn materialize_blob(source: &Path, blob: &Path, hash: &str) -> Result<()> {
     }
     fs::rename(&tmp, blob).context("atomic rename of blob")?;
     set_blob_readonly(blob);
+    // Flush the shard directory so the rename is durable across a power loss;
+    // best-effort, since the blob bytes are already fsynced and a missing dir
+    // entry self-heals to a cache miss rather than corruption.
+    if let Some(parent) = blob.parent() {
+        let _ = fsync_dir(parent);
+    }
     Ok(())
 }
 
@@ -1472,6 +1491,13 @@ mod tests {
         let blob = dir.path().join("blob.bin");
         fs::write(&blob, b"some bytes").unwrap();
         fsync_file(&blob).expect("fsync of a writable file must succeed on all platforms");
+    }
+
+    #[test]
+    fn fsync_dir_succeeds_on_a_real_directory() {
+        // On Unix this exercises the open+sync_all path; elsewhere it's a no-op.
+        let dir = tempfile::tempdir().unwrap();
+        fsync_dir(dir.path()).expect("fsync of a directory must not error");
     }
 
     fn test_config(dir: &Path) -> Config {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -327,7 +327,22 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     // ── Cache miss — compile, then store ─────────────────────────
     let compile_start = std::time::Instant::now();
-    let result = compiler.execute(&parsed)?;
+    let result = match compiler.execute(&parsed) {
+        Ok(r) => r,
+        // A spawn-level failure (missing binary, ENOMEM, fork pressure under
+        // load) must not abort the build: fall back to passthrough so the
+        // configured fallback wrapper still gets a chance and the user sees the
+        // real compiler error rather than a kache anyhow chain.
+        Err(e) => {
+            return cc_passthrough_with_event(
+                config,
+                &parsed,
+                &crate_name,
+                start,
+                format!("compiler spawn failed: {e}"),
+            );
+        }
+    };
     let compile_time_ms = compile_start.elapsed().as_millis() as u64;
 
     if !result.stdout.is_empty() {
@@ -946,7 +961,22 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         &cache_key[..16]
     );
     let compile_start = std::time::Instant::now();
-    let result = compiler.execute(&args)?;
+    let result = match compiler.execute(&args) {
+        Ok(r) => r,
+        // A spawn-level failure (missing binary, ENOMEM, fork pressure under
+        // load) must not abort the build: fall back to passthrough so the
+        // configured fallback wrapper still gets a chance and the user sees the
+        // real compiler error rather than a kache anyhow chain.
+        Err(e) => {
+            return passthrough_with_event(
+                config,
+                &args,
+                crate_name,
+                start,
+                format!("compiler spawn failed: {e}"),
+            );
+        }
+    };
     let compile_time_ms = compile_start.elapsed().as_millis() as u64;
 
     // Print rustc output


### PR DESCRIPTION
Four small, independent robustness/correctness fixes from the code-review backlog,
one commit each. All build clean (`-D warnings`) with tests.

Closes #277
Closes #278
Closes #279
Closes #280

### #278 — list_keys infinite loop (`remote_layout.rs`)
`list_keys` / `list_keys_for_crates` only advanced the continuation token inside the
`is_truncated` branch; a truncated response with a missing/empty token set the token
to `None`, so the next request re-listed page 1 — reporting the same state — looping
forever and flooding the bucket. AWS S3 always sends a token when truncated, but
MinIO/Ceph RGW/R2/proxies have not. Now treats truncated-without-token as
end-of-pagination.

### #279 — blob shard-dir fsync (`store.rs`)
`materialize_blob` fsynced the blob contents and renamed atomically but never fsynced
the parent shard directory (no directory fsync existed anywhere). With the index DB on
WAL + `synchronous=NORMAL`, a power loss could make entry registration durable while
the renamed blob's dir entry was lost. Adds a best-effort `fsync_dir` (no-op on
non-Unix) after the rename. Self-heals to a miss, so it's best-effort.

### #277 — RUSTC_BOOTSTRAP in the cache key (`cache_key.rs`)
`RUSTC_BOOTSTRAP` makes stable/beta rustc accept nightly features and `-Z` flags, so
identical source can compile differently — yet it was never keyed. Folded in **only
when set and non-empty**, so the key is byte-identical for the common case (var unset):
no `CACHE_KEY_VERSION` bump, no cache invalidation.

### #280 — passthrough on spawn failure (`wrapper.rs`)
On a cache miss both paths ran `compiler.execute(..)?`; `execute` returns `Err` only on
a spawn failure (missing binary, ENOMEM, fork pressure), and that `?` exited 1 with a
kache anyhow chain — the one hot-loop path that didn't degrade to passthrough. Now
routes a spawn-level `Err` to `(cc_)passthrough_with_event` so the fallback wrapper
gets a chance and the user sees the real compiler error.

### Tests
New: `key_rustc_bootstrap_presence_changes_key_but_empty_is_identity` (proves empty ==
unset), `fsync_dir_succeeds_on_a_real_directory`. Full `cache_key` (72), `remote_layout`
(6), and `wrapper` (7) suites pass.
