### PR TITLE
ci(bench): target kunobi-runners scale-set by name (fix never-scheduling bench job)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,9 +11,12 @@ name: Bench
 #   - dispatch  : manual, pick a scenario (default all) and pass extra `just
 #                 bench` flags (e.g. `--skip-clone`, `--retry`).
 #
-# Runs on the kunobi self-hosted Linux ARC runner (labels
-# self-hosted,Linux,X64,kunobi — the `kunobi-runners` gha-runner-scale-set in
-# tenant-int-dev/zur1-builder1). These are EPHEMERAL pods (fresh per job,
+# Runs on the kunobi self-hosted Linux ARC runner: the `kunobi-runners`
+# gha-runner-scale-set in tenant-int-dev/zur1-builder1. A gha-runner-scale-set
+# is targeted by its INSTALLATION NAME as a single `runs-on` label
+# (`runs-on: kunobi-runners`) — NOT by a `[self-hosted, Linux, X64, …]` label
+# set (that scheme only matches the legacy multi-label runners, e.g.
+# kunobi-windows). These are EPHEMERAL pods (fresh per job,
 # `_work` is an emptyDir): there is no stale tool state to isolate, but there is
 # also no persistent clone-ref cache, so every run re-clones the upstream repo,
 # and Firefox's `./mach bootstrap` re-provisions ~/.mozbuild each time. The image
@@ -82,7 +85,9 @@ jobs:
   bench:
     name: Bench (${{ matrix.scenario }})
     needs: plan
-    runs-on: ["self-hosted", "Linux", "X64", "kunobi"]
+    # gha-runner-scale-set: match by the scale-set's installation name (single
+    # label), not a `[self-hosted, …]` set. See header comment.
+    runs-on: kunobi-runners
     timeout-minutes: ${{ matrix.timeout }}
     strategy:
       # The arms run concurrently when the scale set has spare runners


### PR DESCRIPTION
## Problem
The `Bench` workflow (added in #353) targets the kunobi Linux runner with:

```yaml
runs-on: ["self-hosted", "Linux", "X64", "kunobi"]
```

But that runner is a **gha-runner-scale-set** (`kunobi-runners`, runner group `kunobi`, on int-dev/zur1-builder1), and a scale-set is matched by its **installation name as a single `runs-on` label** — it does **not** carry `self-hosted`/`Linux`/`X64`/`kunobi` labels. So **no runner can ever match**, and a dispatched bench job sits **queued forever** (never scheduled).

I caught this when a manual `workflow_dispatch` of `Bench` (scenario=substrate) stayed `queued` for 8+ min with no runner assigned, then cancelled it.

## Confirmation (both sides)
- **GitHub**: the org runner list shows `kunobi-runners` registered with a **single label `kunobi-runners`**, runner group `kunobi`, status **Online** — no `Linux`/`self-hosted`/`kunobi` labels.
- **Cluster** (`int-dev/zur1-builder1`, v2): the `actions.github.com` ARC CRDs (`AutoscalingRunnerSet`, `EphemeralRunnerSet`, `EphemeralRunner`) are installed → gha-runner-scale-set, not the legacy multi-label `RunnerDeployment`.

The legacy multi-label scheme (`[self-hosted, Windows, X64, kunobi-windows]`, `[self-hosted, macOS, ARM64]`) only matches the **persistent** runners (kunobi-windows, mac-mini) — not this scale-set.

## Fix
```yaml
runs-on: kunobi-runners
```

Plus a header-comment correction explaining the scale-set-name targeting rule.

## Validation
- `actionlint` clean (only a pre-existing SC2170 false positive in the unchanged disk-precheck step, from actionlint substituting `${{ matrix.min_free_gb }}`).
- After merge, dispatch `Bench` with `scenario=substrate` and confirm the job is **picked up** by a `kunobi-runners` pod (the live infra check this unblocks).

Builds on #353.