### PR TITLE
docs: audit + correct the docs against the codebase (and fix the monitor dedup metric)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,23 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue.svg)](Cargo.toml)
 
-Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — just hardlinks locally and S3 for sharing.
+Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — reflinks where the filesystem supports them, hardlinks or copies otherwise, plus S3 for sharing.
 
-A drop-in `RUSTC_WRAPPER` that caches Rust compilation artifacts. Cache keys are blake3 hashes of normalized rustc invocations; cache hits restore via hardlinks, and identical blobs are stored once and shared. Optional S3 sync (AWS, Ceph, MinIO, R2) shares the cache across machines.
+A drop-in `RUSTC_WRAPPER` that caches Rust compilation artifacts. Cache keys are blake3 hashes of normalized rustc invocations; cache hits restore zero-copy — a reflink (copy-on-write clone) where the filesystem supports it (APFS, btrfs, XFS-with-reflink), and a hardlink or copy otherwise — and identical blobs are stored once and shared. Optional S3 sync (AWS, Ceph, MinIO, R2) shares the cache across machines.
 
 Local caching and direct S3 sync are stable today.
 
-**SOON:** a remote planner that prefetches from workspace manifests, dependency history, and build intent — warming the right artifacts before rustc asks for them.
+**PREVIEW:** a remote planner that prefetches from workspace manifests, dependency history, and build intent — warming the right artifacts before rustc asks for them. The daemon already calls a planner when `KACHE_PLANNER_ENDPOINT` is set; the hosted service is still preview.
 
-![kache: cold build populates the store, then `cargo clean && cargo build` restores every artifact via hardlinks](assets/demo.gif)
+![kache: cold build populates the store, then `cargo clean && cargo build` restores every artifact zero-copy](assets/demo.gif)
 
-> Cold compile populates kache's store, `cargo clean` wipes `target/`, and the second build pulls every artifact back via hardlinks. The recording is reproducible — see [`assets/demo/`](assets/demo/) for the Dockerfile and tape script.
+> Cold compile populates kache's store, `cargo clean` wipes `target/`, and the second build pulls every artifact back zero-copy. The recording is reproducible — see [`assets/demo/`](assets/demo/) for the Dockerfile and tape script.
 
 ## Why local kache is fast
 
 kache is useful even before remote cache is configured:
 
-- Local hits are restored with hardlinks into `target/`, so artifact bytes are not copied.
+- Local hits are restored zero-copy into `target/` — a reflink (copy-on-write clone) where the filesystem supports it, a hardlink or copy otherwise — so artifact bytes are not duplicated.
 - The store is content-addressed by blake3 hash, so identical artifact blobs are stored once and linked many times.
 - Misses compile normally, then kache records the outputs for future builds.
 - The daemon is optional for local caching. If it is not running, local hits and misses still work; remote checks, uploads, and prefetching degrade gracefully.
@@ -64,7 +64,7 @@ kache init -y
 kache doctor
 ```
 
-`kache init` is idempotent — re-run it any time to repair configuration. If you prefer to configure things by hand, just export `RUSTC_WRAPPER=kache` or add it to `~/.cargo/config.toml` under `[build]`.
+`kache init` is idempotent — re-run it any time to repair configuration. Use `kache init --check` to preview the changes without touching any files. If you prefer to configure things by hand, just export `RUSTC_WRAPPER=kache` or add it to `~/.cargo/config.toml` under `[build]`.
 
 ## Use in CI
 
@@ -78,7 +78,7 @@ That uses GitHub Actions cache by default. For S3-backed caching shared across r
 
 ## C/C++ caching (experimental)
 
-Alongside the rustc wrapper, kache can cache **C/C++ object compiles** as a `cc` / `c++` wrapper. It recognizes `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++` on POSIX, and `clang-cl` (clang in MSVC driver mode) on Windows:
+Alongside the rustc wrapper, kache can cache **C/C++ object compiles** as a `cc` / `c++` wrapper. It recognizes `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++` (plus versioned variants like `gcc-13`), and `clang-cl` or any `--driver-mode=cl` invocation (clang in MSVC driver mode) — on every OS, not just Windows, since recognition keys off the driver mode rather than the host. clang-cl is what mozconfigs and the `cc` crate use on Windows:
 
 ```sh
 # POSIX (gcc / clang)
@@ -91,11 +91,11 @@ export CXX="kache c++"
 set "CC=kache clang-cl"
 ```
 
-**What's cached today:** single-source `-c` object compiles (e.g. `cc -c foo.c -o foo.o`, or `clang-cl -c foo.c -Fofoo.obj`). The cache key is the preprocessor expansion (`cc -E -P` for gcc/clang, `clang-cl /EP` for clang-cl, with `SOURCE_DATE_EPOCH` pinned) plus compiler identity, target arch, and codegen flags — so any header change invalidates it. On a hit the object (`.o`, or `.obj` for clang-cl) and its `.d` dep-info restore without re-running the compiler. Any flag kache hasn't classified is **refused** — the invocation passes through to the real compiler rather than risk a silently-wrong object.
+**What's cached today:** single-source `-c` object compiles (e.g. `cc -c foo.c -o foo.o`, or `clang-cl -c foo.c -Fofoo.obj`). The cache key is the preprocessor expansion (`cc -E -P` for gcc/clang, `clang-cl /EP` for clang-cl, with `SOURCE_DATE_EPOCH` forced to `0` so `__DATE__`/`__TIME__` expand deterministically) plus compiler identity, target arch, and codegen flags — so any header change invalidates it. On a hit the object (`.o`, or `.obj` for clang-cl) and its `.d` dep-info restore without re-running the compiler. Any flag kache hasn't classified is **refused** — the invocation passes through to the real compiler rather than risk a silently-wrong object.
 
-For **gcc/clang** the key is portable across machines and worktrees (paths are normalized via `-ffile-prefix-map`). For **clang-cl** the key is currently **machine-local**: clang-cl ignores `-ffile-prefix-map`, so kache keeps literal paths in the key — correct local hits, but no cross-machine sharing yet.
+For **gcc/clang** the key is portable across machines and worktrees (paths are normalized via `-ffile-prefix-map`). Set `KACHE_BASE_DIR` to a user-declared root that gets stripped from the key, covering paths the derived source/build roots miss — e.g. objdir-built units whose `__FILE__` points above the derived root — for cross-checkout hits the automatic roots can't reach. If path normalization ever miscaches, `KACHE_CC_PATH_NORMALIZE=0` is the escape hatch: keys become path-literal (no cross-machine sharing, zero normalization risk). For **clang-cl** the key is already **machine-local**: clang-cl ignores `-ffile-prefix-map`, so kache keeps literal paths in the key — correct local hits, but no cross-machine sharing yet. clang-cl **debug** compiles (`/Z7`, `/Zi`, `-Z7`, or a `-g` form) are cached too: clang-cl embeds debug info straight into the `.obj` (there's no separate compile-time PDB), so kache folds the CodeView path inputs that object embeds — source path, output name, and compilation dir — into the same machine-local key.
 
-**Not cached yet** (these pass through): link / whole-program steps, multi-source and multi-arch invocations, precompiled headers, modules, coverage, and split-DWARF; for clang-cl also **debug info** (`-Z7` / `-g`), `-bigobj`, and `-showIncludes`. C/C++ caching is also **local-only** for now — the Rust path's S3 sharing doesn't extend to `cc` artifacts yet.
+**Not cached yet** (these pass through): link / whole-program steps, multi-source and multi-arch invocations, response-file (`@file`) invocations, precompiled headers, modules, coverage, and split-DWARF; for clang-cl also `-bigobj` and `-showIncludes`. C/C++ caching is also **local-only** for now — the Rust path's S3 sharing doesn't extend to `cc` artifacts yet.
 
 It's experimental and conservative by design: when in doubt, kache misses rather than serve a wrong artifact. Scope and remaining work are tracked in [#49](https://github.com/kunobi-ninja/kache/issues/49).
 
@@ -132,7 +132,7 @@ just bench-retry substrate     # restore cold-state snapshot, re-measure warm on
 
 Each benchmark scenario uses a **per-scenario scratch dir** — `./tmp/bench/<scenario>` by default (override with `--work-dir`) — so firefox, substrate, and any other scenario **coexist** without clobbering each other's clones, cache, or logs; `rm -rf tmp/bench` cleans them all. A `work_dir` lock refuses a second run pointed at the same scratch dir. Two caveats: (1) **concurrent runs on one host invalidate the wall-clock numbers** (CPU/IO/RAM contention) — for valid timing run sequentially or on separate hosts; (2) this per-scenario path is a change from the old shared `./tmp/bench`, so a pre-existing `--retry`/`--skip-clone` snapshot won't be found under the new path — your **first run after upgrading must be a full run** (delete the old `tmp/bench` and `tmp/bench-clone-ref` first).
 
-Each project is described by a [scenario](scenarios/) (`scenarios/bench-*/scenario.toml`) — repo/ref, how to wire kache in, how to build — so adding a workload is dropping a scenario directory, not editing Rust. Both run the same cold→warm, two-clones-at-different-paths benchmark. The Substrate probe is `RUSTC_WRAPPER`-only: it caches the Rust compile surface — the polkadot node's dependency tree plus the nested wasm-runtime compiles — which is the workload where sccache/cachepot never solved cross-clone path-independence. Native C deps (rocksdb, secp256k1) compile outside kache's view by design. Needs `protoc`, `clang`, `cmake`, `pkg-config` installed.
+Each project is described by a [scenario](scenarios/) (`scenarios/bench-*/scenario.toml`) — repo/ref, how to wire kache in, how to build — so adding a workload is dropping a scenario directory, not editing Rust. Both run the same cold→warm, two-clones-at-different-paths benchmark. The Substrate probe is `RUSTC_WRAPPER`-only: it caches the Rust compile surface — the polkadot node's dependency tree plus the nested wasm-runtime compiles — a workload whose hard part is cross-clone path-independence, which kache's normalized keys deliver so two clones at different paths share hits. Native C deps (rocksdb, secp256k1) compile outside kache's view by design. Needs `protoc`, `clang`, `cmake`, `pkg-config` installed.
 
 See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
 
@@ -142,14 +142,14 @@ See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
 |---|---|
 | `kache` | Print help (bare invocation) |
 | `kache init [-y] [--no-service] [--check]` | Interactive setup: cargo wrapper + service install + daemon start |
-| `kache doctor [--fix [--purge-sccache]] [--verify]` | Diagnose setup; `--fix` migrates from sccache, `--verify` checks cache integrity |
+| `kache doctor [--fix [--purge-sccache]] [--verify] [--checksums] [--repair]` | Diagnose setup; `--fix` migrates from sccache, `--verify` checks cache integrity, `--checksums` also hashes blobs, `--repair` deletes corrupted entries |
 | `kache monitor [--since <dur>]` | Live TUI dashboard showing build events, cache stats, and project breakdown |
 | `kache stats [--since <dur>]` | Non-interactive cache stats summary |
 | `kache list [<crate>] [--sort name\|size\|hits\|age]` | List cached entries, or show details for a specific crate |
 | `kache why-miss <crate>` | Explain why a specific crate missed the cache |
-| `kache report [--format text\|json\|markdown\|github] [--since <dur>] [--output <path>]` | Generate a detailed hit/dup/miss build report |
-| `kache sync [--pull] [--push] [--all] [--dry-run]` | Synchronize local cache with S3 remote (pull + push) |
-| `kache save-manifest [--namespace <ns>]` | Save a build manifest for future prefetch warming |
+| `kache report [--format text\|json\|markdown\|github] [--since <dur>] [--top <n>] [--output <path>]` | Generate a detailed hit/dup/miss build report (`--top` defaults to 10) |
+| `kache sync [--manifest-path <path>] [--pull] [--push] [--all] [--dry-run]` | Synchronize local cache with S3 remote (pull + push); `--manifest-path` points the Cargo.lock pull filter at a non-cwd manifest |
+| `kache save-manifest [--manifest-key <key>] [--namespace <ns>]` | Save a build manifest for future prefetch warming; `--manifest-key` overrides the default host-target-triple key |
 | `kache gc [--max-age <dur>]` | Garbage collect — LRU eviction or age-based cleanup |
 | `kache purge [--crate-name <name>]` | Wipe entire cache or entries for a specific crate |
 | `kache clean [--dry-run]` | Find and delete `target/` directories with cache breakdown |
@@ -173,9 +173,9 @@ Configuration is available through `kache config`, environment variables, or con
 
 ## Architecture
 
-- **Wrapper**: `RUSTC_WRAPPER` intercepts rustc calls, computes blake3 cache keys, restores hits via hardlinks
+- **Wrapper**: `RUSTC_WRAPPER` intercepts rustc calls, computes blake3 cache keys, restores hits zero-copy (reflink where supported, else hardlink or copy)
 - **Daemon**: Background process handles async S3 uploads, remote checks, and prefetch. Auto-restarts when binary is updated
-- **Store**: SQLite index + content-addressed blobs under `{cache_dir}/store/`; cache hits hardlink those blobs into `target/`
+- **Store**: content-addressed blobs under `{cache_dir}/store/blobs/<prefix>/<hash>`, indexed by a SQLite DB; cache hits reflink or hardlink those blobs into `target/`
 - **Cache keys**: Deterministic blake3 hash of rustc version, crate name, source, dependencies, and normalized flags — portable across machines
 
 ## Remote service

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -5,29 +5,29 @@ description: All kache CLI commands with flags and examples.
 
 # Command reference
 
-When invoked without arguments, kache opens the TUI monitor. When invoked with a subcommand, it runs that command. When invoked as `RUSTC_WRAPPER` (detected by the rustc path in argv[1]), it operates as a transparent build cache.
+When invoked without arguments, kache prints `--help` and exits — it does not open the TUI monitor (launch it explicitly with `kache monitor`). When invoked with a subcommand, it runs that command. When invoked as `RUSTC_WRAPPER` (detected by the rustc path in argv[1]), it operates as a transparent build cache.
 
 ## Quick reference
 
 | Command | Description |
 |---|---|
-| `kache` | Open the live TUI monitor |
+| `kache` | Print `--help` and exit (use `kache monitor` for the live TUI) |
 | `kache init [-y] [--no-service] [--check]` | Interactive setup: cargo wrapper + service install + daemon start |
 | `kache monitor [--since <dur>]` | Same as bare `kache`, with optional time window |
 | `kache stats [--since <dur>]` | One-shot stats snapshot, no interactive UI |
 | `kache list [<crate>] [--sort <field>]` | List cache entries or show details for one crate |
 | `kache why-miss <crate>` | Diagnose why a crate keeps missing the cache |
-| `kache report [--format <fmt>] [--since <dur>] [--output <path>]` | Build report in text / json / markdown / github format |
+| `kache report [--format <fmt>] [--since <dur>] [--output <path>] [--top <n>]` | Build report in text / json / markdown / github format |
 | `kache gc [--max-age <dur>]` | Evict entries by LRU or age |
 | `kache purge [--crate-name <name>]` | Wipe entire cache or entries for one crate |
 | `kache clean [--dry-run]` | Find and remove `target/` directories |
 | `kache sync [flags]` | Sync local cache with S3 remote |
-| `kache save-manifest [--namespace <ns>]` | Save a build manifest for future prefetch warming |
-| `kache doctor [--fix [--purge-sccache]] [--verify]` | Diagnose and fix setup issues; verify cache integrity |
+| `kache save-manifest [--manifest-key <key>] [--namespace <ns>]` | Save a build manifest for future prefetch warming |
+| `kache doctor [--fix [--purge-sccache]] [--verify] [--checksums] [--repair]` | Diagnose and fix setup issues; verify cache integrity |
 | `kache config` | Open the TUI configuration editor |
 | `kache daemon [subcommand]` | Manage the background daemon |
 
-Duration arguments use a human-friendly format: `7d`, `24h`, `30m`.
+Duration arguments accept days or hours: `7d`, `24h`, or a bare number of hours like `48`. Minutes are not supported — a value like `30m` fails to parse and silently falls back to the default.
 
 ---
 
@@ -37,7 +37,7 @@ Duration arguments use a human-friendly format: `7d`, `24h`, `30m`.
 kache init [-y] [--no-service] [--check]
 ```
 
-Interactive setup. Edits `~/.cargo/config.toml` to set `rustc-wrapper = "kache"`, installs the daemon as a login service (launchd on macOS, systemd user unit on Linux), and starts it. Idempotent — safe to re-run any time to repair configuration.
+Interactive setup. Edits `~/.cargo/config.toml` (or the legacy extensionless `~/.cargo/config` if that file already exists) to set `rustc-wrapper = "kache"`, installs the daemon as a login service (launchd on macOS, systemd user unit on Linux, Task Scheduler on Windows), and starts it. Idempotent — safe to re-run any time to repair configuration.
 
 ```sh
 kache init                # interactive prompts
@@ -100,7 +100,7 @@ kache list serde              # all entries for serde
 ## `kache report`
 
 ```sh
-kache report [--format text|json|markdown|github] [--since <duration>] [--output <path>]
+kache report [--format text|json|markdown|github] [--since <duration>] [--output <path>] [--top <n>]
 ```
 
 Generates a detailed report of recent build activity: per-crate hit/dup/miss counts, cumulative time saved, transfer activity, and store stats. Useful for sharing CI results in a PR comment or feeding the data into other tools.
@@ -112,6 +112,8 @@ Reports keep cache outcomes separate:
 - `miss` means the cache key missed, the compiler ran, and at least one output blob was new.
 
 Hit rate counts hits only. Compiled work is reported as `dups + misses`.
+
+`--top <n>` limits how many crates appear in the per-crate breakdown (default 10).
 
 ```sh
 kache report                                  # text to stdout
@@ -127,14 +129,17 @@ The `github` format is friendly for posting as a PR comment via `gh pr comment -
 ## `kache save-manifest`
 
 ```sh
-kache save-manifest [--namespace <ns>]
+kache save-manifest [--manifest-key <key>] [--namespace <ns>]
 ```
 
 Records the resolved set of crates / cache keys for the current workspace as a build manifest. The remote planner (see [Remote service](/docs/remote-service)) consumes manifests to warm prefetch hints for future runs that look like the same workspace.
 
+- `--manifest-key <key>` overrides the manifest key (defaults to the host target triple).
+- `--namespace <ns>` enables content-addressed shard uploads (requires a `Cargo.lock`); it can also be supplied via the `KACHE_NAMESPACE` environment variable, with the flag taking precedence. With no namespace, only the monolithic manifest is uploaded and shard upload is skipped.
+
 ```sh
-kache save-manifest                           # default namespace (workspace name)
-kache save-manifest --namespace ci-main       # tag manifests by environment
+kache save-manifest                           # upload the monolithic manifest only
+kache save-manifest --namespace ci-main       # also upload shards, tagged by environment
 ```
 
 Saving a manifest is cheap; it is safe to run at the end of a CI build alongside `kache sync --push`.
@@ -233,6 +238,10 @@ kache clean              # delete all target/ directories
 
 This is useful for freeing disk space when you're done with a project or before a fresh build.
 
+<Callout type="info">
+On macOS, the scan skips TCC-protected locations (`/System`, `/Library`, `/private`, `/Applications`, `/Volumes`, and home folders like `~/Desktop`, `~/Documents`, `~/Downloads`, `~/Library`, `~/Pictures`) to avoid permission prompts, so `target/` directories under those paths are never found or cleaned.
+</Callout>
+
 ---
 
 ## `kache sync`
@@ -270,14 +279,22 @@ kache why-miss tokio
 ## `kache doctor`
 
 ```sh
-kache doctor [--fix [--purge-sccache]]
+kache doctor [--fix [--purge-sccache]] [--verify] [--checksums] [--repair]
 ```
 
 Diagnoses common setup issues: missing `RUSTC_WRAPPER`, conflicting wrappers, config file problems, and daemon connectivity. Without `--fix`, it only reports issues.
 
+The verify family checks cache integrity:
+
+- `--verify` checks entry, blob, and metadata integrity (orphaned/missing blobs).
+- `--checksums` additionally re-hashes blob contents to catch silent corruption (slower; implies `--verify`).
+- `--repair` removes corrupted entries and sweeps orphaned blobs (implies `--verify`).
+
 ```sh
 kache doctor           # diagnose only
 kache doctor --fix     # attempt to fix detected issues
+kache doctor --verify  # check cache integrity
+kache doctor --repair  # remove corrupted entries
 ```
 
 If you're migrating from sccache, `--fix` handles the migration automatically. `--purge-sccache` additionally removes sccache's cache and binary:
@@ -294,19 +311,19 @@ kache doctor --fix --purge-sccache
 kache config
 ```
 
-Opens the TUI configuration editor. Shows all config fields, their current values, and which ones are overridden by environment variables. Saves changes directly to `~/.config/kache/config.toml`.
+Opens the TUI configuration editor. Shows all config fields, their current values, and which ones are overridden by environment variables. Saves changes to the active config file: `$KACHE_CONFIG` if set, else the nearest `.kache.toml` in a parent directory, else the global `~/.config/kache/config.toml` (`$XDG_CONFIG_HOME/kache/config.toml`).
 
 ---
 
 ## `kache daemon`
 
 ```sh
-kache daemon                  # show daemon status (running, PID, version)
+kache daemon                  # show daemon status: service install state, running/offline, socket path, log location, daemon version/epoch
 kache daemon start            # start in background, wait until ready
 kache daemon stop             # graceful shutdown
-kache daemon restart          # restart (via launchd/systemd if installed, else manual)
+kache daemon restart          # restart (via launchd/systemd/Task Scheduler if installed, else manual)
 kache daemon run              # start in foreground (for debugging)
-kache daemon install          # install as a system service (launchd/systemd)
+kache daemon install          # install as a system service (launchd/systemd/Task Scheduler)
 kache daemon uninstall        # remove the system service
 kache daemon log              # stream the daemon log
 ```

--- a/docs/daemon/lifecycle.mdx
+++ b/docs/daemon/lifecycle.mdx
@@ -9,12 +9,15 @@ description: Starting, stopping, installing as a service, and how the daemon han
 
 ```sh
 kache daemon start      # start in background, blocks until the socket is ready
-kache daemon stop       # graceful shutdown
-kache daemon            # show status: running/stopped, PID, version, uptime
+kache daemon stop       # graceful shutdown (drains pending uploads, up to 30s)
+kache daemon restart    # restart in place (service-manager kickstart, else stop + fresh spawn)
+kache daemon            # status: binary version/epoch, service install state, running/stopped, socket path, log location, and (if running) the daemon's version/epoch
 kache daemon log        # stream the daemon log (follows like tail -f)
 ```
 
-`kache daemon run` starts the daemon in the foreground. This is mostly useful for debugging — you see log output directly on stderr without needing `kache daemon log`.
+`kache daemon restart` recovers a wedged daemon in three tiers: it first asks the service manager (launchd/systemd) to kickstart it, then falls back to killing any lingering `kache daemon run` processes and wiping stale socket/lock/state files, then spawns a fresh background daemon.
+
+`kache daemon run` starts the daemon in the foreground. This is mostly useful for debugging. By default only warnings and errors print to stderr; set `KACHE_LOG=kache=info` (or `kache=debug`) for verbose daemon logs.
 
 ## Installing as a system service
 
@@ -39,10 +42,11 @@ For the daemon to survive reboots and start automatically, install it as a syste
     kache daemon install
     ```
 
-    This creates a systemd user unit and enables it. The daemon runs under your user session.
+    This creates a systemd user unit (`kache.service`) and enables it. The daemon runs under your user session.
 
     ```sh
-    systemctl --user status kache
+    systemctl --user status kache.service
+    journalctl --user -u kache.service   # logs (or use `kache daemon log`)
     ```
 
     To remove it:
@@ -57,18 +61,37 @@ For the daemon to survive reboots and start automatically, install it as a syste
 
 When you update kache, the old daemon and the new wrapper would disagree on RPC protocol versions. kache handles this automatically.
 
-Each process tracks a **build epoch** — the modification time of the kache binary. When the wrapper makes an RPC call and its epoch is newer than the daemon's, the daemon schedules a graceful shutdown and the wrapper attempts to restart it. The next RPC call hits the fresh daemon. You never need to manually restart the daemon after an update.
+Each process tracks a **build epoch** — the modification time of the kache binary. The daemon reads the client's epoch from incoming Upload/Stats/BuildStarted requests; when a client binary is newer, the daemon sets its own shutdown flag and self-terminates once in-flight work drains. If it was installed as a service, launchd/systemd restarts it with the new binary; otherwise the next upload or CLI/monitor command auto-starts it. The next RPC call hits the fresh daemon. You never need to manually restart the daemon after an update.
 
 <Callout type="info">
-The restart logic runs only in CLI and daemon code paths, never in the wrapper hot path. Restarting the daemon doesn't add latency to any in-progress rustc invocations.
+Restarting the daemon adds no latency to in-progress rustc invocations: the remote-check hot path never starts the daemon (it skips straight to compilation on a miss). Only the background upload path will lazily (re)start a downed daemon.
 </Callout>
+
+## Idle shutdown
+
+The daemon can auto-exit after a stretch with no connections, so zombie daemons don't accumulate when you aren't building. It is re-spawned on the next build.
+
+```toml
+# config.toml
+daemon_idle_timeout_secs = 600   # exit after 10 min idle; 0 disables
+```
+
+You can also set `KACHE_DAEMON_IDLE_TIMEOUT` (seconds). **The default is 600 seconds (10 minutes).** Set it to `0` to disable the watchdog so the daemon runs indefinitely until you stop it, the binary updates, or the OS signals it.
+
+## Lifecycle internals
+
+A few behaviors worth knowing about:
+
+- **Single instance**: a second `kache daemon run` exits cleanly (code 0) if another process holds the run lock or the socket is already live, so launchd/systemd `KeepAlive` won't loop. Stale socket files are removed on startup when nothing is listening.
+- **Background log file**: auto-started daemons write stderr to `<socket>.log` next to the daemon socket (Linux `~/.cache/kache/daemon.log`, macOS `~/Library/Caches/kache/daemon.log`). It is reset to a `--- log rotated ---` marker once it grows past 2 MiB. `kache daemon log` tails this file.
+- **Graceful drain**: on shutdown the daemon closes its upload queue and waits up to 30 s for in-flight S3 uploads to finish before aborting workers.
 
 ## Offline behavior
 
 If the daemon is down or unreachable when the wrapper makes an RPC call, the wrapper continues without it. This affects:
 
 - **Remote checks**: skipped — the wrapper goes straight to compilation on a local miss
-- **Upload jobs**: dropped — new artifacts won't be uploaded until the daemon is running again
+- **Upload jobs**: the wrapper tries to (re)start the daemon and re-send; the job is dropped only if the daemon can't be started. It never fails the build.
 - **Prefetch**: skipped for the current build session
 
 The monitor shows `daemon: offline` when the daemon hasn't responded in the last refresh cycle. Common causes:

--- a/docs/daemon/overview.mdx
+++ b/docs/daemon/overview.mdx
@@ -9,7 +9,7 @@ The daemon is a background process that handles everything that shouldn't block 
 
 ## What the daemon handles
 
-**Upload queue.** After a cache miss and successful compilation, the wrapper sends the new artifact to the daemon and returns immediately. The daemon uploads it to S3 in the background. No build time is spent waiting for uploads.
+**Upload queue.** After a cache miss and successful compilation, the wrapper hands the daemon a reference to the freshly stored entry and returns immediately. The daemon reads it from the local store and uploads to S3 in the background. No build time is spent waiting for uploads.
 
 **Remote checks.** Before compiling a crate that missed locally, the wrapper asks the daemon to check S3 for the artifact. The daemon downloads it if found, then signals the wrapper to restore from the local store.
 
@@ -17,8 +17,10 @@ The daemon is a background process that handles everything that shouldn't block 
 
 The prefetch hint fires once per build session (with a 5-minute cooldown) to avoid redundant work across sequential cargo commands in CI — `cargo check`, `cargo clippy`, `cargo test` may all run within the same session window.
 
+**Garbage collection.** The daemon runs a GC sweep immediately on startup and then every 6 hours — eviction, dedup, orphan-blob cleanup, and incremental-dir pruning — so the store stays bounded without blocking any build.
+
 <Callout type="info">
-**SOON:** a remote planner service ([Remote service](/docs/remote-service)) will replace the metadata-only prefetch with ranked candidates from prior builds — useful on cold runners where `cargo metadata` alone underprefetches. Today the daemon falls back to the metadata path; nothing else is needed.
+When a planner endpoint ([Remote service](/docs/remote-service)) is configured, the daemon asks it first and prefetches its ranked candidates from prior builds — useful on cold runners where `cargo metadata` alone underprefetches. Otherwise it falls back to the metadata/local planner; nothing else is needed. The client support ships in the daemon today; the hosted planner service is still in preview.
 </Callout>
 
 ## When the daemon is optional
@@ -35,15 +37,15 @@ You'll still get local cache hits from previous builds, but the remote is effect
 
 ## Communication
 
-The wrapper communicates with the daemon over a Unix socket at `~/.cache/kache/daemon.sock`. RPC calls are synchronous from the wrapper's perspective but non-blocking — the remote check has a short timeout so a hung daemon doesn't add latency to compilation.
+The wrapper communicates with the daemon over a Unix socket at `<cache_dir>/daemon.sock` (e.g. `~/.cache/kache/daemon.sock` on Linux, `~/Library/Caches/kache/daemon.sock` on macOS; on Windows this becomes a named pipe). The cache dir can be overridden with `KACHE_CACHE_DIR`. RPC calls are synchronous from the wrapper's perspective but non-blocking — the remote check has a 3-second timeout, so even a hung daemon caps the added latency.
 
-If the daemon is unreachable (not running, stale socket, or timeout), the wrapper logs a warning at trace level and continues without it. The monitor shows `daemon: offline` in this state, but local cache data is still displayed.
+If the daemon is unreachable (not running, stale socket, or timeout), the wrapper silently skips the daemon — logging at debug level only on a connect/timeout error — and continues without it. The monitor shows `daemon: offline` in this state, but local cache data is still displayed.
 
 ## Starting the daemon
 
 ```sh
 kache daemon start     # start in background, returns when ready
-kache daemon           # show status (running, pid, version)
+kache daemon           # show status (service, running state, socket, log path, version)
 kache daemon log       # tail the daemon log
 ```
 

--- a/docs/deduplication.mdx
+++ b/docs/deduplication.mdx
@@ -1,11 +1,11 @@
 ---
 title: Deduplication
-description: How hardlinks and content-addressed storage eliminate redundant disk usage.
+description: How content-addressed storage and zero-copy restores eliminate redundant disk usage.
 ---
 
 # Deduplication
 
-Rust's build system compiles the same crate multiple times in a workspace — once per unique combination of features, targets, and profiles. Without a cache, each compilation writes a fresh copy of the output files. kache avoids this through two mechanisms: content-addressed storage and hardlinks.
+Rust's build system compiles the same crate multiple times in a workspace — once per unique combination of features, targets, and profiles. Without a cache, each compilation writes a fresh copy of the output files. kache avoids this through two mechanisms: content-addressed storage and zero-copy restores (reflink where the filesystem supports it, hardlink or copy otherwise).
 
 ## Content-addressed blobs
 
@@ -16,41 +16,48 @@ The store directory layout looks like this:
 ```
 ~/.cache/kache/
 └── store/
-    ├── ab/
-    │   └── abcdef1234...   ← a blob, named by hash
-    ├── cd/
-    │   └── cdabef5678...
-    └── ...
+    └── blobs/
+        ├── ab/
+        │   └── abcdef1234...   ← a blob, named by hash
+        └── cd/
+            └── cdabef5678...
 ```
 
-The SQLite index tracks which blobs belong to which cache entries. When an entry is evicted by GC, the blob is removed only if no other entry references it.
+The cache directory is `~/.cache/kache` on Linux, `~/Library/Caches/kache` on macOS, and `%LOCALAPPDATA%\kache` on Windows; override it with `KACHE_CACHE_DIR`. Blobs live two levels deep, under `store/blobs/<first-2-hex>/<hash>`; cache-entry directories (`<cache_key>/meta.json`) sit directly under `store/`.
 
-## Hardlinks on restore
+The SQLite index (`index.db`, a sibling of `store/`, not inside it) tracks which blobs belong to which cache entries. When an entry is evicted by GC, the blob is removed only if no other entry references it.
 
-When kache restores a cache hit, it doesn't copy blob files into `target/`. It creates hardlinks — additional directory entries pointing to the same inode. The file data is read once from the blob and remains in one place on disk. All `target/` directories that reference the same compiled artifact share the same physical storage.
+## Zero-copy restores
 
-This means the `Deduplicated` figure in the monitor header measures real savings: space that would have been used by file copies if kache hadn't used hardlinks.
+When kache restores a cache hit, it doesn't copy blob files into `target/` if it can avoid it. On every platform it first tries a **reflink** — a copy-on-write clone that is zero-copy *and* gives the restored file an independent inode — where the filesystem supports it (APFS on macOS, btrfs, XFS with reflink, the common dev case). Mutations to a reflinked file never propagate back to the cache blob.
 
-For binary outputs (`bin`, `dylib`, `cdylib`), hardlinks aren't safe because cargo may modify the file after linking. kache copies those instead.
+On filesystems without copy-on-write (e.g. ext4 without `reflink`, tmpfs, NTFS), kache falls back per artifact type:
 
-Hardlinks only work within the same filesystem (same mount point). If `~/.cache/kache` and your project's `target/` directory are on different volumes, kache falls back to copying.
+- **Hardlink** for immutable artifacts (`.rlib` / `.rmeta` / `.d`): an additional directory entry pointing to the same inode, so the data exists once on disk. A hardlink that fails — for example across mount points — falls back to a plain copy.
+- **Copy** for mutable, OS-loaded outputs (`bin`, `dylib`, `cdylib`, `proc-macro`): the build may modify the file after linking (codesigning, stripping), so kache never hardlinks these. Where reflink is available they are still reflinked (then made executable); only the non-CoW fallback is a byte copy.
 
-## The Deduplicated metric
+The single-physical-copy / shared-inode property only holds for the hardlink fallback. Reflinks already store the data once via copy-on-write but each restore has its own inode.
 
-The `Deduplicated: <N bytes> (<M> hardlinks)` line in the monitor header is an estimate computed by a background scan. It works by examining inode link counts in the store and estimating how much data would exist if each reference were a separate copy.
+## The dedup line in the monitor
 
-A few things to keep in mind:
+The monitor header carries a single dedup line, for example:
 
-The value is computed periodically, not per-write. `Dedup: active` means the scan is running right now; `Dedup: idle` means it finished and is waiting for the next scan interval. A freshly built project may not be reflected until the next scan.
+```
+Dedup: 1.2 GiB saved (38.4%)    Blobs: 1.9 GiB physical    Hardlinks: 240 MiB via 312 hardlinks    Scan: idle
+```
 
-The estimate can be conservative. The scan only sees blobs in kache's store, not all hardlinks on the filesystem.
+The pieces map to two independent measurements:
 
-The metric is informational — it doesn't affect behavior and doesn't need to reach any particular value to confirm kache is working correctly.
+- **`Dedup: <bytes> saved (<pct>%)` / `Blobs: <bytes> physical`** — content-addressed blob savings: how much is saved by storing each unique output once (logical − physical blob bytes), and the physical size of the blob store. This figure is cross-platform.
+- **`Hardlinks: <bytes> via <N> hardlinks`** — the inode-link scan: bytes that the hardlink fallback keeps from being separate copies, summed from blob link counts. When no blob has extra links this reads `none — restores prefer reflink/CoW` — the expected state on copy-on-write filesystems (APFS, btrfs, XFS-with-reflink), where restores are reflinks with independent inodes (so `nlink` stays 1) and the real savings are the cross-platform `Dedup` figure above. This scan is Unix-only; on Windows it always reports zero, because Windows does not expose a portable inode link count.
+- **`Scan: <calculating | idle | not scanned>`** — `calculating` means the background scan is running right now, `idle` means it finished and is waiting for the next interval, `not scanned` means it hasn't run yet. A freshly built project may not be reflected until the next scan.
+
+The dedup line is informational — it doesn't affect behavior and doesn't need to reach any particular value to confirm kache is working correctly.
 
 ## `dup` events are different
 
-The monitor's `dup` outcome is not the same thing as the `Deduplicated` storage
-metric. A `dup` event means a cache key missed, the compiler ran, and the
+The monitor's `dup` outcome is not the same thing as the dedup storage
+line above. A `dup` event means a cache key missed, the compiler ran, and the
 compiled output hashes were already present before storing. That usually points
 to equivalent builds under different keys, such as over-specific arguments,
 paths, or environment inputs. It still counts as compiled work.

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -19,7 +19,7 @@ The config file is TOML. You can edit it directly or use the TUI editor:
 kache config
 ```
 
-The TUI editor shows all fields with their current values, marks which ones are coming from env vars, and lets you toggle or edit them interactively.
+The TUI editor surfaces the common fields with their current values, marks which ones are coming from env vars (those are read-only and the cursor skips them), and lets you toggle or edit the rest interactively. Navigate with the arrows or `j`/`k`, jump between sections with Tab/Shift-Tab, Enter edits a field, Space toggles a boolean, `s` (or Ctrl-S) saves, and `q`/Esc quits with an unsaved-changes prompt. Some advanced sections — `[cache.planner]`, `[cc]`, and `cache.path_only_env_vars` — have no form fields and are preserved verbatim on save.
 
 Config file priority:
 
@@ -43,7 +43,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 |---|---|---|---|
 | `KACHE_CACHE_DIR` | `cache.local_store` | `~/Library/Caches/kache` on macOS, `~/.cache/kache` on Linux | Local cache directory |
 | `KACHE_MAX_SIZE` | `cache.local_max_size` | `50GiB` | Maximum local store size |
-| `KACHE_CONFIG` | — | XDG config path | Explicit config file path |
+| `KACHE_CONFIG` | — | — | Explicit config file path; overrides the project-local `.kache.toml` / XDG resolution |
 | `KACHE_S3_BUCKET` | `cache.remote.bucket` | — | S3 bucket name |
 | `KACHE_S3_ENDPOINT` | `cache.remote.endpoint` | — | S3 endpoint URL (required for Ceph, MinIO, R2) |
 | `KACHE_S3_REGION` | `cache.remote.region` | `us-east-1` | AWS region |
@@ -51,8 +51,8 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_S3_PROFILE` | `cache.remote.profile` | — | AWS credentials profile |
 | `KACHE_S3_ACCESS_KEY` | — | — | Explicit S3 access key |
 | `KACHE_S3_SECRET_KEY` | — | — | Explicit S3 secret key |
-| `KACHE_CACHE_EXECUTABLES` | `cache.cache_executables` | `false` | Cache bin/dylib/cdylib/proc-macro outputs |
-| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly |
+| `KACHE_CACHE_EXECUTABLES` | `cache.cache_executables` | `false` | Also cache user-facing executables (`bin` crates and `--test` binaries). dylib/cdylib/proc-macro are always cached and are unaffected by this flag |
+| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly. Env is on unless the value is exactly `0` or `false` (case-insensitive) |
 | — | `cache.exclude` | `[]` | Source-path glob patterns that bypass kache and compile normally without lookup, store, or upload |
 | `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd compression level (1–22) |
 | `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `16` | Max concurrent S3 operations |
@@ -60,12 +60,17 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_DAEMON_IDLE_TIMEOUT` | `cache.daemon_idle_timeout_secs` | `600` | Idle daemon shutdown timeout in seconds (`0` disables auto-shutdown) |
 | `KACHE_KEY_SALT` | `cache.key_salt` | — | Opaque string folded into every cache key. Change it to force a cold cache on a toolchain change kache cannot otherwise see (see [Cache-key salt](#cache-key-salt)) |
 | `KACHE_CC_EXTRA_ALLOWLIST_FLAGS` | `cc.extra_allowlist_flags` | `[]` | C/C++ flags to opt into caching that kache's built-in allow-list doesn't yet model (see [Extra cc allowlist flags](#extra-cc-allowlist-flags)). Env value is whitespace-separated |
-| `KACHE_DISABLED` | — | `0` | Disable caching entirely (pass-through to rustc) |
-| `KACHE_LOG` | — | `kache=warn` | Log level for stderr output |
-| `KACHE_LOG_FILE` | — | `kache=info` | Log level for the file log |
-| `KACHE_PROGRESS` | — | `auto` | CI progress lines: `always`, `never`, or `auto` |
+| `KACHE_DISABLED` | — | `false` | Disable caching entirely (pass-through to rustc). Env-only, no config key: `1` or `true` (case-insensitive) disables; any other value — including `0`, `false`, or unset — leaves caching on |
+| `KACHE_FALLBACK` | `cache.fallback` | — | Secondary compiler-wrapper to hand passed-through compiles to; kache runs `<fallback> <compiler> <args>` when it declines to cache. `off`/`none`/empty disables |
+| `KACHE_PATH_ONLY_ENV_VARS` | `cache.path_only_env_vars` | `[]` | Extra env vars (besides `OUT_DIR`) whose values only locate an `include!`'d file, so kache normalizes their absolute path in the cache key. Env value is comma/whitespace-separated and replaces the file list (see [Path-only env vars](#path-only-env-vars)) |
+| `KACHE_PLANNER_ENDPOINT` | `cache.planner.endpoint` | — | Prefetch-planner service URL; setting it enables the planner client. Empty/whitespace is treated as unset |
+| `KACHE_PLANNER_TIMEOUT_MS` | `cache.planner.timeout_ms` | `750` | Planner request timeout in milliseconds |
+| `KACHE_PLANNER_TOKEN` | `cache.planner.token` | — | Bearer credential sent with planner requests |
+| `KACHE_LOG` | — | `kache=warn` * | Log level for stderr output |
+| `KACHE_LOG_FILE` | — | `kache=info` * | Log level for the file log |
+| `KACHE_PROGRESS` | — | (off) | Per-crate progress lines to stderr: `1`/`hits` prints cache hits only; `verbose`/`all` also prints dups and misses; unset or anything else stays silent |
 
-`KACHE_PROGRESS=auto` (the default) prints per-crate progress lines to stderr when stderr is not a terminal. In CI this is usually the right behavior without any configuration.
+\* In wrapper mode (`RUSTC_WRAPPER`, the common path) stderr logging defaults to **off** and the file log is **disabled** unless `KACHE_LOG_FILE` is set explicitly. The `kache=warn` / `kache=info` defaults apply to CLI and daemon invocations.
 
 ## Excluding Sources
 
@@ -142,11 +147,30 @@ This is **opt-in and scoped per crate**: a crate with no `kache.toml` is unaffec
   from the project config `.kache.toml`; any other key in it is a loud error.
 </Callout>
 
+## Path-only env vars
+
+By default kache normalizes the absolute path baked into `OUT_DIR` so the cache key stays portable across machines and worktrees. Some builds set other env vars that serve the same role — they only point at a generated file that a crate `include!`s, and their absolute value should not bust the key (e.g. Firefox's `BUILDCONFIG_RS` / `MOZ_TOPOBJDIR`).
+
+`cache.path_only_env_vars` opts those vars into the same path-only treatment:
+
+```toml title=".kache.toml"
+[cache]
+path_only_env_vars = ["BUILDCONFIG_RS", "MOZ_TOPOBJDIR"]
+```
+
+Or via the environment (comma- or whitespace-separated; replaces the file list entirely):
+
+```sh
+export KACHE_PATH_ONLY_ENV_VARS="BUILDCONFIG_RS MOZ_TOPOBJDIR"
+```
+
+This is an advanced opt-in: only list vars whose value is purely a path locator. An empty list means only `OUT_DIR` is normalized.
+
 ## Extra cc allowlist flags
 
 kache caches a C/C++ compile only when it recognizes every flag on the command line. Its cc flag classifier is an **allow-list**: each flag is one kache has reasoned about and knows how to key. Anything unrecognized is refused and the compile passes through uncached — the safe default, since a flag kache doesn't model could change the object file without changing the key.
 
-**Supported compilers and dialects.** kache wraps the GNU-dialect drivers (`cc`, `c++`, `gcc`, `g++`, `clang`, `clang++`; POSIX) and the MSVC-dialect `clang-cl` (Windows, or `clang --driver-mode=cl`). The two dialects have separate allow-lists, so each flag is classified in the spelling its compiler actually uses — e.g. `-fno-rtti` (GNU) vs `-GR-` (clang-cl), `-std=c++20` vs `-std:c++20`. For clang-cl, debug info (`-Z7` / `-g`), `-bigobj`, and `-showIncludes` are deliberately **refused** (passed through) for now; the common MSVC codegen set (`-EH*`, `-GR`/`-GS`, `-guard:`, `-std:`, `-fms-compatibility-version=`, `/O*`, `-Gy`/`-Gw`, `-MD`/`-MT`, …) is modeled. `extra_allowlist_flags` entries below are matched against command-line tokens verbatim, so list them in whichever dialect your compiler speaks (a `/`-spelled clang-cl flag included).
+**Supported compilers and dialects.** kache wraps the GNU-dialect drivers (`cc`, `c++`, `gcc`, `g++`, `clang`, `clang++`; POSIX) and the MSVC-dialect `clang-cl` (Windows, or `clang --driver-mode=cl`). The two dialects have separate allow-lists, so each flag is classified in the spelling its compiler actually uses — e.g. `-fno-rtti` (GNU) vs `-GR-` (clang-cl), `-std=c++20` vs `-std:c++20`. For clang-cl, debug info (`/Z7` / `-Z7` / `-g`) **is** cached (machine-local — clang-cl embeds CodeView paths in the `.obj`), while `-bigobj` and `-showIncludes` are still deliberately **refused** (passed through) for now; the common MSVC codegen set (`-EH*`, `-GR`/`-GS`, `-guard:`, `-std:`, `-fms-compatibility-version=`, `/O*`, `-Gy`/`-Gw`, `-MD`/`-MT`, …) is modeled. `extra_allowlist_flags` entries below are matched against command-line tokens verbatim, so list them in whichever dialect your compiler speaks (a `/`-spelled clang-cl flag included).
 
 The cost is that a common-but-unlisted flag disables caching for that compile until kache ships a release adding it. `cc.extra_allowlist_flags` lets you opt such a flag in locally, ahead of official support:
 
@@ -215,14 +239,17 @@ The file log is written to `~/Library/Logs/kache/kache.log` on macOS and `~/.cac
 ## Local store layout
 
 ```
-~/.cache/kache/           # Linux example
-├── index.db          # SQLite index (WAL mode)
-├── events.jsonl      # build event log
-├── daemon.sock       # daemon unix socket
-└── store/            # content-addressed blobs
-    ├── ab/
-    │   └── abcdef...  # blake3 hash-named files
-    └── ...
+<cache_dir>/               # Linux: ~/.cache/kache · macOS: ~/Library/Caches/kache · Windows: %LOCALAPPDATA%\kache
+├── store/
+│   ├── blobs/
+│   │   └── ab/
+│   │       └── abcdef...   # content-addressed blob (blake3), stored once
+│   └── <cache_key>/
+│       └── meta.json       # entry metadata; references its blobs by hash
+├── index.db                # SQLite index (WAL mode) — sibling of store/, not inside it
+├── events.jsonl            # build event log
+├── transfers.jsonl         # transfer log
+└── daemon.sock             # daemon IPC socket (a named pipe on Windows)
 ```
 
-The store directory is excluded from Time Machine and Spotlight on macOS automatically.
+The whole cache directory is excluded from Time Machine and Spotlight on macOS automatically — on first start the daemon sets a `tmutil` exclusion and a `.metadata_never_index` sentinel.

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -5,7 +5,7 @@ description: How to install kache using mise, cargo-binstall, or from source.
 
 # Installation
 
-kache requires Rust 1.95 or later (it uses `let ... && let` chains and other recent stabilizations). The binary is self-contained — no runtime dependencies.
+kache requires Rust 1.95 or later and is built with the 2024 edition (`Cargo.toml` `edition = "2024"`). The binary is self-contained — no runtime dependencies.
 
 ## Methods
 
@@ -18,7 +18,7 @@ kache requires Rust 1.95 or later (it uses `let ... && let` chains and other rec
     mise use -g github:kunobi-ninja/kache@latest
 
     # or pin a specific version
-    mise use -g github:kunobi-ninja/kache@0.3.1
+    mise use -g github:kunobi-ninja/kache@0.5.0
     ```
 
     To pin kache in your project so every contributor gets the same version, add it to your `mise.toml`:
@@ -34,24 +34,30 @@ kache requires Rust 1.95 or later (it uses `let ... && let` chains and other rec
     [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) downloads the pre-built binary from GitHub releases without compiling.
 
     ```sh
-    cargo binstall --git https://github.com/kunobi-ninja/kache kache
+    cargo binstall kache
     ```
+
+    Every release (including RCs) is published to crates.io, so the plain crate
+    name works. To install an unreleased branch build instead, use the `--git`
+    form: `cargo binstall --git https://github.com/kunobi-ninja/kache kache`.
 
     If a pre-built binary isn't available for your target, use the source install method below.
   </Tab>
   <Tab value="from source">
     ```sh
-    cargo install --git https://github.com/kunobi-ninja/kache kache
+    cargo install kache
     ```
 
-    This compiles kache with your local toolchain. It takes a couple of minutes and works on Linux, macOS, and Windows (with the MSVC toolchain).
+    This compiles kache with your local toolchain. It takes a couple of minutes
+    and works on Linux, macOS, and Windows (with the MSVC toolchain). To build an
+    unreleased branch instead, use `cargo install --git https://github.com/kunobi-ninja/kache kache`.
   </Tab>
 </Tabs>
 
 <Callout type="info">
   The methods above install the latest **stable** release. Release-candidates are
   published but never resolve as "latest", so request one explicitly:
-  `cargo install kache --version 0.5.0-rc.4` (or `cargo binstall kache@0.5.0-rc.4`).
+  `cargo install kache --version 0.6.0-rc.1` (or `cargo binstall kache@0.6.0-rc.1`).
 </Callout>
 
 ## Supported platforms
@@ -65,6 +71,7 @@ Pre-built binaries are available for:
 | `x86_64-apple-darwin` | Intel macOS |
 | `aarch64-apple-darwin` | Apple Silicon |
 | `x86_64-pc-windows-msvc` | Windows x64 (MSVC) |
+| `aarch64-pc-windows-msvc` | Windows ARM64 (MSVC) |
 
 ## Verify the installation
 
@@ -72,8 +79,8 @@ Pre-built binaries are available for:
 kache --version
 ```
 
-You should see a version string like `kache 0.3.1`. If the command isn't found, make sure the binary is on your `PATH` (mise handles this automatically).
+You should see a version string like `kache 0.5.0`. If the command isn't found, make sure the binary is on your `PATH` (mise handles this automatically).
 
 ## Next: enable kache for cargo
 
-Installing the binary doesn't yet wire it into cargo. Run `kache init` to configure `~/.cargo/config.toml`, install the daemon as a login service, and start it — see [Quick start](/docs/getting-started/quick-start) for the full walkthrough.
+Installing the binary doesn't yet wire it into cargo. Run `kache init` to configure your cargo config (`~/.cargo/config.toml`, or the legacy `~/.cargo/config` if that file already exists), install the daemon as a login service, and start it — see [Quick start](/docs/getting-started/quick-start) for the full walkthrough.

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quick start
-description: Run kache init, watch a cold build populate the cache, then see the second build restore every artifact via hardlinks.
+description: Run kache init, watch a cold build populate the cache, then see the second build restore every artifact with zero-copy reflinks.
 ---
 
 # Quick start
@@ -21,9 +21,9 @@ kache init --no-service
 kache init --check
 ```
 
-After `kache init`, your next `cargo build` is already cached. The first run is a normal cold compile; the second run restores everything from kache's store via hardlinks.
+After `kache init`, your next `cargo build` is already cached. The first run is a normal cold compile; the second run restores everything from kache's store with zero-copy reflinks (copy-on-write) where the filesystem supports it, and hardlink or copy otherwise.
 
-![kache: cold build populates the store, then `cargo clean && cargo build` restores every artifact via hardlinks](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/demo.gif)
+![kache: cold build populates the store, then `cargo clean && cargo build` restores every artifact with zero-copy reflinks](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/demo.gif)
 
 ## Verify the setup
 
@@ -31,7 +31,7 @@ After `kache init`, your next `cargo build` is already cached. The first run is 
 kache doctor
 ```
 
-`doctor` checks for a working `RUSTC_WRAPPER`, conflicting wrappers (e.g. sccache), config file problems, and daemon connectivity. Add `--fix` to apply automatic repairs, or `--verify` to additionally walk the store and confirm cached blobs are intact.
+`doctor` checks for a working `RUSTC_WRAPPER`, conflicting wrappers (e.g. sccache), config file problems, and daemon connectivity. Add `--fix` to apply automatic repairs. For store integrity, `--verify` walks the store and checks entries, blobs, and metadata; add `--checksums` to also recompute and verify blob content hashes (slower); `--repair` removes corrupted entries.
 
 ## Manual setup (without `kache init`)
 
@@ -72,23 +72,23 @@ If you'd rather wire things up yourself:
     cargo clean && cargo build
     ```
 
-    This time, kache restores every crate from the cache via hardlinks. Cargo should complete in seconds for a project with no source changes.
+    This time, kache restores every crate from the cache with zero-copy reflinks (hardlink or copy where the filesystem has no copy-on-write). Cargo should complete in seconds for a project with no source changes.
   </Step>
 
   <Step>
     **Open the monitor**
 
     ```sh
-    kache
+    kache monitor
     ```
 
-    The TUI monitor opens and shows the Build tab with the events from the last run — each crate listed as a local hit or miss with timing. Press `q` to quit.
+    The TUI monitor opens and shows the Build tab with the events from the last run — each crate listed as a local hit or miss with timing. Press `q` to quit. (Running bare `kache` prints help; use `kache monitor` to open the dashboard.)
   </Step>
 </Steps>
 
 ## How to tell it's working
 
-In CI or any non-terminal environment, kache prints a progress line to stderr for each crate:
+kache can print a one-line summary to stderr per crate, off by default. Enable it with `KACHE_PROGRESS=1` (or `hits`) to show hits, or `KACHE_PROGRESS=verbose` (or `all`) to also show dups and misses:
 
 ```
 [kache] serde: local hit (2ms, 1.2 MB)
@@ -96,7 +96,7 @@ In CI or any non-terminal environment, kache prints a progress line to stderr fo
 [kache] myapp: miss (1.4s, 892 KB)
 ```
 
-In a terminal, these lines are suppressed — open the monitor instead (`kache` or `kache monitor`).
+The `miss` line only appears at `KACHE_PROGRESS=verbose`; at `KACHE_PROGRESS=1`/`hits` only hit lines are shown. For a live view, open the monitor instead with `kache monitor`.
 
 You can also check the cache state directly:
 
@@ -108,9 +108,9 @@ kache stats              # one-shot summary (no UI)
 
 ## What kache does not cache
 
-By default, kache skips binary crates (`bin`), dynamic libraries (`dylib`, `cdylib`), and proc-macros. These outputs depend on the linker and are more expensive to restore correctly. Set `KACHE_CACHE_EXECUTABLES=1` or `cache_executables = true` in the config file to opt in.
+By default, kache skips user-facing executables — `bin` crates and `--test` harnesses — because these linked outputs are more expensive to restore correctly. Dynamic libraries (`dylib`, `cdylib`) and proc-macros stay cached regardless. Set `KACHE_CACHE_EXECUTABLES=1` or `cache_executables = true` in the config file to cache executables too.
 
-Incremental compilation is automatically disabled when kache is active (`CARGO_INCREMENTAL=0`). kache's artifact caching makes incremental redundant, and on macOS, APFS-related corruption can occur when both are active simultaneously.
+Incremental compilation is automatically disabled when kache is active — kache strips the `-C incremental=...` flag from each rustc invocation (setting `CARGO_INCREMENTAL=0` would be too late, since cargo injects the flag before the wrapper runs). kache's artifact caching makes incremental redundant, and on macOS, APFS-related corruption can occur when both are active simultaneously.
 
 ## Disabling kache temporarily
 

--- a/docs/how-it-works/architecture.mdx
+++ b/docs/how-it-works/architecture.mdx
@@ -20,9 +20,9 @@ parse args
     ↓
 compute blake3 cache key
     ↓
-check local store ──── hit → restore via hardlink → done
+check local store ──── hit → restore via reflink → done
     ↓ miss
-check remote (via daemon) ── hit → restore via hardlink → done
+check remote (via daemon) ── hit → restore via reflink → done
     ↓ miss
 acquire per-key build lock
     ↓
@@ -45,6 +45,8 @@ Build outcomes are separated into three cacheable cases:
 | `dup` | Missed | Yes | Already known | a new key produced bytes kache already had |
 | `miss` | Missed | Yes | New | a new key produced at least one new blob |
 
+`hit` is shown as one row, but kache records three hit kinds in the event log — `local_hit`, `prefetch_hit`, and `remote_hit` — distinguished by where the entry was found. Invocations that bypass the cache (non-primary, excluded, or a skipped executable) record a fourth outcome, `passthrough`.
+
 `dup` is a cache-key/content outcome, not the same thing as the storage
 deduplication metric. A high `dup` count can point to over-specific cache keys
 or noisy inputs, because different keys are compiling to identical bytes.
@@ -53,30 +55,30 @@ Non-primary invocations — rustc calls with no source file, like dependency pro
 
 ## The local store
 
-The store lives under `~/.cache/kache/` and has two parts:
+The store lives under your platform cache dir — `~/Library/Caches/kache` on macOS, `~/.cache/kache` on Linux (`$XDG_CACHE_HOME/kache`), `%LOCALAPPDATA%\kache` on Windows — and has two parts:
 
 **SQLite index (`index.db`)** tracks every cache entry: crate name, cache key, file list, feature flags, target, and profile. It runs in WAL mode with a 5-second busy timeout so 300+ parallel rustc processes can all hit it without contention.
 
-**Content-addressed blobs (`store/`)** hold the actual compiled files. Each blob is named after its blake3 hash, so two crates that happen to produce an identical artifact share the same physical file. When kache restores a cache hit, it hardlinks the blob into the project's `target/` directory — no data is copied, the inode is shared.
+**Content-addressed blobs (`store/blobs/`)** hold the actual compiled files, sharded into 256 subdirectories by the first two hex chars of the hash. Each blob is named after its blake3 hash, so two crates that happen to produce an identical artifact share the same physical file. When kache restores a cache hit it reflinks the blob into the build's output dir on copy-on-write filesystems (APFS, btrfs, XFS-with-reflink): zero-copy, but with an independent inode so a later write never mutates the cache blob.
 
-For binary outputs (executables, dylibs), where hardlinks are unsafe because cargo may modify the file in place, kache copies instead.
+On filesystems without reflink, kache falls back to a hardlink for immutable artifacts (`.rlib` / `.rmeta`) or a plain copy for files that may be mutated post-build (executables, dylibs, proc-macros).
 
 ## The daemon
 
 The daemon is a long-running background process that handles everything async: uploading new artifacts to S3, checking the remote before a build starts, and prefetching artifacts for upcoming crates.
 
-The wrapper communicates with the daemon over a Unix socket (`~/.cache/kache/daemon.sock`) using lightweight RPC calls that complete in under a millisecond. If the daemon is down, the wrapper continues without it — local caching works normally, remote features degrade gracefully.
+The wrapper communicates with the daemon over a Unix socket (`daemon.sock` inside the cache dir — see [The local store](#the-local-store) for the platform path; a named pipe on Windows) using lightweight RPC calls. Local-only calls — queuing an upload, a cached remote-check answer — return in well under a millisecond; a remote-check that has to ask S3 takes as long as the network round-trip. If the daemon is down, the wrapper continues without it — local caching works normally, remote features degrade gracefully.
 
 The daemon runs as a separate binary invocation (`kache daemon run`) and can be managed as a system service via launchd (macOS) or systemd (Linux). See [Daemon lifecycle](/docs/daemon/lifecycle) for details.
 
 ## What kache does not touch
 
-As a `RUSTC_WRAPPER`, kache intercepts only `rustc` and `clippy-driver` invocations — not `cargo`, `ld`, or any other tool; linking, proc-macro expansion, and build scripts run unmodified. (Separately, kache can also be set as `CC` / `CXX` to wrap a C/C++ compiler — `gcc`/`clang` on POSIX or `clang-cl` on Windows — for object-compile caching; that path is independent of the rustc wrapper. See [C/C++ caching](https://github.com/kunobi-ninja/kache#cc-caching-experimental).)
+As a `RUSTC_WRAPPER`, kache intercepts only `rustc` and `clippy-driver` invocations — not `cargo`, `ld`, or any other tool; linking, proc-macro expansion, and build scripts run unmodified. (Separately, kache can also be set as `CC` / `CXX` to wrap a C/C++ compiler — `gcc`/`clang`, or `clang` in MSVC driver mode (`clang-cl` / `--driver-mode=cl`, as used by mozconfigs and the `cc` crate on Windows) — for object-compile caching; that path is independent of the rustc wrapper. See [C/C++ caching](https://github.com/kunobi-ninja/kache#cc-caching-experimental).)
 
-By default, kache skips binary crates and dynamic libraries — their outputs depend on the linker, require code signing on macOS, and are more expensive to restore correctly. Enabling `cache_executables` opts in, but most of the compile-time savings come from caching rlibs anyway.
+By default, kache skips only user-facing executables — `bin` crates and `--test` harness binaries — because their outputs depend on the linker and may be mutated post-build (code signing on macOS, stripping). dylib, cdylib, and proc-macro crates stay cached. Enabling `cache_executables` opts the executables in, but most of the compile-time savings come from caching rlibs anyway.
 
-## Coming soon: the remote planner
+## The remote planner
 
-Today, prefetch is driven entirely by the client running `cargo metadata` and asking the daemon to pull every crate in the resolved graph from S3. This is good but not optimal — the metadata pass is workspace-local and can't reason about which artifacts are *most* likely to hit on the current toolchain / target / feature set.
+By default, prefetch is driven entirely by the client running `cargo metadata` and asking the daemon to pull every crate in the resolved graph from S3. This is good but not optimal — the metadata pass is workspace-local and can't reason about which artifacts are *most* likely to hit on the current toolchain / target / feature set.
 
-A separate planner service (see [Remote service](/docs/remote-service)) will accept manifests from clients (`kache save-manifest`), store them in an embedded database, and reply to prefetch queries with a ranked candidate list. When the planner has no useful data, it returns `use_fallback` and the client behaves exactly as it does today. The planner is purely additive — local caching, S3 sync, and metadata-driven prefetch keep working without it.
+A separate planner service (see [Remote service](/docs/remote-service)) accepts manifests from clients (`kache save-manifest`), stores them in an embedded database, and replies to prefetch queries with a ranked candidate list. The client path is already wired: when `KACHE_PLANNER_ENDPOINT` is set, the daemon asks the planner before each build. When the planner has no useful data it returns a fallback disposition and the client behaves exactly as it does without it. The planner is purely additive — local caching, S3 sync, and metadata-driven prefetch keep working with no planner configured. (The hosted planner service itself is still in preview.)

--- a/docs/how-it-works/cache-key.mdx
+++ b/docs/how-it-works/cache-key.mdx
@@ -9,57 +9,32 @@ The cache key is a blake3 hash that uniquely identifies one compiled artifact. T
 
 Getting this right is the core correctness challenge in any build cache. A false positive (same key, different output) corrupts the build. A false negative (different keys, identical output) wastes time.
 
-## Inputs to the key
+## What's in the key
 
-The key is computed from these inputs, in order:
+The principle is simple: **anything that changes the compiled output goes into the key; anything that's just machine-local noise is normalized out.** That's what lets one machine restore what another built.
 
-**Key version.** A hardcoded integer (`CACHE_KEY_VERSION`) that's bumped whenever the key computation logic changes. This invalidates all existing entries without requiring a manual purge.
+What goes in (change any of these and the crate re-keys):
 
-**rustc version.** The full output of `rustc --version --verbose`, which includes the commit hash and host triple. A toolchain update produces different keys for everything. To avoid running `rustc --version` hundreds of times in a parallel build, kache caches the output to disk keyed by the binary's mtime — the first wrapper process writes it, the rest read it in under a millisecond.
+- **Toolchain identity** — the `rustc --version --verbose` banner (commit hash + host triple), plus the linker's `--version` for outputs that actually link.
+- **What you're compiling** — crate name, types, and edition; and every source file the crate reads. kache finds them with a `--emit=dep-info` pre-pass, so modules, `include!()` targets, and build-script output are all covered, and hashes each by content.
+- **How you're compiling it** — target triple, feature/`cfg` flags, codegen (`-C`) options, `RUSTFLAGS`, and the active `--emit` set (so a `cargo check` entry is never served to a `cargo build`).
+- **What it depends on** — each `--extern` rlib/rmeta, hashed by content, so a dependency change propagates to everything downstream.
+- **Compile-time environment** — the `env!()` / `option_env!()` values a build bakes in.
 
-**Target triple.** The `--target` flag, or the host triple if none was specified. When `--target` points at a custom JSON spec file (Firefox / embedded toolchains), the file's _contents_ are hashed too (label `target_spec:`) — that spec encodes data-layout, target features, panic strategy and more that the dep-info pass never lists, so editing the spec in place re-keys the crate.
+What's deliberately left out (machine-local, doesn't affect output): the incremental-compilation directory, the linker path (its *identity* is captured via `--version` instead), and absolute build/checkout paths — those are normalized to stable sentinels so the key is the same regardless of where you built. See [Cross-machine portability](#cross-machine-portability).
 
-**Crate identity.** Crate name, crate types (lib, rlib, proc-macro, etc.), and edition.
+<Callout type="info">
+The authoritative, always-current list for any specific build is what kache actually logs — `kache why-miss <crate>` and `KACHE_LOG=trace` print every component it hashed (see [Debugging cache misses](#debugging-cache-misses)). Prefer that over a hand-kept enumeration, which drifts as the keying logic evolves.
+</Callout>
 
-**Emit kinds.** The `--emit` set (sorted). `cargo check` runs `--emit=metadata` (`.rmeta`) while `cargo build` runs `--emit=link` (`.rlib`); hashing emit keeps them apart so a check-only entry is never served to a build that needs the `.rlib`.
+### Tuning the key
 
-**Codegen options.** All `-C key=value` flags, sorted by key for determinism. Two are excluded: `incremental` (a machine-local path that doesn't affect output) and `linker` (a machine-local absolute path on bootstrapped toolchains, e.g. mozbuild's `-Clinker=/abs/clang++`). The linker's identity is captured separately via its `--version` banner — see *Linker identity* below.
+A few opt-in knobs, all no-ops by default:
 
-**Features and cfg flags.** Feature flags sorted alphabetically, then all other `--cfg` flags sorted. Order-independence is important here: `--cfg feature="a" --cfg feature="b"` and `--cfg feature="b" --cfg feature="a"` must produce the same key.
-
-**Source files.** This is the most important input. Rather than hashing just the crate root (`src/lib.rs`), kache runs a dep-info pre-pass — it invokes `rustc --emit=dep-info` before the real compilation, which produces a Makefile-style dependency file listing every `.rs` file the crate depends on, including modules, `include!()` targets, and build script outputs. All of those files are hashed with blake3, folded in _content-hash order_ rather than path order — so only the set of contents matters and a build-script-generated file moving in the path-sorted order (e.g. a relocated `OUT_DIR`) can't flip the key.
-
-The dep-info pass also captures `env!()` and `option_env!()` dependencies — environment variables that are baked into the binary at compile time. Their values go into the key too, but how depends on usage: an env-dep value is only path-normalized when source inspection proves the macro is used _solely_ inside `include!`/`include_str!`/`include_bytes!` locator contexts (the `OUT_DIR` case). If the value can be baked into the artifact as a runtime value (`env!()`-as-value), the raw absolute path is kept verbatim — which is correct, but means such a crate only shares a key across machines that compiled it at the same path.
-
-`KACHE_PATH_ONLY_ENV_VARS` / `[cache] path_only_env_vars` opts additional env-deps (besides the built-in `OUT_DIR`) into that path-only normalization. The env value is comma/space-separated and overrides the config file.
-
-**Extern dependencies.** For each `--extern name=path` argument, kache hashes the referenced rlib/rmeta. This means a change to a dependency automatically invalidates all crates that depend on it, propagating correctly through the dependency graph.
-
-Sysroot crates (std, core, alloc) can't be read from their installed path on other machines, so kache uses a sentinel instead of their path hash. Their identity is already captured via the rustc version.
-
-**RUSTFLAGS and CARGO_ENCODED_RUSTFLAGS.** Both are included, after normalization: machine-local path prefixes are collapsed to stable sentinels (see *Cross-machine portability* below), runs of whitespace are collapsed and trimmed, and the volatile _from_ side of any `--remap-path-prefix` / clang `-f*-prefix-map` flag is scrubbed to a `<REMAP_FROM>` sentinel (the _to_ target is kept). So `-L /home/runner/project/target/...` and `-L /home/alice/project/target/...` produce the same key, while adding or removing a remap still diverges it. Order is preserved — `-Cfoo=a -Cfoo=b` differs from `-Cfoo=b -Cfoo=a`, since later flags override earlier ones in rustc's parser.
-
-**RUSTC_BOOTSTRAP.** Folded in when set and non-empty: it changes what rustc accepts (nightly features / `-Z` flags on stable), so byte-identical source can compile differently with it on vs off. Unset (the common case) leaves the key untouched.
-
-**Sysroot.** `--sysroot` is hashed (path-normalized), so a custom-built std or a `-Zbuild-std` sysroot keys apart from the default toolchain while a standard rustup layout still shares across machines.
-
-**Native link flags.** `-L [KIND=]PATH` search paths (path-normalized) and `-l` libraries are keyed, preserving order. Cargo's redundant `dependency=`/`crate=` `-L` entries are deliberately skipped — they're already covered by the content-hashed externs and would otherwise bust the key on a target-dir move.
-
-**Unstable flags.** `-Z` flags arriving on argv outside RUSTFLAGS are hashed (label `unstable:`), since they can change codegen (`-Zsanitizer`, `-Zshare-generics`).
-
-**CARGO_CFG_* variables.** These carry platform detection results (e.g., `CARGO_CFG_TARGET_OS=linux`). They're sorted by name before hashing.
-
-**Base-dir override (optional).** `KACHE_BASE_DIR` declares a highest-priority path prefix that's collapsed to a `<BASE_DIR>` sentinel in the key (and emitted as `--remap-path-prefix`). Use it to strip checkout or container-mount paths the auto-derived sentinel rules below can't see.
-
-**Linker identity.** For every output that actually links — `bin` and `--test` binaries plus `dylib` / `cdylib` / `proc-macro` — the first line of the linker's `--version` output is included. This prevents serving an artifact built with one linker to a machine with a different one. Like the rustc version, it's cached to disk keyed by the linker binary's mtime.
-
-**Remap status.** kache adds `--remap-path-prefix` to normalize source paths in debug info, making artifacts portable. But when coverage instrumentation is active (`-C instrument-coverage`), path remapping is skipped so that coverage tools can map profiling data back to source files. The key reflects this decision.
-
-**Key salt (optional).** If `KACHE_KEY_SALT` / `cache.key_salt` is set, its value is folded into the key. This is an escape hatch for toolchain divergence the key cannot otherwise observe — e.g. a `glibc`/`mold`/linker bump or a Nix store rebuild that changes compiled output without changing any tool's `--version` banner. Unset (the default) has no effect. See [Configuration → Cache-key salt](/getting-started/configuration#cache-key-salt).
-
-**Extra cache-key inputs (optional).** A crate can declare files the compiler reads at compile time but never reports — sqlx's `.sqlx/query-*.json`, `migrations/`, `include!`'d data — in a co-located `kache.toml`. Each matched file is folded as its _crate-relative path_ plus _content hash_, so editing one (or swapping two files' contents, where the filename→content binding is load-bearing, like migration order) re-keys that crate, while a worktree move does not. The declared glob set is folded too, so editing `kache.toml` re-keys even at zero matches. Opt-in, per-crate, and union-only — a misdeclared glob can only cost an extra miss, never restore a wrong artifact. See [Configuration → Extra cache-key inputs](/getting-started/configuration#extra-cache-key-inputs).
-
-**Extra cc allowlist flags (optional).** For C/C++ compiles, any flag listed in `cc.extra_allowlist_flags` / `KACHE_CC_EXTRA_ALLOWLIST_FLAGS` that the built-in allow-list doesn't model is folded into the key *verbatim* when present on the command line, so a different flag or value always produces a different key. Unset (the default) has no effect. See [Configuration → Extra cc allowlist flags](/getting-started/configuration#extra-cc-allowlist-flags).
+- **`KACHE_BASE_DIR`** — declare a path prefix to strip from the key (collapsed to `<BASE_DIR>`). Use it for checkout or container-mount paths the automatic sentinels don't catch, so out-of-tree builds still share hits.
+- **`KACHE_KEY_SALT` / `cache.key_salt`** — fold an opaque string into every key to force a cold cache when the toolchain changes in a way no `--version` reveals (a libc/linker bump, a Nix rebuild). See [Configuration](/getting-started/configuration#cache-key-salt).
+- **`kache.toml` extra inputs** — declare files the compiler reads but never reports (sqlx's `.sqlx/`, `migrations/`, `include!`'d data) so editing them re-keys the crate. See [Configuration](/getting-started/configuration#extra-cache-key-inputs).
+- **`path_only_env_vars`** — extra env vars whose value is only a path locator, so kache normalizes their path out of the key for cross-machine hits. See [Configuration](/getting-started/configuration#path-only-env-vars).
 
 ## Cross-machine portability
 
@@ -105,7 +80,7 @@ settings set target.source-map <WORKSPACE> /abs/path/to/your/checkout
 
 Add additional `substitute-path` / `source-map` entries for `<CARGO_HOME>` or `<RUSTUP_HOME>` if you want to step into dependency or std sources.
 
-**Coverage builds are exempt.** When coverage instrumentation is active (`-C instrument-coverage`), kache skips path remapping entirely (see *Remap status* above), so tools like `cargo-llvm-cov` and tarpaulin map profiling data back to real source paths with no extra configuration.
+**Coverage builds are exempt.** When coverage instrumentation is active (`-C instrument-coverage`), kache skips path remapping entirely, so tools like `cargo-llvm-cov` and tarpaulin map profiling data back to real source paths with no extra configuration. (Skipping the remap also changes the key, so coverage builds keep a separate cache from regular ones.)
 
 ## Debugging cache misses
 

--- a/docs/how-it-works/cache-key.mdx
+++ b/docs/how-it-works/cache-key.mdx
@@ -17,27 +17,41 @@ The key is computed from these inputs, in order:
 
 **rustc version.** The full output of `rustc --version --verbose`, which includes the commit hash and host triple. A toolchain update produces different keys for everything. To avoid running `rustc --version` hundreds of times in a parallel build, kache caches the output to disk keyed by the binary's mtime — the first wrapper process writes it, the rest read it in under a millisecond.
 
-**Target triple.** The `--target` flag, or the host triple if none was specified.
+**Target triple.** The `--target` flag, or the host triple if none was specified. When `--target` points at a custom JSON spec file (Firefox / embedded toolchains), the file's _contents_ are hashed too (label `target_spec:`) — that spec encodes data-layout, target features, panic strategy and more that the dep-info pass never lists, so editing the spec in place re-keys the crate.
 
 **Crate identity.** Crate name, crate types (lib, rlib, proc-macro, etc.), and edition.
 
-**Codegen options.** All `-C key=value` flags, sorted by key for determinism. The `incremental` option is excluded — it's a path that varies by machine and doesn't affect the compiled output.
+**Emit kinds.** The `--emit` set (sorted). `cargo check` runs `--emit=metadata` (`.rmeta`) while `cargo build` runs `--emit=link` (`.rlib`); hashing emit keeps them apart so a check-only entry is never served to a build that needs the `.rlib`.
+
+**Codegen options.** All `-C key=value` flags, sorted by key for determinism. Two are excluded: `incremental` (a machine-local path that doesn't affect output) and `linker` (a machine-local absolute path on bootstrapped toolchains, e.g. mozbuild's `-Clinker=/abs/clang++`). The linker's identity is captured separately via its `--version` banner — see *Linker identity* below.
 
 **Features and cfg flags.** Feature flags sorted alphabetically, then all other `--cfg` flags sorted. Order-independence is important here: `--cfg feature="a" --cfg feature="b"` and `--cfg feature="b" --cfg feature="a"` must produce the same key.
 
-**Source files.** This is the most important input. Rather than hashing just the crate root (`src/lib.rs`), kache runs a dep-info pre-pass — it invokes `rustc --emit=dep-info` before the real compilation, which produces a Makefile-style dependency file listing every `.rs` file the crate depends on, including modules, `include!()` targets, and build script outputs. All of those files are hashed with blake3.
+**Source files.** This is the most important input. Rather than hashing just the crate root (`src/lib.rs`), kache runs a dep-info pre-pass — it invokes `rustc --emit=dep-info` before the real compilation, which produces a Makefile-style dependency file listing every `.rs` file the crate depends on, including modules, `include!()` targets, and build script outputs. All of those files are hashed with blake3, folded in _content-hash order_ rather than path order — so only the set of contents matters and a build-script-generated file moving in the path-sorted order (e.g. a relocated `OUT_DIR`) can't flip the key.
 
-The dep-info pass also captures `env!()` and `option_env!()` dependencies — environment variables that are baked into the binary at compile time. Their values go into the key too.
+The dep-info pass also captures `env!()` and `option_env!()` dependencies — environment variables that are baked into the binary at compile time. Their values go into the key too, but how depends on usage: an env-dep value is only path-normalized when source inspection proves the macro is used _solely_ inside `include!`/`include_str!`/`include_bytes!` locator contexts (the `OUT_DIR` case). If the value can be baked into the artifact as a runtime value (`env!()`-as-value), the raw absolute path is kept verbatim — which is correct, but means such a crate only shares a key across machines that compiled it at the same path.
+
+`KACHE_PATH_ONLY_ENV_VARS` / `[cache] path_only_env_vars` opts additional env-deps (besides the built-in `OUT_DIR`) into that path-only normalization. The env value is comma/space-separated and overrides the config file.
 
 **Extern dependencies.** For each `--extern name=path` argument, kache hashes the referenced rlib/rmeta. This means a change to a dependency automatically invalidates all crates that depend on it, propagating correctly through the dependency graph.
 
 Sysroot crates (std, core, alloc) can't be read from their installed path on other machines, so kache uses a sentinel instead of their path hash. Their identity is already captured via the rustc version.
 
-**RUSTFLAGS and CARGO_ENCODED_RUSTFLAGS.** Both are included. Paths inside these flags are normalized by replacing the current working directory with `.`, so flags like `-L /home/runner/project/target/release/deps` produce the same key as `-L /home/alice/project/target/release/deps`.
+**RUSTFLAGS and CARGO_ENCODED_RUSTFLAGS.** Both are included, after normalization: machine-local path prefixes are collapsed to stable sentinels (see *Cross-machine portability* below), runs of whitespace are collapsed and trimmed, and the volatile _from_ side of any `--remap-path-prefix` / clang `-f*-prefix-map` flag is scrubbed to a `<REMAP_FROM>` sentinel (the _to_ target is kept). So `-L /home/runner/project/target/...` and `-L /home/alice/project/target/...` produce the same key, while adding or removing a remap still diverges it. Order is preserved — `-Cfoo=a -Cfoo=b` differs from `-Cfoo=b -Cfoo=a`, since later flags override earlier ones in rustc's parser.
+
+**RUSTC_BOOTSTRAP.** Folded in when set and non-empty: it changes what rustc accepts (nightly features / `-Z` flags on stable), so byte-identical source can compile differently with it on vs off. Unset (the common case) leaves the key untouched.
+
+**Sysroot.** `--sysroot` is hashed (path-normalized), so a custom-built std or a `-Zbuild-std` sysroot keys apart from the default toolchain while a standard rustup layout still shares across machines.
+
+**Native link flags.** `-L [KIND=]PATH` search paths (path-normalized) and `-l` libraries are keyed, preserving order. Cargo's redundant `dependency=`/`crate=` `-L` entries are deliberately skipped — they're already covered by the content-hashed externs and would otherwise bust the key on a target-dir move.
+
+**Unstable flags.** `-Z` flags arriving on argv outside RUSTFLAGS are hashed (label `unstable:`), since they can change codegen (`-Zsanitizer`, `-Zshare-generics`).
 
 **CARGO_CFG_* variables.** These carry platform detection results (e.g., `CARGO_CFG_TARGET_OS=linux`). They're sorted by name before hashing.
 
-**Linker identity.** For binary and dylib outputs, the linker's `--version` output is included. This prevents serving a binary built with one linker to a machine with a different one. Like the rustc version, this is cached to disk keyed by the linker binary's mtime.
+**Base-dir override (optional).** `KACHE_BASE_DIR` declares a highest-priority path prefix that's collapsed to a `<BASE_DIR>` sentinel in the key (and emitted as `--remap-path-prefix`). Use it to strip checkout or container-mount paths the auto-derived sentinel rules below can't see.
+
+**Linker identity.** For every output that actually links — `bin` and `--test` binaries plus `dylib` / `cdylib` / `proc-macro` — the first line of the linker's `--version` output is included. This prevents serving an artifact built with one linker to a machine with a different one. Like the rustc version, it's cached to disk keyed by the linker binary's mtime.
 
 **Remap status.** kache adds `--remap-path-prefix` to normalize source paths in debug info, making artifacts portable. But when coverage instrumentation is active (`-C instrument-coverage`), path remapping is skipped so that coverage tools can map profiling data back to source files. The key reflects this decision.
 
@@ -65,14 +79,17 @@ The same `--remap-path-prefix` rules that make artifacts portable also rewrite t
 
 | Sentinel | Real location |
 |---|---|
+| `<BASE_DIR>` | the `KACHE_BASE_DIR` prefix, if set (highest priority) |
 | `<WORKSPACE>` | the repo / workspace checkout |
 | `<CARGO_HOME>` | usually `~/.cargo` (registry + git deps) |
 | `<RUSTUP_HOME>` | usually `~/.rustup` (std sources) |
 | `<HOME>`, `<TMPDIR>`, `<TARGET>` | per-user / per-job directories |
 
+On Windows the same machinery adds `<APPDATA>`, `<LOCALAPPDATA>` and `<PROGRAMFILES>` sentinels for cargo/rustup state and MSVC/SDK paths that flow into native-link search.
+
 So a backtrace or a debugger opened against a restored binary will show source paths like `<WORKSPACE>/src/main.rs` and won't find the file on disk until you map the sentinel back. This is expected — it is the price of one binary being valid in every checkout — not a sign the cache is corrupt.
 
-This page describes the **rustc** artifact cache. C/C++ object compiles (`cc` / `clang-cl`, see [C/C++ caching](https://github.com/kunobi-ninja/kache#cc-caching-experimental)) are keyed separately — and clang-cl debug compiles (`-Z7` / `-g`) aren't cached yet (they pass through), so there's no clang-cl PDB to remap here.
+This page describes the **rustc** artifact cache. C/C++ object compiles (`cc` / `clang-cl`, see [C/C++ caching](https://github.com/kunobi-ninja/kache#cc-caching-experimental)) are keyed separately. clang-cl debug compiles (`/Z7` / `-Z7` / `-g`) *are* cached, but the key stays machine-local: clang-cl embeds CodeView paths directly in the `.obj` (no separate PDB) and ignores `-ffile-prefix-map`, so kache keeps those paths literal in the key rather than remapping them — correct local hits, no cross-machine sharing.
 
 Point your debugger at the real checkout with a source map. For your own crate sources, map `<WORKSPACE>`:
 
@@ -94,4 +111,10 @@ Add additional `substitute-path` / `source-map` entries for `<CARGO_HOME>` or `<
 
 If a crate keeps missing when you expect a hit, use `kache why-miss <crate-name>`. It compares the cache key from the last known entry against the current build and reports which input changed.
 
-You can also set `KACHE_LOG=kache=trace` to see every component being hashed during key computation.
+For full key-component details, run the command `why-miss` prints:
+
+```sh
+KACHE_LOG=trace cargo build -p <crate-name> 2>&1 | grep '\[key:<crate-name>\]'
+```
+
+This logs every component being hashed during key computation. As a defense-in-depth check, a `KACHE_LOG=warn` run also flags any residual machine-local absolute path that survives normalization (matching prefixes like `/Users/`, `/home/`, `/private/tmp/`, `/var/folders/`, `C:\Users\`), naming the offending key field — a fast signal that something is leaking a per-machine path into the key.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,31 +1,31 @@
 ---
 title: kache
-description: Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — just hardlinks locally and S3 for sharing.
+description: Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — zero-copy restores (reflink where the filesystem supports it, else hardlink) locally and S3 for sharing.
 ---
 
 # Introduction
 
-**kache** is a drop-in `RUSTC_WRAPPER` that caches Rust compilation artifacts. Cache keys are blake3 hashes of normalized rustc invocations; cache hits restore via hardlinks, and identical blobs are stored once and shared. Optional S3 sync (AWS, Ceph, MinIO, R2) shares the cache across machines.
+**kache** is a drop-in `RUSTC_WRAPPER` that caches Rust compilation artifacts. Cache keys are blake3 hashes of normalized rustc invocations; cache hits restore zero-copy (reflink, with a hardlink/copy fallback on filesystems without CoW), and identical blobs are stored once and shared. Optional S3 sync (AWS, Ceph, MinIO, R2) shares the cache across machines. kache can also wrap C/C++ compiles (`CC="kache cc"`), though that coverage is narrower than rustc.
 
 Local caching and direct S3 sync are stable today.
 
 <Callout type="info">
-**SOON:** a remote planner that prefetches from workspace manifests, dependency history, and build intent — warming the right artifacts before rustc asks for them. See [Remote service](/docs/remote-service).
+**PREVIEW:** a remote planner that prefetches from workspace manifests, dependency history, and build intent — warming the right artifacts before rustc asks for them. The daemon already calls a planner when `KACHE_PLANNER_ENDPOINT` is set; the hosted service is still preview. See [Remote service](/docs/remote-service).
 </Callout>
 
-![kache: cold build populates the store, then `cargo clean && cargo build` restores every artifact via hardlinks](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/demo.gif)
+![kache: cold build populates the store, then `cargo clean && cargo build` restores every artifact zero-copy](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/demo.gif)
 
-> Cold compile populates kache's store, `cargo clean` wipes `target/`, and the second build pulls every artifact back via hardlinks.
+> Cold compile populates kache's store, `cargo clean` wipes `target/`, and the second build pulls every artifact back zero-copy (reflink, falling back to hardlink/copy).
 
 ## Why local kache is fast
 
 kache is useful even before remote cache is configured:
 
-- **Hardlinked restores.** Local hits are restored with hardlinks into `target/`, so artifact bytes are not copied.
+- **Zero-copy restores.** Local hits are restored without copying bytes — via reflink (copy-on-write) where the filesystem supports it (APFS, btrfs, XFS-with-reflink), and via hardlink on other filesystems.
 - **Content-addressed storage.** The store is keyed by blake3 hash, so identical artifact blobs are stored once and linked many times.
 - **Compile-then-record on misses.** Misses compile normally, then kache records the outputs for future builds.
 - **Daemon-optional locally.** If the daemon is not running, local hits and misses still work; remote checks, uploads, and prefetching degrade gracefully.
-- **Safer on macOS.** Incremental compilation is disabled while kache wraps rustc — artifact caching replaces that path and avoids APFS-related corruption.
+- **Safer on macOS.** Incremental compilation is disabled on every platform while kache wraps rustc — artifact caching subsumes it. On macOS this also avoids APFS-related incremental-compilation corruption in git worktrees.
 
 ## Try it
 
@@ -44,9 +44,9 @@ kache doctor
 
 ## Architecture in one screen
 
-- **Wrapper** — `RUSTC_WRAPPER` intercepts rustc calls, computes blake3 cache keys, restores hits via hardlinks.
+- **Wrapper** — `RUSTC_WRAPPER` intercepts rustc calls, computes blake3 cache keys, restores hits zero-copy (reflink, falling back to hardlink/copy).
 - **Daemon** — background process handles async S3 uploads, remote checks, and prefetch. Auto-restarts on binary update.
-- **Store** — SQLite index plus content-addressed blobs under `{cache_dir}/store/`; hits hardlink those blobs into `target/`.
+- **Store** — SQLite index at `{cache_dir}/index.db`, plus content-addressed blobs under `{cache_dir}/store/blobs/`; hits restore those blobs into `target/` zero-copy (reflink, falling back to hardlink/copy).
 - **Cache keys** — deterministic blake3 hash of rustc version, crate name, source, dependencies, and normalized flags — portable across machines.
 
 <Cards>

--- a/docs/monitor.mdx
+++ b/docs/monitor.mdx
@@ -5,7 +5,7 @@ description: Reading and using the live TUI dashboard.
 
 # Monitor
 
-Running `kache` with no arguments (or `kache monitor`) opens a live TUI dashboard that shows what's happening in your cache in real time. It refreshes automatically and doesn't require the daemon to be running.
+Running `kache` with no arguments (or `kache monitor`) opens a live TUI dashboard that shows what's happening in your cache in real time. It refreshes automatically and doesn't require the daemon to be running: the monitor makes a best-effort attempt to start one in the background for richer stats, but still works via direct store and event-log reads if the daemon is unavailable (the Transfer line then reads `n/a (daemon offline)`).
 
 ![kache monitor TUI cycling through Build, Projects, Store, Transfer, and Passthrough tabs against a populated cache](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/monitor.gif)
 
@@ -19,7 +19,7 @@ Static layout for reference:
 │  Dedup: 8.2 GiB saved (18.1%)    Blobs: 36.9 GiB physical    Hardlinks: 4.9 GiB via 7023 hardlinks    Scan: idle  │
 │  Transfer: ↑ 0 uploading  ↓ 0 downloading                                                                         │
 │  rustc-wrapper=kache via ~/.cargo/config.toml ✓    unknown                                                        │
-│  kache v0.1.0 (epoch 1777305862)    daemon: v0.1.0 (epoch 1777305862)    Cache: ~/Library/Caches/kache            │
+│  kache vX.Y.Z (epoch 1777305862)    daemon: vX.Y.Z (epoch 1777305862)    Cache: ~/Library/Caches/kache            │
 │                                                                                                                   │
 └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌ Live Build ───────────────────────────────────────────────────────────────────────────────────────────────────────┐
@@ -54,10 +54,10 @@ The header line at the top of the monitor shows the current state of your local 
 | Field | What it means |
 |---|---|
 | `Store` | Bytes used vs. the configured maximum (`KACHE_MAX_SIZE`) |
-| `Hit rate` | Breakdown of cache outcomes over the displayed window: local / prefetch / remote / dup / miss |
+| `Hit rate` | Three headline rates over the window: `count` (% of builds served from cache), `weighted` (% of compile-time saved), and `miss-time` (% of wall-time spent in misses). Falls back to `local \| remote \| miss` percentages when compile-time data is unavailable |
 | `Dedup` | Logical bytes saved by storing shared blobs once |
 | `Blobs` | Physical bytes used by blob files in the local store |
-| `Hardlinks` | Estimated bytes saved by hardlink sharing across project `target/` directories |
+| `Hardlinks` | Unix-only inode-link scan: extra bytes saved because store blobs are hardlinked into `target/` instead of copied. Reads `none — restores prefer reflink/CoW` on copy-on-write filesystems (APFS, btrfs, XFS-with-reflink), where restores are reflinks (independent inodes) and the real savings show up under `Dedup` instead — a zero here is not a problem |
 | `Scan` | Whether the background hardlink scan is still calculating, scanning, or idle |
 | `Transfer` | Number of uploads and downloads currently in-flight via the daemon |
 
@@ -65,7 +65,7 @@ The header line at the top of the monitor shows the current state of your local 
 
 ### 1 — Build
 
-A live event stream showing every rustc invocation kache handled, with outcome, crate name, elapsed time, and artifact size. New events appear at the bottom.
+A live event stream showing every rustc invocation kache handled, as a table with Status (outcome glyph + word), Crate, Action (what kache actually did — built+cached / restored / downloaded), Compile (compile-phase time, shown only for misses and dups), Total (wall time), and Size. New events appear at the bottom.
 
 `dup` means the cache key missed and the compiler ran, but every unique output
 blob already existed in the local store before the store step. It is a
@@ -95,7 +95,7 @@ Press `r` to refresh the project list (it doesn't auto-refresh because scanning 
 
 A table of all cached crate entries, sortable by name, size, hits, or age. Use this to see what's actually in the cache and identify large or stale entries before running GC.
 
-Press `f` to filter by crate name.
+Press `s` to cycle the sort order (size → hits → age → name). Press `f` to filter by crate name or cache key.
 
 ### 4 — Transfer
 
@@ -103,7 +103,7 @@ A log of recent S3 uploads and downloads, with transfer rates and artifact sizes
 
 ### 5 — Passthrough
 
-A table of invocations kache passed through instead of caching. Each row shows the crate or source, whether the generic fallback path handled it, the exit code, and the reason kache declined to cache it.
+A table of invocations kache passed through instead of caching. Each row shows the time, crate, route (`fallback` if a configured fallback wrapper handled it, else `direct`), exit code, and the reason kache declined to cache it.
 
 ## Keyboard shortcuts
 
@@ -113,6 +113,7 @@ Tab         next tab
 1 / 2 / 3 / 4 / 5    switch to tab by number
 ↑ / ↓       scroll
 f           filter (Build, Store, and Passthrough tabs)
+s           cycle sort order (Store tab)
 c           clear build event list (Build tab)
 r           refresh project list (Projects tab)
 ```

--- a/docs/remote-cache/ci.mdx
+++ b/docs/remote-cache/ci.mdx
@@ -42,6 +42,8 @@ env:
 
 For AWS with IAM roles (OIDC), skip the access key variables and let kache use the standard credential chain.
 
+For S3-compatible stores (MinIO, Ceph RGW, R2, and similar), also set `KACHE_S3_ENDPOINT` to the provider's URL. `KACHE_S3_PREFIX` is optional and defaults to `artifacts`.
+
 ## Warming the cache before the build
 
 When the daemon isn't running in CI (which is the common case for ephemeral runners), use an explicit sync step:
@@ -64,9 +66,23 @@ steps:
 
 The `if: always()` on the push step ensures newly built artifacts are stored even when the build fails partway through. Partial cache population still speeds up future runs.
 
+Both subcommands require a configured S3 remote (set the `KACHE_S3_*` variables above, or run `kache config`); without one they error with `No remote configured`. By default `kache sync --pull` is filtered to the crates in the current workspace's `Cargo.lock`, so an ephemeral runner only fetches what this build needs. Use `kache sync --pull --all` to pull every artifact in the bucket regardless of the local lockfile.
+
+<Callout type="warn">
+`kache sync` reports failed transfers as `(N failed)` on its progress line but still exits `0`, so CI cannot detect partial transfer failures from the exit code alone. If that matters, scan the step's stderr for `failed`.
+</Callout>
+
 ## CI progress output
 
-kache prints per-crate progress lines to stderr when running in a non-terminal environment (which is the default in CI):
+kache can print per-crate progress lines to stderr when `KACHE_PROGRESS` is set. It is silent by default — both in CI and locally — to avoid cargo caching the wrapper's stderr as stale compiler diagnostics. Set the variable to opt in:
+
+| Value | Behavior |
+|---|---|
+| unset / anything else | Silent (default) |
+| `1` or `hits` | Print hits only |
+| `verbose` or `all` | Print hits, dups, and misses |
+
+With `KACHE_PROGRESS=verbose`, lines look like:
 
 ```
 [kache] serde: local hit (2ms, 1.2 MB)
@@ -74,13 +90,7 @@ kache prints per-crate progress lines to stderr when running in a non-terminal e
 [kache] myapp: miss (1.4s, 892 KB)
 ```
 
-You can control this with `KACHE_PROGRESS`:
-
-| Value | Behavior |
-|---|---|
-| `auto` (default) | Print when stderr is not a terminal |
-| `always` | Always print |
-| `never` | Never print |
+At `hits`/`1` only the `local hit` lines appear; `miss` and `dup` lines show up only under `verbose`/`all`. The format is `[kache] <crate>: <label> (<elapsed>[, <size>])`. There is no terminal or CI detection — output depends solely on this variable.
 
 ## Coverage and instrumentation
 
@@ -104,4 +114,6 @@ That said, many teams disable kache for coverage runs entirely to keep things si
     KACHE_DISABLED: "1"
 ```
 
-kache still strips incremental flags when disabled, which avoids APFS-related corruption in git worktrees on macOS — even when caching is off.
+Only `1` or `true` (case-insensitive) disable kache. Other values — including `0`, `false`, and empty — are ignored, so to re-enable kache in a later step you must unset the variable rather than set it to `0`.
+
+kache still strips the rustc `-C incremental=…` flags when disabled, which avoids APFS-related corruption in git worktrees on macOS — even when caching is off.

--- a/docs/remote-cache/s3-setup.mdx
+++ b/docs/remote-cache/s3-setup.mdx
@@ -17,6 +17,10 @@ bucket = "my-build-cache"
 
 With just a bucket name and no endpoint, kache uses AWS S3 with the default credential chain (environment variables, `~/.aws/credentials`, IAM role).
 
+<Callout type="warn">
+  If you omit `region`, kache defaults to `us-east-1` rather than your bucket's actual region. Set `region` to your bucket's region for AWS S3, and to whatever value your provider expects (or `auto`) for S3-compatible endpoints.
+</Callout>
+
 ## Provider examples
 
 <Tabs items={["AWS S3", "Cloudflare R2", "Ceph / MinIO"]}>
@@ -52,6 +56,8 @@ With just a bucket name and no endpoint, kache uses AWS S3 with the default cred
     ```
 
     The `profile` field refers to a named profile in `~/.aws/credentials` or `~/.aws/config`. Region is optional for Ceph but you can set it to any non-empty string if your setup requires it.
+
+    kache always uses path-style addressing (`https://endpoint/bucket/key`) for every provider, so self-hosted S3 works without virtual-hosted/bucket-subdomain DNS. This also makes dotted bucket names safe on custom endpoints.
   </Tab>
 </Tabs>
 
@@ -65,24 +71,50 @@ When kache needs S3 credentials, it checks these sources in order:
 
 For CI, option 1 (explicit env vars) or option 3 (IAM roles) are the most common. For local setups with multiple AWS accounts, option 2 (named profile) keeps credentials organized.
 
+<Callout type="warn">
+  Both halves of the explicit pair are required. If only `KACHE_S3_ACCESS_KEY` or only `KACHE_S3_SECRET_KEY` is set, kache logs a warning and falls back to the AWS chain rather than erroring — so a missing half surfaces as confusing "wrong credentials" behavior, not a clear failure.
+</Callout>
+
+### Environment overrides
+
+Every remote config field has a matching `KACHE_S3_*` env var, which takes precedence over the config file. This is handy in CI, where setting env vars is easier than shipping a config file:
+
+| Env var | Overrides config field |
+| --- | --- |
+| `KACHE_S3_BUCKET` | `bucket` |
+| `KACHE_S3_ENDPOINT` | `endpoint` |
+| `KACHE_S3_REGION` | `region` |
+| `KACHE_S3_PREFIX` | `prefix` |
+| `KACHE_S3_PROFILE` | `profile` |
+| `KACHE_S3_ACCESS_KEY` / `KACHE_S3_SECRET_KEY` | (explicit credentials) |
+
 ## S3 bucket layout
 
-Artifacts are stored at:
+Each cached entry is two objects — a packed tarball plus a small JSON manifest used for existence checks and listing:
 
 ```
-{prefix}/{crate_name}/{cache_key}.tar.zst
+{prefix}/v3/packs/{crate_name}/{cache_key}.tar.zst      # the packed artifacts (zstd-compressed tar)
+{prefix}/v3/manifests/{crate_name}/{cache_key}.json     # small manifest for existence/listing
 ```
 
-The default prefix is `artifacts`. Each artifact is a zstd-compressed tarball containing all compiled outputs for that crate. Organizing by crate name makes filtered listing efficient — `kache sync --pull` only lists the S3 prefix for crates in your `Cargo.lock`, not the entire bucket.
+The default prefix is `artifacts`. Organizing by crate name makes filtered listing efficient — `kache sync --pull` issues one `ListObjectsV2` per crate against `{prefix}/v3/manifests/{crate_name}/`, so it only enumerates manifests for crates in your `Cargo.lock` rather than scanning the whole `v3/manifests/` tree. Use `kache sync --pull --all` to list everything.
+
+`kache save-manifest` also writes build manifests under a separate `{prefix}/_manifests/` namespace (and, when a namespace and `Cargo.lock` are present, content-addressed shards under `{prefix}/_manifests/v3/{namespace}/shards/{hash}.json`). Bucket policies that scope by prefix must grant access to `_manifests/` as well as `v3/`.
 
 ## Bucket policies
 
-kache needs `s3:GetObject`, `s3:PutObject`, and `s3:ListBucket` on the bucket. For read-only CI runners that pull but don't push, `s3:GetObject` and `s3:ListBucket` are sufficient.
+kache needs `s3:GetObject`, `s3:PutObject`, and `s3:ListBucket` on the bucket. For read-only CI runners that pull but don't push, `s3:GetObject` and `s3:ListBucket` are sufficient. If you restrict the policy by prefix, cover both `{prefix}/v3/*` and `{prefix}/_manifests/*` (see [S3 bucket layout](#s3-bucket-layout)).
 
 ## Compression
 
-Artifacts are compressed with zstd at level 3 by default. This is fast to compress and decompress, with reasonable size reduction. For larger teams where network bandwidth matters more than CPU time, lower levels (1–2) further reduce compression overhead. Higher levels (10–22) are available but rarely worth it for build artifacts.
+zstd compression applies to the remote `.tar.zst` packs only; the local blob store is kept uncompressed. The default level is `3` — fast to compress and decompress, with reasonable size reduction. Lower levels (1–2) cut compression overhead when network bandwidth matters less than CPU time; higher levels (up to 22) are available but rarely worth it for build artifacts. Values are clamped to the `1`–`22` range.
+
+`KACHE_COMPRESSION_LEVEL` is read when the process that does the compressing starts, so set it on the uploader rather than on a plain `cargo build`:
 
 ```sh
-KACHE_COMPRESSION_LEVEL=1 cargo build   # fastest, larger files
+KACHE_COMPRESSION_LEVEL=1 kache sync --push   # fastest, larger packs
 ```
+
+<Callout>
+  The daemon loads its config once at startup, so changing `KACHE_COMPRESSION_LEVEL` for a single `cargo build` does not reconfigure an already-running daemon — restart the daemon with the var set if uploads run through it.
+</Callout>

--- a/docs/remote-cache/sync.mdx
+++ b/docs/remote-cache/sync.mdx
@@ -19,7 +19,10 @@ kache sync --dry-run    # preview what would transfer, make no changes
 
 ## Workspace filtering
 
-By default, `kache sync --pull` filters downloads to crates referenced in the current workspace's `Cargo.lock`. This avoids pulling the entire bucket contents on every sync — in a shared cache used by multiple projects, you only download what your project needs.
+The pull and push directions filter by two different mechanisms:
+
+- **Pull** filters downloads to every crate listed in the current directory's `Cargo.lock` (all direct and transitive dependencies). This avoids pulling the entire bucket on every sync — in a shared cache used by multiple projects, you only download what your project needs.
+- **Push** filters uploads to workspace member packages, derived by running `cargo metadata --no-deps` on the current `Cargo.toml` (or the `--manifest-path` you pass). Non-workspace local artifacts are silently skipped; a push run outside any workspace (no `Cargo.toml`) uploads everything.
 
 ```sh
 # in your project directory (Cargo.lock must exist)
@@ -29,11 +32,18 @@ kache sync --pull
 kache sync --pull --all
 ```
 
-If kache can't find a `Cargo.lock`, it falls back to pulling everything. You can also point to a specific manifest:
+If kache can't find a `Cargo.lock`, it falls back to pulling everything. The same full-bucket fallback applies if `Cargo.lock` is present but yields no package names.
+
+<Callout type="warn">
+`--manifest-path` controls the **push-side** workspace filter only (which local crates get uploaded). The pull filter always reads `Cargo.lock` from the current working directory and ignores `--manifest-path`, so to pull for a different project, run `kache sync` from that project's directory.
+</Callout>
 
 ```sh
-kache sync --manifest-path /path/to/project/Cargo.toml --pull
+# narrows which local crates get pushed; does NOT change the pull filter
+kache sync --manifest-path /path/to/project/Cargo.toml --push
 ```
+
+Workspace filtering shells out to `cargo metadata`. If `cargo` is missing or metadata fails, kache prints a warning and — when `--manifest-path` was given — yields an empty filter that pushes nothing; otherwise it disables push filtering and uploads everything.
 
 ## How it fits into a build workflow
 
@@ -54,15 +64,22 @@ The `--pull` step fills the local store so that `cargo build` finds local hits i
 
 When the daemon is running and remote is configured, it handles uploads automatically in the background after each compilation. Use `kache sync --push` only in workflows where you want an explicit, synchronous upload step — for example, when the daemon isn't running or you want to ensure the cache is populated before the runner terminates.
 
+`kache sync` is safe to run alongside the daemon and alongside other concurrent syncs. Before downloading, it re-checks each entry and skips any that already landed on disk; imports use `INSERT OR REPLACE`; and pushes skip entries that vanished (via GC or purge) mid-run.
+
+<Callout type="info">
+`--push` still performs a full, unfiltered LIST of all S3 keys to determine what is already uploaded — workspace filtering applies to the upload set, not to this listing. On a large shared bucket that LIST is a non-trivial cost.
+</Callout>
+
 ## S3 layout
 
-Artifacts are organized by crate name for efficient filtered listing:
+Each cached entry is stored as two objects under a versioned `v3` layout — a small manifest used for listing and existence checks, and the packed artifact itself:
 
 ```text
-{prefix}/{crate_name}/{cache_key}.tar.zst
+{prefix}/v3/manifests/{crate_name}/{cache_key}.json      # manifest (listing / existence)
+{prefix}/v3/packs/{crate_name}/{cache_key}.tar.zst       # packed artifacts
 ```
 
-The default prefix is `artifacts`. For example, `serde` artifacts may live under `artifacts/serde/...`.
+The default prefix is `artifacts`, so `serde` packs live under `artifacts/v3/packs/serde/...`. Organizing by crate name keeps filtered listing efficient: a workspace-filtered pull scans only the per-crate manifest prefix `{prefix}/v3/manifests/{crate_name}/`.
 
 ## Dry run
 
@@ -72,7 +89,16 @@ The default prefix is `artifacts`. For example, `serde` artifacts may live under
 kache sync --dry-run
 ```
 
-It prints a list of artifacts that would be pulled or pushed, with sizes.
+It prints the plan (the count of artifacts to pull and push) followed by one line per artifact showing a truncated cache key and the crate name — for example:
+
+```text
+Plan: pull 2 artifacts, push 1 artifact
+  pull  a1b2c3d4e5f6g7h8... (serde)
+  pull  9i8j7k6l5m4n3o2p... (tokio)
+  push  q1r2s3t4u5v6w7x8... (my-crate)
+```
+
+Sizes are not shown — listing does not fetch object sizes.
 
 ## Concurrency
 

--- a/docs/remote-service.mdx
+++ b/docs/remote-service.mdx
@@ -9,15 +9,15 @@ description: Server-side kache — a remote planner that prefetches artifacts fr
 **SOON.** Server-side kache is the next milestone. The deployment model, auth integration, and HA behavior are still hardening — treat the planner service and Helm chart as a preview today.
 </Callout>
 
-The remote planner service warms the *right* artifacts before rustc asks for them. Where local kache reacts to cargo invoking rustc, the planner anticipates: it ingests workspace manifests (`kache save-manifest`), dependency history, and build intent, then advises clients which artifacts to prefetch from S3 at the start of a session.
+The remote planner service warms the *right* artifacts before rustc asks for them. Where local kache reacts to cargo invoking rustc, the planner anticipates: it draws on build manifests (uploaded by `kache save-manifest`), dependency history, and the client's build intent, then advises clients which artifacts to prefetch from S3 at the start of a session.
 
-The service lives in [`crates/kache-service`](https://github.com/kunobi-ninja/kache/tree/main/crates/kache-service). It persists planner state in an embedded SurrealDB database, serves planner endpoints over HTTP, and safely returns `use_fallback` when the database has no matching candidates — so clients always have a working code path even before the planner has data for them.
+The service lives in [`crates/kache-service`](https://github.com/kunobi-ninja/kache/tree/main/crates/kache-service). It persists planner state in an embedded SurrealDB database and serves three HTTP routes: `POST /v1/prefetch-plan` and `POST /v2/prefetch-plan` (both aliased to the same handler — clients default to `/v2`), plus `GET /healthz` and `GET /readyz` probes. It safely returns a `use_fallback` disposition when the database has no matching candidates — so clients always have a working code path even before the planner has data for them.
 
 ## What it does
 
-- **Manifest ingest.** Clients call `kache save-manifest` at the end of a build. The service stores the resolved crate set, target, profile, and feature flags.
-- **Prefetch hints.** At the start of a new build session, the client queries the planner with the current workspace fingerprint. The planner replies with a ranked list of cache keys likely to be needed.
-- **Use-fallback safety.** If the planner has no useful candidates, it returns `use_fallback`. Clients then fall back to filtering S3 prefetch by `Cargo.lock` (the same path the daemon uses today without a planner).
+- **Manifest upload.** Clients call `kache save-manifest` at the end of a build. This uploads a build manifest (and, with `--namespace`, sharded indexes keyed by `Cargo.lock`) to the configured S3 remote — each entry records cache key, crate name, compile time, and artifact size. The planner service consumes that data out of band (it is seeded from a snapshot today; see `KACHE_PLANNER_SEED_STATE_FILE`) — `save-manifest` does not POST to the service.
+- **Prefetch hints.** At the start of a new build session, the client `POST`s a build intent (crate names, namespace, `Cargo.lock` deps) to the planner. The planner replies with a plan: a `disposition` (`Execute` or `UseFallback`) and, when executing, ranked `candidates` (cache key + crate name) likely to be needed.
+- **Use-fallback safety.** If the planner has no service-side state, resolves no candidates, or hits an internal planning error, it returns a `UseFallback` plan rather than an HTTP error. Clients then fall back to filtering S3 prefetch by `Cargo.lock` (the same path the daemon uses today without a planner).
 
 ## Build and run
 
@@ -28,7 +28,7 @@ just image-service-release
 cargo run -p kache-service
 ```
 
-For local development, `cargo run -p kache-service` starts the service on `http://127.0.0.1:8080` with an ephemeral planner database. For a containerized run, the `image-service` recipes produce a multi-arch image suitable for Kubernetes.
+For local development, `cargo run -p kache-service` binds `0.0.0.0:8080` by default (override with `--bind` / `KACHE_PLANNER_BIND`) and persists the embedded SurrealDB planner database at `/var/lib/kache/planner.db` (override with `--db-path` / `KACHE_PLANNER_DB_PATH`). Pass `--token` / `KACHE_PLANNER_TOKEN` to enforce bearer auth on the standalone binary, and `KACHE_LOG` (default `kache_service=info`) to filter logs. For a containerized run, the `image-service` recipes produce a `linux/amd64` image (override `PLATFORM` in `docker-bake.hcl` to target other architectures).
 
 ## Helm chart
 
@@ -36,11 +36,20 @@ For local development, `cargo run -p kache-service` starts the service on `http:
 helm upgrade --install kache-service ./charts/kache-service
 ```
 
-The chart in [`charts/kache-service`](https://github.com/kunobi-ninja/kache/tree/main/charts/kache-service) is intentionally small: one `Deployment`, one `Service`, optional `PersistentVolumeClaim`, security defaults, health probes, optional `kunobi-auth` bearer-token wiring through an existing `Secret`, and optional `kunobi-ha` Lease-based leader election. It does not bundle ingress or cluster-level policy — bring your own.
+The chart in [`charts/kache-service`](https://github.com/kunobi-ninja/kache/tree/main/charts/kache-service) is intentionally small: one `Deployment`, one `Service`, optional `PersistentVolumeClaim`, hardened security defaults (`runAsNonRoot`, UID/GID `65532`, `readOnlyRootFilesystem`, all capabilities dropped — the writable DB path must live on a mounted volume), health probes, optional `kunobi-auth` bearer-token wiring through an existing `Secret`, and optional `kunobi-ha` Lease-based leader election. When `ha.enabled`, it also ships a `ServiceAccount` plus `Role`/`RoleBinding` granting the `coordination.k8s.io` Lease permissions leader election needs (and mounts the service-account token only under HA). It does not bundle ingress or cluster-level policy — bring your own.
+
+### Pointing clients at the planner
+
+Clients only consult the planner when `KACHE_PLANNER_ENDPOINT` is set (or `cache.planner.endpoint` in config) — `KACHE_PLANNER_TOKEN` alone does nothing. Point clients at the in-cluster service:
+
+```sh
+KACHE_PLANNER_ENDPOINT=http://<svc>.<ns>.svc.cluster.local:8080
+# optional: KACHE_PLANNER_TIMEOUT_MS to bound the planner round-trip
+```
 
 ### Bearer-token auth
 
-Auth is enabled by pointing the chart at an existing secret. Clients must send the same token through `KACHE_PLANNER_TOKEN`.
+Auth is enabled by pointing the chart at an existing secret. Clients must send the matching token through `KACHE_PLANNER_TOKEN`. The standalone binary enforces the same check when started with `--token` / `KACHE_PLANNER_TOKEN`; with no token configured, requests are accepted anonymously. A request that lacks valid auth when a token is set gets `401`.
 
 ```yaml title="values.yaml"
 auth:
@@ -50,14 +59,14 @@ auth:
 
 ### Planner state and persistence
 
-The service stores its embedded planner database at `/var/lib/kache/planner.db` by default. The chart supports either ephemeral storage for preview/dev environments or a PVC for persisted state:
+The service stores its embedded planner database at `/var/lib/kache/planner.db` by default (`planner.dbPath`, also `--db-path` / `KACHE_PLANNER_DB_PATH`). The chart default is `persistence.enabled: true` with `type: ephemeral` — an `emptyDir` that does **not** survive pod restarts. Switch `type` to `pvc` for durable planner state:
 
 ```yaml title="values.yaml"
 planner:
   dbPath: /var/lib/kache/planner.db
   persistence:
     enabled: true
-    type: pvc
+    type: pvc          # default is `ephemeral` (emptyDir, lost on restart)
     mountPath: /var/lib/kache
     size: 10Gi
 ```
@@ -66,7 +75,7 @@ For bootstrap / migration only, the service can still import a legacy JSON plann
 
 ### High availability
 
-For HA deployments, enable leader election and raise the replica count. Followers stay healthy but not ready until they acquire the Kubernetes Lease:
+For HA deployments, enable leader election and raise the replica count. `/healthz` always returns `200`, but `/readyz` (and `prefetch-plan`) return `503` until the repository is loaded and leadership is acquired — so followers stay live-but-not-ready until they win the Kubernetes Lease:
 
 ```yaml title="values.yaml"
 replicaCount: 2
@@ -74,6 +83,8 @@ ha:
   enabled: true
   leaseName: kache-service
 ```
+
+The chart's `ha.*` keys map to the binary's `--ha-enabled` / `--ha-namespace` / `--ha-lease-name` flags (`KACHE_HA_ENABLED` / `KACHE_HA_NAMESPACE` / `KACHE_HA_LEASE_NAME`). The namespace resolves from `ha.namespace`, then `POD_NAMESPACE`, then the mounted service-account namespace file — startup fails if none resolve.
 
 When combining HA with PVC-backed planner state, use storage that can be mounted by all scheduled replicas (e.g. ReadWriteMany), or keep `replicaCount: 1`. The Lease itself is fine across replicas — the constraint is the planner DB volume.
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -614,7 +614,12 @@ fn draw_stats_bar(frame: &mut Frame, state: &AppState, area: Rect) {
                     ls.linked_refs,
                 )
             } else {
-                format!("no active hardlinks    Scan: {dedup_status}")
+                // Zero hardlinks is the expected, healthy state on
+                // copy-on-write filesystems (APFS, btrfs, XFS-with-reflink):
+                // restores are reflinks with independent inodes, so store blobs
+                // keep nlink == 1. The real savings are the blob-level `Dedup:`
+                // figure to the left, not this Unix-only hardlink scan.
+                format!("none — restores prefer reflink/CoW    Scan: {dedup_status}")
             }
         } else {
             "n/a".to_string()
@@ -1074,13 +1079,33 @@ fn draw_projects_overview(frame: &mut Frame, state: &AppState, area: Rect) {
     };
 
     let ls = &scan_stats.link_stats;
-    let dedup_ratio = if ls.store_bytes > 0 {
+    // Dedup summary: lead with the cross-platform blob-level savings (storing
+    // each unique artifact once). The hardlink sub-figure is a Unix-only
+    // restore detail that reads zero on copy-on-write filesystems, where
+    // restores are reflinks (independent inodes) rather than hardlinks — so
+    // never present it as the headline dedup number.
+    let hardlink_part = if ls.saved_bytes > 0 {
         format!(
-            "{:.1}x",
-            (ls.store_bytes + ls.saved_bytes) as f64 / ls.store_bytes as f64
+            "Hardlinks: {} via {} hardlinks",
+            ByteSize(ls.saved_bytes),
+            ls.linked_refs,
         )
     } else {
-        "n/a".to_string()
+        "Hardlinks: none — restores prefer reflink/CoW".to_string()
+    };
+    let dedup_summary = if let Some(bs) = state.stats_snapshot.blob_stats.as_ref() {
+        let pct = if bs.total_logical_size > 0 {
+            bs.savings as f64 / bs.total_logical_size as f64 * 100.0
+        } else {
+            0.0
+        };
+        format!(
+            "{} saved ({:.1}%)    {hardlink_part}",
+            ByteSize(bs.savings),
+            pct,
+        )
+    } else {
+        format!("calculating...    {hardlink_part}")
     };
 
     let wrapper_status = crate::wrapper_config::wrapper_status_line();
@@ -1163,11 +1188,7 @@ fn draw_projects_overview(frame: &mut Frame, state: &AppState, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("  Dedup: ", Style::default().fg(Color::Cyan)),
-            Span::raw(format!(
-                "{dedup_ratio}    Hardlinks: {} files saving {}",
-                ls.linked_refs,
-                ByteSize(ls.saved_bytes)
-            )),
+            Span::raw(dedup_summary),
         ]),
         Line::from(transfer_spans),
         Line::from(vec![


### PR DESCRIPTION
## What

A full audit of the documentation (`README.md` + every `docs/*.mdx`) against the actual source, correcting systematic drift, filling gaps, and tightening prose — plus the one code fix the audit surfaced in the monitor TUI.

Two commits:
1. **docs** — the audit corrections + improvements (16 files).
2. **fix(monitor)** — stop presenting the Unix hardlink scan as the dedup result.

## Why

Several claims had drifted from the code, some in load-bearing places (the README's headline pitch). Each fix below is grounded in a `file:line` reference and was verified against the source before writing.

## Headline corrections

- **Restores are reflink-first, not "just hardlinks."** `link.rs` tries a reflink (CoW clone) first on every platform; hardlink/copy are only the non-CoW fallback. The old "hardlinks" framing was wrong on the common APFS/btrfs dev box. Reworded across README, index, architecture, deduplication, quick-start.
- **`KACHE_PROGRESS`** — removed the fabricated `auto`/`always`/`never` + TTY-detection story (3 docs). Real behavior: off by default; `1`/`hits`; `verbose`/`all`.
- **Store layout** — blobs live at `store/blobs/<ab>/<hash>`; `index.db` is a **sibling** of `store/`, not inside it. Fixed in 3 diagrams.
- **S3 layout** — replaced the single-object form with the real `v3/packs/` + `v3/manifests/` pair.
- **`kache daemon` status** — removed invented PID/uptime from 3 docs; idle-timeout default is **600s** (one doc had claimed "disabled by default", contradicting its own code sample).
- **remote-service** — the planner is fed via S3 + seed file, **not** HTTP manifest ingest; documented the required `KACHE_PLANNER_ENDPOINT`; corrected bind address and persistence default.
- **clang-cl debug compiles are now cached** (machine-local) per #315 — updated README + cache-key + configuration, which still said "not cached / refused."
- Stale versions, the clang-cl "Windows-only" framing, and ~40 missing flags / env vars / config keys folded in as gaps.

## The monitor fix (commit 2)

On copy-on-write filesystems, restores are reflinks with independent inodes, so the nlink-based store scan reads ~0 even when dedup works — the monitor looked broken on Mac/Linux. Now:
- Header zero-case reads `none — restores prefer reflink/CoW` instead of `no active hardlinks` (the real savings are the adjacent blob-level `Dedup` figure).
- Projects-tab overview leads with the cross-platform blob-level savings instead of a misleading `1.0x` hardlink-only ratio.

The `monitor` and `deduplication` docs describe this exact wording, so code and docs agree.

## Verification

- `cargo check` + `clippy` clean, `cargo fmt --check` clean, tui/config tests pass.
- Rebased on current `main` (incl. #315); greps confirm no residual stale `hardlink`/`auto`/`PID`/old-layout/old-clang-cl-debug claims, and all MDX components + code fences balance.

## Notes

- Methodology: a multi-agent codebase-vs-docs audit; every finding carries `file:line` evidence and was re-verified by hand.
- Scope is docs + `src/tui.rs` only.
