### PR TITLE
bench(substrate): pin Rust 1.93.0 — fix wasm runtime link failure

### DIFF
--- a/scenarios/bench-substrate/scenario.toml
+++ b/scenarios/bench-substrate/scenario.toml
@@ -9,22 +9,33 @@ tags     = ["suite:bench", "project:substrate", "lang:rust"]
 
 requires = ["cargo", "rustc"]
 
-# Ensure the wasm targets + rust-src on the ambient toolchain (idempotent;
-# best-effort so a missing rustup / pre-installed target doesn't abort).
-# System deps are NOT auto-installed — see the echo'd note.
+# polkadot-stable2603-3 has NO rust-toolchain.toml, so the build would otherwise
+# float to whatever Rust is ambient. A too-new stable (e.g. 1.96) breaks the
+# wasm runtime link (sp_io host fns come out as undefined symbols instead of
+# imports), so we pin substrate's intended Rust (1.93.0) explicitly here and via
+# RUSTUP_TOOLCHAIN in `build`. Install it + its wasm targets / rust-src. Best-
+# effort (|| true) so a non-rustup env doesn't abort; system deps are NOT
+# auto-installed — see the echo'd note.
 setup = [
   "echo '[bench] substrate needs system deps: protoc (REQUIRED), clang, cmake, pkg-config, openssl headers. macOS: brew install protobuf cmake. Debian: apt install protobuf-compiler clang cmake pkg-config libssl-dev.'",
-  "rustup target add wasm32v1-none || true",
-  "rustup target add wasm32-unknown-unknown || true",
-  "rustup component add rust-src || true",
+  "rustup toolchain install 1.93.0 --profile minimal --no-self-update || true",
+  "rustup component add --toolchain 1.93.0 rust-src || true",
+  "rustup target add --toolchain 1.93.0 wasm32v1-none || true",
+  "rustup target add --toolchain 1.93.0 wasm32-unknown-unknown || true",
 ]
 
-# Build the polkadot node. macOS prelude: librocksdb-sys's bindgen build
-# script links @rpath/libclang.dylib with no embedded rpath, so point the
-# loader (and clang-sys via LIBCLANG_PATH) at the active Xcode/CLT lib —
-# no-op off macOS or when an existing LIBCLANG_PATH is set. This shell
-# lives in config rather than Rust, which is the whole point of scenarios.
+# Build the polkadot node. RUSTUP_TOOLCHAIN pins substrate's Rust (1.93.0) for
+# THIS build and — critically — for substrate-wasm-builder's child cargo, which
+# inherits the env (it unsets RUSTC/CARGO_ENCODED_RUSTFLAGS but NOT
+# RUSTUP_TOOLCHAIN). Set here (not just the workflow) so the pin holds wherever
+# the scenario runs; a non-empty value also overrides the workflow's empty reset.
+# macOS prelude: librocksdb-sys's bindgen build script links @rpath/libclang.dylib
+# with no embedded rpath, so point the loader (and clang-sys via LIBCLANG_PATH) at
+# the active Xcode/CLT lib — no-op off macOS or when an existing LIBCLANG_PATH is
+# set. This shell lives in config rather than Rust, which is the whole point of
+# scenarios.
 build = """
+export RUSTUP_TOOLCHAIN=1.93.0
 if [ "$(uname)" = Darwin ]; then
   for d in "$(xcode-select -p 2>/dev/null)/Toolchains/XcodeDefault.xctoolchain/usr/lib" /Library/Developer/CommandLineTools/usr/lib; do
     if [ -f "$d/libclang.dylib" ]; then
@@ -40,7 +51,8 @@ cargo build --release -p polkadot
 [source]
 kind = "clone"
 repo = "https://github.com/paritytech/polkadot-sdk.git"
-# Latest stable as of 2026-05-28; pins Rust 1.93.0 stable.
+# Latest stable as of 2026-05-28. NB: this ref has no rust-toolchain.toml — the
+# Rust pin is enforced by us (1.93.0, see setup/build above), not by the tree.
 ref = "polkadot-stable2603-3"
 objdir = "target"
 


### PR DESCRIPTION
## Problem
The first live `Bench` runs failed the substrate cold build (`cargo … exit 101`) at the **wasm runtime link**:
```
Compiling westend-runtime-blob / rococo-runtime-blob
error: linking with `rust-lld` failed
  sp_io...: undefined symbol: ext_hashing_blake2_128_version_1
            undefined symbol: ext_storage_*  / ext_logging_* / ext_allocator_* ...
```
Those `ext_*_version_1` are substrate **host functions** — in a runtime wasm blob they must stay *imports*, not statically-linked symbols. Building the runtime with a too-new rustc breaks that.

## Root cause (not kache)
`polkadot-stable2603-3` has **no `rust-toolchain.toml`**, and the scenario built with "the ambient toolchain". On the Linux ARC runner that resolved to **Rust 1.96.0** (the workflow's mise step installs `rust` = latest; `RUSTUP_TOOLCHAIN: ""` couldn't help with nothing to defer to). The scenario's own comment says stable2603-3 needs **1.93.0**. The macOS local run worked only because that box's ambient stable was already compatible.

Confirmed from the cold-build log (captured thanks to #365): `Using rustc version: rustc 1.96.0` driving the `wasm32v1-none` runtime build.

## Fix
Pin substrate's intended Rust deterministically (a bench should never float to "newest stable"):
- **setup** installs `1.93.0` + its `wasm32v1-none` / `wasm32-unknown-unknown` targets + `rust-src`.
- **build** `export RUSTUP_TOOLCHAIN=1.93.0` — holds for the node build **and** substrate-wasm-builder's child cargo (inherits env; unsets `RUSTC`/`CARGO_ENCODED_RUSTFLAGS` but not `RUSTUP_TOOLCHAIN`), and overrides the workflow's empty reset.

## Validation
Dispatched against this branch (`workflow_dispatch` uses the branch's tree). Will confirm the runtime links and the bench produces a report before requesting merge.

Stacked on #353 / #363 / #365. (Separate, infra-side issue tracked for firefox: runner OOMKilled at the 16Gi limit during libxul link — not in this PR.)