### PR TITLE
fix(daemon): hash files outside the store mutex in HashFiles (#281)

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -1111,11 +1111,24 @@ enum FileHashCache<'db> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct FileFingerprint {
+pub(crate) struct FileFingerprint {
     path: String,
     size: i64,
     mtime_ns: i64,
     ctime_ns: i64,
+}
+
+/// Result of a content-hash cache lookup that does NOT compute a blake3 — the
+/// lock-narrowing seam for the daemon's `HashFiles` path (#281). The caller
+/// hashes (`hash_file`) outside any store lock on a miss, then records via
+/// [`FileHasher::record_cached`].
+pub(crate) enum FileHashLookup {
+    /// Cached hash found — no hashing needed.
+    Hit(String),
+    /// Cache miss; hash the file then record under this fingerprint.
+    NeedsHash(FileFingerprint),
+    /// Too small to persist, or metadata unreadable — hash but don't cache.
+    Uncacheable,
 }
 
 #[derive(Debug, Clone)]
@@ -1281,6 +1294,50 @@ impl<'db> FileHasher<'db> {
             tracing::debug!("file hash cache update failed for {}: {e}", path.display());
         }
         Ok(hash)
+    }
+
+    /// Cache lookup ONLY — reads the persistent hash cache, never computes a
+    /// blake3. Lets a caller holding a coarse lock (the daemon's `Mutex<Store>`)
+    /// release it before the expensive file read and re-take it only for the
+    /// short record (#281). Mirrors [`Self::hash`]'s fingerprint + min-size +
+    /// cache-get logic exactly, so the cache key is identical.
+    pub(crate) fn lookup_cached(&self, path: &Path) -> FileHashLookup {
+        let Some(cache) = &self.cache else {
+            return FileHashLookup::Uncacheable;
+        };
+        let fingerprint = match FileFingerprint::from_path(path) {
+            Ok(fp) => fp,
+            Err(e) => {
+                tracing::debug!(
+                    "file hash cache metadata lookup failed for {}: {e}",
+                    path.display()
+                );
+                return FileHashLookup::Uncacheable;
+            }
+        };
+        if fingerprint.size < MIN_PERSISTED_HASH_BYTES {
+            return FileHashLookup::Uncacheable;
+        }
+        match cache.get(&fingerprint) {
+            Ok(Some(hash)) => FileHashLookup::Hit(hash),
+            Ok(None) => FileHashLookup::NeedsHash(fingerprint),
+            Err(e) => {
+                // Treat a lookup error as a miss — recompute rather than fail.
+                tracing::debug!("file hash cache lookup failed for {}: {e}", path.display());
+                FileHashLookup::NeedsHash(fingerprint)
+            }
+        }
+    }
+
+    /// Record a freshly-computed hash for `fingerprint` (the miss arm of
+    /// [`Self::lookup_cached`]). Best-effort — a cache write failure is logged,
+    /// not propagated.
+    pub(crate) fn record_cached(&self, fingerprint: &FileFingerprint, hash: &str) {
+        if let Some(cache) = &self.cache
+            && let Err(e) = cache.put(fingerprint, hash)
+        {
+            tracing::debug!("file hash cache update failed: {e}");
+        }
     }
 
     fn record_hit(&self) {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1182,14 +1182,32 @@ impl Daemon {
                 }
             }
 
-            let computed = self.with_store(|store| {
-                let hasher = store.file_hasher();
-                let hash = hasher.hash(Path::new(&file.path))?;
-                Ok((hash, hasher.stats()))
-            });
+            // #281: hold the store mutex only for the cheap cache lookup and
+            // record; run the blake3 read of the whole file OUTSIDE the lock so
+            // it can't stall a concurrent RemoteCheck's `import_restored_entry`.
+            let path = Path::new(&file.path);
+            let computed: anyhow::Result<(String, bool, u64)> =
+                match self.with_store(|store| Ok(store.file_hash_lookup(path))) {
+                    Ok(crate::cache_key::FileHashLookup::Hit(hash)) => Ok((hash, true, 0)),
+                    Ok(crate::cache_key::FileHashLookup::NeedsHash(fp)) => {
+                        crate::cache_key::hash_file(path).map(|hash| {
+                            // Brief re-lock just to persist the result.
+                            let _ = self.with_store(|store| {
+                                store.file_hash_record(&fp, &hash);
+                                Ok(())
+                            });
+                            (hash, false, file.size.max(0) as u64)
+                        })
+                    }
+                    Ok(crate::cache_key::FileHashLookup::Uncacheable) => {
+                        crate::cache_key::hash_file(path)
+                            .map(|hash| (hash, false, file.size.max(0) as u64))
+                    }
+                    Err(e) => Err(e),
+                };
 
             match computed {
-                Ok((hash, stats)) => {
+                Ok((hash, cache_hit, bytes_hashed)) => {
                     if let Ok(mut cache) = self.file_hash_cache.lock() {
                         if cache.len() >= FILE_HASH_MEMORY_CACHE_CAP {
                             cache.clear();
@@ -1203,8 +1221,8 @@ impl Daemon {
                         mtime_ns: file.mtime_ns,
                         ctime_ns: file.ctime_ns,
                         hash: Some(hash),
-                        cache_hit: stats.cache_hits > 0,
-                        bytes_hashed: stats.bytes_hashed,
+                        cache_hit,
+                        bytes_hashed,
                         error: None,
                     });
                 }
@@ -5149,6 +5167,47 @@ mod tests {
         assert_eq!(first_result.hash, second_result.hash);
         assert!(second_result.cache_hit);
         assert_eq!(second_result.bytes_hashed, 0);
+    }
+
+    /// #281: the lock-narrowed HashFiles path (cache lookup under the store
+    /// lock, blake3 outside it, record under the lock) must preserve the
+    /// PERSISTENT cache. A second daemon with a fresh in-memory cache but the
+    /// same `index.db` gets a hit without re-hashing, and every hash matches
+    /// the canonical `hash_file`.
+    #[test]
+    fn handle_hash_files_persistent_cache_hit_across_daemons() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+
+        let file = dir.path().join("big.rlib");
+        std::fs::write(&file, vec![3u8; 80 * 1024]).unwrap(); // ≥ 64 KiB → cacheable
+        let metadata = std::fs::metadata(&file).unwrap();
+        let req = HashFilesRequest {
+            files: vec![HashFileRequest {
+                path: file.to_string_lossy().into_owned(),
+                size: i64::try_from(metadata.len()).unwrap(),
+                mtime_ns: crate::cache_key::metadata_mtime_ns(&metadata),
+                ctime_ns: crate::cache_key::metadata_ctime_ns(&metadata),
+            }],
+        };
+        let expected = crate::cache_key::hash_file(&file).unwrap();
+
+        // Daemon A: cold — persistent-cache miss, computes and records.
+        let a = Daemon::new(config.clone());
+        let ra = a.handle_hash_files(&req);
+        let ra = &ra.hash_results.as_ref().unwrap()[0];
+        assert_eq!(ra.hash.as_deref(), Some(expected.as_str()));
+        assert!(!ra.cache_hit, "first hash is a persistent-cache miss");
+        assert!(ra.bytes_hashed > 0);
+
+        // Daemon B: fresh in-memory cache, same store — must hit the PERSISTENT
+        // cache via the lock-narrowed lookup rather than re-hashing.
+        let b = Daemon::new(config);
+        let rb = b.handle_hash_files(&req);
+        let rb = &rb.hash_results.as_ref().unwrap()[0];
+        assert_eq!(rb.hash.as_deref(), Some(expected.as_str()));
+        assert!(rb.cache_hit, "second daemon must hit the persistent cache");
+        assert_eq!(rb.bytes_hashed, 0);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -357,6 +357,19 @@ impl Store {
         self.file_hasher().with_daemon(socket_path)
     }
 
+    /// Persistent-cache lookup for one file's content hash — DB read only, no
+    /// blake3. Lets the daemon's `HashFiles` path release the store lock before
+    /// the expensive file read (#281). See [`crate::cache_key::FileHashLookup`].
+    pub fn file_hash_lookup(&self, path: &Path) -> crate::cache_key::FileHashLookup {
+        self.file_hasher().lookup_cached(path)
+    }
+
+    /// Record a freshly-computed file content hash (the miss arm of
+    /// [`Self::file_hash_lookup`]); best-effort.
+    pub fn file_hash_record(&self, fingerprint: &crate::cache_key::FileFingerprint, hash: &str) {
+        self.file_hasher().record_cached(fingerprint, hash);
+    }
+
     /// Check if a committed entry exists for this cache key.
     pub fn contains(&self, cache_key: &str) -> bool {
         let entry_dir = self.entry_dir(cache_key);


### PR DESCRIPTION
Completes #281 (the bullet-2 lock-narrowing deferred from #322).

## Problem
`handle_hash_files` computed each file's blake3 **inside** `with_store`, so reading a multi-megabyte file held the daemon's single `Mutex<Store>` for the whole read — directly blocking a concurrent `RemoteCheck`'s `import_restored_entry`, which takes the same lock.

## Fix
Split into three phases so the lock is held only for the cheap DB ops and the expensive read runs unlocked:
1. **lock** → cache lookup (`Store::file_hash_lookup` → `FileHasher::lookup_cached`, DB read only)
2. **unlock** → `hash_file` (full-file blake3) on a miss
3. **lock** → record (`Store::file_hash_record`)

A new `FileHashLookup { Hit | NeedsHash(fingerprint) | Uncacheable }` carries the fingerprint across the unlock, so the record reuses the **exact** fingerprint + min-size + cache-key logic as `FileHasher::hash` — the persistent cache key is byte-identical, nothing is invalidated, and an entry hashed via either path is found via the other. The rustc-wrapper's `FileHasher::hash` is untouched.

## Scope
With **#322** (spawn_blocking dispatch + periodic GC), this lands **all three** fixes the issue proposed — so this **Closes #281**. (The separate observation that `run_gc` holds the store mutex for its whole sweep is a deeper GC-locking change, not part of this issue's proposed fix; happy to file it separately if you want it.)

## Tests / verification
- New: a second daemon with a fresh in-memory cache but the **same `index.db`** hits the persistent cache without re-hashing, and the hashes match the canonical `hash_file` (proves the narrowing preserves caching + correctness).
- `cargo check`/`clippy`/`fmt --check` clean; full bin suite **749 passed, 0 failed**.

Closes #281.