### PR TITLE
ci: skip the build/test matrix on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,65 @@ env:
   KACHE_LOG: kache=debug
 
 jobs:
+  # Decide whether the heavy build/test jobs need to run for this event.
+  # Docs-only PRs (Markdown/MDX and docs/) compile nothing, so running the
+  # Linux/macOS/Windows test matrix on them just burns the flaky self-hosted
+  # runners. This job lists the PR's changed files and sets `code=true` iff any
+  # non-docs file changed; the heavy jobs gate on it.
+  #
+  # Why a job-level `if` and NOT `paths-ignore` on the trigger: the required
+  # status checks (Check (Linux), E2E smoke (Linux/macOS), Nix package,
+  # Test (macOS)) must still REPORT on every PR. A `paths-ignore`d workflow
+  # never creates those check contexts, so branch protection wedges them at
+  # "pending" forever. A job skipped by `if` reports a *skipped* conclusion,
+  # which branch protection counts as success — so docs PRs stay mergeable.
+  #
+  # Non-PR events (push to main, tags, dispatch) always run the full suite.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "non-PR event (${{ github.event_name }}): running full CI"
+            exit 0
+          fi
+          # Fail open: if the file list can't be fetched, run the full suite
+          # rather than skip tests on an unknown change set.
+          files=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename') || {
+            echo "could not list changed files; running full CI to be safe"
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          echo "Changed files:"
+          printf '%s\n' "$files"
+          # Docs-only if every changed file is Markdown/MDX or under docs/.
+          # Anything else (Rust, scenarios/*.toml, CI, manifests, ...) is code.
+          code=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md|*.mdx|docs/*) : ;;   # documentation — does not need the matrix
+              *) code=true ;;            # any other path runs the full suite
+            esac
+          done <<< "$files"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          echo "non-docs changes present: $code"
+
   check:
     name: Check (${{ matrix.os }})
     runs-on: ${{ matrix.runner }}
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     # Job-level cap so a hang in checkout/mise/build is killed in minutes, not
     # the 6h GitHub default — the step-level timeouts below only guard their own
     # steps. (`just ci` itself is additionally capped at 30m.)
@@ -132,6 +188,8 @@ jobs:
   nix-package:
     name: Nix package
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
@@ -147,6 +205,8 @@ jobs:
   e2e:
     name: E2E smoke (${{ matrix.os }})
     runs-on: ${{ matrix.runner }}
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     # Per-arm cap. The self-hosted macOS/Windows runners are persistent and have
     # hung in `checkout` on stale git refs (#208 run hung ~51m before manual
     # cancel); without a job timeout the default is 6h. Normal runs are <10m.
@@ -427,6 +487,8 @@ jobs:
     # matching note on the `e2e` job; fork PRs are gated by the repo's
     # "require approval" Actions setting, not by this expression.
     runs-on: ${{ (github.repository_owner == 'kunobi-ninja' && github.event.pull_request.head.repo.fork != true) && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     # Job-level cap on the persistent self-hosted macOS runner (cargo test is
     # additionally capped at 30m); catches checkout/mise hangs.
     timeout-minutes: 40
@@ -527,6 +589,8 @@ jobs:
   test-windows:
     name: Test (Windows)
     runs-on: ${{ fromJSON('["self-hosted", "Windows", "X64", "kunobi-windows"]') }}
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     # Windows on the self-hosted runner is the slowest leg: a from-scratch
     # `cargo test --workspace` compile alone exceeded the previous 30m step cap.
     # Job cap must cover the test step (45m) + clippy step (30m) + setup.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,20 +18,11 @@ env:
   KACHE_LOG: kache=debug
 
 jobs:
-  # Decide whether the heavy build/test jobs need to run for this event.
-  # Docs-only PRs (Markdown/MDX and docs/) compile nothing, so running the
-  # Linux/macOS/Windows test matrix on them just burns the flaky self-hosted
-  # runners. This job lists the PR's changed files and sets `code=true` iff any
-  # non-docs file changed; the heavy jobs gate on it.
-  #
-  # Why a job-level `if` and NOT `paths-ignore` on the trigger: the required
-  # status checks (Check (Linux), E2E smoke (Linux/macOS), Nix package,
-  # Test (macOS)) must still REPORT on every PR. A `paths-ignore`d workflow
-  # never creates those check contexts, so branch protection wedges them at
-  # "pending" forever. A job skipped by `if` reports a *skipped* conclusion,
-  # which branch protection counts as success — so docs PRs stay mergeable.
-  #
-  # Non-PR events (push to main, tags, dispatch) always run the full suite.
+  # Skip the build matrix on docs-only PRs (*.md, *.mdx, docs/**), which compile
+  # nothing. Heavy jobs gate on `code`. We use a job-level `if`, not trigger
+  # `paths-ignore`: the required checks must still report, and a *skipped* job
+  # counts as success while a never-created one wedges branch protection at
+  # "pending". Fails open (runs everything) on non-PR events or any API error.
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
@@ -42,35 +33,20 @@ jobs:
       - id: filter
         env:
           GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
         run: |
+          set -o pipefail
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "code=true" >> "$GITHUB_OUTPUT"
-            echo "non-PR event (${{ github.event_name }}): running full CI"
-            exit 0
+            echo "code=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          # Fail open: if the file list can't be fetched, run the full suite
-          # rather than skip tests on an unknown change set.
-          files=$(gh api --paginate \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename') || {
-            echo "could not list changed files; running full CI to be safe"
-            echo "code=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          }
-          echo "Changed files:"
+          files=$(gh api --paginate "repos/${{ github.repository }}/pulls/$PR/files" \
+            --jq '.[].filename') || { echo "code=true" >> "$GITHUB_OUTPUT"; exit 0; }
           printf '%s\n' "$files"
-          # Docs-only if every changed file is Markdown/MDX or under docs/.
-          # Anything else (Rust, scenarios/*.toml, CI, manifests, ...) is code.
-          code=false
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            case "$f" in
-              *.md|*.mdx|docs/*) : ;;   # documentation — does not need the matrix
-              *) code=true ;;            # any other path runs the full suite
-            esac
-          done <<< "$files"
-          echo "code=$code" >> "$GITHUB_OUTPUT"
-          echo "non-docs changes present: $code"
+          if printf '%s\n' "$files" | grep -qvE '(\.mdx?$|^docs/)'; then
+            echo "code=true"  >> "$GITHUB_OUTPUT"   # a non-docs file changed
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"   # docs only -> skip the matrix
+          fi
 
   check:
     name: Check (${{ matrix.os }})


### PR DESCRIPTION
## Problem
`ci.yml` triggers on every `pull_request` with no path filter, so a docs-only PR (this one's siblings #405, the README/benchmark docs) runs the full Linux/macOS/Windows matrix — `check` (tarpaulin coverage), `e2e`, `test-macos`, `test-windows`, `nix-package` — including the self-hosted runners that flake constantly. Docs compile nothing.

## Fix
Add a tiny `changes` job that lists the PR's changed files and sets `code=true` iff any **non-docs** file changed (docs = `*.md`, `*.mdx`, `docs/**`). Gate the five heavy jobs on it. Non-PR events (push to main, tags, dispatch) always run the full suite, so `main` and releases stay fully tested.

## Why a job-level `if`, not `paths-ignore`
The repo's required status checks are **Check (Linux), E2E smoke (Linux), E2E smoke (macOS), Nix package, Test (macOS)**. A workflow skipped via `paths-ignore` never creates those check contexts, so branch protection wedges them at *pending* forever and the PR can't merge. A job skipped by `if` reports a **skipped** conclusion, which branch protection treats as success — so docs PRs stay green and mergeable while running nothing heavy.

Fails **open**: if the changed-file list can't be fetched, it runs the full suite rather than skip tests on an unknown change set.

## Verify
After merge, rebase a docs-only PR (e.g. #405) and confirm: the `changes` job runs, the five heavy jobs show **skipped**, and the PR is still mergeable. `version-consistency` is intentionally left ungated (trivial manifest check, not a required check, and wired into the release gate).

## Note
`pull_request` workflows execute the workflow file from the PR's merge commit, so this saving applies to PRs **rebased onto a main that contains this change** — not retroactively to already-open PRs.