### PR TITLE
fix(cache): emit-coverage gate + residual-args folding (#324, #325)

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -3,6 +3,63 @@ use std::path::{Path, PathBuf};
 
 use crate::compiler::rustc::RustcCompiler;
 
+/// rustc flags that affect only diagnostics, lint levels, queries, or carry a
+/// path already reflected in the key elsewhere — never the emitted artifact
+/// bytes. Their separated value (`--flag value`) is skipped during parsing so
+/// neither the flag nor its value reaches the `residual_args` catch-all and
+/// over-keys the result (kunobi-ninja/kache#324).
+///
+/// `--remap-path-prefix` is path-bearing but already reflected in the key via
+/// the remap-sentinel set, so it is dropped here as well.
+const IGNORED_VALUE_FLAGS: &[&str] = &[
+    "--error-format",
+    "--json",
+    "--color",
+    "--diagnostic-width",
+    "--cap-lints",
+    "--check-cfg",
+    "--remap-path-prefix",
+    "--print",
+    "--explain",
+    "-W",
+    "--warn",
+    "-A",
+    "--allow",
+    "-D",
+    "--deny",
+    "-F",
+    "--forbid",
+    "--force-warn",
+];
+
+/// Attached (`--flag=value` / `-Xvalue`) forms of the diagnostics / lint flags
+/// above, plus the single-letter lint prefixes (`-Wunused`, `-Dwarnings`). Used
+/// to drop the attached spellings from the cache key alongside their separated
+/// counterparts in [`IGNORED_VALUE_FLAGS`].
+const IGNORED_ATTACHED_PREFIXES: &[&str] = &[
+    "--error-format=",
+    "--json=",
+    "--color=",
+    "--diagnostic-width=",
+    "--cap-lints=",
+    "--check-cfg=",
+    "--remap-path-prefix=",
+    "--print=",
+    "--explain=",
+    "--warn=",
+    "--allow=",
+    "--deny=",
+    "--forbid=",
+    "--force-warn=",
+    "-W",
+    "-A",
+    "-D",
+    "-F",
+];
+
+/// Boolean diagnostics / query flags (no value) that must not reach the key.
+const IGNORED_BOOL_FLAGS: &[&str] = &["-v", "--verbose", "-V", "--version", "-h", "--help"];
+
 /// Parsed rustc invocation arguments relevant to caching.
 #[derive(Debug, Clone, Default)]
 pub struct RustcArgs {
@@ -58,6 +115,12 @@ pub struct RustcArgs {
     pub inner_rustc: Option<PathBuf>,
     /// All original arguments (everything after the rustc path)
     pub all_args: Vec<String>,
+    /// Argv tokens not matched by any modeled flag above, excluding the
+    /// diagnostics / lint / query / already-keyed path flags that parsing
+    /// explicitly drops. These can still affect codegen (e.g. `-O`, `-g`, or a
+    /// future rustc flag) yet were previously invisible to the cache key, so
+    /// they are folded in under a versioned tag (kunobi-ninja/kache#324).
+    pub residual_args: Vec<String>,
     /// Whether this is a `--test` compilation (test harness binary)
     pub is_test: bool,
     /// Whether this looks like a primary compilation (has source file + crate name)
@@ -112,6 +175,7 @@ impl RustcArgs {
             unstable_flags: Vec::new(),
             inner_rustc,
             all_args: rustc_args.to_vec(),
+            residual_args: Vec::new(),
             is_test: false,
             is_primary: false,
         };
@@ -271,6 +335,14 @@ impl RustcArgs {
                 _ if arg.starts_with("-Z") && arg.len() > 2 => {
                     parsed.unstable_flags.push(arg["-Z".len()..].to_string());
                 }
+                // Diagnostics / lint / query / already-keyed path flags: never
+                // change the artifact, so drop them (and their separated value)
+                // before the residual catch-all (kunobi-ninja/kache#324).
+                _ if IGNORED_VALUE_FLAGS.contains(&arg.as_str()) => {
+                    i += 1; // skip the value argument
+                }
+                _ if IGNORED_BOOL_FLAGS.contains(&arg.as_str()) => {}
+                _ if IGNORED_ATTACHED_PREFIXES.iter().any(|p| arg.starts_with(p)) => {}
                 // Positional argument: source file (doesn't start with -)
                 _ if !arg.starts_with('-')
                     && parsed.source_file.is_none()
@@ -278,7 +350,13 @@ impl RustcArgs {
                 {
                     parsed.source_file = Some(PathBuf::from(arg));
                 }
-                _ => {}
+                // Anything else is an argv token kache does not model. It may
+                // affect codegen (e.g. `-O`, `-g`), so keep it for the cache key
+                // (folded normalized + sorted in `cache_key.rs`) rather than
+                // dropping it silently (kunobi-ninja/kache#324).
+                _ => {
+                    parsed.residual_args.push(arg.clone());
+                }
             }
             i += 1;
         }

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -694,6 +694,31 @@ pub fn compute_cache_key(
         tracing::trace!("[key:{}] unstable:{}", crate_name, z);
     }
 
+    // Residual argv tokens (kunobi-ninja/kache#324): flags kache does not model
+    // explicitly still reach rustc and can affect codegen (`-O`, `-g`, or a
+    // future flag), yet were previously invisible to the key — the `_ => {}`
+    // catch-all in `args.rs` dropped them. Fold the NORMALIZED, sorted residual
+    // under a versioned tag so an unmodeled codegen-affecting flag changes the
+    // key. Diagnostics / lint / query / already-keyed path flags are stripped
+    // during arg parsing, so they never reach here. Normalize via PathNormalizer
+    // (a residual token can embed a machine-local path) and sort so argv order /
+    // host paths don't perturb the key. Folded only when non-empty, so the
+    // common case (no residual) is byte-identical and needs no
+    // CACHE_KEY_VERSION bump (same precedent as RUSTC_BOOTSTRAP above).
+    if !args.residual_args.is_empty() {
+        let mut residual: Vec<String> = args
+            .residual_args
+            .iter()
+            .map(|tok| path_normalizer.normalize(tok))
+            .collect();
+        residual.sort();
+        for tok in &residual {
+            check_for_path_leak(tok, "residual_arg");
+            fold_field(&mut hasher, b"residual_args.v1:", tok.as_bytes());
+            tracing::trace!("[key:{}] residual_arg:{}", crate_name, tok);
+        }
+    }
+
     // Relevant CARGO_CFG_* env vars (sorted for determinism —
     // std::env::vars() iteration order is platform-defined and not stable)
     let mut cargo_cfgs: Vec<(String, String)> = std::env::vars()
@@ -2211,6 +2236,76 @@ mod tests {
         assert_ne!(ssl, crypto, "a different -l lib must change the key");
         // Attached form parses identically to the separate form.
         assert_eq!(ssl, key_of(&flag_base(&source, &["-lssl"])));
+    }
+
+    /// kunobi-ninja/kache#324: an unmodeled argv flag that can affect codegen
+    /// (`-g`, `-O`) used to land in the `_ => {}` catch-all and never enter the
+    /// key. It must now change the key via the residual-args fold.
+    #[test]
+    fn residual_unmodeled_flag_changes_key() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+
+        let base = key_of_flags(&flag_base(&source, &[]));
+        let debug = key_of_flags(&flag_base(&source, &["-g"]));
+        let opt = key_of_flags(&flag_base(&source, &["-O"]));
+        assert_ne!(base, debug, "an unmodeled `-g` must change the key");
+        assert_ne!(base, opt, "an unmodeled `-O` must change the key");
+        assert_ne!(debug, opt, "`-g` and `-O` must produce distinct keys");
+    }
+
+    /// kunobi-ninja/kache#324: residual tokens are sorted before folding, so
+    /// argv order does not perturb the key (the fold is a coarse safety net for
+    /// unmodeled flags, not an order-sensitive channel).
+    #[test]
+    fn residual_args_are_order_independent() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+
+        let a = key_of_flags(&flag_base(
+            &source,
+            &["--unmodeled-a", "alpha", "--unmodeled-b", "beta"],
+        ));
+        let b = key_of_flags(&flag_base(
+            &source,
+            &["--unmodeled-b", "beta", "--unmodeled-a", "alpha"],
+        ));
+        assert_eq!(a, b, "residual argv order must not change the key");
+    }
+
+    /// kunobi-ninja/kache#324: diagnostics / lint / query / already-keyed path
+    /// flags are stripped during parsing, so they must NOT reach the residual
+    /// fold and over-key the result. Guards the same invariant as the
+    /// `key_matrix_*_does_not_change_key` tests for flags cargo passes routinely.
+    #[test]
+    fn residual_strips_diagnostic_and_query_flags() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+
+        let base = key_of_flags(&flag_base(&source, &[]));
+        for extra in [
+            vec!["--check-cfg", "cfg(foo)"],
+            vec!["--diagnostic-width=80"],
+            vec!["--json=artifacts"],
+            vec!["--cap-lints", "allow"],
+            vec!["--color", "always"],
+            vec!["-W", "unused"],
+            vec!["-Wunused"],
+            vec!["--force-warn", "deprecated"],
+            vec!["--verbose"],
+        ] {
+            assert_eq!(
+                base,
+                key_of_flags(&flag_base(&source, &extra)),
+                "diagnostics/query flag {extra:?} must not change the key"
+            );
+        }
     }
 
     /// H1: a build-script native search path must diverge the key, but

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -338,6 +338,49 @@ pub fn classify_by_filename(name: &str) -> ArtifactKind {
     }
 }
 
+/// Canonical rustc `--emit` kind that a stored output filename satisfies, or
+/// `None` if the file is not a recognized emit product (e.g. a `.dSYM` / `.pdb`
+/// debug sidecar that no `--emit` kind requests directly).
+///
+/// This is the "filename → emit kind" sibling of [`classify_by_filename`] and
+/// the single source of truth for the emit-coverage gate (kunobi-ninja/kache#325):
+/// the store records the set of kinds an entry actually contains, and lookup
+/// refuses an entry that doesn't cover what the invocation's `--emit` requested.
+///
+/// The returned strings match rustc's own `--emit` tokens (and the `emit` field
+/// of its `artifact` JSON notifications), so they compare directly against
+/// [`crate::args::RustcArgs::emit`]. A lib `--emit=link` legitimately also emits
+/// `.rmeta`, so `metadata` may appear in an entry's covered set without having
+/// been requested — the gate is superset-tolerant, so that is fine.
+/// The canonical rustc `--emit` kinds the coverage gate reasons about — exactly
+/// the values [`emit_kind_for_filename`] can return (kunobi-ninja/kache#325). A
+/// requested kind outside this set is ignored by the gate so it never refuses on
+/// a kind kache can't map to a stored file.
+pub const GATED_EMIT_KINDS: [&str; 8] = [
+    "link", "metadata", "obj", "dep-info", "asm", "llvm-ir", "llvm-bc", "mir",
+];
+
+pub fn emit_kind_for_filename(name: &str) -> Option<&'static str> {
+    let ext = std::path::Path::new(name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    match ext {
+        // Linked output: rlib / staticlib / dylib / cdylib / bin / proc-macro.
+        "rlib" | "so" | "dylib" | "dll" | "exe" | "a" | "lib" => Some("link"),
+        "rmeta" => Some("metadata"),
+        "o" | "obj" => Some("obj"),
+        "d" | "pp" => Some("dep-info"),
+        "s" | "asm" => Some("asm"),
+        "ll" => Some("llvm-ir"),
+        "bc" => Some("llvm-bc"),
+        "mir" => Some("mir"),
+        // Extensionless file = bin executable (rustc's Unix convention).
+        "" => Some("link"),
+        _ => None,
+    }
+}
+
 /// Why a signature is being applied. Today the only purpose is
 /// [`SigningPurpose::OsLoading`], but `Sign(SigningPurpose)` is structured
 /// this way so future cases (distribution signing, supply-chain attestation)
@@ -927,6 +970,41 @@ mod tests {
         match classify_by_filename("foo.lock") {
             ArtifactKind::Other("unknown-ext") => {}
             other => panic!("expected Other(unknown-ext), got {other:?}"),
+        }
+    }
+
+    /// kunobi-ninja/kache#325: filename → canonical `--emit` kind, the SSOT for
+    /// the emit-coverage gate. Every mapped value is in [`GATED_EMIT_KINDS`];
+    /// unmapped sidecars return `None`.
+    #[test]
+    fn emit_kind_for_filename_maps_outputs() {
+        let cases = [
+            ("libfoo-abc.rlib", Some("link")),
+            ("libfoo.so", Some("link")),
+            ("libfoo.dylib", Some("link")),
+            ("foo.dll", Some("link")),
+            ("foo.exe", Some("link")),
+            ("my_bin-abc123", Some("link")), // extensionless bin
+            ("libfoo-abc.rmeta", Some("metadata")),
+            ("foo-abc.123.rcgu.o", Some("obj")),
+            ("foo.obj", Some("obj")),
+            ("foo-abc.d", Some("dep-info")),
+            ("foo.s", Some("asm")),
+            ("foo.ll", Some("llvm-ir")),
+            ("foo.bc", Some("llvm-bc")),
+            ("foo.mir", Some("mir")),
+            ("foo.dwo", None),
+            ("foo.pdb", None),
+            ("foo.lock", None),
+        ];
+        for (name, expected) in cases {
+            assert_eq!(emit_kind_for_filename(name), expected, "for {name}");
+            if let Some(kind) = expected {
+                assert!(
+                    GATED_EMIT_KINDS.contains(&kind),
+                    "{kind} (from {name}) must be in GATED_EMIT_KINDS"
+                );
+            }
         }
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -195,6 +195,36 @@ pub struct EntryMeta {
     pub profile: String,
     #[serde(default)]
     pub compile_time_ms: u64,
+    /// Canonical rustc `--emit` kinds this entry actually contains, derived
+    /// from the stored output files at put time (kunobi-ninja/kache#325). Lookup
+    /// uses it to reject an entry that doesn't cover what the invocation's
+    /// `--emit` requested. `#[serde(default)]` keeps pre-gate `meta.json` (no
+    /// field) deserializable — an empty set means "unknown", so the lookup gate
+    /// skips the check rather than mass-invalidating old entries.
+    #[serde(default)]
+    pub emit_kinds: Vec<String>,
+}
+
+impl EntryMeta {
+    /// Whether this entry's recorded outputs cover every `--emit` kind the
+    /// caller requested (kunobi-ninja/kache#325). Superset-tolerant: an entry
+    /// that contains more kinds than requested still covers it (a lib
+    /// `--emit=link` legitimately also produces `.rmeta`).
+    ///
+    /// Returns `true` when `emit_kinds` is empty — pre-gate entries recorded no
+    /// coverage, so the check is skipped rather than mass-invalidating them.
+    /// Requested kinds that map to no stored file class (e.g. an exotic emit
+    /// kache doesn't model) are ignored so the gate never rejects on a kind it
+    /// can't reason about.
+    pub fn covers_requested_emit(&self, requested: &[String]) -> bool {
+        if self.emit_kinds.is_empty() {
+            return true;
+        }
+        requested
+            .iter()
+            .filter(|kind| crate::compiler::GATED_EMIT_KINDS.contains(&kind.as_str()))
+            .all(|kind| self.emit_kinds.iter().any(|have| have == kind))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -294,6 +324,20 @@ fn is_executable(metadata: &fs::Metadata) -> bool {
 fn fold_field(h: &mut blake3::Hasher, bytes: &[u8]) {
     h.update(&(bytes.len() as u64).to_le_bytes());
     h.update(bytes);
+}
+
+/// Derive the deduplicated, sorted set of canonical rustc `--emit` kinds an
+/// entry covers, from its stored output filenames (kunobi-ninja/kache#325).
+/// Files that map to no emit kind (debug sidecars, etc.) are ignored.
+fn emit_kinds_for_files(files: &[CachedFile]) -> Vec<String> {
+    let mut kinds: Vec<String> = files
+        .iter()
+        .filter_map(|f| crate::compiler::emit_kind_for_filename(&f.name))
+        .map(str::to_string)
+        .collect();
+    kinds.sort();
+    kinds.dedup();
+    kinds
 }
 
 /// Compute a LOCAL content-dedup hash for an entry (the `content_hash` column,
@@ -755,6 +799,11 @@ impl Store {
 
         let content_hash = compute_content_hash(&cached_files);
 
+        // Record which rustc `--emit` kinds this entry actually contains, derived
+        // from the stored output files (kunobi-ninja/kache#325). Lookup rejects an
+        // entry that doesn't cover what the invocation's `--emit` requested.
+        let emit_kinds = emit_kinds_for_files(&cached_files);
+
         // Write metadata (only meta.json in the entry directory)
         let meta = EntryMeta {
             cache_key: cache_key.to_string(),
@@ -767,6 +816,7 @@ impl Store {
             target: target.to_string(),
             profile: profile.to_string(),
             compile_time_ms,
+            emit_kinds,
         };
         let meta_json =
             serde_json::to_string_pretty(&meta).context("serializing entry metadata")?;
@@ -2517,6 +2567,7 @@ mod tests {
             target: "x86_64-unknown-linux-gnu".to_string(),
             profile: "dev".to_string(),
             compile_time_ms: 0,
+            emit_kinds: Vec::new(),
         };
         let meta_json = serde_json::to_string_pretty(&meta).unwrap();
         std::fs::write(entry_dir.join("meta.json"), meta_json).unwrap();
@@ -2552,6 +2603,7 @@ mod tests {
             target: String::new(),
             profile: "dev".to_string(),
             compile_time_ms: 0,
+            emit_kinds: Vec::new(),
         };
         let meta_json = serde_json::to_string_pretty(&meta).unwrap();
         std::fs::write(entry_dir.join("meta.json"), meta_json).unwrap();
@@ -2593,6 +2645,7 @@ mod tests {
             target: String::new(),
             profile: "dev".to_string(),
             compile_time_ms: 0,
+            emit_kinds: Vec::new(),
         };
         fs::write(
             entry_dir.join("meta.json"),
@@ -2787,6 +2840,7 @@ mod tests {
             target: String::new(),
             profile: "dev".to_string(),
             compile_time_ms: 0,
+            emit_kinds: Vec::new(),
         };
         let meta_json = serde_json::to_string_pretty(&meta).unwrap();
         std::fs::write(entry_dir.join("meta.json"), meta_json).unwrap();
@@ -3503,6 +3557,7 @@ mod tests {
             target: String::new(),
             profile: "dev".to_string(),
             compile_time_ms: 0,
+            emit_kinds: Vec::new(),
         };
         fs::write(
             entry_dir.join("meta.json"),
@@ -3567,6 +3622,7 @@ mod tests {
                 target: String::new(),
                 profile: "dev".to_string(),
                 compile_time_ms: 0,
+                emit_kinds: Vec::new(),
             };
             fs::write(
                 entry_dir.join("meta.json"),
@@ -4062,6 +4118,7 @@ mod tests {
             target: String::new(),
             profile: "dev".to_string(),
             compile_time_ms: 0,
+            emit_kinds: Vec::new(),
         };
         fs::write(
             entry_dir.join("meta.json"),
@@ -4268,6 +4325,94 @@ mod tests {
         assert_eq!(stats.savings, 4, "savings should be 4 bytes");
     }
 
+    /// kunobi-ninja/kache#324: pin an exact `content_hash` for a fixed
+    /// multi-file entry. `compute_content_hash` folds `(name, hash, size,
+    /// exec-bit)` in a stable serialization; this golden value fails loudly if
+    /// that serialization ever drifts (field order, length-prefixing, exec-bit
+    /// encoding), which would silently change dedup behavior across versions.
+    #[test]
+    fn content_hash_golden_pins_serialization() {
+        let cf = |name: &str, size: u64, hash: &str, executable: bool| CachedFile {
+            name: name.to_string(),
+            size,
+            hash: hash.to_string(),
+            executable,
+        };
+        // Deliberately unsorted on input — compute_content_hash sorts internally.
+        let files = vec![
+            cf("foo", 4096, "cccccccccccccccccccccccccccccccc", true),
+            cf(
+                "libfoo.rlib",
+                1024,
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                false,
+            ),
+            cf(
+                "libfoo.rmeta",
+                256,
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                false,
+            ),
+        ];
+        assert_eq!(
+            compute_content_hash(&files),
+            "2dd3b89296eb2d5469d11aa00b312cee8734923698b97890f43ea6a8b9a37585",
+        );
+    }
+
+    /// kunobi-ninja/kache#325: an entry's covered emit kinds are derived from
+    /// its stored filenames, deduped and sorted.
+    #[test]
+    fn emit_kinds_derived_from_files() {
+        let cf = |name: &str| CachedFile {
+            name: name.to_string(),
+            size: 1,
+            hash: "h".to_string(),
+            executable: false,
+        };
+        // A lib `--emit=link` build: rlib + side rmeta + dep-info.
+        let kinds = emit_kinds_for_files(&[
+            cf("libfoo.rlib"),
+            cf("libfoo.rmeta"),
+            cf("foo.d"),
+            cf("foo.dSYM"), // sidecar → no emit kind, ignored
+        ]);
+        assert_eq!(kinds, vec!["dep-info", "link", "metadata"]);
+    }
+
+    /// kunobi-ninja/kache#325: the lookup gate is superset-tolerant, skips empty
+    /// (pre-gate) entries, and rejects genuinely-missing kinds.
+    #[test]
+    fn covers_requested_emit_semantics() {
+        let mk = |kinds: &[&str]| EntryMeta {
+            cache_key: "k".into(),
+            crate_name: "c".into(),
+            crate_types: vec![],
+            files: vec![],
+            stdout: String::new(),
+            stderr: String::new(),
+            features: vec![],
+            target: String::new(),
+            profile: String::new(),
+            compile_time_ms: 0,
+            emit_kinds: kinds.iter().map(|s| s.to_string()).collect(),
+        };
+        let req = |kinds: &[&str]| -> Vec<String> { kinds.iter().map(|s| s.to_string()).collect() };
+
+        // Superset: entry has link+metadata+dep-info, request just link.
+        assert!(mk(&["dep-info", "link", "metadata"]).covers_requested_emit(&req(&["link"])));
+        // Exact.
+        assert!(
+            mk(&["dep-info", "metadata"]).covers_requested_emit(&req(&["dep-info", "metadata"]))
+        );
+        // Missing the requested obj → not covered.
+        assert!(!mk(&["link"]).covers_requested_emit(&req(&["link", "obj"])));
+        // Pre-gate entry (no recorded kinds) → skip the check.
+        assert!(mk(&[]).covers_requested_emit(&req(&["link", "obj"])));
+        // A requested kind the gate can't map to a file is ignored, not rejected.
+        assert!(mk(&["link"]).covers_requested_emit(&req(&["link", "future-exotic"])));
+    }
+
     #[test]
     fn test_put_stores_content_hash() {
         let tmp = tempfile::tempdir().unwrap();
@@ -4338,6 +4483,7 @@ mod tests {
             target: "x86_64-unknown-linux-gnu".to_string(),
             profile: "dev".to_string(),
             compile_time_ms: 0,
+            emit_kinds: Vec::new(),
         };
         std::fs::write(
             entry_dir.join("meta.json"),

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1134,6 +1134,49 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         return Ok(result.exit_code);
     }
 
+    // Emit-coverage gate (kunobi-ninja/kache#325): refuse to store an entry that
+    // doesn't physically contain an output for every `--emit` kind this
+    // invocation requested. The discovered output set is authoritative for cargo
+    // builds (rustc's `--json=artifacts` reports every file), so this only fires
+    // on the directory-scan fallback or an unclassified emit — exactly the paths
+    // that can silently capture a partial set. Storing a partial entry would let
+    // a later identical invocation hit it and find a requested `--emit=obj` /
+    // `llvm-ir` missing. The compile already ran and is in place; we just decline
+    // to cache it (mirrors the too-new guard above).
+    if let Some(missing) = missing_requested_emit(&args, &result.artifacts) {
+        tracing::warn!(
+            "not caching {}: discovered outputs do not cover requested --emit {} \
+             (have {:?}) — refusing to store a partial entry",
+            crate_name,
+            missing,
+            result
+                .artifacts
+                .outputs()
+                .iter()
+                .map(|a| a.store_name.as_str())
+                .collect::<Vec<_>>()
+        );
+        let elapsed = start.elapsed().as_millis() as u64;
+        log_event_with_hash_stats(
+            config,
+            &event_root,
+            crate_name,
+            EventResult::Skipped,
+            elapsed,
+            compile_time_ms,
+            0,
+            &cache_key,
+            key_ms,
+            key_hash_stats,
+            lookup_ms,
+            0,
+            0,
+        );
+        print_progress(crate_name, EventResult::Skipped, elapsed, 0);
+        drop(lock);
+        return Ok(result.exit_code);
+    }
+
     // 5. Store the output files
     let target = args.target.as_deref().unwrap_or("host");
     let profile = match args.get_codegen_opt("opt-level") {
@@ -1325,6 +1368,30 @@ fn materialize_cached_artifact(
 }
 
 /// Restore cached artifacts to the target output paths.
+/// Return the first requested `--emit` kind not covered by the discovered
+/// output set, or `None` when every gated requested kind is present
+/// (kunobi-ninja/kache#325).
+///
+/// Only kinds in [`crate::compiler::GATED_EMIT_KINDS`] are checked; an exotic
+/// emit kache can't map to a stored file is ignored so the gate never refuses on
+/// a kind it can't reason about. A bare invocation with no `--emit` yields
+/// `None`. A lib `--emit=link` also producing `.rmeta` is fine — coverage is
+/// superset-tolerant.
+fn missing_requested_emit(args: &RustcArgs, artifacts: &ArtifactSet) -> Option<String> {
+    let present: std::collections::HashSet<&str> = artifacts
+        .outputs()
+        .iter()
+        .filter_map(|a| crate::compiler::emit_kind_for_filename(&a.store_name))
+        .collect();
+    args.emit
+        .iter()
+        .find(|kind| {
+            crate::compiler::GATED_EMIT_KINDS.contains(&kind.as_str())
+                && !present.contains(kind.as_str())
+        })
+        .cloned()
+}
+
 fn restore_from_cache(
     _config: &Config,
     compiler: &RustcCompiler,
@@ -1332,6 +1399,23 @@ fn restore_from_cache(
     args: &RustcArgs,
     meta: &crate::store::EntryMeta,
 ) -> Result<()> {
+    // Emit-coverage gate (kunobi-ninja/kache#325): a stored entry must contain
+    // outputs covering every `--emit` kind this invocation requested. An entry
+    // that doesn't — a partial store from a pre-gate / directory-scan producer,
+    // or on-disk corruption — is evicted and surfaced as an error so the caller
+    // recompiles a complete entry. Entries with no recorded `emit_kinds`
+    // (pre-gate `meta.json`) skip the check, so no mass invalidation.
+    if !meta.covers_requested_emit(&args.emit) {
+        let _ = store.remove_entry(&meta.cache_key);
+        anyhow::bail!(
+            "cached entry for {} covers --emit {:?} but this invocation requested {:?} \
+             — evicting partial entry and recompiling",
+            meta.crate_name,
+            meta.emit_kinds,
+            args.emit
+        );
+    }
+
     // Determine where output files go: either -o parent dir, or --out-dir
     let output_dir = if let Some(output) = &args.output {
         output.parent().unwrap_or(Path::new(".")).to_path_buf()
@@ -2063,6 +2147,7 @@ mod tests {
                 target: String::new(),
                 profile: String::new(),
                 compile_time_ms: 0,
+                emit_kinds: Vec::new(),
             }
         }
 


### PR DESCRIPTION
Closes #324. Closes #325.

Two cache-soundness hardening items. #324 was already ~90% shipped (v16: inode in the fingerprint, length-prefixed key fields, the `compute_content_hash` rewrite, exec-bit, and the too-new-input guard via #341/#343); this finishes the last two sub-items. #325 is new.

## #325 — emit-coverage gate
`--emit` is folded into the cache key, but nothing verified that a stored entry actually *contains* outputs covering the requested emit kinds — a directory-scan fallback or unclassified emit could store a partial entry, and lookup wouldn't notice a missing `--emit=obj` / `llvm-ir`.

- **`emit_kind_for_filename` + `GATED_EMIT_KINDS`** (`compiler/mod.rs`): single source of truth mapping a stored filename → canonical rustc `--emit` kind.
- **`EntryMeta.emit_kinds`** (`#[serde(default)]`): recorded at `put` time from the actual stored files.
- **Refuse-to-store** (wrapper): skip storing an entry whose discovered outputs don't cover the requested emit. rustc's `--json=artifacts` is authoritative for cargo builds (present ⊇ requested always holds), so this only fires on the directory-scan fallback — **normal builds never regress**.
- **Lookup gate** (`restore_from_cache`): `EntryMeta::covers_requested_emit` is superset-tolerant (a lib `--emit=link` legitimately also emits `.rmeta`), evicts + recompiles on a miss. Pre-gate entries (empty field) are skipped → **no mass invalidation**.

## #324 — finish the v16 hardening
- **Residual-args folding**: unmodeled argv tokens used to hit the `_ => {}` catch-all in `args.rs` and never entered the key (so `-O` / `-g` / a future flag passed outside the modeled channels was invisible). They're now captured into `RustcArgs.residual_args`, with explicit arms stripping diagnostics / lint / query / already-keyed-path flags (`--error-format`, `--json`, `--check-cfg`, `--diagnostic-width`, `-D warnings`, `--remap-path-prefix`, …). `cache_key.rs` folds them normalized + sorted under `residual_args.v1`, **only when present** — common case is byte-identical, so no `CACHE_KEY_VERSION` bump (same precedent as `RUSTC_BOOTSTRAP`).
- **Golden-hash test** pinning an exact `content_hash` for a fixed multi-file entry so the serialization can't silently drift.

## Tests / checks
- 7 new tests (residual unmodeled-flag / order-independence / diagnostics-stripping; emit-kind mapping; coverage semantics; emit-kinds derivation; golden hash).
- Existing over-keying guards (`key_matrix_lint_level_does_not_change_key`, `key_matrix_error_format_does_not_change_key`) stay green.
- `cargo fmt`, `cargo clippy --all-targets`, full workspace build, and all 782 lib tests pass.
