### PR TITLE
docs: refresh README and CI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,6 @@ kache is useful even before remote cache is configured:
 
 ![kache clean TUI listing target/ dirs with cached percentages](assets/clean.gif)
 
-## Star history
-
-[![Star History Chart](https://api.star-history.com/chart?repos=kunobi-ninja/kache&type=date&legend=top-left)](https://www.star-history.com/?repos=kunobi-ninja%2Fkache&type=date&legend=top-left)
-
 ## Install
 
 ```sh
@@ -275,3 +271,7 @@ When combining HA with PVC-backed planner state, use storage that can be mounted
 ## Contributing
 
 Bug reports, feature ideas, and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev setup, coding conventions, and PR process. To report a security vulnerability privately, follow [SECURITY.md](SECURITY.md).
+
+## Project activity
+
+[![Star History Chart](https://api.star-history.com/chart?repos=kunobi-ninja/kache&type=date&legend=top-left)](https://www.star-history.com/?repos=kunobi-ninja%2Fkache&type=date&legend=top-left)

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue.svg)](Cargo.toml)
 
-Zero-copy, content-addressed build cache for Rust, C/C++ and more. No copies, no wasted disk — reflinks where the filesystem supports them, hardlinks or copies otherwise, plus S3 for sharing.
+Zero-copy, content-addressed build cache for Rust and C/C++ object compiles. No copies, no wasted disk — reflinks where the filesystem supports them, hardlinks or copies otherwise, plus S3 for Rust artifact sharing.
 
-A drop-in `RUSTC_WRAPPER` that caches Rust compilation artifacts. Cache keys are blake3 hashes of normalized rustc invocations; cache hits restore zero-copy — a reflink (copy-on-write clone) where the filesystem supports it (APFS, btrfs, XFS-with-reflink), and a hardlink or copy otherwise — and identical blobs are stored once and shared. Optional S3 sync (AWS, Ceph, MinIO, R2) shares the cache across machines.
+A drop-in `RUSTC_WRAPPER` for Rust and a `cc` / `c++` compiler wrapper for C/C++ object compiles. Cache keys are blake3 hashes of normalized compiler inputs; cache hits restore zero-copy — a reflink (copy-on-write clone) where the filesystem supports it (APFS, btrfs, XFS-with-reflink), and a hardlink or copy otherwise — and identical blobs are stored once and shared. Optional S3 sync (AWS, Ceph, MinIO, R2) shares Rust artifacts across machines.
 
-Local caching and direct S3 sync are stable today.
+Local Rust caching, local C/C++ object caching, and direct S3 sync are working today. C/C++ artifacts are local-only for now; unsupported compiler shapes pass through to the real compiler.
 
 **PREVIEW:** a remote planner that prefetches from workspace manifests, dependency history, and build intent — warming the right artifacts before rustc asks for them. The daemon already calls a planner when `KACHE_PLANNER_ENDPOINT` is set; the hosted service is still preview.
 
@@ -36,6 +36,10 @@ kache is useful even before remote cache is configured:
 `kache clean` — find target/ dirs and see what's already in the kache store:
 
 ![kache clean TUI listing target/ dirs with cached percentages](assets/clean.gif)
+
+## Star history
+
+[![Star History Chart](https://api.star-history.com/chart?repos=kunobi-ninja/kache&type=date&legend=top-left)](https://www.star-history.com/?repos=kunobi-ninja%2Fkache&type=date&legend=top-left)
 
 ## Install
 
@@ -113,7 +117,7 @@ kache doctor
 
 That uses GitHub Actions cache by default. For S3-backed caching shared across repos or runners, pass `s3-bucket` plus credentials — see the action's README for the full input list.
 
-## C/C++ caching (experimental)
+## C/C++ caching
 
 Alongside the rustc wrapper, kache can cache **C/C++ object compiles** as a `cc` / `c++` wrapper. It recognizes `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++` (plus versioned variants like `gcc-13`), and `clang-cl` or any `--driver-mode=cl` invocation (clang in MSVC driver mode) — on every OS, not just Windows, since recognition keys off the driver mode rather than the host. clang-cl is what mozconfigs and the `cc` crate use on Windows:
 
@@ -128,13 +132,13 @@ export CXX="kache c++"
 set "CC=kache clang-cl"
 ```
 
-**What's cached today:** single-source `-c` object compiles (e.g. `cc -c foo.c -o foo.o`, or `clang-cl -c foo.c -Fofoo.obj`). The cache key is the preprocessor expansion (`cc -E -P` for gcc/clang, `clang-cl /EP` for clang-cl, with `SOURCE_DATE_EPOCH` forced to `0` so `__DATE__`/`__TIME__` expand deterministically) plus compiler identity, target arch, and codegen flags — so any header change invalidates it. On a hit the object (`.o`, or `.obj` for clang-cl) and its `.d` dep-info restore without re-running the compiler. Any flag kache hasn't classified is **refused** — the invocation passes through to the real compiler rather than risk a silently-wrong object.
+**What's cached today:** single-source `-c` object compiles (e.g. `cc -c foo.c -o foo.o`, `c++ -c foo.cpp -o foo.o`, or `clang-cl -c foo.c -Fofoo.obj`). The cache key is the preprocessor expansion (`cc -E -P` for gcc/clang, `clang-cl /EP` for clang-cl, with `SOURCE_DATE_EPOCH` forced to `0` so `__DATE__`/`__TIME__` expand deterministically) plus compiler identity, target arch, and codegen flags — so any header change invalidates it. On a hit the object (`.o`, or `.obj` for clang-cl) and its `.d` dep-info restore without re-running the compiler. Any flag kache hasn't classified is **refused** — the invocation passes through to the real compiler rather than risk a silently-wrong object.
 
 For **gcc/clang** the key is portable across machines and worktrees (paths are normalized via `-ffile-prefix-map`). Set `KACHE_BASE_DIR` to a user-declared root that gets stripped from the key, covering paths the derived source/build roots miss — e.g. objdir-built units whose `__FILE__` points above the derived root — for cross-checkout hits the automatic roots can't reach. If path normalization ever miscaches, `KACHE_CC_PATH_NORMALIZE=0` is the escape hatch: keys become path-literal (no cross-machine sharing, zero normalization risk). For **clang-cl** the key is already **machine-local**: clang-cl ignores `-ffile-prefix-map`, so kache keeps literal paths in the key — correct local hits, but no cross-machine sharing yet. clang-cl **debug** compiles (`/Z7`, `/Zi`, `-Z7`, or a `-g` form) are cached too: clang-cl embeds debug info straight into the `.obj` (there's no separate compile-time PDB), so kache folds the CodeView path inputs that object embeds — source path, output name, and compilation dir — into the same machine-local key.
 
 **Not cached yet** (these pass through): link / whole-program steps, multi-source and multi-arch invocations, response-file (`@file`) invocations, precompiled headers, modules, coverage, and split-DWARF; for clang-cl also `-bigobj` and `-showIncludes`. C/C++ caching is also **local-only** for now — the Rust path's S3 sharing doesn't extend to `cc` artifacts yet.
 
-It's experimental and conservative by design: when in doubt, kache misses rather than serve a wrong artifact. Scope and remaining work are tracked in [#49](https://github.com/kunobi-ninja/kache/issues/49).
+C/C++ caching is live but still conservative by design: when in doubt, kache misses rather than serve a wrong artifact. See [C/C++ caching](docs/getting-started/c-cpp.mdx) for setup, status, and limitations. Scope and remaining work are tracked in [#49](https://github.com/kunobi-ninja/kache/issues/49).
 
 ## Development
 
@@ -151,11 +155,11 @@ The repo uses `just` as its single task runner. `mise.toml` pins the local Rust 
 
 **Work in progress.** The `kache-scenario` runner drives kache through real benchmark scenarios such as Firefox (cold + warm builds against one shared cache, cross-clone key-stability check, leak detection, honest verdict gate). It's the tool that surfaced the linker-path key leak fixed in v7 of the cache-key version.
 
-It is intentionally a hard scenario. Firefox combines a large Rust workspace with extensive C/C++ via mozbuild's bootstrapped toolchain, LTO, and per-objdir cargo-linker shims — and by compile count the build is dominated by C/C++, not Rust (~85% of the compiles in a Firefox build are C/C++ units). **Caching Firefox end-to-end is therefore a long-term objective**: kache's Rust path is mature, but its C/C++ path (`cc.rs`-driven invocations, clang/gcc arg parsing, embedded-build-system flags) is still maturing. Until that side catches up, Firefox's C/C++ compiles passthrough uncached and bound the achievable warm speedup, regardless of how well the Rust side caches.
+It is intentionally a hard scenario. Firefox combines a large Rust workspace with extensive C/C++ via mozbuild's bootstrapped toolchain, LTO, and per-objdir cargo-linker shims — and by compile count the build is dominated by C/C++, not Rust (~85% of the compiles in a Firefox build are C/C++ units). **Caching Firefox end-to-end is therefore a long-term objective**: kache's Rust path is mature, and its C/C++ path now handles common single-source object compiles, but Firefox still contains link-mode, whole-program, multi-source, and still-unmodeled shapes that correctly pass through.
 
 So the current bench measures progress against that long-term objective rather than a finished product. The verdict reliably reports `ok` for cache-key portability on the Rust side after v7 (88% cross-clone stability), but two known limitations keep the weighted speedup modest:
 
-1. **C/C++ caching maturity** — C/C++ dominates the Firefox build (~85% of compiles), and so far only single-source `-c` object compiles are cached (see [C/C++ caching](#cc-caching-experimental)). Link/whole-program steps, multi-source units, and any still-unmodeled flag pass through, and `cc` caching is local-only — so most of Firefox's C/C++ work isn't warm-cached yet. (0.4.0 broadened the `cc` flag coverage considerably — Gecko/Darwin/clang and C++ ABI flags — but the bottleneck is now the broader scope above, not a single rejected flag.) This is the bottleneck; closing it is the multi-step C/C++ maturity work.
+1. **C/C++ scope** — C/C++ dominates the Firefox build (~85% of compiles). kache caches supported single-source `-c` object compiles today (see [C/C++ caching](#cc-caching)), including common gcc/clang, C++, dep-info, and clang-cl debug shapes, but link/whole-program steps, multi-source units, and any still-unmodeled flag pass through. `cc` caching is also local-only — the Rust path's S3 sharing does not extend to `cc` artifacts yet.
 2. **Workspace-local Rust crate instability** — a handful of Mozilla-local crates (`gkrust_shared`, `style`, `webrender`, …) still miss across clones for a non-path-leak reason, separate from the v7 linker fix.
 
 Treat the benchmark as a diagnostic platform first and a headline-number tool second — the structural improvements come out of running it, not today's speedup figure.
@@ -202,7 +206,7 @@ See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
 | `kache daemon uninstall` | Remove the daemon service |
 | `kache daemon log` | Stream daemon logs |
 
-Durations use human-friendly format: `7d`, `24h`, `30m`.
+Durations use days, hours, or bare hours: `7d`, `24h`, `1h`, `48`.
 
 ## Remote cache and configuration
 

--- a/docs/getting-started/c-cpp.mdx
+++ b/docs/getting-started/c-cpp.mdx
@@ -1,0 +1,77 @@
+---
+title: C/C++ caching
+description: Wrap cc, c++, gcc, clang, and clang-cl for local object-compile caching.
+---
+
+# C/C++ caching
+
+kache can wrap C and C++ compilers in addition to rustc. This path is live for local object compiles and intentionally conservative: if kache cannot model an invocation safely, it passes through to the real compiler.
+
+## Setup
+
+For Make, CMake, autotools, or build scripts that honor `CC` / `CXX`:
+
+```sh
+export CC="kache cc"
+export CXX="kache c++"
+```
+
+For clang-cl / MSVC-driver mode:
+
+```bat
+set "CC=kache clang-cl"
+```
+
+kache recognizes `cc`, `c++`, `gcc`, `g++`, `clang`, `clang++`, versioned variants like `gcc-13`, `clang-cl`, and `clang --driver-mode=cl`.
+
+## What Is Cached
+
+kache caches single-source object compiles:
+
+```sh
+cc -c src/foo.c -o build/foo.o
+c++ -c src/foo.cpp -o build/foo.o
+clang-cl -c foo.c -Fofoo.obj
+```
+
+On a hit, kache restores the object file and dep-info sidecar without re-running the compiler. The key includes:
+
+- preprocessor output, so header edits invalidate the object
+- compiler identity and resolved target/codegen flags
+- source path normalization for gcc/clang
+- CodeView path inputs for clang-cl debug compiles (`/Z7`, `-Z7`, `-g`)
+
+For gcc/clang, keys are portable across worktrees when paths normalize cleanly. Use `KACHE_BASE_DIR` for checkout or container mount prefixes the automatic detection cannot strip.
+
+For clang-cl debug builds, keys are machine-local. clang-cl embeds CodeView paths in the `.obj` and does not honor `-ffile-prefix-map`, so kache keeps those paths literal instead of pretending the object is portable.
+
+## What Passes Through
+
+These shapes compile normally but are not cached yet:
+
+- link or whole-program steps
+- multi-source or multi-arch invocations
+- response files (`@file`)
+- precompiled headers and modules
+- coverage and split-DWARF
+- clang-cl `-bigobj` and `-showIncludes`
+- flags kache has not classified
+
+C/C++ artifacts are local-only today. S3 sync and remote sharing apply to Rust artifacts, not `cc` objects.
+
+## Diagnosing Passthroughs
+
+Use `kache monitor` and open the Passthrough tab, or run with debug logging:
+
+```sh
+KACHE_LOG=kache=debug make
+```
+
+If a safe flag is missing from kache's built-in allow-list, opt it in locally:
+
+```toml title=".kache.toml"
+[cc]
+extra_allowlist_flags = ["-ffunction-sections", "-fdata-sections"]
+```
+
+The flag is folded into the key verbatim. Avoid host-dependent values like `-march=native`, because the same spelling can produce different objects on different CPUs.

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -201,6 +201,8 @@ This is an advanced opt-in: only list vars whose value is purely a path locator.
 
 kache caches a C/C++ compile only when it recognizes every flag on the command line. Its cc flag classifier is an **allow-list**: each flag is one kache has reasoned about and knows how to key. Anything unrecognized is refused and the compile passes through uncached — the safe default, since a flag kache doesn't model could change the object file without changing the key.
 
+For setup and the current C/C++ support matrix, see [C/C++ caching](/docs/getting-started/c-cpp).
+
 **Supported compilers and dialects.** kache wraps the GNU-dialect drivers (`cc`, `c++`, `gcc`, `g++`, `clang`, `clang++`; POSIX) and the MSVC-dialect `clang-cl` (Windows, or `clang --driver-mode=cl`). The two dialects have separate allow-lists, so each flag is classified in the spelling its compiler actually uses — e.g. `-fno-rtti` (GNU) vs `-GR-` (clang-cl), `-std=c++20` vs `-std:c++20`. For clang-cl, debug info (`/Z7` / `-Z7` / `-g`) **is** cached (machine-local — clang-cl embeds CodeView paths in the `.obj`), while `-bigobj` and `-showIncludes` are still deliberately **refused** (passed through) for now; the common MSVC codegen set (`-EH*`, `-GR`/`-GS`, `-guard:`, `-std:`, `-fms-compatibility-version=`, `/O*`, `-Gy`/`-Gw`, `-MD`/`-MT`, …) is modeled. `extra_allowlist_flags` entries below are matched against command-line tokens verbatim, so list them in whichever dialect your compiler speaks (a `/`-spelled clang-cl flag included).
 
 The cost is that a common-but-unlisted flag disables caching for that compile until kache ships a release adding it. `cc.extra_allowlist_flags` lets you opt such a flag in locally, ahead of official support:

--- a/docs/getting-started/meta.json
+++ b/docs/getting-started/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Getting Started",
-  "pages": ["installation", "quick-start", "configuration"]
+  "pages": ["installation", "quick-start", "c-cpp", "configuration"]
 }

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -112,6 +112,17 @@ By default, kache skips user-facing executables — `bin` crates and `--test` ha
 
 Incremental compilation is automatically disabled when kache is active — kache strips the `-C incremental=...` flag from each rustc invocation (setting `CARGO_INCREMENTAL=0` would be too late, since cargo injects the flag before the wrapper runs). kache's artifact caching makes incremental redundant, and on macOS, APFS-related corruption can occur when both are active simultaneously.
 
+## C/C++ object compiles
+
+kache can also wrap C/C++ compilers for local object-compile caching:
+
+```sh
+export CC="kache cc"
+export CXX="kache c++"
+```
+
+This is separate from `RUSTC_WRAPPER`: supported single-source `-c` compiles are cached, while link steps and unmodeled compiler shapes pass through. See [C/C++ caching](/docs/getting-started/c-cpp).
+
 ## Disabling kache temporarily
 
 ```sh

--- a/docs/how-it-works/architecture.mdx
+++ b/docs/how-it-works/architecture.mdx
@@ -73,7 +73,7 @@ The daemon runs as a separate binary invocation (`kache daemon run`) and can be 
 
 ## What kache does not touch
 
-As a `RUSTC_WRAPPER`, kache intercepts only `rustc` and `clippy-driver` invocations — not `cargo`, `ld`, or any other tool; linking, proc-macro expansion, and build scripts run unmodified. (Separately, kache can also be set as `CC` / `CXX` to wrap a C/C++ compiler — `gcc`/`clang`, or `clang` in MSVC driver mode (`clang-cl` / `--driver-mode=cl`, as used by mozconfigs and the `cc` crate on Windows) — for object-compile caching; that path is independent of the rustc wrapper. See [C/C++ caching](https://github.com/kunobi-ninja/kache#cc-caching-experimental).)
+As a `RUSTC_WRAPPER`, kache intercepts only `rustc` and `clippy-driver` invocations — not `cargo`, `ld`, or any other tool; linking, proc-macro expansion, and build scripts run unmodified. Separately, kache can be set as `CC` / `CXX` to wrap a C/C++ compiler — `gcc`/`clang`, or `clang` in MSVC driver mode (`clang-cl` / `--driver-mode=cl`, as used by mozconfigs and the `cc` crate on Windows) — for local object-compile caching. That path is independent of the rustc wrapper. See [C/C++ caching](/docs/getting-started/c-cpp).
 
 By default, kache skips only user-facing executables — `bin` crates and `--test` harness binaries — because their outputs depend on the linker and may be mutated post-build (code signing on macOS, stripping). dylib, cdylib, and proc-macro crates stay cached. Enabling `cache_executables` opts the executables in, but most of the compile-time savings come from caching rlibs anyway.
 

--- a/docs/how-it-works/cache-key.mdx
+++ b/docs/how-it-works/cache-key.mdx
@@ -64,7 +64,7 @@ On Windows the same machinery adds `<APPDATA>`, `<LOCALAPPDATA>` and `<PROGRAMFI
 
 So a backtrace or a debugger opened against a restored binary will show source paths like `<WORKSPACE>/src/main.rs` and won't find the file on disk until you map the sentinel back. This is expected — it is the price of one binary being valid in every checkout — not a sign the cache is corrupt.
 
-This page describes the **rustc** artifact cache. C/C++ object compiles (`cc` / `clang-cl`, see [C/C++ caching](https://github.com/kunobi-ninja/kache#cc-caching-experimental)) are keyed separately. clang-cl debug compiles (`/Z7` / `-Z7` / `-g`) *are* cached, but the key stays machine-local: clang-cl embeds CodeView paths directly in the `.obj` (no separate PDB) and ignores `-ffile-prefix-map`, so kache keeps those paths literal in the key rather than remapping them — correct local hits, no cross-machine sharing.
+This page describes the **rustc** artifact cache. C/C++ object compiles (`cc` / `c++` / `clang-cl`, see [C/C++ caching](/docs/getting-started/c-cpp)) are keyed separately. clang-cl debug compiles (`/Z7` / `-Z7` / `-g`) *are* cached, but the key stays machine-local: clang-cl embeds CodeView paths directly in the `.obj` (no separate PDB) and ignores `-ffile-prefix-map`, so kache keeps those paths literal in the key rather than remapping them — correct local hits, no cross-machine sharing.
 
 Point your debugger at the real checkout with a source map. For your own crate sources, map `<WORKSPACE>`:
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: kache
-description: Zero-copy, content-addressed build cache for Rust, C/C++ and more. No copies, no wasted disk — zero-copy restores (reflink where the filesystem supports it, else hardlink) locally and S3 for sharing.
+description: Zero-copy, content-addressed build cache for Rust and C/C++ object compiles. No copies, no wasted disk — zero-copy restores locally and S3 for Rust artifact sharing.
 ---
 
 # Introduction
 
-**kache** is a drop-in `RUSTC_WRAPPER` that caches Rust compilation artifacts. Cache keys are blake3 hashes of normalized rustc invocations; cache hits restore zero-copy (reflink, with a hardlink/copy fallback on filesystems without CoW), and identical blobs are stored once and shared. Optional S3 sync (AWS, Ceph, MinIO, R2) shares the cache across machines. kache can also wrap C/C++ compiles (`CC="kache cc"`), though that coverage is narrower than rustc.
+**kache** is a drop-in `RUSTC_WRAPPER` for Rust and a `cc` / `c++` compiler wrapper for C/C++ object compiles. Cache keys are blake3 hashes of normalized compiler inputs; cache hits restore zero-copy (reflink, with a hardlink/copy fallback on filesystems without CoW), and identical blobs are stored once and shared. Optional S3 sync (AWS, Ceph, MinIO, R2) shares Rust artifacts across machines.
 
-Local caching and direct S3 sync are stable today.
+Local Rust caching, local C/C++ object caching, and direct S3 sync are working today. C/C++ artifacts are local-only for now; unsupported compiler shapes pass through to the real compiler.
 
 <Callout type="info">
 **PREVIEW:** a remote planner that prefetches from workspace manifests, dependency history, and build intent — warming the right artifacts before rustc asks for them. The daemon already calls a planner when `KACHE_PLANNER_ENDPOINT` is set; the hosted service is still preview. See [Remote service](/docs/remote-service).
@@ -44,7 +44,7 @@ kache doctor
 
 ## Architecture in one screen
 
-- **Wrapper** — `RUSTC_WRAPPER` intercepts rustc calls, computes blake3 cache keys, restores hits zero-copy (reflink, falling back to hardlink/copy).
+- **Wrapper** — `RUSTC_WRAPPER` intercepts rustc calls; `CC="kache cc"` and `CXX="kache c++"` intercept supported C/C++ object compiles. Hits restore zero-copy (reflink, falling back to hardlink/copy).
 - **Daemon** — background process handles async S3 uploads, remote checks, and prefetch. Auto-restarts on binary update.
 - **Store** — SQLite index at `{cache_dir}/index.db`, plus content-addressed blobs under `{cache_dir}/store/blobs/`; hits restore those blobs into `target/` zero-copy (reflink, falling back to hardlink/copy).
 - **Cache keys** — deterministic blake3 hash of rustc version, crate name, source, dependencies, and normalized flags — portable across machines.
@@ -52,6 +52,7 @@ kache doctor
 <Cards>
   <Card title="Installation" href="/docs/getting-started/installation" description="mise, cargo-binstall, or build from source" />
   <Card title="Quick start" href="/docs/getting-started/quick-start" description="kache init, first build, verifying hits" />
+  <Card title="C/C++ caching" href="/docs/getting-started/c-cpp" description="Wrap cc, c++, gcc, clang, and clang-cl object compiles" />
   <Card title="How it works" href="/docs/how-it-works/architecture" description="Wrapper, store, daemon — the full picture" />
   <Card title="Cache key" href="/docs/how-it-works/cache-key" description="What's hashed and why keys are portable" />
   <Card title="Remote cache (S3)" href="/docs/remote-cache/s3-setup" description="AWS, R2, Ceph, MinIO — same config" />

--- a/docs/remote-cache/ci.mdx
+++ b/docs/remote-cache/ci.mdx
@@ -15,21 +15,68 @@ steps:
   - uses: dtolnay/rust-toolchain@stable
 
   - uses: kunobi-ninja/kache-action@v1
-    with:
-      github-cache: "true"
 
   - run: cargo build --release
 ```
 
-The action installs kache, sets `RUSTC_WRAPPER=kache`, and configures GitHub's built-in cache as the remote storage backend. No S3 bucket required — it uses the same cache infrastructure as `actions/cache`.
+The action installs kache, sets `RUSTC_WRAPPER=kache`, and persists the local kache store with GitHub's built-in Actions cache by default. No S3 bucket is required.
 
 <Callout type="info">
-`github-cache: true` is the right choice for most open-source projects. For private infrastructure or when you need to share the cache across multiple repositories, use an S3 bucket instead.
+The default GitHub Actions cache backend is the simplest choice for most open-source projects. For private infrastructure, larger caches, or sharing across repositories, use an S3 bucket instead.
 </Callout>
 
-## Using an S3 bucket in CI
+## Using S3 with kache-action
 
-If you have an S3 bucket, configure kache via environment variables in the workflow:
+If you have an S3 bucket, pass it to the action:
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: dtolnay/rust-toolchain@stable
+
+  - uses: kunobi-ninja/kache-action@v1
+    with:
+      s3-bucket: my-build-cache
+      s3-region: eu-west-1
+      s3-access-key-id: ${{ secrets.S3_ACCESS_KEY_ID }}
+      s3-secret-access-key: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+
+  - run: cargo build --release
+  - run: cargo test
+```
+
+For S3-compatible stores such as MinIO, Ceph, or R2, also set `s3-endpoint`:
+
+```yaml
+- uses: kunobi-ninja/kache-action@v1
+  with:
+    s3-bucket: my-build-cache
+    s3-endpoint: https://minio.internal:9000
+    s3-access-key-id: ${{ secrets.S3_ACCESS_KEY_ID }}
+    s3-secret-access-key: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+```
+
+With S3 configured, the action starts the kache daemon for warm prefetch, saves a build manifest after the build, pushes new artifacts with `kache sync --push`, writes a job summary, and can post a sticky PR comment with `kache report --format github`.
+
+Useful action inputs:
+
+| Input | Default | Description |
+|---|---|---|
+| `version` | latest release | kache version to install |
+| `github-cache` | `true` | Use GitHub Actions cache when S3 is not configured |
+| `s3-bucket` | — | S3 bucket name; enables the S3 backend |
+| `s3-region` | `us-east-1` | S3 region |
+| `s3-prefix` | `artifacts` | S3 key prefix |
+| `s3-endpoint` | — | Custom endpoint for MinIO, Ceph, R2, etc. |
+| `sync` | `false` | With S3, pull the full remote cache during setup |
+| `warm` | `true` | With S3, prefetch likely artifacts from the saved build manifest |
+| `manifest-key` | target triple | Scope saved manifests for different build shapes |
+| `pr-comment` | `true` | Post or update a sticky PR cache summary comment |
+| `max-size` | `50GiB` | Local store cap, mapped to `KACHE_MAX_SIZE` |
+
+## Other CI systems
+
+Outside GitHub Actions, configure kache directly via environment variables:
 
 ```yaml
 env:
@@ -42,31 +89,24 @@ env:
 
 For AWS with IAM roles (OIDC), skip the access key variables and let kache use the standard credential chain.
 
-For S3-compatible stores (MinIO, Ceph RGW, R2, and similar), also set `KACHE_S3_ENDPOINT` to the provider's URL. `KACHE_S3_PREFIX` is optional and defaults to `artifacts`.
+For S3-compatible stores, also set `KACHE_S3_ENDPOINT`. `KACHE_S3_PREFIX` is optional and defaults to `artifacts`.
 
-## Warming the cache before the build
-
-When the daemon isn't running in CI (which is the common case for ephemeral runners), use an explicit sync step:
+When no daemon is running in an ephemeral runner, use explicit sync steps:
 
 ```yaml
-steps:
-  - uses: kunobi-ninja/kache-action@v1
-    with:
-      github-cache: "true"
+- name: Warm cache
+  run: kache sync --pull
 
-  - name: Warm cache
-    run: kache sync --pull
+- run: cargo build --release
 
-  - run: cargo build --release
-
-  - name: Push new artifacts
-    run: kache sync --push
-    if: always()   # push even if the build failed, to preserve partial results
+- name: Push new artifacts
+  run: kache sync --push
+  if: always()
 ```
 
-The `if: always()` on the push step ensures newly built artifacts are stored even when the build fails partway through. Partial cache population still speeds up future runs.
+The `if: always()` on the push step stores newly built artifacts even when the build fails partway through. Partial cache population still speeds up future runs.
 
-Both subcommands require a configured S3 remote (set the `KACHE_S3_*` variables above, or run `kache config`); without one they error with `No remote configured`. By default `kache sync --pull` is filtered to the crates in the current workspace's `Cargo.lock`, so an ephemeral runner only fetches what this build needs. Use `kache sync --pull --all` to pull every artifact in the bucket regardless of the local lockfile.
+Both sync subcommands require a configured S3 remote. Without one they error with `No remote configured`. By default `kache sync --pull` is filtered to the crates in the current workspace's `Cargo.lock`, so an ephemeral runner only fetches what this build needs. Use `kache sync --pull --all` to pull every artifact in the bucket regardless of the local lockfile.
 
 <Callout type="warn">
 `kache sync` reports failed transfers as `(N failed)` on its progress line but still exits `0`, so CI cannot detect partial transfer failures from the exit code alone. If that matters, scan the step's stderr for `failed`.


### PR DESCRIPTION
## Summary

- Add the star history chart to the README.
- Refresh README and docs positioning for Rust, C/C++ object caching, and local-only C/C++ artifact status.
- Add a dedicated C/C++ caching docs page and link it from the docs landing, quick start, config, architecture, and cache-key pages.
- Update CI docs for `kunobi-ninja/kache-action@v1`, including default GitHub Actions cache behavior, S3 inputs, warm/push behavior, PR comments, and job summaries.
- Fix README duration examples to match the current parser.

## Validation

- `git diff --check`
- `git diff --cached --check`

Docs-only change; full test suite not run.
