### PR TITLE
fix(cc): splice -ffile-prefix-map flags before the `--` separator (#300)

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2750,6 +2750,12 @@ fn file_prefix_map_args(prefix_maps: &[CcPrefixMap]) -> Vec<String> {
 /// multiple source files` (#300). Splicing them in ahead of `--` keeps
 /// them classified as options. With no `--` present this is a plain
 /// append, identical to the prior behaviour.
+///
+/// Splices before the *first* bare `--` — the only token clang/clang-cl/
+/// gcc treat as the end-of-options marker (later `--` are inputs). It
+/// matches `rest` literally, so a `--` that is some option's separated
+/// value, or one hidden inside an `@response-file`, is not recognised;
+/// both are out of scope for the cc-rs `-c` compiles that reach here.
 fn compose_cc_args(rest: &[String], appended: Vec<String>) -> Vec<String> {
     if appended.is_empty() {
         return rest.to_vec();
@@ -5485,6 +5491,33 @@ mod tests {
     fn compose_cc_args_is_identity_when_nothing_appended() {
         let rest = s(&["-c", "-Fofoo.o", "--", "windows.c"]);
         assert_eq!(compose_cc_args(&rest, Vec::new()), rest);
+    }
+
+    #[test]
+    fn compose_cc_args_splices_before_the_first_double_dash() {
+        // Only the first bare `--` is the end-of-options marker; a later
+        // `--` is an input. Splicing before the first keeps the injected
+        // flags as options regardless of any trailing `--`.
+        let rest = s(&["-c", "--", "a.c", "--", "b.c"]);
+        let out = compose_cc_args(&rest, s(&["-ffile-prefix-map=/a=<CC_ROOT>"]));
+        assert_eq!(
+            out,
+            s(&[
+                "-c",
+                "-ffile-prefix-map=/a=<CC_ROOT>",
+                "--",
+                "a.c",
+                "--",
+                "b.c"
+            ])
+        );
+    }
+
+    #[test]
+    fn compose_cc_args_handles_double_dash_as_first_token() {
+        let rest = s(&["--", "a.c"]);
+        let out = compose_cc_args(&rest, s(&["-ffile-prefix-map=/a=<CC_ROOT>"]));
+        assert_eq!(out, s(&["-ffile-prefix-map=/a=<CC_ROOT>", "--", "a.c"]));
     }
 
     #[cfg(unix)]

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2738,6 +2738,38 @@ fn file_prefix_map_args(prefix_maps: &[CcPrefixMap]) -> Vec<String> {
         .collect()
 }
 
+/// Compose the final argv for an `execute` invocation: the original
+/// args with kache's `appended` flags placed *before* the `--`
+/// end-of-options separator if one is present, otherwise at the end.
+///
+/// The clang / clang-cl driver treats every token after `--` as an
+/// input file, not a flag — and cc-rs emits `--` before the source on
+/// clang-cl invocations. Appending `-ffile-prefix-map=…` after that
+/// separator makes the driver see the flags as extra source files,
+/// producing `clang-cl: error: cannot specify '-Fo…' when compiling
+/// multiple source files` (#300). Splicing them in ahead of `--` keeps
+/// them classified as options. With no `--` present this is a plain
+/// append, identical to the prior behaviour.
+fn compose_cc_args(rest: &[String], appended: Vec<String>) -> Vec<String> {
+    if appended.is_empty() {
+        return rest.to_vec();
+    }
+    match rest.iter().position(|a| a == "--") {
+        Some(sep) => {
+            let mut out = Vec::with_capacity(rest.len() + appended.len());
+            out.extend_from_slice(&rest[..sep]);
+            out.extend(appended);
+            out.extend_from_slice(&rest[sep..]);
+            out
+        }
+        None => {
+            let mut out = rest.to_vec();
+            out.extend(appended);
+            out
+        }
+    }
+}
+
 fn cc_trace_name(parsed: &CcArgs) -> String {
     parsed
         .sources
@@ -3305,15 +3337,15 @@ impl Compiler for CcCompiler {
 
         // Invoke the underlying compiler with the original argv, plus a
         // set of `-ffile-prefix-map` rules so the object doesn't embed
-        // clone-local build/source roots. Appended last so they win
-        // over any user-supplied map for the same prefix.
+        // clone-local build/source roots. Spliced in before any `--`
+        // separator (see `compose_cc_args`) so the driver still reads
+        // them as flags, then last among the flags so they win over any
+        // user-supplied map for the same prefix.
         crate::opcounts::record_compiler_run();
         let mut command = Command::new(&parsed.program);
-        command.args(&parsed.rest);
         let prefix_maps = cc_prefix_maps(parsed);
-        for flag in file_prefix_map_args(&prefix_maps) {
-            command.arg(flag);
-        }
+        let args = compose_cc_args(&parsed.rest, file_prefix_map_args(&prefix_maps));
+        command.args(&args);
         let output = command
             .output()
             .with_context(|| format!("executing {}", parsed.program))?;
@@ -5415,6 +5447,44 @@ mod tests {
         assert!(cc_prefix_maps_cfg(&cl, cwd, None).is_empty());
         let gnu = CcArgs::parse(&s(&["gcc", "-c", "/work/proj/a.c"])).unwrap();
         assert!(!cc_prefix_maps_cfg(&gnu, cwd, None).is_empty());
+    }
+
+    /// #300: cc-rs emits `--` before the source on clang-cl, and the
+    /// clang/clang-cl driver treats everything after `--` as an input
+    /// file. Appended `-ffile-prefix-map` flags must therefore be spliced
+    /// in *before* the separator, or the driver counts them as extra
+    /// source files and fails with "cannot specify '-Fo…' when compiling
+    /// multiple source files".
+    #[test]
+    fn compose_cc_args_splices_appended_flags_before_double_dash() {
+        let rest = s(&["-c", "-Fofoo.o", "--", "windows.c"]);
+        let appended = s(&["-ffile-prefix-map=/a=<CC_ROOT>"]);
+        let out = compose_cc_args(&rest, appended);
+        assert_eq!(
+            out,
+            s(&[
+                "-c",
+                "-Fofoo.o",
+                "-ffile-prefix-map=/a=<CC_ROOT>",
+                "--",
+                "windows.c"
+            ]),
+            "appended flags must land before `--`, not after"
+        );
+    }
+
+    #[test]
+    fn compose_cc_args_appends_at_end_without_double_dash() {
+        let rest = s(&["-c", "foo.c"]);
+        let appended = s(&["-ffile-prefix-map=/a=<CC_ROOT>"]);
+        let out = compose_cc_args(&rest, appended);
+        assert_eq!(out, s(&["-c", "foo.c", "-ffile-prefix-map=/a=<CC_ROOT>"]));
+    }
+
+    #[test]
+    fn compose_cc_args_is_identity_when_nothing_appended() {
+        let rest = s(&["-c", "-Fofoo.o", "--", "windows.c"]);
+        assert_eq!(compose_cc_args(&rest, Vec::new()), rest);
     }
 
     #[cfg(unix)]

--- a/tests/cc_prefix_map_separator_test.rs
+++ b/tests/cc_prefix_map_separator_test.rs
@@ -1,0 +1,120 @@
+//! End-to-end regression test for issue #300 ("Firefox fails to build
+//! whatsys on Windows").
+//!
+//! cc-rs emits a `--` end-of-options separator before the source file on
+//! clang-cl invocations, and the clang/clang-cl driver treats every token
+//! *after* `--` as an input file. kache injects `-ffile-prefix-map=…`
+//! path-portability rules when it runs the real compiler; the old code
+//! appended them to the very end of the argv, so they landed after `--`
+//! and the driver parsed them as extra source files:
+//!
+//! ```text
+//! clang-cl: error: cannot specify '-Fo…' when compiling multiple source files
+//! clang-cl: warning: -ffile-prefix-map=…: 'linker' input unused
+//! ```
+//!
+//! This drives the real `kache` binary as a `cc` wrapper around a fake
+//! compiler that records the argv it actually receives, then asserts the
+//! injected `-ffile-prefix-map` flag arrives *before* the `--` separator
+//! — i.e. classified as an option, not an input. It exercises the full
+//! path (wrapper → passthrough → `execute` → `compose_cc_args` → spawned
+//! command), so a regression in the `execute` wiring — not just the
+//! `compose_cc_args` helper — fails the test.
+//!
+//! Unix-only: it relies on a shell-script stand-in for the compiler. The
+//! splice logic itself is also covered by the `compose_cc_args` unit
+//! tests in `src/compiler/cc.rs`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+fn kache_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_kache")
+}
+
+#[test]
+fn injected_prefix_map_lands_before_the_double_dash_separator() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Fake compiler: dump every argument it receives, one per line, then
+    // succeed. A real clang-cl would *fail* on this argv if a flag landed
+    // after `--`; we assert the ordering directly instead of depending on
+    // a real clang-cl being installed.
+    // Named `cc` (no extension) so kache's wrapper recognizer accepts it
+    // as a C compiler and a GNU dialect is inferred — the dialect that
+    // injects `-ffile-prefix-map` today (clang-cl injection is gated by
+    // #285).
+    let argv_dump = dir.path().join("argv.txt");
+    let fake = dir.path().join("cc");
+    fs::write(
+        &fake,
+        format!(
+            "#!/bin/sh\n: > '{dump}'\nfor a in \"$@\"; do printf '%s\\n' \"$a\" >> '{dump}'; done\nexit 0\n",
+            dump = argv_dump.display()
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&fake, fs::Permissions::from_mode(0o755)).unwrap();
+
+    // A real source so the prefix-map derivation has something to anchor
+    // on; `KACHE_BASE_DIR` guarantees at least one map is injected
+    // regardless of the test process's cwd.
+    let source = dir.path().join("windows.c");
+    fs::write(&source, b"int main(void){return 0;}\n").unwrap();
+
+    let cache_dir = dir.path().join("cache");
+    let config = dir.path().join("kache.toml");
+
+    // Mirror the cc-rs clang-cl shape: flags, an object output, then the
+    // source behind a `--` separator. A GNU-dialect compiler name keeps
+    // prefix-map injection enabled (clang-cl injection is gated by #285),
+    // so this guards the argv ordering on the path that injects today.
+    let output = Command::new(kache_binary())
+        .args([
+            fake.to_str().unwrap(),
+            "-c",
+            "-o",
+            "windows.o",
+            "--",
+            source.to_str().unwrap(),
+        ])
+        .current_dir(dir.path())
+        .env("KACHE_CACHE_DIR", &cache_dir)
+        .env("KACHE_CONFIG", &config)
+        .env("KACHE_BASE_DIR", dir.path())
+        .env("KACHE_LOG", "kache=debug")
+        .output()
+        .expect("failed to run kache as a cc wrapper");
+
+    assert!(
+        output.status.success(),
+        "kache cc passthrough should succeed; status={:?}\nstderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let recorded = fs::read_to_string(&argv_dump).expect("fake compiler did not record argv");
+    let args: Vec<&str> = recorded.lines().collect();
+
+    let sep = args.iter().position(|a| *a == "--");
+    let map = args
+        .iter()
+        .position(|a| a.starts_with("-ffile-prefix-map="));
+
+    assert!(
+        map.is_some(),
+        "kache should have injected a -ffile-prefix-map flag; recorded argv: {args:?}"
+    );
+    assert!(
+        sep.is_some(),
+        "the `--` separator should be preserved in the spawned argv: {args:?}"
+    );
+    assert!(
+        map < sep,
+        "injected -ffile-prefix-map (idx {map:?}) must precede `--` (idx {sep:?}), \
+         else the driver treats it as an input file (#300); recorded argv: {args:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #300 — Firefox fails to build `whatsys` on Windows.

## Root cause

When kache wraps `clang-cl`, the underlying compiler is invoked through `CcCompiler::execute()`. That function ran the original argv and then **appended** kache's injected `-ffile-prefix-map=...` portability rules to the end:

```rust
command.args(&parsed.rest);
for flag in file_prefix_map_args(&prefix_maps) {
    command.arg(flag);
}
```

But cc-rs emits a `--` end-of-options separator before the source file on clang-cl invocations, and the clang/clang-cl driver treats **every token after `--` as an input file**. So the appended flags became "source files":

```
clang-cl: error: cannot specify '-Fo...windows.o' when compiling multiple source files
clang-cl: warning: -ffile-prefix-map=D:\firefox\...\whatsys=<CC_ROOT>: 'linker' input unused
clang-cl: warning: -ffile-prefix-map=\\?\D:\firefox\...\whatsys=<CC_ROOT>: 'linker' input unused
```

The two `'linker' input unused` warnings are the smoking gun: the driver parsed our flags as inputs, giving it 1 real source + 2 phantom inputs → multiple source files → `-Fo` rejected.

## Fix

Extract a pure `compose_cc_args(rest, appended)` helper that splices the appended flags in **before** the first bare `--` (plain append when there's no `--`), and use it in `execute()`. Before `--`, the driver reads them as flags again. The flags still come last among the options, so kache's maps keep winning over any user-supplied map for the same prefix.

## Scope / what this actually fixes

This is a fix to the **argv builder**, and that framing matters for verification:

- The original failing log was from a **pre-#295 release**. PR #285/#295 (merged the same morning) added a `Dialect::Cl => return Vec::new()` guard in `cc_prefix_maps_cfg`, so on current `main` clang-cl injects **no** prefix maps — the exact repro no longer fires from a fresh `main` build. **The reporter's immediate unblock is the release that contains #295**, not this PR.
- This PR removes the **latent argv-construction bug** underneath that guard. It still matters because:
  - the same flaw applies to any **gnu/clang-dialect** compile that carries `--`, and
  - **Layer 3** (clang-cl cross-machine portability, currently paused/gated on #299) will **re-enable** `-ffile-prefix-map` injection for clang-cl — at which point #300 regresses instantly unless the ordering is correct.

So the argv ordering needs to be right independently of the temporary Cl guard. This change is the durable root-cause fix and Layer 3 prerequisite.

## Known limitations (documented in the helper)

`compose_cc_args` matches only a literal bare `--`. A `--` that is an option's separated value, or one hidden inside an `@response-file`, is not recognised — both are out of scope for the cc-rs `-c` compiles that reach `execute()` (response-file invocations refuse caching, and the Cl path is gated anyway).

## Testing

- `cargo test compiler::cc::` — all green
- New regression tests: splice-before-`--`, plain-append-without-`--`, identity-when-nothing-appended, splice-before-**first**-of-multiple-`--`, `--`-as-leading-token
- `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean

Reviewed with a second model (Fable): verdict sound, no blockers; the extra edge-case tests and the limitations note above were added in response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)