### PR TITLE
fix(extra_inputs): warn on unset env var in a pattern

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -760,15 +760,25 @@ fn shellexpand(s: &str) -> PathBuf {
     PathBuf::from(s)
 }
 
-fn expand_env_vars(s: &str) -> String {
-    expand_env_vars_with(s, |key| std::env::var(key).ok())
-}
-
-fn expand_env_vars_with<F>(s: &str, lookup: F) -> String
+/// Core `$VAR` / `${VAR}` expander. Returns the expanded string plus the names
+/// of every referenced env var that was *unset* (no value and no
+/// [`default_env_var_value`]) and so was left as a literal `$VAR` in the output.
+///
+/// An unset reference matters to cache-key callers: it silently survives as
+/// text that matches nothing, so they fold a replayable pattern-set-only key
+/// while believing the intended files are tracked. Reporting the unset names
+/// lets those callers warn instead of degrading silently.
+fn expand_env_vars_collecting<F>(s: &str, lookup: F) -> (String, Vec<String>)
 where
     F: Fn(&str) -> Option<String>,
 {
     let mut out = String::with_capacity(s.len());
+    let mut unset: Vec<String> = Vec::new();
+    let mut note_unset = |key: &str| {
+        if !unset.iter().any(|k| k == key) {
+            unset.push(key.to_string());
+        }
+    };
     let mut chars = s.chars().peekable();
     while let Some(ch) = chars.next() {
         if ch != '$' {
@@ -788,6 +798,7 @@ where
             if let Some(value) = lookup(&key).or_else(|| default_env_var_value(&key)) {
                 out.push_str(&value);
             } else {
+                note_unset(&key);
                 out.push_str("${");
                 out.push_str(&key);
                 out.push('}');
@@ -809,11 +820,12 @@ where
         } else if let Some(value) = lookup(&key).or_else(|| default_env_var_value(&key)) {
             out.push_str(&value);
         } else {
+            note_unset(&key);
             out.push('$');
             out.push_str(&key);
         }
     }
-    out
+    (out, unset)
 }
 
 fn default_env_var_value(key: &str) -> Option<String> {
@@ -826,9 +838,18 @@ fn default_env_var_value(key: &str) -> Option<String> {
 }
 
 pub(crate) fn expand_exclude_pattern(pattern: &str) -> String {
-    shellexpand(&expand_env_vars(pattern))
-        .to_string_lossy()
-        .into_owned()
+    expand_exclude_pattern_collecting(pattern).0
+}
+
+/// Like [`expand_exclude_pattern`] but also returns the names of env vars that
+/// were referenced (`$VAR` / `${VAR}`) but unset. Such references stay literal
+/// in the returned pattern and match nothing, so a caller folding the pattern
+/// into a cache key warns rather than silently keying on a matches-nothing
+/// pattern. See [`expand_env_vars_collecting`].
+pub(crate) fn expand_exclude_pattern_collecting(pattern: &str) -> (String, Vec<String>) {
+    let (expanded, unset) = expand_env_vars_collecting(pattern, |key| std::env::var(key).ok());
+    let s = shellexpand(&expanded).to_string_lossy().into_owned();
+    (s, unset)
 }
 
 fn push_unique(paths: &mut Vec<PathBuf>, path: PathBuf) {
@@ -1257,11 +1278,37 @@ mod tests {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
         let cargo_home = home.join(".cargo").to_string_lossy().into_owned();
 
-        let expanded = expand_env_vars_with("$CARGO_HOME/registry/src/**", |_| None);
+        let (expanded, _) = expand_env_vars_collecting("$CARGO_HOME/registry/src/**", |_| None);
         assert_eq!(expanded, format!("{cargo_home}/registry/src/**"));
 
-        let expanded_braced = expand_env_vars_with("${CARGO_HOME}/registry/src/**", |_| None);
+        let (expanded_braced, _) =
+            expand_env_vars_collecting("${CARGO_HOME}/registry/src/**", |_| None);
         assert_eq!(expanded_braced, format!("{cargo_home}/registry/src/**"));
+    }
+
+    #[test]
+    fn expand_collecting_reports_unset_vars_only_once() {
+        let (expanded, unset) =
+            expand_env_vars_collecting("$MISSING/$MISSING/${ALSO_MISSING}/x", |_| None);
+        // Unset refs stay literal so the caller can see they matched nothing.
+        assert_eq!(expanded, "$MISSING/$MISSING/${ALSO_MISSING}/x");
+        // Deduplicated, in first-seen order.
+        assert_eq!(
+            unset,
+            vec!["MISSING".to_string(), "ALSO_MISSING".to_string()]
+        );
+    }
+
+    #[test]
+    fn expand_collecting_no_unset_when_resolved_or_defaulted() {
+        let (expanded, unset) =
+            expand_env_vars_collecting("$FOO/x", |k| (k == "FOO").then(|| "bar".to_string()));
+        assert_eq!(expanded, "bar/x");
+        assert!(unset.is_empty());
+
+        // CARGO_HOME has a built-in default, so it is not reported as unset.
+        let (_, unset_default) = expand_env_vars_collecting("$CARGO_HOME/x", |_| None);
+        assert!(unset_default.is_empty());
     }
 
     #[test]

--- a/src/extra_inputs.rs
+++ b/src/extra_inputs.rs
@@ -380,7 +380,20 @@ fn crate_relative_path(crate_dir: &Path, path: &Path) -> String {
 /// warning: reaching outside the crate is the author's explicit, fail-safe
 /// choice, but it makes the key host-/layout-specific.
 fn normalize_pattern(crate_name: &str, crate_dir: &Path, pattern: &str) -> Option<String> {
-    let normalized = crate::config::expand_exclude_pattern(pattern);
+    let (normalized, unset_vars) = crate::config::expand_exclude_pattern_collecting(pattern);
+
+    // An unset `$VAR` in a pattern is the one failure mode the rest of this
+    // module handles loudly but this path used to swallow: the reference stays a
+    // literal, matches nothing, and folds a pattern-set-only key that replays
+    // regardless of the files the author meant to track. Warn so the missing
+    // var is visible instead of presenting as a clean (but wrong) cache hit.
+    if !unset_vars.is_empty() {
+        tracing::warn!(
+            "[key:{crate_name}] extra_inputs pattern {pattern:?} references unset env var(s) \
+             {unset_vars:?}; they stay literal and match nothing — set the var(s) or remove the \
+             reference, otherwise this folds a replayable matches-nothing key"
+        );
+    }
 
     // A `\x1f` (the fold separator) in a glob is never legitimate and would let
     // a crafted pattern cross the pattern/hash section boundary in the digest.


### PR DESCRIPTION
## Problem

An unset `$VAR` / `${VAR}` in an `extra_inputs` pattern was the **one** failure mode this module swallowed silently. The reference stays a literal, matches nothing on disk, and folds a *pattern-set-only* key that replays regardless of the files the author intended to track — while every other rejection path (control separator, bad glob, out-of-crate, filesystem-root walk, all-rejected) already warns loudly.

## Fix

Add `expand_env_vars_collecting` / `expand_exclude_pattern_collecting`, which return the names of referenced-but-unset vars alongside the expanded string, and warn in `normalize_pattern` when any survive. Vars with a built-in default (e.g. `CARGO_HOME`) are not reported. Folding behavior is otherwise unchanged (still fail-safe).

## Context

Surfaced by @lovesegfault's review in [rio-build#51](https://github.com/lovesegfault/rio-build/pull/51): *"warn on unset `$VAR` in `extra_inputs` patterns: it stays a literal, matches nothing, and folds a replayable pattern-set-only key. everything else in `extra_inputs.rs` fails loudly, this one is silent."*

## Test

`expand_collecting_reports_unset_vars_only_once` (dedup + first-seen order) and `expand_collecting_no_unset_when_resolved_or_defaulted` (resolved + defaulted vars not reported). Clippy clean.