### PR TITLE
test: coverage follow-ups for build-intent, remote listing, incremental prune

### DIFF
--- a/notes/coverage-progress.md
+++ b/notes/coverage-progress.md
@@ -4,6 +4,20 @@ Tooling: `cargo llvm-cov` (already set up; mise pins 0.8.7). NOT tarpaulin —
 llvm-cov is the established, more accurate tool here. CI threshold: 35%.
 Run with: `just coverage` (writes tmp/llvm-cov/coverage.json).
 
+## Follow-up session (post-#389 merge, on PR #402 — branch test/coverage-followups)
+Clean baseline after the big PR + later feature merges: **88.00%** (29827/33895).
+Targeted the gaps the recent feature merges introduced:
+- build_intent.rs (was 67.4%): discover() via rustc --out-dir, run_cargo_metadata
+  virtual-workspace branch, load_cargo_lock_deps success/missing.
+- remote_layout.rs: list_keys + list_keys_for_crates (wire-mock S3).
+- store.rs: clean_registered_incremental_dirs non-directory prune arm.
+- wrapper.rs: event-root helpers from #397 (event_root_string/override).
+- fallback_planner.rs (was **0%** — whole untested module): history_candidates,
+  shard_candidates no-remote error, key_cache_keys_for_crate empty arm.
+Remaining gaps are the documented hard tail: service.rs OS exec, cli.rs/tui.rs
+interactive loops, wrapper.rs real-compile run paths, platform.rs signal
+handlers, cc.rs clang-cl/preprocessor-dependent cache_key folds.
+
 !!! MEASUREMENT GOTCHA (discovered Run 33) !!!
 ALWAYS `cargo llvm-cov clean --workspace` before `just coverage`. Incremental
 builds + interleaved `cargo test` runs bloat the denominator with extra generic

--- a/src/build_intent.rs
+++ b/src/build_intent.rs
@@ -308,6 +308,92 @@ edition = "2021"
         assert!(parse_metadata_graph(&[0xff, 0xfe, 0x00], None).is_none());
     }
 
+    /// Build a minimal two-member cargo workspace under a temp dir and return
+    /// its root. `app` depends on `dep`.
+    fn scaffold_workspace() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\", \"dep\"]\nresolver = \"2\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("app/src")).unwrap();
+        std::fs::write(
+            root.join("app/Cargo.toml"),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ndep = { path = \"../dep\" }\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("app/src/lib.rs"), "").unwrap();
+        std::fs::create_dir_all(root.join("dep/src")).unwrap();
+        std::fs::write(
+            root.join("dep/Cargo.toml"),
+            "[package]\nname = \"dep\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("dep/src/lib.rs"), "").unwrap();
+        dir
+    }
+
+    #[test]
+    fn discover_builds_intent_from_out_dir_args() {
+        // `discover` resolves the manifest from a rustc --out-dir that sits under
+        // a `target/` tree (candidate_manifest_paths -> manifest_from_target_out_dir),
+        // runs cargo metadata, and returns the workspace crate order. Covers
+        // discover + discover_metadata + candidate_manifest_paths end-to-end.
+        let ws = scaffold_workspace();
+        let root = ws.path();
+        let out_dir = root.join("target/debug/deps");
+        std::fs::create_dir_all(&out_dir).unwrap();
+
+        let args = RustcArgs::parse(&[
+            "rustc".to_string(),
+            "--out-dir".to_string(),
+            out_dir.to_string_lossy().into_owned(),
+        ])
+        .unwrap();
+
+        let intent = discover(Some(&args)).expect("discover should resolve the workspace");
+        // dep is a dependency of app, so reverse topo order lists dep before app.
+        assert!(intent.crate_names.contains(&"app".to_string()));
+        assert!(intent.crate_names.contains(&"dep".to_string()));
+        // No KACHE_NAMESPACE set in the common case -> no namespace, no lock deps.
+        assert!(intent.namespace.is_none());
+    }
+
+    #[test]
+    fn run_cargo_metadata_workspace_manifest_lists_all_members() {
+        // Passing the workspace's *virtual* root manifest (no [package]) means no
+        // single package matches, so graph_crate_order falls to the workspace-iter
+        // branch and returns every member. Covers that else branch.
+        let ws = scaffold_workspace();
+        let discovery = run_cargo_metadata(Some(&ws.path().join("Cargo.toml")))
+            .expect("metadata for workspace");
+        let mut names = discovery.crate_names.clone();
+        names.sort();
+        assert_eq!(names, vec!["app", "dep"]);
+    }
+
+    #[test]
+    fn load_cargo_lock_deps_parses_a_valid_lockfile() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        std::fs::write(
+            &lock,
+            "version = 3\n\n[[package]]\nname = \"serde\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        let deps = load_cargo_lock_deps(&lock).expect("valid lock parses");
+        assert_eq!(deps, vec![("serde".to_string(), "1.0.0".to_string())]);
+    }
+
+    #[test]
+    fn load_cargo_lock_deps_returns_none_for_missing_lockfile() {
+        // A missing Cargo.lock surfaces the parse-error -> debug-log -> None arm.
+        assert!(load_cargo_lock_deps(Path::new("/nonexistent/Cargo.lock")).is_none());
+    }
+
     #[test]
     fn test_build_intent_into_request_preserves_shard_context() {
         let intent = BuildIntent {

--- a/src/fallback_planner.rs
+++ b/src/fallback_planner.rs
@@ -103,3 +103,111 @@ impl PlannerDataSource for LocalPlannerSource<'_> {
         Ok(keys)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS, DEFAULT_S3_POOL_IDLE_SECS};
+    use crate::store::Store;
+
+    fn test_config(
+        cache_dir: std::path::PathBuf,
+        remote: Option<crate::config::RemoteConfig>,
+    ) -> Config {
+        Config {
+            fallback: None,
+            key_salt: None,
+            cc_extra_allowlist_flags: Vec::new(),
+            local_only: false,
+            modified_input_guard: false,
+            path_only_env_vars: Vec::new(),
+            cache_dir,
+            max_size: 1024 * 1024,
+            remote,
+            disabled: false,
+            cache_executables: false,
+            clean_incremental: true,
+            event_log_max_size: 1024 * 1024,
+            event_log_keep_lines: 1000,
+            compression_level: 3,
+            s3_concurrency: 16,
+            daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
+            s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
+        }
+    }
+
+    /// Seed one committed store entry for `crate_name` in `config`'s cache dir.
+    fn seed_entry(config: &Config, cache_key: &str, crate_name: &str, dir: &std::path::Path) {
+        let store = Store::open(config).unwrap();
+        let src = dir.join(format!("{crate_name}.rlib"));
+        std::fs::write(&src, b"artifact").unwrap();
+        store
+            .put(
+                cache_key,
+                crate_name,
+                &["lib".to_string()],
+                &[],
+                "x86_64-unknown-linux-gnu",
+                "debug",
+                &[(src, format!("{crate_name}.rlib"))],
+                "",
+                "",
+            )
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn history_candidates_returns_local_store_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"), None);
+        seed_entry(&config, "key_serde_1", "serde", dir.path());
+
+        let daemon = Arc::new(Daemon::new(config));
+        let source = LocalPlannerSource { daemon: &daemon };
+
+        let candidates = source
+            .history_candidates(&["serde".to_string()])
+            .await
+            .expect("history_candidates should succeed");
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].cache_key, "key_serde_1");
+        assert_eq!(candidates[0].crate_name, "serde");
+
+        // A crate with no entries yields nothing.
+        let none = source
+            .history_candidates(&["nonexistent".to_string()])
+            .await
+            .unwrap();
+        assert!(none.is_empty());
+    }
+
+    #[tokio::test]
+    async fn shard_candidates_errors_when_no_remote_configured() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"), None); // remote = None
+        let daemon = Arc::new(Daemon::new(config));
+        let source = LocalPlannerSource { daemon: &daemon };
+
+        let err = source
+            .shard_candidates("ns", &[("serde".to_string(), "1.0.0".to_string())])
+            .await
+            .expect_err("no remote -> error");
+        assert!(
+            err.to_string().contains("no remote configured"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn key_cache_keys_for_crate_is_empty_until_populated() {
+        // A fresh daemon's S3 key cache is unpopulated, so the planner source
+        // resolves no extra candidates (the `if !keys.is_empty()` false arm).
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"), None);
+        let daemon = Arc::new(Daemon::new(config));
+        let source = LocalPlannerSource { daemon: &daemon };
+
+        let keys = source.key_cache_keys_for_crate("serde").await.unwrap();
+        assert!(keys.is_empty());
+    }
+}

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -1062,4 +1062,69 @@ mod tests {
         assert_eq!(result.format, "v3");
         server.shutdown();
     }
+
+    /// A ListBucketResult XML body listing the given object keys.
+    fn list_bucket_xml(keys: &[&str]) -> String {
+        let contents: String = keys
+            .iter()
+            .map(|k| format!("<Contents><Key>{k}</Key><Size>10</Size></Contents>"))
+            .collect();
+        format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <Name>bucket</Name><KeyCount>{}</KeyCount><MaxKeys>1000</MaxKeys>\
+             <IsTruncated>false</IsTruncated>{contents}</ListBucketResult>",
+            keys.len()
+        )
+    }
+
+    #[tokio::test]
+    async fn list_keys_maps_manifest_objects_to_crate_and_key() {
+        let remote = test_remote();
+        let xml = list_bucket_xml(&[
+            "artifacts/v3/manifests/serde/aaaa1111.json",
+            "artifacts/v3/manifests/tokio/bbbb2222.json",
+            // Non-manifest junk under the prefix is ignored (no .json suffix).
+            "artifacts/v3/manifests/serde/notes.txt",
+        ]);
+        let (server, client) = mock_client(vec![ReplayedEvent::with_body(xml)]).await;
+        let layout = RemoteLayout::new(&client, &remote);
+
+        let keys = layout.list_keys().await.expect("list_keys should succeed");
+        assert_eq!(keys.get("aaaa1111").map(String::as_str), Some("serde"));
+        assert_eq!(keys.get("bbbb2222").map(String::as_str), Some("tokio"));
+        assert_eq!(keys.len(), 2, "non-.json objects must be ignored: {keys:?}");
+        server.shutdown();
+    }
+
+    #[tokio::test]
+    async fn list_keys_for_crates_queries_each_crate_prefix() {
+        let remote = test_remote();
+        // One LIST per crate; HashSet iteration order is nondeterministic, so
+        // each response carries BOTH crates' manifests. The per-crate prefix the
+        // method queries (and strips) is what selects the right key — a key under
+        // a different crate's prefix is ignored. So the mapping is correct no
+        // matter which crate's LIST consumes which (identical) response.
+        let body = list_bucket_xml(&[
+            "artifacts/v3/manifests/serde/aaaa1111.json",
+            "artifacts/v3/manifests/tokio/bbbb2222.json",
+        ]);
+        let (server, client) = mock_client(vec![
+            ReplayedEvent::with_body(&body),
+            ReplayedEvent::with_body(&body),
+        ])
+        .await;
+        let layout = RemoteLayout::new(&client, &remote);
+
+        let mut crates = std::collections::HashSet::new();
+        crates.insert("serde".to_string());
+        crates.insert("tokio".to_string());
+        let keys = layout
+            .list_keys_for_crates(&crates)
+            .await
+            .expect("list_keys_for_crates should succeed");
+        assert_eq!(keys.get("aaaa1111").map(String::as_str), Some("serde"));
+        assert_eq!(keys.get("bbbb2222").map(String::as_str), Some("tokio"));
+        server.shutdown();
+    }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -2456,6 +2456,32 @@ mod tests {
     }
 
     #[test]
+    fn clean_registered_incremental_dirs_prunes_a_non_directory_path() {
+        // A registered incremental path that now points at a *file* (not a dir)
+        // is pruned without being counted as cleaned. Covers the
+        // `!path.is_dir()` branch of clean_registered_incremental_dirs.
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let bogus = dir.path().join("not-a-dir");
+        std::fs::write(&bogus, b"i am a file").unwrap();
+        store.remember_incremental_dir(&bogus).unwrap();
+
+        let cleaned = store.clean_registered_incremental_dirs().unwrap();
+        assert_eq!(cleaned, 0, "a non-directory is pruned, not cleaned");
+        // The file is left in place (we only remove directories), but its row is gone.
+        assert!(bogus.exists(), "the non-directory file is not deleted");
+        let remaining: i64 = store
+            .db
+            .query_row("SELECT COUNT(*) FROM incremental_dirs", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(remaining, 0, "the bogus registration was pruned");
+    }
+
+    #[test]
     fn test_store_locking() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_config(dir.path());

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2418,4 +2418,57 @@ mod tests {
         assert!(content.trim().parse::<u64>().is_ok(), "got {content:?}");
         assert!(marker_is_fresh(&marker, 60));
     }
+
+    #[test]
+    fn event_root_string_none_is_empty() {
+        assert_eq!(event_root_string(None), "");
+    }
+
+    #[test]
+    fn event_root_string_absolute_path_is_canonicalized() {
+        // An existing absolute path canonicalizes to its real path.
+        let dir = tempfile::tempdir().unwrap();
+        let real = std::fs::canonicalize(dir.path()).unwrap();
+        let got = event_root_string(Some(dir.path().to_path_buf()));
+        assert_eq!(got, real.to_string_lossy());
+    }
+
+    #[test]
+    fn event_root_string_relative_path_is_joined_to_cwd_and_absolute() {
+        // A relative root is resolved against the current dir, yielding an
+        // absolute path (canonicalize falls back to the joined path when the
+        // target doesn't exist). Covers the relative-branch join.
+        let got = event_root_string(Some(PathBuf::from("kache-nonexistent-rel-xyz")));
+        assert!(
+            Path::new(&got).is_absolute(),
+            "relative root must resolve to an absolute path: {got}"
+        );
+        assert!(
+            got.ends_with("kache-nonexistent-rel-xyz"),
+            "resolved path should retain the relative segment: {got}"
+        );
+    }
+
+    #[test]
+    fn event_root_override_reads_kache_event_root_env() {
+        // KACHE_EVENT_ROOT, when set and non-empty, overrides the event root.
+        // No other unit test reads this var, so a scoped set/restore is safe.
+        let prev = std::env::var_os("KACHE_EVENT_ROOT");
+        unsafe {
+            std::env::set_var("KACHE_EVENT_ROOT", "/some/forest/root");
+        }
+        assert_eq!(
+            event_root_override(),
+            Some(PathBuf::from("/some/forest/root"))
+        );
+        // Empty value is treated as unset.
+        unsafe {
+            std::env::set_var("KACHE_EVENT_ROOT", "");
+        }
+        assert_eq!(event_root_override(), None);
+        match prev {
+            Some(v) => unsafe { std::env::set_var("KACHE_EVENT_ROOT", v) },
+            None => unsafe { std::env::remove_var("KACHE_EVENT_ROOT") },
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up coverage on code merged into `main` after PR #389, targeting the
newly-added but previously-untested helpers. Clean-build coverage is **88.0%**;
these tests close gaps in three areas surfaced by the recent feature merges.

## What's covered

- **`build_intent.rs`** (was 67.4%) — the build-intent discovery path:
  - `discover()` end-to-end via rustc `--out-dir` args (drives
    `discover_metadata` → `candidate_manifest_paths` →
    `manifest_from_target_out_dir` → `cargo metadata`)
  - `run_cargo_metadata` with a virtual workspace manifest, hitting
    `graph_crate_order`'s workspace-iter branch (lists all members)
  - `load_cargo_lock_deps` success + missing-file (parse-error → `None`) arms
- **`remote_layout.rs`** — the two v3 manifest listing methods, via in-process
  wire-mock S3 (no network):
  - `list_keys` (maps `{prefix}/v3/manifests/{crate}/{key}.json` → crate+key,
    ignores non-`.json` objects)
  - `list_keys_for_crates` (per-crate prefix query + strip)
- **`store.rs`** — `clean_registered_incremental_dirs` non-directory prune branch
  (a registered path now pointing at a file is pruned, not cleaned).

## Testing

- `cargo test --workspace --all-features` → **967 unit + all integration pass**
- `cargo clippy --all-targets -D warnings` clean; `cargo fmt --check` clean
- Mocking: `aws_smithy_http_client` wire-mock for the S3 listing methods;
  temp cargo workspaces for the metadata discovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
