### PR TITLE
fix(ci): send Linux checksums to Homebrew formula dispatch

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -178,8 +178,9 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # brew — dispatch a formula update to the existing tap homebrew-kunobi.
-  # macOS-only formula (arm64 + x86_64). The receiver writes Formula/kache.rb
-  # (stable) or Formula/kache-unstable.rb (unstable).
+  # macOS + Linux formula (arm64 + x86_64 each; Linux uses the musl tarballs).
+  # The receiver writes Formula/kache.rb (stable) or Formula/kache-unstable.rb
+  # (unstable).
   # ---------------------------------------------------------------------------
   brew:
     needs: [resolve, gate]
@@ -187,7 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Download macOS tarball checksums from the release
+      - name: Download macOS + Linux tarball checksums from the release
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.resolve.outputs.version }}
@@ -197,21 +198,29 @@ jobs:
             --repo "${GH_OWNER}/${GH_REPO}" \
             --pattern 'kache-x86_64-apple-darwin.tar.gz.sha256' \
             --pattern 'kache-aarch64-apple-darwin.tar.gz.sha256' \
+            --pattern 'kache-x86_64-unknown-linux-musl.tar.gz.sha256' \
+            --pattern 'kache-aarch64-unknown-linux-musl.tar.gz.sha256' \
             --dir /tmp/sha
 
-      - name: Extract macOS SHA256 values
+      - name: Extract SHA256 values
         id: sha
         run: |
           set -euo pipefail
           # .sha256 sibling files contain "<hex>  <filename>"; take field 1.
           SHA_X86=$(cut -d ' ' -f1 < /tmp/sha/kache-x86_64-apple-darwin.tar.gz.sha256)
           SHA_ARM=$(cut -d ' ' -f1 < /tmp/sha/kache-aarch64-apple-darwin.tar.gz.sha256)
-          if [[ -z "$SHA_X86" || -z "$SHA_ARM" ]]; then
-            echo "Error: missing macOS SHA256 values" >&2
+          SHA_LINUX_X86=$(cut -d ' ' -f1 < /tmp/sha/kache-x86_64-unknown-linux-musl.tar.gz.sha256)
+          SHA_LINUX_ARM=$(cut -d ' ' -f1 < /tmp/sha/kache-aarch64-unknown-linux-musl.tar.gz.sha256)
+          if [[ -z "$SHA_X86" || -z "$SHA_ARM" || -z "$SHA_LINUX_X86" || -z "$SHA_LINUX_ARM" ]]; then
+            echo "Error: missing macOS or Linux SHA256 values" >&2
             exit 1
           fi
-          echo "x86_64=$SHA_X86"   >> "$GITHUB_OUTPUT"
-          echo "aarch64=$SHA_ARM"  >> "$GITHUB_OUTPUT"
+          {
+            echo "x86_64=$SHA_X86"
+            echo "aarch64=$SHA_ARM"
+            echo "linux_x86_64=$SHA_LINUX_X86"
+            echo "linux_aarch64=$SHA_LINUX_ARM"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Trigger Homebrew formula update
         uses: peter-evans/repository-dispatch@v3
@@ -226,7 +235,9 @@ jobs:
               "version": "${{ needs.resolve.outputs.version }}",
               "channel": "${{ needs.resolve.outputs.channel }}",
               "sha256_x86_64": "${{ steps.sha.outputs.x86_64 }}",
-              "sha256_aarch64": "${{ steps.sha.outputs.aarch64 }}"
+              "sha256_aarch64": "${{ steps.sha.outputs.aarch64 }}",
+              "sha256_linux_x86_64": "${{ steps.sha.outputs.linux_x86_64 }}",
+              "sha256_linux_aarch64": "${{ steps.sha.outputs.linux_aarch64 }}"
             }
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The `brew` job in `package-publish.yml` only forwarded the **macOS** aarch64/x86_64 tarball checksums to the homebrew-kunobi tap. The tap therefore rendered formulas whose `url`/`sha256` lived only inside an `on_macos` block — so on Linux the formula had no URL at all, which Homebrew 6.0.0 rejects:

```
kunobi-ninja/kunobi/kache: formula requires at least a URL
```

This broke `brew update` / `brew tap` for every Linux user (reported in [homebrew-kunobi#38](https://github.com/kunobi-ninja/homebrew-kunobi/issues/38)).

## What

- Download the `kache-{aarch64,x86_64}-unknown-linux-musl.tar.gz.sha256` siblings alongside the macOS ones.
- Forward them as `sha256_linux_{x86_64,aarch64}` in the repository-dispatch payload.

## Companion / merge order

Pairs with **homebrew-kunobi#39**, which adds the matching renderer inputs (now **required**) + `on_linux` template and ships the immediate hand-fixed formulas.

**Merge this PR before homebrew-kunobi#39.** Once #39 lands, the receiver requires the `sha256_linux_*` payload fields; a release dispatched from `kache` main without this change would fail validation. Merging this first closes that window.

## Validation

`actionlint` clean; YAML parses.