### PR TITLE
fix(store): fold inode into the file-hash memo key (#324)

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -1116,6 +1116,10 @@ pub(crate) struct FileFingerprint {
     size: i64,
     mtime_ns: i64,
     ctime_ns: i64,
+    /// Filesystem inode (0 on non-Unix / unavailable). Folded into the memo key
+    /// so an in-place swap that preserves path+size+mtime+ctime but changes the
+    /// inode (and content) can't return a stale memoized hash (kunobi-ninja/kache#324).
+    inode: i64,
 }
 
 /// Result of a content-hash cache lookup that does NOT compute a blake3 — the
@@ -1211,6 +1215,7 @@ impl<'db> FileHasher<'db> {
                 size: fingerprint.size,
                 mtime_ns: fingerprint.mtime_ns,
                 ctime_ns: fingerprint.ctime_ns,
+                inode: fingerprint.inode,
             });
         }
 
@@ -1231,6 +1236,7 @@ impl<'db> FileHasher<'db> {
                             size: result.size,
                             mtime_ns: result.mtime_ns,
                             ctime_ns: result.ctime_ns,
+                            inode: result.inode,
                         },
                         PrefetchedHash {
                             hash,
@@ -1388,12 +1394,13 @@ impl<'db> FileHashCache<'db> {
         self.db()
             .query_row(
                 "SELECT hash FROM file_hashes
-                 WHERE path = ?1 AND size = ?2 AND mtime_ns = ?3 AND ctime_ns = ?4",
+                 WHERE path = ?1 AND size = ?2 AND mtime_ns = ?3 AND ctime_ns = ?4 AND inode = ?5",
                 params![
                     fingerprint.path,
                     fingerprint.size,
                     fingerprint.mtime_ns,
-                    fingerprint.ctime_ns
+                    fingerprint.ctime_ns,
+                    fingerprint.inode
                 ],
                 |row| row.get(0),
             )
@@ -1403,13 +1410,14 @@ impl<'db> FileHashCache<'db> {
     fn put(&self, fingerprint: &FileFingerprint, hash: &str) -> rusqlite::Result<()> {
         self.db().execute(
             "INSERT OR REPLACE INTO file_hashes
-             (path, size, mtime_ns, ctime_ns, hash, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'))",
+             (path, size, mtime_ns, ctime_ns, inode, hash, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))",
             params![
                 fingerprint.path,
                 fingerprint.size,
                 fingerprint.mtime_ns,
                 fingerprint.ctime_ns,
+                fingerprint.inode,
                 hash
             ],
         )?;
@@ -1424,15 +1432,20 @@ pub(crate) fn ensure_file_hash_cache_schema(db: &Connection) -> rusqlite::Result
             size       INTEGER NOT NULL,
             mtime_ns   INTEGER NOT NULL,
             ctime_ns   INTEGER NOT NULL DEFAULT 0,
+            inode      INTEGER NOT NULL DEFAULT 0,
             hash       TEXT NOT NULL,
             updated_at TEXT NOT NULL DEFAULT (datetime('now'))
         );",
     )?;
-    if let Err(e) =
-        db.execute_batch("ALTER TABLE file_hashes ADD COLUMN ctime_ns INTEGER NOT NULL DEFAULT 0")
-        && !e.to_string().contains("duplicate column name")
-    {
-        return Err(e);
+    for column in [
+        "ALTER TABLE file_hashes ADD COLUMN ctime_ns INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE file_hashes ADD COLUMN inode INTEGER NOT NULL DEFAULT 0",
+    ] {
+        if let Err(e) = db.execute_batch(column)
+            && !e.to_string().contains("duplicate column name")
+        {
+            return Err(e);
+        }
     }
     Ok(())
 }
@@ -1448,6 +1461,7 @@ impl FileFingerprint {
             size: i64::try_from(metadata.len()).unwrap_or(i64::MAX),
             mtime_ns: metadata_mtime_ns(&metadata),
             ctime_ns: metadata_ctime_ns(&metadata),
+            inode: metadata_inode(&metadata),
         })
     }
 }
@@ -1459,6 +1473,20 @@ fn absolute_path(path: &Path) -> PathBuf {
         std::env::current_dir()
             .map(|cwd| cwd.join(path))
             .unwrap_or_else(|_| path.to_path_buf())
+    }
+}
+
+/// Filesystem inode number (0 where unavailable, e.g. non-Unix).
+pub(crate) fn metadata_inode(metadata: &std::fs::Metadata) -> i64 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        i64::try_from(metadata.ino()).unwrap_or(i64::MAX)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        0
     }
 }
 
@@ -2904,6 +2932,35 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         let hash1 = hasher.hash(&file).unwrap();
         let hash2 = hasher.hash(&file).unwrap();
         assert_eq!(hash1, hash2, "FileHasher must be deterministic");
+    }
+
+    #[test]
+    fn file_hash_memo_key_includes_inode() {
+        // An in-place swap that preserves path+size+mtime+ctime but changes the
+        // inode (and content) must NOT return a stale memoized hash
+        // (kunobi-ninja/kache#324).
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        ensure_file_hash_cache_schema(&conn).unwrap();
+        let cache = FileHashCache::Borrowed(&conn);
+
+        let fp = |inode: i64| FileFingerprint {
+            path: "/x/lib.rlib".to_string(),
+            size: 100,
+            mtime_ns: 1,
+            ctime_ns: 2,
+            inode,
+        };
+
+        cache.put(&fp(10), "hash_for_inode_10").unwrap();
+        assert_eq!(
+            cache.get(&fp(10)).unwrap().as_deref(),
+            Some("hash_for_inode_10")
+        );
+        assert_eq!(
+            cache.get(&fp(20)).unwrap(),
+            None,
+            "a different inode (same path/size/mtime/ctime) must miss the memo"
+        );
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -356,6 +356,8 @@ pub struct HashFileRequest {
     pub size: i64,
     pub mtime_ns: i64,
     pub ctime_ns: i64,
+    #[serde(default)]
+    pub inode: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -364,6 +366,8 @@ pub struct HashFileResult {
     pub size: i64,
     pub mtime_ns: i64,
     pub ctime_ns: i64,
+    #[serde(default)]
+    pub inode: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hash: Option<String>,
     #[serde(default)]
@@ -870,6 +874,7 @@ struct FileHashCacheKey {
     size: i64,
     mtime_ns: i64,
     ctime_ns: i64,
+    inode: i64,
 }
 
 impl Daemon {
@@ -1131,6 +1136,7 @@ impl Daemon {
                 size: file.size,
                 mtime_ns: file.mtime_ns,
                 ctime_ns: file.ctime_ns,
+                inode: file.inode,
             };
 
             if let Ok(cache) = self.file_hash_cache.lock()
@@ -1141,6 +1147,7 @@ impl Daemon {
                     size: file.size,
                     mtime_ns: file.mtime_ns,
                     ctime_ns: file.ctime_ns,
+                    inode: file.inode,
                     hash: Some(hash),
                     cache_hit: true,
                     bytes_hashed: 0,
@@ -1153,13 +1160,15 @@ impl Daemon {
                 Ok(metadata)
                     if i64::try_from(metadata.len()).unwrap_or(i64::MAX) == file.size
                         && crate::cache_key::metadata_mtime_ns(&metadata) == file.mtime_ns
-                        && crate::cache_key::metadata_ctime_ns(&metadata) == file.ctime_ns => {}
+                        && crate::cache_key::metadata_ctime_ns(&metadata) == file.ctime_ns
+                        && crate::cache_key::metadata_inode(&metadata) == file.inode => {}
                 Ok(_) => {
                     results.push(HashFileResult {
                         path: file.path.clone(),
                         size: file.size,
                         mtime_ns: file.mtime_ns,
                         ctime_ns: file.ctime_ns,
+                        inode: file.inode,
                         hash: None,
                         cache_hit: false,
                         bytes_hashed: 0,
@@ -1173,6 +1182,7 @@ impl Daemon {
                         size: file.size,
                         mtime_ns: file.mtime_ns,
                         ctime_ns: file.ctime_ns,
+                        inode: file.inode,
                         hash: None,
                         cache_hit: false,
                         bytes_hashed: 0,
@@ -1220,6 +1230,7 @@ impl Daemon {
                         size: file.size,
                         mtime_ns: file.mtime_ns,
                         ctime_ns: file.ctime_ns,
+                        inode: file.inode,
                         hash: Some(hash),
                         cache_hit,
                         bytes_hashed,
@@ -1231,6 +1242,7 @@ impl Daemon {
                     size: file.size,
                     mtime_ns: file.mtime_ns,
                     ctime_ns: file.ctime_ns,
+                    inode: file.inode,
                     hash: None,
                     cache_hit: false,
                     bytes_hashed: 0,
@@ -5151,6 +5163,7 @@ mod tests {
                 size: i64::try_from(metadata.len()).unwrap(),
                 mtime_ns: crate::cache_key::metadata_mtime_ns(&metadata),
                 ctime_ns: crate::cache_key::metadata_ctime_ns(&metadata),
+                inode: crate::cache_key::metadata_inode(&metadata),
             }],
         };
 
@@ -5188,6 +5201,7 @@ mod tests {
                 size: i64::try_from(metadata.len()).unwrap(),
                 mtime_ns: crate::cache_key::metadata_mtime_ns(&metadata),
                 ctime_ns: crate::cache_key::metadata_ctime_ns(&metadata),
+                inode: crate::cache_key::metadata_inode(&metadata),
             }],
         };
         let expected = crate::cache_key::hash_file(&file).unwrap();
@@ -5356,6 +5370,7 @@ mod tests {
                 size: 123,
                 mtime_ns: 456,
                 ctime_ns: 789,
+                inode: 1011,
             }],
         });
         let json = serde_json::to_string(&req).unwrap();


### PR DESCRIPTION
Second of the **non-invalidating** correctness fixes from #324 (no `CACHE_KEY_VERSION` bump, no fleet rebuild). Follows #340.

## The gap

`FileFingerprint` keyed the file-hash memo (`file_hashes` table) on `(path, size, mtime_ns, ctime_ns)` only. An in-place swap that preserves all four but changes the file's content — e.g. an atomic `rename`-over, which also changes the **inode** — could return a **stale memoized hash**, so the cache key would be computed from the wrong content.

## The fix

Add `inode` to the memo key and thread it consistently so the in-process and daemon-assisted hash paths agree:

- `FileFingerprint` gains an `inode` field; `from_path` fills it via a new `metadata_inode` helper (`MetadataExt::ino()` on Unix, `0` elsewhere).
- `file_hashes` schema gains an `inode` column (+ `ALTER TABLE` migration alongside the existing `ctime_ns` one); the `get`/`put` queries include it.
- The daemon IPC (`HashFileRequest`/`HashFileResult`, `#[serde(default)]` for rolling-restart safety) and the `FileHashCacheKey` carry inode; the `HashFiles` handler's "metadata changed before hashing" re-stat guard now also compares inode.

This is a **local memo only** — `inode` never enters the cache key and never crosses the remote wire — so there's **no version bump**. Old rows default `inode = 0` and re-hash once.

## Tests

- New `file_hash_memo_key_includes_inode`: a put under one inode misses a get with a different inode (same path/size/mtime/ctime).
- Existing memo + daemon `hash_files` tests (incl. the IPC serde and cross-daemon persistent-cache tests) still pass.

`cargo fmt`, `clippy --all-targets`, `cache_key` (73) and the daemon `hash_files` tests are green.

## Remaining from #324

- too-new-input guard (refuse-to-store within an FS-granularity margin of invocation start) — non-invalidating.
- the `v16` bump: length-prefixed key fields + residual-args — the only fleet-invalidating part.
