### PR TITLE
feat(observability): trace key_salt application and surface it in why-miss

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -200,9 +200,22 @@ fn scrub_remap_value(value: &str) -> String {
 ///
 /// Shared by every compiler family (rustc and cc) so the salt applies
 /// uniformly regardless of which adapter produced `base`.
-pub(crate) fn apply_key_salt(base: String, salt: Option<&str>) -> String {
+///
+/// `label` is the crate/source name used in the `[key:…]` trace line so a
+/// salt-induced miss is visible under `KACHE_LOG=trace` alongside the other key
+/// components — previously the salt was the one key part that folded silently,
+/// so a miss caused by a (stray or rotated) salt was invisible to the
+/// `why-miss` grep recipe.
+pub(crate) fn apply_key_salt(base: String, salt: Option<&str>, label: &str) -> String {
     match salt {
-        Some(salt) if !salt.is_empty() => fold_labeled(base, "key_salt", salt),
+        Some(salt) if !salt.is_empty() => {
+            let keyed = fold_labeled(base, "key_salt", salt);
+            tracing::trace!(
+                "[key:{label}] key_salt={salt:?} -> {}",
+                &keyed[..keyed.len().min(16)]
+            );
+            keyed
+        }
         _ => base,
     }
 }
@@ -1997,21 +2010,21 @@ mod tests {
         // None and empty/whitespace are both treated as "unsalted" and
         // must return the base key byte-for-byte (no CACHE_KEY_VERSION
         // bump, no effect for projects that never set it).
-        assert_eq!(apply_key_salt(base.clone(), None), base);
-        assert_eq!(apply_key_salt(base.clone(), Some("")), base);
+        assert_eq!(apply_key_salt(base.clone(), None, "crate"), base);
+        assert_eq!(apply_key_salt(base.clone(), Some(""), "crate"), base);
     }
 
     #[test]
     fn apply_key_salt_changes_key_and_is_salt_specific() {
         let base = "deadbeef".to_string();
-        let a = apply_key_salt(base.clone(), Some("toolchain-A"));
-        let b = apply_key_salt(base.clone(), Some("toolchain-B"));
+        let a = apply_key_salt(base.clone(), Some("toolchain-A"), "crate");
+        let b = apply_key_salt(base.clone(), Some("toolchain-B"), "crate");
         // A salt re-keys, and distinct salts produce distinct keys.
         assert_ne!(a, base);
         assert_ne!(b, base);
         assert_ne!(a, b);
         // Deterministic: same (base, salt) → same key.
-        assert_eq!(a, apply_key_salt(base, Some("toolchain-A")));
+        assert_eq!(a, apply_key_salt(base, Some("toolchain-A"), "crate"));
     }
 
     #[test]
@@ -2020,8 +2033,8 @@ mod tests {
         // base is mixed into the hash, not just the salt).
         let salt = Some("nix-rev-abc");
         assert_ne!(
-            apply_key_salt("aaaa".to_string(), salt),
-            apply_key_salt("bbbb".to_string(), salt),
+            apply_key_salt("aaaa".to_string(), salt, "crate"),
+            apply_key_salt("bbbb".to_string(), salt, "crate"),
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -620,6 +620,20 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
         );
     }
 
+    // ── Active key salt ───────────────────────────────────────────────
+    // The salt is folded into every key but isn't recorded per entry, so a
+    // salt change can't be diffed against a stored entry — it shifts the key
+    // wholesale and looks like a clean miss. Surfacing the active salt makes
+    // that cause visible: a stray machine-global `KACHE_KEY_SALT`, or a
+    // rotated salt, alone explains every miss here.
+    if let Some(salt) = config.key_salt.as_deref().filter(|s| !s.is_empty()) {
+        println!("\n  Active key_salt: {salt:?}");
+        println!(
+            "    (folded into every key; if it changed or was set unexpectedly since the \
+             last hit, that alone shifts the key and explains the miss)"
+        );
+    }
+
     println!("\n  For full key component details, run:");
     println!(
         "    KACHE_LOG=trace cargo build -p {crate_name} 2>&1 | grep '\\[key:{crate_name}\\]'"

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -3515,7 +3515,7 @@ impl Compiler for CcCompiler {
             true,
             ctx.file_hasher,
         );
-        let key = crate::cache_key::apply_key_salt(key, ctx.key_salt);
+        let key = crate::cache_key::apply_key_salt(key, ctx.key_salt, &trace_name);
         tracing::trace!(
             target: "kache::cache_key",
             "[key:{}] final={}",

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -97,7 +97,11 @@ impl Compiler for RustcCompiler {
             parsed.is_primary,
             ctx.file_hasher,
         );
-        Ok(crate::cache_key::apply_key_salt(key, ctx.key_salt))
+        Ok(crate::cache_key::apply_key_salt(
+            key,
+            ctx.key_salt,
+            parsed.crate_name.as_deref().unwrap_or("unknown"),
+        ))
     }
 
     fn execute(&self, parsed: &RustcArgs) -> Result<CompileResult> {


### PR DESCRIPTION
## Problem

`apply_key_salt` folded the salt into every key **silently**, so a miss caused by a stray machine-global `KACHE_KEY_SALT` (or a rotated salt) was invisible even at `KACHE_LOG=trace` — and the `why-miss` grep recipe (`[key:<crate>]`) couldn't show it either.

## Fix

- Emit a `[key:<crate>] key_salt=… -> <key-prefix>` trace line when a salt is applied, matching the other key-component trace lines (so the existing grep recipe surfaces it). `apply_key_salt` now takes the crate/source label. The unsalted path stays **byte-identical** and silent — no `CACHE_KEY_VERSION` impact.
- Surface the active `key_salt` in `kache why-miss` output. The salt isn't recorded per entry (a separate, larger change), so it can't be diffed against a stored entry — but showing it makes a salt-induced miss diagnosable.

## Context

Surfaced by @lovesegfault's review in [rio-build#51](https://github.com/lovesegfault/rio-build/pull/51): *"observability for the new key parts: `apply_key_salt` emits no tracing, so a salt-induced miss is invisible even at `KACHE_LOG=trace`… happy to PR the trace line + why-miss fields."*

## Test

Existing `apply_key_salt_*` tests updated for the new label param; unsalted-identity invariant still asserted. Clippy clean.