### PR TITLE
fix(package-publish): gate on release upload + drop private builder image

### DIFF
--- a/.github/actions/setup-pgp-kms-signing/action.yml
+++ b/.github/actions/setup-pgp-kms-signing/action.yml
@@ -91,7 +91,8 @@ runs:
           exit 1
         fi
         # Capture the OpenPGP V4 fingerprint for traceability and downstream use.
-        FPR=$(gpg2 --with-colons --show-keys "$CERT_PATH" | awk -F: '/^fpr/{print $10; exit}')
+        # GnuPG 2.x is `gpg` on the GitHub-hosted runner (no `gpg2` binary).
+        FPR=$(gpg --with-colons --show-keys "$CERT_PATH" | awk -F: '/^fpr/{print $10; exit}')
         if [ -z "$FPR" ]; then
           echo "::error::Could not extract fingerprint from $CERT_PATH"
           exit 1

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -73,26 +73,48 @@ jobs:
         run: bash scripts/ci/resolve-version.sh
 
   # ---------------------------------------------------------------------------
+  # Gate — wait for the release build to finish UPLOADING assets before any
+  # publisher runs. The CI `release` job publishes the GitHub Release (which
+  # fires this workflow) and only THEN uploads the .deb / .exe / tarballs, so on
+  # a release event the assets briefly don't exist yet. Block on
+  # `release / Upload release assets` going green — the same fail-closed
+  # require-ci-green.sh gate that publish-crates / service-image use. Skipped on
+  # workflow_dispatch backfills, where the release already has its assets.
+  # ---------------------------------------------------------------------------
+  gate:
+    needs: resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout (for scripts)
+        uses: actions/checkout@v4
+      - name: Wait for the release build to finish uploading assets
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # CI gates (~15m) + cross-build (~15m) + upload can approach ~40m;
+          # give headroom: 120 × 30s = 60m.
+          CI_GREEN_MAX_ATTEMPTS: "120"
+        run: ./scripts/require-ci-green.sh "${{ github.sha }}" "release / Upload release assets"
+
+  # ---------------------------------------------------------------------------
   # apt — build + sign the Debian repo and publish to R2.
   # ---------------------------------------------------------------------------
   apt:
-    needs: resolve
+    needs: [resolve, gate]
     # Run unless `only` explicitly selects a different single track.
     if: ${{ github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'apt' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # zondax/builder-ubuntu22 ships reprepro + rclone + gpg2 preinstalled.
-    # Fallback if the image is unavailable: drop `container:` and add a step
-    #   run: sudo apt-get update && sudo apt-get install -y reprepro rclone gnupg2 dpkg-dev
-    container:
-      image: zondax/builder-ubuntu22:22.04.5
-      options: --tty
-    defaults:
-      run:
-        shell: bash
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Install apt-repo tooling
+        # On the GitHub-hosted runner reprepro + rclone aren't preinstalled (gpg
+        # is). This replaces the private zondax/builder-ubuntu22 image, which the
+        # hosted runner can't pull.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends reprepro rclone gnupg dpkg-dev
 
       - name: Setup PGP KMS signing
         id: pgp-kms
@@ -160,7 +182,7 @@ jobs:
   # (stable) or Formula/kache-unstable.rb (unstable).
   # ---------------------------------------------------------------------------
   brew:
-    needs: resolve
+    needs: [resolve, gate]
     if: ${{ github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'brew' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -217,7 +239,7 @@ jobs:
   # (winget-cli #3279 / #4242).
   # ---------------------------------------------------------------------------
   winget:
-    needs: resolve
+    needs: [resolve, gate]
     if: ${{ github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'winget' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/scripts/apt/smoke-test.sh
+++ b/scripts/apt/smoke-test.sh
@@ -61,12 +61,12 @@ done
 
 # Assert the KMS-rooted key fingerprint is present in the served gpg.key.
 if [ -n "${CERT_PATH:-}" ] && [ -f "${CERT_PATH}" ]; then
-  NEW_FPR=$(gpg2 --with-colons --show-keys "${CERT_PATH}" \
+  NEW_FPR=$(gpg --with-colons --show-keys "${CERT_PATH}" \
             | awk -F: '/^fpr/{print $10; exit}')
   if [ -n "$NEW_FPR" ]; then
     PUBLISHED_KEY=$(mktemp)
     curl -sf "${REPO_URL}/gpg.key" -o "${PUBLISHED_KEY}"
-    if ! gpg2 --with-colons --show-keys "${PUBLISHED_KEY}" \
+    if ! gpg --with-colons --show-keys "${PUBLISHED_KEY}" \
          | awk -F: '/^fpr/{print $10}' | grep -q "$NEW_FPR"; then
       rm -f "${PUBLISHED_KEY}"
       echo "FAIL: key fingerprint $NEW_FPR not in published gpg.key"


### PR DESCRIPTION
Fixes both failures from the v0.7.0-rc.3 publish run.

**1. Asset race (apt/brew/winget all 404'd).** `package-publish` triggers on `release: published`, but the CI `release` job publishes the GitHub Release *before* it finishes uploading the `.deb`/`.exe`/tarballs — so the publishers ran against an asset-less release. Add a **`gate`** job that blocks on `release / Upload release assets` going green (reuses `require-ci-green.sh` — the same fail-closed gate `publish-crates`/`service-image` use). apt/brew/winget now `needs: [resolve, gate]`. The wait is skipped on `workflow_dispatch` backfills (the release already has assets).

**2. Private builder image.** The apt job used `container: zondax/builder-ubuntu22` — private, so the hosted runner got `pull access denied`. Now runs on `ubuntu-latest` with `apt-get install reprepro rclone gnupg dpkg-dev`, and the composite + smoke-test use `gpg` instead of `gpg2` (no `gpg2` binary on hosted runners).

After merge, re-run publish for v0.7.0-rc.3 via workflow_dispatch once its build has uploaded assets.