### PR TITLE
fix: support x86 cc flags in monitor

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1653,6 +1653,17 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         dialect: None,
     },
     FlagSpec {
+        // x86 width / SIMD feature flags seen in Firefox passthroughs (#375).
+        // These materially change the object by selecting the target width or
+        // enabled ISA features. The resolved `cc -###` stream records the
+        // resulting target triple / `-target-feature` set, so the cache key
+        // differentiates each value. Listed tightly instead of opening `-m*`.
+        matcher: Matcher::Regex(r"-m(?:32|64|sse2|sse4\.1|sse4\.2|avx2)"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #375 — x86 width and SIMD feature flags from Firefox passthroughs.",
+        dialect: None,
+    },
+    FlagSpec {
         matcher: Matcher::Exact("-ffunction-sections"),
         class: FlagClass::CapturedByProbe,
         source: "Issue #115 — function-per-section object layout.",
@@ -4676,7 +4687,6 @@ mod tests {
             "-funroll-loops",
             "-fno-pic",
             "-mtune=skylake",
-            "-mavx2",
             // unmodeled optimization / debug variants
             "-Ofast",
             "-gdwarf-5",
@@ -5171,6 +5181,13 @@ mod tests {
             "-march=armv8.2-a+i8mm",
             // WASM SIMD
             "-msimd128",
+            // x86 width / SIMD feature flags from issue #375
+            "-m64",
+            "-m32",
+            "-msse2",
+            "-msse4.1",
+            "-msse4.2",
+            "-mavx2",
             // Section layout
             "-ffunction-sections",
             "-fdata-sections",
@@ -5275,8 +5292,8 @@ mod tests {
             // codegen)
             "-fno-function-sections",
             "-fno-data-sections",
-            // SIMD adjacent — not `-msimd128`
-            "-msse4.2",
+            // SIMD adjacent — not listed by #115/#375
+            "-mavx",
             "-mavx512f",
         ] {
             let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1627,7 +1627,7 @@ fn draw_passthrough_table(frame: &mut Frame, state: &AppState, area: Rect) {
         return;
     }
 
-    let header = Row::new(vec!["Time", "Crate", "Route", "Exit", "Reason"])
+    let header = Row::new(vec!["Time", "Crate", "Route", "Exit", "Kind", "Reason"])
         .style(Style::default().add_modifier(Modifier::BOLD));
 
     let visible_rows = (area.height as usize).saturating_sub(3);
@@ -1646,11 +1646,7 @@ fn draw_passthrough_table(frame: &mut Frame, state: &AppState, area: Rect) {
                 .map(|code| code.to_string())
                 .unwrap_or_default();
             let route = if event.fallback { "fallback" } else { "direct" };
-            let reason = if event.passthrough_reason.is_empty() {
-                "unknown"
-            } else {
-                &event.passthrough_reason
-            };
+            let (kind, reason) = passthrough_reason_parts(&event.passthrough_reason);
 
             let exit_style = match event.exit_code {
                 Some(0) => Style::default().fg(Color::Green),
@@ -1663,6 +1659,7 @@ fn draw_passthrough_table(frame: &mut Frame, state: &AppState, area: Rect) {
                 Cell::from(event.crate_name.clone()),
                 Cell::from(route).style(Style::default().fg(Color::Magenta)),
                 Cell::from(exit).style(exit_style),
+                Cell::from(kind.to_string()).style(Style::default().fg(Color::Cyan)),
                 Cell::from(reason.to_string()),
             ])
         })
@@ -1673,11 +1670,30 @@ fn draw_passthrough_table(frame: &mut Frame, state: &AppState, area: Rect) {
         Constraint::Min(18),
         Constraint::Length(10),
         Constraint::Length(6),
+        Constraint::Length(14),
         Constraint::Percentage(45),
     ];
 
     let table = Table::new(rows, widths).header(header).block(block);
     frame.render_widget(table, area);
+}
+
+fn passthrough_reason_parts(reason: &str) -> (&str, &str) {
+    let reason = reason.trim();
+    if reason.is_empty() {
+        return ("unknown", "unknown");
+    }
+
+    if let Some((kind, detail)) = reason.split_once('|') {
+        let kind = kind.trim();
+        let detail = detail.trim();
+        return (
+            if kind.is_empty() { "unknown" } else { kind },
+            if detail.is_empty() { "unknown" } else { detail },
+        );
+    }
+
+    ("legacy", reason.strip_prefix("refused: ").unwrap_or(reason))
 }
 
 fn draw_passthrough_help(frame: &mut Frame, state: &AppState, area: Rect) {
@@ -1722,6 +1738,19 @@ mod tests {
 
         // Error is the only red outcome.
         assert_eq!(event_presentation(EventResult::Error).3, Color::Red);
+    }
+
+    #[test]
+    fn passthrough_reason_parts_split_structured_reasons() {
+        assert_eq!(
+            passthrough_reason_parts("unsupported|cc unsupported flag(s): -foo — not yet"),
+            ("unsupported", "cc unsupported flag(s): -foo — not yet")
+        );
+        assert_eq!(
+            passthrough_reason_parts("refused: cc: unsupported flag(s): -m64"),
+            ("legacy", "cc: unsupported flag(s): -m64")
+        );
+        assert_eq!(passthrough_reason_parts(""), ("unknown", "unknown"));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1693,7 +1693,7 @@ fn passthrough_reason_parts(reason: &str) -> (&str, &str) {
         );
     }
 
-    ("legacy", reason.strip_prefix("refused: ").unwrap_or(reason))
+    ("N/A", reason.strip_prefix("refused: ").unwrap_or(reason))
 }
 
 fn draw_passthrough_help(frame: &mut Frame, state: &AppState, area: Rect) {
@@ -1748,7 +1748,7 @@ mod tests {
         );
         assert_eq!(
             passthrough_reason_parts("refused: cc: unsupported flag(s): -m64"),
-            ("legacy", "cc: unsupported flag(s): -m64")
+            ("N/A", "cc: unsupported flag(s): -m64")
         );
         assert_eq!(passthrough_reason_parts(""), ("unknown", "unknown"));
     }


### PR DESCRIPTION
## Summary
- Classify common x86 width/SIMD cc flags from the Firefox passthrough log as probe-keyed: -m32, -m64, -msse2, -msse4.1, -msse4.2, and -mavx2.
- Keep adjacent -m flags refused so the table does not become a broad -m* wildcard.
- Add a passthrough monitor Kind column that splits structured category|detail reasons while preserving legacy event display.

Fixes #375.

## Validation
- cargo fmt --check
- cargo build -p kache -p kache-e2e
- cargo test -p kache --bins