### PR TITLE
fix(store,remote): harden the remote-import + store-removal seam (#212, #276, #211, #213)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1145,13 +1145,26 @@ pub fn purge(config: &Config, crate_filter: Option<&str>) -> Result<()> {
     if let Some(name) = crate_filter {
         let entries = store.list_entries("name")?;
         let mut removed = 0;
+        let mut skipped = 0;
         for entry in &entries {
             if entry.crate_name == name {
-                store.remove_entry(&entry.cache_key)?;
+                // A corrupt entry (unloadable meta.json) refuses removal to
+                // avoid leaking blob refcounts (#276); report it and keep going.
+                if let Err(e) = store.remove_entry(&entry.cache_key) {
+                    eprintln!("  skipped {}: {e:#}", entry.cache_key);
+                    skipped += 1;
+                    continue;
+                }
                 removed += 1;
             }
         }
         println!("Removed {removed} entries for '{name}'.");
+        if skipped > 0 {
+            println!(
+                "Skipped {skipped} corrupt entr{} (see warnings above).",
+                if skipped == 1 { "y" } else { "ies" }
+            );
+        }
     } else {
         store.clear()?;
         println!("Cleared entire local store.");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1562,30 +1562,31 @@ impl Daemon {
             }
         }
 
-        // Check download dedup — if another task is already downloading this key, wait for it
-        {
-            let guard = self.downloading.read().await;
-            if guard.contains(&req.key) {
-                drop(guard);
-                tracing::debug!("already downloading {}, waiting for completion", &req.key);
-                // Poll until the in-flight download finishes (up to 30s)
-                for _ in 0..300 {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    if !self.downloading.read().await.contains(&req.key) {
-                        break;
-                    }
+        // Download dedup — atomically claim this key. `insert` returns false if
+        // another task already holds the claim, collapsing the old
+        // read-check-then-write window where two tasks both saw "not
+        // downloading" and both downloaded (racing on the destructive
+        // entry_dir remove/recreate inside extraction) (#213).
+        if !self.downloading.write().await.insert(req.key.clone()) {
+            tracing::debug!("already downloading {}, waiting for completion", &req.key);
+            // Poll until the in-flight download finishes (up to 30s).
+            for _ in 0..300 {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                if !self.downloading.read().await.contains(&req.key) {
+                    break;
                 }
-                // Check if the entry is now available on disk
-                let entry_dir = PathBuf::from(&req.entry_dir);
-                if entry_dir.join("meta.json").exists() {
-                    let was_prefetched = self.prefetched_keys.read().await.contains(&req.key);
-                    return Response::found_prefetched(true, was_prefetched);
-                }
-                // Download failed or timed out — fall through to retry ourselves
             }
+            // If the other task succeeded, the entry is on disk — done.
+            let entry_dir = PathBuf::from(&req.entry_dir);
+            if entry_dir.join("meta.json").exists() {
+                let was_prefetched = self.prefetched_keys.read().await.contains(&req.key);
+                return Response::found_prefetched(true, was_prefetched);
+            }
+            // The in-flight download failed or timed out; re-claim the key so we
+            // own it for our own retry below.
+            self.downloading.write().await.insert(req.key.clone());
         }
-        self.downloading.write().await.insert(req.key.clone());
-        // Released on every exit path below (including panic) by Drop.
+        // We hold the claim — released on every exit path below (incl. panic) by Drop.
         let _dl_guard = DownloadingGuard::new(self.downloading.clone(), req.key.clone());
 
         // Acquire semaphore for download

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -14,6 +14,16 @@ const V3_MANIFESTS: &str = "manifests";
 const V3_PACKS: &str = "packs";
 const V3_MANIFEST_VERSION: u32 = 3;
 
+/// Cap on total bytes written while extracting one downloaded entry pack.
+/// Generous for real artifact packs (a large crate's rlib + rmeta + debug
+/// info), but lethal to a decompression bomb that expands a few KB into
+/// terabytes. Paired with [`MAX_ZSTD_WINDOW_LOG`] on the decoder (#212).
+const MAX_EXTRACTED_BYTES: u64 = 8 * 1024 * 1024 * 1024; // 8 GiB
+
+/// Max zstd window-log accepted on decode (2^27 = 128 MiB). Bounds the
+/// decoder's allocation regardless of what the frame header claims (#212).
+const MAX_ZSTD_WINDOW_LOG: u32 = 27;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct V3Manifest {
     version: u32,
@@ -113,8 +123,14 @@ impl<'a> RemoteLayout<'a> {
         let compressed_len = compressed.len() as u64;
 
         let extract_start = std::time::Instant::now();
-        let decoder = zstd::stream::Decoder::new(std::io::Cursor::new(&compressed))
+        let mut decoder = zstd::stream::Decoder::new(std::io::Cursor::new(&compressed))
             .context("creating v3 zstd decoder")?;
+        // Bound the decompression window so a hostile/buggy frame can't force a
+        // huge allocation. 27 = 128 MiB, well above what level-3 packs use and
+        // independent of the bomb guard on extracted bytes below (#212).
+        decoder
+            .window_log_max(MAX_ZSTD_WINDOW_LOG)
+            .context("setting v3 zstd window-log cap")?;
         let original_bytes = extract_entry_pack(decoder, entry_dir)?;
         let extract_ms = extract_start.elapsed().as_millis() as u64;
 
@@ -363,7 +379,17 @@ fn create_entry_pack_zstd(
 }
 
 fn blob_path(blobs_dir: &Path, hash: &str) -> PathBuf {
-    blobs_dir.join(&hash[..2]).join(hash)
+    // Panic-safe slice; hash shape is validated at the trust boundary in
+    // `extract_entry_pack`, but never let a malformed hash crash here (#211).
+    let prefix = hash.get(..2).unwrap_or(hash);
+    blobs_dir.join(prefix).join(hash)
+}
+
+/// A blob hash is a 64-char blake3 hex digest. Validated where untrusted
+/// `meta.json` enters (download/import) so a malformed hash can never reach
+/// path construction or the integrity gate (#211).
+fn is_blob_hash(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 /// A writer that tees everything written through it into a blake3 hasher, so a
@@ -397,7 +423,17 @@ fn extract_entry_pack<R: std::io::Read>(reader: R, dest_dir: &Path) -> Result<u6
 
     for entry in archive.entries()? {
         let mut entry = entry?;
-        total_bytes += entry.size();
+        // Bomb guard: a tar can declare an enormous entry that a tiny zstd
+        // frame expands to. tar framing means the reader below yields at most
+        // `entry.size()` bytes, so the running declared total upper-bounds what
+        // we will ever write to disk — reject before writing anything (#212).
+        total_bytes = total_bytes.saturating_add(entry.size());
+        if total_bytes > MAX_EXTRACTED_BYTES {
+            bail!(
+                "entry pack exceeds the {MAX_EXTRACTED_BYTES}-byte extraction cap \
+                 (possible decompression bomb)"
+            );
+        }
         let path = entry.path()?.to_path_buf();
 
         if path.is_absolute() {
@@ -447,6 +483,29 @@ fn extract_entry_pack<R: std::io::Read>(reader: R, dest_dir: &Path) -> Result<u6
         std::fs::read_to_string(&meta_path).context("reading downloaded meta.json")?;
     let meta: EntryMeta =
         serde_json::from_str(&meta_content).context("parsing downloaded meta.json")?;
+    // Validate declared fields from the untrusted meta.json before they flow
+    // into hash/path logic (#211). A malformed hash or an unsafe file name is a
+    // hostile/corrupt remote — reject loudly rather than build a bad path.
+    for cached_file in &meta.files {
+        if !is_blob_hash(&cached_file.hash) {
+            bail!(
+                "downloaded entry declares a malformed blob hash for {}: {:?}",
+                cached_file.name,
+                cached_file.hash
+            );
+        }
+        let name = Path::new(&cached_file.name);
+        if name.is_absolute()
+            || name
+                .components()
+                .any(|c| c == std::path::Component::ParentDir)
+        {
+            bail!(
+                "downloaded entry declares an unsafe file name: {:?}",
+                cached_file.name
+            );
+        }
+    }
     for cached_file in &meta.files {
         match computed_hashes.get(Path::new(&cached_file.name)) {
             Some(actual) if actual == &cached_file.hash => {}
@@ -493,11 +552,35 @@ fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{blob_path, create_entry_pack_zstd, extract_entry_pack};
+    use super::{blob_path, create_entry_pack_zstd, extract_entry_pack, is_blob_hash};
     use crate::config::{Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS, DEFAULT_S3_POOL_IDLE_SECS};
     use crate::store::{EntryMeta, Store};
     use aws_sdk_s3::error::ErrorMetadata;
     use aws_sdk_s3::operation::head_object::HeadObjectError;
+
+    /// #211: the trust-boundary hash validator accepts only a 64-char blake3
+    /// hex digest and rejects everything a hostile/corrupt meta.json might
+    /// carry (empty, short, wrong length, non-hex, traversal-shaped).
+    #[test]
+    fn is_blob_hash_accepts_only_blake3_hex() {
+        assert!(is_blob_hash(&"a".repeat(64)));
+        assert!(is_blob_hash(&"0123456789abcdef".repeat(4)));
+        assert!(!is_blob_hash(""));
+        assert!(!is_blob_hash("ab"));
+        assert!(!is_blob_hash(&"a".repeat(63)));
+        assert!(!is_blob_hash(&"a".repeat(65)));
+        assert!(!is_blob_hash(&"g".repeat(64))); // non-hex
+        assert!(!is_blob_hash("../../etc/passwd"));
+    }
+
+    /// #211: building a blob path from a malformed (short) hash must not panic
+    /// on the `[..2]` slice, even though such a hash is rejected upstream.
+    #[test]
+    fn blob_path_is_panic_safe_for_short_hash() {
+        let dir = std::path::Path::new("/store/blobs");
+        let _ = blob_path(dir, "a");
+        let _ = blob_path(dir, "");
+    }
 
     #[test]
     fn v3_pack_roundtrip_restores_meta_and_files() {

--- a/src/store.rs
+++ b/src/store.rs
@@ -124,7 +124,12 @@ fn materialize_blob(source: &Path, blob: &Path, hash: &str) -> Result<()> {
 }
 
 fn blob_path_in_store_dir(store_dir: &Path, hash: &str) -> PathBuf {
-    let prefix = &hash[..2];
+    // Defensive slice: a malformed hash (e.g. from a hand-edited or malicious
+    // remote `meta.json`) must not panic. Hash shape is validated at the
+    // remote trust boundary (`extract_entry_pack`), so a bad hash never gets
+    // stored; this keeps the local path build panic-free even if one slips
+    // through (#211).
+    let prefix = hash.get(..2).unwrap_or(hash);
     store_dir.join("blobs").join(prefix).join(hash)
 }
 
@@ -942,7 +947,13 @@ impl Store {
                 if current_size <= target {
                     break;
                 }
-                self.remove_entry(&key)?;
+                if let Err(e) = self.remove_entry(&key) {
+                    // A corrupt entry (unloadable meta.json) refuses removal to
+                    // avoid leaking blob refcounts (#276); skip it and keep
+                    // evicting the rest rather than aborting the whole sweep.
+                    tracing::warn!("gc: skipping eviction of {key}: {e:#}");
+                    continue;
+                }
                 stats.entries_evicted += 1;
                 stats.bytes_freed += size as u64;
                 current_size = current_size.saturating_sub(size as u64);
@@ -975,7 +986,10 @@ impl Store {
 
         let mut stats = GcStats::default();
         for (key, size) in &rows {
-            self.remove_entry(key)?;
+            if let Err(e) = self.remove_entry(key) {
+                tracing::warn!("gc: skipping eviction of {key}: {e:#}");
+                continue;
+            }
             stats.entries_evicted += 1;
             stats.bytes_freed += *size as u64;
         }
@@ -1007,7 +1021,10 @@ impl Store {
 
         let mut stats = GcStats::default();
         for (key, size) in &rows {
-            self.remove_entry(key)?;
+            if let Err(e) = self.remove_entry(key) {
+                tracing::warn!("gc: skipping eviction of {key}: {e:#}");
+                continue;
+            }
             stats.entries_evicted += 1;
             stats.bytes_freed += *size as u64;
         }
@@ -1158,14 +1175,49 @@ impl Store {
         let entry_dir = self.entry_dir(cache_key);
         let meta_path = entry_dir.join("meta.json");
 
-        let hashes: Vec<String> = if meta_path.exists() {
-            fs::read_to_string(&meta_path)
-                .ok()
-                .and_then(|c| serde_json::from_str::<EntryMeta>(&c).ok())
-                .map(|meta| meta.files.iter().map(|f| f.hash.clone()).collect())
-                .unwrap_or_default()
-        } else {
-            Vec::new()
+        // Load the blob hashes this entry references. If `meta.json` exists but
+        // can't be read or parsed, we CANNOT know which blobs to decrement —
+        // deleting the entry row anyway permanently orphans those refcounts (the
+        // blobs keep their DB row and evade size-based eviction forever). Refuse
+        // the removal so a corrupt entry never silently leaks (#276); callers
+        // (GC / purge / `doctor --repair`) log and move on, and the entry stays
+        // accounted-for until a fresh `put` (INSERT OR REPLACE) overwrites it.
+        let hashes: Vec<String> = match fs::read_to_string(&meta_path) {
+            Ok(content) => {
+                let meta: EntryMeta = serde_json::from_str(&content).with_context(|| {
+                    format!(
+                        "entry {cache_key}: meta.json unparseable — refusing removal so blob \
+                         refcounts are not leaked (#276)"
+                    )
+                })?;
+                meta.files.iter().map(|f| f.hash.clone()).collect()
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // No meta.json. If a DB row still exists, its blob list is
+                // unknown and deleting the row would leak — refuse. If neither
+                // a row nor a dir exists, there is nothing to remove (idempotent
+                // for already-gone / never-existed keys).
+                let row_exists: i64 = self.db.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM entries WHERE cache_key = ?1)",
+                    params![cache_key],
+                    |row| row.get(0),
+                )?;
+                if row_exists != 0 {
+                    anyhow::bail!(
+                        "entry {cache_key}: meta.json missing but DB row present — refusing \
+                         removal so blob refcounts are not leaked (#276)"
+                    );
+                }
+                return Ok(());
+            }
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!(
+                        "entry {cache_key}: reading meta.json — refusing removal so blob \
+                         refcounts are not leaked (#276)"
+                    )
+                });
+            }
         };
 
         {
@@ -1940,6 +1992,115 @@ mod tests {
         store.remove_entry("rem1").unwrap();
         assert!(!store.contains("rem1"));
         assert_eq!(store.entry_count().unwrap(), 0);
+    }
+
+    /// #276: removing an entry whose meta.json is unparseable must NOT delete
+    /// the entry row or silently drop blob refcounts — that orphans the blobs
+    /// forever (they keep a DB row and evade size-based eviction). It must
+    /// refuse, leaving the entry and its refcounts intact.
+    #[test]
+    fn remove_entry_refuses_on_corrupt_meta_no_refcount_leak() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let output = dir.path().join("lib.rlib");
+        std::fs::write(&output, b"content").unwrap();
+        store
+            .put(
+                "corrupt1",
+                "c1",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        let refcount_sum = |s: &Store| -> i64 {
+            s.db.query_row("SELECT COALESCE(SUM(refcount), 0) FROM blobs", [], |r| {
+                r.get(0)
+            })
+            .unwrap()
+        };
+        let row_present = |s: &Store| -> i64 {
+            s.db.query_row(
+                "SELECT COUNT(*) FROM entries WHERE cache_key = 'corrupt1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(refcount_sum(&store), 1, "one blob at refcount 1 after put");
+        assert_eq!(row_present(&store), 1);
+
+        // Corrupt the entry's meta.json so its blob list can't be loaded.
+        let meta_path = store.entry_dir("corrupt1").join("meta.json");
+        std::fs::write(&meta_path, b"{ not valid json").unwrap();
+
+        assert!(
+            store.remove_entry("corrupt1").is_err(),
+            "remove_entry must error on unparseable meta.json rather than leak"
+        );
+        assert_eq!(
+            row_present(&store),
+            1,
+            "corrupt entry row must survive a refused removal"
+        );
+        assert_eq!(
+            refcount_sum(&store),
+            1,
+            "blob refcounts must be unchanged — no orphan"
+        );
+    }
+
+    /// #276: a missing meta.json while the DB row persists is the same hazard.
+    #[test]
+    fn remove_entry_refuses_when_meta_missing_but_row_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let output = dir.path().join("lib.rlib");
+        std::fs::write(&output, b"x").unwrap();
+        store
+            .put(
+                "m1",
+                "c1",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+        std::fs::remove_file(store.entry_dir("m1").join("meta.json")).unwrap();
+        assert!(store.remove_entry("m1").is_err());
+        let still_there: i64 = store
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM entries WHERE cache_key = 'm1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(still_there, 1, "entry row must survive a refused removal");
+    }
+
+    /// #211: blob path construction must be panic-safe for a malformed (short)
+    /// hash that bypasses validation; it must not slice `[..2]` on `len < 2`.
+    #[test]
+    fn blob_path_is_panic_safe_for_short_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        // Would panic on `&hash[..2]` before the fix.
+        let _ = store.blob_path("a");
+        let _ = store.blob_path("");
     }
 
     #[test]


### PR DESCRIPTION
A focused hardening batch on the shared remote/store seam — four related correctness/security fixes the triage flagged as still-valid on `main`.

## Fixes #212 — decompression bomb (security)
The automatic background prefetch path decoded entry packs with **no size bound** — a tiny hostile/buggy object could expand to terabytes and exhaust disk/inodes on every daemon pointed at the bucket (#308's metadata cap doesn't cover entry packs). Now:
- 128 MiB **window-log cap** on the zstd decoder (bounds decode allocation).
- 8 GiB **running-bytes budget** in `extract_entry_pack`; tar framing means declared entry sizes upper-bound what's written, so the cumulative check rejects a bomb before writing anything.

## Fixes #276 — refcount leak (correctness, data)
`remove_entry` deleted the entry row even when `meta.json` was missing/unparseable, so its blobs were **never decremented, kept their DB row, and evaded size-based eviction forever** (reachable via `doctor --repair`). Now it **refuses** removal when the blob list can't be loaded, leaving the entry accounted-for until a fresh `put` (INSERT OR REPLACE) overwrites it. GC/purge **log and continue** instead of aborting the sweep.

## Hardens #211 — remote import trust boundary (security)
The #178 blake3 gate already blocks the false-hit vector; this closes the residual gaps:
- Validate declared **blob-hash shape** (64 hex) and **file names** (no absolute / `..` traversal) from the untrusted `meta.json` before they reach hash/path logic.
- Make blob-path construction **panic-safe** on a malformed hash (no two-char prefix slice when shorter), in both `store` and `remote_layout`.
- The integrity gate already runs in `extract_entry_pack` (the download/import seam), so no relocation was needed.

## Addresses #213 (Part A) — daemon download race (correctness)
The download dedup did a read-check then a **separate** write-insert — two tasks could both see "not downloading" and download the same key concurrently, racing on extraction's destructive `entry_dir` remove/recreate. Replaced with an **atomic `insert()`-bool claim**. (Part B — the `S3KeyCache` lost-insert — is left as a follow-up.)

## Tests / verification
New unit tests: corrupt- and missing-meta removal **refuses without leaking refcounts**; `is_blob_hash` validation; panic-safe `blob_path` for short hashes. `cargo check`/`clippy`/`fmt --check` clean; full bin suite **744 passed, 0 failed**.

Leaving #211 and #213 open for you to close after review (only #212/#276 are auto-closed here, since #211's gate-relocation and #213's Part B are judgment calls / follow-ups).