### PR TITLE
kache gap follow-ups from lovesegfault's rio-build#51 review

### DIFF
--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -44,6 +44,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_CACHE_DIR` | `cache.local_store` | `~/Library/Caches/kache` on macOS, `~/.cache/kache` on Linux | Local cache directory |
 | `KACHE_MAX_SIZE` | `cache.local_max_size` | `50GiB` | Maximum local store size |
 | `KACHE_CONFIG` | — | — | Explicit config file path; overrides the project-local `.kache.toml` / XDG resolution |
+| `KACHE_BASE_DIR` | — | — | Path prefix stripped from cache keys (collapsed to `<BASE_DIR>`) for checkout / container-mount paths the automatic sentinels don't catch — the analog of ccache's `CCACHE_BASEDIR` (see [Cache key](/docs/how-it-works/cache-key)) |
 | `KACHE_S3_BUCKET` | `cache.remote.bucket` | — | S3 bucket name |
 | `KACHE_S3_ENDPOINT` | `cache.remote.endpoint` | — | S3 endpoint URL (required for Ceph, MinIO, R2) |
 | `KACHE_S3_REGION` | `cache.remote.region` | `us-east-1` | AWS region |
@@ -67,6 +68,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_PLANNER_ENDPOINT` | `cache.planner.endpoint` | — | Prefetch-planner service URL; setting it enables the planner client. Empty/whitespace is treated as unset |
 | `KACHE_PLANNER_TIMEOUT_MS` | `cache.planner.timeout_ms` | `750` | Planner request timeout in milliseconds |
 | `KACHE_PLANNER_TOKEN` | `cache.planner.token` | — | Bearer credential sent with planner requests |
+| `KACHE_NAMESPACE` | — | — | Enables content-addressed shard uploads/prefetch (requires a `Cargo.lock`); the `kache save-manifest --namespace` flag takes precedence. Unset uploads only the monolithic manifest |
 | `KACHE_LOG` | — | `kache=warn` * | Log level for stderr output |
 | `KACHE_LOG_FILE` | — | `kache=info` * | Log level for the file log |
 | `KACHE_PROGRESS` | — | (off) | Per-crate progress lines to stderr: `1`/`hits` prints cache hits only; `verbose`/`all` also prints dups and misses; unset or anything else stays silent |
@@ -143,6 +145,16 @@ This is **opt-in and scoped per crate**: a crate with no `kache.toml` is unaffec
   root or an unusually large number of files.
 </Callout>
 
+<Callout type="warn">
+  `extra_inputs` is only evaluated **when cargo invokes the compiler**. Editing a
+  tracked file in a warm in-place target — changing `.sqlx/` without touching any
+  `.rs` — doesn't re-invoke rustc on its own, so the key isn't recomputed and the
+  prior artifact is restored. To make such edits re-key, your build script must
+  emit a matching `cargo:rerun-if-changed` for the path (cargo then re-runs the
+  crate when it changes). `kache doctor` flags crates that declare `extra_inputs`
+  but whose build script won't re-trigger the compiler.
+</Callout>
+
 <Callout type="info">
   `kache.toml` (no leading dot) is **only** for `extra_inputs`. It is distinct
   from the project config `.kache.toml`; any other key in it is a loud error.
@@ -216,6 +228,21 @@ bucket = "build-cache"
 endpoint = "https://s3.example.com"
 profile = "ceph"
 ```
+
+## Composing with other compiler wrappers
+
+kache works as a `RUSTC_WRAPPER` and composes with a second wrapper in either direction.
+
+**Behind another workspace wrapper** (`RUSTC_WORKSPACE_WRAPPER`, e.g. `clippy-driver`): when cargo has both `RUSTC_WRAPPER=kache` and a `RUSTC_WORKSPACE_WRAPPER` set, it invokes `kache <workspace-wrapper> <rustc> <args>`. kache detects that the inner argument is itself a compiler, forwards the real rustc path as the workspace wrapper expects, and keys/caches around it. `cargo clippy` (which drives `clippy-driver`) is handled the same way — no extra configuration needed.
+
+**In front of another wrapper** — when you want a second wrapper to cache the compiles kache *declines*: set [`KACHE_FALLBACK`](#all-settings) (or `cache.fallback`). kache then runs `<fallback> <compiler> <args>` for passed-through invocations, so e.g. sccache gets a chance at the compiles kache won't cache.
+
+<Callout type="info">
+  `KACHE_DISABLED=1` makes kache a transparent shim (no lookup, store, or
+  upload) while still stripping incremental flags — useful to temporarily
+  bypass kache in a wrapper chain without unsetting the env var. Only `1` or
+  `true` (case-insensitive) disable; `0`/`false`/unset leave caching on.
+</Callout>
 
 ## Size values
 

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -200,9 +200,22 @@ fn scrub_remap_value(value: &str) -> String {
 ///
 /// Shared by every compiler family (rustc and cc) so the salt applies
 /// uniformly regardless of which adapter produced `base`.
-pub(crate) fn apply_key_salt(base: String, salt: Option<&str>) -> String {
+///
+/// `label` is the crate/source name used in the `[key:…]` trace line so a
+/// salt-induced miss is visible under `KACHE_LOG=trace` alongside the other key
+/// components — previously the salt was the one key part that folded silently,
+/// so a miss caused by a (stray or rotated) salt was invisible to the
+/// `why-miss` grep recipe.
+pub(crate) fn apply_key_salt(base: String, salt: Option<&str>, label: &str) -> String {
     match salt {
-        Some(salt) if !salt.is_empty() => fold_labeled(base, "key_salt", salt),
+        Some(salt) if !salt.is_empty() => {
+            let keyed = fold_labeled(base, "key_salt", salt);
+            tracing::trace!(
+                "[key:{label}] key_salt={salt:?} -> {}",
+                &keyed[..keyed.len().min(16)]
+            );
+            keyed
+        }
         _ => base,
     }
 }
@@ -1997,21 +2010,21 @@ mod tests {
         // None and empty/whitespace are both treated as "unsalted" and
         // must return the base key byte-for-byte (no CACHE_KEY_VERSION
         // bump, no effect for projects that never set it).
-        assert_eq!(apply_key_salt(base.clone(), None), base);
-        assert_eq!(apply_key_salt(base.clone(), Some("")), base);
+        assert_eq!(apply_key_salt(base.clone(), None, "crate"), base);
+        assert_eq!(apply_key_salt(base.clone(), Some(""), "crate"), base);
     }
 
     #[test]
     fn apply_key_salt_changes_key_and_is_salt_specific() {
         let base = "deadbeef".to_string();
-        let a = apply_key_salt(base.clone(), Some("toolchain-A"));
-        let b = apply_key_salt(base.clone(), Some("toolchain-B"));
+        let a = apply_key_salt(base.clone(), Some("toolchain-A"), "crate");
+        let b = apply_key_salt(base.clone(), Some("toolchain-B"), "crate");
         // A salt re-keys, and distinct salts produce distinct keys.
         assert_ne!(a, base);
         assert_ne!(b, base);
         assert_ne!(a, b);
         // Deterministic: same (base, salt) → same key.
-        assert_eq!(a, apply_key_salt(base, Some("toolchain-A")));
+        assert_eq!(a, apply_key_salt(base, Some("toolchain-A"), "crate"));
     }
 
     #[test]
@@ -2020,8 +2033,8 @@ mod tests {
         // base is mixed into the hash, not just the salt).
         let salt = Some("nix-rev-abc");
         assert_ne!(
-            apply_key_salt("aaaa".to_string(), salt),
-            apply_key_salt("bbbb".to_string(), salt),
+            apply_key_salt("aaaa".to_string(), salt, "crate"),
+            apply_key_salt("bbbb".to_string(), salt, "crate"),
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -620,6 +620,20 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
         );
     }
 
+    // ── Active key salt ───────────────────────────────────────────────
+    // The salt is folded into every key but isn't recorded per entry, so a
+    // salt change can't be diffed against a stored entry — it shifts the key
+    // wholesale and looks like a clean miss. Surfacing the active salt makes
+    // that cause visible: a stray machine-global `KACHE_KEY_SALT`, or a
+    // rotated salt, alone explains every miss here.
+    if let Some(salt) = config.key_salt.as_deref().filter(|s| !s.is_empty()) {
+        println!("\n  Active key_salt: {salt:?}");
+        println!(
+            "    (folded into every key; if it changed or was set unexpectedly since the \
+             last hit, that alone shifts the key and explains the miss)"
+        );
+    }
+
     println!("\n  For full key component details, run:");
     println!(
         "    KACHE_LOG=trace cargo build -p {crate_name} 2>&1 | grep '\\[key:{crate_name}\\]'"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2035,6 +2035,57 @@ pub fn doctor(
         });
     }
 
+    // extra_inputs warm-target coverage: a crate that declares extra_inputs but
+    // whose build script won't re-trigger rustc gets stale artifacts when a
+    // tracked file changes in a warm target. Only surfaced when at least one
+    // crate in the tree declares extra_inputs (no noise for the common case).
+    if let Ok(cwd) = std::env::current_dir() {
+        let audit = crate::extra_inputs::audit_rerun_coverage(&cwd);
+        if audit.declaring > 0 {
+            if audit.gaps.is_empty() {
+                checks.push(Check {
+                    label: "extra_inputs",
+                    pass: true,
+                    detail: format!(
+                        "{} crate(s), build scripts re-trigger rustc",
+                        audit.declaring
+                    ),
+                    fix: None,
+                });
+            } else {
+                let listed: Vec<String> = audit
+                    .gaps
+                    .iter()
+                    .take(5)
+                    .map(|g| {
+                        let rel = g.crate_dir.strip_prefix(&cwd).unwrap_or(&g.crate_dir);
+                        let shown = if rel.as_os_str().is_empty() {
+                            ".".to_string()
+                        } else {
+                            rel.display().to_string()
+                        };
+                        format!("{shown} ({})", g.reason)
+                    })
+                    .collect();
+                let more = audit.gaps.len().saturating_sub(listed.len());
+                let mut detail = listed.join(", ");
+                if more > 0 {
+                    detail.push_str(&format!(", +{more} more"));
+                }
+                checks.push(Check {
+                    label: "extra_inputs",
+                    pass: false,
+                    detail,
+                    fix: Some(
+                        "edits to these tracked files won't re-key in a warm target; emit \
+                         cargo:rerun-if-changed for them from build.rs (see configuration docs)"
+                            .into(),
+                    ),
+                });
+            }
+        }
+    }
+
     // Print
     let version = crate::VERSION;
     let rustc_version = std::process::Command::new("rustc")

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -418,6 +418,20 @@ pub(crate) fn pre_clean_outputs(
                 }
             }
         }
+    } else {
+        // Neither a concrete output path nor an (out_dir, crate_name) pair to
+        // scan: a lenient/partial parse (an unusual rustc spawner) left nothing
+        // to identify the outputs by, so we can't pre-empt a warm read-only
+        // restore and the compiler may then fail with EACCES. Surface it at
+        // debug so the failure mode is diagnosable rather than silent — a
+        // conservative "remove every read-only file in the dir" sweep would
+        // risk deleting unrelated cached artifacts, so we report instead of
+        // guess (rio-build#51 / kache#242).
+        tracing::debug!(
+            "pre_clean_outputs: nothing to identify outputs by \
+             (out_dir={out_dir:?}, crate_name={crate_name:?}); skipping read-only pre-clean — \
+             a warm restore in this directory may block this compile"
+        );
     }
 }
 
@@ -529,6 +543,25 @@ mod tests {
         assert!(
             unrelated.exists(),
             "unrelated crate files should not be removed"
+        );
+    }
+
+    #[test]
+    fn test_pre_clean_without_identity_is_a_safe_noop() {
+        // Unusual spawner: no output path and no crate_name to identify
+        // outputs by. pre_clean must not touch anything (and must not panic) —
+        // it logs at debug instead of sweeping the directory.
+        let dir = tempfile::tempdir().unwrap();
+        let readonly = dir.path().join("libfoo-abc123.rlib");
+        fs::write(&readonly, b"cached").unwrap();
+        make_readonly(&readonly);
+
+        pre_clean_outputs(None, Some(dir.path()), None, None);
+        pre_clean_outputs(None, None, None, None);
+
+        assert!(
+            readonly.exists(),
+            "with no crate identity, pre_clean must not remove files"
         );
     }
 

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -3515,7 +3515,7 @@ impl Compiler for CcCompiler {
             true,
             ctx.file_hasher,
         );
-        let key = crate::cache_key::apply_key_salt(key, ctx.key_salt);
+        let key = crate::cache_key::apply_key_salt(key, ctx.key_salt, &trace_name);
         tracing::trace!(
             target: "kache::cache_key",
             "[key:{}] final={}",

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -97,7 +97,11 @@ impl Compiler for RustcCompiler {
             parsed.is_primary,
             ctx.file_hasher,
         );
-        Ok(crate::cache_key::apply_key_salt(key, ctx.key_salt))
+        Ok(crate::cache_key::apply_key_salt(
+            key,
+            ctx.key_salt,
+            parsed.crate_name.as_deref().unwrap_or("unknown"),
+        ))
     }
 
     fn execute(&self, parsed: &RustcArgs) -> Result<CompileResult> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -254,14 +254,14 @@ impl Config {
 
         let max_size = std::env::var("KACHE_MAX_SIZE")
             .ok()
-            .and_then(|s| parse_size(&s))
+            .and_then(|s| parse_size_checked(&s, "KACHE_MAX_SIZE"))
             .or_else(|| {
                 file_config
                     .as_ref()
                     .ok()
                     .and_then(|c| c.cache.as_ref())
                     .and_then(|c| c.local_max_size.as_ref())
-                    .and_then(|s| parse_size(s))
+                    .and_then(|s| parse_size_checked(s, "[cache] local_max_size"))
             })
             .unwrap_or(50 * 1024 * 1024 * 1024); // 50 GiB
 
@@ -292,7 +292,7 @@ impl Config {
             .ok()
             .and_then(|c| c.cache.as_ref())
             .and_then(|c| c.event_log_max_size.as_ref())
-            .and_then(|s| parse_size(s))
+            .and_then(|s| parse_size_checked(s, "[cache] event_log_max_size"))
             .unwrap_or(10 * 1024 * 1024); // 10 MiB
 
         let event_log_keep_lines = file_config
@@ -911,6 +911,26 @@ pub(crate) fn parse_size(s: &str) -> Option<u64> {
     s.parse::<ByteSize>().ok().map(|b| b.as_u64())
 }
 
+/// Parse a human size string, warning loudly when it is set but malformed.
+///
+/// A value `ByteSize` can't parse (a typo'd unit like `100 gigs`, digit
+/// grouping like `1_000`, plain garbage) otherwise degrades silently:
+/// `Config::load` falls through to the next source and finally to a hardcoded
+/// default, so the cap the user asked for is ignored without a word. `source`
+/// names where the value came from (e.g. `KACHE_MAX_SIZE`) so the warning
+/// points at the right place.
+pub(crate) fn parse_size_checked(value: &str, source: &str) -> Option<u64> {
+    let parsed = parse_size(value);
+    if parsed.is_none() {
+        tracing::warn!(
+            "ignoring malformed size {value:?} from {source}: expected an integer with an \
+             optional unit like `50GiB`, `512MiB`, or `1000000`; falling back to the next \
+             configured source or the default"
+        );
+    }
+    parsed
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -962,6 +982,21 @@ mod tests {
         assert_eq!(parse_size("50GiB"), Some(50 * 1024 * 1024 * 1024));
         assert_eq!(parse_size("1MiB"), Some(1024 * 1024));
         assert!(parse_size("invalid").is_none());
+    }
+
+    #[test]
+    fn parse_size_checked_rejects_malformed_and_mirrors_parse_size() {
+        // Values ByteSize can't parse: a typo'd unit and digit grouping. These
+        // are exactly what used to silently degrade to the hardcoded default.
+        for bad in ["100 gigs", "1_000", "abc", ""] {
+            assert!(parse_size(bad).is_none(), "expected {bad:?} to be invalid");
+            assert!(parse_size_checked(bad, "KACHE_MAX_SIZE").is_none());
+        }
+        // Valid values pass through unchanged.
+        assert_eq!(
+            parse_size_checked("2GiB", "KACHE_MAX_SIZE"),
+            Some(2 * 1024 * 1024 * 1024)
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -760,15 +760,25 @@ fn shellexpand(s: &str) -> PathBuf {
     PathBuf::from(s)
 }
 
-fn expand_env_vars(s: &str) -> String {
-    expand_env_vars_with(s, |key| std::env::var(key).ok())
-}
-
-fn expand_env_vars_with<F>(s: &str, lookup: F) -> String
+/// Core `$VAR` / `${VAR}` expander. Returns the expanded string plus the names
+/// of every referenced env var that was *unset* (no value and no
+/// [`default_env_var_value`]) and so was left as a literal `$VAR` in the output.
+///
+/// An unset reference matters to cache-key callers: it silently survives as
+/// text that matches nothing, so they fold a replayable pattern-set-only key
+/// while believing the intended files are tracked. Reporting the unset names
+/// lets those callers warn instead of degrading silently.
+fn expand_env_vars_collecting<F>(s: &str, lookup: F) -> (String, Vec<String>)
 where
     F: Fn(&str) -> Option<String>,
 {
     let mut out = String::with_capacity(s.len());
+    let mut unset: Vec<String> = Vec::new();
+    let mut note_unset = |key: &str| {
+        if !unset.iter().any(|k| k == key) {
+            unset.push(key.to_string());
+        }
+    };
     let mut chars = s.chars().peekable();
     while let Some(ch) = chars.next() {
         if ch != '$' {
@@ -788,6 +798,7 @@ where
             if let Some(value) = lookup(&key).or_else(|| default_env_var_value(&key)) {
                 out.push_str(&value);
             } else {
+                note_unset(&key);
                 out.push_str("${");
                 out.push_str(&key);
                 out.push('}');
@@ -809,11 +820,12 @@ where
         } else if let Some(value) = lookup(&key).or_else(|| default_env_var_value(&key)) {
             out.push_str(&value);
         } else {
+            note_unset(&key);
             out.push('$');
             out.push_str(&key);
         }
     }
-    out
+    (out, unset)
 }
 
 fn default_env_var_value(key: &str) -> Option<String> {
@@ -826,9 +838,18 @@ fn default_env_var_value(key: &str) -> Option<String> {
 }
 
 pub(crate) fn expand_exclude_pattern(pattern: &str) -> String {
-    shellexpand(&expand_env_vars(pattern))
-        .to_string_lossy()
-        .into_owned()
+    expand_exclude_pattern_collecting(pattern).0
+}
+
+/// Like [`expand_exclude_pattern`] but also returns the names of env vars that
+/// were referenced (`$VAR` / `${VAR}`) but unset. Such references stay literal
+/// in the returned pattern and match nothing, so a caller folding the pattern
+/// into a cache key warns rather than silently keying on a matches-nothing
+/// pattern. See [`expand_env_vars_collecting`].
+pub(crate) fn expand_exclude_pattern_collecting(pattern: &str) -> (String, Vec<String>) {
+    let (expanded, unset) = expand_env_vars_collecting(pattern, |key| std::env::var(key).ok());
+    let s = shellexpand(&expanded).to_string_lossy().into_owned();
+    (s, unset)
 }
 
 fn push_unique(paths: &mut Vec<PathBuf>, path: PathBuf) {
@@ -1257,11 +1278,37 @@ mod tests {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
         let cargo_home = home.join(".cargo").to_string_lossy().into_owned();
 
-        let expanded = expand_env_vars_with("$CARGO_HOME/registry/src/**", |_| None);
+        let (expanded, _) = expand_env_vars_collecting("$CARGO_HOME/registry/src/**", |_| None);
         assert_eq!(expanded, format!("{cargo_home}/registry/src/**"));
 
-        let expanded_braced = expand_env_vars_with("${CARGO_HOME}/registry/src/**", |_| None);
+        let (expanded_braced, _) =
+            expand_env_vars_collecting("${CARGO_HOME}/registry/src/**", |_| None);
         assert_eq!(expanded_braced, format!("{cargo_home}/registry/src/**"));
+    }
+
+    #[test]
+    fn expand_collecting_reports_unset_vars_only_once() {
+        let (expanded, unset) =
+            expand_env_vars_collecting("$MISSING/$MISSING/${ALSO_MISSING}/x", |_| None);
+        // Unset refs stay literal so the caller can see they matched nothing.
+        assert_eq!(expanded, "$MISSING/$MISSING/${ALSO_MISSING}/x");
+        // Deduplicated, in first-seen order.
+        assert_eq!(
+            unset,
+            vec!["MISSING".to_string(), "ALSO_MISSING".to_string()]
+        );
+    }
+
+    #[test]
+    fn expand_collecting_no_unset_when_resolved_or_defaulted() {
+        let (expanded, unset) =
+            expand_env_vars_collecting("$FOO/x", |k| (k == "FOO").then(|| "bar".to_string()));
+        assert_eq!(expanded, "bar/x");
+        assert!(unset.is_empty());
+
+        // CARGO_HOME has a built-in default, so it is not reported as unset.
+        let (_, unset_default) = expand_env_vars_collecting("$CARGO_HOME/x", |_| None);
+        assert!(unset_default.is_empty());
     }
 
     #[test]

--- a/src/extra_inputs.rs
+++ b/src/extra_inputs.rs
@@ -380,7 +380,20 @@ fn crate_relative_path(crate_dir: &Path, path: &Path) -> String {
 /// warning: reaching outside the crate is the author's explicit, fail-safe
 /// choice, but it makes the key host-/layout-specific.
 fn normalize_pattern(crate_name: &str, crate_dir: &Path, pattern: &str) -> Option<String> {
-    let normalized = crate::config::expand_exclude_pattern(pattern);
+    let (normalized, unset_vars) = crate::config::expand_exclude_pattern_collecting(pattern);
+
+    // An unset `$VAR` in a pattern is the one failure mode the rest of this
+    // module handles loudly but this path used to swallow: the reference stays a
+    // literal, matches nothing, and folds a pattern-set-only key that replays
+    // regardless of the files the author meant to track. Warn so the missing
+    // var is visible instead of presenting as a clean (but wrong) cache hit.
+    if !unset_vars.is_empty() {
+        tracing::warn!(
+            "[key:{crate_name}] extra_inputs pattern {pattern:?} references unset env var(s) \
+             {unset_vars:?}; they stay literal and match nothing — set the var(s) or remove the \
+             reference, otherwise this folds a replayable matches-nothing key"
+        );
+    }
 
     // A `\x1f` (the fold separator) in a glob is never legitimate and would let
     // a crafted pattern cross the pattern/hash section boundary in the digest.

--- a/src/extra_inputs.rs
+++ b/src/extra_inputs.rs
@@ -489,6 +489,103 @@ fn unparseable_digest(crate_name: &str, config_path: &Path, raw: &[u8]) -> Strin
     hasher.finalize().to_hex().to_string()
 }
 
+/// A crate whose co-located `kache.toml` declares `extra_inputs` but whose
+/// build script won't re-invoke rustc when those files change. Because the key
+/// is only (re)computed when cargo spawns rustc, editing a tracked file in a
+/// warm in-place target restores the stale artifact instead of re-keying —
+/// unless a build script emits a matching `cargo:rerun-if-changed`. Surfaced by
+/// `kache doctor` (rio-build#51 point 1).
+pub(crate) struct RerunGap {
+    pub crate_dir: PathBuf,
+    pub reason: &'static str,
+}
+
+/// Result of [`audit_rerun_coverage`].
+pub(crate) struct RerunAudit {
+    /// Crates found with a non-empty `extra_inputs` declaration.
+    pub declaring: usize,
+    /// Of those, the ones whose build script won't re-trigger rustc.
+    pub gaps: Vec<RerunGap>,
+}
+
+/// Cap on directory entries visited by [`audit_rerun_coverage`], so a `doctor`
+/// run in a huge tree can't walk forever. Generous for any real workspace.
+const AUDIT_WALK_LIMIT: usize = 50_000;
+
+/// Walk `root` for crates that declare `extra_inputs` without a build script
+/// that re-triggers rustc on a tracked-file change.
+///
+/// Heuristic and advisory: a static scan can't know what a build script emits
+/// at runtime, so this only checks whether a `build.rs` exists and mentions
+/// `rerun-if-changed` at all — it can't confirm the rerun path actually covers
+/// the declared globs, nor see a script that emits the directive without the
+/// literal string. Skips `target`, `.git`, and hidden directories.
+pub(crate) fn audit_rerun_coverage(root: &Path) -> RerunAudit {
+    let mut declaring = 0usize;
+    let mut gaps = Vec::new();
+    let mut visited = 0usize;
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            visited += 1;
+            if visited > AUDIT_WALK_LIMIT {
+                return RerunAudit { declaring, gaps };
+            }
+            let path = entry.path();
+            let file_type = entry.file_type();
+            if file_type.map(|t| t.is_dir()).unwrap_or(false) {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                // Skip build output, VCS metadata, and hidden dirs — none hold
+                // a crate root we'd warn about, and `target/` is enormous.
+                if name == "target" || name.starts_with('.') {
+                    continue;
+                }
+                stack.push(path);
+                continue;
+            }
+            if entry.file_name() != COLOCATED_NAME {
+                continue;
+            }
+            // A co-located kache.toml: check its declaration.
+            let Some(crate_dir) = path.parent().map(Path::to_path_buf) else {
+                continue;
+            };
+            let Ok(text) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(config) = toml::from_str::<ColocatedConfig>(&text) else {
+                continue;
+            };
+            if config.extra_inputs.is_empty() {
+                continue;
+            }
+            declaring += 1;
+
+            let build_rs = crate_dir.join("build.rs");
+            let reason = if !build_rs.is_file() {
+                Some("no build.rs to emit cargo:rerun-if-changed")
+            } else {
+                match std::fs::read_to_string(&build_rs) {
+                    Ok(src) if src.contains("rerun-if-changed") => None,
+                    Ok(_) => Some("build.rs emits no cargo:rerun-if-changed"),
+                    Err(_) => None,
+                }
+            };
+            if let Some(reason) = reason {
+                gaps.push(RerunGap { crate_dir, reason });
+            }
+        }
+    }
+
+    gaps.sort_by(|a, b| a.crate_dir.cmp(&b.crate_dir));
+    RerunAudit { declaring, gaps }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -875,5 +972,55 @@ mod tests {
             unreadable, absent,
             "unreadable must not alias absent (false-hit guard)"
         );
+    }
+
+    #[test]
+    fn audit_rerun_coverage_flags_only_uncovered_declaring_crates() {
+        let root = tempfile::tempdir().unwrap();
+        let r = root.path();
+
+        // A: declares extra_inputs, no build.rs -> gap.
+        std::fs::create_dir_all(r.join("a")).unwrap();
+        std::fs::write(r.join("a/kache.toml"), "extra_inputs = [\".sqlx/**\"]").unwrap();
+
+        // B: declares extra_inputs, build.rs WITH rerun-if-changed -> covered.
+        std::fs::create_dir_all(r.join("b")).unwrap();
+        std::fs::write(r.join("b/kache.toml"), "extra_inputs = [\".sqlx/**\"]").unwrap();
+        std::fs::write(
+            r.join("b/build.rs"),
+            "fn main() { println!(\"cargo:rerun-if-changed=.sqlx\"); }",
+        )
+        .unwrap();
+
+        // C: declares extra_inputs, build.rs WITHOUT rerun-if-changed -> gap.
+        std::fs::create_dir_all(r.join("c")).unwrap();
+        std::fs::write(r.join("c/kache.toml"), "extra_inputs = [\"migrations/**\"]").unwrap();
+        std::fs::write(r.join("c/build.rs"), "fn main() {}").unwrap();
+
+        // D: empty declaration (opt-out) -> not counted at all.
+        std::fs::create_dir_all(r.join("d")).unwrap();
+        std::fs::write(r.join("d/kache.toml"), "extra_inputs = []").unwrap();
+
+        // target/ must be skipped even if it holds a kache.toml.
+        std::fs::create_dir_all(r.join("target/x")).unwrap();
+        std::fs::write(r.join("target/x/kache.toml"), "extra_inputs = [\"z/**\"]").unwrap();
+
+        let audit = audit_rerun_coverage(r);
+        assert_eq!(
+            audit.declaring, 3,
+            "A, B, C declare; D opts out; target skipped"
+        );
+        let gap_dirs: Vec<_> = audit
+            .gaps
+            .iter()
+            .map(|g| {
+                g.crate_dir
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        assert_eq!(gap_dirs, vec!["a".to_string(), "c".to_string()]);
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1359,6 +1359,21 @@ fn passthrough(args: &RustcArgs, fallback: Option<&str>) -> Result<PassthroughOu
         );
     }
 
+    // A prior cache hit may have restored read-only (0444) hardlinks into the
+    // target dir; rustc can't overwrite those and fails with EACCES. The cached
+    // path pre-cleans them in `run_rustc`, and the disabled/re-entrant path does
+    // so in `run_compiler_directly` — but a kache-declined *passthrough* (refuse
+    // reason, non-primary, etc.) ran straight into the read-only outputs. Clean
+    // them here too. When the parse couldn't recover crate_name/extra-filename
+    // this still can't act, but `pre_clean_outputs` now logs that at debug
+    // (rio-build#51 / kache#242).
+    compile::pre_clean_outputs(
+        args.output.as_deref(),
+        args.out_dir.as_deref(),
+        args.crate_name.as_deref(),
+        args.extra_filename.as_deref(),
+    );
+
     // Configured fallback wrapper: `<fallback> <rustc> [<inner-rustc>]
     // <args>`. Falls through to a plain passthrough if the fallback
     // binary is not on PATH.


### PR DESCRIPTION
Consolidates the quick-wins batch addressing @lovesegfault's [rio-build#51 review](https://github.com/lovesegfault/rio-build/pull/51#issuecomment-4674696268) of kache into a single PR (one commit per change, so the history is preserved while CI runs once).

Supersedes #355, #356, #357, #358, #359, #360 — each carries an independent regression self-review in its thread. (#354 `--unpretty` and #361 Windows CI timeout already merged.)

## Commits

1. **fix(extra_inputs): warn on unset env var in a pattern** — an unset `$VAR`/`${VAR}` was the one silent failure path (stays literal, matches nothing, folds a replayable key). Now warns, via `expand_env_vars_collecting`. Cache key unchanged.
2. **fix(config): warn on malformed size strings** — `KACHE_MAX_SIZE`/`local_max_size`/`event_log_max_size` that `ByteSize` rejects no longer degrade silently to the default; `parse_size_checked` warns and names the source.
3. **feat(observability): trace key_salt + surface in why-miss** — a salt-induced miss was invisible; `apply_key_salt` now emits a `[key:<crate>] key_salt=…` trace line and `why-miss` shows the active salt. Key byte-identical (label is trace-only).
4. **fix(passthrough): pre-clean read-only restores** — a kache-declined passthrough hit EACCES over a warm read-only target; now pre-cleans like the cached/disabled paths, with a debug line when outputs can't be identified.
5. **feat(doctor): warn when extra_inputs lack rerun-if-changed** — `kache doctor` flags crates that declare `extra_inputs` but whose build script won't re-trigger rustc on a tracked-file change. Diagnostic-only, bounded walk.
6. **docs(config): extra_inputs timing caveat, wrapper chaining, env vars** — documents the warm-target re-key limitation, `RUSTC_WORKSPACE_WRAPPER` chaining, and adds `KACHE_BASE_DIR`/`KACHE_NAMESPACE` to the env table.

## Verification

Local: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --bin kache` (767 passed) all green on the combined branch. Each change additionally reviewed for regressions (verdict: none) — see the superseded PR threads.

Already-fixed-in-0.7.0 review points (no change needed): `-Z` flags are keyed, `RUSTC_WORKSPACE_WRAPPER` chaining is implemented, `KACHE_DISABLED` values are documented.