### PR TITLE
docs: describe kache as multi-language (Rust, C/C++ and more)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kache"
 version = "0.7.0-rc.2"
 edition = "2024"
-description = "Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — just hardlinks locally and S3 for sharing."
+description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more. No copies, no wasted disk — just hardlinks locally and S3 for sharing."
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"
 homepage = "https://kunobi.ninja/docs/kache"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue.svg)](Cargo.toml)
 
-Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — reflinks where the filesystem supports them, hardlinks or copies otherwise, plus S3 for sharing.
+Zero-copy, content-addressed build cache for Rust, C/C++ and more. No copies, no wasted disk — reflinks where the filesystem supports them, hardlinks or copies otherwise, plus S3 for sharing.
 
 A drop-in `RUSTC_WRAPPER` that caches Rust compilation artifacts. Cache keys are blake3 hashes of normalized rustc invocations; cache hits restore zero-copy — a reflink (copy-on-write clone) where the filesystem supports it (APFS, btrfs, XFS-with-reflink), and a hardlink or copy otherwise — and identical blobs are stored once and shared. Optional S3 sync (AWS, Ceph, MinIO, R2) shares the cache across machines.
 

--- a/assets/demo/demo.tape
+++ b/assets/demo/demo.tape
@@ -14,7 +14,7 @@ Set Padding 16
 Set TypingSpeed 30ms
 
 # Banner
-Type "# kache: zero-copy Rust build cache via RUSTC_WRAPPER"
+Type "# kache: zero-copy build cache for Rust, C/C++ and more via RUSTC_WRAPPER"
 Sleep 1500ms
 Ctrl+U
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: kache
-description: Zero-copy, content-addressed Rust build cache. No copies, no wasted disk — zero-copy restores (reflink where the filesystem supports it, else hardlink) locally and S3 for sharing.
+description: Zero-copy, content-addressed build cache for Rust, C/C++ and more. No copies, no wasted disk — zero-copy restores (reflink where the filesystem supports it, else hardlink) locally and S3 for sharing.
 ---
 
 # Introduction

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "kache - Zero-copy, content-addressed Rust build cache";
+  description = "kache - Zero-copy, content-addressed build cache for Rust, C/C++ and more";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -25,7 +25,7 @@
   hasSystemd = options ? systemd;
 in {
   options.services.kache = {
-    enable = lib.mkEnableOption "kache, a Rust build cache";
+    enable = lib.mkEnableOption "kache, a build cache for Rust, C/C++ and more";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -64,7 +64,7 @@ buildRustPackage {
   env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   meta = {
-    description = "Zero-copy, content-addressed Rust build cache";
+    description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more";
     homepage = "https://github.com/kunobi-ninja/kache";
     license = lib.licenses.asl20;
     mainProgram = "kache";

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ pub const VERSION: &str = {
     }
 };
 
-/// kache: Content-addressed Rust build cache with hardlinks and S3 remote storage.
+/// kache: Content-addressed build cache for Rust, C/C++ and more with hardlinks and S3 remote storage.
 ///
 /// When invoked as RUSTC_WRAPPER (arg[1] is a path to rustc), kache acts as a
 /// transparent build cache. Otherwise, it provides CLI commands for cache management.


### PR DESCRIPTION
kache caches **C/C++ as well as Rust** (and may extend further, e.g. TS), but the canonical descriptions still call it a "Rust build cache." This normalizes that wording everywhere it's the product's identity.

`Rust build cache` → `build cache for Rust, C/C++ and more` in:
- `Cargo.toml` `description` (**crates.io listing**)
- `README.md` tagline
- `src/main.rs` `--help` doc comment
- `docs/index.mdx` (**docs site**)
- `nix/package.nix`, `nix/module.nix`, `flake.nix`
- `assets/demo/demo.tape` caption

Docs/metadata only — no behavior change. Note: the demo `.gif`/`.cast` asset would need a `vhs` re-render to reflect the new caption (left for whoever regenerates the demo).