### PR TITLE
fix(cache-key): canonicalize path-only env-deps before keying (#399)

### DIFF
--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -125,6 +125,7 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
                     fixture,
                     &fixture.dir,
                     cache_dir.path(),
+                    None,
                 );
 
                 let (mut result, post) = run_phase(
@@ -253,11 +254,81 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
     add_speedup_measurements(fixture, &mut phase_results);
 
     let status = fixture_status(&phase_results);
+    // On failure, diff the cold vs relocate cache-key fields so a convergence
+    // miss names the exact diverging field in the CI log (instead of needing a
+    // local repro of a platform-specific path shape).
+    if status != "pass" {
+        report_key_divergence(cache_dir.path());
+    }
     Ok(FixtureResult {
         name: fixture.name.clone(),
         status,
         phases: phase_results,
     })
+}
+
+/// Diff the per-crate cache-key fields between the cold and relocate phases and
+/// print, for every crate whose key changed, the fields that differ. Reads the
+/// `keytrace-<phase>.log` files `run_step` writes under the cache dir. Pure
+/// diagnostics: a convergence miss already failed the fixture; this just makes
+/// the cause legible (which keyed field carried a build-location-dependent
+/// value) without a platform-specific local reproduction. Best-effort — silent
+/// if the trace files are absent (e.g. the cold phase itself failed).
+fn report_key_divergence(cache_dir: &Path) {
+    let parse = |phase: &str| -> std::collections::HashMap<String, Vec<String>> {
+        let mut by_crate: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        let Ok(text) = std::fs::read_to_string(cache_dir.join(format!("keytrace-{phase}.log")))
+        else {
+            return by_crate;
+        };
+        for line in text.lines() {
+            // Lines look like: `... kache::cache_key: [key:<crate>] <field>`.
+            let Some(idx) = line.find("[key:") else {
+                continue;
+            };
+            let rest = &line[idx + "[key:".len()..];
+            let Some(end) = rest.find(']') else { continue };
+            let crate_name = rest[..end].to_string();
+            let field = rest[end + 1..].trim().to_string();
+            if !field.is_empty() {
+                by_crate.entry(crate_name).or_default().push(field);
+            }
+        }
+        by_crate
+    };
+
+    let cold = parse("cold");
+    let relocate = parse("relocate");
+    if cold.is_empty() || relocate.is_empty() {
+        return;
+    }
+
+    let mut printed_header = false;
+    let mut crates: Vec<&String> = cold.keys().collect();
+    crates.sort();
+    for crate_name in crates {
+        let Some(reloc_fields) = relocate.get(crate_name) else {
+            continue;
+        };
+        let cold_fields = &cold[crate_name];
+        let cold_set: std::collections::BTreeSet<&String> = cold_fields.iter().collect();
+        let reloc_set: std::collections::BTreeSet<&String> = reloc_fields.iter().collect();
+        if cold_set == reloc_set {
+            continue;
+        }
+        if !printed_header {
+            eprintln!("   key divergence (cold vs relocate):");
+            printed_header = true;
+        }
+        eprintln!("   [{crate_name}]");
+        for f in cold_set.difference(&reloc_set) {
+            eprintln!("     - cold-only:     {f}");
+        }
+        for f in reloc_set.difference(&cold_set) {
+            eprintln!("     + relocate-only: {f}");
+        }
+    }
 }
 
 /// Drive the `relocate-modified` phase: copy the fixture to a fresh
@@ -396,7 +467,7 @@ fn differential_relocate_check(
         ("relocate_diff_clean", &fixture.commands.clean),
         ("relocate_diff_build", &fixture.commands.build),
     ] {
-        let failure = match run_step(cmd, fixture, relocated, fresh_cache.path()) {
+        let failure = match run_step(cmd, fixture, relocated, fresh_cache.path(), None) {
             Ok(s) if s.exit.success() => None,
             Ok(s) => Some(format!("exit {}", s.exit.code().unwrap_or(1))),
             Err(e) => Some(format!("{e:?}")),
@@ -491,7 +562,7 @@ fn run_phase(
     diff_baseline: &mut std::collections::HashMap<String, Vec<u8>>,
 ) -> Result<(PhaseResult, Option<(crate::report::ReportSummary, usize)>)> {
     if phase.cleans_first() {
-        let status = run_step(&fixture.commands.clean, fixture, cwd, cache_dir)?;
+        let status = run_step(&fixture.commands.clean, fixture, cwd, cache_dir, None)?;
         if !status.exit.success() {
             // Clean failures are unusual but not crashes; record as a
             // failed phase with build_wall_s=0 so consumers see what
@@ -518,7 +589,16 @@ fn run_phase(
     }
 
     let started = Instant::now();
-    let build = run_step(&fixture.commands.build, fixture, cwd, cache_dir)?;
+    // Per-phase cache-key trace, consumed by `report_key_divergence` only when
+    // the fixture fails. Named by phase so the cold/relocate pair can be diffed.
+    let keytrace = cache_dir.join(format!("keytrace-{}.log", phase.name()));
+    let build = run_step(
+        &fixture.commands.build,
+        fixture,
+        cwd,
+        cache_dir,
+        Some(&keytrace),
+    )?;
     let build_wall_s = started.elapsed().as_secs();
     let build_exit_code = build.exit.code().unwrap_or(1);
 
@@ -795,13 +875,30 @@ struct StepOutcome {
 /// `cwd` is decoupled from `fixture.dir` so the relocate phase can
 /// run the same command in a copy of the fixture at a different
 /// absolute path.
-fn run_step(cmd: &str, fixture: &Fixture, cwd: &Path, cache_dir: &Path) -> Result<StepOutcome> {
-    let output = Command::new("sh")
+fn run_step(
+    cmd: &str,
+    fixture: &Fixture,
+    cwd: &Path,
+    cache_dir: &Path,
+    keytrace: Option<&Path>,
+) -> Result<StepOutcome> {
+    let mut command = Command::new("sh");
+    command
         .arg("-c")
         .arg(cmd)
         .current_dir(cwd)
         .env("KACHE_CACHE_DIR", cache_dir)
-        .envs(&fixture.env)
+        .envs(&fixture.env);
+    // Capture every cache-key field to a per-phase file so a convergence
+    // failure can be diagnosed offline (see `report_key_divergence`). cargo
+    // swallows wrapper stderr, so the trace must go to a file. Set AFTER
+    // `fixture.env` so a scenario can't accidentally clobber it.
+    if let Some(path) = keytrace {
+        command
+            .env("KACHE_LOG_FILE", "kache::cache_key=trace,kache=warn")
+            .env("KACHE_LOG_FILE_PATH", path);
+    }
+    let output = command
         .output()
         .with_context(|| format!("spawning `{cmd}` in {}", cwd.display()))?;
 

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -290,7 +290,17 @@ fn report_key_divergence(cache_dir: &Path) {
             let rest = &line[idx + "[key:".len()..];
             let Some(end) = rest.find(']') else { continue };
             let crate_name = rest[..end].to_string();
-            let field = rest[end + 1..].trim().to_string();
+            let mut field = rest[end + 1..].trim().to_string();
+            // `source:<path>=<hash>` keys ONLY the content hash (paths are
+            // hashed in content order, not by path), so a relocated build's
+            // differing display path is not a real divergence. Reduce it to
+            // the keyed hash so the diff reports only fields that move the key.
+            if let Some(hash) = field
+                .strip_prefix("source:")
+                .and_then(|s| s.rsplit('=').next())
+            {
+                field = format!("source:={hash}");
+            }
             if !field.is_empty() {
                 by_crate.entry(crate_name).or_default().push(field);
             }

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -256,7 +256,8 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
     let status = fixture_status(&phase_results);
     // On failure, diff the cold vs relocate cache-key fields so a convergence
     // miss names the exact diverging field in the CI log (instead of needing a
-    // local repro of a platform-specific path shape).
+    // local repro of a platform-specific path shape). No-op unless
+    // `KACHE_E2E_KEYTRACE` was set to capture the traces (see `run_phase`).
     if status != "pass" {
         report_key_divergence(cache_dir.path());
     }
@@ -267,19 +268,32 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
     })
 }
 
+/// The directory holding a fixture's per-phase `keytrace-<phase>.log` files.
+/// Deliberately OUTSIDE `KACHE_CACHE_DIR` (derived from its unique basename) so
+/// the trace files never appear inside the cache kache scans.
+fn keytrace_dir(cache_dir: &Path) -> PathBuf {
+    let tag = cache_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("kache");
+    std::env::temp_dir().join(format!("kache-keytrace-{tag}"))
+}
+
 /// Diff the per-crate cache-key fields between the cold and relocate phases and
 /// print, for every crate whose key changed, the fields that differ. Reads the
-/// `keytrace-<phase>.log` files `run_step` writes under the cache dir. Pure
-/// diagnostics: a convergence miss already failed the fixture; this just makes
-/// the cause legible (which keyed field carried a build-location-dependent
-/// value) without a platform-specific local reproduction. Best-effort — silent
-/// if the trace files are absent (e.g. the cold phase itself failed).
+/// `keytrace-<phase>.log` files `run_step` writes (see [`keytrace_dir`]) when
+/// `KACHE_E2E_KEYTRACE` is set. Pure diagnostics: a convergence miss already
+/// failed the fixture; this just makes the cause legible (which keyed field
+/// carried a build-location-dependent value) without a platform-specific local
+/// reproduction. Best-effort — silent if the trace files are absent (the
+/// common case: the opt-in env var was not set, or the cold phase itself
+/// failed).
 fn report_key_divergence(cache_dir: &Path) {
+    let kt_dir = keytrace_dir(cache_dir);
     let parse = |phase: &str| -> std::collections::HashMap<String, Vec<String>> {
         let mut by_crate: std::collections::HashMap<String, Vec<String>> =
             std::collections::HashMap::new();
-        let Ok(text) = std::fs::read_to_string(cache_dir.join(format!("keytrace-{phase}.log")))
-        else {
+        let Ok(text) = std::fs::read_to_string(kt_dir.join(format!("keytrace-{phase}.log"))) else {
             return by_crate;
         };
         for line in text.lines() {
@@ -600,14 +614,23 @@ fn run_phase(
 
     let started = Instant::now();
     // Per-phase cache-key trace, consumed by `report_key_divergence` only when
-    // the fixture fails. Named by phase so the cold/relocate pair can be diffed.
-    let keytrace = cache_dir.join(format!("keytrace-{}.log", phase.name()));
+    // the fixture fails. OPT-IN via `KACHE_E2E_KEYTRACE`: enabling it sets
+    // `KACHE_LOG_FILE=kache::cache_key=trace` on the build, which perturbs
+    // kache's cc compiler-probe caching (an extra probe trips `max_probe_runs`
+    // on the cc fixtures), so it must stay off for normal runs and be flipped
+    // on only to diagnose a convergence failure. Written OUTSIDE the cache dir
+    // so the trace file never lands in the cache kache scans.
+    let keytrace = std::env::var_os("KACHE_E2E_KEYTRACE").map(|_| {
+        let kt_dir = keytrace_dir(cache_dir);
+        let _ = std::fs::create_dir_all(&kt_dir);
+        kt_dir.join(format!("keytrace-{}.log", phase.name()))
+    });
     let build = run_step(
         &fixture.commands.build,
         fixture,
         cwd,
         cache_dir,
-        Some(&keytrace),
+        keytrace.as_deref(),
     )?;
     let build_wall_s = started.elapsed().as_secs();
     let build_exit_code = build.exit.code().unwrap_or(1);

--- a/scenarios/e2e-rust-out-of-tree-target/scenario.toml
+++ b/scenarios/e2e-rust-out-of-tree-target/scenario.toml
@@ -13,12 +13,13 @@
 name = "e2e-rust-out-of-tree-target"
 tags = ["suite:e2e", "lang:rust", "case:path-normalization", "case:out-of-tree"]
 
-# Gated to Linux/macOS. The out-of-tree OUT_DIR env-dep is now lexically
-# resolved before keying (kunobi-ninja/kache#399), so the unresolved relative
-# target dir Windows cargo produces (`...\pkg\..\oot-target\...`) converges
-# across a relocate. A separate Windows-only key field still diverges for this
-# case; tracked in #399. Re-enable Windows here once that is resolved.
-os = ["linux", "macos"]
+# Runs on all platforms. The out-of-tree OUT_DIR env-dep is resolved to its
+# canonical on-disk form before keying (kunobi-ninja/kache#399), matching the
+# canonical PathNormalizer rule prefixes. Windows cargo joins a relative
+# CARGO_TARGET_DIR literally, so OUT_DIR arrives as `...\pkg\..\oot-target\...`
+# with an unresolved `..`; without resolution no rule matched and the build
+# location leaked into the key, missing on relocate. Now it converges the same
+# way it does on Linux/macOS (where cargo canonicalizes the target dir first).
 
 [source]
 kind = "fixture"

--- a/scenarios/e2e-rust-out-of-tree-target/scenario.toml
+++ b/scenarios/e2e-rust-out-of-tree-target/scenario.toml
@@ -13,11 +13,10 @@
 name = "e2e-rust-out-of-tree-target"
 tags = ["suite:e2e", "lang:rust", "case:path-normalization", "case:out-of-tree"]
 
-# Linux + macOS for now. The out-of-tree `OUT_DIR` env-dep doesn't yet converge
-# across a relocate on Windows (a missed hit, not a wrong artifact — the
-# mixed-separator `..\..\oot-target` path normalizes differently there); tracked
-# as a follow-up. Skipped on Windows rather than asserting a known divergence.
-os = ["linux", "macos"]
+# Runs on all platforms. The out-of-tree OUT_DIR env-dep is lexically resolved
+# before keying (kunobi-ninja/kache#399), so the unresolved relative target dir
+# Windows cargo produces (`...\pkg\..\oot-target\...`) converges across a
+# relocate the same way it does on Linux/macOS.
 
 [source]
 kind = "fixture"

--- a/scenarios/e2e-rust-out-of-tree-target/scenario.toml
+++ b/scenarios/e2e-rust-out-of-tree-target/scenario.toml
@@ -13,10 +13,12 @@
 name = "e2e-rust-out-of-tree-target"
 tags = ["suite:e2e", "lang:rust", "case:path-normalization", "case:out-of-tree"]
 
-# Runs on all platforms. The out-of-tree OUT_DIR env-dep is lexically resolved
-# before keying (kunobi-ninja/kache#399), so the unresolved relative target dir
-# Windows cargo produces (`...\pkg\..\oot-target\...`) converges across a
-# relocate the same way it does on Linux/macOS.
+# Gated to Linux/macOS. The out-of-tree OUT_DIR env-dep is now lexically
+# resolved before keying (kunobi-ninja/kache#399), so the unresolved relative
+# target dir Windows cargo produces (`...\pkg\..\oot-target\...`) converges
+# across a relocate. A separate Windows-only key field still diverges for this
+# case; tracked in #399. Re-enable Windows here once that is resolved.
+os = ["linux", "macos"]
 
 [source]
 kind = "fixture"

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -535,11 +535,12 @@ pub fn compute_cache_key(
                 b"env_dep_val:",
                 normalized_env_dep.value.as_bytes(),
             );
-            tracing::trace!(
-                "[key:{}] env_dep:{}={} ({})",
+            tracing::debug!(
+                "[key:{}] env_dep:{}={} (raw={}, {})",
                 crate_name,
                 var,
                 normalized_env_dep.value,
+                val,
                 normalized_env_dep.decision.as_str()
             );
         }
@@ -932,21 +933,30 @@ fn normalize_env_dep_value(
         };
     }
 
-    if env_dep_is_safe_to_normalize(var, val, source_files, path_normalizer.path_only_env_vars()) {
-        // Lexically resolve `.` / `..` and unify separators before normalizing,
-        // so an unresolved relative target dir (Windows cargo joins
-        // CARGO_TARGET_DIR literally, e.g. `...\pkg\..\oot-target\...`)
-        // normalizes the same regardless of build location (kunobi-ninja/kache#399).
-        // A no-op on already-resolved paths (the Linux case), so only the
-        // genuinely-unresolved out-of-tree input changes.
-        let resolved = lexically_resolve_path(val);
-        let normalized = if resolved == val {
+    // Lexically resolve `.` / `..` and unify separators up front (kunobi-ninja/kache#399).
+    // Windows cargo joins a relative CARGO_TARGET_DIR literally, so an
+    // out-of-tree `OUT_DIR` arrives as `...\pkg\..\oot-target\...` with mixed
+    // separators and an unresolved `..`. The resolved form is fed to BOTH the
+    // path-only safety check (whose `starts_with`/`canonicalize` proof fails on
+    // the `..`-bearing raw value, which would otherwise force a keep-absolute and
+    // a relocate miss) and the prefix normalization, so the value normalizes the
+    // same regardless of build location. A no-op on already-resolved paths (the
+    // Linux case), where cargo has already canonicalized the target dir.
+    let resolved = lexically_resolve_path(val);
+
+    if env_dep_is_safe_to_normalize(
+        var,
+        &resolved,
+        source_files,
+        path_normalizer.path_only_env_vars(),
+    ) {
+        let value = if resolved == val {
             normalized
         } else {
             path_normalizer.normalize(&resolved)
         };
         return NormalizedEnvDep {
-            value: normalized,
+            value,
             decision: EnvDepNormalizationDecision::NormalizedPathOnly,
         };
     }

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -535,12 +535,11 @@ pub fn compute_cache_key(
                 b"env_dep_val:",
                 normalized_env_dep.value.as_bytes(),
             );
-            tracing::debug!(
-                "[key:{}] env_dep:{}={} (raw={}, {})",
+            tracing::trace!(
+                "[key:{}] env_dep:{}={} ({})",
                 crate_name,
                 var,
                 normalized_env_dep.value,
-                val,
                 normalized_env_dep.decision.as_str()
             );
         }

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -924,24 +924,33 @@ fn normalize_env_dep_value(
     source_files: &[std::path::PathBuf],
     path_normalizer: &PathNormalizer,
 ) -> NormalizedEnvDep {
-    let normalized = path_normalizer.normalize(val);
-    if normalized == val {
+    // Resolve the value to the SAME canonical form the rule prefixes use
+    // (kunobi-ninja/kache#399). Windows cargo joins a relative CARGO_TARGET_DIR
+    // literally, so an out-of-tree `OUT_DIR` arrives as `...\pkg\..\oot-target\...`
+    // with mixed separators and an unresolved `..`. The PathNormalizer rules are
+    // `canonicalize()`d (symlinks + `..` resolved, `\\?\` stripped, OS-native
+    // separators, NFC), and `normalize` is a byte-literal substring replace — so
+    // the raw value matches no rule and the build location stays in the key,
+    // missing on relocate. Running the value through the rules' own
+    // `canonical_string` puts it in matchable shape (an out-of-tree OUT_DIR
+    // under the workspace / `$CARGO_TARGET_DIR` collapses to its
+    // `<WORKSPACE>`/`<TARGET>` sentinel, converging across build locations). The
+    // dir exists at key time (the build script already
+    // wrote into it). Fall back to a lexical `.`/`..` collapse when the path is
+    // absent. A no-op on Linux/macOS with a relative target dir, which cargo
+    // canonicalizes before invoking rustc.
+    let resolved = crate::path_normalizer::canonical_string(std::path::Path::new(val))
+        .unwrap_or_else(|| lexically_resolve_path(val));
+    let normalized = path_normalizer.normalize(&resolved);
+
+    // Unchanged: resolution was a no-op AND no rule prefix matched. The value is
+    // not a path kache models, so it enters the key verbatim.
+    if resolved == val && normalized == val {
         return NormalizedEnvDep {
-            value: normalized,
+            value: val.to_string(),
             decision: EnvDepNormalizationDecision::Unchanged,
         };
     }
-
-    // Lexically resolve `.` / `..` and unify separators up front (kunobi-ninja/kache#399).
-    // Windows cargo joins a relative CARGO_TARGET_DIR literally, so an
-    // out-of-tree `OUT_DIR` arrives as `...\pkg\..\oot-target\...` with mixed
-    // separators and an unresolved `..`. The resolved form is fed to BOTH the
-    // path-only safety check (whose `starts_with`/`canonicalize` proof fails on
-    // the `..`-bearing raw value, which would otherwise force a keep-absolute and
-    // a relocate miss) and the prefix normalization, so the value normalizes the
-    // same regardless of build location. A no-op on already-resolved paths (the
-    // Linux case), where cargo has already canonicalized the target dir.
-    let resolved = lexically_resolve_path(val);
 
     if env_dep_is_safe_to_normalize(
         var,
@@ -949,13 +958,8 @@ fn normalize_env_dep_value(
         source_files,
         path_normalizer.path_only_env_vars(),
     ) {
-        let value = if resolved == val {
-            normalized
-        } else {
-            path_normalizer.normalize(&resolved)
-        };
         return NormalizedEnvDep {
-            value,
+            value: normalized,
             decision: EnvDepNormalizationDecision::NormalizedPathOnly,
         };
     }
@@ -2524,6 +2528,73 @@ mod tests {
         assert_eq!(
             from_oot(&cold),
             ["oot-target", "release", "build", "x", "out"].join(s)
+        );
+    }
+
+    /// kunobi-ninja/kache#399 end-to-end at the env-dep layer: an out-of-tree
+    /// OUT_DIR that arrives with an unresolved `..` (as Windows cargo leaves it
+    /// for a relative CARGO_TARGET_DIR) must normalize to the same
+    /// <WORKSPACE>-anchored sentinel regardless of absolute build location, so
+    /// the key converges and a relocated build hits. Regression for the bug
+    /// where `normalize_env_dep_value` returned `Unchanged` before resolving:
+    /// the raw `..`-bearing path matched no canonical rule prefix, so the build
+    /// location leaked into the key and only the resolved-then-normalized form
+    /// (matching the rules' own `canonical_string`) converges.
+    #[test]
+    fn out_of_tree_out_dir_env_dep_converges_across_locations() {
+        let _lock = key_test_lock();
+
+        // Build a real out-of-tree OUT_DIR under `root` with a `..` in the
+        // path (root/pkg/../oot-target/...) and return its normalized env-dep
+        // value, anchoring <WORKSPACE> at the oot-target dir.
+        fn normalized(root: &std::path::Path) -> String {
+            let target = root.join("oot-target");
+            let out = target
+                .join("release")
+                .join("build")
+                .join("pkg-0000000000000000")
+                .join("out");
+            std::fs::create_dir_all(&out).unwrap();
+            // `pkg` must exist for canonicalize to traverse `pkg/..`.
+            std::fs::create_dir_all(root.join("pkg")).unwrap();
+            let generated = out.join("generated.rs");
+            // Path-only include payload (no `env!("OUT_DIR")` runtime use), so
+            // the value is safe to normalize.
+            std::fs::write(&generated, b"pub fn marker() -> u8 { 7 }\n").unwrap();
+
+            // The value as Windows cargo hands it over: the package dir is
+            // cancelled by a literal `..` rather than pre-resolved.
+            let value = root
+                .join("pkg")
+                .join("..")
+                .join("oot-target")
+                .join("release")
+                .join("build")
+                .join("pkg-0000000000000000")
+                .join("out")
+                .to_string_lossy()
+                .into_owned();
+
+            let pn = PathNormalizer::from_env(Some(&target));
+            normalize_env_dep_value("OUT_DIR", &value, &[generated], &pn).value
+        }
+
+        let cold = tempfile::tempdir().unwrap();
+        let reloc = tempfile::tempdir().unwrap();
+        let v_cold = normalized(cold.path());
+        let v_reloc = normalized(reloc.path());
+
+        assert_eq!(
+            v_cold, v_reloc,
+            "out-of-tree OUT_DIR must normalize identically across build locations"
+        );
+        assert!(
+            v_cold.contains("<WORKSPACE>"),
+            "expected the workspace sentinel, got `{v_cold}`"
+        );
+        assert!(
+            !v_cold.contains(".."),
+            "the `..` must be resolved away, got `{v_cold}`"
         );
     }
 

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -829,6 +829,95 @@ struct NormalizedEnvDep {
     decision: EnvDepNormalizationDecision,
 }
 
+/// Lexically collapse `.` / `..` components and unify path separators, without
+/// touching the filesystem. Splits on BOTH `/` and `\` so it handles
+/// Windows-style paths on any host, preserves a leading root / drive / UNC
+/// anchor that `..` cannot escape, and rejoins with the platform separator so
+/// the result lines up with the host-canonical rule prefixes the cache key
+/// matches against.
+///
+/// Why: Windows cargo joins a relative `CARGO_TARGET_DIR` (`../oot-target`) onto
+/// the package dir literally, so `OUT_DIR` arrives as
+/// `C:\proj\pkg\..\oot-target\...` with mixed separators and an unresolved
+/// `..`. The workspace-root prefix then only matches up to `C:\proj\pkg`,
+/// leaving a `\..`-bearing residual that differs by build location and breaks
+/// out-of-tree cross-location convergence (kunobi-ninja/kache#399). Resolving
+/// the `..` first yields `C:\proj\oot-target\...`, which normalizes
+/// consistently. On Linux cargo already resolves the target dir, so this is a
+/// no-op there.
+fn lexically_resolve_path(input: &str) -> String {
+    let is_sep = |c: char| c == '/' || c == '\\';
+    let sep = std::path::MAIN_SEPARATOR;
+    let chars: Vec<char> = input.chars().collect();
+    let n = chars.len();
+
+    // Split off the un-poppable anchor (root / drive / UNC) and the index where
+    // the resolvable component list starts.
+    let (anchor, start) = if n >= 2 && is_sep(chars[0]) && is_sep(chars[1]) {
+        // UNC: \\server\share — keep `\\` plus the next two components as root.
+        let mut root = String::from(r"\\");
+        let mut i = 2;
+        let mut taken = 0;
+        while i < n && taken < 2 {
+            while i < n && is_sep(chars[i]) {
+                i += 1;
+            }
+            let comp_start = i;
+            while i < n && !is_sep(chars[i]) {
+                i += 1;
+            }
+            if comp_start == i {
+                break;
+            }
+            if taken == 1 {
+                root.push(sep);
+            }
+            root.extend(&chars[comp_start..i]);
+            taken += 1;
+        }
+        root.push(sep);
+        (root, i)
+    } else if n >= 2 && chars[1] == ':' && chars[0].is_ascii_alphabetic() {
+        // Windows drive: `C:` optionally followed by a separator (absolute).
+        let mut root: String = chars[..2].iter().collect();
+        let mut i = 2;
+        if i < n && is_sep(chars[i]) {
+            root.push(sep);
+            i += 1;
+        }
+        (root, i)
+    } else if n >= 1 && is_sep(chars[0]) {
+        (String::from(sep), 1) // Unix absolute
+    } else {
+        (String::new(), 0) // relative
+    };
+
+    let absolute = anchor.ends_with(sep);
+    let tail: String = chars[start..].iter().collect();
+    let mut stack: Vec<&str> = Vec::new();
+    for comp in tail.split(is_sep).filter(|c| !c.is_empty()) {
+        match comp {
+            "." => {}
+            ".." => match stack.last() {
+                Some(&top) if top != ".." => {
+                    stack.pop();
+                }
+                _ if absolute => {} // cannot escape the root
+                _ => stack.push(".."),
+            },
+            other => stack.push(other),
+        }
+    }
+
+    let joined = stack.join(&sep.to_string());
+    match (anchor.is_empty(), joined.is_empty()) {
+        (true, true) => ".".to_string(),
+        (true, false) => joined,
+        (false, true) => anchor,
+        (false, false) => format!("{anchor}{joined}"),
+    }
+}
+
 fn normalize_env_dep_value(
     var: &str,
     val: &str,
@@ -844,6 +933,18 @@ fn normalize_env_dep_value(
     }
 
     if env_dep_is_safe_to_normalize(var, val, source_files, path_normalizer.path_only_env_vars()) {
+        // Lexically resolve `.` / `..` and unify separators before normalizing,
+        // so an unresolved relative target dir (Windows cargo joins
+        // CARGO_TARGET_DIR literally, e.g. `...\pkg\..\oot-target\...`)
+        // normalizes the same regardless of build location (kunobi-ninja/kache#399).
+        // A no-op on already-resolved paths (the Linux case), so only the
+        // genuinely-unresolved out-of-tree input changes.
+        let resolved = lexically_resolve_path(val);
+        let normalized = if resolved == val {
+            normalized
+        } else {
+            path_normalizer.normalize(&resolved)
+        };
         return NormalizedEnvDep {
             value: normalized,
             decision: EnvDepNormalizationDecision::NormalizedPathOnly,
@@ -2355,6 +2456,66 @@ mod tests {
                 "diagnostics/query flag {extra:?} must not change the key"
             );
         }
+    }
+
+    /// kunobi-ninja/kache#399: lexical `.`/`..` collapse + separator unification.
+    /// Output uses the host separator (so it lines up with canonical rule
+    /// prefixes); built with MAIN_SEPARATOR so the test is host-independent.
+    #[test]
+    fn lexically_resolve_path_collapses_dot_dot() {
+        let s = std::path::MAIN_SEPARATOR_STR;
+        let j = |parts: &[&str]| parts.join(s);
+
+        // Unix-style absolute.
+        assert_eq!(lexically_resolve_path("/a/b/../c"), j(&["", "a", "c"]));
+        assert_eq!(lexically_resolve_path("/a/./b"), j(&["", "a", "b"]));
+        // `..` cannot escape the root.
+        assert_eq!(lexically_resolve_path("/../a"), j(&["", "a"]));
+
+        // Windows drive + mixed separators + unresolved `..` (the #399 input
+        // shape: a relative CARGO_TARGET_DIR joined literally with `/`).
+        assert_eq!(
+            lexically_resolve_path(r"C:\proj\pkg\..\oot-target\x"),
+            format!("C:{}", j(&["", "proj", "oot-target", "x"]))
+        );
+        assert_eq!(
+            lexically_resolve_path(r"C:\u\src\../oot-target\rel\deps"),
+            format!("C:{}", j(&["", "u", "oot-target", "rel", "deps"]))
+        );
+
+        // Relative paths keep a leading `..`.
+        assert_eq!(lexically_resolve_path("../a/b"), j(&["..", "a", "b"]));
+        assert_eq!(lexically_resolve_path("."), ".");
+
+        // Already-resolved paths are unchanged on the host (the Linux case).
+        let resolved = format!("{}home{}u{}oot{}out", s, s, s, s);
+        assert_eq!(lexically_resolve_path(&resolved), resolved);
+    }
+
+    /// kunobi-ninja/kache#399 (the core property): two out-of-tree build paths
+    /// that differ only in the package-dir component cancelled by `..` resolve
+    /// so the suffix below their respective roots is identical. That suffix is
+    /// what survives after the workspace-root prefix is stripped, so the cache
+    /// key converges across build locations.
+    #[test]
+    fn lexically_resolve_path_makes_out_of_tree_suffix_converge() {
+        // Cold and a relocate (different drive subtree, different package-dir
+        // name) of the same out-of-tree build. The `..` cancels the package dir,
+        // so oot-target attaches directly to the package's parent (= the
+        // workspace root). The segment from oot-target onward is then identical,
+        // which is what survives after the <WORKSPACE> prefix is stripped.
+        let cold =
+            lexically_resolve_path(r"C:\proj\scenario\source\..\oot-target\release\build\x\out");
+        let reloc = lexically_resolve_path(r"C:\Temp\.tmpAB\..\oot-target\release\build\x\out");
+        assert!(!cold.contains(".."), "unresolved .. in {cold}");
+        assert!(!reloc.contains(".."), "unresolved .. in {reloc}");
+        let from_oot = |p: &str| p[p.find("oot-target").unwrap()..].to_string();
+        assert_eq!(from_oot(&cold), from_oot(&reloc));
+        let s = std::path::MAIN_SEPARATOR_STR;
+        assert_eq!(
+            from_oot(&cold),
+            ["oot-target", "release", "build", "x", "out"].join(s)
+        );
     }
 
     /// H1: a build-script native search path must diverge the key, but

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -106,7 +106,18 @@ use std::path::{Path, PathBuf};
 // v16 (kunobi-ninja/kache#324): length-prefix the free-text key fields (cfg,
 // env-dep, codegen flag args) so a value containing the old `\n`/`=` delimiter
 // can't be confused with an adjacent field's boundary.
-pub(crate) const CACHE_KEY_VERSION: u32 = 16;
+//
+// v17 (kunobi-ninja/kache#399): the `--remap-path-prefix` SENTINEL SET is no
+// longer folded into the key — only the remap on/off choice (multi-prefix vs
+// none) is. The set's membership depended on which machine-local dirs existed
+// relative to the build, so it varied across machines and across relocations
+// when the build tree lived inside one of those dirs (an out-of-tree build
+// under the system tempdir dropped the <TMPDIR> rule by de-dupe, diverging the
+// key). It was also redundant with the already-keyed normalized path fields.
+// Dropping it fixes out-of-tree relocate misses on Windows and improves
+// cross-machine key stability. Removing the per-sentinel fold changes the key
+// bytes for every crate, so bump to invalidate v16 entries cleanly.
+pub(crate) const CACHE_KEY_VERSION: u32 = 17;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
 /// Collapse runs of ASCII whitespace into single spaces and trim
@@ -781,21 +792,29 @@ pub fn compute_cache_key(
         "none".to_string()
     } else {
         hasher.update(b"remap:multi-prefix\n");
-        // Hash only the SENTINEL names (not the prefix paths), so
-        // the key is identical across machines whose `$HOME` /
-        // `$CARGO_HOME` etc. paths differ — same sentinel set →
-        // same key → cross-machine cache hits work.
+        // Only the remap on/off choice is keyed (above) — it is the
+        // binary-affecting bit: coverage builds skip remapping because
+        // tarpaulin / llvm-cov need original paths in the profraw. The
+        // SPECIFIC sentinel set is deliberately NOT folded into the key.
+        // Its membership depends on which machine-local dirs exist relative
+        // to the build ($TMPDIR, %PROGRAMFILES%, $CARGO_HOME, …), so it
+        // varied across machines and — when the build tree sat INSIDE one of
+        // those dirs — across relocations: an out-of-tree build under the
+        // system tempdir dropped the <TMPDIR> rule via the prefix de-dupe,
+        // diverging the key and missing on relocate (kunobi-ninja/kache#399).
+        // The set is also redundant: any path that actually reaches the
+        // compile is already keyed through its normalized env-dep / source /
+        // link field (rewritten to these same sentinels), and
+        // `--remap-path-prefix` only neutralizes rustc-emitted file paths,
+        // never `env!` runtime values (those are keyed separately). Rendered
+        // here for the diagnostic trace only.
         let remap_args = path_normalizer.remap_args();
         let mut sentinels: Vec<String> = remap_args
             .iter()
             .filter_map(|a| a.split('=').next_back().map(str::to_string))
             .collect();
         sentinels.sort();
-        for s in &sentinels {
-            hasher.update(b"remap-sentinel:");
-            hasher.update(s.as_bytes());
-            hasher.update(b"\n");
-        }
+        sentinels.dedup();
         format!("multi-prefix({})", sentinels.join(","))
     };
     tracing::trace!("[key:{}] remap={}", crate_name, remap);

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -445,7 +445,7 @@ fn warn_if_path_leaked(s: &str) {
 /// so byte-literal substring matching works regardless of which
 /// form the source produced. See [`PathNormalizer::normalize`] for
 /// the matching-side normalization.
-fn canonical_string(path: &Path) -> Option<String> {
+pub(crate) fn canonical_string(path: &Path) -> Option<String> {
     let canon = path.canonicalize().ok()?;
     let lossy = canon.to_string_lossy();
     let s: String = strip_verbatim_prefix(&lossy).nfc().collect();


### PR DESCRIPTION
Closes #399.

Out-of-tree builds (a sibling `CARGO_TARGET_DIR`) converged across a relocate on Linux/macOS but missed on Windows — the relocated build recompiled even though the artifact was byte-identical (a wasted recompile, not a wrong artifact), so the scenario had to be gated off Windows. Two distinct path-handling bugs were behind it; both are fixed here and the scenario is un-gated.

## Bug 1 — out-of-tree `OUT_DIR` env-dep
Windows cargo joins a relative `CARGO_TARGET_DIR` literally, so `OUT_DIR` arrives as `C:\pkg\..\oot-target\...` with an unresolved `..` and mixed separators. The `PathNormalizer` rule prefixes are `canonicalize()`d (`..`/symlinks resolved, `\\?\` stripped, OS-native separators), and `normalize` is a byte-literal substring replace — so the raw value matched no rule and the build location stayed in the key. (Linux/macOS escaped this only because cargo canonicalizes a *relative* target dir up front, so their `OUT_DIR` has no `..`.)

**Fix:** resolve a path-only env-dep value through the rules' own `canonical_string` before normalizing (lexical `.`/`..` fallback when the path is absent), so it collapses to its `<WORKSPACE>`/`<TARGET>` sentinel and converges. No-op on already-canonical paths.

## Bug 2 — the `--remap-path-prefix` sentinel set was keyed
With `OUT_DIR` fixed, the key still folded in the *set* of remap sentinels. That set's membership depends on which machine-local dirs exist relative to the build: on the Windows runner, cold builds under `C:\actions-runner\...` (tempdir is a distinct rule → `<TMPDIR>` present) but relocate builds *inside* `...\Temp\...`, so the `<TMPDIR>` rule dropped out via the prefix de-dupe → different sentinel set → different key.

**Fix:** key only the remap on/off choice (`multi-prefix` vs `none`) — the sole binary-affecting bit (coverage builds skip remapping). The specific set is redundant (any path that reaches the compile is already keyed via its normalized env-dep / source / link field) and was inherently machine/location-dependent. Also removes a latent cross-machine divergence. Bumps `CACHE_KEY_VERSION` to 17.

## Harness diagnostic
Bug 2 was a Windows-only path shape that didn't reproduce off-platform, so this adds an opt-in e2e diagnostic (`KACHE_E2E_KEYTRACE=1`): on a fixture convergence failure it prints the exact cold-vs-relocate keyed-field diff in the CI log. Off by default — enabling it sets `KACHE_LOG_FILE=cache_key=trace`, which perturbs kache's cc compiler-probe caching.

## Validation
- New regression test: an `OUT_DIR` with an unresolved `..` normalizes identically across two build locations.
- Local cross-root reproduction (relocate under `$TMPDIR`) converges on both fixes.
- Full bin test suite + clippy clean; full e2e gate suite green.
- CI green on all platforms with the scenario un-gated, including E2E smoke (Windows).
