### PR TITLE
Fix GC lock contention follow-ups

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1083,16 +1083,19 @@ pub fn list(config: &Config, crate_name: Option<&str>, sort_by: &str) -> Result<
 /// Run garbage collection via the daemon.
 pub fn gc(config: &Config, max_age_hours: Option<u64>) -> Result<()> {
     match crate::daemon::send_gc_request(config, max_age_hours) {
-        Ok(evicted) => {
+        Ok(outcome) if outcome.skipped => {
+            println!("Another GC is already running; skipping.");
+        }
+        Ok(outcome) => {
             if let Some(hours) = max_age_hours {
                 println!(
                     "Evicted {} entries older than {hours}h.",
-                    evicted.unwrap_or(0)
+                    outcome.evicted.unwrap_or(0)
                 );
             } else {
                 println!(
                     "Evicted {} entries to stay under size limit.",
-                    evicted.unwrap_or(0)
+                    outcome.evicted.unwrap_or(0)
                 );
             }
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -517,6 +517,8 @@ pub(crate) struct Response {
     pub ok: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evicted: Option<usize>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub skipped: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub found: Option<bool>,
     /// True when the artifact was downloaded during manifest/shard prefetch.
@@ -532,11 +534,16 @@ pub(crate) struct Response {
     pub error: Option<String>,
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 impl Response {
     fn ok() -> Self {
         Self {
             ok: true,
             evicted: None,
+            skipped: false,
             found: None,
             prefetched: None,
             stats: None,
@@ -550,6 +557,21 @@ impl Response {
         Self {
             ok: true,
             evicted: Some(n),
+            skipped: false,
+            found: None,
+            prefetched: None,
+            stats: None,
+            batch_results: None,
+            hash_results: None,
+            error: None,
+        }
+    }
+
+    fn ok_gc_skipped() -> Self {
+        Self {
+            ok: true,
+            evicted: Some(0),
+            skipped: true,
             found: None,
             prefetched: None,
             stats: None,
@@ -563,6 +585,7 @@ impl Response {
         Self {
             ok: true,
             evicted: None,
+            skipped: false,
             found: None,
             prefetched: None,
             stats: Some(stats),
@@ -576,6 +599,7 @@ impl Response {
         Self {
             ok: true,
             evicted: None,
+            skipped: false,
             found: None,
             prefetched: None,
             stats: None,
@@ -589,6 +613,7 @@ impl Response {
         Self {
             ok: true,
             evicted: None,
+            skipped: false,
             found: None,
             prefetched: None,
             stats: None,
@@ -602,6 +627,7 @@ impl Response {
         Self {
             ok: true,
             evicted: None,
+            skipped: false,
             found: Some(val),
             prefetched: None,
             stats: None,
@@ -615,6 +641,7 @@ impl Response {
         Self {
             ok: true,
             evicted: None,
+            skipped: false,
             found: Some(val),
             prefetched: Some(prefetched),
             stats: None,
@@ -628,6 +655,7 @@ impl Response {
         Self {
             ok: false,
             evicted: None,
+            skipped: false,
             found: None,
             prefetched: None,
             stats: None,
@@ -1257,6 +1285,7 @@ impl Daemon {
     /// Handle a GC request — pure logic against the store.
     pub fn handle_gc(&self, req: &GcRequest) -> Response {
         match self.run_gc(req.max_age_hours) {
+            Ok(stats) if stats.skipped => Response::ok_gc_skipped(),
             Ok(stats) => Response::ok_evicted(stats.entries_evicted),
             Err(e) => Response::err(format!("gc failed: {e}")),
         }
@@ -2092,6 +2121,15 @@ impl Daemon {
     /// After a successful upload, check if store exceeds max_size → LRU eviction.
     fn maybe_evict_after_upload(&self) {
         let _ = self.with_store(|store| {
+            let _gc_lock = match store.try_gc_lock()? {
+                Some(lock) => lock,
+                None => {
+                    tracing::debug!(
+                        "gc.lock held by another GC; skipping upload-triggered eviction"
+                    );
+                    return Ok(());
+                }
+            };
             let size = store.total_size()?;
             if size > self.config.max_size {
                 tracing::info!(
@@ -2115,8 +2153,11 @@ impl Daemon {
         let _gc_lock = match self.with_store(|store| store.try_gc_lock())? {
             Some(lock) => lock,
             None => {
-                tracing::debug!("gc.lock held by another GC; skipping this run");
-                return Ok(crate::store::GcStats::default());
+                tracing::info!("gc.lock held by another GC; skipping this run");
+                return Ok(crate::store::GcStats {
+                    skipped: true,
+                    ..Default::default()
+                });
             }
         };
         let (dedup_stats, evict_stats, incremental_cleaned, orphan_stats) =
@@ -2182,6 +2223,7 @@ impl Daemon {
                 + evict_stats.blobs_removed
                 + orphan_stats.removed,
             duration_ms: start.elapsed().as_millis() as u64,
+            skipped: false,
         };
 
         tracing::info!(
@@ -3187,8 +3229,13 @@ pub fn send_upload_job(
     Ok(()) // Non-blocking: don't fail the build
 }
 
+pub struct GcRequestOutcome {
+    pub evicted: Option<usize>,
+    pub skipped: bool,
+}
+
 /// Send a GC request to the daemon. Auto-starts daemon if needed.
-pub fn send_gc_request(config: &Config, max_age_hours: Option<u64>) -> Result<Option<usize>> {
+pub fn send_gc_request(config: &Config, max_age_hours: Option<u64>) -> Result<GcRequestOutcome> {
     let socket_path = config.socket_path();
 
     let req = Request::Gc(GcRequest { max_age_hours });
@@ -3202,7 +3249,10 @@ pub fn send_gc_request(config: &Config, max_age_hours: Option<u64>) -> Result<Op
     match try_send(&socket_path) {
         Ok(resp) => {
             if resp.ok {
-                Ok(resp.evicted)
+                Ok(GcRequestOutcome {
+                    evicted: resp.evicted,
+                    skipped: resp.skipped,
+                })
             } else {
                 anyhow::bail!("daemon GC error: {}", resp.error.unwrap_or_default());
             }
@@ -3212,7 +3262,10 @@ pub fn send_gc_request(config: &Config, max_age_hours: Option<u64>) -> Result<Op
             if start_daemon_background()? {
                 let resp = try_send(&socket_path)?;
                 if resp.ok {
-                    Ok(resp.evicted)
+                    Ok(GcRequestOutcome {
+                        evicted: resp.evicted,
+                        skipped: resp.skipped,
+                    })
                 } else {
                     anyhow::bail!("daemon GC error: {}", resp.error.unwrap_or_default());
                 }
@@ -4578,6 +4631,13 @@ mod tests {
     }
 
     #[test]
+    fn test_response_gc_skipped_serde() {
+        let resp = Response::ok_gc_skipped();
+        let json = serde_json::to_string(&resp).unwrap();
+        assert_eq!(json, r#"{"ok":true,"evicted":0,"skipped":true}"#);
+    }
+
+    #[test]
     fn test_response_found_true_serde() {
         let resp = Response::found(true);
         let json = serde_json::to_string(&resp).unwrap();
@@ -4674,6 +4734,22 @@ mod tests {
     }
 
     #[test]
+    fn test_handle_gc_reports_lock_skip() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let _gc_lock = store.try_gc_lock().unwrap().expect("gc lock");
+        let daemon = Daemon::new(config);
+
+        let resp = daemon.handle_gc(&GcRequest {
+            max_age_hours: None,
+        });
+        assert!(resp.ok);
+        assert!(resp.skipped);
+        assert_eq!(resp.evicted, Some(0));
+    }
+
+    #[test]
     fn test_handle_gc_with_max_age() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_config(dir.path());
@@ -4721,6 +4797,46 @@ mod tests {
         assert!(
             stats.entries_evicted > 0,
             "should have evicted at least 1 entry"
+        );
+    }
+
+    #[test]
+    fn test_upload_triggered_eviction_respects_gc_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.max_size = 100;
+
+        let src_file = dir.path().join("big.rlib");
+        std::fs::write(&src_file, vec![0u8; 200]).unwrap();
+
+        let store = Store::open(&config).unwrap();
+        store
+            .put(
+                "upload_evict_key",
+                "testcrate",
+                &["lib".into()],
+                &[],
+                "host",
+                "dev",
+                &[(src_file, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        let gc_lock = store.try_gc_lock().unwrap().expect("gc lock");
+        let daemon = Daemon::new(config);
+        daemon.maybe_evict_after_upload();
+        assert!(
+            store.contains("upload_evict_key"),
+            "upload-triggered eviction must skip while gc.lock is held"
+        );
+
+        drop(gc_lock);
+        daemon.maybe_evict_after_upload();
+        assert!(
+            !store.contains("upload_evict_key"),
+            "eviction should run once gc.lock is available"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -190,6 +190,8 @@ pub struct GcStats {
     pub bytes_freed: u64,
     pub blobs_removed: usize,
     pub duration_ms: u64,
+    #[serde(default)]
+    pub skipped: bool,
 }
 
 /// Statistics returned by [`Store::sweep_orphan_blobs`].
@@ -214,9 +216,23 @@ pub struct KeyLock {
     path: PathBuf,
 }
 
+/// Lock guard for store-wide GC. Dropping it releases the OS lock.
+pub struct GcLock {
+    file: Option<fs::File>,
+}
+
 impl Drop for KeyLock {
     fn drop(&mut self) {
         let _ = fs::remove_file(&self.path);
+    }
+}
+
+impl Drop for GcLock {
+    fn drop(&mut self) {
+        if let Some(file) = self.file.take() {
+            let _ = file.unlock();
+            drop(file);
+        }
     }
 }
 
@@ -534,10 +550,9 @@ impl Store {
     /// Acquire the cross-process GC lock so concurrent GC drivers — a manual
     /// `kache gc`, the daemon's periodic sweep, `maybe_evict_after_upload`, or a
     /// second daemon — don't double-scan and contend. Returns `None` if another
-    /// GC already holds it (the caller should skip). Stale-recovers a lock left
-    /// by a dead process, mirroring [`Self::try_lock`] (kunobi-ninja/kache#326).
-    pub fn try_gc_lock(&self) -> Result<Option<KeyLock>> {
-        self.try_acquire_lock(self.config.store_dir().join("gc.lock"))
+    /// GC already holds it (the caller should skip).
+    pub fn try_gc_lock(&self) -> Result<Option<GcLock>> {
+        self.try_acquire_file_lock(self.config.store_dir().join("gc.lock"))
     }
 
     /// Create `lock_path` exclusively (writing the holder PID for debugging),
@@ -577,6 +592,30 @@ impl Store {
                 }
             }
             Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Acquire an exclusive OS lock on `lock_path` and write the holder PID for
+    /// debugging. The OS releases this lock if the process exits, so no PID
+    /// stale-recovery or age timeout is needed.
+    fn try_acquire_file_lock(&self, lock_path: PathBuf) -> Result<Option<GcLock>> {
+        fs::create_dir_all(lock_path.parent().unwrap())?;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+
+        match file.try_lock() {
+            Ok(()) => {
+                use std::io::{Seek, SeekFrom, Write};
+                file.set_len(0)?;
+                file.seek(SeekFrom::Start(0))?;
+                let _ = write!(file, "{}", std::process::id());
+                Ok(Some(GcLock { file: Some(file) }))
+            }
+            Err(std::fs::TryLockError::WouldBlock) => Ok(None),
+            Err(std::fs::TryLockError::Error(e)) => Err(e.into()),
         }
     }
 
@@ -3699,6 +3738,30 @@ mod tests {
             store.try_gc_lock().unwrap().is_some(),
             "the GC lock is re-acquirable after release"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn gc_lock_does_not_expire_live_holder_by_mtime() {
+        // A live holder must not be considered stale just because the marker
+        // file is old; large stores can make GC run for a long time.
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let first = store.try_gc_lock().unwrap().expect("first GC lock");
+        let lock_path = config.store_dir().join("gc.lock");
+        let old = filetime::FileTime::from_system_time(
+            std::time::SystemTime::now() - std::time::Duration::from_secs(2 * 3600),
+        );
+        filetime::set_file_mtime(&lock_path, old).unwrap();
+
+        assert!(
+            store.try_gc_lock().unwrap().is_none(),
+            "an old marker file must not let a second GC steal a live lock"
+        );
+        drop(first);
+        assert!(store.try_gc_lock().unwrap().is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Use an OS-backed `gc.lock` for store-wide garbage collection so a live long-running GC cannot be treated as stale by marker mtime.
- Make upload-triggered eviction respect the same GC lock.
- Report GC lock contention as a clean skipped outcome through daemon responses and CLI output.

## Why

The merged GC lock change still used stale-file recovery semantics. That is appropriate for per-key build locks, but store-wide GC may legitimately run longer than the stale timeout. A second GC could therefore steal the lock and run concurrently.

## Validation

- `cargo test`
- `cargo test gc_lock`
- `cargo test test_handle_gc`
- `cargo fmt --check`
- `git diff --check`
