### PR TITLE
feat(config): add `ignore_env` to pin a config against env overrides

### DIFF
--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -63,6 +63,7 @@ profile = "my-aws-profile"            # omit to use the default credential chain
 | `KACHE_CC_EXTRA_ALLOWLIST_FLAGS` | `cc.extra_allowlist_flags` | `[]` | C/C++ flags to opt into caching that kache's built-in allow-list doesn't yet model (see [Extra cc allowlist flags](#extra-cc-allowlist-flags)). Env value is whitespace-separated |
 | `KACHE_DISABLED` | — | `false` | Disable caching entirely (pass-through to rustc). Env-only, no config key: `1` or `true` (case-insensitive) disables; any other value — including `0`, `false`, or unset — leaves caching on |
 | `KACHE_LOCAL_ONLY` | `cache.local_only` | `false` | Strict local-only mode: ignore **all** remote and planner config/env (no S3 bucket, no planner endpoint, no egress) for a guaranteed-hermetic build. Local caching stays fully on — unlike `KACHE_DISABLED`. `1`/`true` enables; env wins over the file (an explicit `0` overrides `local_only = true`) |
+| — (file-only) | `cache.ignore_env` | `false` | Make the config file authoritative by ignoring `KACHE_*` env overrides for file-backed settings (see [Pinning config against env](#pinning-config-against-env)) |
 | `KACHE_FALLBACK` | `cache.fallback` | — | Secondary compiler-wrapper to hand passed-through compiles to; kache runs `<fallback> <compiler> <args>` when it declines to cache. `off`/`none`/empty disables |
 | `KACHE_PATH_ONLY_ENV_VARS` | `cache.path_only_env_vars` | `[]` | Extra env vars (besides `OUT_DIR`) whose values only locate an `include!`'d file, so kache normalizes their absolute path in the cache key. Env value is comma/whitespace-separated and replaces the file list (see [Path-only env vars](#path-only-env-vars)) |
 | `KACHE_PLANNER_ENDPOINT` | `cache.planner.endpoint` | — | Prefetch-planner service URL; setting it enables the planner client. Empty/whitespace is treated as unset |
@@ -91,6 +92,22 @@ exclude = [
 Patterns are globs matched against the compiler's primary source path. Relative patterns are matched relative to the current build directory and, when kache can infer it, the Cargo workspace root. Excluded invocations bypass local lookup, remote lookup, store, and upload.
 
 Exclude patterns support `~`, `$VAR`, and `${VAR}` expansion. `$CARGO_HOME` falls back to Cargo's default `~/.cargo` when the environment variable is not set, so registry-source exclusions work on default Cargo installs.
+
+## Pinning config against env
+
+By default every `KACHE_*` environment variable **wins** over the config file — convenient for CI overrides, but it means a stray machine-global export can silently change behavior. The riskiest case is `KACHE_KEY_SALT`: a leaked export would shift *every* cache key without a word.
+
+Set `ignore_env` to make a pinned config authoritative:
+
+```toml title=".kache.toml"
+[cache]
+ignore_env = true
+key_salt = "v3-toolchain-abc"
+```
+
+With this, kache ignores the `KACHE_*` overrides for **file-backed settings** (cache dir, max size, key salt, fallback, S3/planner settings, the toggles, etc.) and takes the file value (or built-in default) instead. When an ignored override is actually set, kache logs a warning naming it, so the suppression is never silent.
+
+`ignore_env` is **file-only** by design — an env var can't re-enable env overrides, or the lockdown would be trivially undone by the same stray export it defends against. It deliberately does **not** cover bootstrap/operational vars that have no file representation (`KACHE_CONFIG`, `KACHE_DISABLED`, `KACHE_LOG` / `KACHE_LOG_FILE` / `KACHE_PROGRESS`, `KACHE_NAMESPACE`, `KACHE_BASE_DIR`) or S3 credentials (`KACHE_S3_ACCESS_KEY` / `KACHE_S3_SECRET_KEY`), which are secrets rather than config.
 
 ## Cache-key salt
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,6 +132,9 @@ pub(crate) struct CacheFileConfig {
     pub(crate) local_only: Option<bool>,
     /// Too-new-input guard. See [`Config::modified_input_guard`].
     pub(crate) modified_input_guard: Option<bool>,
+    /// Ignore `KACHE_*` env overrides for file-backed settings. File-only by
+    /// design (env must not re-enable env). See [`Config::ignore_env_enabled`].
+    pub(crate) ignore_env: Option<bool>,
     pub(crate) cache_executables: Option<bool>,
     pub(crate) clean_incremental: Option<bool>,
     pub(crate) exclude: Option<Vec<String>>,
@@ -197,21 +200,26 @@ pub(crate) struct EnvOverrides {
 
 impl EnvOverrides {
     pub(crate) fn detect() -> Self {
+        // When the pinned config sets `ignore_env`, gated env vars no longer win,
+        // so they must NOT show as env-locked in the TUI. `KACHE_DISABLED` is
+        // ungated and always reflects its real env state.
+        let ignore_env = Config::ignore_env_enabled(&Config::load_file_config());
         Self {
             disabled: std::env::var("KACHE_DISABLED").is_ok(),
-            local_only: std::env::var("KACHE_LOCAL_ONLY").is_ok(),
-            cache_dir: std::env::var("KACHE_CACHE_DIR").is_ok(),
-            max_size: std::env::var("KACHE_MAX_SIZE").is_ok(),
-            cache_executables: std::env::var("KACHE_CACHE_EXECUTABLES").is_ok(),
-            clean_incremental: std::env::var("KACHE_CLEAN_INCREMENTAL").is_ok(),
-            s3_bucket: std::env::var("KACHE_S3_BUCKET").is_ok(),
-            s3_endpoint: std::env::var("KACHE_S3_ENDPOINT").is_ok(),
-            s3_region: std::env::var("KACHE_S3_REGION").is_ok(),
-            s3_prefix: std::env::var("KACHE_S3_PREFIX").is_ok(),
-            s3_profile: std::env::var("KACHE_S3_PROFILE").is_ok(),
-            fallback: std::env::var("KACHE_FALLBACK").is_ok(),
-            key_salt: std::env::var("KACHE_KEY_SALT").is_ok(),
-            cc_extra_allowlist_flags: std::env::var("KACHE_CC_EXTRA_ALLOWLIST_FLAGS").is_ok(),
+            local_only: env_or_ignored("KACHE_LOCAL_ONLY", ignore_env).is_ok(),
+            cache_dir: env_or_ignored("KACHE_CACHE_DIR", ignore_env).is_ok(),
+            max_size: env_or_ignored("KACHE_MAX_SIZE", ignore_env).is_ok(),
+            cache_executables: env_or_ignored("KACHE_CACHE_EXECUTABLES", ignore_env).is_ok(),
+            clean_incremental: env_or_ignored("KACHE_CLEAN_INCREMENTAL", ignore_env).is_ok(),
+            s3_bucket: env_or_ignored("KACHE_S3_BUCKET", ignore_env).is_ok(),
+            s3_endpoint: env_or_ignored("KACHE_S3_ENDPOINT", ignore_env).is_ok(),
+            s3_region: env_or_ignored("KACHE_S3_REGION", ignore_env).is_ok(),
+            s3_prefix: env_or_ignored("KACHE_S3_PREFIX", ignore_env).is_ok(),
+            s3_profile: env_or_ignored("KACHE_S3_PROFILE", ignore_env).is_ok(),
+            fallback: env_or_ignored("KACHE_FALLBACK", ignore_env).is_ok(),
+            key_salt: env_or_ignored("KACHE_KEY_SALT", ignore_env).is_ok(),
+            cc_extra_allowlist_flags: env_or_ignored("KACHE_CC_EXTRA_ALLOWLIST_FLAGS", ignore_env)
+                .is_ok(),
         }
     }
 }
@@ -231,15 +239,85 @@ fn normalize_cc_flags(raw: impl IntoIterator<Item = String>) -> Vec<String> {
     out
 }
 
+/// The `KACHE_*` env vars suppressed by `[cache] ignore_env`: every file-backed
+/// setting. Deliberately excludes bootstrap/operational vars that have no file
+/// representation — `KACHE_CONFIG` (locates the file itself), `KACHE_DISABLED`
+/// (operational kill switch), `KACHE_LOG`/`KACHE_LOG_FILE`/`KACHE_PROGRESS`,
+/// `KACHE_NAMESPACE`, `KACHE_BASE_DIR` — and S3 credentials
+/// (`KACHE_S3_ACCESS_KEY`/`KACHE_S3_SECRET_KEY`), which are secrets, not config.
+/// Used only to warn which overrides are being ignored; the gating itself is
+/// done inline via [`env_or_ignored`].
+const IGNORE_ENV_GATED_VARS: &[&str] = &[
+    "KACHE_CACHE_DIR",
+    "KACHE_MAX_SIZE",
+    "KACHE_CACHE_EXECUTABLES",
+    "KACHE_CLEAN_INCREMENTAL",
+    "KACHE_COMPRESSION_LEVEL",
+    "KACHE_S3_CONCURRENCY",
+    "KACHE_DAEMON_IDLE_TIMEOUT",
+    "KACHE_S3_POOL_IDLE_SECS",
+    "KACHE_FALLBACK",
+    "KACHE_KEY_SALT",
+    "KACHE_CC_EXTRA_ALLOWLIST_FLAGS",
+    "KACHE_PATH_ONLY_ENV_VARS",
+    "KACHE_S3_BUCKET",
+    "KACHE_S3_ENDPOINT",
+    "KACHE_S3_REGION",
+    "KACHE_S3_PREFIX",
+    "KACHE_S3_PROFILE",
+    "KACHE_LOCAL_ONLY",
+    "KACHE_MODIFIED_INPUT_GUARD",
+    "KACHE_PLANNER_ENDPOINT",
+    "KACHE_PLANNER_TIMEOUT_MS",
+    "KACHE_PLANNER_TOKEN",
+];
+
+/// Read a `KACHE_*` env var, unless the pinned config asked to ignore env
+/// (`[cache] ignore_env = true`). Returns `Err(NotPresent)` when locked, so
+/// every existing env -> file -> default fallback arm transparently skips the
+/// env value and takes the file/default. A drop-in for `std::env::var` on the
+/// file-backed settings (see [`IGNORE_ENV_GATED_VARS`]).
+fn env_or_ignored(name: &str, ignore_env: bool) -> Result<String, std::env::VarError> {
+    if ignore_env {
+        Err(std::env::VarError::NotPresent)
+    } else {
+        std::env::var(name)
+    }
+}
+
+/// Warn (once, loudly) which gated `KACHE_*` overrides are present but being
+/// ignored because the pinned config set `ignore_env = true`. The whole point
+/// of the feature is that a stray machine-global export (e.g. `KACHE_KEY_SALT`)
+/// can't *silently* shift the cache key — so make the suppression visible.
+fn warn_ignored_env_overrides() {
+    let present: Vec<&str> = IGNORE_ENV_GATED_VARS
+        .iter()
+        .copied()
+        .filter(|name| std::env::var_os(name).is_some())
+        .collect();
+    if !present.is_empty() {
+        tracing::warn!(
+            "[cache] ignore_env = true: ignoring set env override(s) {present:?} in favor of the \
+             config file"
+        );
+    }
+}
+
 impl Config {
     pub fn load() -> Result<Self> {
         let file_config = Self::load_file_config();
+        let ignore_env = Self::ignore_env_enabled(&file_config);
+        if ignore_env {
+            warn_ignored_env_overrides();
+        }
 
+        // NOTE: `KACHE_DISABLED` is intentionally NOT gated by `ignore_env` —
+        // it's an operational kill switch, not a file-backed setting.
         let disabled = std::env::var("KACHE_DISABLED")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
 
-        let cache_dir = std::env::var("KACHE_CACHE_DIR")
+        let cache_dir = env_or_ignored("KACHE_CACHE_DIR", ignore_env)
             .map(PathBuf::from)
             .or_else(|_| {
                 file_config
@@ -252,7 +330,7 @@ impl Config {
             })
             .unwrap_or_else(|_| default_cache_dir());
 
-        let max_size = std::env::var("KACHE_MAX_SIZE")
+        let max_size = env_or_ignored("KACHE_MAX_SIZE", ignore_env)
             .ok()
             .and_then(|s| parse_size_checked(&s, "KACHE_MAX_SIZE"))
             .or_else(|| {
@@ -265,7 +343,7 @@ impl Config {
             })
             .unwrap_or(50 * 1024 * 1024 * 1024); // 50 GiB
 
-        let cache_executables = std::env::var("KACHE_CACHE_EXECUTABLES")
+        let cache_executables = env_or_ignored("KACHE_CACHE_EXECUTABLES", ignore_env)
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or_else(|_| {
                 file_config
@@ -276,7 +354,7 @@ impl Config {
                     .unwrap_or(false)
             });
 
-        let clean_incremental = std::env::var("KACHE_CLEAN_INCREMENTAL")
+        let clean_incremental = env_or_ignored("KACHE_CLEAN_INCREMENTAL", ignore_env)
             .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
             .unwrap_or_else(|_| {
                 file_config
@@ -302,7 +380,7 @@ impl Config {
             .and_then(|c| c.event_log_keep_lines)
             .unwrap_or(1000);
 
-        let compression_level = std::env::var("KACHE_COMPRESSION_LEVEL")
+        let compression_level = env_or_ignored("KACHE_COMPRESSION_LEVEL", ignore_env)
             .ok()
             .and_then(|s| s.parse::<i32>().ok())
             .or_else(|| {
@@ -315,7 +393,7 @@ impl Config {
             .unwrap_or(3)
             .clamp(1, 22);
 
-        let s3_concurrency = std::env::var("KACHE_S3_CONCURRENCY")
+        let s3_concurrency = env_or_ignored("KACHE_S3_CONCURRENCY", ignore_env)
             .ok()
             .and_then(|s| s.parse::<u32>().ok())
             .or_else(|| {
@@ -327,7 +405,7 @@ impl Config {
             })
             .unwrap_or(16);
 
-        let daemon_idle_timeout_secs = std::env::var("KACHE_DAEMON_IDLE_TIMEOUT")
+        let daemon_idle_timeout_secs = env_or_ignored("KACHE_DAEMON_IDLE_TIMEOUT", ignore_env)
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
             .or_else(|| {
@@ -339,7 +417,7 @@ impl Config {
             })
             .unwrap_or(DEFAULT_DAEMON_IDLE_TIMEOUT_SECS);
 
-        let s3_pool_idle_secs = std::env::var("KACHE_S3_POOL_IDLE_SECS")
+        let s3_pool_idle_secs = env_or_ignored("KACHE_S3_POOL_IDLE_SECS", ignore_env)
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
             .or_else(|| {
@@ -353,7 +431,7 @@ impl Config {
 
         // Fallback compiler-wrapper for passed-through compiles. Env
         // wins over the file; empty / "off" / "none" disables it.
-        let fallback = std::env::var("KACHE_FALLBACK")
+        let fallback = env_or_ignored("KACHE_FALLBACK", ignore_env)
             .ok()
             .or_else(|| {
                 file_config
@@ -369,7 +447,7 @@ impl Config {
 
         // Cache-key salt. Env wins over the file; an empty / whitespace
         // value is treated as unset so it never silently shifts the key.
-        let key_salt = std::env::var("KACHE_KEY_SALT")
+        let key_salt = env_or_ignored("KACHE_KEY_SALT", ignore_env)
             .ok()
             .or_else(|| {
                 file_config
@@ -384,22 +462,23 @@ impl Config {
         // User-declared cc allowlist flags (issue #95). Env wins over the
         // file: a set `KACHE_CC_EXTRA_ALLOWLIST_FLAGS` (whitespace-separated,
         // possibly empty → disables) replaces the file list entirely.
-        let cc_extra_allowlist_flags = match std::env::var("KACHE_CC_EXTRA_ALLOWLIST_FLAGS") {
-            Ok(val) => normalize_cc_flags(val.split_whitespace().map(str::to_string)),
-            Err(_) => normalize_cc_flags(
-                file_config
-                    .as_ref()
-                    .ok()
-                    .and_then(|c| c.cc.as_ref())
-                    .and_then(|c| c.extra_allowlist_flags.clone())
-                    .unwrap_or_default(),
-            ),
-        };
+        let cc_extra_allowlist_flags =
+            match env_or_ignored("KACHE_CC_EXTRA_ALLOWLIST_FLAGS", ignore_env) {
+                Ok(val) => normalize_cc_flags(val.split_whitespace().map(str::to_string)),
+                Err(_) => normalize_cc_flags(
+                    file_config
+                        .as_ref()
+                        .ok()
+                        .and_then(|c| c.cc.as_ref())
+                        .and_then(|c| c.extra_allowlist_flags.clone())
+                        .unwrap_or_default(),
+                ),
+            };
 
         // Path-only env-var allowlist (the OUT_DIR-style normalization opt-in).
         // Env wins over the file: a set `KACHE_PATH_ONLY_ENV_VARS`
         // (comma/whitespace-separated) replaces the file list entirely.
-        let path_only_env_vars = match std::env::var("KACHE_PATH_ONLY_ENV_VARS") {
+        let path_only_env_vars = match env_or_ignored("KACHE_PATH_ONLY_ENV_VARS", ignore_env) {
             Ok(val) => val
                 .split([',', ' ', '\t', '\n'])
                 .filter(|p| !p.is_empty())
@@ -495,25 +574,30 @@ impl Config {
     }
 
     fn load_remote_config(file_config: &Result<FileConfig>) -> Option<RemoteConfig> {
-        let bucket = std::env::var("KACHE_S3_BUCKET").ok().or_else(|| {
-            file_config
-                .as_ref()
-                .ok()
-                .and_then(|c| c.cache.as_ref())
-                .and_then(|c| c.remote.as_ref())
-                .and_then(|r| r.bucket.clone())
-        })?;
+        let ignore_env = Self::ignore_env_enabled(file_config);
+        let bucket = env_or_ignored("KACHE_S3_BUCKET", ignore_env)
+            .ok()
+            .or_else(|| {
+                file_config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.cache.as_ref())
+                    .and_then(|c| c.remote.as_ref())
+                    .and_then(|r| r.bucket.clone())
+            })?;
 
-        let endpoint = std::env::var("KACHE_S3_ENDPOINT").ok().or_else(|| {
-            file_config
-                .as_ref()
-                .ok()
-                .and_then(|c| c.cache.as_ref())
-                .and_then(|c| c.remote.as_ref())
-                .and_then(|r| r.endpoint.clone())
-        });
+        let endpoint = env_or_ignored("KACHE_S3_ENDPOINT", ignore_env)
+            .ok()
+            .or_else(|| {
+                file_config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.cache.as_ref())
+                    .and_then(|c| c.remote.as_ref())
+                    .and_then(|r| r.endpoint.clone())
+            });
 
-        let region = std::env::var("KACHE_S3_REGION")
+        let region = env_or_ignored("KACHE_S3_REGION", ignore_env)
             .ok()
             .or_else(|| {
                 file_config
@@ -525,7 +609,7 @@ impl Config {
             })
             .unwrap_or_else(|| "us-east-1".to_string());
 
-        let prefix = std::env::var("KACHE_S3_PREFIX")
+        let prefix = env_or_ignored("KACHE_S3_PREFIX", ignore_env)
             .ok()
             .or_else(|| {
                 file_config
@@ -537,7 +621,7 @@ impl Config {
             })
             .unwrap_or_else(|| "artifacts".to_string());
 
-        let profile = std::env::var("KACHE_S3_PROFILE")
+        let profile = env_or_ignored("KACHE_S3_PROFILE", ignore_env)
             .ok()
             .or_else(|| {
                 file_config
@@ -563,8 +647,27 @@ impl Config {
     /// file, mirroring the other toggles: `KACHE_LOCAL_ONLY=1`/`=true` (or any
     /// other value to force it *off*, overriding the file), else
     /// `[cache] local_only`, else off.
+    /// Whether the pinned config asked kache to ignore `KACHE_*` env overrides
+    /// for file-backed settings (`[cache] ignore_env = true`).
+    ///
+    /// Deliberately **file-only**: an env var must not be able to re-enable env
+    /// overrides, or the lockdown a pinned config wants would be trivially
+    /// undone by the same stray export it's meant to defend against. The intent
+    /// is to let a project pin its config so a machine-global `KACHE_KEY_SALT`
+    /// (or any other override) can't silently change behavior — see
+    /// [`IGNORE_ENV_GATED_VARS`] for exactly what is and isn't covered.
+    fn ignore_env_enabled(file_config: &Result<FileConfig>) -> bool {
+        file_config
+            .as_ref()
+            .ok()
+            .and_then(|c| c.cache.as_ref())
+            .and_then(|c| c.ignore_env)
+            .unwrap_or(false)
+    }
+
     fn local_only_enabled(file_config: &Result<FileConfig>) -> bool {
-        if let Ok(v) = std::env::var("KACHE_LOCAL_ONLY") {
+        let ignore_env = Self::ignore_env_enabled(file_config);
+        if let Ok(v) = env_or_ignored("KACHE_LOCAL_ONLY", ignore_env) {
             return v == "1" || v.eq_ignore_ascii_case("true");
         }
         file_config
@@ -579,7 +682,8 @@ impl Config {
     /// Env wins over the file: `KACHE_MODIFIED_INPUT_GUARD=1`/`=true`, else
     /// `[cache] modified_input_guard`, else off.
     fn modified_input_guard_enabled(file_config: &Result<FileConfig>) -> bool {
-        if let Ok(v) = std::env::var("KACHE_MODIFIED_INPUT_GUARD") {
+        let ignore_env = Self::ignore_env_enabled(file_config);
+        if let Ok(v) = env_or_ignored("KACHE_MODIFIED_INPUT_GUARD", ignore_env) {
             return v == "1" || v.eq_ignore_ascii_case("true");
         }
         file_config
@@ -592,6 +696,7 @@ impl Config {
 
     pub fn load_planner_config() -> Option<PlannerConfig> {
         let file_config = Self::load_file_config();
+        let ignore_env = Self::ignore_env_enabled(&file_config);
 
         // Strict local-only mode (#221) suppresses the planner entirely —
         // symmetric with `remote` being forced to `None` in `load`.
@@ -599,7 +704,7 @@ impl Config {
             return None;
         }
 
-        let endpoint = std::env::var("KACHE_PLANNER_ENDPOINT")
+        let endpoint = env_or_ignored("KACHE_PLANNER_ENDPOINT", ignore_env)
             .ok()
             .or_else(|| {
                 file_config
@@ -612,7 +717,7 @@ impl Config {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())?;
 
-        let timeout_ms = std::env::var("KACHE_PLANNER_TIMEOUT_MS")
+        let timeout_ms = env_or_ignored("KACHE_PLANNER_TIMEOUT_MS", ignore_env)
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
             .or_else(|| {
@@ -625,7 +730,7 @@ impl Config {
             })
             .unwrap_or(DEFAULT_PLANNER_TIMEOUT_MS);
 
-        let token = std::env::var("KACHE_PLANNER_TOKEN")
+        let token = env_or_ignored("KACHE_PLANNER_TOKEN", ignore_env)
             .ok()
             .or_else(|| {
                 file_config
@@ -1000,12 +1105,52 @@ mod tests {
     }
 
     #[test]
+    fn ignore_env_makes_file_win_over_env() {
+        let _lock = config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = dir.path().join("config.toml");
+
+        // Restore KACHE_KEY_SALT after the test regardless of outcome.
+        struct SaltGuard(Option<OsString>);
+        impl Drop for SaltGuard {
+            fn drop(&mut self) {
+                unsafe {
+                    match self.0.as_ref() {
+                        Some(v) => std::env::set_var("KACHE_KEY_SALT", v),
+                        None => std::env::remove_var("KACHE_KEY_SALT"),
+                    }
+                }
+            }
+        }
+        let _salt = SaltGuard(std::env::var_os("KACHE_KEY_SALT"));
+        unsafe { std::env::set_var("KACHE_KEY_SALT", "from-env") };
+
+        let _g = set_kache_config_for_test(&cfg);
+
+        // ignore_env = true: the pinned file's salt wins; the stray env is
+        // ignored (the exact footgun the feature defends against).
+        std::fs::write(
+            &cfg,
+            "[cache]\nignore_env = true\nkey_salt = \"from-file\"\n",
+        )
+        .unwrap();
+        let loaded = Config::load().unwrap();
+        assert_eq!(loaded.key_salt.as_deref(), Some("from-file"));
+
+        // Without ignore_env, default precedence holds: env wins over the file.
+        std::fs::write(&cfg, "[cache]\nkey_salt = \"from-file\"\n").unwrap();
+        let loaded = Config::load().unwrap();
+        assert_eq!(loaded.key_salt.as_deref(), Some("from-env"));
+    }
+
+    #[test]
     fn test_file_config_roundtrip() {
         let config = FileConfig {
             cc: None,
             cache: Some(CacheFileConfig {
                 local_only: None,
                 modified_input_guard: None,
+                ignore_env: None,
                 fallback: None,
                 key_salt: None,
                 path_only_env_vars: None,
@@ -1446,6 +1591,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
             cache: Some(CacheFileConfig {
                 local_only: None,
                 modified_input_guard: None,
+                ignore_env: None,
                 fallback: None,
                 key_salt: None,
                 path_only_env_vars: None,

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -98,6 +98,10 @@ struct EditorState {
     /// `[cache] modified_input_guard` as loaded — the editor has no form field
     /// for it, so carry it through verbatim on save (kunobi-ninja/kache#324).
     preserved_modified_input_guard: Option<bool>,
+    /// `[cache] ignore_env` as loaded — the editor has no form field for it, so
+    /// carry it through verbatim on save (dropping it would silently disable the
+    /// env lockdown).
+    preserved_ignore_env: Option<bool>,
 }
 
 // ── Build form fields from FileConfig ─────────────────────────────────────
@@ -401,6 +405,7 @@ fn fields_to_file_config(
     preserved_path_only_env_vars: Option<Vec<String>>,
     preserved_local_only: Option<bool>,
     preserved_modified_input_guard: Option<bool>,
+    preserved_ignore_env: Option<bool>,
 ) -> FileConfig {
     let get = |key: &str| -> Option<String> {
         fields.iter().find(|f| f.key == key).and_then(|f| {
@@ -478,6 +483,7 @@ fn fields_to_file_config(
             planner: preserved_planner,
             local_only: preserved_local_only,
             modified_input_guard: preserved_modified_input_guard,
+            ignore_env: preserved_ignore_env,
             cache_executables: get_bool("cache_executables"),
             clean_incremental: get_bool("clean_incremental"),
             exclude: get_list("exclude"),
@@ -531,6 +537,7 @@ pub fn run_config_editor() -> Result<()> {
             .cache
             .as_ref()
             .and_then(|c| c.modified_input_guard),
+        preserved_ignore_env: file_config.cache.as_ref().and_then(|c| c.ignore_env),
     };
 
     // Run initial validation
@@ -710,6 +717,7 @@ fn do_save(state: &mut EditorState) {
         state.preserved_path_only_env_vars.clone(),
         state.preserved_local_only,
         state.preserved_modified_input_guard,
+        state.preserved_ignore_env,
     );
     match Config::save_file_config(&config) {
         Ok(()) => {
@@ -1151,6 +1159,7 @@ mod tests {
             cache: Some(CacheFileConfig {
                 local_only: None,
                 modified_input_guard: None,
+                ignore_env: None,
                 fallback: None,
                 key_salt: None,
                 path_only_env_vars: None,
@@ -1196,6 +1205,7 @@ mod tests {
                 .and_then(|c| c.path_only_env_vars.clone()),
             original.cache.as_ref().and_then(|c| c.local_only),
             original.cache.as_ref().and_then(|c| c.modified_input_guard),
+            original.cache.as_ref().and_then(|c| c.ignore_env),
         );
 
         let cache = reconstructed.cache.as_ref().unwrap();
@@ -1229,7 +1239,7 @@ mod tests {
     fn test_fields_to_file_config_empty_omits_remote() {
         let config = FileConfig::default();
         let fields = build_fields(&config, &empty_env());
-        let result = fields_to_file_config(&fields, None, None, None, None, None);
+        let result = fields_to_file_config(&fields, None, None, None, None, None, None);
         assert!(result.cache.as_ref().unwrap().remote.is_none());
     }
 


### PR DESCRIPTION
## Problem

Every `KACHE_*` env var wins over the config file in every `Config::load` arm. Convenient for CI, but a stray machine-global export can **silently** change behavior — the worst case being `KACHE_KEY_SALT`, which would shift every cache key without a word. The rio-build wrapper ships an allowlist-scrub solely to defend against this.

## Fix

A file-only `[cache] ignore_env`:

```toml
[cache]
ignore_env = true
key_salt = "v3-toolchain-abc"
```

When set, kache ignores `KACHE_*` overrides for **file-backed** settings and uses the file value (or default). Implemented via a drop-in `env_or_ignored(name, ignore_env)` returning `Err(NotPresent)` when locked, so every existing env→file→default arm transparently takes the file value. When an ignored override *is* set, a warning names it — the suppression is never silent.

**Scope (intentional):** file-only (env can't re-enable env, or the lockdown is trivially undone). Does **not** cover bootstrap/operational vars (`KACHE_CONFIG`, `KACHE_DISABLED`, `KACHE_LOG*`, `KACHE_NAMESPACE`, `KACHE_BASE_DIR`) or S3 credentials (secrets, not config). The full gated set is `IGNORE_ENV_GATED_VARS`.

TUI carries the field through verbatim on save; `EnvOverrides::detect` respects it so locked fields aren't shown as env-overridden.

## Context

From @lovesegfault's [rio-build#51 review](https://github.com/lovesegfault/rio-build/pull/51): *"env lockdown for pinned configs (`ignore_env = true` or similar): my wrapper ships an allowlist scrub solely because env beats file in every `Config::load` arm… a stray machine-global export would use [`KACHE_KEY_SALT`] to silently shift every key."*

## Test

`ignore_env_makes_file_win_over_env` — with a stray `KACHE_KEY_SALT=from-env`, `ignore_env=true` yields the file's salt; without it, env wins (default precedence preserved). `cargo test --bin kache` (768) + clippy `--all-targets` green. Docs: new "Pinning config against env" section + table row.