### PR TITLE
ci(bench): fix upload step — drop fragile hashFiles gate, capture build logs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -171,21 +171,26 @@ jobs:
           RUSTUP_TOOLCHAIN: ""
 
       - name: Upload bench reports
-        # always(): a failed/leaky run's reports + key-diff are the most useful
-        # artifacts to inspect. Gated on the scratch dir existing so a precheck
-        # failure (which produces nothing) doesn't error the upload.
-        if: always() && hashFiles(format('tmp/bench/bench-{0}/**', matrix.scenario)) != ''
+        # always(): a failed/leaky run's reports + build/wrapper logs are the most
+        # useful artifacts to inspect. NO hashFiles() gate: hashFiles globs the
+        # WHOLE scratch tree (multi-GB clone worktrees, .git, the engine's live
+        # unix socket) and THROWS on the socket/special files — which errored the
+        # upload even on a valid run and discarded build-cold.log. `if-no-files-found:
+        # warn` already makes an empty match (e.g. after a precheck failure) a no-op.
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: bench-${{ matrix.scenario }}
-          # Reports, per-phase JSON/MD, key-diff, and wrapper logs. Excludes the
-          # multi-GB clone worktrees / objdirs / cache so the artifact stays small.
+          # Reports, per-phase JSON/MD, key-diff, and ALL top-level logs
+          # (build-cold/build-warm/wrapper-* — the build logs hold the actual
+          # compile error on a failed run). These are flat globs in the scratch
+          # dir, so they exclude the multi-GB clone worktrees / objdirs / cache.
           path: |
             tmp/bench/bench-${{ matrix.scenario }}/*.json
             tmp/bench/bench-${{ matrix.scenario }}/*.md
             tmp/bench/bench-${{ matrix.scenario }}/report-*.json
             tmp/bench/bench-${{ matrix.scenario }}/report-*.md
             tmp/bench/bench-${{ matrix.scenario }}/key-diff.*
-            tmp/bench/bench-${{ matrix.scenario }}/wrapper-*.log
+            tmp/bench/bench-${{ matrix.scenario }}/*.log
           retention-days: 30
           if-no-files-found: warn


### PR DESCRIPTION
## Problem
The `Bench` workflow's **Upload bench reports** step errored on a real run and uploaded **nothing**:

```
##[error]hashFiles('tmp/bench/bench-substrate/**') failed.
Fail to hash files under directory '/home/runner/_work/kache/kache'
```

The step was gated on:
```yaml
if: always() && hashFiles(format('tmp/bench/bench-{0}/**', matrix.scenario)) != ''
```
`hashFiles('…/**')` recursively hashes the **entire** scratch tree — which contains the multi-GB clone worktrees, their `.git` dirs, and the bench engine's **live unix socket**. `hashFiles` throws on the socket / special files, so the step failed **even on an otherwise valid run**.

Worse: this discarded `build-cold.log` — the only place the cold-build's compile output is written — so a failed bench (`cargo build … exit 101`) is left **undiagnosable**.

## Fix
- **Drop the `hashFiles` gate** → `if: always()`. `if-no-files-found: warn` already makes an empty match (e.g. after a precheck failure) a no-op, so the gate was both redundant and broken.
- **Broaden the log glob** from `wrapper-*.log` to `*.log` so `build-cold.log` / `build-warm.log` upload alongside the wrapper logs. All globs are **flat** (single dir), so the giant clone worktrees / objdirs / cache are still excluded and the artifact stays small.

## Context
Found while running the first live `Bench` dispatches after #353/#363. Two separate issues surfaced:
1. **This PR** — the upload step bug (latent since #353; would have failed every run).
2. A **substrate cold-build failure** (`cargo build --release -p polkadot`, exit 101) — still being diagnosed; this PR is the prerequisite to actually capture its log.

## Validation
Re-dispatched substrate against this branch (`workflow_dispatch` uses the branch's workflow file) to confirm the artifact — including `build-cold.log` — uploads even on a failed build. Will confirm before merge.

Builds on #353, #363.