### PR TITLE
feat(cc): cache clang-cl debug compiles (#312)

### DIFF
--- a/scenarios/e2e-cc-cl-debug/scenario.toml
+++ b/scenarios/e2e-cc-cl-debug/scenario.toml
@@ -1,0 +1,69 @@
+# kache-e2e fixture: clang-cl debug compile (#312). The `/Brepro /Z7 -c`
+# step embeds source path, output name, and compilation dir in the
+# object's CodeView (box-confirmed); /Brepro makes it reproducible.
+# kache keys those path inputs (capture, not remap — clang-cl is
+# path-literal), so a same-path rebuild HITS (byte-identical), but a
+# RELOCATED build MISSES — the inverse of e2e-cpp-hello, encoding "debug
+# objects are path-local." Skips where clang-cl is not on PATH.
+
+name = "e2e-cc-cl-debug"
+tags = ["suite:e2e", "lang:cc", "os:windows"]
+requires = ["clang-cl"]
+
+[source]
+kind = "fixture"
+path = "source"
+
+[env]
+CC = "$KACHE clang-cl"
+
+[commands]
+build = "make"
+clean = "make clean"
+
+[verify]
+run = "./build/a.exe"
+expected_stdout_contains = ["clang-cl debug fixture"]
+
+[modify]
+file = "a.c"
+find = "clang-cl debug fixture"
+replace = "edited debug fixture"
+
+# Cold: the -c compile of a.c is a miss → one cache entry.
+# One compiler run (the real compile on miss).
+[assertions.cold]
+min_entries_after = 1
+max_compiler_runs = 1
+
+# Warm: clean + rebuild → the compile hits.
+# max_compiler_runs = 0 proves the hit skipped the compile.
+[assertions.warm]
+min_hits = 1
+max_compiler_runs = 0
+
+# Noop: make sees build/a.obj + build/a.exe up to date and does
+# nothing. No CC invocation, so no kache event.
+# should_not_recompile = false: no stdout marker to assert against;
+# make's own incrementality is what's exercised.
+[assertions.noop]
+should_not_recompile = false
+
+# Relocate: /Z7 bakes source path, output name, and compilation dir
+# into the CodeView block of the .obj. A cross-path build produces a
+# different key → MISS. This is the inverse of e2e-cpp-hello (which
+# hits on relocate because the preprocessor-expansion key is
+# path-independent). min_misses = 1 is the headline assertion.
+# NOTE: no [diff] section — [diff] compares the relocated artifact
+# against the cold baseline and would fail here by design (different
+# embedded paths → different bytes). The miss assertion is the correct
+# correctness signal for this fixture.
+[assertions.relocate]
+min_misses = 1
+max_compiler_runs = 1
+
+# Relocate-modified: relocated AND edited — the changed source MUST
+# also miss and recompile.
+[assertions.relocate-modified]
+min_misses = 1
+max_compiler_runs = 1

--- a/scenarios/e2e-cc-cl-debug/source/Makefile
+++ b/scenarios/e2e-cc-cl-debug/source/Makefile
@@ -1,0 +1,22 @@
+# clang-cl debug-info fixture for kache (#312). CC is overridden by the
+# e2e harness to "$KACHE clang-cl". /Z7 embeds CodeView in the .obj;
+# /Brepro makes the object reproducible (box-confirmed) so a cache hit
+# is byte-identical to a fresh compile.
+CC    ?= clang-cl
+BUILD := build
+OBJ   := $(BUILD)/a.obj
+BIN   := $(BUILD)/a.exe
+
+all: $(BIN)
+
+$(BUILD):
+	mkdir $(BUILD)
+
+$(OBJ): a.c | $(BUILD)
+	$(CC) /Brepro /Z7 -c a.c -Fo$(OBJ)
+
+$(BIN): $(OBJ)
+	$(CC) $(OBJ) -Fe$(BIN)
+
+clean:
+	rm -rf $(BUILD)

--- a/scenarios/e2e-cc-cl-debug/source/a.c
+++ b/scenarios/e2e-cc-cl-debug/source/a.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+int main(void) {
+    printf("clang-cl debug fixture\n");
+    return 0;
+}

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2515,9 +2515,7 @@ fn cc_flags_need_resolved_invocation(parsed: &CcArgs) -> bool {
 /// object. clang-cl puts debug info in the `.obj` for all of these (no
 /// compile-time PDB — box-confirmed), so each is a single cacheable
 /// artifact once the embedded path inputs are keyed.
-const CL_DEBUG_FLAGS: &[&str] = &[
-    "/Z7", "/Zi", "/ZI", "/Zd", "-Z7", "-Zi", "-ZI", "-Zd",
-];
+const CL_DEBUG_FLAGS: &[&str] = &["/Z7", "/Zi", "/ZI", "/Zd", "-Z7", "-Zi", "-ZI", "-Zd"];
 
 /// Whether this clang-cl invocation requests debug info (native MSVC
 /// spelling or a `-g` form parsed into `debug_level`). Only meaningful
@@ -3755,7 +3753,10 @@ mod tests {
         assert!(
             dbg.refuse_reasons(&[]).is_empty(),
             "-Z7 must be cacheable after #312, got: {:?}",
-            dbg.refuse_reasons(&[]).iter().map(|r| r.description()).collect::<Vec<_>>()
+            dbg.refuse_reasons(&[])
+                .iter()
+                .map(|r| r.description())
+                .collect::<Vec<_>>()
         );
         assert!(
             cl_debug_path_inputs(&dbg).is_some(),
@@ -4460,7 +4461,11 @@ mod tests {
         }
         // gcc debug never goes through the cl path-fold path.
         let gnu = CcArgs::parse(&s(&["gcc", "-c", "a.c", "-g2"])).unwrap();
-        assert_eq!(cl_debug_path_inputs(&gnu), None, "gnu debug must not fold cl paths");
+        assert_eq!(
+            cl_debug_path_inputs(&gnu),
+            None,
+            "gnu debug must not fold cl paths"
+        );
     }
 
     #[test]
@@ -4475,7 +4480,10 @@ mod tests {
         }
         // -g form too.
         let g = CcArgs::parse(&s(&["clang-cl", "-c", "a.c", "-Foa.obj", "-g"])).unwrap();
-        assert!(g.refuse_reasons(&[]).is_empty(), "-g clang-cl must be cacheable");
+        assert!(
+            g.refuse_reasons(&[]).is_empty(),
+            "-g clang-cl must be cacheable"
+        );
     }
 
     #[test]
@@ -4492,7 +4500,10 @@ mod tests {
         );
         // And the debug form stays cacheable too.
         let d = CcArgs::parse(&s(&["clang-cl", "/c", "a.c", "-Foa.obj", "/Z7"])).unwrap();
-        assert!(d.refuse_reasons(&[]).is_empty(), "clang-cl /c /Z7 must not be refused");
+        assert!(
+            d.refuse_reasons(&[]).is_empty(),
+            "clang-cl /c /Z7 must not be refused"
+        );
     }
 
     #[test]
@@ -6304,12 +6315,18 @@ mod tests {
         let foo = comp(&["clang-cl", "-c", "foo.c", "-Fofoo.obj", "/Z7"]);
         let bar = comp(&["clang-cl", "-c", "bar.c", "-Fobar.obj", "/Z7"]);
         assert!(foo.is_some() && bar.is_some());
-        assert_ne!(foo, bar, "different source/output must change the component (H1/D3)");
+        assert_ne!(
+            foo, bar,
+            "different source/output must change the component (H1/D3)"
+        );
 
         // Absolute source path leaks (H2).
         let a1 = comp(&["clang-cl", "-c", "C:\\d1\\a.c", "-Foa.obj", "/Z7"]);
         let a2 = comp(&["clang-cl", "-c", "C:\\d2\\a.c", "-Foa.obj", "/Z7"]);
-        assert_ne!(a1, a2, "absolute source path must change the component (H2)");
+        assert_ne!(
+            a1, a2,
+            "absolute source path must change the component (H2)"
+        );
 
         // Output name leaks independently (D3): same source, different -Fo.
         let p = comp(&["clang-cl", "-c", "a.c", "-Fopp.obj", "/Z7"]);
@@ -6318,7 +6335,11 @@ mod tests {
 
         // Explicit -fdebug-compilation-dir is used (else current_dir()).
         let explicit = comp(&[
-            "clang-cl", "-c", "a.c", "-Foa.obj", "/Z7",
+            "clang-cl",
+            "-c",
+            "a.c",
+            "-Foa.obj",
+            "/Z7",
             "-fdebug-compilation-dir=C:\\proj\\x",
         ])
         .unwrap();
@@ -6329,7 +6350,10 @@ mod tests {
 
         // /Zi, /ZI, -Zi also trigger the fold.
         for f in ["/Zi", "/ZI", "-Zi"] {
-            assert!(comp(&["clang-cl", "-c", "a.c", "-Foa.obj", f]).is_some(), "{f} must fold");
+            assert!(
+                comp(&["clang-cl", "-c", "a.c", "-Foa.obj", f]).is_some(),
+                "{f} must fold"
+            );
         }
 
         // Non-debug cl → None (no fold; preserves cross-CWD/name hit-rate).

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2520,6 +2520,14 @@ const CL_DEBUG_FLAGS: &[&str] = &["/Z7", "/Zi", "/ZI", "/Zd", "-Z7", "-Zi", "-ZI
 /// Whether this clang-cl invocation requests debug info (native MSVC
 /// spelling or a `-g` form parsed into `debug_level`). Only meaningful
 /// for `Dialect::Cl`; the caller gates on dialect.
+///
+/// NOTE: `cl_debug_present` does NOT imply the `-###` probe is forced.
+/// The native `/Z*` spellings are modeled `CapturedByProbe` (the
+/// `/Z7`-vs-`/ZI` variant split is keyed via resolved tokens, bailing if
+/// the probe is absent). The bare `-g` form has no such variant — it is
+/// `ModeledInKey` via `debug_level` and its embedded paths are folded
+/// here — so a `-g`-only clang-cl compile keys correctly without the
+/// probe. Don't assume `cl_debug_present ⇒ probe required`.
 fn cl_debug_present(parsed: &CcArgs) -> bool {
     parsed.family.dialect() == Dialect::Cl
         && (parsed.debug_level.is_some_and(|d| d > 0)

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2503,6 +2503,80 @@ fn cc_flags_need_resolved_invocation(parsed: &CcArgs) -> bool {
         .any(|arg| analyze_cc_arg(arg, dialect).bucket == CcArgBucket::ProbeKeyed)
 }
 
+/// MSVC debug-info markers that embed absolute CodeView paths into the
+/// object. clang-cl puts debug info in the `.obj` for all of these (no
+/// compile-time PDB — box-confirmed), so each is a single cacheable
+/// artifact once the embedded path inputs are keyed.
+const CL_DEBUG_FLAGS: &[&str] = &[
+    "/Z7", "/Zi", "/ZI", "/Zd", "-Z7", "-Zi", "-ZI", "-Zd",
+];
+
+/// Whether this clang-cl invocation requests debug info (native MSVC
+/// spelling or a `-g` form parsed into `debug_level`). Only meaningful
+/// for `Dialect::Cl`; the caller gates on dialect.
+fn cl_debug_present(parsed: &CcArgs) -> bool {
+    parsed.family.dialect() == Dialect::Cl
+        && (parsed.debug_level.is_some_and(|d| d > 0)
+            || parsed
+                .rest
+                .iter()
+                .any(|a| CL_DEBUG_FLAGS.contains(&a.as_str())))
+}
+
+/// The per-TU path inputs a clang-cl debug object embeds in CodeView that
+/// the cache key would otherwise miss: the source file path(s) as spelled
+/// on the command line, the output object name from `-Fo`/`-o`, and the
+/// effective compilation directory (an explicit `-fdebug-compilation-dir`
+/// or `-ffile-compilation-dir` value if present, otherwise the OS cwd).
+/// These are exactly the tokens `config_args()` strips (source, output)
+/// plus the compilation directory. `-I` dirs and flags are already in the
+/// key via the resolved tokens. Capture, not remap — clang-cl stays
+/// path-literal (#299/#312). `None` when this is not a clang-cl debug
+/// compile (no fold; non-debug objects don't embed these, so
+/// cross-CWD/name hits stay correct).
+fn cl_debug_path_inputs(parsed: &CcArgs) -> Option<Vec<String>> {
+    if !cl_debug_present(parsed) {
+        return None;
+    }
+    let mut out = Vec::new();
+    // Paths are encoded lossily; on Windows (where clang-cl runs) paths
+    // are always valid UTF-16 → UTF-8, so no two distinct paths collapse.
+    for src in &parsed.sources {
+        out.push(format!("src={}", src.to_string_lossy()));
+    }
+    if let Some(o) = &parsed.output {
+        out.push(format!("out={}", o.to_string_lossy()));
+    }
+    // NOTE (#312): when the clang-cl debug refusal is lifted, each of
+    // these compilation-dir spellings must also be modeled in CC_FLAGS
+    // (clang-cl dialect) — otherwise an invocation that passes one
+    // explicitly hits the unmodeled-flag refusal before this fold is
+    // reached. Tracked for the refusal-lift task.
+    let dir = parsed
+        .rest
+        .iter()
+        .find_map(|a| {
+            [
+                "-fdebug-compilation-dir=",
+                "-ffile-compilation-dir=",
+                "/fdebug-compilation-dir=",
+                "/ffile-compilation-dir=",
+            ]
+            .iter()
+            .find_map(|p| a.strip_prefix(p))
+            .map(str::to_string)
+        })
+        .or_else(|| {
+            std::env::current_dir()
+                .ok()
+                .map(|p| p.to_string_lossy().into_owned())
+        });
+    if let Some(d) = dir {
+        out.push(format!("dir={d}"));
+    }
+    Some(out)
+}
+
 /// Prefix maps that make C/C++ objects path-stable across worktrees.
 ///
 /// A `-g` compile bakes paths into DWARF (`DW_AT_comp_dir`) and
@@ -3216,6 +3290,26 @@ impl Compiler for CcCompiler {
                 "[key:{}] debug={dbg}",
                 trace_name
             );
+        }
+        // clang-cl debug objects embed per-TU path inputs the rest of
+        // the key misses: the source path/filename and output (-Fo) name
+        // (both stripped from config_args, so the memoized `-###` tokens
+        // can't be trusted for them) and the compilation dir (CWD, not in
+        // the key at all). Fold them so distinct objects never share a
+        // key — capture, not remap (clang-cl is path-literal; #299/#312).
+        if let Some(paths) = cl_debug_path_inputs(parsed) {
+            hasher.update(b"cl_debug_paths:");
+            for p in &paths {
+                hasher.update(p.as_bytes());
+                hasher.update(b"\x1f");
+                tracing::trace!(
+                    target: "kache::cache_key",
+                    "[key:{}] cl_debug_path={}",
+                    trace_name,
+                    p
+                );
+            }
+            hasher.update(b"\n");
         }
         if let Some(std) = &parsed.std {
             hasher.update(b"std:");
@@ -6118,5 +6212,47 @@ mod tests {
         // -bigobj and -showIncludes still refuse.
         let big = CcArgs::parse(&s(&["clang-cl", "-c", "foo.c", "-Fofoo.obj", "-bigobj"])).unwrap();
         assert!(!big.refuse_reasons(&[]).is_empty());
+    }
+
+    #[test]
+    fn cl_debug_path_inputs_folds_source_output_and_dir() {
+        let comp = |args: &[&str]| cl_debug_path_inputs(&CcArgs::parse(&s(args)).unwrap());
+
+        // Source filename leaks (H1): foo.c vs bar.c → different components.
+        let foo = comp(&["clang-cl", "-c", "foo.c", "-Fofoo.obj", "/Z7"]);
+        let bar = comp(&["clang-cl", "-c", "bar.c", "-Fobar.obj", "/Z7"]);
+        assert!(foo.is_some() && bar.is_some());
+        assert_ne!(foo, bar, "different source/output must change the component (H1/D3)");
+
+        // Absolute source path leaks (H2).
+        let a1 = comp(&["clang-cl", "-c", "C:\\d1\\a.c", "-Foa.obj", "/Z7"]);
+        let a2 = comp(&["clang-cl", "-c", "C:\\d2\\a.c", "-Foa.obj", "/Z7"]);
+        assert_ne!(a1, a2, "absolute source path must change the component (H2)");
+
+        // Output name leaks independently (D3): same source, different -Fo.
+        let p = comp(&["clang-cl", "-c", "a.c", "-Fopp.obj", "/Z7"]);
+        let q = comp(&["clang-cl", "-c", "a.c", "-Foqq.obj", "/Z7"]);
+        assert_ne!(p, q, "different -Fo must change the component (D3)");
+
+        // Explicit -fdebug-compilation-dir is used (else current_dir()).
+        let explicit = comp(&[
+            "clang-cl", "-c", "a.c", "-Foa.obj", "/Z7",
+            "-fdebug-compilation-dir=C:\\proj\\x",
+        ])
+        .unwrap();
+        assert!(
+            explicit.iter().any(|e| e.contains("C:\\proj\\x")),
+            "explicit compilation-dir must appear in the component"
+        );
+
+        // /Zi, /ZI, -Zi also trigger the fold.
+        for f in ["/Zi", "/ZI", "-Zi"] {
+            assert!(comp(&["clang-cl", "-c", "a.c", "-Foa.obj", f]).is_some(), "{f} must fold");
+        }
+
+        // Non-debug cl → None (no fold; preserves cross-CWD/name hit-rate).
+        assert_eq!(comp(&["clang-cl", "-c", "a.c", "-Foa.obj"]), None);
+        // gnu debug → None (gnu normalizes via -ffile-prefix-map, not this path).
+        assert_eq!(comp(&["gcc", "-c", "a.c", "-g"]), None);
     }
 }

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -298,6 +298,17 @@ static CC_ARG_SPECS: &[CcArgSpec] = &[
         dialect: None,
     },
     CcArgSpec {
+        // MSVC `/c` slash spelling of the compile-only marker. clang-cl
+        // accepts both `-c` and `/c`; without this kache misreads `/c`
+        // builds as link mode and passes them through (box-confirmed).
+        matcher: Matcher::Exact("/c"),
+        value_form: CcArgValueForm::Flag,
+        action: CcArgAction::SetMode(CompileMode::Compile),
+        bucket: CcArgBucket::Structural,
+        source: "compile mode marker (cl)",
+        dialect: Some(Dialect::Cl),
+    },
+    CcArgSpec {
         matcher: Matcher::Exact("-E"),
         value_form: CcArgValueForm::Flag,
         action: CcArgAction::SetMode(CompileMode::Preprocess),
@@ -3929,6 +3940,22 @@ mod tests {
     fn parse_dash_c_sets_compile_mode() {
         let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o"])).unwrap();
         assert_eq!(parsed.mode, CompileMode::Compile);
+    }
+
+    #[test]
+    fn parse_slash_c_sets_compile_mode_for_cl_only() {
+        // clang-cl accepts the MSVC `/c` spelling; kache must treat it as a
+        // compile (not default link mode → passthrough). Box-confirmed gap.
+        let cl = CcArgs::parse(&s(&["clang-cl", "/c", "a.c", "-Foa.obj"])).unwrap();
+        assert_eq!(cl.mode, CompileMode::Compile, "cl `/c` must set Compile");
+
+        // Dash `-c` still works for cl.
+        let cl_dash = CcArgs::parse(&s(&["clang-cl", "-c", "a.c"])).unwrap();
+        assert_eq!(cl_dash.mode, CompileMode::Compile);
+
+        // gnu must NOT treat `/c` as a compile marker (it's a path there).
+        let gnu = CcArgs::parse(&s(&["gcc", "/c", "a.c"])).unwrap();
+        assert_ne!(gnu.mode, CompileMode::Compile, "gnu `/c` is not a flag");
     }
 
     #[test]

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1337,6 +1337,18 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         dialect: None,
     },
     FlagSpec {
+        // MSVC `/c` slash spelling of the compile-mode marker (cl only).
+        // The parser already routes `/c` to CompileMode::Compile via
+        // CC_ARG_SPECS; this row tells the unsupported-flag classifier the
+        // token is known (ParserHandled) so it isn't rejected. Without it,
+        // a `/c` clang-cl compile is refused as `unsupported flag(s): /c`
+        // (box-confirmed). Mirrors the `-c` row above. (#312)
+        matcher: Matcher::Exact("/c"),
+        class: FlagClass::ParserHandled,
+        source: "Issue #312 — MSVC /c compile-mode marker, cl dialect.",
+        dialect: Some(Dialect::Cl),
+    },
+    FlagSpec {
         matcher: Matcher::Exact("-E"),
         class: FlagClass::ParserHandled,
         source: "Flag audit — preprocessor mode marker parsed into CompileMode.",
@@ -4464,6 +4476,23 @@ mod tests {
         // -g form too.
         let g = CcArgs::parse(&s(&["clang-cl", "-c", "a.c", "-Foa.obj", "-g"])).unwrap();
         assert!(g.refuse_reasons(&[]).is_empty(), "-g clang-cl must be cacheable");
+    }
+
+    #[test]
+    fn clang_cl_slash_c_compile_is_not_refused() {
+        // `/c` must be cacheable end-to-end: the parser sets compile mode AND
+        // the unsupported-flag classifier must accept it (ParserHandled).
+        // Regression for the box-found gap where `/c` hit "unsupported flag(s): /c".
+        let p = CcArgs::parse(&s(&["clang-cl", "/c", "a.c", "-Foa.obj"])).unwrap();
+        assert_eq!(p.mode, CompileMode::Compile);
+        assert!(
+            p.refuse_reasons(&[]).is_empty(),
+            "clang-cl /c must not be refused, got: {:?}",
+            p.refuse_reasons(&[])
+        );
+        // And the debug form stays cacheable too.
+        let d = CcArgs::parse(&s(&["clang-cl", "/c", "a.c", "-Foa.obj", "/Z7"])).unwrap();
+        assert!(d.refuse_reasons(&[]).is_empty(), "clang-cl /c /Z7 must not be refused");
     }
 
     #[test]

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -704,28 +704,6 @@ impl CcArgs {
             )),
         }
 
-        // clang-cl debug info embeds absolute CodeView /
-        // -fdebug-compilation-dir paths the preprocessor hash doesn't
-        // capture, and clang-cl ignores -ffile-prefix-map — a cached
-        // object would carry another checkout's paths. Refuse until
-        // Layer 3 lands a cl path-remap (#285). Catches both the `-g`
-        // form (parsed into debug_level) and the native MSVC `/Z7`/`/Zi`
-        // spellings (not yet modeled — refuse explicitly so this guard,
-        // not the incidental unsupported-flag path, owns the contract).
-        let cl_native_debug = self.rest.iter().any(|a| {
-            matches!(
-                a.as_str(),
-                "/Z7" | "/Zi" | "/ZI" | "/Zd" | "-Z7" | "-Zi" | "-ZI" | "-Zd"
-            )
-        });
-        if self.family.dialect() == Dialect::Cl
-            && (self.debug_level.is_some_and(|d| d > 0) || cl_native_debug)
-        {
-            reasons.push(RefuseReason::Unsupported(
-                "cc: clang-cl debug info embeds non-portable paths (not yet supported)",
-            ));
-        }
-
         // Output to stdout — `-o -` is unambiguous; an `-o` followed
         // by a literal `-` arg. Cacheable in principle (cache the
         // stdout bytes); not yet implemented.
@@ -2290,6 +2268,24 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         source: "#285 Layer 4 — clang-cl external-header warning level (/external:*). Diagnostics only; no object effect.",
         dialect: Some(Dialect::Cl),
     },
+    // ── clang-cl debug-info flags (#312) ─────────────────────────
+    //
+    // MSVC `/Z7`/`/Zi`/`/ZI`/`/Zd` and their `-` spellings embed
+    // CodeView debug info in the object. Their codegen effect is in the
+    // `-cc1` line (`-gcodeview`, `-debug-info-kind`, edit-and-continue),
+    // so the variant is keyed via the `cc -###` resolved tokens —
+    // `CapturedByProbe`. This also enforces the safety contract: if the
+    // probe is unavailable the compile bails rather than under-keying
+    // (box-confirmed: `/Z7` and `/Zi` resolve identically and produce
+    // identical objects, but `/ZI` differs). The PATH inputs the debug
+    // object embeds (source/output/compilation-dir) are a separate
+    // concern, folded into the key by `cl_debug_path_inputs`.
+    FlagSpec {
+        matcher: Matcher::Regex(r"[-/]Z[7iId]"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #312 — clang-cl CodeView debug-info flags; variant captured via cc -### resolved tokens; embedded paths folded by cl_debug_path_inputs.",
+        dialect: Some(Dialect::Cl),
+    },
 ];
 
 #[derive(Debug, Default)]
@@ -2547,11 +2543,13 @@ fn cl_debug_path_inputs(parsed: &CcArgs) -> Option<Vec<String>> {
     if let Some(o) = &parsed.output {
         out.push(format!("out={}", o.to_string_lossy()));
     }
-    // NOTE (#312): when the clang-cl debug refusal is lifted, each of
-    // these compilation-dir spellings must also be modeled in CC_FLAGS
-    // (clang-cl dialect) — otherwise an invocation that passes one
-    // explicitly hits the unmodeled-flag refusal before this fold is
-    // reached. Tracked for the refusal-lift task.
+    // NOTE (#312 follow-up): the compilation-dir spellings below are
+    // NOT yet modeled in CC_FLAGS, so a clang-cl debug compile that
+    // passes one EXPLICITLY currently hits the unmodeled-flag refusal
+    // (passthrough — safe, not a miscache) before reaching this fold.
+    // The common case (clang auto-injects -fdebug-compilation-dir at
+    // -cc1, not on the driver line) is unaffected. Modeling these flags
+    // to also cache the explicit-dir case is a deferred follow-up.
     let dir = parsed
         .rest
         .iter()
@@ -3719,7 +3717,7 @@ mod tests {
 
     #[test]
     fn clang_cl_firefox_style_invocation_is_cacheable() {
-        // The flags from issue #285's swgl log, minus -Z7 (debug, refused until Layer 3).
+        // The flags from issue #285's swgl log — non-debug subset.
         let p = CcArgs::parse(&s(&[
             "clang-cl",
             "-c",
@@ -3740,9 +3738,17 @@ mod tests {
             "should be cacheable, refused: {:?}",
             refuse.iter().map(|r| r.description()).collect::<Vec<_>>()
         );
-        // And with -Z7 it MUST refuse (debug, Layer 1 guard).
+        // As of #312, -Z7 is also cacheable (path inputs are folded into the key).
         let dbg = CcArgs::parse(&s(&["clang-cl", "-c", "foo.c", "-Fofoo.obj", "-Z7"])).unwrap();
-        assert!(!dbg.refuse_reasons(&[]).is_empty());
+        assert!(
+            dbg.refuse_reasons(&[]).is_empty(),
+            "-Z7 must be cacheable after #312, got: {:?}",
+            dbg.refuse_reasons(&[]).iter().map(|r| r.description()).collect::<Vec<_>>()
+        );
+        assert!(
+            cl_debug_path_inputs(&dbg).is_some(),
+            "-Z7 must activate the cl_debug_path_inputs key fold"
+        );
     }
 
     // ── recognize ────────────────────────────────────────────────
@@ -4418,20 +4424,46 @@ mod tests {
     }
 
     #[test]
-    fn clang_cl_debug_refuses_until_layer3() {
-        // The `-g` form (parsed into debug_level) and the native MSVC
-        // `/Z7` / `-Z7` spellings (not yet modeled) must both refuse with
-        // the clang-cl debug reason — this guard owns the contract.
-        for flag in ["-g2", "/Z7", "-Z7", "/Zi"] {
-            let descs = refuse_descriptions(&["clang-cl", "-c", flag, "a.c"]);
+    fn clang_cl_debug_is_now_cacheable_and_path_keyed() {
+        // As of #312 the old "clang-cl debug" refusal is gone. The `-g`
+        // form and the native MSVC `/Z7`/`-Z7`/`/Zi` spellings must all
+        // cache (empty refuse_reasons) and must be recognised as a debug
+        // compile that folds path inputs into the key.
+        for flag in ["-g2", "/Z7", "-Z7", "/Zi", "/ZI", "/Zd"] {
+            let p = CcArgs::parse(&s(&["clang-cl", "-c", "a.c", "-Foa.obj", flag])).unwrap();
+            let descs = p
+                .refuse_reasons(&[])
+                .iter()
+                .map(|r| r.description())
+                .collect::<Vec<_>>();
             assert!(
-                descs.iter().any(|d| d.contains("clang-cl debug")),
-                "{flag} should refuse with the clang-cl debug reason, got: {descs:?}"
+                descs.is_empty(),
+                "{flag} must be cacheable now, got: {descs:?}"
+            );
+            // cl_debug_path_inputs must return Some(…) so the key fold fires.
+            assert!(
+                cl_debug_path_inputs(&p).is_some(),
+                "{flag}: cl_debug_path_inputs must recognise a debug compile"
             );
         }
-        // gcc debug never hits the clang-cl path-embedding refusal.
-        let gnu = refuse_descriptions(&["gcc", "-c", "-g2", "a.c"]);
-        assert!(!gnu.iter().any(|d| d.contains("clang-cl debug")));
+        // gcc debug never goes through the cl path-fold path.
+        let gnu = CcArgs::parse(&s(&["gcc", "-c", "a.c", "-g2"])).unwrap();
+        assert_eq!(cl_debug_path_inputs(&gnu), None, "gnu debug must not fold cl paths");
+    }
+
+    #[test]
+    fn clang_cl_debug_compiles_are_no_longer_refused() {
+        for f in ["/Z7", "/Zi", "/ZI", "-Z7"] {
+            let p = CcArgs::parse(&s(&["clang-cl", "-c", "a.c", "-Foa.obj", f])).unwrap();
+            let reasons = p.refuse_reasons(&[]);
+            assert!(
+                reasons.is_empty(),
+                "{f}: clang-cl debug must be cacheable now, got: {reasons:?}"
+            );
+        }
+        // -g form too.
+        let g = CcArgs::parse(&s(&["clang-cl", "-c", "a.c", "-Foa.obj", "-g"])).unwrap();
+        assert!(g.refuse_reasons(&[]).is_empty(), "-g clang-cl must be cacheable");
     }
 
     #[test]
@@ -6212,6 +6244,27 @@ mod tests {
         // -bigobj and -showIncludes still refuse.
         let big = CcArgs::parse(&s(&["clang-cl", "-c", "foo.c", "-Fofoo.obj", "-bigobj"])).unwrap();
         assert!(!big.refuse_reasons(&[]).is_empty());
+    }
+
+    #[test]
+    fn clang_cl_debug_flags_require_the_resolved_probe() {
+        // /Z7 etc. are CapturedByProbe: their variant/codegen is only safely
+        // keyed via `cc -###`, so the compile must require the probe (bail if
+        // absent) — otherwise /ZI and /Z7, which differ, could collide.
+        for f in ["/Z7", "/Zi", "/ZI", "/Zd", "-Z7"] {
+            let p = CcArgs::parse(&s(&["clang-cl", "-c", "a.c", "-Foa.obj", f])).unwrap();
+            assert!(
+                cc_flags_need_resolved_invocation(&p),
+                "{f}: clang-cl debug must require the -### probe (CapturedByProbe)"
+            );
+        }
+        // A non-debug clang-cl compile with only modeled flags need NOT
+        // require the probe (sanity: the assertion above isn't vacuously true).
+        let nodebug = CcArgs::parse(&s(&["clang-cl", "-c", "a.c", "-Foa.obj"])).unwrap();
+        assert!(
+            !cc_flags_need_resolved_invocation(&nodebug),
+            "plain clang-cl compile without debug flags must not require the probe"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #312.

## What

Make clang-cl **debug** compiles (`/Z7`, `/Zi`, `/ZI`, `/Zd`, `-g`) cacheable instead of passed through. clang-cl stays path-literal / machine-local by design (per #299 — no `__FILE__` remap); we *capture* the per-TU path inputs the debug object embeds into the cache key rather than remapping them.

- Lift the `cc.rs` clang-cl debug refusal; model the debug flags in `CC_FLAGS` as **`CapturedByProbe`** (their codegen variant is in the `cc -###` resolved tokens; the bail-if-no-probe safety contract keeps `/ZI`, which differs, from ever colliding with `/Z7`).
- Fold the inputs a `/Z7` object embeds that the key would otherwise miss — **source path/filename, output (`-Fo`) name, and the compilation dir** — into a debug-gated key component (`cl_debug_path_inputs`). These are exactly the tokens `config_args()` strips, plus the CWD.
- Recognize the MSVC **`/c`** slash spelling as compile mode (parser **and** classifier — without the classifier row it was refused as an unsupported flag).
- Add `scenarios/e2e-cc-cl-debug` encoding the path-local contract (relocate ⇒ **miss**, the inverse of `e2e-cpp-hello`); auto-skips where `clang-cl` isn't on PATH.

No `CACHE_KEY_VERSION` bump: clang-cl debug was never cached (no stale entries) and non-debug clang-cl keys are unchanged (the new component is debug-gated).

## Why it's safe (hardware-verified on Windows, clang-cl 19.1.5)

Every distinct object gets a distinct key — validated on the real box:

| Check | Result |
|---|---|
| `/Z7` cold→miss, warm→hit | ✅ |
| rename source (same content) | distinct key → miss ✅ |
| absolute source path move | distinct key → miss ✅ |
| `-Fo` output name change | distinct key → miss ✅ |
| different build dir (CWD) | distinct key → miss ✅ |
| `/Zi` ≡ `/Z7` (identical objects) | same key → hit/dup ✅ |
| `/ZI` (different object) | distinct key → miss ✅ |
| `/c` slash | now cached ✅ |
| non-debug regression | identical content → hit ✅ |
| residual-leak guard | kache-restored obj **byte-identical** to a fresh `clang-cl /Brepro /Z7` compile ✅ |

`/Brepro` (what Firefox uses) makes objects reproducible; caching a non-`/Brepro` object is still correct (a restored object is a valid compile).

## Deferred follow-up

Explicit driver-level `-fdebug-compilation-dir=` is not yet modeled in `CC_FLAGS`, so a debug compile that passes one explicitly still passes through (safe — not a miscache). The common case (clang auto-injects it at `-cc1`, as Firefox does) is unaffected.
