### PR TITLE
fix(daemon): persist build-session marker through the locked handle (#348)

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1742,6 +1742,52 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    /// Regression for kache #348: the build-session marker must record a fresh
+    /// timestamp even though `maybe_trigger_prefetch` writes it *while still
+    /// holding the exclusive lock* on the same file.
+    ///
+    /// On Windows `File::try_lock` is a *mandatory* `LockFileEx` lock, so a
+    /// write through a *second* handle (`std::fs::write`) to the locked file
+    /// fails with a lock violation — the timestamp never lands, the marker
+    /// stays empty, and every subsequent rustc re-detects a "new build
+    /// session" and re-fires the prefetch hint (the 1147-crate spam in the
+    /// bug report). On Unix `flock(2)` is advisory and the second write
+    /// succeeds, which is why this only reproduces on Windows and was never
+    /// caught by the Linux/macOS `cargo test` jobs.
+    #[test]
+    fn build_session_marker_persists_while_lock_is_held() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(".build-session");
+
+        // Mirror maybe_trigger_prefetch exactly: open the marker, take the
+        // exclusive lock, then persist the freshness timestamp while the lock
+        // is still held.
+        let lock_file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&marker)
+            .unwrap();
+        assert!(
+            lock_file.try_lock().is_ok(),
+            "the first lock on a fresh marker must succeed"
+        );
+
+        write_marker_timestamp(&marker);
+
+        // Release the lock before reading back: on Windows a mandatory lock
+        // also blocks cross-handle reads, so `marker_is_fresh` (which opens
+        // its own handle) could only observe the write after we unlock.
+        let _ = std::fs::File::unlock(&lock_file);
+        drop(lock_file);
+
+        assert!(
+            marker_is_fresh(&marker, 300),
+            "marker must record a fresh timestamp even though the writer held \
+             the exclusive lock; otherwise every rustc re-fires the prefetch hint"
+        );
+    }
+
     /// `rewrite_depinfo_outputs` rewrites dep-info files in place and the
     /// relativize→expand round trip re-roots the cached blob's paths at
     /// the restoring build's target dir — the property that lets dep-info

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1691,8 +1691,10 @@ fn maybe_trigger_prefetch(config: &Config, args: &RustcArgs) {
 
     // Write current epoch AFTER the prefetch succeeds so a failed/hung attempt
     // (e.g. cargo metadata hangs on a git dep) doesn't block retries for the
-    // full session timeout.
-    write_marker_timestamp(&marker);
+    // full session timeout. Write through `lock_file` — the handle that owns
+    // the exclusive lock — so the timestamp lands even on Windows, where the
+    // lock is mandatory and a second handle could not write (kache #348).
+    write_marker_timestamp(&lock_file);
 }
 
 /// Check if the marker file contains a timestamp within `timeout_secs` of now.
@@ -1712,13 +1714,26 @@ fn marker_is_fresh(marker: &std::path::Path, timeout_secs: u64) -> bool {
     now.saturating_sub(stamp) < timeout_secs
 }
 
-/// Write the current Unix epoch to the marker file.
-fn write_marker_timestamp(marker: &std::path::Path) {
+/// Write the current Unix epoch to the marker file, reusing the caller's
+/// already-locked handle.
+///
+/// The caller holds an exclusive lock on this file (see `maybe_trigger_prefetch`).
+/// On Windows that lock is *mandatory* (`LockFileEx`), so writing through a
+/// *separate* handle (e.g. `std::fs::write`) to the locked file fails with a
+/// lock violation — the timestamp never lands and every rustc re-detects a new
+/// build session, re-firing the prefetch hint. Writing through the same handle
+/// that owns the lock is always permitted. (kache #348)
+fn write_marker_timestamp(mut file: &std::fs::File) {
+    use std::io::{Seek, SeekFrom, Write};
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    let _ = std::fs::write(marker, now.to_string());
+    // Truncate any previous (longer) timestamp and rewrite from the start.
+    let _ = file.set_len(0);
+    let _ = file.seek(SeekFrom::Start(0));
+    let _ = file.write_all(now.to_string().as_bytes());
+    let _ = file.flush();
 }
 
 /// Remove the incremental compilation directory for this crate.
@@ -1773,7 +1788,7 @@ mod tests {
             "the first lock on a fresh marker must succeed"
         );
 
-        write_marker_timestamp(&marker);
+        write_marker_timestamp(&lock_file);
 
         // Release the lock before reading back: on Windows a mandatory lock
         // also blocks cross-handle reads, so `marker_is_fresh` (which opens


### PR DESCRIPTION
## Problem (#348)

On Windows CI runners, users saw the daemon re-fire its prefetch hint on
nearly every rustc invocation — `build session detected, sending prefetch hint
for 1147 crates` repeating throughout the build — and very slow setup. The hint
is meant to fire **once per build session**.

## Root cause

`maybe_trigger_prefetch` opens the `.build-session` marker, takes an **exclusive
lock** on it, then writes the freshness timestamp through a **second handle**
(`std::fs::write`). On Unix `flock(2)` is advisory, so the second write
succeeds. On Windows `File::try_lock` is a **mandatory** `LockFileEx` lock, so
writing to the locked file from a different handle fails with a lock violation —
the error was swallowed (`let _ = ...`), the timestamp never landed, and every
subsequent rustc re-detected a "new build session" and re-sent the prefetch
hint. This also explains the slowness: each re-trigger re-ran `cargo metadata`
on the whole dependency graph and re-sent the full prefetch RPC.

## Fix

Write the timestamp through the **same handle that owns the lock** (seek + set_len
+ write) instead of opening a second handle.

## Test

Adds `build_session_marker_persists_while_lock_is_held`, which writes the marker
while holding the exclusive lock and asserts it reads back fresh. It passes on
Unix either way (advisory locks) and fails on the unfixed code on Windows
(mandatory locks) — the regression is genuinely Windows-only.

Verified on a physical Windows box: a standalone repro of the exact helper logic
reproduces `buggy → FAIL, fixed → PASS`, and the real test passes with the fix.

> Follow-up (separate PR): enable `cargo test --workspace` on the Windows CI
> runner so Windows-only regressions like this are caught automatically. Running
> it already surfaced ~11 pre-existing Windows test failures being addressed there.