### PR TITLE
feat(store): cross-process gc.lock so concurrent GC drivers don't double-scan (#326)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1100,6 +1100,16 @@ pub fn gc(config: &Config, max_age_hours: Option<u64>) -> Result<()> {
             println!("Daemon GC failed ({e}), running locally...");
             let store = Store::open(config)?;
 
+            // Cross-process GC mutual exclusion (kunobi-ninja/kache#326): bail if
+            // another GC (e.g. a live daemon's sweep) already holds gc.lock.
+            let _gc_lock = match store.try_gc_lock()? {
+                Some(lock) => lock,
+                None => {
+                    println!("Another GC is already running; skipping.");
+                    return Ok(());
+                }
+            };
+
             // Backfill content hashes for legacy entries
             print!("Backfilling content hashes...");
             std::io::Write::flush(&mut std::io::stdout()).ok();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2109,6 +2109,16 @@ impl Daemon {
     /// Returns aggregated GcStats and persists them to `gc_stats.json` in the cache dir.
     pub fn run_gc(&self, max_age_hours: Option<u64>) -> Result<crate::store::GcStats> {
         let start = Instant::now();
+        // Cross-process GC mutual exclusion (kunobi-ninja/kache#326): if another
+        // GC driver (a manual `kache gc`, a second daemon) holds gc.lock, skip
+        // this run rather than double-scan and contend. Held until run_gc returns.
+        let _gc_lock = match self.with_store(|store| store.try_gc_lock())? {
+            Some(lock) => lock,
+            None => {
+                tracing::debug!("gc.lock held by another GC; skipping this run");
+                return Ok(crate::store::GcStats::default());
+            }
+        };
         let (dedup_stats, evict_stats, incremental_cleaned, orphan_stats) =
             self.with_store(|store| {
                 // Backfill content_hash for legacy entries

--- a/src/store.rs
+++ b/src/store.rs
@@ -528,10 +528,23 @@ impl Store {
 
     /// Acquire a build lock for a cache key. Returns None if another process holds it.
     pub fn try_lock(&self, cache_key: &str) -> Result<Option<KeyLock>> {
-        let lock_path = self.entry_dir(cache_key).with_extension("lock");
-        fs::create_dir_all(lock_path.parent().unwrap())?;
+        self.try_acquire_lock(self.entry_dir(cache_key).with_extension("lock"))
+    }
 
-        // Try to create the lock file exclusively
+    /// Acquire the cross-process GC lock so concurrent GC drivers — a manual
+    /// `kache gc`, the daemon's periodic sweep, `maybe_evict_after_upload`, or a
+    /// second daemon — don't double-scan and contend. Returns `None` if another
+    /// GC already holds it (the caller should skip). Stale-recovers a lock left
+    /// by a dead process, mirroring [`Self::try_lock`] (kunobi-ninja/kache#326).
+    pub fn try_gc_lock(&self) -> Result<Option<KeyLock>> {
+        self.try_acquire_lock(self.config.store_dir().join("gc.lock"))
+    }
+
+    /// Create `lock_path` exclusively (writing the holder PID for debugging),
+    /// stale-recovering a lock left by a dead process. `None` means another live
+    /// process holds it.
+    fn try_acquire_lock(&self, lock_path: PathBuf) -> Result<Option<KeyLock>> {
+        fs::create_dir_all(lock_path.parent().unwrap())?;
         match fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -539,7 +552,6 @@ impl Store {
         {
             Ok(mut f) => {
                 use std::io::Write;
-                // Write PID for debugging
                 let _ = write!(f, "{}", std::process::id());
                 Ok(Some(KeyLock { path: lock_path }))
             }
@@ -3666,6 +3678,27 @@ mod tests {
         assert_eq!(blob_refcount(&store, shared_hash), None);
         assert_eq!(blob_refcount(&store, unique2_hash), None);
         assert_eq!(blob_table_count(&store), 0);
+    }
+
+    #[test]
+    fn gc_lock_is_mutually_exclusive() {
+        // kunobi-ninja/kache#326: the cross-process GC lock admits one holder at
+        // a time and is re-acquirable after release.
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let first = store.try_gc_lock().unwrap();
+        assert!(first.is_some(), "first GC lock acquires");
+        assert!(
+            store.try_gc_lock().unwrap().is_none(),
+            "a second GC lock is refused while the first is held"
+        );
+        drop(first);
+        assert!(
+            store.try_gc_lock().unwrap().is_some(),
+            "the GC lock is re-acquirable after release"
+        );
     }
 
     #[test]


### PR DESCRIPTION
First, self-contained piece of #326: cross-process mutual exclusion for GC.

## The gap

Nothing serialized the GC drivers against each other over a shared store:

- a manual `kache gc` (its **local-fallback** path, when the daemon request fails),
- the daemon's periodic 6h sweep and `maybe_evict_after_upload`,
- a second daemon.

Two drivers running at once double-scan the store and contend on the SQLite write lock — wasteful, and a source of the "GC racing a build" worry.

## The fix

`Store::try_gc_lock()` — a single advisory `gc.lock` in the store dir, with the **same PID-based stale-recovery** as the per-key build lock (the lock body is refactored into a shared `try_acquire_lock`, so a lock left by a dead process is reclaimed). The daemon's `run_gc` and the CLI local-GC path acquire it up front and **skip** if another GC holds it. The guard is held for the GC's duration and released on drop.

## Tests

- `gc_lock_is_mutually_exclusive`: one holder at a time, re-acquirable after release.
- `cargo fmt`, `clippy --all-targets`, the `store` module (74) and the daemon `run_gc` tests are green.

## Scope / follow-ups

This is the contained piece of #326. The rest — a per-entry **version-guard** (async store mutations no-op if superseded), an **active-pin** (pin a blob while a live build references it), and a **lock heartbeat** (U21, detect a wedged-but-alive holder) — are deferred to follow-ups. Note the GC-vs-*restore* corruption the issue worries about is already largely mitigated by `sweep_orphan_blobs`' min-age grace (a just-written blob is too young to be reaped); this PR closes the GC-vs-GC double-scan/contention gap.
