### PR TITLE
docs: surface bench verdict, substrate scenario, and run scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ Firefox is the headline stress case: a huge mixed Rust + C/C++ build driven by
 mozbuild. kache intentionally still passes through unsupported shapes such as
 link/whole-program steps, multi-source units, preprocessor-only probes, and any
 still-unmodeled flags; those passthroughs are reported so the benchmark shows
-both today's wins and the next optimization targets. Adding another workload
-such as LLVM is a scenario-file addition, not a runner rewrite.
+both today's wins and the next optimization targets. Adding another workload is a
+scenario-file addition, not a runner rewrite — the LLVM scenario is one such
+almost-pure-C/C++ counterpart.
 
 ```sh
 just bench                 # list kache-backed benchmark profiles
@@ -178,6 +179,7 @@ just bench-trace firefox   # also emit key-diff.{json,md}
 just bench-sccache         # list sccache-backed benchmark profiles
 just bench-sccache firefox # same Firefox shape, with sccache
 just bench substrate       # Rust-heavy polkadot-sdk benchmark (tens of min to ~1.5h, ~20-40 GB)
+just bench llvm            # almost-pure C/C++ CMake benchmark (tens of min, large scratch)
 ```
 
 Each run writes root-level "latest run" artifacts under

--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ such as LLVM is a scenario-file addition, not a runner rewrite.
 
 ```sh
 just bench                 # list kache-backed benchmark profiles
-just bench firefox         # full cold + warm Firefox benchmark
-just bench-retry firefox   # restore the cold snapshot, re-measure warm only
+just bench firefox         # full cold + warm Firefox benchmark (tens of min to hours, ~50 GB)
+just bench-retry firefox   # restore the cold snapshot, re-measure warm only (~25 min)
 just bench-trace firefox   # also emit key-diff.{json,md}
 just bench-sccache         # list sccache-backed benchmark profiles
 just bench-sccache firefox # same Firefox shape, with sccache
-just bench substrate       # Rust-heavy polkadot-sdk benchmark
+just bench substrate       # Rust-heavy polkadot-sdk benchmark (tens of min to ~1.5h, ~20-40 GB)
 ```
 
 Each run writes root-level "latest run" artifacts under

--- a/docs/benchmarks.mdx
+++ b/docs/benchmarks.mdx
@@ -19,6 +19,7 @@ accidentally depends on the checkout path will miss in the warm build.
 ```sh
 just bench                 # list kache-backed benchmark profiles
 just bench firefox         # full cold + warm Firefox benchmark
+just bench substrate       # Rust-heavy polkadot-sdk benchmark
 just bench-retry firefox   # restore the cold snapshot, re-measure warm only
 just bench-trace firefox   # also emit key-diff.{json,md}
 
@@ -26,8 +27,19 @@ just bench-sccache         # list sccache-backed benchmark profiles
 just bench-sccache firefox # same Firefox shape, with sccache
 ```
 
-Benchmarks are intentionally large. Run them sequentially on an otherwise quiet
-host; concurrent builds make wall-clock results noisy.
+Benchmarks are intentionally large. Firefox is a mixed Rust + C/C++ build that
+runs for tens of minutes to hours and needs roughly 50 GB of scratch; substrate
+is Rust-heavy and lighter. Run them sequentially on an otherwise quiet host;
+concurrent builds make wall-clock results noisy.
+
+## Is it working?
+
+The headline numbers (cold/warm wall-clock, speedup, and hit rate) live in the
+`<scenario>.json` summary, but they are only meaningful when the run's
+`verdict` is `ok`. A `DEGRADED RUN` verdict means a guard tripped: a key leaked
+across checkouts, a clone missed for a non-path reason, or sccache changed cache
+location between phases. Treat the speedup as suspect until the listed issues are
+addressed. Check the verdict first, then the speedup.
 
 ## Read the output
 
@@ -76,4 +88,5 @@ Adding a workload such as LLVM should be a new scenario directory, not a runner
 rewrite.
 
 See [`scenarios/README.md`](https://github.com/kunobi-ninja/kache/tree/main/scenarios#readme)
-for the scenario format.
+for the scenario format, and the [`kache report`](/docs/commands/reference)
+reference for the trace and report formats these artifacts use.

--- a/docs/benchmarks.mdx
+++ b/docs/benchmarks.mdx
@@ -20,6 +20,7 @@ accidentally depends on the checkout path will miss in the warm build.
 just bench                 # list kache-backed benchmark profiles
 just bench firefox         # full cold + warm Firefox benchmark
 just bench substrate       # Rust-heavy polkadot-sdk benchmark
+just bench llvm            # almost-pure C/C++ CMake benchmark
 just bench-retry firefox   # restore the cold snapshot, re-measure warm only
 just bench-trace firefox   # also emit key-diff.{json,md}
 
@@ -84,8 +85,10 @@ is invalid.
 
 Benchmarks are scenario files under `scenarios/bench-*`. A scenario declares the
 repo/ref, wrapper wiring, setup, build command, tags, and optional patch files.
-Adding a workload such as LLVM should be a new scenario directory, not a runner
-rewrite.
+Adding a workload is a new scenario directory, not a runner rewrite. The shipped
+scenarios are the worked examples: `bench-firefox` (mixed Rust + C/C++ via
+mozbuild), `bench-substrate` (Rust-only `RUSTC_WRAPPER`), and `bench-llvm`
+(almost-pure C/C++ via CMake compiler launchers).
 
 See [`scenarios/README.md`](https://github.com/kunobi-ninja/kache/tree/main/scenarios#readme)
 for the scenario format, and the [`kache report`](/docs/commands/reference)


### PR DESCRIPTION
Follow-up to #400.

## Summary
- **benchmarks.mdx**: add an "Is it working?" section so readers check the run `verdict` (and know speedup/hit-rate are only meaningful when it is `ok`) before trusting numbers.
- Add the `substrate` scenario to the run list (page was firefox-only) and state run scale/runtime (firefox: tens of min to hours, ~50 GB; substrate lighter) so a multi-hour build isn't kicked off blind.
- Cross-link the `kache report` reference for the trace/report formats.
- **README**: restore the size/time hints (~50 GB, ~25 min, ~20-40 GB) dropped in #400's rewrite.

## Validation
- `git diff --check` clean
- no em-dashes in benchmarks.mdx
- all claims verified against `src/store.rs`, `src/cli.rs`, `justfile`, `scenarios/`, `crates/kache-e2e/src/bench_runner.rs`