### PR TITLE
fix(#311): binstall pkg-url derives extension from pkg-fmt — Windows ships .zip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,9 +95,20 @@ assert_cmd = "2"
 predicates = "3"
 serde_json = "1"
 
+# `{ archive-suffix }` resolves from each target's pkg-fmt (".tar.gz" for
+# tgz, ".zip" for zip) — never hardcode the extension here: the release
+# workflow (_release-rust.yml) packages Windows targets as .zip and
+# everything else as .tar.gz (see #311). Guarded by
+# tests/binstall_metadata_test.rs.
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
 pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
+[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+pkg-fmt = "zip"
 
 [profile.release]
 lto = "fat"

--- a/tests/binstall_metadata_test.rs
+++ b/tests/binstall_metadata_test.rs
@@ -1,0 +1,92 @@
+//! Guard test for issue #311 ("cargo binstall fails; it expects `.sig`
+//! files rather than `.sha256`").
+//!
+//! The real failure behind that report: the `[package.metadata.binstall]`
+//! `pkg-url` hardcoded `.tar.gz`, but the release workflow
+//! (`_release-rust.yml`) packages Windows targets as `.zip`. binstall
+//! therefore 404'd on `kache-{target}-pc-windows-msvc.tar.gz`, fell back
+//! to quickinstall (also absent), and finally built from source. The
+//! `.sig` 404 in the issue title is a harmless side effect — binstall
+//! skips signature verification when no `.sig` is published.
+//!
+//! This test keeps the binstall metadata in sync with what CI actually
+//! publishes: the URL template must derive its extension from `pkg-fmt`
+//! (via `{ archive-suffix }`), and every Windows target in the release
+//! matrix must carry a `pkg-fmt = "zip"` override.
+
+use std::fs;
+use std::path::Path;
+
+fn repo_file(rel: &str) -> String {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    fs::read_to_string(root.join(rel)).unwrap_or_else(|e| panic!("reading {rel}: {e}"))
+}
+
+/// The release target matrix from ci.yml's `_release-rust.yml` invocation.
+fn release_targets() -> Vec<String> {
+    let ci = repo_file(".github/workflows/ci.yml");
+    let line = ci
+        .lines()
+        .find(|l| l.trim_start().starts_with("targets: '["))
+        .expect("ci.yml should pass a JSON `targets:` array to _release-rust.yml");
+    let json = line
+        .trim_start()
+        .trim_start_matches("targets: ")
+        .trim_matches('\'');
+    serde_json::from_str(json).expect("targets array should be valid JSON")
+}
+
+#[test]
+fn pkg_url_extension_follows_pkg_fmt() {
+    let manifest = repo_file("Cargo.toml");
+    let pkg_url = manifest
+        .lines()
+        .find(|l| l.trim_start().starts_with("pkg-url"))
+        .expect("Cargo.toml should define [package.metadata.binstall] pkg-url");
+
+    assert!(
+        pkg_url.contains("{ archive-suffix }"),
+        "pkg-url must end in {{ archive-suffix }} so the extension tracks each \
+         target's pkg-fmt (Windows ships .zip, everything else .tar.gz):\n  {pkg_url}"
+    );
+    for hardcoded in [".tar.gz", ".tgz", ".zip"] {
+        assert!(
+            !pkg_url.contains(hardcoded),
+            "pkg-url must not hardcode `{hardcoded}` — Windows release artifacts \
+             are .zip while unix ones are .tar.gz:\n  {pkg_url}"
+        );
+    }
+}
+
+#[test]
+fn every_windows_release_target_overrides_pkg_fmt_to_zip() {
+    let manifest = repo_file("Cargo.toml");
+    let targets = release_targets();
+    let windows: Vec<_> = targets.iter().filter(|t| t.contains("-windows-")).collect();
+    assert!(
+        !windows.is_empty(),
+        "release matrix should contain Windows targets; if they were dropped, \
+         delete this test together with the binstall overrides"
+    );
+
+    for target in windows {
+        let header = format!("[package.metadata.binstall.overrides.{target}]");
+        let section = manifest.split(&header).nth(1).unwrap_or_else(|| {
+            panic!(
+                "Cargo.toml is missing `{header}` — _release-rust.yml packages \
+                     {target} as .zip, so binstall needs a pkg-fmt override"
+            )
+        });
+        let pkg_fmt = section
+            .lines()
+            .map(str::trim)
+            .take_while(|l| !l.starts_with('['))
+            .find(|l| l.starts_with("pkg-fmt"))
+            .unwrap_or_else(|| panic!("`{header}` should set pkg-fmt"));
+        assert!(
+            pkg_fmt.contains("\"zip\""),
+            "`{header}` must set pkg-fmt = \"zip\" to match the release artifact, \
+             got: {pkg_fmt}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #311.

## Root cause

`[package.metadata.binstall]` hardcoded `.tar.gz` in `pkg-url`, but the release workflow (`_release-rust.yml`) packages Windows targets as `.zip` (`kache-aarch64-pc-windows-msvc.zip`, etc.). On Windows, cargo-binstall looked for a `.tar.gz` that doesn't exist, fell back to quickinstall (not indexed), and finally built from source.

The `.sig` 404 in the issue title is a red herring — binstall optionally checks for minisign signatures and gracefully skips verification when none are published (`DEBUG Failed to download signature, skipping verification`). We publish `.sha256` checksums, which binstall doesn't consume; that's fine and unrelated to the failure.

## Fix

- `pkg-url` now ends in `{ archive-suffix }`, which binstall resolves from each target's `pkg-fmt` (`.tar.gz` for `tgz`, `.zip` for `zip`).
- Added `pkg-fmt = "zip"` overrides for `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`.
- Guard test (`tests/binstall_metadata_test.rs`) parses ci.yml's release target matrix and asserts every Windows target has a zip override and that pkg-url never hardcodes an extension again.

## Verification

Dry-run against the **existing** v0.6.0-rc.1 release with the fixed manifest (`cargo binstall kache --manifest-path . --version 0.6.0-rc.1 --targets <t> --dry-run`):

| target | before | after |
|---|---|---|
| aarch64-pc-windows-msvc | falls back to source build | `downloaded from github.com` ✅ |
| x86_64-pc-windows-msvc | falls back to source build | `downloaded from github.com` ✅ |
| aarch64-apple-darwin | ok | still ok ✅ |
| x86_64-unknown-linux-musl | ok | still ok ✅ |

Note: this takes effect for crates.io-driven installs once the next version is published (the metadata travels with the crate); `--git` installs pick it up from the repo immediately.