### PR TITLE
ci: pin mise CLI to dodge v2026.6.10 Windows regression (+ bounded e2e retry)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,12 +315,27 @@ jobs:
         # results.json. Replaces the previous per-language bash scripts.
         run: |
           mkdir -p tmp/e2e
-          ./target/release/kache-scenario${{ matrix.exe_suffix }} \
+          # Bounded retry to absorb transient self-hosted-runner / Windows
+          # file-system flakes (e.g. a relocate-phase build hiccup). Each
+          # attempt is a full clean re-run, so cache assertions stay sound.
+          # A real failure fails all attempts; retries are logged as warnings
+          # so a genuinely-intermittent issue stays visible, not hidden.
+          n=0
+          until ./target/release/kache-scenario${{ matrix.exe_suffix }} \
             --kache ./target/release/kache${{ matrix.exe_suffix }} \
             --scenarios ./scenarios \
             --select suite:e2e \
             --select tier:gate \
             --out tmp/e2e/results.json
+          do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::e2e harness failed after $n attempts"
+              exit 1
+            fi
+            echo "::warning::e2e harness attempt $n failed; retrying (transient-flake mitigation)"
+            sleep 15
+          done
       - name: Run e2e negative-control (falsifiability check)
         # Reruns every fixture with kache disabled (KACHE_DISABLED=1)
         # and asserts each non-exempt result FLIPS to a failure — a
@@ -347,7 +362,19 @@ jobs:
         # Independent signal; `always()` so it runs even if the
         # harness step above failed.
         if: always() && hashFiles(format('target/release/kache{0}', matrix.exe_suffix)) != ''
-        run: ./scripts/sccache-fallback-check.sh ./target/release/kache${{ matrix.exe_suffix }}
+        run: |
+          # Bounded retry, same rationale as the harness step above.
+          n=0
+          until ./scripts/sccache-fallback-check.sh ./target/release/kache${{ matrix.exe_suffix }}
+          do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::sccache fallback check failed after $n attempts"
+              exit 1
+            fi
+            echo "::warning::sccache fallback check attempt $n failed; retrying (transient-flake mitigation)"
+            sleep 15
+          done
       - name: Show aggregated e2e results
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
       # cargo-llvm-cov.
       - uses: jdx/mise-action@v4
         with:
+          # Pin the mise CLI. v2026.6.10 (2026-06-14) regressed binary
+          # resolution ("mise ERROR cannot find binary path"), reddening every
+          # run after its release — including unchanged code that passed hours
+          # earlier. mise.toml already pins every *tool* for exactly this
+          # reason; the CLI was the one unpinned surface. Bump deliberately once
+          # upstream fixes it.
+          version: 2026.6.9
           cache: false
       - uses: docker/setup-buildx-action@v4
       - uses: kunobi-ninja/kache-action@v1
@@ -271,6 +278,8 @@ jobs:
           TEMP: ${{ env.MISE_DL_TMPDIR }}
           TMP: ${{ env.MISE_DL_TMPDIR }}
         with:
+          # Pin mise CLI — see the bootstrap job's note (v2026.6.10 regression).
+          version: 2026.6.9
           install_args: --force rust github:mozilla/sccache
           cache: false
           reshim: false
@@ -474,6 +483,8 @@ jobs:
           TEMP: ${{ env.MISE_DL_TMPDIR }}
           TMP: ${{ env.MISE_DL_TMPDIR }}
         with:
+          # Pin mise CLI — see the bootstrap job's note (v2026.6.10 regression).
+          version: 2026.6.9
           install_args: --force rust
           cache: false
           reshim: false


### PR DESCRIPTION
## Primary fix — pin the mise CLI to 2026.6.9

**mise v2026.6.10 (released 2026-06-14 23:41Z) regressed runtime binary resolution** on the self-hosted Windows runner: `mise ERROR cannot find binary path`. kache correctly passes `rustc -vV` through to the real compiler, but mise then fails to resolve the binary, so rustc exits 1 and cargo aborts the build (exit 101). It hits the `e2e-rust-sccache` fixture and the `KACHE_FALLBACK` check.

This is **not a kache code regression** — the failure correlates exactly with the mise release:

| Run | Time (UTC) | mise | Result |
|---|---|---|---|
| #342, #343, **#344 (PR)** | 06-14 14:06 → 20:46 | ≤2026.6.9 | **pass** |
| — mise v2026.6.10 released — | **06-14 23:41** | | |
| **#344 merge → main** (same code as its green PR) | 06-15 10:05 | 2026.6.10 | **fail** |
| #345 (PR) | 06-15 10:59 | 2026.6.10 | fail |

`mise.toml` already pins every *tool* ("a tool release can't break CI with no code change") — the mise *CLI* was the one unpinned surface. This pins all three `jdx/mise-action@v4` blocks to **2026.6.9** (the version the last green run used). Bump deliberately once upstream fixes it.

## Secondary — bounded e2e retry (transient-flake hygiene)

Wraps the e2e harness + sccache-fallback steps in a bounded 3-attempt retry. Each attempt is a full clean re-run (cache assertions stay sound); a real failure fails all attempts; retries log as `::warning::` so genuine intermittent regressions stay visible. This does **not** mask the mise issue (that was deterministic — it would fail all 3 attempts); it absorbs the unrelated transient runner flakes (e.g. macOS "lost communication").

Closes the current red-CI state; unblocks #345 (whose failure was this same mise regression, not its gc.lock change).