### PR TITLE
chore(release): bump version to 0.5.1-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.5.1-rc.2"
+version = "0.5.1-rc.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.5.1-rc.2"
+version = "0.5.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.5.1-rc.2"
+version = "0.5.1-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.5.1-rc.2"
+version = "0.5.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.5.1-rc.2"
+version = "0.5.1-rc.3"
 edition = "2024"
 description = "Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — just hardlinks locally and S3 for sharing."
 license = "Apache-2.0"
@@ -45,7 +45,7 @@ aws-smithy-http-client = { version = "1", features = ["rustls-ring"] }
 # Direct dep so we can install ring as the process-wide rustls crypto
 # provider (reqwest uses `rustls-no-provider`, so one must be installed).
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.5.1-rc.2", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.5.1-rc.3", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.5.1-rc.2"
+version = "0.5.1-rc.3"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.5.1-rc.2"
+version = "0.5.1-rc.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.5.1-rc.2"
+version = "0.5.1-rc.3"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps the workspace to `0.5.1-rc.3` via `just bump`.

Purpose: re-run the release pipeline against the **fixed Windows-msvc cross toolchain**. rc.1 and rc.2's `*-pc-windows-msvc` builds never linked because the shared release workflow (`_release-rust.yml@v10`) installed Ubuntu's stale **clang-18**, which mis-compiles zstd-sys (SSE2 `_mm_*` undefined at link, x86_64) and the MSVC `<intrin.h>` (`__prefetch` conflicting types, aarch64 — via zstd-sys + rusqlite bundled).

Fix landed in **Zondax/_workflows#99** (clang/lld 21 from apt.llvm.org); `v10` now points at it. Verified locally: clang-22 builds both Windows targets to working PE32+ binaries; clang-18 fails both.

After merge: `just release` cuts `v0.5.1-rc.3` → fresh pipeline that resolves `@v10` to the fixed toolchain.