### PR TITLE
ci: finalize code-signing (pin _workflows@v10, restore gates & publishing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -614,10 +614,8 @@ jobs:
     # the full validation suite — `version-consistency` rejects a tag that
     # disagrees with the manifest BEFORE any binary builds; `e2e` includes the
     # (blocking) Windows arm, so a tag won't release unless Windows e2e is green.
-    # TEMP (signing-test branch): gates removed so build+sign runs immediately on a tag.
-    # Restore before merge: [check, nix-package, e2e, test-macos, test-windows, version-consistency]
-    needs: []
-    uses: zondax/_workflows/.github/workflows/_release-rust.yml@feat/code-signing
+    needs: [check, nix-package, e2e, test-macos, test-windows, version-consistency]
+    uses: zondax/_workflows/.github/workflows/_release-rust.yml@v10
     with:
       binary_name: kache
       # Both Windows targets (x64 + arm64) ship as `-pc-windows-msvc`, cross-built

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -10,8 +10,6 @@ permissions:
 jobs:
   publish:
     name: Publish crates.io packages
-    # TEMP (signing-test branch): crate publishing disabled. Remove this line to restore.
-    if: false
     runs-on: ubuntu-latest
     # Every published GitHub Release publishes to crates.io, release-candidates
     # included (Policy B): the manifest carries the prerelease version (e.g.

--- a/.github/workflows/service-image.yml
+++ b/.github/workflows/service-image.yml
@@ -39,9 +39,7 @@ jobs:
         run: docker buildx bake -f docker-bake.hcl --set '*.cache-from=' service
 
   release:
-    # TEMP (signing-test branch): image build+publish disabled.
-    # Restore: if: github.event_name != 'pull_request'
-    if: false
+    if: github.event_name != 'pull_request'
     name: Build Service Image
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What

Finalizes the GCP-KMS OS code-signing rollout for release binaries. Signing was proven end-to-end on a test tag (\`v0.7.0-beta.2\`): all six \`release / Build *\` jobs green across **Linux / macOS / Windows** (both x86_64 + aarch64), with valid detached PGP signatures (issuer \`6069…A73B\`), Authenticode (jsign + Cloud KMS), and rcodesign + notarization.

This PR promotes off the temporary test scaffolding:

- **Pin the reusable workflow:** \`_release-rust.yml@feat/code-signing\` → **\`@v10\`** (the signing composite actions are pinned \`@v1\` inside \`_workflows\`; both were released as floating major tags).
- **Restore the release-job gates:** \`needs: [check, nix-package, e2e, test-macos, test-windows, version-consistency]\` (was temporarily \`needs: []\`).
- **Re-enable publishing** that was temporarily \`if: false\`:
  - \`publish-crates.yaml\` — crates.io
  - \`service-image.yml\` — service Docker image release job

## Upstream (already merged/tagged)

- \`Zondax/actions\` #12 → tagged \`v1.2.0\`, floating \`v1\` moved
- \`Zondax/_workflows\` #97 → floating \`v10\` moved (backward-compatible: signing is opt-in, default off)
- \`Zondax/gcp-code-signer\` #4 → \`kache\` added to \`MAIN_ONLY_REPOS\`; WIF binding live

## Effect

The next real \`v*\` tag will: build → **sign** → publish signed assets to the GitHub Release, **and** publish to crates.io + Docker Hub (restored).