### PR TITLE
feat: publish to brew, apt & winget package managers

### DIFF
--- a/.github/actions/setup-pgp-kms-signing/action.yml
+++ b/.github/actions/setup-pgp-kms-signing/action.yml
@@ -1,0 +1,101 @@
+name: 'Setup PGP KMS Signing'
+description: 'Authenticate with GCP via WIF, install kunobi-pgp-kms via mise, and materialize the OpenPGP cert from a secret'
+
+# Adapted from kunobi-frontend's setup-pgp-kms-signing. Differences for kache:
+#   - The signing cert ALREADY exists (stored as secret PGP_CERT_BASE64); this
+#     action only materializes it. There is NO cert-generation path here.
+#   - No legacy GPG dual-signing inputs (kache's apt repo is new — single
+#     KMS-rooted trust root from day one).
+
+inputs:
+  signer-version:
+    description: 'Tag of kunobi-ninja/kunobi-pgp-kms to install. Defaults to "latest" — pin to a specific tag only to roll back or freeze.'
+    required: false
+    default: 'latest'
+  workload-identity-provider:
+    description: 'Full WIF provider resource (vars.PGP_SIGN_WIF_PROVIDER)'
+    required: true
+  gcp-project-id:
+    description: 'GCP project ID (vars.PGP_SIGN_GCP_PROJECT_ID)'
+    required: true
+  service-account:
+    description: 'Service account email to impersonate after WIF auth. On kache pro this is vars.PGP_SIGN_SERVICE_ACCOUNT (cloudkms.signer is bound to the SA, not the principal-set).'
+    required: false
+    default: ''
+  gh-pat:
+    description: 'PAT with read access to private kunobi-ninja/kunobi-pgp-kms releases (secrets.GH_PAT_KUNOBI_NINJA_RELEASES). Used by mise github backend.'
+    required: true
+  cert-base64:
+    description: 'Base64-encoded OpenPGP cert (the .asc public key block). Sourced from secret PGP_CERT_BASE64. REQUIRED — there is no generation fallback.'
+    required: true
+
+outputs:
+  cert-path:
+    description: 'Path to the materialized OpenPGP cert (under RUNNER_TEMP)'
+    value: ${{ steps.cert.outputs.path }}
+  fingerprint:
+    description: 'OpenPGP V4 fingerprint of the materialized cert (40 hex chars)'
+    value: ${{ steps.cert.outputs.fingerprint }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Authenticate with GCP (WIF)
+      uses: zondax/actions/gcp-wif-auth@v1
+      with:
+        workload_identity_provider: ${{ inputs.workload-identity-provider }}
+        project_id: ${{ inputs.gcp-project-id }}
+        # On kache pro, cloudkms.signer is bound to the codesign service
+        # account, so we impersonate it. Empty would use direct principal-set
+        # auth (not used here).
+        service_account: ${{ inputs.service-account }}
+
+    - name: Install kunobi-pgp-kms via mise (github backend)
+      shell: bash
+      env:
+        VERSION: ${{ inputs.signer-version }}
+        # mise's github backend reads MISE_GITHUB_TOKEN for private repo access.
+        MISE_GITHUB_TOKEN: ${{ inputs.gh-pat }}
+      run: |
+        set -euo pipefail
+        # Bootstrap mise if the runner/container doesn't already have it.
+        if ! command -v mise >/dev/null; then
+          curl -fsSL https://mise.jdx.dev/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
+        fi
+        # The github backend matches the tag verbatim; strip any leading 'v'
+        # so callers can pass either "v0.2.0" or "0.2.0".
+        BARE_VERSION="${VERSION#v}"
+        mise use --global "github:kunobi-ninja/kunobi-pgp-kms@${BARE_VERSION}"
+        mise reshim
+        echo "$HOME/.local/share/mise/shims" >> "$GITHUB_PATH"
+        export PATH="$HOME/.local/share/mise/shims:$PATH"
+        kunobi-pgp-kms --version
+
+    - name: Materialize OpenPGP cert
+      id: cert
+      shell: bash
+      env:
+        CERT_B64: ${{ inputs.cert-base64 }}
+      run: |
+        set -euo pipefail
+        if [ -z "$CERT_B64" ]; then
+          echo "::error::cert-base64 is empty. Set secret PGP_CERT_BASE64 (env-scoped: pro)."
+          exit 1
+        fi
+        CERT_PATH="$RUNNER_TEMP/kache.pub.asc"
+        echo "$CERT_B64" | base64 -d > "$CERT_PATH"
+        if ! grep -q 'BEGIN PGP PUBLIC KEY BLOCK' "$CERT_PATH"; then
+          echo "::error::Decoded cert-base64 does not contain a valid PGP PUBLIC KEY BLOCK"
+          exit 1
+        fi
+        # Capture the OpenPGP V4 fingerprint for traceability and downstream use.
+        FPR=$(gpg2 --with-colons --show-keys "$CERT_PATH" | awk -F: '/^fpr/{print $10; exit}')
+        if [ -z "$FPR" ]; then
+          echo "::error::Could not extract fingerprint from $CERT_PATH"
+          exit 1
+        fi
+        echo "  cert fingerprint: $FPR"
+        echo "fingerprint=$FPR" >> "$GITHUB_OUTPUT"
+        echo "path=$CERT_PATH" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,6 +618,11 @@ jobs:
     uses: zondax/_workflows/.github/workflows/_release-rust.yml@v10
     with:
       binary_name: kache
+      # Build .deb assets (kache_<version>_{amd64,arm64}.deb) for the apt repo,
+      # consumed by .github/workflows/package-publish.yml after release publish.
+      # NOTE: requires the _workflows `build_deb` change merged AND the `v10` tag
+      # moved to include it first — so THIS PR must merge AFTER that _workflows PR.
+      build_deb: true
       # Both Windows targets (x64 + arm64) ship as `-pc-windows-msvc`, cross-built
       # on the Linux runner via cargo-xwin: clang-cl + lld-link against the MSVC
       # CRT and Windows SDK that `xwin` downloads. TLS uses the `ring` crypto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,6 +623,12 @@ jobs:
       # NOTE: requires the _workflows `build_deb` change merged AND the `v10` tag
       # moved to include it first — so THIS PR must merge AFTER that _workflows PR.
       build_deb: true
+      # Also publish the bare signed kache.exe per Windows arch as a first-class
+      # release asset (kache-<triple>-pc-windows-msvc.exe), so winget can install
+      # it as InstallerType: portable (see package-publish.yml). Same merge-order
+      # caveat as build_deb: needs the _workflows `upload_windows_exe` change in
+      # `v10` first. The .zip is still produced (cargo-binstall consumes it).
+      upload_windows_exe: true
       # Both Windows targets (x64 + arm64) ship as `-pc-windows-msvc`, cross-built
       # on the Linux runner via cargo-xwin: clang-cl + lld-link against the MSVC
       # CRT and Windows SDK that `xwin` downloads. TLS uses the `ring` crypto

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -81,7 +81,6 @@ jobs:
     if: ${{ github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'apt' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    environment: pro
     # zondax/builder-ubuntu22 ships reprepro + rclone + gpg2 preinstalled.
     # Fallback if the image is unavailable: drop `container:` and add a step
     #   run: sudo apt-get update && sudo apt-get install -y reprepro rclone gnupg2 dpkg-dev
@@ -99,9 +98,9 @@ jobs:
         id: pgp-kms
         uses: ./.github/actions/setup-pgp-kms-signing
         with:
-          workload-identity-provider: ${{ vars.PGP_SIGN_WIF_PROVIDER }}
-          gcp-project-id: ${{ vars.PGP_SIGN_GCP_PROJECT_ID }}
-          service-account: ${{ vars.PGP_SIGN_SERVICE_ACCOUNT }}
+          workload-identity-provider: ${{ secrets.PGP_SIGN_WIF_PROVIDER }}
+          gcp-project-id: ${{ secrets.PGP_SIGN_GCP_PROJECT_ID }}
+          service-account: ${{ secrets.PGP_SIGN_SERVICE_ACCOUNT }}
           gh-pat: ${{ secrets.GH_PAT_KUNOBI_NINJA_RELEASES }}
           cert-base64: ${{ secrets.PGP_CERT_BASE64 }}
 
@@ -124,7 +123,7 @@ jobs:
 
       - name: Generate APT repo with reprepro
         env:
-          KMS_KEY: ${{ vars.PGP_SIGN_KMS_KEY_VERSION }}
+          KMS_KEY: ${{ secrets.PGP_SIGN_KMS_KEY_VERSION }}
           CERT_PATH: ${{ steps.pgp-kms.outputs.cert-path }}
           APT_CHANNEL: ${{ needs.resolve.outputs.channel }}
           CONF_DIR: ./apt_config
@@ -165,7 +164,6 @@ jobs:
     if: ${{ github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'brew' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: pro
     steps:
       - name: Download macOS tarball checksums from the release
         env:
@@ -223,7 +221,6 @@ jobs:
     if: ${{ github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'winget' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: pro
     steps:
       - name: Install komac
         env:

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -1,0 +1,292 @@
+name: Package Publish
+
+# Publishes the kache CLI to OS package managers after a GitHub release:
+#   - apt    : Debian repo on Cloudflare R2 (served at https://r2.kunobi.com/kache/apt/)
+#   - brew   : Homebrew formula via repo-dispatch to kunobi-ninja/homebrew-kunobi
+#   - winget : komac PR to microsoft/winget-pkgs
+#
+# Triggered automatically when a release is published, or manually via
+# workflow_dispatch (e.g. to re-run one track or backfill an older release).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 0.7.0, 0.7.0-rc.1, or "latest")'
+        required: false
+        type: string
+        default: 'latest'
+      channel:
+        description: 'Release channel (auto-detected from version if "auto")'
+        required: false
+        type: choice
+        options:
+          - auto
+          - stable
+          - unstable
+        default: 'auto'
+      only:
+        description: 'Which tracks to run'
+        required: false
+        type: choice
+        options:
+          - all
+          - apt
+          - brew
+          - winget
+        default: 'all'
+
+# OIDC for GCP WIF (KMS PGP signing); read-only repo contents.
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  GH_OWNER: kunobi-ninja
+  GH_REPO: kache
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Resolve version + channel. On a release event the tag drives both; on
+  # workflow_dispatch the inputs do (with "latest"/"auto" resolution).
+  # ---------------------------------------------------------------------------
+  resolve:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      channel: ${{ steps.resolve.outputs.channel }}
+    steps:
+      - name: Checkout (for scripts)
+        uses: actions/checkout@v4
+
+      - name: Resolve version and channel
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # release event: github.event.release.tag_name (e.g. v0.7.0-rc.1).
+          # workflow_dispatch: the version input (default "latest").
+          VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}
+          CHANNEL: ${{ github.event_name == 'release' && 'auto' || inputs.channel }}
+        run: bash scripts/ci/resolve-version.sh
+
+  # ---------------------------------------------------------------------------
+  # apt — build + sign the Debian repo and publish to R2.
+  # ---------------------------------------------------------------------------
+  apt:
+    needs: resolve
+    # Run unless `only` explicitly selects a different single track.
+    if: ${{ github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'apt' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: pro
+    # zondax/builder-ubuntu22 ships reprepro + rclone + gpg2 preinstalled.
+    # Fallback if the image is unavailable: drop `container:` and add a step
+    #   run: sudo apt-get update && sudo apt-get install -y reprepro rclone gnupg2 dpkg-dev
+    container:
+      image: zondax/builder-ubuntu22:22.04.5
+      options: --tty
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PGP KMS signing
+        id: pgp-kms
+        uses: ./.github/actions/setup-pgp-kms-signing
+        with:
+          workload-identity-provider: ${{ vars.PGP_SIGN_WIF_PROVIDER }}
+          gcp-project-id: ${{ vars.PGP_SIGN_GCP_PROJECT_ID }}
+          service-account: ${{ vars.PGP_SIGN_SERVICE_ACCOUNT }}
+          gh-pat: ${{ secrets.GH_PAT_KUNOBI_NINJA_RELEASES }}
+          cert-base64: ${{ secrets.PGP_CERT_BASE64 }}
+
+      - name: Download .deb assets from the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/debs
+          # Primary path: the .deb assets are attached to the release by the
+          # _workflows build_deb step. Names: kache_<version>_{amd64,arm64}.deb
+          gh release download "v${VERSION}" \
+            --repo "${GH_OWNER}/${GH_REPO}" \
+            --pattern 'kache_*_amd64.deb' \
+            --pattern 'kache_*_arm64.deb' \
+            --dir /tmp/debs
+          echo "Downloaded:"
+          ls -la /tmp/debs
+
+      - name: Generate APT repo with reprepro
+        env:
+          KMS_KEY: ${{ vars.PGP_SIGN_KMS_KEY_VERSION }}
+          CERT_PATH: ${{ steps.pgp-kms.outputs.cert-path }}
+          APT_CHANNEL: ${{ needs.resolve.outputs.channel }}
+          CONF_DIR: ./apt_config
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: ./scripts/apt/generate-repo.sh
+
+      - name: Validate repository
+        env:
+          APT_CHANNEL: ${{ needs.resolve.outputs.channel }}
+          CERT_PATH: ${{ steps.pgp-kms.outputs.cert-path }}
+        run: ./scripts/apt/validate.sh
+
+      - name: Publish to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          APT_CHANNEL: ${{ needs.resolve.outputs.channel }}
+        run: ./scripts/apt/publish.sh
+
+      - name: Smoke test live URLs
+        env:
+          APT_CHANNEL: ${{ needs.resolve.outputs.channel }}
+          CERT_PATH: ${{ steps.pgp-kms.outputs.cert-path }}
+        run: ./scripts/apt/smoke-test.sh
+
+  # ---------------------------------------------------------------------------
+  # brew — dispatch a formula update to the existing tap homebrew-kunobi.
+  # macOS-only formula (arm64 + x86_64). The receiver writes Formula/kache.rb
+  # (stable) or Formula/kache-unstable.rb (unstable).
+  # ---------------------------------------------------------------------------
+  brew:
+    needs: resolve
+    if: ${{ github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'brew' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: pro
+    steps:
+      - name: Download macOS tarball checksums from the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release download "v${VERSION}" \
+            --repo "${GH_OWNER}/${GH_REPO}" \
+            --pattern 'kache-x86_64-apple-darwin.tar.gz.sha256' \
+            --pattern 'kache-aarch64-apple-darwin.tar.gz.sha256' \
+            --dir /tmp/sha
+
+      - name: Extract macOS SHA256 values
+        id: sha
+        run: |
+          set -euo pipefail
+          # .sha256 sibling files contain "<hex>  <filename>"; take field 1.
+          SHA_X86=$(cut -d ' ' -f1 < /tmp/sha/kache-x86_64-apple-darwin.tar.gz.sha256)
+          SHA_ARM=$(cut -d ' ' -f1 < /tmp/sha/kache-aarch64-apple-darwin.tar.gz.sha256)
+          if [[ -z "$SHA_X86" || -z "$SHA_ARM" ]]; then
+            echo "Error: missing macOS SHA256 values" >&2
+            exit 1
+          fi
+          echo "x86_64=$SHA_X86"   >> "$GITHUB_OUTPUT"
+          echo "aarch64=$SHA_ARM"  >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Homebrew formula update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_DISPATCH_TOKEN }}
+          repository: kunobi-ninja/homebrew-kunobi
+          event-type: update-kache-formula
+          # channel routes the receiver to Formula/kache.rb (stable) or
+          # Formula/kache-unstable.rb (unstable).
+          client-payload: |
+            {
+              "version": "${{ needs.resolve.outputs.version }}",
+              "channel": "${{ needs.resolve.outputs.channel }}",
+              "sha256_x86_64": "${{ steps.sha.outputs.x86_64 }}",
+              "sha256_aarch64": "${{ steps.sha.outputs.aarch64 }}"
+            }
+
+  # ---------------------------------------------------------------------------
+  # winget — submit a komac PR to microsoft/winget-pkgs for BOTH stable and
+  # unstable identifiers. Installer type: zip → nested portable kache.exe.
+  # ---------------------------------------------------------------------------
+  winget:
+    needs: resolve
+    if: ${{ github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'winget' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: pro
+    steps:
+      - name: Install komac
+        env:
+          KOMAC_VERSION: "2.15.0"
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/russellbanks/Komac/releases/download/v${KOMAC_VERSION}/komac-${KOMAC_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | sudo tar xz -C /usr/local/bin komac
+          komac --version
+
+      - name: Resolve PackageIdentifier from channel
+        id: pkg
+        env:
+          CHANNEL: ${{ needs.resolve.outputs.channel }}
+        run: |
+          set -euo pipefail
+          case "$CHANNEL" in
+            stable)
+              echo "id=kunobi-ninja.kache"          >> "$GITHUB_OUTPUT"
+              ;;
+            unstable)
+              echo "id=kunobi-ninja.kache.Unstable" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Error: unknown channel '$CHANNEL' (expected stable or unstable)" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Verify Windows zip assets are accessible
+        id: urls
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          BASE="https://github.com/${GH_OWNER}/${GH_REPO}/releases/download/v${VERSION}"
+          URL_X64="${BASE}/kache-x86_64-pc-windows-msvc.zip"
+          URL_ARM="${BASE}/kache-aarch64-pc-windows-msvc.zip"
+          for url in "$URL_X64" "$URL_ARM"; do
+            HTTP_STATUS=$(curl -o /dev/null -w "%{http_code}" -L --head -fsS "$url" || true)
+            if [[ "$HTTP_STATUS" != "200" ]]; then
+              echo "Error: installer not found at $url (HTTP $HTTP_STATUS)" >&2
+              exit 1
+            fi
+            echo "Verified $url"
+          done
+          echo "x64=$URL_X64" >> "$GITHUB_OUTPUT"
+          echo "arm64=$URL_ARM" >> "$GITHUB_OUTPUT"
+
+      - name: Submit winget manifest update
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          PACKAGE_ID: ${{ steps.pkg.outputs.id }}
+          URL_X64: ${{ steps.urls.outputs.x64 }}
+          URL_ARM: ${{ steps.urls.outputs.arm64 }}
+          RELEASE_NOTES_URL: ${{ github.event.release.html_url }}
+          GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          KOMAC_FORK_OWNER: kunobi-ninja
+        run: |
+          set -euo pipefail
+          # Fall back to the release HTML page when not running on a release
+          # event (workflow_dispatch leaves github.event.release empty).
+          NOTES_URL="${RELEASE_NOTES_URL:-}"
+          if [[ -z "$NOTES_URL" ]]; then
+            NOTES_URL="https://github.com/${GH_OWNER}/${GH_REPO}/releases/tag/v${VERSION}"
+          fi
+          komac update "$PACKAGE_ID" \
+            --urls "${URL_X64},${URL_ARM}" \
+            --version "$VERSION" \
+            --release-notes-url "$NOTES_URL" \
+            --submit

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -285,8 +285,13 @@ jobs:
           if [[ -z "$NOTES_URL" ]]; then
             NOTES_URL="https://github.com/${GH_OWNER}/${GH_REPO}/releases/tag/v${VERSION}"
           fi
+          # komac >= v2.0.0 takes SPACE-separated URLs (two args), not a
+          # comma-joined string. NOTE: `update` targets an existing package;
+          # the very first submission of a brand-new id must be bootstrapped
+          # with `komac new` (see PR notes). WINGET_TOKEN must be a CLASSIC PAT
+          # with public_repo scope — a fine-grained PAT fails at PR-open.
           komac update "$PACKAGE_ID" \
-            --urls "${URL_X64},${URL_ARM}" \
+            --urls "$URL_X64" "$URL_ARM" \
             --version "$VERSION" \
             --release-notes-url "$NOTES_URL" \
             --submit

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -211,7 +211,12 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # winget — submit a komac PR to microsoft/winget-pkgs for BOTH stable and
-  # unstable identifiers. Installer type: zip → nested portable kache.exe.
+  # unstable identifiers. Installer shape: bare .exe as InstallerType: portable.
+  # The signed kache-<triple>-pc-windows-msvc.exe is published as a first-class
+  # release asset by the release pipeline (_release-rust.yml, opt-in
+  # `upload_windows_exe`), so winget installs it directly — no nested-installer
+  # fields, and it sidesteps the nested-portable upgrade/uninstall hang
+  # (winget-cli #3279 / #4242).
   # ---------------------------------------------------------------------------
   winget:
     needs: resolve
@@ -248,15 +253,15 @@ jobs:
               ;;
           esac
 
-      - name: Verify Windows zip assets are accessible
+      - name: Verify Windows portable .exe assets are accessible
         id: urls
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           set -euo pipefail
           BASE="https://github.com/${GH_OWNER}/${GH_REPO}/releases/download/v${VERSION}"
-          URL_X64="${BASE}/kache-x86_64-pc-windows-msvc.zip"
-          URL_ARM="${BASE}/kache-aarch64-pc-windows-msvc.zip"
+          URL_X64="${BASE}/kache-x86_64-pc-windows-msvc.exe"
+          URL_ARM="${BASE}/kache-aarch64-pc-windows-msvc.exe"
           for url in "$URL_X64" "$URL_ARM"; do
             HTTP_STATUS=$(curl -o /dev/null -w "%{http_code}" -L --head -fsS "$url" || true)
             if [[ "$HTTP_STATUS" != "200" ]]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,29 @@ pkg-fmt = "zip"
 [package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
 pkg-fmt = "zip"
 
+# Debian packaging (cargo-deb). Read by the _workflows build_deb step to
+# produce kache_<version>_{amd64,arm64}.deb, which package-publish.yml then
+# pushes into the apt repo on R2. cargo-deb reads this regardless of the
+# --target passed, so the same config drives both amd64 and arm64 builds.
+[package.metadata.deb]
+maintainer = "Zondax <feedback@kunobi.ninja>"
+copyright = "2026, Zondax AG"
+license-file = ["LICENSE", "0"]
+extended-description = """\
+kache is a zero-copy, content-addressed Rust build cache. It avoids file \
+copies and wasted disk by hardlinking artifacts locally and sharing them \
+via S3-compatible object storage."""
+section = "utils"
+priority = "optional"
+# CRITICAL: empty depends. kache is built as a static musl binary, so it has
+# no shared-library runtime dependencies. An auto-resolved or non-empty
+# `depends` would pin glibc and break install on musl/minimal systems.
+depends = ""
+assets = [
+    ["target/release/kache", "usr/bin/kache", "755"],
+    ["README.md", "usr/share/doc/kache/README", "644"],
+]
+
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,8 +119,8 @@ maintainer = "Zondax <feedback@kunobi.ninja>"
 copyright = "2026, Zondax AG"
 license-file = ["LICENSE", "0"]
 extended-description = """\
-kache is a zero-copy, content-addressed build cache for compiled languages \
-(Rust, C/C++ and more). It avoids file \
+kache is a zero-copy, content-addressed build cache for Rust, C/C++ and more. \
+It avoids file \
 copies and wasted disk by hardlinking artifacts locally and sharing them \
 via S3-compatible object storage."""
 section = "utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,8 @@ maintainer = "Zondax <feedback@kunobi.ninja>"
 copyright = "2026, Zondax AG"
 license-file = ["LICENSE", "0"]
 extended-description = """\
-kache is a zero-copy, content-addressed Rust build cache. It avoids file \
+kache is a zero-copy, content-addressed build cache for compiled languages \
+(Rust, C/C++ and more). It avoids file \
 copies and wasted disk by hardlinking artifacts locally and sharing them \
 via S3-compatible object storage."""
 section = "utils"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,35 @@ cargo install kache
 cargo binstall kache
 ```
 
+### OS package managers
+
+**Homebrew (macOS):**
+
+```sh
+brew install kunobi-ninja/kunobi/kache
+```
+
+**APT (Debian/Ubuntu):**
+
+```sh
+# Add the signing key (KMS-rooted OpenPGP cert)
+sudo curl -fsSL https://r2.kunobi.com/kache/apt/gpg.key \
+  -o /usr/share/keyrings/kache.gpg
+
+# Add the repository (stable channel; use `unstable` for RC/beta builds)
+echo "deb [signed-by=/usr/share/keyrings/kache.gpg] https://r2.kunobi.com/kache/apt stable main" \
+  | sudo tee /etc/apt/sources.list.d/kache.list
+
+sudo apt update
+sudo apt install kache
+```
+
+**winget (Windows):**
+
+```powershell
+winget install kunobi-ninja.kache
+```
+
 ## Quick start
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ cargo binstall kache
 **Homebrew (macOS):**
 
 ```sh
+# Stable
 brew install kunobi-ninja/kunobi/kache
+
+# Pre-release channel (RC/beta)
+brew install kunobi-ninja/kunobi/kache-unstable
 ```
 
 **APT (Debian/Ubuntu):**
@@ -76,7 +80,11 @@ sudo apt install kache
 **winget (Windows):**
 
 ```powershell
+# Stable
 winget install kunobi-ninja.kache
+
+# Pre-release channel (RC/beta)
+winget install kunobi-ninja.kache.Unstable
 ```
 
 ## Quick start

--- a/apt_config/distributions
+++ b/apt_config/distributions
@@ -4,7 +4,7 @@ Suite: stable
 Codename: stable
 Architectures: amd64 arm64
 Components: main
-Description: kache — content-addressed Rust build cache (stable releases)
+Description: kache — content-addressed zero-copy build cache for Rust, C/C++ and more (stable releases)
 
 Origin: kache
 Label: kache
@@ -12,4 +12,4 @@ Suite: unstable
 Codename: unstable
 Architectures: amd64 arm64
 Components: main
-Description: kache — content-addressed Rust build cache (pre-releases: RC/Beta)
+Description: kache — content-addressed zero-copy build cache for Rust, C/C++ and more (pre-releases: RC/Beta)

--- a/apt_config/distributions
+++ b/apt_config/distributions
@@ -1,0 +1,15 @@
+Origin: kache
+Label: kache
+Suite: stable
+Codename: stable
+Architectures: amd64 arm64
+Components: main
+Description: kache — content-addressed Rust build cache (stable releases)
+
+Origin: kache
+Label: kache
+Suite: unstable
+Codename: unstable
+Architectures: amd64 arm64
+Components: main
+Description: kache — content-addressed Rust build cache (pre-releases: RC/Beta)

--- a/scripts/apt/configure-rclone.sh
+++ b/scripts/apt/configure-rclone.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Configures the rclone r2: remote for Cloudflare R2 access.
+# Sourced by generate-repo.sh and publish.sh.
+#
+# Required env vars:
+#   R2_ACCESS_KEY_ID      - Cloudflare R2 access key
+#   R2_SECRET_ACCESS_KEY  - Cloudflare R2 secret key
+#   R2_ACCOUNT_ID         - Cloudflare account ID
+
+: "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID is required}"
+: "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY is required}"
+: "${R2_ACCOUNT_ID:?R2_ACCOUNT_ID is required}"
+
+if [ ! -f ~/.config/rclone/rclone.conf ]; then
+  mkdir -p ~/.config/rclone
+  cat > ~/.config/rclone/rclone.conf <<EOF
+[r2]
+type = s3
+provider = Cloudflare
+access_key_id = ${R2_ACCESS_KEY_ID}
+secret_access_key = ${R2_SECRET_ACCESS_KEY}
+endpoint = https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com
+acl = private
+no_check_bucket = true
+EOF
+fi

--- a/scripts/apt/download-debs.sh
+++ b/scripts/apt/download-debs.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Downloads .deb packages from R2 — FALLBACK path only.
+#
+# The package-publish.yml workflow's PRIMARY path is `gh release download`,
+# pulling the .deb assets straight off the GitHub Release. This script exists
+# for manual/local runs where the .debs live on R2 instead (e.g. re-publishing
+# from object storage without a fresh release event).
+#
+# Required env vars:
+#   VERSION   - package version (e.g. 0.7.0-rc.1)
+#   R2_URL    - R2 base URL (e.g. https://r2.kunobi.com)
+#   ARCHS     - space-separated Debian architectures (e.g. "amd64 arm64")
+#
+# Optional env vars:
+#   DEBS_DIR  - output directory (default: /tmp/debs)
+
+: "${VERSION:?VERSION is required}"
+: "${R2_URL:?R2_URL is required}"
+: "${ARCHS:?ARCHS is required}"
+
+DEBS_DIR="${DEBS_DIR:-/tmp/debs}"
+mkdir -p "${DEBS_DIR}"
+
+for arch in ${ARCHS}; do
+  # Mirrors the GitHub Release asset naming: kache_<version>_<arch>.deb
+  url="${R2_URL}/kache/releases/v${VERSION}/kache_${VERSION}_${arch}.deb"
+  dest="${DEBS_DIR}/kache_${VERSION}_${arch}.deb"
+  echo "Downloading ${url}..."
+  curl -sfL -o "${dest}" "${url}"
+done
+
+echo "Downloaded .deb files:"
+ls -la "${DEBS_DIR}/"

--- a/scripts/apt/generate-repo.sh
+++ b/scripts/apt/generate-repo.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generates the kache APT repository structure using reprepro.
+# Supports multi-channel: stable releases go to both the stable and unstable
+# suites; unstable releases go to unstable only.
+#
+# Required env vars:
+#   KMS_KEY       - Full GCP KMS key version path for kunobi-pgp-kms
+#   APT_CHANNEL   - release channel ("stable" or "unstable")
+#   CERT_PATH     - path to the materialized OpenPGP cert (from setup-pgp-kms-signing)
+#
+# Optional env vars:
+#   DEBS_DIR      - directory containing .deb files (default: /tmp/debs)
+#   APT_REPO_DIR  - output repo directory (default: /tmp/apt-repo)
+#   CONF_DIR      - directory containing distributions config (default: ./apt_config)
+#   APT_STATE_DIR - directory for persistent db (local testing only)
+#
+# R2 db persistence (download only):
+#   If R2 credentials are set (R2_ACCESS_KEY_ID, R2_BUCKET, etc.), the script
+#   downloads the existing reprepro db/ from R2 (prefix kache/apt-state/db/)
+#   before generating. publish.sh uploads it back AFTER public files are
+#   confirmed, so db/ is never ahead of the published state.
+
+: "${KMS_KEY:?KMS_KEY is required}"
+: "${APT_CHANNEL:?APT_CHANNEL is required (stable or unstable)}"
+: "${CERT_PATH:?CERT_PATH is required (path to materialized OpenPGP cert)}"
+
+DEBS_DIR="${DEBS_DIR:-/tmp/debs}"
+APT_REPO_DIR="${APT_REPO_DIR:-/tmp/apt-repo}"
+CONF_DIR="${CONF_DIR:-./apt_config}"
+
+export REPREPRO_BASE_DIR="${APT_REPO_DIR}"
+mkdir -p "${APT_REPO_DIR}/conf"
+
+# ── Restore persistent db from R2 (if credentials available) ──
+# First run: no db/ on R2 yet, reprepro bootstraps a fresh one.
+if [[ -n "${R2_ACCESS_KEY_ID:-}" && -n "${R2_BUCKET:-}" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # shellcheck source=scripts/apt/configure-rclone.sh
+  source "${SCRIPT_DIR}/configure-rclone.sh"
+  echo "Downloading reprepro db/ from R2 (kache/apt-state/db/)..."
+  rclone copy "r2:${R2_BUCKET}/kache/apt-state/db/" "${APT_REPO_DIR}/db/" \
+    --quiet 2>/dev/null || echo "No existing db/ on R2 (first run — bootstrapping)"
+fi
+
+# ── Restore from local state dir (for local testing) ──
+if [[ -n "${APT_STATE_DIR:-}" && -d "${APT_STATE_DIR}/db" ]]; then
+  echo "Restoring reprepro db/ from ${APT_STATE_DIR}..."
+  cp -r "${APT_STATE_DIR}/db" "${APT_REPO_DIR}/db"
+fi
+
+# ── Install distributions config verbatim (no SignWith — we sign manually) ──
+cp "${CONF_DIR}/distributions" "${APT_REPO_DIR}/conf/distributions"
+
+# ── Select target suites ──
+# Stable releases land in BOTH suites (unstable users also get stable updates).
+# Unstable releases land in unstable only.
+if [[ "${APT_CHANNEL}" == "stable" ]]; then
+  DISTS=("stable" "unstable")
+elif [[ "${APT_CHANNEL}" == "unstable" ]]; then
+  DISTS=("unstable")
+else
+  echo "Error: APT_CHANNEL must be 'stable' or 'unstable', got '${APT_CHANNEL}'" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+debs=("${DEBS_DIR}"/*.deb)
+shopt -u nullglob
+
+if [[ ${#debs[@]} -eq 0 ]]; then
+  echo "Error: No .deb files found in ${DEBS_DIR}" >&2
+  exit 1
+fi
+
+# ── Normalize Debian pre-release version (repack) ──
+# cargo-deb stamps the crate version verbatim, so a pre-release tag produces a
+# control Version like "0.7.0-rc.1". In Debian, '-' separates upstream from the
+# Debian revision and "0.7.0-rc.1" sorts ABOVE "0.7.0" — apt would never offer
+# the GA to a pre-release user. Rewrite the FIRST '-' to '~' (tilde sorts below
+# anything, including GA) inside the control file, keeping the .deb FILENAME's
+# hyphen untouched. Idempotent: skips .debs whose Version has no '-'.
+for deb in "${debs[@]}"; do
+  current=$(dpkg-deb -f "${deb}" Version)
+  case "${current}" in
+    *-*)
+      desired="${current/-/~}"
+      echo "Normalizing ${deb##*/}: Version ${current} -> ${desired}"
+      tmp="$(mktemp -d)"
+      dpkg-deb -R "${deb}" "${tmp}"
+      sed -i.bak "s|^Version: .*|Version: ${desired}|" "${tmp}/DEBIAN/control"
+      rm "${tmp}/DEBIAN/control.bak"
+      # --root-owner-group: keep files owned by root:root (else repack stamps
+      # the runner's uid/gid onto installed files on user machines).
+      dpkg-deb --root-owner-group -b "${tmp}" "${deb}" >/dev/null
+      rm -rf "${tmp}"
+      ;;
+    *)
+      echo "Version ${current} for ${deb##*/} needs no normalization"
+      ;;
+  esac
+done
+
+# ── Add packages to suites ──
+for deb in "${debs[@]}"; do
+  for dist in "${DISTS[@]}"; do
+    echo "Adding ${deb} to ${dist}..."
+    reprepro includedeb "${dist}" "${deb}"
+  done
+done
+
+# ── Sign Release files with kunobi-pgp-kms ──
+ARGS_BASE=(--kms-key "${KMS_KEY}" --cert "${CERT_PATH}")
+
+for dist in "${DISTS[@]}"; do
+  SUITE="${dist}"
+  echo "Signing APT Release for ${SUITE}..."
+  kunobi-pgp-kms clearsign   "${ARGS_BASE[@]}" \
+    --in  "${APT_REPO_DIR}/dists/${SUITE}/Release" \
+    --out "${APT_REPO_DIR}/dists/${SUITE}/InRelease"
+  kunobi-pgp-kms detach-sign "${ARGS_BASE[@]}" \
+    --in  "${APT_REPO_DIR}/dists/${SUITE}/Release" \
+    --out "${APT_REPO_DIR}/dists/${SUITE}/Release.gpg"
+done
+
+# ── Publish gpg.key (the KMS-rooted cert — the single trust root) ──
+cat "${CERT_PATH}" > "${APT_REPO_DIR}/gpg.key"
+
+echo "Generated repository structure:"
+find "${APT_REPO_DIR}" -not -path '*/db/*' -not -path '*/conf/*' | sort

--- a/scripts/apt/publish.sh
+++ b/scripts/apt/publish.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publishes the kache APT repository to R2 (prefix kache/apt/) using surgical
+# per-suite uploads. Only uploads dists/ for suites that were modified,
+# preserving the other channel's metadata on R2. Pool uploads are additive.
+#
+# Served at: https://r2.kunobi.com/kache/apt/
+#
+# Required env vars:
+#   R2_ACCESS_KEY_ID      - Cloudflare R2 access key
+#   R2_SECRET_ACCESS_KEY  - Cloudflare R2 secret key
+#   R2_ACCOUNT_ID         - Cloudflare account ID
+#   R2_BUCKET             - R2 bucket name
+#   APT_CHANNEL           - release channel ("stable" or "unstable")
+#
+# Optional env vars:
+#   APT_REPO_DIR  - repo directory to publish (default: /tmp/apt-repo)
+
+: "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID is required}"
+: "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY is required}"
+: "${R2_ACCOUNT_ID:?R2_ACCOUNT_ID is required}"
+: "${R2_BUCKET:?R2_BUCKET is required}"
+: "${APT_CHANNEL:?APT_CHANNEL is required (stable or unstable)}"
+
+APT_REPO_DIR="${APT_REPO_DIR:-/tmp/apt-repo}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/apt/configure-rclone.sh
+source "${SCRIPT_DIR}/configure-rclone.sh"
+
+if [[ "${APT_CHANNEL}" == "stable" ]]; then
+  DISTS=("stable" "unstable")
+elif [[ "${APT_CHANNEL}" == "unstable" ]]; then
+  DISTS=("unstable")
+else
+  echo "Error: APT_CHANNEL must be 'stable' or 'unstable', got '${APT_CHANNEL}'" >&2
+  exit 1
+fi
+
+# Upload dists/ per suite (sync replaces metadata for that codename only).
+for dist in "${DISTS[@]}"; do
+  if [ -d "${APT_REPO_DIR}/dists/${dist}" ]; then
+    echo "Syncing dists/${dist}/ to R2..."
+    rclone sync \
+      "${APT_REPO_DIR}/dists/${dist}/" \
+      "r2:${R2_BUCKET}/kache/apt/dists/${dist}/" \
+      --progress \
+      --checksum
+  fi
+done
+
+# Upload pool (additive — never deletes old .debs from other releases).
+if [ -d "${APT_REPO_DIR}/pool" ]; then
+  echo "Copying pool/ to R2 (additive)..."
+  rclone copy \
+    "${APT_REPO_DIR}/pool/" \
+    "r2:${R2_BUCKET}/kache/apt/pool/" \
+    --progress \
+    --checksum
+fi
+
+# Upload GPG public key.
+if [ -f "${APT_REPO_DIR}/gpg.key" ]; then
+  echo "Uploading gpg.key..."
+  rclone copyto \
+    "${APT_REPO_DIR}/gpg.key" \
+    "r2:${R2_BUCKET}/kache/apt/gpg.key" \
+    --checksum
+fi
+
+# Persist updated reprepro db/ to R2 LAST — only after public files are confirmed,
+# so db/ is never ahead of the actual published state.
+if [ -d "${APT_REPO_DIR}/db" ]; then
+  echo "Persisting reprepro db/ to R2..."
+  rclone sync \
+    "${APT_REPO_DIR}/db/" \
+    "r2:${R2_BUCKET}/kache/apt-state/db/" \
+    --checksum
+fi
+
+echo "kache APT repository published to R2 (channel: ${APT_CHANNEL}, suites: ${DISTS[*]})"

--- a/scripts/apt/smoke-test.sh
+++ b/scripts/apt/smoke-test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests live kache APT repository URLs after publishing.
+# Only tests suites that were published based on APT_CHANNEL.
+#
+# Required env vars:
+#   APT_CHANNEL   - release channel ("stable" or "unstable")
+#
+# Optional env vars:
+#   BASE_URL    - APT repo base URL (default: https://r2.kunobi.com/kache/apt)
+#   CERT_PATH   - materialized cert; when set, asserts its fingerprint is in
+#                 the served gpg.key
+
+: "${APT_CHANNEL:?APT_CHANNEL is required (stable or unstable)}"
+
+BASE_URL="${BASE_URL:-https://r2.kunobi.com/kache/apt}"
+REPO_URL="${BASE_URL}"
+ARCHES=(amd64 arm64)
+
+GNUPGHOME=$(mktemp -d)
+export GNUPGHOME
+chmod 700 "${GNUPGHOME}"
+trap 'rm -rf "${GNUPGHOME}"' EXIT
+
+if [[ "${APT_CHANNEL}" == "stable" ]]; then
+  DISTS=("stable" "unstable")
+elif [[ "${APT_CHANNEL}" == "unstable" ]]; then
+  DISTS=("unstable")
+else
+  echo "Error: APT_CHANNEL must be 'stable' or 'unstable', got '${APT_CHANNEL}'" >&2
+  exit 1
+fi
+
+# Download + import the published gpg.key the way real users do.
+echo "Testing gpg.key at ${BASE_URL}/gpg.key..."
+GPG_KEY_FILE=$(mktemp)
+curl -sf "${BASE_URL}/gpg.key" -o "${GPG_KEY_FILE}"
+gpg --with-colons --import-options show-only --import "${GPG_KEY_FILE}" | grep -q "pub"
+gpg --batch --import "${GPG_KEY_FILE}"
+rm -f "${GPG_KEY_FILE}"
+echo "GPG key valid"
+
+for dist in "${DISTS[@]}"; do
+  echo ""
+  echo "==> Testing suite: ${dist}"
+
+  echo "  Testing InRelease at ${BASE_URL}/dists/${dist}/InRelease..."
+  tmp_inrelease=$(mktemp)
+  curl -sf "${BASE_URL}/dists/${dist}/InRelease" -o "${tmp_inrelease}"
+  gpg --verify "${tmp_inrelease}"
+  rm -f "${tmp_inrelease}"
+
+  for arch in "${ARCHES[@]}"; do
+    echo "  Testing Packages.gz at ${BASE_URL}/dists/${dist}/main/binary-${arch}/Packages.gz..."
+    curl -sf "${BASE_URL}/dists/${dist}/main/binary-${arch}/Packages.gz" \
+      | zcat | grep -q "^Package: kache"
+  done
+  echo "  ${dist} smoke tests passed"
+done
+
+# Assert the KMS-rooted key fingerprint is present in the served gpg.key.
+if [ -n "${CERT_PATH:-}" ] && [ -f "${CERT_PATH}" ]; then
+  NEW_FPR=$(gpg2 --with-colons --show-keys "${CERT_PATH}" \
+            | awk -F: '/^fpr/{print $10; exit}')
+  if [ -n "$NEW_FPR" ]; then
+    PUBLISHED_KEY=$(mktemp)
+    curl -sf "${REPO_URL}/gpg.key" -o "${PUBLISHED_KEY}"
+    if ! gpg2 --with-colons --show-keys "${PUBLISHED_KEY}" \
+         | awk -F: '/^fpr/{print $10}' | grep -q "$NEW_FPR"; then
+      rm -f "${PUBLISHED_KEY}"
+      echo "FAIL: key fingerprint $NEW_FPR not in published gpg.key"
+      exit 1
+    fi
+    rm -f "${PUBLISHED_KEY}"
+    echo "KMS key fingerprint $NEW_FPR verified in published gpg.key"
+  fi
+fi
+
+echo ""
+echo "All smoke tests passed (suites: ${DISTS[*]})"

--- a/scripts/apt/validate.sh
+++ b/scripts/apt/validate.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validates the generated kache APT repository.
+# Checks: GPG signatures, Packages indices (amd64 + arm64), Release hashes.
+# Validates all suites that were published based on APT_CHANNEL.
+#
+# Required env vars:
+#   APT_CHANNEL   - release channel ("stable" or "unstable")
+#   CERT_PATH     - path to OpenPGP cert for the KMS-rooted signing key
+#
+# Optional env vars:
+#   APT_REPO_DIR  - repo directory to validate (default: /tmp/apt-repo)
+
+: "${APT_CHANNEL:?APT_CHANNEL is required (stable or unstable)}"
+: "${CERT_PATH:?CERT_PATH is required (OpenPGP cert for the KMS signing key)}"
+
+APT_REPO_DIR="${APT_REPO_DIR:-/tmp/apt-repo}"
+ARCHES=(amd64 arm64)
+
+# Import the signing public key into a scratch keyring so gpg --verify can
+# resolve the kunobi-pgp-kms signatures.
+GNUPGHOME=$(mktemp -d)
+export GNUPGHOME
+chmod 700 "${GNUPGHOME}"
+trap 'rm -rf "${GNUPGHOME}"' EXIT
+
+gpg --batch --import "${CERT_PATH}"
+
+if [[ "${APT_CHANNEL}" == "stable" ]]; then
+  DISTS=("stable" "unstable")
+elif [[ "${APT_CHANNEL}" == "unstable" ]]; then
+  DISTS=("unstable")
+else
+  echo "Error: APT_CHANNEL must be 'stable' or 'unstable', got '${APT_CHANNEL}'" >&2
+  exit 1
+fi
+
+for dist in "${DISTS[@]}"; do
+  DIST_DIR="${APT_REPO_DIR}/dists/${dist}"
+
+  if [ ! -d "${DIST_DIR}" ]; then
+    echo "Error: dists/${dist}/ does not exist" >&2
+    exit 1
+  fi
+
+  echo "==> Validating suite: ${dist}"
+
+  # --- GPG signatures ---
+  echo "  Validating GPG signatures..."
+  gpg --verify "${DIST_DIR}/Release.gpg" "${DIST_DIR}/Release"
+  gpg --verify "${DIST_DIR}/InRelease"
+  echo "  GPG signatures valid"
+
+  # --- Packages indices (amd64 + arm64) ---
+  for arch in "${ARCHES[@]}"; do
+    echo "  Validating ${arch} Packages index..."
+    if [ -f "${DIST_DIR}/main/binary-${arch}/Packages.gz" ]; then
+      zcat "${DIST_DIR}/main/binary-${arch}/Packages.gz" | grep -q "^Package: kache"
+      echo "  ${arch} Packages index contains kache"
+    else
+      echo "  Error: ${arch} Packages index not found in ${dist}" >&2
+      exit 1
+    fi
+  done
+
+  # --- Release hashes ---
+  echo "  Validating Release hashes..."
+  (
+    cd "${DIST_DIR}"
+    awk '/^SHA256:/{found=1; next} /^[^ ]/{found=0} found{print $1 "  " $3}' Release \
+      | while read -r hash file; do
+          if [ -f "${file}" ]; then
+            echo "${hash}  ${file}" | sha256sum -c -
+          else
+            echo "Error: Release lists '${file}' but file is missing" >&2
+            exit 1
+          fi
+        done
+  )
+  echo "  All Release hashes verified for ${dist}"
+  echo ""
+done
+
+echo "All validations passed (suites: ${DISTS[*]})"

--- a/scripts/ci/resolve-version.sh
+++ b/scripts/ci/resolve-version.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Resolve release version and channel for the kache publish workflow.
+#
+# Inputs (env vars):
+#   VERSION            – version string (with or without leading 'v') or "latest"
+#   CHANNEL            – "stable", "unstable", "auto", or "" (default: "auto")
+#   GITHUB_REPOSITORY  – owner/repo for gh release list (required)
+#   GH_TOKEN           – GitHub token (required)
+#
+# Outputs:
+#   stdout:        version=X.Y.Z and channel=stable|unstable (one per line)
+#   GITHUB_OUTPUT: same key=value pairs appended (when set)
+#
+# Channel inference (kache semver):
+#   vX.Y.Z            -> stable
+#   vX.Y.Z-rc.N       -> unstable
+#   vX.Y.Z-beta.N     -> unstable
+
+set -euo pipefail
+
+VERSION="${VERSION:-latest}"
+CHANNEL="${CHANNEL:-auto}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+# Normalize a possibly-empty / "auto" channel coming from workflow_dispatch.
+[[ -z "$CHANNEL" ]] && CHANNEL="auto"
+
+case "$CHANNEL" in
+  auto|stable|unstable) ;;
+  *)
+    echo "Error: Invalid CHANNEL '$CHANNEL' (must be one of: auto stable unstable)" >&2
+    exit 1
+    ;;
+esac
+
+# Strip a leading 'v' from explicit versions so the rest of the script works
+# on bare semver.
+VERSION="${VERSION#v}"
+
+# ---------------------------------------------------------------------------
+# Resolve version ("latest" → most recent release, filtered by channel)
+# ---------------------------------------------------------------------------
+if [[ -z "$VERSION" || "$VERSION" == "latest" ]]; then
+  if [[ "$CHANNEL" == "stable" ]]; then
+    JQ_FILTER='[.[].tagName | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | first // "" | ltrimstr("v")'
+  elif [[ "$CHANNEL" == "unstable" ]]; then
+    JQ_FILTER='[.[].tagName | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+-(rc|beta|alpha)"))] | first // "" | ltrimstr("v")'
+  else
+    # Any release (stable or pre-release)
+    JQ_FILTER='[.[].tagName | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+(-(rc|beta|alpha).*)?$"))] | first // "" | ltrimstr("v")'
+  fi
+
+  VERSION=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 50 --json tagName --jq "$JQ_FILTER")
+
+  if [[ -z "$VERSION" ]]; then
+    echo "Error: No matching release found in $GITHUB_REPOSITORY (channel=$CHANNEL)" >&2
+    exit 1
+  fi
+else
+  # Validate the explicit version exists as a release.
+  if ! gh release view "v${VERSION}" --repo "$GITHUB_REPOSITORY" --json tagName &>/dev/null; then
+    echo "Error: No matching release found in $GITHUB_REPOSITORY (version=v${VERSION})" >&2
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve channel (infer from version if empty or "auto")
+# ---------------------------------------------------------------------------
+if [[ -z "$CHANNEL" || "$CHANNEL" == "auto" ]]; then
+  if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    CHANNEL="stable"
+  elif [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(rc|beta|alpha) ]]; then
+    CHANNEL="unstable"
+  else
+    echo "Error: Cannot infer channel from version '$VERSION'" >&2
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+echo "Resolved version: $VERSION" >&2
+echo "Resolved channel: $CHANNEL" >&2
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+  echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+fi
+
+echo "version=$VERSION"
+echo "channel=$CHANNEL"


### PR DESCRIPTION
## Summary

Adds the full OS-package-manager publishing system for the kache CLI, modeled faithfully on `kunobi-frontend`. Three tracks fire after a GitHub release is `published` (also runnable via `workflow_dispatch`):

| Track | Target | Mechanism |
|-------|--------|-----------|
| **apt** | Debian repo on Cloudflare R2 (`kache/apt/` → `https://r2.kunobi.com/kache/apt/`) | `reprepro` + `kunobi-pgp-kms` KMS signing, suites `stable`+`unstable`, arches `amd64 arm64` |
| **brew** | tap `kunobi-ninja/homebrew-kunobi` | `repository-dispatch` event `update-kache-formula` (macOS arm64+x86_64) |
| **winget** | `microsoft/winget-pkgs` | `komac update` PR for both `kunobi-ninja.kache` (stable) and `kunobi-ninja.kache.Unstable` (unstable) |

The new workflow (`.github/workflows/package-publish.yml`) has a `resolve` job (version + channel) feeding three independent jobs gated on the `only` input. Channel rules: `vX.Y.Z` → `stable`, `-rc.N`/`-beta.N` → `unstable`. A **stable** deb lands in both suites; an **unstable** deb lands in `unstable` only.

## Files

**New**
- `.github/workflows/package-publish.yml` — orchestrator (resolve → apt/brew/winget)
- `.github/actions/setup-pgp-kms-signing/action.yml` — composite: GCP WIF auth + mise-install `kunobi-pgp-kms` + materialize cert from `PGP_CERT_BASE64` (no generation path)
- `apt_config/distributions` — reprepro config (two suites, amd64+arm64, no `SignWith:`)
- `scripts/apt/{configure-rclone,download-debs,generate-repo,publish,validate,smoke-test}.sh`
- `scripts/ci/resolve-version.sh`

**Changed**
- `Cargo.toml` — `[package.metadata.deb]` (empty `depends` for static musl, asset map for `kache` + README)
- `.github/workflows/ci.yml` — `build_deb: true` in the `_release-rust.yml@v10` release job
- `README.md` — Install section for brew / apt / winget

## New secrets required (env `pro`)
`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ACCOUNT_ID`, `R2_BUCKET`, `HOMEBREW_DISPATCH_TOKEN`, `WINGET_TOKEN`

## Reused signing secrets (already configured)
`PGP_SIGN_WIF_PROVIDER`, `PGP_SIGN_GCP_PROJECT_ID`, `PGP_SIGN_SERVICE_ACCOUNT`, `PGP_SIGN_KMS_KEY_VERSION`, `PGP_CERT_BASE64`, `GH_PAT_KUNOBI_NINJA_RELEASES`

## Dependencies / merge order
1. **Merge AFTER the `_workflows` `.deb` PR**: `build_deb: true` requires the `_workflows` `build_deb` input merged and the `v10` tag moved to include it. Until then the release job would error on an unknown input.
2. **homebrew-kunobi handler** (separate PR): the tap must handle the `update-kache-formula` dispatch event and write `Formula/kache.rb` / `Formula/kache-unstable.rb`.
3. The `.deb` release assets (`kache_<version>_{amd64,arm64}.deb`) are produced by the `_workflows` change; this workflow consumes them via `gh release download`.

## Validation
- All YAML parses (`yaml.safe_load`); all scripts pass `bash -n` and `shellcheck` (clean); `cargo metadata` reads the `[package.metadata.deb]` block correctly.

## Open items / uncertainties
- **Container image**: apt job uses `zondax/builder-ubuntu22:22.04.5`; fallback documented inline (`ubuntu-latest` + `apt-get install reprepro rclone gnupg2 dpkg-dev`).
- **reprepro db bootstrap**: first run finds no `db/` on R2 and bootstraps fresh — handled gracefully in `generate-repo.sh`.
- **winget zip/portable manifest**: the kache Windows assets are `.zip` containing a portable `kache.exe`. komac should infer the nested-portable installer type from the zip; if its heuristics don't pick up the nested exe automatically, the manifest may need an explicit `NestedInstallerType: portable` / `NestedInstallerFiles` (komac usually prompts, but `--submit` is non-interactive — may need a follow-up).
- **Debian pre-release normalization**: `.deb` control `Version:` `1.2.0-rc.1` → `1.2.0~rc.1` (tilde sorts below GA) is applied via dpkg-deb repack in `generate-repo.sh`, filename hyphen preserved.
