### PR TITLE
fix(passthrough): pre-clean read-only restores; log when outputs are unidentifiable

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -418,6 +418,20 @@ pub(crate) fn pre_clean_outputs(
                 }
             }
         }
+    } else {
+        // Neither a concrete output path nor an (out_dir, crate_name) pair to
+        // scan: a lenient/partial parse (an unusual rustc spawner) left nothing
+        // to identify the outputs by, so we can't pre-empt a warm read-only
+        // restore and the compiler may then fail with EACCES. Surface it at
+        // debug so the failure mode is diagnosable rather than silent — a
+        // conservative "remove every read-only file in the dir" sweep would
+        // risk deleting unrelated cached artifacts, so we report instead of
+        // guess (rio-build#51 / kache#242).
+        tracing::debug!(
+            "pre_clean_outputs: nothing to identify outputs by \
+             (out_dir={out_dir:?}, crate_name={crate_name:?}); skipping read-only pre-clean — \
+             a warm restore in this directory may block this compile"
+        );
     }
 }
 
@@ -529,6 +543,25 @@ mod tests {
         assert!(
             unrelated.exists(),
             "unrelated crate files should not be removed"
+        );
+    }
+
+    #[test]
+    fn test_pre_clean_without_identity_is_a_safe_noop() {
+        // Unusual spawner: no output path and no crate_name to identify
+        // outputs by. pre_clean must not touch anything (and must not panic) —
+        // it logs at debug instead of sweeping the directory.
+        let dir = tempfile::tempdir().unwrap();
+        let readonly = dir.path().join("libfoo-abc123.rlib");
+        fs::write(&readonly, b"cached").unwrap();
+        make_readonly(&readonly);
+
+        pre_clean_outputs(None, Some(dir.path()), None, None);
+        pre_clean_outputs(None, None, None, None);
+
+        assert!(
+            readonly.exists(),
+            "with no crate identity, pre_clean must not remove files"
         );
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1359,6 +1359,21 @@ fn passthrough(args: &RustcArgs, fallback: Option<&str>) -> Result<PassthroughOu
         );
     }
 
+    // A prior cache hit may have restored read-only (0444) hardlinks into the
+    // target dir; rustc can't overwrite those and fails with EACCES. The cached
+    // path pre-cleans them in `run_rustc`, and the disabled/re-entrant path does
+    // so in `run_compiler_directly` — but a kache-declined *passthrough* (refuse
+    // reason, non-primary, etc.) ran straight into the read-only outputs. Clean
+    // them here too. When the parse couldn't recover crate_name/extra-filename
+    // this still can't act, but `pre_clean_outputs` now logs that at debug
+    // (rio-build#51 / kache#242).
+    compile::pre_clean_outputs(
+        args.output.as_deref(),
+        args.out_dir.as_deref(),
+        args.crate_name.as_deref(),
+        args.extra_filename.as_deref(),
+    );
+
     // Configured fallback wrapper: `<fallback> <rustc> [<inner-rustc>]
     // <args>`. Falls through to a plain passthrough if the fallback
     // binary is not on PATH.


### PR DESCRIPTION
## Problem

A prior cache hit restores read-only (0444) hardlinks into the target dir. The cached compile path pre-cleans them (`run_rustc`) and the disabled/re-entrant path does too (`run_compiler_directly`) — but a kache-**declined** passthrough (a refuse reason, non-primary, etc.) ran straight into the read-only outputs and rustc failed with EACCES. And when a lenient/partial parse couldn't recover `crate_name`/`extra-filename`, `pre_clean_outputs` identified nothing and **silently** cleaned nothing.

## Fix

- Call `pre_clean_outputs` in `wrapper::passthrough`, before both the fallback-wrapper and plain-rustc paths.
- Add a `debug!` line in `pre_clean_outputs` for the no-identity case. A conservative "remove every read-only file in the dir" sweep would risk deleting unrelated cached artifacts, so it **reports rather than guesses** — exactly the reviewer's "or at least a debug line" suggestion.

## Context

Surfaced by @lovesegfault's review in [rio-build#51](https://github.com/lovesegfault/rio-build/pull/51) (re kache PR #242): *"when the lenient parse can't recover crate_name/extra-filename, the passthrough cleans nothing. A conservative fallback (or at least a debug line) would close the gap for weird spawners."*

## Test

`test_pre_clean_without_identity_is_a_safe_noop` (no-identity → no files touched, no panic). Existing pre_clean + `run_compiler_directly` tests still green. Clippy clean.