### PR TITLE
fix(store): reflink-first ingest + CoW store accounting; bench measures real disk

### DIFF
--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -232,6 +232,18 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         profile.apply_files(clone, &kache)?;
     }
 
+    // Snapshot the volume's free space before any build runs, so the real
+    // footprint of the cold+warm builds can be measured (free-space delta) and
+    // used to VERIFY the CoW-corrected disk-layout estimate. Only on a full
+    // run: on `--retry` cold is restored from a snapshot rather than built, so
+    // the delta would not cover the cold pool. Clones already exist at this
+    // point; the cache and objdirs do not (cold wipes the cache first).
+    let disk_free_before = if config.retry {
+        None
+    } else {
+        available_bytes(&work_dir)
+    };
+
     // cold: either run it fresh (full run) or restore the snapshot saved
     // by a prior full run (`--retry`) and reuse cold's metrics. Either
     // way we emerge with `cold_metrics` + `cold_raw`.
@@ -281,6 +293,15 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     let (warm_leaks, warm_leak_samples) =
         scan_leak_warnings(&work_dir.join(format!("wrapper-{}.log", Phase::Warm.name())));
 
+    // Free-space delta = real disk the cold+warm builds consumed (CoW/dedup/
+    // compression-honest). `checked_sub` guards the rare case where background
+    // activity freed more than the builds wrote, which would not be a usable
+    // measurement.
+    let disk_measured_bytes = match (disk_free_before, available_bytes(&work_dir)) {
+        (Some(before), Some(after)) => before.checked_sub(after),
+        _ => None,
+    };
+
     let speedup = if warm_s > 0 {
         cold_metrics.wall_s as f64 / warm_s as f64
     } else {
@@ -298,7 +319,7 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         &warm_metrics,
         profile.checks.assertions.for_phase(Phase::Warm.name()),
     );
-    let measure_warnings = bench_measure_warnings(
+    let mut measure_warnings = bench_measure_warnings(
         &warm_metrics,
         speedup,
         profile.checks.measure.for_phase(Phase::Warm.name()),
@@ -310,6 +331,37 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     // this clone" disk usage.
     let cold_objdir_bytes = dir_size_kb(&clone_a.join(&objdir)).saturating_mul(1024);
     let warm_objdir_bytes = dir_size_kb(&clone_b.join(&objdir)).saturating_mul(1024);
+
+    // Verify: the measured free-space delta should land near the CoW-corrected
+    // estimate of the three-pool footprint. They agree on any filesystem — on
+    // a CoW one because the shared bytes are subtracted, on a non-CoW one
+    // because nothing is shared and the estimate stays at the apparent sum. A
+    // gap therefore means the storage byte accounting is off (not merely "no
+    // CoW"), which is worth surfacing. A 20% band absorbs the cache snapshot,
+    // logs, and df noise.
+    if let Some(measured) = disk_measured_bytes {
+        let warm_st = &warm_metrics.storage;
+        let store_shared = cold_metrics
+            .storage
+            .store_reflinked_bytes
+            .saturating_add(warm_st.store_reflinked_bytes);
+        let shared_total = warm_st.reflinked_bytes.saturating_add(store_shared);
+        let sum_apparent = cold_objdir_bytes
+            .saturating_add(warm_objdir_bytes)
+            .saturating_add(warm_st.blob_bytes);
+        let estimate = sum_apparent.saturating_sub(shared_total);
+        let within_band = measured <= estimate.saturating_mul(6) / 5
+            && measured >= estimate.saturating_mul(4) / 5;
+        if estimate > 0 && !within_band {
+            measure_warnings.push(format!(
+                "disk: measured on-disk {} diverges from the CoW-corrected estimate {} \
+                 (apparent {}) — storage byte accounting may be off",
+                human_bytes(measured),
+                human_bytes(estimate),
+                human_bytes(sum_apparent),
+            ));
+        }
+    }
 
     // With `--trace-keys`, both phases logged every key-input the hasher
     // consumed (one line per input, prefixed `[key:CRATE]`). Diff the
@@ -335,6 +387,7 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         cache_size_mb: round1(dir_size_kb(&cache_dir) as f64 / 1024.0),
         cold_objdir_bytes,
         warm_objdir_bytes,
+        disk_measured_bytes,
         key_stability: stability,
         warm_leak_samples,
         verdict,
@@ -1180,6 +1233,29 @@ fn dir_size_kb(dir: &Path) -> u64 {
     bytes / 1024
 }
 
+/// Available bytes on the filesystem backing `path`, via `df -kP`.
+///
+/// `-kP` forces 1024-byte blocks and the POSIX one-line-per-filesystem format,
+/// so the "Available" column is field 4 on both macOS and Linux. Returns
+/// `None` if `df` is missing or unparseable (e.g. Windows) — the caller treats
+/// a missing measurement as "skip the free-space verify", never as an error.
+fn available_bytes(path: &Path) -> Option<u64> {
+    let out = Command::new("df").arg("-kP").arg(path).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    // Line 0 is the header; the first data line's 4th field is available KiB.
+    let avail_kb: u64 = text
+        .lines()
+        .nth(1)?
+        .split_whitespace()
+        .nth(3)?
+        .parse()
+        .ok()?;
+    Some(avail_kb.saturating_mul(1024))
+}
+
 /// Deserialize a JSON file into `T`.
 fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T> {
     let s = std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
@@ -1258,18 +1334,26 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
     eprintln!("{bar}");
 
     // ── disk layout: the three pools and what sharing buys ──
-    // Apparent = sum of file lengths. On APFS,
-    // bytes that kache reflinked from the cache into the warm clone
-    // appear in both inodes' apparent sizes but only occupy disk once.
-    // Subtracting `warm reflinked_bytes` from the apparent sum gives a
-    // conservative estimate of what's actually on disk — conservative
-    // because the cold-phase store path also CoW-shares blocks via
-    // `fs::copy → clonefile` on APFS, but kache doesn't tally those.
+    // Apparent = sum of file lengths. The same physical blocks appear in more
+    // than one pool's apparent size whenever kache CoW-reflinked them, so the
+    // naive sum triple-counts shared content. Three distinct sharings exist,
+    // and each is now a measured byte count (not an untallied side effect):
+    //   • warm RESTORE reflink  — clone-b/obj bytes that share with the cache
+    //   • cold STORE reflink    — cache blobs that share with clone-a/obj (the
+    //                             blob was cloned from the cold build's output)
+    //   • warm STORE reflink    — cache blobs from warm misses that share with
+    //                             clone-b/obj
+    // Subtracting all three from the apparent sum yields the real footprint.
+    let cold_st = &r.cold.storage;
+    let store_shared = cold_st
+        .store_reflinked_bytes
+        .saturating_add(st.store_reflinked_bytes);
+    let shared_total = st.reflinked_bytes.saturating_add(store_shared);
     let sum_apparent = r
         .cold_objdir_bytes
         .saturating_add(r.warm_objdir_bytes)
         .saturating_add(st.blob_bytes);
-    let approx_on_disk = sum_apparent.saturating_sub(st.reflinked_bytes);
+    let approx_on_disk = sum_apparent.saturating_sub(shared_total);
     eprintln!("  disk layout — three pools, sharing blocks via CoW reflinks");
     eprintln!(
         "    clone-a/obj   {:>10}   cold-built objdir",
@@ -1281,9 +1365,19 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
         human_bytes(st.reflinked_bytes),
     );
     eprintln!(
-        "    kache cache   {:>10}   {} blobs, {} dedup vs {} raw",
+        "    kache cache   {:>10}   {} blobs; {} reflinked from build output, {} copied",
         human_bytes(st.blob_bytes),
         st.store_blobs,
+        human_bytes(store_shared),
+        human_bytes(
+            cold_st
+                .store_copied_bytes
+                .saturating_add(st.store_copied_bytes)
+        ),
+    );
+    eprintln!(
+        "                  {:>10}   ({} dedup vs {} raw)",
+        "",
         human_bytes(st.dedup_saved_bytes),
         human_bytes(st.logical_bytes),
     );
@@ -1293,10 +1387,21 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
         human_bytes(sum_apparent),
     );
     eprintln!(
-        "    ≈ on disk    ~{:>10}   warm-restore CoW saves {} on APFS",
+        "    ≈ on disk    ~{:>10}   CoW sharing saves {} ({} restore + {} store)",
         human_bytes(approx_on_disk),
+        human_bytes(shared_total),
         human_bytes(st.reflinked_bytes),
+        human_bytes(store_shared),
     );
+    if let Some(measured) = r.disk_measured_bytes {
+        // Ground truth: the volume's free-space delta across the two build
+        // phases. CoW/dedup/compression-honest and filesystem-agnostic — it
+        // VERIFIES the estimate above rather than trusting kache's own tally.
+        eprintln!(
+            "    measured      {:>10}   actual free-space delta (cold+warm builds)",
+            human_bytes(measured),
+        );
+    }
     eprintln!("{bar}");
 
     // ── diagnostics: did the run actually exercise kache? ──
@@ -1384,6 +1489,13 @@ struct BenchResult {
     /// cache on APFS — print_summary subtracts that to report "unique
     /// to this clone".
     warm_objdir_bytes: u64,
+    /// Real disk the cold+warm builds consumed, measured as the volume's
+    /// free-space delta across both phases. CoW/dedup/compression-honest and
+    /// filesystem-agnostic — the ground-truth check on the `approx_on_disk`
+    /// estimate. `None` on `--retry` (cold is restored, not built, so the
+    /// delta wouldn't cover the full three-pool layout).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    disk_measured_bytes: Option<u64>,
     /// Cross-clone cache-key stability — the deterministic correctness
     /// signal.
     key_stability: KeyStability,
@@ -1492,6 +1604,14 @@ struct StorageInfo {
     restored_bytes: u64,
     /// Share of restored bytes that cost no physical copy.
     zero_copy_pct: f64,
+    /// Bytes that entered the store by a CoW reflink — they share blocks with
+    /// the build's own output file, so the store is NOT a second copy of them.
+    /// The disk-layout estimate subtracts these (they're double-counted in the
+    /// apparent objdir + cache sum).
+    store_reflinked_bytes: u64,
+    /// Bytes that entered the store by a full copy (no CoW) — a genuine second
+    /// copy, so they are NOT subtracted from the on-disk estimate.
+    store_copied_bytes: u64,
     /// Unique content-addressed blobs in the store.
     store_blobs: u64,
     /// Sum of cache-entry sizes — what the store would be without dedup.
@@ -1515,6 +1635,8 @@ impl StorageInfo {
             copied_bytes: u("copied_bytes"),
             restored_bytes: u("restored_bytes"),
             zero_copy_pct: st["zero_copy_pct"].as_f64().unwrap_or(0.0),
+            store_reflinked_bytes: u("store_reflinked_bytes"),
+            store_copied_bytes: u("store_copied_bytes"),
             store_blobs: u("store_blobs"),
             logical_bytes: u("logical_bytes"),
             blob_bytes: u("blob_bytes"),
@@ -1992,6 +2114,8 @@ mod tests {
                 copied_bytes: 0,
                 restored_bytes: 0,
                 zero_copy_pct: 0.0,
+                store_reflinked_bytes: 0,
+                store_copied_bytes: 0,
                 store_blobs: 0,
                 logical_bytes: 0,
                 blob_bytes: 0,

--- a/src/events.rs
+++ b/src/events.rs
@@ -86,6 +86,15 @@ pub struct BuildEvent {
     /// when neither reflink nor hardlink is available.
     #[serde(default)]
     pub copied_bytes: u64,
+    /// Bytes ingested into the store by a CoW reflink on a miss — the blob
+    /// shares blocks with the build's own output file, so it costs ~no extra
+    /// disk (APFS / btrfs / XFS-with-reflink).
+    #[serde(default)]
+    pub store_reflinked_bytes: u64,
+    /// Bytes ingested into the store by a full physical copy on a miss — a
+    /// genuine second copy, the fallback on a filesystem without CoW.
+    #[serde(default)]
+    pub store_copied_bytes: u64,
     /// Why kache passed the invocation through instead of caching it.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub passthrough_reason: String,
@@ -455,6 +464,11 @@ pub struct EventStats {
     pub hardlinked_bytes: u64,
     /// Bytes restored by a full physical copy.
     pub copied_bytes: u64,
+    /// Bytes ingested into the store by a CoW reflink (shares blocks with the
+    /// build's output — not a second physical copy).
+    pub store_reflinked_bytes: u64,
+    /// Bytes ingested into the store by a full physical copy (a real second copy).
+    pub store_copied_bytes: u64,
 }
 
 pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
@@ -482,6 +496,8 @@ pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
         reflinked_bytes: 0,
         hardlinked_bytes: 0,
         copied_bytes: 0,
+        store_reflinked_bytes: 0,
+        store_copied_bytes: 0,
     };
 
     for event in events {
@@ -534,6 +550,8 @@ pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
         stats.reflinked_bytes += event.reflinked_bytes;
         stats.hardlinked_bytes += event.hardlinked_bytes;
         stats.copied_bytes += event.copied_bytes;
+        stats.store_reflinked_bytes += event.store_reflinked_bytes;
+        stats.store_copied_bytes += event.store_copied_bytes;
     }
 
     stats
@@ -577,6 +595,8 @@ mod tests {
             reflinked_bytes: 0,
             hardlinked_bytes: 0,
             copied_bytes: 0,
+            store_reflinked_bytes: 0,
+            store_copied_bytes: 0,
             passthrough_reason: String::new(),
             fallback: false,
             exit_code: None,
@@ -614,6 +634,8 @@ mod tests {
             reflinked_bytes: 0,
             hardlinked_bytes: 0,
             copied_bytes: 0,
+            store_reflinked_bytes: 0,
+            store_copied_bytes: 0,
             passthrough_reason: String::new(),
             fallback: false,
             exit_code: None,

--- a/src/link.rs
+++ b/src/link.rs
@@ -118,8 +118,12 @@ fn set_executable_perms(path: &Path) -> Result<()> {
 }
 
 /// Try a reflink (copy-on-write) clone.
+///
+/// `pub(crate)` so the store-ingest path can reflink a freshly-compiled
+/// artifact into the content-addressed store (sharing blocks with the
+/// build's own output) and account for it, mirroring the restore side.
 #[cfg(target_os = "macos")]
-fn try_reflink(src: &Path, dst: &Path) -> Result<()> {
+pub(crate) fn try_reflink(src: &Path, dst: &Path) -> Result<()> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
 
@@ -141,7 +145,7 @@ fn try_reflink(src: &Path, dst: &Path) -> Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-fn try_reflink(src: &Path, dst: &Path) -> Result<()> {
+pub(crate) fn try_reflink(src: &Path, dst: &Path) -> Result<()> {
     use std::os::unix::io::AsRawFd;
 
     let src_file = fs::File::open(src)?;
@@ -162,7 +166,7 @@ fn try_reflink(src: &Path, dst: &Path) -> Result<()> {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-fn try_reflink(_src: &Path, _dst: &Path) -> Result<()> {
+pub(crate) fn try_reflink(_src: &Path, _dst: &Path) -> Result<()> {
     anyhow::bail!("reflink not supported on this platform")
 }
 

--- a/src/opcounts.rs
+++ b/src/opcounts.rs
@@ -103,6 +103,45 @@ pub fn copied_bytes() -> u64 {
     COPIED_BYTES.load(Ordering::Relaxed)
 }
 
+// ── Store-method byte counters ──────────────────────────────────────────────
+//
+// The mirror image of the restore counters above: how a freshly-compiled
+// artifact entered the content-addressed store on a miss. The store tries a
+// CoW reflink (clonefile / FICLONE) first, so on APFS / btrfs / XFS-with-reflink
+// the blob shares blocks with the build's own output file — storing costs
+// ~no physical bytes. It falls back to a full copy on a filesystem without CoW
+// (ext4 without reflink, tmpfs, a cross-volume store).
+//
+// Splitting store bytes by mechanism is what lets `kache report` (and the
+// clone benchmark) account for disk honestly: a blob reflinked from the
+// objdir is NOT a second physical copy, so a naive "objdir + store" sum
+// double-counts it. Deterministic given the same source + filesystem.
+
+static STORE_REFLINKED_BYTES: AtomicU64 = AtomicU64::new(0);
+static STORE_COPIED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+/// Record `bytes` ingested into the store by a CoW reflink (shares blocks
+/// with the build's output file — physically zero-copy).
+pub fn record_store_reflinked(bytes: u64) {
+    STORE_REFLINKED_BYTES.fetch_add(bytes, Ordering::Relaxed);
+}
+
+/// Record `bytes` ingested into the store by a full physical copy (the
+/// filesystem has no CoW, so the blob is a genuine second copy).
+pub fn record_store_copied(bytes: u64) {
+    STORE_COPIED_BYTES.fetch_add(bytes, Ordering::Relaxed);
+}
+
+/// Bytes ingested into the store by CoW reflink so far in this process.
+pub fn store_reflinked_bytes() -> u64 {
+    STORE_REFLINKED_BYTES.load(Ordering::Relaxed)
+}
+
+/// Bytes ingested into the store by a full copy so far in this process.
+pub fn store_copied_bytes() -> u64 {
+    STORE_COPIED_BYTES.load(Ordering::Relaxed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -140,5 +179,13 @@ mod tests {
         record_hardlinked(32);
         record_copied(16);
         assert!(reflinked_bytes() + hardlinked_bytes() + copied_bytes() >= before + 112);
+    }
+
+    #[test]
+    fn store_byte_counters_increment_monotonically() {
+        let before = store_reflinked_bytes() + store_copied_bytes();
+        record_store_reflinked(128);
+        record_store_copied(64);
+        assert!(store_reflinked_bytes() + store_copied_bytes() >= before + 192);
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -112,7 +112,10 @@ pub struct TimingBreakdown {
 /// to a hardlink, then a full copy.
 ///
 /// **Store side** — content-addressed dedup: an artifact whose content is
-/// already in the store is referenced, not stored a second time.
+/// already in the store is referenced, not stored a second time. And how a
+/// new blob entered the store: a CoW reflink (shares blocks with the build's
+/// own output — not a second physical copy) or a full copy on a filesystem
+/// without CoW.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StorageBreakdown {
     /// Bytes restored by CoW reflink — zero physical copy.
@@ -125,6 +128,12 @@ pub struct StorageBreakdown {
     pub restored_bytes: u64,
     /// Share of restored bytes that cost no physical copy (reflink + hardlink).
     pub zero_copy_pct: f64,
+    /// Bytes ingested into the store by a CoW reflink (shares blocks with the
+    /// build's output — the store is not a second physical copy of these).
+    pub store_reflinked_bytes: u64,
+    /// Bytes ingested into the store by a full physical copy (a real second
+    /// copy — the fallback on a filesystem without CoW).
+    pub store_copied_bytes: u64,
     /// Unique content-addressed blobs in the local store.
     pub store_blobs: u64,
     /// Sum of every cache entry's logical size — what the store would
@@ -457,6 +466,8 @@ pub fn generate_report(config: &Config, hours: u64, top: usize) -> Result<BuildR
         } else {
             0.0
         },
+        store_reflinked_bytes: stats.store_reflinked_bytes,
+        store_copied_bytes: stats.store_copied_bytes,
         store_blobs: blob_stats.total_blobs as u64,
         logical_bytes: blob_stats.total_logical_size,
         blob_bytes: blob_stats.total_blob_size,
@@ -1094,6 +1105,8 @@ fn has_storage_data(storage: &StorageBreakdown) -> bool {
         || storage.logical_bytes > 0
         || storage.blob_bytes > 0
         || storage.dedup_saved_bytes > 0
+        || storage.store_reflinked_bytes > 0
+        || storage.store_copied_bytes > 0
 }
 
 fn push_storage_table(lines: &mut Vec<String>, storage: &StorageBreakdown) {
@@ -1120,6 +1133,18 @@ fn push_storage_table(lines: &mut Vec<String>, storage: &StorageBreakdown) {
             format_bytes(storage.dedup_saved_bytes),
         ));
         lines.push(format!("| Store blobs | {} |", storage.store_blobs));
+    }
+    let ingested = storage.store_reflinked_bytes + storage.store_copied_bytes;
+    if ingested > 0 {
+        // Reflinked ingest shares blocks with the build's own output, so it
+        // adds ~no physical disk; only copied ingest is a genuine second copy.
+        let reflink_pct = storage.store_reflinked_bytes as f64 / ingested as f64 * 100.0;
+        lines.push(format!(
+            "| Store ingest | {} reflinked (CoW), {} copied — {:.1}% shared with build output |",
+            format_bytes(storage.store_reflinked_bytes),
+            format_bytes(storage.store_copied_bytes),
+            (reflink_pct * 10.0).round() / 10.0,
+        ));
     }
 }
 
@@ -2277,6 +2302,8 @@ mod tests {
             reflinked_bytes: 0,
             hardlinked_bytes: 0,
             copied_bytes: 0,
+            store_reflinked_bytes: 0,
+            store_copied_bytes: 0,
             passthrough_reason: String::new(),
             fallback: false,
             exit_code: None,

--- a/src/store.rs
+++ b/src/store.rs
@@ -98,16 +98,33 @@ fn unlink_blob(blob: &Path) {
 }
 
 /// Durably materialize `source` into the content-addressed store at `blob`,
-/// unless the blob already exists: copy to a unique temp, fsync, atomic rename,
-/// mark read-only. Idempotent — when the blob is present this is just a `stat`.
+/// unless the blob already exists: clone (or copy) to a unique temp, fsync,
+/// atomic rename, mark read-only. Idempotent — when the blob is present this
+/// is just a `stat`.
+///
+/// The temp is created by a CoW reflink first, falling back to a full byte
+/// copy on a filesystem without copy-on-write. On APFS / btrfs / XFS-with-
+/// reflink the blob then shares physical blocks with the build's own output
+/// file, so storing costs ~no extra disk — the store is not a second copy.
+/// Whichever path runs is recorded (`record_store_reflinked` /
+/// `record_store_copied`) so `kache report` can account for disk honestly,
+/// mirroring the restore side in `link.rs`.
 fn materialize_blob(source: &Path, blob: &Path, hash: &str) -> Result<()> {
     if blob.is_file() {
         return Ok(());
     }
     fs::create_dir_all(blob.parent().unwrap()).context("creating blob shard directory")?;
     let tmp = blob_tmp_path(blob, hash);
-    fs::copy(source, &tmp)
-        .with_context(|| format!("copying {} to blob store", source.display()))?;
+    let bytes = fs::metadata(source).map(|m| m.len()).unwrap_or(0);
+    // CoW reflink first (zero physical bytes on APFS/btrfs/XFS-with-reflink);
+    // fall back to a real copy where the filesystem has no CoW.
+    if crate::link::try_reflink(source, &tmp).is_ok() {
+        crate::opcounts::record_store_reflinked(bytes);
+    } else {
+        fs::copy(source, &tmp)
+            .with_context(|| format!("copying {} to blob store", source.display()))?;
+        crate::opcounts::record_store_copied(bytes);
+    }
     if let Err(e) = fsync_file(&tmp) {
         let _ = fs::remove_file(&tmp);
         return Err(e).context("flushing blob to disk");
@@ -1855,6 +1872,50 @@ mod tests {
             .unwrap();
         assert_eq!(stats.removed, 0);
         assert!(orphan_path.exists());
+    }
+
+    #[test]
+    fn store_ingest_accounts_new_blob_bytes_as_reflink_or_copy() {
+        // A new-blob put must record the artifact's bytes against exactly one
+        // store-ingest counter — reflink on a CoW filesystem (APFS/btrfs),
+        // copy elsewhere. The counters are process-global and monotonic, so a
+        // delta of at least the artifact size is a safe assertion under
+        // parallel test execution.
+        let cache_dir = tempfile::tempdir().unwrap();
+        let config = test_config(cache_dir.path());
+        let store = Store::open(&config).unwrap();
+
+        // Unique content so this is genuinely a new blob, not a dup of a blob
+        // some concurrent test happened to store (which would skip ingest).
+        let payload = b"store-ingest-accounting-unique-artifact-bytes-0xC0FFEE".repeat(64);
+        let output_file = cache_dir.path().join("output.rlib");
+        std::fs::write(&output_file, &payload).unwrap();
+
+        let before =
+            crate::opcounts::store_reflinked_bytes() + crate::opcounts::store_copied_bytes();
+        let put_result = store
+            .put(
+                "ingest_key",
+                "ingestlib",
+                &["lib".to_string()],
+                &[],
+                "host",
+                "dev",
+                &[(output_file, "libingest.rlib".to_string())],
+                "",
+                "",
+            )
+            .unwrap();
+        assert_eq!(put_result.new_blobs, 1, "expected a genuinely new blob");
+
+        let after =
+            crate::opcounts::store_reflinked_bytes() + crate::opcounts::store_copied_bytes();
+        assert!(
+            after >= before + payload.len() as u64,
+            "store ingest must account the new blob's bytes (delta {} < {})",
+            after - before,
+            payload.len()
+        );
     }
 
     #[test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1614,6 +1614,8 @@ fn log_event_details(
         reflinked_bytes: crate::opcounts::reflinked_bytes(),
         hardlinked_bytes: crate::opcounts::hardlinked_bytes(),
         copied_bytes: crate::opcounts::copied_bytes(),
+        store_reflinked_bytes: crate::opcounts::store_reflinked_bytes(),
+        store_copied_bytes: crate::opcounts::store_copied_bytes(),
         passthrough_reason,
         fallback,
         exit_code,


### PR DESCRIPTION
## Problem

The store-ingest path (`materialize_blob`) used `fs::copy`, which **clonefiles on APFS but reports nothing** — unlike the restore path (`link.rs`), which explicitly reflinks and counts. So a cache blob that CoW-shares blocks with the build's own output file looked like a genuine second physical copy, both in `kache report` and in the clone benchmark.

Concretely: the Firefox clone bench reported **~34 GB on disk** when the real footprint was **~20 GB** — it only subtracted the warm-restore reflink from the apparent objdir+cache sum, never the cold-store clone.

Empirically confirmed (`fs::copy` of a 3 GB incompressible file → −1 MB free-space delta on APFS = clonefile), so the fix is accounting, not behavior change on CoW filesystems.

## Store side (kache)

- `materialize_blob` now **reflinks first** (reusing `link::try_reflink`), falling back to a real `fs::copy` only on a filesystem without CoW — and records which path ran.
- New `store_reflinked_bytes` / `store_copied_bytes` counters flow `opcounts → BuildEvent → EventStats → kache report` storage section, mirroring the existing restore-side reflink/hardlink/copy accounting.
- `kache report` now shows store ingest split by reflink vs copy.

## Bench (kache-e2e)

- The disk-layout estimate subtracts **all three** CoW sharings (warm-restore + cold-store + warm-store reflinks), not just the warm restore → the honest ~20 GB.
- Adds a **free-space delta measurement** (`df -kP` before cold / after warm) as filesystem-agnostic ground truth, plus a verify that warns when it diverges >20% from the corrected estimate — catching future accounting drift.

## Validation

- Smoke test: a trivial compile reports `store_reflinked_bytes == blob_bytes` (the cache costs ~0 physical bytes on APFS).
- 769 kache + 67 kache-e2e tests pass (incl. 3 new); clippy clean; fmt clean.

## Note

Prior bench JSON predates these fields; a fresh `just bench-trace firefox` on this branch prints the corrected `≈ on disk` with a `measured` line confirming it.