### PR TITLE
ci: raise Test (Windows) timeouts (test step exceeds 30m)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,7 +527,10 @@ jobs:
   test-windows:
     name: Test (Windows)
     runs-on: ${{ fromJSON('["self-hosted", "Windows", "X64", "kunobi-windows"]') }}
-    timeout-minutes: 40
+    # Windows on the self-hosted runner is the slowest leg: a from-scratch
+    # `cargo test --workspace` compile alone exceeded the previous 30m step cap.
+    # Job cap must cover the test step (45m) + clippy step (30m) + setup.
+    timeout-minutes: 90
     defaults:
       run:
         shell: bash
@@ -588,7 +591,7 @@ jobs:
         run: |
           rustc --version && cargo --version
           cargo test --workspace
-        timeout-minutes: 30
+        timeout-minutes: 45
         env:
           RUSTC_WRAPPER: ""
       # Clippy otherwise runs only on Linux, leaving `#[cfg(windows)]` code


### PR DESCRIPTION
## Problem

The self-hosted Windows runner is the slowest CI leg. In [run 27760930922](https://github.com/kunobi-ninja/kache/actions/runs/27760930922/job/82134827163) the **`cargo test (workspace)`** step ran the full **30 minutes** (12:56:24 → 13:26:32) and was killed by its `timeout-minutes: 30` step cap — a from-scratch compile of the workspace on Windows alone exceeds 30m.

## Fix

- `cargo test (workspace)` step: `30` → **45** min.
- `test-windows` job cap: `40` → **90** min, so it covers the test step (45m) + clippy step (30m) + setup with headroom, while still killing a genuine hang well under GitHub's 6h default.

Scoped to `test-windows` only (the `check` job is Linux-only; macOS is unchanged).