### PR TITLE
fix(cc): default cc path normalization off on Windows (#299)

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1793,7 +1793,9 @@ fn cc_prefix_maps(parsed: &CcArgs) -> Vec<CcPrefixMap> {
     // no maps → the key hashes raw paths AND `execute` injects no
     // `-ffile-prefix-map`. The conservative escape hatch — cc keys become
     // path-literal (no cross-machine cc sharing, but zero normalization
-    // miscache risk). Default on.
+    // miscache risk). Default on everywhere except Windows, where it is
+    // off (issue #299: clang's `-ffile-prefix-map` rewrites `__FILE__` and
+    // mangles its `\` separators) — see `parse_cc_normalize_toggle`.
     if !cc_path_normalize_enabled() {
         return Vec::new();
     }
@@ -1833,18 +1835,36 @@ fn cc_prefix_maps_cfg(parsed: &CcArgs, cwd: &Path, base_dir: Option<&Path>) -> V
 }
 
 /// Whether cc path normalization is active. `KACHE_CC_PATH_NORMALIZE` set
-/// to `0` / `false` / `off` / `no` disables it; default on.
+/// to `0` / `false` / `off` / `no` disables it; `1` / anything else
+/// enables it. With no explicit value the default is platform-dependent:
+/// ON everywhere except Windows (see [`parse_cc_normalize_toggle`]).
 fn cc_path_normalize_enabled() -> bool {
-    parse_cc_normalize_toggle(std::env::var("KACHE_CC_PATH_NORMALIZE").ok().as_deref())
+    parse_cc_normalize_toggle(
+        std::env::var("KACHE_CC_PATH_NORMALIZE").ok().as_deref(),
+        cfg!(windows),
+    )
 }
 
-fn parse_cc_normalize_toggle(value: Option<&str>) -> bool {
+/// Resolve the cc-path-normalization toggle from an optional env value and
+/// the host kind. Pure (host passed in) so both platform defaults are
+/// unit-testable on any machine.
+///
+/// An explicit env value always wins. With no value, the default is ON —
+/// **except on Windows**, where it is OFF (issue #299): the
+/// `-ffile-prefix-map` flags this gate would otherwise inject make clang
+/// rewrite `__FILE__` and normalize its `\` separators to `/`, which
+/// silently changes the program's observable `__FILE__` and breaks builds
+/// that assert on the native spelling (Firefox's `location.cc`
+/// `static_assert`). Windows users who want cross-machine cc sharing —
+/// and accept the `__FILE__` rewrite — opt back in with
+/// `KACHE_CC_PATH_NORMALIZE=1`.
+fn parse_cc_normalize_toggle(value: Option<&str>, is_windows: bool) -> bool {
     match value {
         Some(v) => !matches!(
             v.trim().to_ascii_lowercase().as_str(),
             "0" | "false" | "off" | "no"
         ),
-        None => true,
+        None => !is_windows,
     }
 }
 
@@ -4592,30 +4612,57 @@ mod tests {
         );
     }
 
-    /// The kill-switch: any explicit off-value disables cc path
-    /// normalization; everything else (including unset and empty) leaves it
-    /// on — normalization is the default, opt-out only.
+    /// An explicit env value always wins, regardless of host: any
+    /// off-value disables cc path normalization; everything else
+    /// (including empty / garbage) keeps it on. This is the opt-in knob
+    /// Windows users reach for to recover cross-machine cc sharing.
     #[test]
-    fn parse_cc_normalize_toggle_defaults_on_opts_out_explicitly() {
-        for on in [
-            None,
-            Some("1"),
-            Some("yes"),
-            Some("on"),
-            Some(""),
-            Some("garbage"),
-        ] {
-            assert!(parse_cc_normalize_toggle(on), "{on:?} should keep it on");
+    fn parse_cc_normalize_toggle_honors_explicit_value_on_every_host() {
+        for is_windows in [false, true] {
+            for on in [
+                Some("1"),
+                Some("yes"),
+                Some("on"),
+                Some(""),
+                Some("garbage"),
+            ] {
+                assert!(
+                    parse_cc_normalize_toggle(on, is_windows),
+                    "{on:?} should keep it on (is_windows={is_windows})"
+                );
+            }
+            for off in [
+                Some("0"),
+                Some("false"),
+                Some("off"),
+                Some("no"),
+                Some("  OFF "),
+            ] {
+                assert!(
+                    !parse_cc_normalize_toggle(off, is_windows),
+                    "{off:?} should disable it (is_windows={is_windows})"
+                );
+            }
         }
-        for off in [
-            Some("0"),
-            Some("false"),
-            Some("off"),
-            Some("no"),
-            Some("  OFF "),
-        ] {
-            assert!(!parse_cc_normalize_toggle(off), "{off:?} should disable it");
-        }
+    }
+
+    /// Issue #299: with no explicit env override, cc path normalization is
+    /// ON everywhere EXCEPT Windows. On Windows, the `-ffile-prefix-map`
+    /// flags kache would inject make clang rewrite `__FILE__` (and mangle
+    /// its backslash separators to forward slashes), breaking builds that
+    /// assert on the native `__FILE__` spelling (e.g. Firefox's
+    /// `security/sandbox/.../location.cc`). So Windows defaults off and
+    /// users opt back in with `KACHE_CC_PATH_NORMALIZE=1`.
+    #[test]
+    fn parse_cc_normalize_toggle_default_is_off_on_windows_on_elsewhere() {
+        assert!(
+            parse_cc_normalize_toggle(None, false),
+            "non-Windows hosts default cc path normalization ON"
+        );
+        assert!(
+            !parse_cc_normalize_toggle(None, true),
+            "Windows defaults cc path normalization OFF (issue #299)"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Fixes #299.

## Root cause

On a cache miss, kache injects `-ffile-prefix-map=<root>=<sentinel>` into the real compile (`src/compiler/cc.rs` `execute`) so cached objects don't embed clone-local build/source roots — this is what makes cross-machine cc caching work.

`-ffile-prefix-map` is `-fdebug-prefix-map` **+ `-fmacro-prefix-map`**. I verified on real clang:

| flag | rewrites `__FILE__`? |
|------|----------------------|
| `-fdebug-prefix-map` | no |
| `-fmacro-prefix-map` | **yes** |
| `-ffile-prefix-map` | **yes** (implies macro) |

So the injected flag rewrites `__FILE__`. On Windows, clang's prefix mapper additionally normalizes `__FILE__`'s `\` separators to `/`. kache passes the source path to the compiler **verbatim** (`rest.to_vec()`), so the injected `-ffile-prefix-map` is the sole cause.

This breaks any source that asserts on the native `__FILE__` spelling. Firefox's `security/sandbox/chromium/base/location.cc`:

```cpp
static_assert(StrEndsWith(__FILE__, kStrippedPrefixLength, "base\\location.cc"), ...)
```

`__FILE__` arrives as `D:/firefox/.../base/location.cc` (forward slashes) instead of `...base\location.cc` → assertion fails → build aborts.

## Why this fix

There is **no clang flag** that remaps `__FILE__` while preserving native separators. Keeping `-fdebug-prefix-map` but dropping `-fmacro-prefix-map`, while the cache key still maps `__FILE__` in the preprocessed text, would let two machines with different paths share a key but produce objects with different `__FILE__` strings — a **miscache**. So the coherent, correctness-first fix is to disable cc path normalization on Windows entirely (key + compile stay consistent on raw paths).

**Change:** default `KACHE_CC_PATH_NORMALIZE` to **off on Windows**, unchanged (on) elsewhere.

- Windows cc keys become path-literal: no cross-machine cc cache sharing by default, but `__FILE__` is untouched and builds are correct. Local (same-path) caching is unaffected.
- Opt back in with `KACHE_CC_PATH_NORMALIZE=1` (accepting the `__FILE__` rewrite) to recover cross-machine sharing.
- The existing `=0` kill-switch still works everywhere.

## Tests

`parse_cc_normalize_toggle` now takes the host kind as a parameter, so **both platform defaults are unit-testable on any machine** — the same host-independent approach used for the sibling Windows cc bug #286 ("Firefox fails to build swgl", whose Windows shapes are covered by unit tests rather than a Windows-only integration test).

- `parse_cc_normalize_toggle_default_is_off_on_windows_on_elsewhere` — the regression guard for #299.
- `parse_cc_normalize_toggle_honors_explicit_value_on_every_host` — explicit env override still wins on every host (the opt-in path).

Full `kache` test suite: 695 passed. `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.

### Note on a Windows e2e scenario

I considered a `scenarios/` fixture to reproduce the symptom on the self-hosted Windows runner, but did not add one: the fixture schema can't swap the source per-OS, the `__FILE__` separator is intrinsically Unix-incompatible to assert, and the e2e harness drives compiles through MSYS `make` (forward-slash paths) rather than Firefox's `mozmake` (backslashes), so a fixture likely wouldn't even reproduce the backslash condition — and it can't be validated from a Unix dev box. The host-independent unit tests are the durable guard, consistent with the #286 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)