### PR TITLE
ci: run cargo test --workspace + clippy on Windows; fix the Windows-only failures it surfaced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,22 +384,6 @@ jobs:
             echo "::warning::sccache fallback check attempt $n failed; retrying (transient-flake mitigation)"
             sleep 15
           done
-      # Run the workspace unit/integration tests on Windows. Linux covers them
-      # via `just ci` and macOS via the dedicated `Test (macOS)` job, but until
-      # now nothing ran `cargo test` on Windows — so a Windows-only regression
-      # could pass every gate. #348 was exactly that: the build-session marker
-      # was written through a second handle while the exclusive lock was held,
-      # which fails silently under Windows' *mandatory* file lock (it works on
-      # Unix's advisory flock), so every rustc re-fired the prefetch hint.
-      # Windows-only here so we don't duplicate the Linux/macOS coverage.
-      - name: cargo test (workspace, Windows)
-        if: runner.os == 'Windows'
-        run: |
-          rustc --version && cargo --version
-          cargo test --workspace
-        timeout-minutes: 30
-        env:
-          RUSTC_WRAPPER: ""
       - name: Show aggregated e2e results
         if: always()
         run: |
@@ -525,6 +509,95 @@ jobs:
         timeout-minutes: 30
         env:
           RUSTC_WRAPPER: ""
+      # Clippy otherwise runs only on Linux (`just ci` → `lint`), so lints
+      # inside `#[cfg(target_os = "macos")]` code went unchecked. Run it here too.
+      - name: cargo clippy (workspace)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+        timeout-minutes: 30
+        env:
+          RUSTC_WRAPPER: ""
+
+  # --- Windows test suite ---
+  # Mirrors `test-macos`: the Linux `check` job runs the full `just ci` and
+  # macOS has its own focused pass, but until now nothing ran `cargo test` (or
+  # clippy) on Windows — so Windows-only regressions slipped through every gate
+  # (e.g. #348: the build-session marker write failing under a mandatory file
+  # lock). Self-hosted Windows runner, same as the e2e job's Windows arm.
+  # Blocking: Windows is a first-class supported platform.
+  test-windows:
+    name: Test (Windows)
+    runs-on: ${{ fromJSON('["self-hosted", "Windows", "X64", "kunobi-windows"]') }}
+    timeout-minutes: 40
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+        timeout-minutes: 10
+      # Fail fast if the runner is missing a build tool the dep graph needs
+      # (ring → nasm, *-sys → cc). Mirrors the e2e job's check.
+      - name: Verify Windows build toolchain
+        run: |
+          missing=
+          for t in cc c++ make nasm; do
+            if ! command -v "$t" >/dev/null 2>&1; then
+              echo "MISSING on runner PATH: $t — provision it (see ans-runners/tasks/setup_windows.yml)"
+              missing=1
+            fi
+          done
+          [ -z "$missing" ] || exit 1
+          echo "all build/fixture tools present"
+      # Keep Rust + mise install/cache/state under the per-run temp dir so setup
+      # is isolated from this persistent runner's shared drift. See the e2e and
+      # test-macos jobs for the full rationale.
+      - name: Isolate tool state
+        run: |
+          mkdir -p \
+            "$RUNNER_TEMP/rustup" \
+            "$RUNNER_TEMP/cargo" \
+            "$RUNNER_TEMP/mise-data/bin" \
+            "$RUNNER_TEMP/mise-data/shims" \
+            "$RUNNER_TEMP/mise-cache" \
+            "$RUNNER_TEMP/mise-state"
+          rm -rf "$RUNNER_TEMP/mise"
+          safe_runner=$(printf '%s' "$RUNNER_NAME" | tr -c 'A-Za-z0-9_.-' '_')
+          rm -rf "$RUNNER_TEMP"/mise-dl-"$safe_runner"-* 2>/dev/null || true
+          mise_dl="$RUNNER_TEMP/mise-dl-$safe_runner-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          mkdir -p "$mise_dl"
+          echo "MISE_DL_TMPDIR=$mise_dl" >> "$GITHUB_ENV"
+          echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
+          echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
+          echo "MISE_DATA_DIR=$RUNNER_TEMP/mise-data" >> "$GITHUB_ENV"
+          echo "MISE_CACHE_DIR=$RUNNER_TEMP/mise-cache" >> "$GITHUB_ENV"
+          echo "MISE_STATE_DIR=$RUNNER_TEMP/mise-state" >> "$GITHUB_ENV"
+      - name: Install Rust via mise
+        uses: jdx/mise-action@v4
+        env:
+          TMPDIR: ${{ env.MISE_DL_TMPDIR }}
+          TEMP: ${{ env.MISE_DL_TMPDIR }}
+          TMP: ${{ env.MISE_DL_TMPDIR }}
+        with:
+          # Pin mise CLI — see the bootstrap job's note (v2026.6.10 regression).
+          version: 2026.6.9
+          install_args: --force rust
+          cache: false
+          reshim: false
+      # No "toolchain first on PATH" step: on Windows mise-action puts cargo on
+      # PATH directly and there is no competing system Rust to shadow it.
+      - name: cargo test (workspace)
+        run: |
+          rustc --version && cargo --version
+          cargo test --workspace
+        timeout-minutes: 30
+        env:
+          RUSTC_WRAPPER: ""
+      # Clippy otherwise runs only on Linux, leaving `#[cfg(windows)]` code
+      # unlinted. Run it here so platform-gated lints are caught on Windows too.
+      - name: cargo clippy (workspace)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+        timeout-minutes: 30
+        env:
+          RUSTC_WRAPPER: ""
 
   # --- Release (only on v* tags) ---
   release:
@@ -538,7 +611,7 @@ jobs:
     # the full validation suite — `version-consistency` rejects a tag that
     # disagrees with the manifest BEFORE any binary builds; `e2e` includes the
     # (blocking) Windows arm, so a tag won't release unless Windows e2e is green.
-    needs: [check, nix-package, e2e, test-macos, version-consistency]
+    needs: [check, nix-package, e2e, test-macos, test-windows, version-consistency]
     uses: zondax/_workflows/.github/workflows/_release-rust.yml@v10
     with:
       binary_name: kache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,22 @@ jobs:
             echo "::warning::sccache fallback check attempt $n failed; retrying (transient-flake mitigation)"
             sleep 15
           done
+      # Run the workspace unit/integration tests on Windows. Linux covers them
+      # via `just ci` and macOS via the dedicated `Test (macOS)` job, but until
+      # now nothing ran `cargo test` on Windows — so a Windows-only regression
+      # could pass every gate. #348 was exactly that: the build-session marker
+      # was written through a second handle while the exclusive lock was held,
+      # which fails silently under Windows' *mandatory* file lock (it works on
+      # Unix's advisory flock), so every rustc re-fired the prefetch hint.
+      # Windows-only here so we don't duplicate the Linux/macOS coverage.
+      - name: cargo test (workspace, Windows)
+        if: runner.os == 'Windows'
+        run: |
+          rustc --version && cargo --version
+          cargo test --workspace
+        timeout-minutes: 30
+        env:
+          RUSTC_WRAPPER: ""
       - name: Show aggregated e2e results
         if: always()
         run: |

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -79,7 +79,8 @@ jobs:
         run: |
           ./scripts/require-ci-green.sh "$(git rev-parse HEAD)" \
             "Check (Linux)" "Nix package" \
-            "E2E smoke (Linux)" "E2E smoke (macOS)" "E2E smoke (Windows)" "Test (macOS)"
+            "E2E smoke (Linux)" "E2E smoke (macOS)" "E2E smoke (Windows)" \
+            "Test (macOS)" "Test (Windows)"
 
       - name: Package kache-core
         run: cargo package -p kache-core --locked

--- a/crates/kache-e2e/src/bench_profile.rs
+++ b/crates/kache-e2e/src/bench_profile.rs
@@ -565,7 +565,9 @@ build = "b"
 setup = ["echo hi"]
 setup_marker = "{}"
 "#,
-                marker.display()
+                // Forward slashes: backslashes are escape sequences in TOML
+                // strings, so a raw Windows path would fail to parse.
+                marker.display().to_string().replace('\\', "/")
             ),
         );
         let p = BenchProfile::load(&path).unwrap();

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -447,7 +447,20 @@ fn remove_if_readonly(path: &Path) {
 mod tests {
     use super::*;
     use std::fs;
+    // Used only by the `#[cfg(unix)]` hardlink test below, which relies on
+    // Unix mode bits; the portable read-only tests use `make_readonly`.
+    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+
+    /// Mark a file read-only on any platform. Unix mode bits (`from_mode`)
+    /// aren't available on Windows, and `remove_if_readonly` keys off the
+    /// portable `permissions().readonly()` flag anyway — so this also lets
+    /// these tests exercise the Windows read-only branch of the cleaner.
+    fn make_readonly(path: &std::path::Path) {
+        let mut perms = fs::metadata(path).unwrap().permissions();
+        perms.set_readonly(true);
+        fs::set_permissions(path, perms).unwrap();
+    }
 
     #[test]
     fn test_pre_clean_removes_readonly_output() {
@@ -456,7 +469,7 @@ mod tests {
 
         // Simulate a kache hardlink: create a read-only file
         fs::write(&output, b"cached content").unwrap();
-        fs::set_permissions(&output, fs::Permissions::from_mode(0o444)).unwrap();
+        make_readonly(&output);
         assert!(fs::metadata(&output).unwrap().permissions().readonly());
 
         pre_clean_outputs(Some(&output), None, None, None);
@@ -473,7 +486,7 @@ mod tests {
 
         for path in [&rlib, &rmeta, &dep] {
             fs::write(path, b"cached").unwrap();
-            fs::set_permissions(path, fs::Permissions::from_mode(0o444)).unwrap();
+            make_readonly(path);
         }
 
         pre_clean_outputs(Some(&rlib), None, Some("foo"), Some("-abc123"));
@@ -506,7 +519,7 @@ mod tests {
 
         for path in [&rlib, &rmeta, &unrelated] {
             fs::write(path, b"cached").unwrap();
-            fs::set_permissions(path, fs::Permissions::from_mode(0o444)).unwrap();
+            make_readonly(path);
         }
 
         pre_clean_outputs(None, Some(dir.path()), Some("mycrate"), Some("-def456"));

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -5936,8 +5936,9 @@ mod tests {
             // Compare via `Path` so the separator the platform normalised the
             // build dir to (e.g. `\tmp\kache-relocated` on Windows) still
             // matches the `/`-form fixture.
-            maps.iter().any(|m| Path::new(&m.from) == Path::new("/tmp/kache-relocated")
-                && m.to == CC_ROOT_SENTINEL),
+            maps.iter()
+                .any(|m| Path::new(&m.from) == Path::new("/tmp/kache-relocated")
+                    && m.to == CC_ROOT_SENTINEL),
             "in-tree shallow relocations should use the same root sentinel, got {maps:?}"
         );
     }

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -5414,6 +5414,12 @@ mod tests {
         assert!(!cc_flags_need_resolved_invocation(&modeled_only));
     }
 
+    // Unix-only: uses `/usr/bin/true` as a stand-in "compiler" that accepts
+    // `--version` but emits no `-cc1` line. There is no equivalent always-present
+    // no-op binary on Windows (spawning `true` there fails outright), and the
+    // guard's logic itself is covered cross-platform by
+    // `probe_captured_flags_require_resolved_invocation`.
+    #[cfg(unix)]
     #[test]
     fn cache_key_refuses_probe_captured_flags_without_resolved_invocation() {
         // `/usr/bin/true` accepts `--version` but produces no `-###`
@@ -5927,8 +5933,11 @@ mod tests {
         let maps = cc_prefix_maps_for(&parsed, Path::new("/tmp/kache-relocated"));
 
         assert!(
-            maps.iter()
-                .any(|m| m.from == "/tmp/kache-relocated" && m.to == CC_ROOT_SENTINEL),
+            // Compare via `Path` so the separator the platform normalised the
+            // build dir to (e.g. `\tmp\kache-relocated` on Windows) still
+            // matches the `/`-form fixture.
+            maps.iter().any(|m| Path::new(&m.from) == Path::new("/tmp/kache-relocated")
+                && m.to == CC_ROOT_SENTINEL),
             "in-tree shallow relocations should use the same root sentinel, got {maps:?}"
         );
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4097,11 +4097,11 @@ fn wait_for_socket_until(
 
 // ── Tests ────────────────────────────────────────────────────────
 
-// Daemon tests exercise the Unix socket transport directly and are gated to
-// Unix targets. Windows uses a different IPC primitive (named pipes) that
-// will be migrated in a follow-up PR; until then the daemon's RPC paths are
-// no-ops on Windows.
-#[cfg(all(test, unix))]
+// Daemon tests run on every platform via the cross-platform `transport` layer
+// (Unix domain sockets on Unix, named pipes on Windows). The handful of tests
+// that exercise Unix-only semantics directly — socket *files* on disk, POSIX
+// process termination via `sh` — are individually `#[cfg(unix)]`-gated below.
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::mpsc;
@@ -4391,6 +4391,8 @@ mod tests {
         assert!(json.contains("\"key\":\"abc123\""));
     }
 
+    // Unix-only: binds a real socket *file* on disk via `UnixListener`.
+    #[cfg(unix)]
     #[test]
     fn test_wait_for_socket_until_observes_late_socket() {
         let dir = tempfile::tempdir().unwrap();
@@ -4419,6 +4421,8 @@ mod tests {
         assert!(!ready);
     }
 
+    // Unix-only: `UnixListener` socket file + `sh` child process.
+    #[cfg(unix)]
     #[test]
     fn test_wait_for_socket_until_ignores_clean_child_exit_if_socket_appears() {
         let dir = tempfile::tempdir().unwrap();
@@ -4443,6 +4447,8 @@ mod tests {
         assert!(ready);
     }
 
+    // Unix-only: spawns a stuck `sh` child to exercise POSIX child termination.
+    #[cfg(unix)]
     #[test]
     fn test_wait_for_socket_until_kills_stuck_child_after_timeout() {
         let dir = tempfile::tempdir().unwrap();
@@ -4494,6 +4500,8 @@ mod tests {
         assert!(read_daemon_state(&socket_path).is_none());
     }
 
+    // Unix-only: spawns a real `sh` PID and asserts POSIX termination.
+    #[cfg(unix)]
     #[test]
     fn test_recover_unhealthy_daemon_terminates_recent_recorded_pid() {
         let dir = tempfile::tempdir().unwrap();
@@ -4521,6 +4529,8 @@ mod tests {
         assert!(read_daemon_state(&socket_path).is_none());
     }
 
+    // Unix-only: spawns a real `sh` PID and asserts POSIX termination.
+    #[cfg(unix)]
     #[test]
     fn test_recover_unhealthy_daemon_terminates_stale_recorded_pid() {
         let dir = tempfile::tempdir().unwrap();
@@ -4549,6 +4559,8 @@ mod tests {
         assert!(read_daemon_state(&socket_path).is_none());
     }
 
+    // Unix-only: spawns a real `sh` PID to verify it is NOT killed.
+    #[cfg(unix)]
     #[test]
     fn test_recover_unhealthy_daemon_does_not_kill_pid_without_run_lock() {
         let dir = tempfile::tempdir().unwrap();
@@ -5041,6 +5053,8 @@ mod tests {
         );
     }
 
+    // Unix-only: a stale socket *file* + `UnixStream::connect` semantics.
+    #[cfg(unix)]
     #[test]
     fn test_stale_socket_cleanup() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4127,6 +4127,59 @@ mod tests {
         TokioStream::connect(name).await.expect("connect")
     }
 
+    /// Bind a *synchronous* listener at `path` so `transport::is_reachable`
+    /// reports the endpoint as live. Cross-platform (UDS file on Unix, named
+    /// pipe on Windows) and, unlike the tokio listener, needs no async runtime
+    /// — so it can be created inside a plain `std::thread`.
+    fn bind_sync_listener(path: &Path) -> interprocess::local_socket::Listener {
+        let name = socket_name(path).expect("socket name");
+        ListenerOptions::new()
+            .name(name)
+            .create_sync()
+            .expect("create_sync listener")
+    }
+
+    /// Spawn a child that exits immediately with success — a stand-in for a
+    /// daemon-starter process that returns before the socket is ready.
+    fn spawn_quick_exit_child() -> std::process::Child {
+        #[cfg(unix)]
+        {
+            std::process::Command::new("sh")
+                .args(["-c", "exit 0"])
+                .spawn()
+                .unwrap()
+        }
+        #[cfg(windows)]
+        {
+            std::process::Command::new("cmd")
+                .args(["/c", "exit", "0"])
+                .spawn()
+                .unwrap()
+        }
+    }
+
+    /// Spawn a child that blocks long enough (~30s) to be killed by the code
+    /// under test. `sleep` on Unix; on Windows a 30-ping loop, since `timeout`
+    /// needs a console and fails under captured stdio.
+    fn spawn_blocking_child() -> std::process::Child {
+        #[cfg(unix)]
+        {
+            std::process::Command::new("sh")
+                .args(["-c", "sleep 30"])
+                .spawn()
+                .unwrap()
+        }
+        #[cfg(windows)]
+        {
+            std::process::Command::new("cmd")
+                .args(["/c", "ping", "-n", "31", "127.0.0.1"])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .unwrap()
+        }
+    }
+
     /// Run one client request→response roundtrip against a daemon socket and
     /// return the parsed response.
     ///
@@ -4391,8 +4444,6 @@ mod tests {
         assert!(json.contains("\"key\":\"abc123\""));
     }
 
-    // Unix-only: binds a real socket *file* on disk via `UnixListener`.
-    #[cfg(unix)]
     #[test]
     fn test_wait_for_socket_until_observes_late_socket() {
         let dir = tempfile::tempdir().unwrap();
@@ -4401,8 +4452,9 @@ mod tests {
 
         let handle = std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(150));
-            let _listener = std::os::unix::net::UnixListener::bind(socket_path_bg).unwrap();
+            let listener = bind_sync_listener(&socket_path_bg);
             std::thread::sleep(Duration::from_millis(200));
+            drop(listener);
         });
 
         let ready = wait_for_socket_until(&socket_path, None, Duration::from_secs(1)).unwrap();
@@ -4421,8 +4473,6 @@ mod tests {
         assert!(!ready);
     }
 
-    // Unix-only: `UnixListener` socket file + `sh` child process.
-    #[cfg(unix)]
     #[test]
     fn test_wait_for_socket_until_ignores_clean_child_exit_if_socket_appears() {
         let dir = tempfile::tempdir().unwrap();
@@ -4431,14 +4481,12 @@ mod tests {
 
         let handle = std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(150));
-            let _listener = std::os::unix::net::UnixListener::bind(socket_path_bg).unwrap();
+            let listener = bind_sync_listener(&socket_path_bg);
             std::thread::sleep(Duration::from_millis(200));
+            drop(listener);
         });
 
-        let mut child = std::process::Command::new("sh")
-            .args(["-c", "exit 0"])
-            .spawn()
-            .unwrap();
+        let mut child = spawn_quick_exit_child();
 
         let ready =
             wait_for_socket_until(&socket_path, Some(&mut child), Duration::from_secs(1)).unwrap();
@@ -4447,16 +4495,11 @@ mod tests {
         assert!(ready);
     }
 
-    // Unix-only: spawns a stuck `sh` child to exercise POSIX child termination.
-    #[cfg(unix)]
     #[test]
     fn test_wait_for_socket_until_kills_stuck_child_after_timeout() {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.path().join("missing.sock");
-        let mut child = std::process::Command::new("sh")
-            .args(["-c", "sleep 30"])
-            .spawn()
-            .unwrap();
+        let mut child = spawn_blocking_child();
 
         let ready =
             wait_for_socket_until(&socket_path, Some(&mut child), Duration::from_millis(150))
@@ -4500,8 +4543,6 @@ mod tests {
         assert!(read_daemon_state(&socket_path).is_none());
     }
 
-    // Unix-only: spawns a real `sh` PID and asserts POSIX termination.
-    #[cfg(unix)]
     #[test]
     fn test_recover_unhealthy_daemon_terminates_recent_recorded_pid() {
         let dir = tempfile::tempdir().unwrap();
@@ -4509,10 +4550,7 @@ mod tests {
         std::fs::write(&socket_path, b"stale").unwrap();
         let run_lock_handle = hold_run_lock_for_test(&socket_path, Duration::from_millis(150));
 
-        let mut child = std::process::Command::new("sh")
-            .args(["-c", "sleep 30"])
-            .spawn()
-            .unwrap();
+        let mut child = spawn_blocking_child();
 
         let state = DaemonCoordState {
             pid: child.id(),
@@ -4529,8 +4567,6 @@ mod tests {
         assert!(read_daemon_state(&socket_path).is_none());
     }
 
-    // Unix-only: spawns a real `sh` PID and asserts POSIX termination.
-    #[cfg(unix)]
     #[test]
     fn test_recover_unhealthy_daemon_terminates_stale_recorded_pid() {
         let dir = tempfile::tempdir().unwrap();
@@ -4538,10 +4574,7 @@ mod tests {
         std::fs::write(&socket_path, b"stale").unwrap();
         let run_lock_handle = hold_run_lock_for_test(&socket_path, Duration::from_millis(150));
 
-        let mut child = std::process::Command::new("sh")
-            .args(["-c", "sleep 30"])
-            .spawn()
-            .unwrap();
+        let mut child = spawn_blocking_child();
 
         let state = DaemonCoordState {
             pid: child.id(),
@@ -4559,18 +4592,13 @@ mod tests {
         assert!(read_daemon_state(&socket_path).is_none());
     }
 
-    // Unix-only: spawns a real `sh` PID to verify it is NOT killed.
-    #[cfg(unix)]
     #[test]
     fn test_recover_unhealthy_daemon_does_not_kill_pid_without_run_lock() {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.path().join("daemon.sock");
         std::fs::write(&socket_path, b"stale").unwrap();
 
-        let mut child = std::process::Command::new("sh")
-            .args(["-c", "sleep 30"])
-            .spawn()
-            .unwrap();
+        let mut child = spawn_blocking_child();
 
         let state = DaemonCoordState {
             pid: child.id(),
@@ -5053,7 +5081,11 @@ mod tests {
         );
     }
 
-    // Unix-only: a stale socket *file* + `UnixStream::connect` semantics.
+    // Unix-only by nature: it asserts that a leftover regular *file* at the
+    // socket path is not a connectable socket and can be removed. Windows uses
+    // named pipes, which leave no on-disk artifact at the path, so there is no
+    // equivalent stale-file scenario to test. (Stale daemon *state* cleanup is
+    // covered cross-platform by test_recover_unhealthy_daemon_cleans_*.)
     #[cfg(unix)]
     #[test]
     fn test_stale_socket_cleanup() {

--- a/src/extra_inputs.rs
+++ b/src/extra_inputs.rs
@@ -456,7 +456,10 @@ fn walks_filesystem_root(glob_pattern: &str) -> bool {
     // drive), but "/" is still the current-drive root there and walks a huge
     // tree — treat a leading RootDir as rooted on every platform.
     let rooted = base.is_absolute()
-        || matches!(base.components().next(), Some(std::path::Component::RootDir));
+        || matches!(
+            base.components().next(),
+            Some(std::path::Component::RootDir)
+        );
     rooted && base.parent().is_none()
 }
 

--- a/src/extra_inputs.rs
+++ b/src/extra_inputs.rs
@@ -452,7 +452,12 @@ fn walks_filesystem_root(glob_pattern: &str) -> bool {
         return false;
     };
     let base = Path::new(&glob_pattern[..=slash]);
-    base.is_absolute() && base.parent().is_none()
+    // `Path::is_absolute()` is false for a bare "/" on Windows (it expects a
+    // drive), but "/" is still the current-drive root there and walks a huge
+    // tree — treat a leading RootDir as rooted on every platform.
+    let rooted = base.is_absolute()
+        || matches!(base.components().next(), Some(std::path::Component::RootDir));
+    rooted && base.parent().is_none()
 }
 
 /// Deterministic opaque digest for an unreadable / unparseable `kache.toml`:
@@ -580,7 +585,13 @@ mod tests {
         let ext_file = ext.path().join("shared.json");
         std::fs::write(&ext_file, "v1").unwrap();
 
-        let toml = format!("extra_inputs = [\"{}\"]", ext_file.display());
+        // Forward slashes: backslashes are escape sequences in TOML strings (a
+        // raw Windows path would be mis-parsed), and Windows path resolution
+        // accepts `/` just fine.
+        let toml = format!(
+            "extra_inputs = [\"{}\"]",
+            ext_file.display().to_string().replace('\\', "/")
+        );
         let (_d, src) = crate_fixture(&[("kache.toml", toml.as_str())]);
         let before = dig(&src).expect("absolute external input folds");
         std::fs::write(&ext_file, "v2").unwrap();

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -981,7 +981,10 @@ mod tests {
 
         let mut rules = Vec::new();
         push_rule_with_variants(&mut rules, Some(canonical), "<BASE_DIR>");
-        let n = PathNormalizer { rules };
+        let n = PathNormalizer {
+            rules,
+            path_only_env_vars: Vec::new(),
+        };
 
         let input = format!("{short}\\src\\main.rs");
         let out = n.normalize(&input);

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -257,14 +257,14 @@ impl PathNormalizer {
         );
 
         // De-dupe: if (e.g.) CARGO_HOME == workspace_root, the second
-        // entry would never fire. Also keep order stable so the
-        // first-listed sentinel wins for identical prefixes. Variants
-        // pushed by `push_rule_with_variants` are already adjacent
-        // per-base prefix, so a stable dedup catches duplicates
-        // introduced when (e.g.) `~/.cargo` happens to canonicalize
-        // identically to one of its forward-slash variants on a
-        // unix host (no-op then).
-        rules.dedup_by(|a, b| a.prefix == b.prefix);
+        // entry would never fire. Keep order stable so the first-listed
+        // sentinel wins for identical prefixes. Use a *global* keep-first
+        // dedup rather than `dedup_by` (adjacent-only): two sources that
+        // share a canonical form expand to interleaved variant blocks
+        // (e.g. on Windows `[canon_a, \a]` then `[canon_b, \b]`), so the
+        // duplicate prefixes are not adjacent and `dedup_by` would miss them.
+        let mut seen = std::collections::HashSet::new();
+        rules.retain(|r| seen.insert(r.prefix.clone()));
 
         Self {
             rules,
@@ -1105,17 +1105,24 @@ mod tests {
         let mut rules = Vec::new();
         push_rule_with_variants(&mut rules, Some("/same/path".to_string()), "<FIRST>");
         push_rule_with_variants(&mut rules, Some("/same/path".to_string()), "<SECOND>");
-        rules.dedup_by(|a, b| a.prefix == b.prefix);
-        // Order preserved — first occurrence wins. Note this exercises
-        // the same dedup the real `from_env` does.
+        // Mirror the real `from_env` global keep-first dedup.
+        let mut seen = std::collections::HashSet::new();
+        rules.retain(|r| seen.insert(r.prefix.clone()));
         let names: Vec<_> = rules_for(&PathNormalizer {
             rules,
             path_only_env_vars: Vec::new(),
         })
         .into_iter()
         .collect();
-        assert_eq!(names.len(), 1);
-        assert_eq!(names[0].1, "<FIRST>");
+        // The SECOND source's prefixes all duplicate the FIRST's, so every
+        // surviving rule comes from FIRST. (Unix: one rule for `/same/path`;
+        // Windows: that plus the backslash variant — all `<FIRST>`.)
+        assert!(!names.is_empty());
+        assert!(names.iter().all(|(_, sentinel)| *sentinel == "<FIRST>"));
+        assert!(names.iter().any(|(prefix, _)| prefix == "/same/path"));
+        // No prefix survives more than once.
+        let unique: std::collections::HashSet<_> = names.iter().map(|(p, _)| p).collect();
+        assert_eq!(unique.len(), names.len());
     }
 
     #[test]

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -554,6 +554,18 @@ fn push_slash_and_case_variants(rules: &mut Vec<Rule>, prefix: &str, sentinel: &
         });
     }
 
+    // Backslash variant — when the canonical arrives in forward-slash form
+    // (e.g. a `CARGO_HOME` set with `/`), rustc/cargo still emit `\` paths, so
+    // the backslash form must be in the rule set too. The `replace('\\', "/")`
+    // above only covers the opposite direction.
+    let bs = prefix.replace('/', "\\");
+    if bs != prefix {
+        rules.push(Rule {
+            prefix: bs.clone(),
+            sentinel,
+        });
+    }
+
     // Lower-case drive variant.
     let lc = lowercase_drive_letter(prefix);
     if let Some(ref lc_str) = lc
@@ -572,6 +584,17 @@ fn push_slash_and_case_variants(rules: &mut Vec<Rule>, prefix: &str, sentinel: &
     {
         rules.push(Rule {
             prefix: fs_lc,
+            sentinel,
+        });
+    }
+
+    // Both: backslash + lower-case drive.
+    if let Some(bs_lc) = lowercase_drive_letter(&bs)
+        && bs_lc != bs
+        && Some(&bs_lc) != lc.as_ref()
+    {
+        rules.push(Rule {
+            prefix: bs_lc,
             sentinel,
         });
     }
@@ -706,7 +729,12 @@ mod tests {
     fn home_rule_normalizes_paths_inside_home() {
         let n = PathNormalizer::from_env(None);
         if let Some(home) = dirs::home_dir().and_then(|p| p.canonicalize().ok()) {
-            let input = format!("{}/some/thing", home.display());
+            // Windows `canonicalize()` yields a `\\?\C:\…` verbatim path; real
+            // cargo/rustc paths don't carry that prefix, so strip it before
+            // building the test input (no-op on Unix).
+            let home = home.display().to_string();
+            let home = home.strip_prefix(r"\\?\").unwrap_or(&home);
+            let input = format!("{home}/some/thing");
             // Either <HOME> or <CARGO_HOME> may match (cargo home is
             // inside home by default). Either is a valid normalization.
             let out = n.normalize(&input);

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -410,6 +410,22 @@ impl<W: std::io::Write> std::io::Write for HashingWriter<W> {
     }
 }
 
+/// True if `path` is absolute or filesystem-rooted on *either* platform.
+///
+/// `Path::is_absolute()` is host-specific: on Windows it is false for a
+/// Unix-style `/etc/passwd` (no drive letter), so a tar produced on Unix could
+/// otherwise smuggle a rooted entry past the guard when extracted on Windows
+/// (and vice-versa for a `C:\...` entry on Unix). Reject any entry whose first
+/// component is a root or a drive/UNC prefix, regardless of host.
+fn is_rooted_path(path: &Path) -> bool {
+    use std::path::Component;
+    path.is_absolute()
+        || matches!(
+            path.components().next(),
+            Some(Component::RootDir | Component::Prefix(_))
+        )
+}
+
 fn extract_entry_pack<R: std::io::Read>(reader: R, dest_dir: &Path) -> Result<u64> {
     let parent = dest_dir.parent().unwrap_or(Path::new("/tmp"));
     std::fs::create_dir_all(parent)?;
@@ -436,7 +452,7 @@ fn extract_entry_pack<R: std::io::Read>(reader: R, dest_dir: &Path) -> Result<u6
         }
         let path = entry.path()?.to_path_buf();
 
-        if path.is_absolute() {
+        if is_rooted_path(&path) {
             bail!("tar entry contains absolute path: {}", path.display());
         }
         if path
@@ -495,7 +511,7 @@ fn extract_entry_pack<R: std::io::Read>(reader: R, dest_dir: &Path) -> Result<u6
             );
         }
         let name = Path::new(&cached_file.name);
-        if name.is_absolute()
+        if is_rooted_path(name)
             || name
                 .components()
                 .any(|c| c == std::path::Component::ParentDir)

--- a/src/store.rs
+++ b/src/store.rs
@@ -2904,7 +2904,11 @@ mod tests {
         let path = store.blob_path(hash);
         // Normalise separators: the path is built with `PathBuf::join`, so the
         // shard dirs are `blobs\ab\…` on Windows.
-        assert!(path.to_string_lossy().replace('\\', "/").contains("blobs/ab/"));
+        assert!(
+            path.to_string_lossy()
+                .replace('\\', "/")
+                .contains("blobs/ab/")
+        );
         assert!(path.to_string_lossy().ends_with(hash));
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -112,7 +112,20 @@ fn materialize_blob(source: &Path, blob: &Path, hash: &str) -> Result<()> {
         let _ = fs::remove_file(&tmp);
         return Err(e).context("flushing blob to disk");
     }
-    fs::rename(&tmp, blob).context("atomic rename of blob")?;
+    if let Err(e) = fs::rename(&tmp, blob) {
+        // A concurrent writer may have materialized the same content-addressed
+        // blob first and marked it read-only. On Windows, renaming onto a
+        // read-only file fails with ACCESS_DENIED (os error 5); on Unix the
+        // rename succeeds. Since the blob is content-addressed the winner wrote
+        // byte-identical content, so a lost race is benign: drop our temp and
+        // succeed if the destination now exists. Only a genuine failure (no
+        // blob present afterwards) is a real error.
+        let _ = fs::remove_file(&tmp);
+        if blob.is_file() {
+            return Ok(());
+        }
+        return Err(e).context("atomic rename of blob");
+    }
     set_blob_readonly(blob);
     // Flush the shard directory so the rename is durable across a power loss;
     // best-effort, since the blob bytes are already fsynced and a missing dir
@@ -2889,7 +2902,9 @@ mod tests {
 
         let hash = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
         let path = store.blob_path(hash);
-        assert!(path.to_string_lossy().contains("blobs/ab/"));
+        // Normalise separators: the path is built with `PathBuf::join`, so the
+        // shard dirs are `blobs\ab\…` on Windows.
+        assert!(path.to_string_lossy().replace('\\', "/").contains("blobs/ab/"));
         assert!(path.to_string_lossy().ends_with(hash));
     }
 

--- a/src/wrapper_config.rs
+++ b/src/wrapper_config.rs
@@ -177,9 +177,14 @@ mod tests {
         )
         .unwrap();
 
+        // current_dir = None: on Windows the temp dir lives *under*
+        // %USERPROFILE%, so an ancestor walk would discover the developer's
+        // real ~/.cargo/config.toml and shadow the injected cargo_home. This
+        // test only exercises the cargo_home fallback; ancestor-walk precedence
+        // is covered by nearest_project_cargo_config_overrides_home_config.
         let setting = resolve_wrapper_setting_from(
             None,
-            Some(dir.path()),
+            None,
             Some(cargo_home.clone()),
             Some(dir.path().to_path_buf()),
         )
@@ -241,6 +246,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(setting.0, "kache");
-        assert!(display_path(&config_path).ends_with(".cargo/config.toml"));
+        assert!(
+            display_path(&config_path)
+                .replace('\\', "/")
+                .ends_with(".cargo/config.toml")
+        );
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -454,6 +454,11 @@ edition = "2024"
 
 [lib]
 path = "src/lib.rs"
+
+# Standalone workspace root so cargo never walks up into an ancestor workspace
+# (e.g. when the system temp dir lives under one — common on Windows, where
+# %TEMP% is under the user profile).
+[workspace]
 "#,
     )
     .unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -360,9 +360,12 @@ fn test_wrapper_hello_world() {
 
     assert!(status.success(), "first build with kache should succeed");
 
-    // Verify the binary was produced
+    // Verify the binary was produced (`.exe` on Windows).
     assert!(
-        target_dir.path().join("debug/hello-world").exists(),
+        target_dir
+            .path()
+            .join(format!("debug/hello-world{}", std::env::consts::EXE_SUFFIX))
+            .exists(),
         "binary should be produced"
     );
 
@@ -474,22 +477,28 @@ pub fn value() -> u8 {
     std::fs::remove_dir_all(target_dir.path()).unwrap();
     run_cargo_build_with_kache(project.path(), cache_dir.path(), target_dir.path());
 
-    let (depinfo_path, depinfo) = find_depinfo_containing(target_dir.path(), "src/../README.md")
+    // rustc writes dep-info source paths with the OS-native separator:
+    // "src/../README.md" on Unix, "src\..\README.md" on Windows.
+    let sep = std::path::MAIN_SEPARATOR;
+    let parent_rel = format!("src{sep}..{sep}README.md");
+    let (depinfo_path, depinfo) = find_depinfo_containing(target_dir.path(), &parent_rel)
         .expect("restored target dir should contain rustc's parent-relative README.md dep-info");
     assert!(
-        depinfo.contains("src/../README.md"),
+        depinfo.contains(&parent_rel),
         "restored dep-info should preserve rustc's parent-relative include_str path in {}:\n{}",
         depinfo_path.display(),
         depinfo
     );
     assert!(
-        !depinfo.contains("src/./"),
+        !depinfo.contains(&format!("src{sep}.{sep}")),
         "restore must not inject the target dir into a parent-relative source path in {}:\n{}",
         depinfo_path.display(),
         depinfo
     );
     assert!(
-        !depinfo.contains("__kache_root__/"),
+        // Match either separator so a leaked sentinel can't slip through on
+        // Windows (`__kache_root__\`).
+        !depinfo.contains("__kache_root__"),
         "restored-facing dep-info must not expose kache sentinels in {}:\n{}",
         depinfo_path.display(),
         depinfo

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -482,10 +482,11 @@ pub fn value() -> u8 {
     std::fs::remove_dir_all(target_dir.path()).unwrap();
     run_cargo_build_with_kache(project.path(), cache_dir.path(), target_dir.path());
 
-    // rustc writes dep-info source paths with the OS-native separator:
-    // "src/../README.md" on Unix, "src\..\README.md" on Windows.
+    // rustc joins the package-relative dir with the OS separator but keeps the
+    // `include_str!` literal's own slashes verbatim, so the recorded path is
+    // "src/../README.md" on Unix and "src\../README.md" on Windows.
     let sep = std::path::MAIN_SEPARATOR;
-    let parent_rel = format!("src{sep}..{sep}README.md");
+    let parent_rel = format!("src{sep}../README.md");
     let (depinfo_path, depinfo) = find_depinfo_containing(target_dir.path(), &parent_rel)
         .expect("restored target dir should contain rustc's parent-relative README.md dep-info");
     assert!(
@@ -495,7 +496,7 @@ pub fn value() -> u8 {
         depinfo
     );
     assert!(
-        !depinfo.contains(&format!("src{sep}.{sep}")),
+        !depinfo.contains(&format!("src{sep}./")),
         "restore must not inject the target dir into a parent-relative source path in {}:\n{}",
         depinfo_path.display(),
         depinfo


### PR DESCRIPTION
Follow-up to #350 (the #348 build-session marker fix). #348 slipped through CI
because **the unit-test suite never ran on Windows** — the Windows CI only built
kache and ran the e2e cache scenarios. This PR closes that gap and fixes
everything enabling it surfaced.

## CI

- New **Test (Windows)** job (mirrors **Test (macOS)**): `cargo test --workspace`
  on the self-hosted Windows runner. Now a required check and a publish gate.
- **clippy on macOS and Windows.** Clippy previously ran only on Linux (`just ci`
  → `lint`), so lints inside `#[cfg(windows)]` / `#[cfg(target_os="macos")]` code
  were never checked. Added a clippy step to both Test jobs.

## Real cross-platform bugs found (production code)

- **store::materialize_blob** — the atomic rename failed with `ACCESS_DENIED`
  when a concurrent writer had already materialized the same content-addressed
  blob and marked it read-only (Windows denies renaming onto a read-only file;
  Unix allows it). Any build compiling shared deps concurrently could fail a
  cache `put`. A lost race is benign (identical bytes): drop the temp and
  succeed if the blob now exists.
- **remote_layout** — the tar path-traversal guard used `Path::is_absolute()`,
  which is `false` for a Unix-style `/etc/passwd` on Windows. Now rejects any
  RootDir/Prefix component on either platform.
- **path_normalizer** — `push_slash_and_case_variants` only generated
  forward-slash variants, so a forward-slash canonical never got its backslash
  form; and the rule dedup was adjacent-only (`dedup_by`), which missed
  interleaved duplicates from colliding sources. Added the backslash variants
  and switched to a global keep-first dedup.
- **extra_inputs::walks_filesystem_root** — missed a bare `/` on Windows (not
  `is_absolute` there); treat a leading RootDir as rooted on every platform.

## Test enablement / corrections

- **daemon test module** was `#[cfg(all(test, unix))]` ("migrate to named pipes
  in a follow-up"). The transport is already cross-platform, so it's enabled on
  Windows; the socket-readiness and pid-termination tests were rewritten to use
  the cross-platform transport + portable child helpers (one test, all
  platforms) instead of being Unix-gated. Only `test_stale_socket_cleanup` stays
  `#[cfg(unix)]` (on-disk socket-file semantics with no named-pipe analog).
- Stale Windows-only test rot that never compiled (compile.rs, path_normalizer,
  daemon `handle_request_sync`).
- Path-separator / TOML-escaping / temp-isolation assumptions in unit tests
  (store, wrapper_config, cc, path_normalizer, extra_inputs).

## Validation

Run on a physical Windows x64 box:
- `cargo test --workspace` bin suite: **736 passed, 0 failed**.
- `cargo clippy --workspace --all-targets -- -D warnings`: **clean**.
- The `tests/integration_test.rs` cc-driven tests need a provisioned C compiler
  (`cc`), which that box lacks — they get their first Windows run on the
  **Test (Windows)** CI job here (they already pass on Linux/macOS).