### PR TITLE
feat(daemon): self-restart when the config file changes

### DIFF
--- a/docs/daemon/lifecycle.mdx
+++ b/docs/daemon/lifecycle.mdx
@@ -63,6 +63,8 @@ When you update kache, the old daemon and the new wrapper would disagree on RPC 
 
 Each process tracks a **build epoch** — the modification time of the kache binary. The daemon reads the client's epoch from incoming Upload/Stats/BuildStarted requests; when a client binary is newer, the daemon sets its own shutdown flag and self-terminates once in-flight work drains. If it was installed as a service, launchd/systemd restarts it with the new binary; otherwise the next upload or CLI/monitor command auto-starts it. The next RPC call hits the fresh daemon. You never need to manually restart the daemon after an update.
 
+The daemon applies the same self-restart to **config changes**. It loads its config once at startup, so it periodically re-fingerprints the active config file; when the file changes on disk (e.g. you edit `local_max_size`), it schedules the same graceful restart and comes back up with the new config — no manual `kache daemon stop` needed. Only the config *file* is watched: a running process's environment is fixed, so `KACHE_*` env overrides still apply only to freshly started daemons.
+
 <Callout type="info">
 Restarting the daemon adds no latency to in-progress rustc invocations: the remote-check hot path never starts the daemon (it skips straight to compilation on a miss). Only the background upload path will lazily (re)start a downed daemon.
 </Callout>

--- a/src/config.rs
+++ b/src/config.rs
@@ -818,6 +818,32 @@ pub(crate) fn resolve_config_path() -> PathBuf {
     )
 }
 
+/// A fingerprint of the *active config file* — its resolved path plus content,
+/// or a stable sentinel when the file is absent. The daemon records this at
+/// startup and self-restarts when it changes, so editing e.g. `local_max_size`
+/// takes effect on the next build without a manual `kache daemon stop`.
+///
+/// Only the file is fingerprinted, not env overrides: a running process's
+/// environment is fixed for its lifetime, so the file is the only thing that
+/// can change under a live daemon. Resolved the same way the daemon loads its
+/// config, so it always tracks the exact file in effect.
+pub(crate) fn config_file_fingerprint() -> u64 {
+    use std::hash::{Hash, Hasher};
+    let path = resolve_config_path();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    path.to_string_lossy().hash(&mut hasher);
+    match std::fs::read(&path) {
+        Ok(bytes) => {
+            1u8.hash(&mut hasher); // present
+            bytes.hash(&mut hasher);
+        }
+        // Absent file: distinct from any present-but-empty file, so the
+        // fingerprint still moves when a config is later created or removed.
+        Err(_) => 0u8.hash(&mut hasher),
+    }
+    hasher.finish()
+}
+
 fn resolve_config_path_from(
     kache_config: Option<PathBuf>,
     current_dir: Option<PathBuf>,
@@ -1141,6 +1167,31 @@ mod tests {
         std::fs::write(&cfg, "[cache]\nkey_salt = \"from-file\"\n").unwrap();
         let loaded = Config::load().unwrap();
         assert_eq!(loaded.key_salt.as_deref(), Some("from-env"));
+    }
+
+    #[test]
+    fn config_file_fingerprint_tracks_content_and_presence() {
+        let _lock = config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = dir.path().join("config.toml");
+        let _g = set_kache_config_for_test(&cfg);
+
+        // Absent file has a stable fingerprint, distinct from any present file.
+        let absent = config_file_fingerprint();
+        assert_eq!(absent, config_file_fingerprint(), "absent must be stable");
+
+        std::fs::write(&cfg, "[cache]\nlocal_max_size = \"10GiB\"\n").unwrap();
+        let v10 = config_file_fingerprint();
+        assert_ne!(absent, v10, "present must differ from absent");
+        assert_eq!(
+            v10,
+            config_file_fingerprint(),
+            "same content must be stable"
+        );
+
+        // A content change moves the fingerprint (the daemon-restart trigger).
+        std::fs::write(&cfg, "[cache]\nlocal_max_size = \"20GiB\"\n").unwrap();
+        assert_ne!(v10, config_file_fingerprint(), "content change must re-key");
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -23,6 +23,12 @@ const REMOTE_HEAD_DEGRADED_FOR: Duration = Duration::from_secs(45);
 const DAEMON_START_TIMEOUT: Duration = Duration::from_secs(8);
 const DAEMON_START_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const DAEMON_COORD_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
+
+/// How often the daemon re-checks its config file for changes. On a change it
+/// schedules a graceful restart so the new config (e.g. `local_max_size`) takes
+/// effect — no manual `kache daemon stop`. Cheap (one small-file read); rare to
+/// fire, so a coarse interval is fine.
+const DAEMON_CONFIG_WATCH_INTERVAL: Duration = Duration::from_secs(15);
 const DAEMON_COORD_STALE_AFTER: Duration = Duration::from_secs(15);
 const VERSION: &str = crate::VERSION;
 const FILE_HASH_MEMORY_CACHE_CAP: usize = 4096;
@@ -2539,6 +2545,34 @@ async fn server_main(config: &Config, coord: DaemonCoordFile) -> Result<()> {
     // out the periodic idle tick — see issue #288.
     let shutdown_notify = Arc::new(Notify::new());
 
+    // Config watchdog: the daemon loads its config once at startup, so an edit
+    // to the config file (e.g. `local_max_size`) would otherwise require a
+    // manual `kache daemon stop`. Periodically re-fingerprint the active config
+    // file; on a change, schedule a graceful restart so the service manager (or
+    // the next build's auto-spawn) brings the daemon back up with the new
+    // config. This watches only the file the daemon itself resolved — it sends
+    // no per-client signal, so it can't thrash across projects.
+    let config_fingerprint = crate::config::config_file_fingerprint();
+    let config_watch_flag = Arc::clone(&shutdown_flag);
+    let config_watch_notify = Arc::clone(&shutdown_notify);
+    let config_watch_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(DAEMON_CONFIG_WATCH_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            if config_watch_flag.load(Ordering::Relaxed) {
+                break;
+            }
+            if crate::config::config_file_fingerprint() != config_fingerprint {
+                tracing::info!("config file changed on disk, scheduling restart to reload it");
+                config_watch_flag.store(true, Ordering::Relaxed);
+                config_watch_notify.notify_one();
+                break;
+            }
+        }
+    });
+
     // Idle watchdog: exit if no connections received for this duration.
     // Prevents zombie daemons from accumulating when the user isn't building.
     // The daemon will be auto-started again on the next build.
@@ -2567,6 +2601,7 @@ async fn server_main(config: &Config, coord: DaemonCoordFile) -> Result<()> {
         h.abort();
     }
     heartbeat_handle.abort();
+    config_watch_handle.abort();
 
     // Graceful shutdown: drop the daemon's sender to close the unbounded buffer,
     // which will cause the enqueue task to exit, closing the worker channel,


### PR DESCRIPTION
## Problem

The daemon loads its config once at startup, so editing a setting like `local_max_size` had no effect until you ran `kache daemon stop` by hand.

## Fix

Mirror the existing **build-epoch** restart, but for config. A background watchdog periodically (15s) re-fingerprints the active config file via `config_file_fingerprint()` (resolved path + content, with a distinct sentinel for "absent"). On a change it sets the shutdown flag → the daemon drains in-flight work and exits → the service manager (or the next build's auto-spawn) brings it back up with the new config.

### Why daemon-side watch, not a client-sent hash

The daemon is a per-user singleton serving **all** projects, and config resolution is cwd-dependent (project-local `.kache.toml`). A client-sent config hash would differ between projects and **thrash** the daemon. Watching only the daemon's *own* resolved config file avoids that entirely. Env overrides aren't fingerprinted because a running process's environment is fixed — they already only apply to freshly started daemons (unchanged behavior).

## Context

From @lovesegfault's [rio-build#51 review](https://github.com/lovesegfault/rio-build/pull/51): *"config epoch for the daemon: you already restart stale daemons on `build_epoch`. The same trick on a config-content hash would remove the 'run `kache daemon stop` after changing max_size' step."*

## Test

`config_file_fingerprint_tracks_content_and_presence` — absent is stable and distinct from present; equal content is stable; a content change re-keys. `cargo test --bin kache` (768) + clippy `--all-targets` green. Docs: lifecycle.mdx gains a config-restart paragraph alongside build-epoch.