### PR TITLE
fix: clarify passthrough reason reporting

### DIFF
--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -801,7 +801,10 @@ fn read_event_log(path: &Path) -> EventLogStats {
         return EventLogStats::default();
     };
     let mut stats = EventLogStats::default();
-    let mut reasons: HashMap<String, u64> = HashMap::new();
+    // Keyed by (action, structured reason). The reason is the kache-emitted
+    // `category|detail`; print time splits it into the category / description
+    // columns.
+    let mut reasons: HashMap<(String, String), u64> = HashMap::new();
     let stream = serde_json::Deserializer::from_reader(std::io::BufReader::new(file))
         .into_iter::<serde_json::Value>();
     for item in stream {
@@ -825,7 +828,18 @@ fn read_event_log(path: &Path) -> EventLogStats {
                 if let Some(reason) = ev["passthrough_reason"].as_str()
                     && !reason.is_empty()
                 {
-                    *reasons.entry(reason.to_string()).or_default() += 1;
+                    // `action`: what kache did with the compile — delegated to a
+                    // configured fallback (e.g. sccache) or just ran the real
+                    // compiler. Keyed alongside the reason so the two dispositions
+                    // never merge into one row.
+                    let action = if ev["fallback"].as_bool().unwrap_or(false) {
+                        "fallback"
+                    } else {
+                        "reject"
+                    };
+                    *reasons
+                        .entry((action.to_string(), reason.to_string()))
+                        .or_default() += 1;
                 }
             }
             "error" => stats.errored += 1,
@@ -834,7 +848,11 @@ fn read_event_log(path: &Path) -> EventLogStats {
     }
     let mut top: Vec<ReasonCount> = reasons
         .into_iter()
-        .map(|(reason, count)| ReasonCount { reason, count })
+        .map(|((action, reason), count)| ReasonCount {
+            action,
+            reason,
+            count,
+        })
         .collect();
     top.sort_by_key(|rc| std::cmp::Reverse(rc.count));
     top.truncate(8);
@@ -1420,10 +1438,30 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
         el.total, el.cached, el.passed_through, el.errored
     );
     if !el.top_passthrough.is_empty() {
-        eprintln!("  passthrough   : top reasons —");
+        // Decision table, not an error list: `action  category  description`.
+        // The header says the build ran normally so the rows don't read as
+        // failures. Fixed-width action/category columns align; the variable
+        // description trails last.
+        eprintln!(
+            "  passthrough   : top reasons (kache declined to cache; the build ran normally) —"
+        );
         for rc in el.top_passthrough.iter().take(5) {
-            let reason: String = rc.reason.chars().take(72).collect();
-            eprintln!("    {:>6}x  {}", rc.count, reason);
+            // Reason is the kache-emitted `category|detail`; older logs without
+            // the `|` fall back to category "—" and the whole string as detail.
+            let (category, detail) = rc
+                .reason
+                .split_once('|')
+                .unwrap_or(("—", rc.reason.as_str()));
+            let action = if rc.action.is_empty() {
+                "reject"
+            } else {
+                rc.action.as_str()
+            };
+            let detail: String = detail.chars().take(64).collect();
+            eprintln!(
+                "    {:>6}x  {:<8}  {:<14}  {}",
+                rc.count, action, category, detail
+            );
         }
     }
     eprintln!(
@@ -1672,6 +1710,11 @@ struct EventLogStats {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ReasonCount {
+    /// What kache did: `reject` (ran the real compiler) or `fallback`
+    /// (delegated to a configured fallback wrapper, e.g. sccache).
+    #[serde(default)]
+    action: String,
+    /// The kache-emitted structured reason, `category|detail`.
     reason: String,
     count: u64,
 }

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -697,14 +697,14 @@ impl CcArgs {
         match self.mode {
             CompileMode::Compile => {}
             CompileMode::Link => reasons.push(RefuseReason::Unsupported(
-                "cc: link mode (whole-program caching not yet supported)",
+                "cc link mode (whole-program caching) — not yet",
             )),
             CompileMode::Preprocess => reasons.push(RefuseReason::Unsupported(
-                "cc: preprocessor mode -E (not yet supported)",
+                "cc preprocessor mode -E — not yet",
             )),
-            CompileMode::Assemble => reasons.push(RefuseReason::Unsupported(
-                "cc: assembly mode -S (not yet supported)",
-            )),
+            CompileMode::Assemble => {
+                reasons.push(RefuseReason::Unsupported("cc assembly mode -S — not yet"))
+            }
         }
 
         // Output to stdout — `-o -` is unambiguous; an `-o` followed
@@ -713,9 +713,7 @@ impl CcArgs {
         if let Some(output) = &self.output
             && output.as_os_str() == "-"
         {
-            reasons.push(RefuseReason::Unsupported(
-                "cc: output to stdout (not yet supported)",
-            ));
+            reasons.push(RefuseReason::Unsupported("cc output to stdout — not yet"));
         }
 
         // If a non-`-c` refusal accumulated, return early — running
@@ -742,7 +740,7 @@ impl CcArgs {
         // expansion + path normalization.
         if self.rest.iter().any(|a| a.starts_with('@')) {
             reasons.push(RefuseReason::Unsupported(
-                "cc: response file @file (expansion not yet supported)",
+                "cc response file @file (expansion) — not yet",
             ));
         }
 
@@ -751,7 +749,7 @@ impl CcArgs {
         let arch_count = self.rest.windows(2).filter(|w| w[0] == "-arch").count();
         if arch_count > 1 {
             reasons.push(RefuseReason::Unsupported(
-                "cc: multi-arch -arch X -arch Y (fat-binary caching not yet supported)",
+                "cc multi-arch -arch X -arch Y (fat-binary caching) — not yet",
             ));
         }
 
@@ -759,7 +757,7 @@ impl CcArgs {
         for flag in &["--coverage", "-fprofile-arcs", "-ftest-coverage"] {
             if self.rest.iter().any(|a| a == flag) {
                 reasons.push(RefuseReason::Unsupported(
-                    "cc: coverage instrumentation (not yet supported)",
+                    "cc coverage instrumentation — not yet",
                 ));
                 break;
             }
@@ -767,16 +765,14 @@ impl CcArgs {
 
         // Split DWARF (separate .dwo file alongside .o).
         if self.rest.iter().any(|a| a == "-gsplit-dwarf") {
-            reasons.push(RefuseReason::Unsupported(
-                "cc: -gsplit-dwarf (not yet supported)",
-            ));
+            reasons.push(RefuseReason::Unsupported("cc -gsplit-dwarf — not yet"));
         }
 
         // Precompiled headers.
         for flag in &["-include-pch", "-emit-pch"] {
             if self.rest.iter().any(|a| a == flag) {
                 reasons.push(RefuseReason::Unsupported(
-                    "cc: precompiled headers (not yet supported)",
+                    "cc precompiled headers — not yet",
                 ));
                 break;
             }
@@ -789,7 +785,7 @@ impl CcArgs {
                 && (next.ends_with(".pch") || next.ends_with(".gch"))
             {
                 reasons.push(RefuseReason::Unsupported(
-                    "cc: precompiled headers (not yet supported)",
+                    "cc precompiled headers — not yet",
                 ));
                 break;
             }
@@ -798,7 +794,7 @@ impl CcArgs {
         // Modules (clang/gcc).
         for flag in &["-fmodules", "-fcxx-modules"] {
             if self.rest.iter().any(|a| a == flag) {
-                reasons.push(RefuseReason::Unsupported("cc: modules (not yet supported)"));
+                reasons.push(RefuseReason::Unsupported("cc modules — not yet"));
                 break;
             }
         }
@@ -827,7 +823,8 @@ impl CcArgs {
             // process handles one compile then exits, so the leak is
             // bounded and short-lived.
             let detail: &'static str = Box::leak(
-                format!("cc: unsupported flag(s): {}", rejected.join(" ")).into_boxed_str(),
+                format!("cc unsupported flag(s): {} — not yet", rejected.join(" "))
+                    .into_boxed_str(),
             );
             tracing::debug!("{detail} — passthrough");
             reasons.push(RefuseReason::Unsupported(detail));
@@ -849,12 +846,10 @@ impl CcArgs {
         // convert most of these.
         if self.sources.len() > 1 {
             reasons.push(RefuseReason::Unsupported(
-                "cc: multi-source compile (per-source split not yet supported)",
+                "cc multi-source compile (per-source split) — not yet",
             ));
         } else if self.sources.is_empty() {
-            reasons.push(RefuseReason::Unsupported(
-                "cc: no source file (not yet supported)",
-            ));
+            reasons.push(RefuseReason::Unsupported("cc no source file — not yet"));
         }
 
         reasons
@@ -1234,15 +1229,23 @@ fn preprocess_hash(parsed: &CcArgs, prefix_maps: &[CcPrefixMap]) -> Result<Strin
     if !output.status.success() {
         // Preprocess failed — the real compile would also fail.
         // Bail so the wrapper falls back to passthrough, which runs
-        // the real compiler and surfaces the real diagnostic.
-        anyhow::bail!("preprocessor exited {} for cache key", output.status);
+        // the real compiler and surfaces the real diagnostic. Worded as the
+        // `uncacheable` passthrough detail, not a failure: often a configure
+        // probe that is *meant* to fail.
+        anyhow::bail!(
+            "cc -E key probe exited {}",
+            output
+                .status
+                .code()
+                .map_or_else(|| "by signal".to_string(), |c| c.to_string())
+        );
     }
     if output.stdout.is_empty() {
         // Zero preprocessor output: a mis-detected family ran the wrong
         // preprocess flags (gnu `-E -P` under clang-cl writes to a file),
         // or a degenerate empty TU. Either way refuse rather than hash
         // nothing → passthrough.
-        anyhow::bail!("preprocessor produced empty output for cache key");
+        anyhow::bail!("cc -E key probe produced no output");
     }
     let stdout = apply_cc_prefix_maps_to_bytes(output.stdout, prefix_maps);
     Ok(blake3::hash(&stdout).to_hex().to_string())
@@ -5503,11 +5506,11 @@ mod tests {
         );
         // Must read as a deferral, not a permanent limitation.
         assert!(
-            descs.iter().any(|d| d.contains("not yet supported")),
-            "preprocessor mode message must read as deferral ('not yet supported'), got: {descs:?}"
+            descs.iter().any(|d| d.contains("— not yet")),
+            "preprocessor mode message must read as deferral ('— not yet'), got: {descs:?}"
         );
 
-        // Link mode — also `Unsupported` with "(not yet supported)".
+        // Link mode — also `Unsupported` with "— not yet".
         // Same short-circuit: the flag classifier's complaint about
         // `-fuse-ld=lld` would be misleading because the issue is
         // "link mode", not the flag.
@@ -5626,7 +5629,7 @@ mod tests {
             "multi-source compile must be refused, got: {descs:?}"
         );
         assert!(
-            descs.iter().any(|d| d.contains("not yet supported")),
+            descs.iter().any(|d| d.contains("— not yet")),
             "multi-source message must read as deferral, got: {descs:?}"
         );
     }
@@ -5847,7 +5850,7 @@ mod tests {
         // it is a safe non-cache, the conservative trade-off.)
         let parsed = CcArgs::parse(&s(&["true", "-c", "a.c"])).unwrap();
         let err = preprocess_hash(&parsed, &[]).unwrap_err();
-        assert!(err.to_string().contains("empty"), "got: {err}");
+        assert!(err.to_string().contains("no output"), "got: {err}");
     }
 
     #[test]

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -128,13 +128,27 @@ pub enum RefuseReason {
 }
 
 impl RefuseReason {
-    /// Stable, human-readable description of why caching was refused.
-    /// Used by the wrapper for diagnostic logging and (future) metrics.
+    /// Stable, human-readable *detail* of why caching was refused — the
+    /// specifics (`cc link mode (whole-program caching) — not yet`). Pairs
+    /// with [`category`](Self::category), which gives the coarse class. Used
+    /// by the wrapper for the structured passthrough reason and by reporting.
     /// The string is a contract — changing it is observable.
     pub fn description(&self) -> &'static str {
         match self {
-            RefuseReason::NotPrimary => "not a primary compilation",
+            RefuseReason::NotPrimary => "query / probe (--print, -vV)",
             RefuseReason::Unsupported(detail) => detail,
+        }
+    }
+
+    /// Coarse class of the refusal, for the passthrough report's `category`
+    /// column. `not-a-compile` is a query/probe that is conceptually not a
+    /// compilation at all; `unsupported` is a real compile kache could cache
+    /// with engineering effort but doesn't model yet (its detail reads
+    /// "— not yet"). Neither is a failure — the build runs the compiler.
+    pub fn category(&self) -> &'static str {
+        match self {
+            RefuseReason::NotPrimary => "not-a-compile",
+            RefuseReason::Unsupported(_) => "unsupported",
         }
     }
 }

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -163,7 +163,7 @@ fn rustc_refuse_reasons(
     }
     if parsed.is_build_script_probe(build_script_out_dir) {
         reasons.push(RefuseReason::Unsupported(
-            "rustc build-script probe (not yet supported)",
+            "rustc build-script probe — not yet",
         ));
     }
     // Response files: any arg starting with `@` (a path to a file containing
@@ -174,7 +174,7 @@ fn rustc_refuse_reasons(
     // Refuse to cache until expansion is supported. Mirrors the cc adapter guard.
     if parsed.all_args.iter().any(|a| a.starts_with('@')) {
         reasons.push(RefuseReason::Unsupported(
-            "rustc: response file @file (expansion not yet supported)",
+            "rustc response file @file (expansion) — not yet",
         ));
     }
     // `--pretty`/`--unpretty` (and the `-Z unpretty=…` form) make rustc dump
@@ -194,7 +194,7 @@ fn rustc_refuse_reasons(
         .any(|z| z == "unpretty" || z.starts_with("unpretty="));
     if wants_source_dump {
         reasons.push(RefuseReason::Unsupported(
-            "rustc: --pretty/--unpretty source dump (not cacheable)",
+            "rustc --pretty/--unpretty source dump — not cacheable",
         ));
     }
     reasons
@@ -386,7 +386,7 @@ mod tests {
         assert_eq!(reasons.len(), 1);
         assert_eq!(
             reasons[0].description(),
-            "rustc build-script probe (not yet supported)"
+            "rustc build-script probe — not yet"
         );
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -178,7 +178,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             &parsed,
             &crate_name,
             start,
-            format!("refused: {}", reasons.join("; ")),
+            refuse_reason_string(&refuse),
         );
     }
 
@@ -237,7 +237,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                 &parsed,
                 &crate_name,
                 start,
-                format!("cache key failed: {e}"),
+                format!("uncacheable|{e}"),
             );
         }
     };
@@ -408,6 +408,22 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     );
     print_progress(&crate_name, event_result, elapsed, size);
     Ok(result.exit_code)
+}
+
+/// Format a refusal as the structured passthrough reason `category|detail`
+/// the report renderers parse into columns. `category` is the coarse class
+/// (`unsupported` / `not-a-compile`) of the first reason; `detail` joins the
+/// specific reasons. Deliberately NOT prefixed "refused:" / "failed:" — a
+/// refusal is a scope decision (the build runs the compiler normally), not an
+/// error, and the renderer supplies the `action` (`reject` / `fallback`).
+fn refuse_reason_string(refuse: &[crate::compiler::RefuseReason]) -> String {
+    let category = refuse.first().map_or("unsupported", |r| r.category());
+    let detail = refuse
+        .iter()
+        .map(|r| r.description())
+        .collect::<Vec<_>>()
+        .join("; ");
+    format!("{category}|{detail}")
 }
 
 /// Run a cc-family invocation without caching — invoke the compiler
@@ -644,7 +660,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             &args,
             crate_name,
             start,
-            format!("refused: {}", reasons.join("; ")),
+            refuse_reason_string(&refuse),
         );
     }
 
@@ -726,7 +742,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                 &args,
                 crate_name,
                 start,
-                format!("cache key failed: {e}"),
+                format!("uncacheable|{e}"),
             );
         }
     };


### PR DESCRIPTION
## Summary
- Emit structured passthrough reasons as category/detail pairs.
- Split benchmark passthrough summaries into action, category, and description columns.
- Reword refusal messages so unsupported compile shapes read as deferred support, not build failures.

## Validation
- cargo fmt --check
- cargo build -p kache -p kache-e2e
- cargo test -p kache --bins