### PR TITLE
test(cc): guard #299 — clang-cl invocations get zero injected flags

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -5455,6 +5455,42 @@ mod tests {
         assert!(!cc_prefix_maps_cfg(&gnu, cwd, None).is_empty());
     }
 
+    /// #299 ("Firefox fails to build sandbox on Windows"): a clang-cl
+    /// invocation must reach the real compiler with the EXACT argv kache was
+    /// given — zero injected flags. clang-cl rejects `-ffile-prefix-map` as
+    /// an unknown argument, so injecting it makes any `-Werror` compile fail.
+    /// Firefox's `configure` detects `-ffile-reproducible` with a `-Werror`
+    /// probe run through the compiler wrapper; an injected `-ffile-prefix-map`
+    /// turned that probe into an error, so `-ffile-reproducible` was reported
+    /// unsupported and dropped. Without it, `__FILE__` kept mozbuild's
+    /// forward slashes and chromium's `base\location.cc` `static_assert`
+    /// failed. clang-cl gets empty prefix maps (#295), so the composed argv
+    /// (what `execute` spawns) must be byte-identical to the original `rest`.
+    #[test]
+    fn clang_cl_invocation_injects_no_flags_issue_299() {
+        let cwd = std::path::Path::new("/work/proj");
+        let cl = CcArgs::parse(&s(&[
+            "clang-cl",
+            "-Werror",
+            "-ffile-reproducible",
+            "-c",
+            "/work/proj/a.c",
+            "-Foa.obj",
+        ]))
+        .unwrap();
+        let maps = cc_prefix_maps_cfg(&cl, cwd, None);
+        assert!(
+            maps.is_empty(),
+            "clang-cl must get no prefix maps (#295/#299)"
+        );
+        let composed = compose_cc_args(&cl.rest, file_prefix_map_args(&maps));
+        assert_eq!(
+            composed, cl.rest,
+            "kache must inject nothing into a clang-cl argv, or it poisons \
+             `-Werror` compiles/probes (#299); got {composed:?}"
+        );
+    }
+
     /// #300: cc-rs emits `--` before the source on clang-cl, and the
     /// clang/clang-cl driver treats everything after `--` as an input
     /// file. Appended `-ffile-prefix-map` flags must therefore be spliced


### PR DESCRIPTION
Regression test for #299 ("Firefox fails to build sandbox on Windows"), root-caused on real Windows hardware.

## The bug (verified end-to-end)

1. mozbuild passes **forward-slash** source paths to clang-cl.
2. Chromium's `location.cc` `static_assert`s (under `__clang__ && _WIN32`) that `__FILE__` ends with **`base\location.cc`** (backslash).
3. Firefox relies on **`-ffile-reproducible`** to normalize `__FILE__` to native backslashes — that's what makes the assert pass.
4. Firefox's `configure` detects `-ffile-reproducible` with a **`-Werror` compile probe run through the compiler wrapper**. kache 0.5.1-rc.4 (pre-clang-cl-support) **injected `-ffile-prefix-map`**, which clang-cl rejects (`unknown argument ignored`). Under `-Werror` that became an error → the probe failed → `-ffile-reproducible` was reported **unsupported** and dropped → `__FILE__` kept forward slashes → the assert failed → build aborted.

Proof on one box, Firefox tree, wrapper the only variable:
```
bare clang-cl  -Werror -ffile-reproducible  → exit 0
rc.4 wrapper                                → exit 1  (clang-cl: error: unknown argument '-ffile-prefix-map=…' [-Werror,-Wunknown-argument])
main wrapper                                → exit 0
```
And configure: `…supports -ffile-reproducible… no` (rc.4) vs `…yes` (main).

**#295 already fixes this** by giving clang-cl empty prefix maps (`cc_prefix_maps_cfg` returns empty for `Dialect::Cl`) — so kache injects nothing. This PR adds a regression guard for that invariant.

## The test

Host-independent unit test `clang_cl_invocation_injects_no_flags_issue_299`: a clang-cl parse → `cc_prefix_maps_cfg` empty → `compose_cc_args(rest, file_prefix_map_args(maps))` is byte-identical to the original `rest`. If anyone re-introduces injection for clang-cl, it fails.

### Why unit, not a Windows integration test
CI runs `cargo test` **only on Linux/macOS** (the Windows job runs the e2e scenario harness, not `cargo test`) — which is why every existing integration test here is `#![cfg(unix)]`. A `#![cfg(windows)]` test would never execute in CI. The real-clang-cl symptom can't be faked (the bug *is* clang-cl's `-Werror` rejection), so it was verified manually on Windows hardware (above). A Windows **e2e scenario** could add a live symptom check on the existing Windows runner — happy to follow up if wanted.

135 cc tests pass; `cargo fmt --check` + `clippy --all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)