### PR TITLE
test(e2e): gate-speed __FILE__ out-of-tree reproducers + cmake in docker

### DIFF
--- a/docker/e2e.Dockerfile
+++ b/docker/e2e.Dockerfile
@@ -13,11 +13,15 @@
 #
 # Rust pin matches docker/service.Dockerfile. build-essential gives
 # cc/c++/make for the gnu C fixtures; clang adds the clang / clang-cl
-# (`--driver-mode=cl`) path the Firefox-flag fixture (issue #411) exercises.
+# (`--driver-mode=cl`) path the Firefox-flag fixture (issue #411) exercises;
+# cmake + ninja-build drive the CMake out-of-tree fixtures (e2e-cmake-out-of-tree,
+# e2e-cmake-file-macro-oot) — the LLVM-bench build-system shape. Without these,
+# `requires = ["cmake"]` fixtures SKIP silently in the container instead of
+# running the path-normalization checks they exist to guard.
 FROM rust:1.95-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential clang make rsync ca-certificates \
+    && apt-get install -y --no-install-recommends build-essential clang make cmake ninja-build rsync ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /work

--- a/scenarios/e2e-cc-file-macro-oot/scenario.toml
+++ b/scenarios/e2e-cc-file-macro-oot/scenario.toml
@@ -1,0 +1,72 @@
+# kache-e2e fixture for the cold Firefox bench failure (kunobi-ninja/kache#410).
+#
+# Last night's nightly Firefox build failed COLD compiling Chromium's
+# security/sandbox/chromium/base/location.cc:
+#
+#   static assertion failed ... StrEndsWith("<CC_SOURCE>/location.cc", …,
+#   "base/location.cc"): The file name does not match the expected prefix format.
+#
+# Root cause (#410): kache injects its source-path normalization into the REAL
+# compile via -ffile-prefix-map. For a sibling out-of-tree build, the old
+# push_cwd_source_roots mapped the source file's IMMEDIATE parent to <CC_SOURCE>,
+# which wins under longest-match and flattens __FILE__ to "<CC_SOURCE>/location.cc",
+# dropping the "base/" component — and Chromium static_asserts __FILE__ ends with
+# "base/location.cc", so the build dies at cold compile (before any cache hit).
+#
+# This fixture reproduces that exact shape with one C++ TU at src/base/location.cc,
+# built out of tree (Makefile, no cmake — so it also runs in the Linux e2e
+# container where the bug first appeared) with kache as the compiler launcher — at
+# gate speed, so the regression is caught on every PR instead of only by the
+# hours-long bench.
+#
+# Two contracts, both required:
+#   1. The build SUCCEEDS (cold + relocate) — the static_assert holds, i.e. kache
+#      kept "base/location.cc" in __FILE__. This is what last night's bench failed.
+#   2. The relocated out-of-tree rebuild HITS with zero misses — normalization still
+#      converges across clones. The #410 fix had to preserve the dir structure
+#      WITHOUT losing cross-clone stability; this phase guards that second half.
+name = "e2e-cc-file-macro-oot"
+tags = ["suite:e2e", "lang:cpp", "case:path-normalization", "case:out-of-tree", "case:file-macro"]
+
+# gnu/clang only: exercises the cc prefix-map normalization, disabled for the MSVC
+# `cl` dialect (path-literal keys by design). Runs on Linux + macOS; skipped on
+# Windows. Mirrors e2e-cmake-out-of-tree.
+os = ["linux", "macos"]
+
+[source]
+kind = "fixture"
+path = "source"
+
+[env]
+# kache as the C++ compiler launcher: make invokes `<kache> c++ <args>`.
+CXX = "$KACHE c++"
+
+[commands]
+# The Makefile does the sibling out-of-tree compile (../oot-build) and sets
+# KACHE_BASE_DIR to the source root — see the Makefile header.
+build = "make"
+clean = "make clean"
+
+[verify]
+run = "../oot-build/location"
+expected_stdout_contains = ["location ok"]
+
+# A hit must restore a byte-identical object.
+[diff]
+artifacts = ["../oot-build/location.o"]
+
+[assertions.cold]
+min_entries_after = 1
+
+[assertions.warm]
+min_hits = 1
+
+[assertions.noop]
+should_not_recompile = false
+
+# The crux: relocated + rebuilt out-of-tree at a new absolute path. The build must
+# still succeed (static_assert holds: __FILE__ keeps base/location.cc) AND the cc
+# key must be location-independent so the compile HITS — the two halves of #410.
+[assertions.relocate]
+min_hits = 1
+max_misses = 0

--- a/scenarios/e2e-cc-file-macro-oot/source/Makefile
+++ b/scenarios/e2e-cc-file-macro-oot/source/Makefile
@@ -1,0 +1,29 @@
+# Out-of-tree C++ build for the #410 __FILE__-normalization reproducer.
+#
+# The compile runs from a SIBLING build dir (../oot-build) with the source passed
+# as an absolute path, so kache's push_cwd_source_roots takes the sibling branch
+# and injects an -ffile-prefix-map into the real compile — the exact topology that
+# flattened __FILE__ to "<CC_SOURCE>/location.cc" and failed the cold Firefox build.
+#
+# CXX defaults to plain c++; the harness overrides it with `$KACHE c++` to route
+# through kache. KACHE_BASE_DIR is the per-clone source root (the documented knob
+# the real Firefox/LLVM benches use): it normalizes the working-dir basename out of
+# __FILE__ so a relocated/cross-clone build converges. No -g: DWARF path baking is a
+# separate concern.
+CXX      ?= c++
+CXXFLAGS ?= -std=c++17 -O0
+SRCDIR   := $(CURDIR)
+BUILD    := $(CURDIR)/../oot-build
+SRC      := $(SRCDIR)/src/base/location.cc
+
+.PHONY: all clean run
+all:
+	mkdir -p $(BUILD)
+	cd $(BUILD) && KACHE_BASE_DIR=$(SRCDIR) $(CXX) $(CXXFLAGS) -c $(SRC) -o location.o
+	cd $(BUILD) && $(CXX) location.o -o location
+
+run:
+	$(BUILD)/location
+
+clean:
+	rm -rf $(BUILD)

--- a/scenarios/e2e-cc-file-macro-oot/source/src/base/location.cc
+++ b/scenarios/e2e-cc-file-macro-oot/source/src/base/location.cc
@@ -1,0 +1,52 @@
+// Minimal reproducer for the cold Firefox bench failure (kunobi-ninja/kache#410):
+// Chromium's base/location.cc static_asserts that __FILE__ keeps its trailing
+// directory component ("base/location.cc"). kache rewrites the source path in the
+// REAL compile via -ffile-prefix-map (it injects the same map it folds into the
+// cache key). For a sibling out-of-tree build, the buggy normalization mapped the
+// source file's IMMEDIATE parent to <CC_SOURCE>, which wins under longest-match and
+// flattens __FILE__ to "<CC_SOURCE>/location.cc" — dropping the "base/" component
+// and failing this assert at COLD compile, before any cache hit is even possible.
+//
+// Folding the shared <CC_ROOT> instead preserves "…/base/location.cc", so the
+// assert holds while the key still normalizes across clones (see the relocate
+// phase in scenario.toml). This file mirrors Chromium's compile-time check so the
+// regression is caught at gate speed instead of only by the hours-long bench.
+#include <cstddef>
+#include <iostream>
+
+namespace {
+constexpr std::size_t StrLen(const char* s) {
+    std::size_t n = 0;
+    while (s[n] != '\0') {
+        ++n;
+    }
+    return n;
+}
+
+// True iff `name` ends with `suffix`. Mirrors Chromium base/location.cc.
+constexpr bool StrEndsWith(const char* name, const char* suffix) {
+    const std::size_t name_len = StrLen(name);
+    const std::size_t suffix_len = StrLen(suffix);
+    if (name_len < suffix_len) {
+        return false;
+    }
+    const char* tail = name + (name_len - suffix_len);
+    for (std::size_t i = 0; i < suffix_len; ++i) {
+        if (tail[i] != suffix[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// The crux: __FILE__ must retain its directory component after kache's
+// path normalization. A flattened "<CC_SOURCE>/location.cc" fails here.
+static_assert(StrEndsWith(__FILE__, "base/location.cc"),
+              "__FILE__ lost its 'base/' directory component — kache normalization "
+              "flattened the source path. See kunobi-ninja/kache#410.");
+}  // namespace
+
+int main() {
+    std::cout << "location ok\n";
+    return 0;
+}

--- a/scenarios/e2e-cmake-file-macro-oot/scenario.toml
+++ b/scenarios/e2e-cmake-file-macro-oot/scenario.toml
@@ -1,0 +1,58 @@
+# CMake counterpart of e2e-cc-file-macro-oot (kunobi-ninja/kache#410).
+#
+# Same Chromium-style __FILE__ static_assert reproducer, driven through CMake's
+# CMAKE_CXX_COMPILER_LAUNCHER instead of a Makefile — i.e. the LLVM-bench build
+# shape. The make variant mirrors Firefox (gmake), this one mirrors LLVM (CMake +
+# Ninja), so the same kache path-normalization bug is guarded from both build
+# systems the nightly benches actually use. See e2e-cc-file-macro-oot for the full
+# root-cause writeup of #410.
+name = "e2e-cmake-file-macro-oot"
+tags = ["suite:e2e", "lang:cpp", "case:path-normalization", "case:out-of-tree", "case:file-macro", "tool:cmake"]
+
+# gnu/clang only: the cc prefix-map normalization is disabled for the MSVC `cl`
+# dialect (path-literal keys by design). Runs on Linux + macOS; skipped on Windows.
+os = ["linux", "macos"]
+requires = ["cmake"]
+
+[source]
+kind = "fixture"
+path = "source"
+
+[env]
+# kache as the C++ compiler launcher: CMake invokes `<kache> <c++> <args>`.
+CMAKE_CXX_COMPILER_LAUNCHER = "$KACHE"
+
+[commands]
+# Sibling out-of-tree build (../cmake-build). KACHE_BASE_DIR="$PWD" (the per-clone
+# source root) is the documented knob the real LLVM/Firefox benches use: the
+# automatic out-of-tree normalization folds only the working dir's PARENT to
+# <CC_ROOT>, so the working-dir basename still leaks into __FILE__ and a
+# __FILE__-bearing TU diverges across clones. KACHE_BASE_DIR normalizes that
+# basename out while preserving base/location.cc — the relocate phase asserts it.
+# No -g: DWARF path baking is a separate concern.
+build = "KACHE_BASE_DIR=\"$PWD\" cmake -S . -B ../cmake-build -DCMAKE_CXX_FLAGS=-O0 >/dev/null && KACHE_BASE_DIR=\"$PWD\" cmake --build ../cmake-build"
+clean = "rm -rf ../cmake-build"
+
+[verify]
+run = "../cmake-build/location"
+expected_stdout_contains = ["location ok"]
+
+# A hit must restore a byte-identical object.
+[diff]
+artifacts = ["../cmake-build/CMakeFiles/location.dir/src/base/location.cc.o"]
+
+[assertions.cold]
+min_entries_after = 1
+
+[assertions.warm]
+min_hits = 1
+
+[assertions.noop]
+should_not_recompile = false
+
+# Relocated + rebuilt out-of-tree at a new absolute path: the build must still
+# succeed (static_assert holds: __FILE__ keeps base/location.cc) AND the cc key
+# must be location-independent so the compile HITS — the two halves of #410.
+[assertions.relocate]
+min_hits = 1
+max_misses = 0

--- a/scenarios/e2e-cmake-file-macro-oot/source/CMakeLists.txt
+++ b/scenarios/e2e-cmake-file-macro-oot/source/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.13)
+project(oot_file_macro CXX)
+
+# A single C++ TU one directory deep (src/base/location.cc). Built OUT OF TREE
+# (a sibling build dir, see scenario.toml) with kache as CMAKE_CXX_COMPILER_LAUNCHER
+# — the LLVM-bench build shape. kache takes the sibling branch of
+# push_cwd_source_roots and injects an -ffile-prefix-map into the real compile.
+# The buggy map flattened __FILE__ to "<CC_SOURCE>/location.cc"; the fixed one
+# folds <CC_ROOT> and keeps "…/base/location.cc", which the source static_asserts.
+add_executable(location src/base/location.cc)

--- a/scenarios/e2e-cmake-file-macro-oot/source/src/base/location.cc
+++ b/scenarios/e2e-cmake-file-macro-oot/source/src/base/location.cc
@@ -1,0 +1,52 @@
+// Minimal reproducer for the cold Firefox bench failure (kunobi-ninja/kache#410):
+// Chromium's base/location.cc static_asserts that __FILE__ keeps its trailing
+// directory component ("base/location.cc"). kache rewrites the source path in the
+// REAL compile via -ffile-prefix-map (it injects the same map it folds into the
+// cache key). For a sibling out-of-tree build, the buggy normalization mapped the
+// source file's IMMEDIATE parent to <CC_SOURCE>, which wins under longest-match and
+// flattens __FILE__ to "<CC_SOURCE>/location.cc" — dropping the "base/" component
+// and failing this assert at COLD compile, before any cache hit is even possible.
+//
+// Folding the shared <CC_ROOT> instead preserves "…/base/location.cc", so the
+// assert holds while the key still normalizes across clones (see the relocate
+// phase in scenario.toml). This file mirrors Chromium's compile-time check so the
+// regression is caught at gate speed instead of only by the hours-long bench.
+#include <cstddef>
+#include <iostream>
+
+namespace {
+constexpr std::size_t StrLen(const char* s) {
+    std::size_t n = 0;
+    while (s[n] != '\0') {
+        ++n;
+    }
+    return n;
+}
+
+// True iff `name` ends with `suffix`. Mirrors Chromium base/location.cc.
+constexpr bool StrEndsWith(const char* name, const char* suffix) {
+    const std::size_t name_len = StrLen(name);
+    const std::size_t suffix_len = StrLen(suffix);
+    if (name_len < suffix_len) {
+        return false;
+    }
+    const char* tail = name + (name_len - suffix_len);
+    for (std::size_t i = 0; i < suffix_len; ++i) {
+        if (tail[i] != suffix[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// The crux: __FILE__ must retain its directory component after kache's
+// path normalization. A flattened "<CC_SOURCE>/location.cc" fails here.
+static_assert(StrEndsWith(__FILE__, "base/location.cc"),
+              "__FILE__ lost its 'base/' directory component — kache normalization "
+              "flattened the source path. See kunobi-ninja/kache#410.");
+}  // namespace
+
+int main() {
+    std::cout << "location ok\n";
+    return 0;
+}


### PR DESCRIPTION
## Why

Last night's nightly Firefox bench (run 27933998259) failed at the **cold** build compiling Chromium `security/sandbox/chromium/base/location.cc`:

```
static assertion failed ... StrEndsWith("<CC_SOURCE>/location.cc", …, "base/location.cc")
```

That's #410: for a sibling out-of-tree build, kache injects its source-path normalization into the **real** compile via `-ffile-prefix-map` and flattened `__FILE__` to `<CC_SOURCE>/location.cc`, dropping the `base/` component — which Chromium `static_assert`s on. It's already fixed by `acc2f6d`, but was only caught by an hours-long bench and only covered by a unit test.

## What

Two gate-tier e2e fixtures reproduce the exact shape at PR speed — one C++ TU at `src/base/location.cc` with a Chromium-style `static_assert(StrEndsWith(__FILE__, "base/location.cc"))`, built out of tree with kache as the compiler launcher:

| Fixture | Build system | Mirrors |
|---|---|---|
| `e2e-cc-file-macro-oot` | Makefile | Firefox (`mach`/gmake) |
| `e2e-cmake-file-macro-oot` | `CMAKE_CXX_COMPILER_LAUNCHER` | LLVM (CMake + Ninja) |

Each asserts **both** halves of #410:
1. the build **succeeds** (static_assert holds → kache kept `base/location.cc` in `__FILE__`), and
2. the relocated out-of-tree rebuild **hits with zero misses** (normalization still converges cross-clone).

`KACHE_BASE_DIR` is set to the source root, mirroring how the real benches converge `__FILE__`-bearing TUs.

## Validation

- **Red→green proven**: reverting `acc2f6d`'s match arm reproduces the cold static_assert failure with the *exact* nightly error.
- Green on **Linux** (`just e2e-docker`) and **macOS**; both fixtures join the PR gate automatically.

## Also: cmake in the docker e2e image

`docker/e2e.Dockerfile` now installs `cmake` + `ninja-build`. Without them, every `requires = ["cmake"]` fixture — including the existing `e2e-cmake-out-of-tree` — **skipped silently** under `just e2e-docker` instead of running on Linux, the platform where this bug surfaced.

## Follow-up (not in this PR)

Keytrace shows a `__FILE__`-bearing out-of-tree TU only converges cross-clone *because* `KACHE_BASE_DIR` is set: `push_cwd_source_roots` folds only the working dir's **parent** to `<CC_ROOT>`, so the working-dir basename (`clone-a`/`clone-b`) leaks into `__FILE__`. Worth considering a `<CC_SOURCE_ROOT>` sentinel inferred from project evidence (CMakeCache / VCS root) so this converges without the explicit knob.