### PR TITLE
fix(cc): converge out-of-tree build keys + CMake e2e scenario (#304, #394)

### DIFF
--- a/crates/kache-e2e/src/fixture.rs
+++ b/crates/kache-e2e/src/fixture.rs
@@ -115,6 +115,16 @@ pub struct Fixture {
     #[serde(default)]
     pub requires: Vec<String>,
 
+    /// Operating systems this fixture supports, by `std::env::consts::OS`
+    /// value (`"linux"`, `"macos"`, `"windows"`). Empty (default) = all.
+    /// When non-empty and the current OS isn't listed, the harness SKIPS the
+    /// fixture (like a missing `requires` tool) instead of running it — for
+    /// fixtures that only make sense on some platforms, e.g. the cc out-of-tree
+    /// convergence scenario which exercises the gnu/clang prefix-map path and
+    /// not MSVC `cl` (kunobi-ninja/kache#394).
+    #[serde(default)]
+    pub os: Vec<String>,
+
     /// Overrides applied only when the harness runs on Windows (see
     /// [`OsOverride`]). Parsed on every platform but consulted only there.
     #[serde(default)]

--- a/crates/kache-e2e/src/fixture_runner.rs
+++ b/crates/kache-e2e/src/fixture_runner.rs
@@ -93,6 +93,21 @@ pub fn run(config: FixtureRunConfig) -> Result<()> {
     let mut fixture_results = Vec::new();
     let mut any_failed = false;
     for fixture in fixtures.values() {
+        if !fixture.os.is_empty() && !fixture.os.iter().any(|o| o == std::env::consts::OS) {
+            eprintln!(
+                "=> {}: skipped — not supported on {} (os = {:?})",
+                fixture.name,
+                std::env::consts::OS,
+                fixture.os
+            );
+            eprintln!();
+            fixture_results.push(FixtureResult {
+                name: fixture.name.clone(),
+                status: "skip".to_string(),
+                phases: Vec::new(),
+            });
+            continue;
+        }
         let missing = missing_tools(&fixture.requires);
         if !missing.is_empty() {
             eprintln!(

--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,11 @@ rust = { version = "latest", components = "rustfmt,clippy" }
 # code change. Bump deliberately. (rust is intentionally left to
 # rust-toolchain.toml via idiomatic_version_file_enable_tools above.)
 helm = "4.2.0"
+# Drives the out-of-tree CMake e2e scenario (e2e-cmake-out-of-tree, #394) so it
+# runs on the Linux/macOS gate instead of skipping. The scenario itself is
+# gnu/clang-only (`os = ["linux", "macos"]`), so cmake here is just the build
+# driver on those runners.
+cmake = "4.3.4"
 # Test-coverage + sccache fallback. Listed here (not as separate
 # CI install actions) so the same `mise install` populates every
 # tool the repo needs.

--- a/scenarios/e2e-cmake-out-of-tree/scenario.toml
+++ b/scenarios/e2e-cmake-out-of-tree/scenario.toml
@@ -14,7 +14,12 @@
 name = "e2e-cmake-out-of-tree"
 tags = ["suite:e2e", "lang:cc", "case:path-normalization", "case:out-of-tree", "tool:cmake"]
 
-# Skip (don't fail) on runners without cmake — same mechanism the clang-cl
+# gnu/clang only: this exercises the cc prefix-map normalization, which is
+# disabled for the MSVC `cl` dialect (path-literal keys by design), so it can't
+# converge on a Windows/MSVC build. Runs on Linux + macOS; skipped on Windows.
+os = ["linux", "macos"]
+# Belt-and-suspenders: skip (don't fail) where cmake isn't on PATH. cmake is
+# provisioned for CI via mise.toml; this is the same mechanism the clang-cl
 # fixture uses.
 requires = ["cmake"]
 

--- a/scenarios/e2e-cmake-out-of-tree/scenario.toml
+++ b/scenarios/e2e-cmake-out-of-tree/scenario.toml
@@ -1,0 +1,59 @@
+# kache-e2e fixture for kunobi-ninja/kache#394 — the ORIGINAL #304 concern.
+#
+# @mathstuf raised this for CMake: an out-of-tree build dir that is a sibling of
+# the source tree (`build` / `build-static` / `build-mpich`). Here CMake builds
+# into a sibling `../cmake-build`, with kache as the compiler launcher. A header
+# is generated into the build tree and included via an absolute `-I` into that
+# out-of-tree build dir — exactly the path #304 worried would defeat
+# normalization. The relocate phase moves the source (and rebuilds out-of-tree
+# at a new location); the cc cache key must normalize the out-of-tree paths so
+# the compile converges and hits, regardless of where the build tree lives.
+#
+# Requires `cmake` on PATH.
+
+name = "e2e-cmake-out-of-tree"
+tags = ["suite:e2e", "lang:cc", "case:path-normalization", "case:out-of-tree", "tool:cmake"]
+
+# Skip (don't fail) on runners without cmake — same mechanism the clang-cl
+# fixture uses.
+requires = ["cmake"]
+
+[source]
+kind = "fixture"
+path = "source"
+
+[env]
+# kache as the compiler launcher: CMake invokes `<kache> <cc> <args>`, which is
+# kache's argv[0]=kache, argv[1]=compiler convention.
+CMAKE_C_COMPILER_LAUNCHER = "$KACHE"
+
+[commands]
+# Out-of-tree build into a sibling of the source dir. No `-g`: debug info embeds
+# absolute build/source paths in DWARF, a separate concern from the
+# -I/path-normalization this scenario isolates.
+build = "cmake -S . -B ../cmake-build -DCMAKE_C_FLAGS=-O0 >/dev/null && cmake --build ../cmake-build"
+clean = "rm -rf ../cmake-build"
+
+[verify]
+run = "../cmake-build/foo"
+expected_stdout_contains = ["hello from cmake out-of-tree (42)"]
+
+# The object a hit restores must be byte-identical to the cold real compile.
+[diff]
+artifacts = ["../cmake-build/CMakeFiles/foo.dir/src/foo.c.o"]
+
+[assertions.cold]
+min_entries_after = 1
+
+[assertions.warm]
+min_hits = 1
+
+[assertions.noop]
+should_not_recompile = false
+
+# The crux: relocated + rebuilt out-of-tree at a new absolute path. The cc key
+# must be location-independent, so the out-of-tree compile HITS — proving #304's
+# CMake concern is handled.
+[assertions.relocate]
+min_hits = 1
+max_misses = 0

--- a/scenarios/e2e-cmake-out-of-tree/source/CMakeLists.txt
+++ b/scenarios/e2e-cmake-out-of-tree/source/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.13)
+project(oot_c C)
+
+# A header generated INTO the build tree and included via the build dir (-I).
+# This is the cross-variant generated-source case from kunobi-ninja/kache#304:
+# the compile carries an absolute -I into the out-of-tree build dir, which must
+# normalize so a relocated build still converges.
+configure_file(version.h.in version.h @ONLY)
+
+add_executable(foo src/foo.c)
+target_include_directories(foo PRIVATE "${CMAKE_CURRENT_BINARY_DIR}" src)

--- a/scenarios/e2e-cmake-out-of-tree/source/src/bar.h
+++ b/scenarios/e2e-cmake-out-of-tree/source/src/bar.h
@@ -1,0 +1,4 @@
+#ifndef BAR_H
+#define BAR_H
+static inline int bar_value(void) { return 42; }
+#endif

--- a/scenarios/e2e-cmake-out-of-tree/source/src/foo.c
+++ b/scenarios/e2e-cmake-out-of-tree/source/src/foo.c
@@ -1,0 +1,8 @@
+#include "version.h"
+#include "bar.h"
+#include <stdio.h>
+
+int main(void) {
+    printf("%s (%d)\n", GREETING, bar_value());
+    return 0;
+}

--- a/scenarios/e2e-cmake-out-of-tree/source/version.h.in
+++ b/scenarios/e2e-cmake-out-of-tree/source/version.h.in
@@ -1,0 +1,1 @@
+#define GREETING "hello from cmake out-of-tree"

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2770,14 +2770,7 @@ fn cc_prefix_maps_for(parsed: &CcArgs, cwd: &Path) -> Vec<CcPrefixMap> {
         .unwrap_or_else(|| source_abs.clone());
 
     let mut roots: Vec<(PathBuf, &'static str)> = Vec::new();
-    if let Some(common) = common_ancestor(&cwd_abs, &source_parent)
-        && stable_cc_common_root(&common, &cwd_abs, &source_parent)
-    {
-        roots.push((common, CC_ROOT_SENTINEL));
-    } else {
-        roots.push((cwd_abs.clone(), CC_BUILD_SENTINEL));
-        roots.push((source_parent.clone(), CC_SOURCE_SENTINEL));
-    }
+    push_cwd_source_roots(&mut roots, &cwd_abs, &source_parent);
 
     let cwd_canon = canonicalize_or_self(&cwd_abs);
     let source_canon = canonicalize_or_self(&source_abs);
@@ -2816,6 +2809,65 @@ fn cc_prefix_maps_for(parsed: &CcArgs, cwd: &Path) -> Vec<CcPrefixMap> {
     }
 
     prefix_maps_from_roots(roots)
+}
+
+/// Push the build (cwd) and source-dir roots, choosing the sentinel scheme by
+/// TOPOLOGY rather than absolute location, so the same build converges
+/// regardless of where its tree lives — the fix for out-of-tree build trees
+/// (kunobi-ninja/kache#304, #394).
+///
+/// - **Nested** (one dir is under the other — the ordinary under-source build,
+///   where the common ancestor IS the build or source dir): a single
+///   `<CC_ROOT>` at the common ancestor is stable and preserves the
+///   build↔source relative structure. Unchanged from before.
+/// - **Sibling / out-of-tree** (the common ancestor is a *strict* ancestor of
+///   both): the single-root scheme is fragile — whether the common ancestor is
+///   judged "useful" depends on absolute properties (its depth, whether it is a
+///   temp dir), so the SAME logical build picks `<CC_ROOT>` at one location and
+///   split `<CC_BUILD>`/`<CC_SOURCE>` at another, and the cc key diverges.
+///   Always use the split sentinels here (location-independent), and still fold
+///   the shared root for paths under it (sibling includes) when it is a stable,
+///   non-degenerate prefix. Prefix maps apply longest-first, so the split maps
+///   (more specific) win for the build/source paths while `<CC_ROOT>` covers the
+///   rest.
+fn push_cwd_source_roots(
+    roots: &mut Vec<(PathBuf, &'static str)>,
+    cwd_abs: &Path,
+    source_parent: &Path,
+) {
+    let common = common_ancestor(cwd_abs, source_parent);
+    let nested = matches!(&common, Some(c) if c == cwd_abs || c == source_parent);
+    if nested {
+        if let Some(common) = common {
+            roots.push((common, CC_ROOT_SENTINEL));
+        }
+    } else {
+        roots.push((cwd_abs.to_path_buf(), CC_BUILD_SENTINEL));
+        roots.push((source_parent.to_path_buf(), CC_SOURCE_SENTINEL));
+        // Fold the shared root too, so paths under it (sibling includes, an
+        // objdir's `__FILE__` into the source tree) normalize. Gate on the
+        // common having at least one normal component — i.e. anything but a bare
+        // filesystem root (`/`, a drive root), which would over-map unrelated
+        // absolute paths. This is a LOCATION-INDEPENDENT test: unlike the old
+        // depth/temp-dir heuristic it yields the same `<CC_ROOT>` membership
+        // whether the build lives in `~/proj`, a deep CI path, or `$TMPDIR` — so
+        // the prefix-map sentinel SET (hashed into the key) no longer flips with
+        // location, and an out-of-tree build converges across machines / a
+        // relocate (kunobi-ninja/kache#304, #394).
+        if let Some(common) = common
+            && has_normal_component(&common)
+        {
+            roots.push((common, CC_ROOT_SENTINEL));
+        }
+    }
+}
+
+/// Whether `path` has at least one normal component — true for any real
+/// directory, false only for a bare filesystem root (`/`) or a drive/UNC root.
+/// Folding a bare root to a sentinel would collapse unrelated absolute paths.
+fn has_normal_component(path: &Path) -> bool {
+    path.components()
+        .any(|c| matches!(c, std::path::Component::Normal(_)))
 }
 
 fn prefix_maps_from_roots<I>(roots: I) -> Vec<CcPrefixMap>
@@ -6089,6 +6141,48 @@ mod tests {
             maps.iter()
                 .any(|m| m.from == "/work" && m.to == CC_BASE_SENTINEL),
             "explicit KACHE_BASE_DIR must map to the base sentinel, got {maps:?}"
+        );
+    }
+
+    /// kunobi-ninja/kache#304, #394: an out-of-tree (sibling) build must produce
+    /// the SAME prefix-map sentinel set regardless of where the tree lives, so
+    /// the cc cache key converges across machines / a relocate. Previously a
+    /// deep common root got `<CC_ROOT>` while a shallow / temp one did not,
+    /// flipping the set (which is hashed into the key) and forcing a miss.
+    #[test]
+    fn cc_prefix_maps_sentinel_set_is_location_independent_for_out_of_tree() {
+        let sentinels = |cwd: &str, src: &str| -> Vec<&'static str> {
+            let parsed = CcArgs::parse(&s(&["cc", "-c", src, "-o", "foo.o"])).unwrap();
+            let mut set: Vec<&'static str> =
+                cc_prefix_maps_cfg(&parsed, Path::new(cwd), None, None)
+                    .iter()
+                    .map(|m| m.to)
+                    .collect();
+            set.sort_unstable();
+            set.dedup();
+            set
+        };
+        // Same sibling out-of-tree topology (build dir is a sibling of the
+        // source dir), at a deep root vs a shallow / temp-like root.
+        let deep = sentinels("/home/user/proj/build", "/home/user/proj/src/foo.c");
+        let shallow = sentinels("/tmp/build", "/tmp/src/foo.c");
+        assert_eq!(
+            deep, shallow,
+            "out-of-tree prefix-map sentinel set must not depend on absolute location"
+        );
+        assert!(
+            deep.contains(&CC_ROOT_SENTINEL)
+                && deep.contains(&CC_BUILD_SENTINEL)
+                && deep.contains(&CC_SOURCE_SENTINEL),
+            "out-of-tree build should fold build, source, and shared-root sentinels, got {deep:?}"
+        );
+
+        // A bare filesystem root as the only common ancestor must NOT be folded
+        // — mapping `/` would collapse unrelated absolute paths.
+        let rooted = sentinels("/build", "/src/foo.c");
+        assert!(
+            !rooted.contains(&CC_ROOT_SENTINEL),
+            "a bare root must not become <CC_ROOT>, got {rooted:?}"
         );
     }
 


### PR DESCRIPTION
Closes the cc half of #304; part of #394.

## The bug
An **out-of-tree / sibling build tree** (a `build` / `cmake-build` dir *beside* the source tree, not under it — @mathstuf's #304 layout) failed to share the cc cache across locations: a relocated or cross-machine compile **missed** even though the produced object was **byte-identical**. A missed hit, not a correctness issue — but it defeats remote/cross-clone caching for exactly the CMake out-of-tree workflow #304 raised.

## Root cause
The cc prefix-map's single-`<CC_ROOT>` vs split-`<CC_BUILD>`/`<CC_SOURCE>` decision was made on **absolute-location** properties: the common ancestor's *depth* (`≥3` components) and whether it was a temp dir. For a sibling build the common ancestor is a *strict* ancestor of both build and source, and whether it earned a `<CC_ROOT>` sentinel **flipped with where the tree lived** (deep repo path → yes; `/tmp` or `$TMPDIR` → no). Because the prefix-map **sentinel set is hashed into the key**, the set flipping diverged the key.

## Fix — decide by topology, not location
`push_cwd_source_roots`:
- **Nested** (ordinary under-source build, common == build or source dir): single `<CC_ROOT>` — **unchanged**, no key change for existing builds.
- **Sibling / out-of-tree** (strict-ancestor common): always split into `<CC_BUILD>`/`<CC_SOURCE>`, and fold `<CC_ROOT>` whenever the common is not a **bare filesystem root** (has ≥1 normal component). That last test is **location-independent**, so the sentinel set is identical whether the tree lives in `~/proj`, a deep CI path, or `$TMPDIR`. Out-of-tree builds converge across machines / a relocate. (`/` is still excluded, to avoid over-mapping unrelated absolute paths.)

The objdir/Firefox cross-checkout case (also a sibling topology, deep repo root) is unaffected — it already folded `<CC_ROOT>` and still does.

## Tests
- **`e2e-cmake-out-of-tree`**: CMake builds into a sibling `../cmake-build`, generated header included via an absolute `-I` into the out-of-tree build dir, kache as `CMAKE_C_COMPILER_LAUNCHER`. `relocate` converges (`min_hits=1, max_misses=0`, byte-identical) and is **falsifiable** under `--negative-control`. (Requires `cmake`.)
- Unit test pinning the location-independent sentinel set (deep vs shallow root identical; bare `/` not folded).
- Full e2e suite (21 scenarios, no regressions) + 792 unit tests + clippy/fmt green.
