### PR TITLE
bench: add LLVM CMake/C++ benchmark scenario

### DIFF
--- a/scenarios/bench-llvm/scenario.toml
+++ b/scenarios/bench-llvm/scenario.toml
@@ -1,0 +1,69 @@
+# LLVM compile-cache benchmark scenario for kache-scenario.
+#
+# A large, almost pure C/C++ CMake build — the counterpart to Firefox's mixed
+# Rust + C/C++ workload. kache wires in as the compiler launcher via CMake's
+# CMAKE_C_COMPILER_LAUNCHER / CMAKE_CXX_COMPILER_LAUNCHER (the `<kache> <cc>
+# <args>` convention), so every `-c` translation unit goes through the cache and
+# link/archive steps pass through. There is no Rust here.
+#
+# Why LLVM is a good cc stress case:
+#   * Thousands of single-source C++ object compiles — the shape kache caches.
+#   * TableGen emits `*.inc` headers INTO the out-of-tree build dir, pulled in by
+#     absolute `-I` paths. That is exactly the out-of-tree / generated-header
+#     normalization concern (#304) — here at scale. The cross-clone metric only
+#     passes if kache normalizes those build-dir paths out of the cache key.
+name = "bench-llvm"
+tags = ["suite:bench", "project:llvm", "backend:kache", "lang:cc", "lang:cpp"]
+
+# PATH checks for the tools the build driver needs around the checkout. cmake +
+# ninja drive the build; the C/C++ compiler itself is whatever CMake detects
+# (system clang/gcc / AppleClang) and is checked by CMake's configure step.
+requires = ["cmake", "ninja"]
+
+# Configure once into an out-of-tree build dir, then build. Run per clone, so
+# each clone configures at its own absolute path — the cross-clone test.
+#
+# KACHE_BASE_DIR="$PWD" makes kache rewrite paths under the checkout root
+# (source AND the {objdir} build tree, which lives under it) to a stable
+# sentinel in the cache key, so the two clones at different absolute paths
+# produce the same key and share hits. This is the documented knob for
+# out-of-tree C/C++ layouts (getting-started/c-cpp: "Out-of-tree builds").
+#
+# Build choices, all aimed at a fair, reproducible cc cache workload:
+#   * Release, assertions OFF, no `-g`: a representative non-debug build with no
+#     DWARF absolute paths (debug info is a separate path-baking concern; cf.
+#     the e2e-cmake-out-of-tree fixture, which also drops -g).
+#   * LLVM_TARGETS_TO_BUILD=X86 only: bounds the build to one backend so it
+#     stays in the tens-of-minutes range instead of all targets.
+#   * LLVM_APPEND_VC_REV=OFF: stops LLVM baking the git revision into a couple of
+#     TUs, which would otherwise diverge those objects across clones.
+#   * tests/benchmarks/examples OFF: trims non-library compiles that add noise.
+build = """
+export KACHE_BASE_DIR="$PWD"
+cmake -S llvm -B {objdir} -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_TARGETS_TO_BUILD=X86 \
+  -DLLVM_ENABLE_ASSERTIONS=OFF \
+  -DLLVM_APPEND_VC_REV=OFF \
+  -DLLVM_INCLUDE_TESTS=OFF \
+  -DLLVM_INCLUDE_BENCHMARKS=OFF \
+  -DLLVM_INCLUDE_EXAMPLES=OFF \
+  -DCMAKE_C_COMPILER_LAUNCHER={kache} \
+  -DCMAKE_CXX_COMPILER_LAUNCHER={kache}
+cmake --build {objdir}
+"""
+
+[source]
+kind   = "clone"
+repo   = "https://github.com/llvm/llvm-project.git"
+ref    = "llvmorg-21.1.8"
+objdir = "build-kache-bench"
+
+# Provisional gate, mirroring the Firefox thresholds. LLVM cross-clone stability
+# is not yet measured, so the first run establishes the baseline; tighten these
+# once a real number exists. max_errors = 0 stays strict — a compile error is
+# always a hard fail, never a "degraded but acceptable" run.
+[checks.assert.warm]
+min_key_stability_pct = 50.0
+max_passthrough_pct = 40.0
+max_errors = 0


### PR DESCRIPTION
## Summary
Adds `scenarios/bench-llvm/` — a large, almost pure C/C++ CMake workload, the counterpart to the mixed Rust + C/C++ Firefox bench. Makes the "adding a workload such as LLVM is a scenario-file addition, not a runner rewrite" claim concrete.

- kache wires in as the compiler launcher via `CMAKE_C_COMPILER_LAUNCHER` / `CMAKE_CXX_COMPILER_LAUNCHER`; link/archive steps pass through.
- **Why it's a good cc stress case:** TableGen emits `*.inc` headers into the out-of-tree build dir, pulled in by absolute `-I`. The cross-clone metric only passes if kache normalizes those build-dir paths out of the cache key — the #304 out-of-tree concern, at scale. Gated by `KACHE_BASE_DIR="$PWD"` (the documented out-of-tree knob).
- Bounded to `LLVM_TARGETS_TO_BUILD=X86`, Release, no `-g`, `LLVM_APPEND_VC_REV=OFF` for reproducibility. Pinned to `llvmorg-21.1.8`.

Run with `just bench llvm`.

## Validation
- `cargo build --release -p kache-e2e --bin kache-scenario` clean
- `kache-scenario --list --select suite:bench --select backend:kache --profile llvm` resolves `llvm` (discovery runs full `load()` validation: name-match + clone repo/ref/objdir parse)
- A full `just bench llvm` run (tens of minutes, large scratch) is not run in CI; thresholds in `[checks.assert.warm]` are provisional and to be calibrated from the first measured run.