### PR TITLE
fix(remote): enforce import trust boundary — re-hash + validate names/hashes (#211)

### DIFF
--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -388,8 +388,23 @@ fn blob_path(blobs_dir: &Path, hash: &str) -> PathBuf {
 /// A blob hash is a 64-char blake3 hex digest. Validated where untrusted
 /// `meta.json` enters (download/import) so a malformed hash can never reach
 /// path construction or the integrity gate (#211).
-fn is_blob_hash(s: &str) -> bool {
+pub(crate) fn is_blob_hash(s: &str) -> bool {
     s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// A cached artifact's `name` must be a single, normal path component — no
+/// absolute/rooted path, no `..`, no separators. `meta.json` names are
+/// attacker-influenced for a shared/MITM'd bucket, and `Path::join` with an
+/// absolute or `..`-bearing component escapes the entry/target dir (e.g.
+/// `dir.join("/etc/x") == "/etc/x"`), giving an arbitrary read/overwrite
+/// primitive. Enforced at the import and restore trust boundaries (#211).
+pub(crate) fn is_safe_artifact_name(name: &str) -> bool {
+    use std::path::Component;
+    let mut components = Path::new(name).components();
+    matches!(
+        (components.next(), components.next()),
+        (Some(Component::Normal(_)), None)
+    )
 }
 
 /// A writer that tees everything written through it into a blake3 hasher, so a
@@ -568,7 +583,9 @@ fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{blob_path, create_entry_pack_zstd, extract_entry_pack, is_blob_hash};
+    use super::{
+        blob_path, create_entry_pack_zstd, extract_entry_pack, is_blob_hash, is_safe_artifact_name,
+    };
     use crate::config::{Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS, DEFAULT_S3_POOL_IDLE_SECS};
     use crate::store::{EntryMeta, Store};
     use aws_sdk_s3::error::ErrorMetadata;
@@ -587,6 +604,20 @@ mod tests {
         assert!(!is_blob_hash(&"a".repeat(65)));
         assert!(!is_blob_hash(&"g".repeat(64))); // non-hex
         assert!(!is_blob_hash("../../etc/passwd"));
+    }
+
+    /// #211: a cached artifact name must be a single normal component — reject
+    /// absolute, rooted, parent-dir, separator-bearing, and empty names.
+    #[test]
+    fn is_safe_artifact_name_requires_single_normal_component() {
+        assert!(is_safe_artifact_name("libfoo-abc123.rlib"));
+        assert!(is_safe_artifact_name("foo.d"));
+        assert!(!is_safe_artifact_name(""));
+        assert!(!is_safe_artifact_name("/etc/passwd"));
+        assert!(!is_safe_artifact_name("../escape"));
+        assert!(!is_safe_artifact_name("a/b"));
+        assert!(!is_safe_artifact_name("./a"));
+        assert!(!is_safe_artifact_name(".."));
     }
 
     /// #211: building a blob path from a malformed (short) hash must not panic

--- a/src/store.rs
+++ b/src/store.rs
@@ -872,25 +872,66 @@ impl Store {
         let meta: EntryMeta =
             serde_json::from_str(&content).context("parsing downloaded meta.json")?;
 
-        // Verify all files listed in meta.json exist on disk and match expected size
+        // Remote `meta.json` is untrusted (a shared / MITM'd bucket can poison
+        // its `files[]`), so validate the trust boundary before any field reaches
+        // path construction, the blob store, or the user's `target/` (#211).
+        let short_key = cache_key.get(..16).unwrap_or(cache_key);
         for cached_file in &meta.files {
+            // C: a malformed `hash` becomes a shard path component (`&hash[..2]`)
+            // — reject anything that isn't a 64-char blake3 hex digest so it can
+            // never panic a slice or escape the blob shard.
+            if !crate::remote_layout::is_blob_hash(&cached_file.hash) {
+                anyhow::bail!(
+                    "downloaded entry {short_key}: rejecting file {} — malformed blob hash {:?}",
+                    cached_file.name,
+                    cached_file.hash,
+                );
+            }
+            // B: a `name` that is absolute or contains `..` escapes the entry dir
+            // on join — require a single normal component.
+            if !crate::remote_layout::is_safe_artifact_name(&cached_file.name) {
+                anyhow::bail!(
+                    "downloaded entry {short_key}: rejecting unsafe artifact name {:?}",
+                    cached_file.name,
+                );
+            }
+
             let file_path = entry_dir.join(&cached_file.name);
             if !file_path.is_file() {
                 anyhow::bail!(
-                    "downloaded entry {} missing file: {}",
-                    cache_key.get(..16).unwrap_or(cache_key),
+                    "downloaded entry {short_key} missing file: {}",
                     cached_file.name
                 );
             }
-            if let Ok(file_meta) = fs::metadata(&file_path)
-                && file_meta.len() != cached_file.size
-            {
+            let file_meta = fs::metadata(&file_path).with_context(|| {
+                format!("downloaded entry {short_key}: stat {}", cached_file.name)
+            })?;
+            if file_meta.len() != cached_file.size {
                 anyhow::bail!(
-                    "downloaded entry {} file {} size mismatch (expected {}, got {})",
-                    cache_key.get(..16).unwrap_or(cache_key),
+                    "downloaded entry {short_key} file {} size mismatch (expected {}, got {})",
                     cached_file.name,
                     cached_file.size,
                     file_meta.len(),
+                );
+            }
+            // A: re-hash the bytes and reject if they don't match the claimed
+            // address. Size-only is insufficient for untrusted content — a
+            // same-length substituted/corrupted object would otherwise be
+            // installed under its claimed hash and hardlinked into the build as
+            // if content-verified. blake3 is fast; do it before any rename/INSERT.
+            let actual = crate::cache_key::hash_file(&file_path).with_context(|| {
+                format!(
+                    "downloaded entry {short_key}: hashing {} for trust-boundary check",
+                    cached_file.name
+                )
+            })?;
+            if actual != cached_file.hash {
+                anyhow::bail!(
+                    "downloaded entry {short_key}: content hash mismatch for {} \
+                     (claimed {}, actual {})",
+                    cached_file.name,
+                    cached_file.hash,
+                    actual,
                 );
             }
         }
@@ -2551,6 +2592,9 @@ mod tests {
 
         let artifact_content = b"fake artifact";
         std::fs::write(entry_dir.join("lib.rlib"), artifact_content).unwrap();
+        // Real content hash — the import trust boundary re-hashes and rejects a
+        // mismatch (kunobi-ninja/kache#211).
+        let hash = crate::cache_key::hash_file(&entry_dir.join("lib.rlib")).unwrap();
         let meta = EntryMeta {
             cache_key: "downloaded_key".to_string(),
             crate_name: "downloaded_crate".to_string(),
@@ -2558,7 +2602,7 @@ mod tests {
             files: vec![CachedFile {
                 name: "lib.rlib".to_string(),
                 size: artifact_content.len() as u64,
-                hash: "abc".to_string(),
+                hash,
                 executable: false,
             }],
             stdout: String::new(),
@@ -2594,7 +2638,8 @@ mod tests {
             files: vec![CachedFile {
                 name: "lib.rlib".to_string(),
                 size: 42,
-                hash: "abc".to_string(),
+                // Valid-shaped hash so validation reaches the missing-file check.
+                hash: "a".repeat(64),
                 executable: false,
             }],
             stdout: String::new(),
@@ -2831,7 +2876,8 @@ mod tests {
             files: vec![CachedFile {
                 name: "lib.rlib".to_string(),
                 size: 9999, // Wrong size
-                hash: "abc".to_string(),
+                // Valid-shaped hash so validation reaches the size check.
+                hash: "a".repeat(64),
                 executable: false,
             }],
             stdout: String::new(),
@@ -2851,6 +2897,107 @@ mod tests {
             err.to_string().contains("size mismatch"),
             "expected 'size mismatch' error, got: {err}"
         );
+    }
+
+    /// Build a downloaded entry dir with one artifact and a `meta.json` whose
+    /// `CachedFile` is overridden by `mutate`, then try to import it.
+    #[cfg(test)]
+    fn import_with_poisoned_meta(
+        store: &Store,
+        config: &Config,
+        key: &str,
+        content: &[u8],
+        mutate: impl FnOnce(&mut CachedFile),
+    ) -> anyhow::Result<()> {
+        let entry_dir = config.store_dir().join(key);
+        std::fs::create_dir_all(&entry_dir).unwrap();
+        std::fs::write(entry_dir.join("lib.rlib"), content).unwrap();
+        let mut file = CachedFile {
+            name: "lib.rlib".to_string(),
+            size: content.len() as u64,
+            hash: crate::cache_key::hash_file(&entry_dir.join("lib.rlib")).unwrap(),
+            executable: false,
+        };
+        mutate(&mut file);
+        let meta = EntryMeta {
+            cache_key: key.to_string(),
+            crate_name: "c".to_string(),
+            crate_types: vec!["lib".to_string()],
+            files: vec![file],
+            stdout: String::new(),
+            stderr: String::new(),
+            features: vec![],
+            target: String::new(),
+            profile: "dev".to_string(),
+            compile_time_ms: 0,
+            emit_kinds: Vec::new(),
+        };
+        std::fs::write(
+            entry_dir.join("meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+        store.import_downloaded_entry(key)
+    }
+
+    /// kunobi-ninja/kache#211-A: a same-size object whose bytes don't match the
+    /// claimed hash is rejected — size-only validation is insufficient for
+    /// untrusted remote content.
+    #[test]
+    fn import_rejects_content_hash_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        // Claim the hash of *different* same-length bytes.
+        let bogus = blake3::hash(b"DIFFERENT!!!!").to_hex().to_string();
+        let err =
+            import_with_poisoned_meta(&store, &config, "ch_mismatch", b"real_content!", |f| {
+                f.hash = bogus;
+            })
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("content hash mismatch"),
+            "expected content hash mismatch, got: {err}"
+        );
+        assert!(!store.contains("ch_mismatch"));
+    }
+
+    /// kunobi-ninja/kache#211-C: a hash that isn't a 64-char blake3 hex digest
+    /// is rejected before it can reach path construction.
+    #[test]
+    fn import_rejects_malformed_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let err = import_with_poisoned_meta(&store, &config, "bad_hash", b"data", |f| {
+            f.hash = "../../etc/passwd".to_string();
+        })
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("malformed blob hash"),
+            "expected malformed blob hash, got: {err}"
+        );
+        assert!(!store.contains("bad_hash"));
+    }
+
+    /// kunobi-ninja/kache#211-B: an absolute or `..`-bearing artifact name is
+    /// rejected — `Path::join` with it would escape the entry/target dir.
+    #[test]
+    fn import_rejects_unsafe_artifact_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        for bad in ["/etc/passwd", "../escape.rlib", "sub/dir.rlib"] {
+            let err = import_with_poisoned_meta(&store, &config, "unsafe_name", b"data", |f| {
+                f.name = bad.to_string();
+            })
+            .unwrap_err();
+            assert!(
+                err.to_string().contains("unsafe artifact name"),
+                "name {bad:?} should be rejected, got: {err}"
+            );
+        }
+        assert!(!store.contains("unsafe_name"));
     }
 
     #[test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1452,6 +1452,18 @@ fn restore_from_cache(
     );
 
     for cached_file in &meta.files {
+        // Defense-in-depth trust-boundary check (kunobi-ninja/kache#211):
+        // `import_downloaded_entry` already rejects unsafe names, but a name that
+        // is absolute or contains `..` would escape `--out-dir` on join
+        // (`dir.join("/abs") == "/abs"`), overwriting files outside `target/`.
+        // Refuse to restore such an entry — the caller recompiles.
+        if !crate::remote_layout::is_safe_artifact_name(&cached_file.name) {
+            anyhow::bail!(
+                "refusing to restore cache entry with unsafe artifact name {:?}",
+                cached_file.name
+            );
+        }
+
         // For -o mode, the primary output goes to the exact -o path;
         // for --out-dir mode, everything goes into the directory.
         let target_path = if let Some(output) = &args.output {


### PR DESCRIPTION
Closes #211.

Remote entries are driven entirely by a downloaded `meta.json`, whose `files[].name`, `.size`, `.hash` are attacker-/corruption-influenced for a shared or MITM'd bucket. `import_downloaded_entry` validated only `size`, then renamed each file into the content-addressed store under its **claimed** hash and registered it — so kache's "bytes under `blobs/<hash>` actually hash to `<hash>`" guarantee was never enforced on the remote path. This closes the three gaps from the issue at the import / restore trust boundary.

### A — re-hash on import (HIGH)
`import_downloaded_entry` now recomputes blake3 for each artifact and **rejects the entry if it ≠ the claimed hash**, before any rename/INSERT. A same-length substituted/corrupted S3 object no longer installs under its claimed address. (blake3 is fast; the prior size-only check is insufficient for untrusted content.)

### B — validate `name` (HIGH)
Names are validated to be a **single normal path component** (`is_safe_artifact_name`) — no absolute/rooted path, no `..`, no separators. `Path::join` with an absolute or `..`-bearing name escapes the entry/`target` dir (`dir.join("/abs") == "/abs"`), an arbitrary read/overwrite primitive. Enforced in `import_downloaded_entry` **and**, defense-in-depth, in `restore_from_cache` before the `output_dir.join`.

### C — validate `hash` shape (MEDIUM + panic-safety)
Any hash that isn't a 64-char blake3 hex digest is rejected, so it can never become a shard path component or panic a slice. (`blob_path` already slices via `get(..2)`, so it's panic-safe regardless.)

The validators (`is_blob_hash`, new `is_safe_artifact_name`) live in `remote_layout` as the shared trust-boundary SSOT — the same place `extract_entry_pack` already validates tar members.

## Tests / checks
- New `import_rejects_content_hash_mismatch` / `import_rejects_malformed_hash` / `import_rejects_unsafe_artifact_name`, plus an `is_safe_artifact_name` unit test.
- Existing import tests updated to use real blake3 hashes (they previously used placeholder `"abc"` hashes the boundary now correctly rejects).
- Full suite: 787 tests pass; `cargo fmt` + `clippy --all-targets` clean.
