### PR TITLE
feat(cc): model bench-observed codegen flags so Firefox/LLVM TUs cache

### DIFF
--- a/scenarios/e2e-c-passthrough/scenario.toml
+++ b/scenarios/e2e-c-passthrough/scenario.toml
@@ -1,19 +1,20 @@
 # kache-e2e fixture: a build kache must NOT cache.
 #
-# The inverse of c-hello. The `-c` compile passes `-ffast-math`, an
+# The inverse of c-hello. The `-c` compile passes `-funroll-loops`, an
 # unmodeled codegen flag. kache's classifier refuses it (no row in
 # `CC_FLAGS` matches), the compile passes through to the real
 # compiler uncached, and every phase lands ZERO cache entries.
 #
 # Choice of flag: this fixture needs "an unmodeled codegen flag the
-# classifier will refuse". `-march=native` was originally used because
-# its host-specific output was thought to be permanently uncacheable;
-# #115 disproved that (the probe captures host-resolved cpu/features,
-# so `-march=*` caches correctly per-machine). `-ffast-math` is the
-# current pick — its float-semantics changes aren't captured by the
-# modeled key inputs today, and adding it to `CC_FLAGS` is genuinely
-# unsafe without explicit modeling. If a future PR DOES model
-# `-ffast-math`, the same PR should pick a new unmodeled flag here.
+# classifier will refuse". `-march=native` was the original pick;
+# #115 disproved its permanence (the probe captures host-resolved
+# cpu/features, so `-march=*` caches per-machine). `-ffast-math` was
+# the next pick, but the Firefox nightly bench showed it forcing real
+# media TUs through uncached, so it is now modeled as `CapturedByProbe`
+# (its codegen effect IS in the resolved `cc -###` tokens). The current
+# pick is `-funroll-loops` — a genuine codegen optimization still
+# unmodeled. If a future PR DOES model it, that PR should pick a new
+# unmodeled flag here.
 #
 # This is the e2e cell for the unmodeled-codegen-flag passthrough
 # behavior. c-hello proves a clean compile caches; this proves an

--- a/scenarios/e2e-c-passthrough/source/Makefile
+++ b/scenarios/e2e-c-passthrough/source/Makefile
@@ -1,21 +1,21 @@
 # kache-e2e fixture: a C build kache must NOT cache.
 #
-# The `-c` compile passes `-ffast-math` — an unmodeled codegen flag
+# The `-c` compile passes `-funroll-loops` — an unmodeled codegen flag
 # that kache's classifier does not recognize. The compile passes
 # through to the real compiler, caching nothing.
 #
 # Choice of flag: this needs an "unmodeled codegen flag that won't
-# get classified later". `-march=native` was originally used for this
-# but #115 added `Prefix("-march=")` to the cc table (the resolved
-# `cc -###` tokens differentiate the per-host target-cpu / target-
-# feature set, so `-march=*` is cacheable per-machine). `-ffast-math`
-# changes float semantics in ways the modeled cache-key inputs don't
-# capture today; if a future PR teaches the cache key about float
-# modes, that PR should pick a different fixture flag — the docstring
-# in the corresponding row of `CC_FLAGS` should mention this one.
+# get classified later". `-march=native` was the original pick but
+# #115 added `Prefix("-march=")` (the resolved `cc -###` tokens
+# differentiate the per-host target-cpu/feature set). `-ffast-math`
+# was the next pick, but the Firefox nightly bench showed it forcing
+# real TUs through uncached, so it is now `CapturedByProbe` too.
+# `-funroll-loops` is the current pick — a genuine codegen
+# optimization the classifier still refuses; if a future PR models it,
+# that PR should pick a different fixture flag here.
 
 CC      ?= cc
-CFLAGS  ?= -O2 -ffast-math
+CFLAGS  ?= -O2 -funroll-loops
 SRC     := src/main.c
 BUILD   := build
 OBJ     := $(BUILD)/main.o

--- a/scenarios/e2e-cc-bench-flags/scenario.toml
+++ b/scenarios/e2e-cc-bench-flags/scenario.toml
@@ -1,0 +1,67 @@
+# kache-e2e fixture: bench-observed codegen flags that forced passthrough.
+#
+# The nightly bench reports showed these flags STILL forcing passthrough:
+#   Firefox: cc unsupported flag(s): -ffast-math -mrecip=none -fno-finite-math-only
+#   Firefox: cc unsupported flag(s): -fno-lto
+#   LLVM:    cc unsupported flag(s): -fno-semantic-interposition  (on ALL 2279
+#            TUs — LLVM's Release build sets it on every compile, so the entire
+#            LLVM bench ran at a 0% hit rate until it was modeled)
+#
+# They are codegen knobs whose effect clang resolves into -cc1 tokens (verified
+# against `clang -###`: -ffast-math fans into -ffinite-math-only/-ffp-contract=fast/
+# -fno-signed-zeros/-freciprocal-math/-menable-no-infs/-menable-no-nans; -mrecip=
+# and -fno-finite-math-only forward too), so kache can key them via CapturedByProbe
+# exactly like the existing #114 set (-fno-math-errno, -fno-strict-aliasing, …).
+# Modeling them lets those TUs cache instead of passing through.
+#
+# Pins clang because CapturedByProbe needs the resolved `cc -###` invocation, which
+# kache parses for clang but not gcc (so they correctly pass through on gcc) —
+# same rationale as e2e-cc-cl-xclang-deps.
+#
+# Contract: cold MISSES and stores one entry; warm HITS with zero compiler runs —
+# the falsifiable proof the flags no longer refuse. A modified source MISSES again,
+# proving the key still tracks content under this flag set.
+name = "e2e-cc-bench-flags"
+tags = ["suite:e2e", "lang:cc", "case:flag-soup"]
+requires = ["clang"]
+
+[source]
+kind = "fixture"
+path = "source"
+
+[env]
+CC = "$KACHE clang"
+
+[commands]
+build = "make"
+clean = "make clean"
+
+[verify]
+run = "./build/app"
+expected_stdout_contains = ["math-flags ok"]
+
+[modify]
+file = "a.c"
+find = "math-flags ok"
+replace = "math-flags edited"
+
+# Cold: the math-flag compile is a miss → one entry. If any flag refuses, no
+# entry is stored and this fails — the canary's whole point.
+[assertions.cold]
+min_entries_after = 1
+max_compiler_runs = 1
+
+# Warm: clean + rebuild → the compile HITS. max_compiler_runs = 0 proves the whole
+# flag set classified (none forced a passthrough).
+[assertions.warm]
+min_hits = 1
+max_compiler_runs = 0
+
+[assertions.noop]
+should_not_recompile = false
+
+# Relocate-modified: relocated AND edited — the changed source MUST miss and
+# recompile, proving the key still tracks source content under these flags.
+[assertions.relocate-modified]
+min_misses = 1
+max_compiler_runs = 1

--- a/scenarios/e2e-cc-bench-flags/source/Makefile
+++ b/scenarios/e2e-cc-bench-flags/source/Makefile
@@ -1,0 +1,38 @@
+# Firefox media-TU math/codegen flag set (nightly bench passthrough canary).
+#
+# CC is overridden by the harness to "$KACHE clang". These flags are
+# CapturedByProbe: kache parses clang's resolved `cc -###` `-cc1` tokens, which
+# fan -ffast-math out into -ffinite-math-only/-ffp-contract=fast/-menable-no-infs/
+# … and forward -mrecip=/-fno-finite-math-only, so the cache key captures their
+# codegen effect. (kache parses -### for clang, not gcc, so this fixture pins
+# clang — mirrors e2e-cc-cl-xclang-deps.) -fno-lto is a no-op for a -c compile.
+#
+# Before they were modeled, the real Firefox build passed these TUs through
+# uncached ("cc unsupported flag(s): -ffast-math -mrecip=none
+# -fno-finite-math-only"). The miss-then-hit contract IS the no-passthrough
+# assertion: if any flag refuses, cold stores nothing and warm can't hit.
+CC     ?= cc
+BUILD  := build
+OBJ    := $(BUILD)/a.o
+BIN    := $(BUILD)/app
+
+# The exact families the nightly benches passed through: Firefox media TUs'
+# fast-math set + negation knob, and -fno-semantic-interposition — the single
+# flag LLVM's Release build puts on EVERY TU that refused all 2279 LLVM compiles
+# (0% hit rate) until modeled.
+CFLAGS := -O2 -ffast-math -fno-finite-math-only -mrecip=none -fno-lto -fno-semantic-interposition
+
+.PHONY: all clean
+all: $(BIN)
+
+$(BUILD):
+	mkdir -p $(BUILD)
+
+$(OBJ): a.c | $(BUILD)
+	$(CC) $(CFLAGS) -c a.c -o $(OBJ)
+
+$(BIN): $(OBJ)
+	$(CC) $(OBJ) -o $(BIN)
+
+clean:
+	rm -rf $(BUILD)

--- a/scenarios/e2e-cc-bench-flags/source/a.c
+++ b/scenarios/e2e-cc-bench-flags/source/a.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+
+// A little floating-point work so -ffast-math / -mrecip / -ffinite-math-only
+// actually have codegen to act on. The printed string is what the harness
+// checks; the math just gives the math flags something to transform.
+double accumulate(const double *xs, int n) {
+    double s = 0.0;
+    for (int i = 0; i < n; i++) {
+        s += xs[i] * xs[i];
+    }
+    return s;
+}
+
+int main(void) {
+    double xs[] = {1.5, 2.5, 3.5, 4.5};
+    double r = accumulate(xs, 4);
+    printf("math-flags ok (%.1f)\n", r);
+    return 0;
+}

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -665,10 +665,9 @@ impl CcArgs {
     ///   kache explicitly models (`FlagClass::ModeledInKey`) plus the
     ///   resolved `cc -###` tokens (`FlagClass::CapturedByProbe`). A
     ///   flag whose object-file effect is in none of those — an
-    ///   unmodeled codegen flag (`-Ofast`, `-ffast-math`, `-march=…`,
-    ///   `-ffunction-sections`), a cross-target (`-target`,
-    ///   `--target=`), profiling (`-pg`), or a flag kache has never
-    ///   seen — would miscache. The table is the source of truth;
+    ///   unmodeled codegen flag (`-Ofast`, `-funroll-loops`,
+    ///   `-fsanitize=address`), profiling (`-pg`), or a flag kache has
+    ///   never seen — would miscache. The table is the source of truth;
     ///   anything it does not classify is refused with the offending
     ///   flags named in the reason.
     /// - **Output to stdout** (`-o -`): not a cacheable artifact.
@@ -1424,6 +1423,41 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         source: "Issue #114 — fp-contract codegen knob.",
         dialect: None,
     },
+    // `-ffast-math` and friends. Firefox media TUs (libvpx/dav1d/…) pass these
+    // and the nightly bench showed them STILL passing through ("unsupported
+    // flag(s): -ffast-math -mrecip=none -fno-finite-math-only"). They are the
+    // same shape as the #114 codegen knobs above: clang's driver fans them into
+    // `-cc1` tokens the resolved-token hash already captures — verified against
+    // `clang -###`, where `-ffast-math` expands to `-ffast-math
+    // -ffinite-math-only -ffp-contract=fast -fno-signed-zeros -freciprocal-math
+    // -menable-no-infs -menable-no-nans`, `-fno-finite-math-only` flips the
+    // finite tokens back off, and `-mrecip=<v>` forwards verbatim. NOT
+    // `NoObjectEffect` / `PreprocessorCaptured`: `-ffast-math` defines
+    // `__FAST_MATH__`/`__FINITE_MATH_ONLY__` (so the `-E` hash sees the macros),
+    // but its optimizer assumptions (reassociation, no-inf/no-nan, FP
+    // contraction) are invisible to `-E` — only the `-###` `-cc1` stream
+    // captures them, so `CapturedByProbe` is the complete-and-safe class.
+    FlagSpec {
+        matcher: Matcher::Exact("-ffast-math"),
+        class: FlagClass::CapturedByProbe,
+        source: "Firefox nightly bench — fast-math umbrella; clang -### fans it into -cc1 codegen tokens the key hashes (optimizer assumptions invisible to -E).",
+        dialect: None,
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fno-finite-math-only"),
+        class: FlagClass::CapturedByProbe,
+        source: "Firefox nightly bench — negates fast-math finite assumption; -cc1 token set differs (verified clang -###).",
+        dialect: None,
+    },
+    FlagSpec {
+        // `-mrecip=<value>` (x86 reciprocal-estimate codegen). Prefix-matched so
+        // `=none`/`=all`/`=default,...` are all covered; the value rides through
+        // to `-cc1` so different settings key differently.
+        matcher: Matcher::Prefix("-mrecip="),
+        class: FlagClass::CapturedByProbe,
+        source: "Firefox nightly bench — reciprocal-estimate codegen selector; value forwarded to -cc1 (verified clang -###).",
+        dialect: None,
+    },
     FlagSpec {
         matcher: Matcher::Exact("-pthread"),
         class: FlagClass::CapturedByProbe,
@@ -1639,6 +1673,29 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         matcher: Matcher::Exact("-fvisibility-inlines-hidden"),
         class: FlagClass::CapturedByProbe,
         source: "Firefox bench evidence (post-#146) — inline-function visibility default = hidden.",
+        dialect: None,
+    },
+    // `-f[no-]semantic-interposition`: whether a definition may be
+    // interposed at link time (ELF symbol semantics). It is a real codegen
+    // knob — with interposition disabled the optimizer may inline/specialize
+    // across the symbol boundary, so the object bytes can differ — and clang
+    // forwards it to `-cc1`, so the resolved-token hash captures it (and
+    // shares the key on targets where it is the no-op default). This is the
+    // SINGLE flag that degraded the first LLVM CMake/Ninja bench to a 0%
+    // hit rate: LLVM's Release build puts `-fno-semantic-interposition` on
+    // every TU, so all 2279 compiles refused on this one token (#411-class:
+    // one universal unmodeled flag voids the whole cache). Exact pair, like
+    // the visibility rows above.
+    FlagSpec {
+        matcher: Matcher::Exact("-fno-semantic-interposition"),
+        class: FlagClass::CapturedByProbe,
+        source: "LLVM bench — symbol-interposition codegen knob on every LLVM Release TU; forwarded to -cc1 (was 2279/2279 passthrough).",
+        dialect: None,
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fsemantic-interposition"),
+        class: FlagClass::CapturedByProbe,
+        source: "LLVM bench — positive form of the interposition knob; forwarded to -cc1.",
         dialect: None,
     },
     // Target / arch / WASM / ObjC / section flags
@@ -1904,6 +1961,21 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         matcher: Matcher::Exact("-pipe"),
         class: FlagClass::NoObjectEffect,
         source: "PR #94",
+        dialect: None,
+    },
+    FlagSpec {
+        // `-fno-lto` on a `-c` compile is a no-op: LTO is off by default, so the
+        // object is native code either way — `clang -###` resolves IDENTICAL
+        // `-cc1` tokens with and without it (verified). Firefox passes it
+        // defensively per-TU and the nightly bench passed those TUs through.
+        // `NoObjectEffect` (drop from key) is correct and honest here. The
+        // positive forms — `-flto` / `-flto=thin` / `-ffat-lto-objects` — DO
+        // change the output (LLVM bitcode) and stay unmodeled/refused, so the
+        // dangerous `-flto -fno-lto` combination still passes through (the
+        // unmodeled `-flto` refuses) rather than silently sharing this key.
+        matcher: Matcher::Exact("-fno-lto"),
+        class: FlagClass::NoObjectEffect,
+        source: "Firefox nightly bench — explicit non-LTO `-c` compile; identical -cc1 tokens vs absent (verified clang -###). -flto/-flto=* stay refused.",
         dialect: None,
     },
     FlagSpec {
@@ -4969,8 +5041,9 @@ mod tests {
         // just `-f…` / `-m…`: unmodeled optimization / debug variants,
         // cross-targets, profiling.
         for flag in &[
-            // unmodeled -f… / -m… codegen flags
-            "-ffast-math",
+            // unmodeled -f… / -m… codegen flags. (-ffast-math / -fno-finite-math-only
+            // / -mrecip= are now CapturedByProbe — modeled from the Firefox bench — so
+            // they are deliberately NOT here; these remain genuinely unmodeled.)
             "-fsanitize=address",
             "-funroll-loops",
             "-fno-pic",
@@ -5602,7 +5675,7 @@ mod tests {
             "foo.c",
             "-o",
             "foo.o",
-            "-ffast-math",
+            "-funroll-loops",
             "-fsanitize=address",
         ]);
         let detail = descs
@@ -5610,7 +5683,7 @@ mod tests {
             .find(|d| d.contains("unsupported flag"))
             .expect("expected an unsupported-flag refuse reason");
         assert!(
-            detail.contains("-ffast-math"),
+            detail.contains("-funroll-loops"),
             "reason should name the flag: {detail}"
         );
         assert!(


### PR DESCRIPTION
## Why

The nightly bench reports show codegen flags **still forcing TUs through uncached**:

| bench | flags | impact |
|---|---|---|
| Firefox | `-ffast-math -mrecip=none -fno-finite-math-only`, `-fno-lto` | media TUs (libvpx/dav1d) passthrough |
| **LLVM** | `-fno-semantic-interposition` | **on ALL 2279 TUs → 0% hit rate, DEGRADED run** |

The LLVM one is the #411 class: a single universal unmodeled flag voids the entire cache. These are codegen knobs of the same shape as the #114/#146 set already modeled (`-fno-math-errno`, `-ffp-contract=`, `-fvisibility-inlines-hidden`, …): clang's driver fans them into `-cc1` tokens the resolved-token hash already captures.

## Classification (verified `clang -###` + cross-checked with codex)

| flag | resolution | class |
|---|---|---|
| `-ffast-math` | `-ffast-math -ffinite-math-only -ffp-contract=fast -fno-signed-zeros -freciprocal-math -menable-no-infs -menable-no-nans` | `CapturedByProbe` |
| `-fno-finite-math-only` | flips finite-math tokens back off | `CapturedByProbe` |
| `-mrecip=<v>` | forwarded verbatim | `CapturedByProbe` |
| `-f[no-]semantic-interposition` | interposition codegen knob, forwarded to `-cc1` | `CapturedByProbe` |
| `-fno-lto` | **identical** `-cc1` tokens vs absent (no-op for `-c`) | `NoObjectEffect` |

**Why `CapturedByProbe` not `NoObjectEffect` for `-ffast-math`:** it defines `__FAST_MATH__`/`__FINITE_MATH_ONLY__` (the `-E` hash sees the macros), but its optimizer assumptions (reassociation, no-inf/no-nan, FP contraction) are invisible to `-E` — only the `-cc1` stream captures them.

**`-fno-lto` safety:** positive `-flto`/`-flto=thin`/`-ffat-lto-objects` change the output (bitcode) and stay refused, so `-flto -fno-lto` still passes through rather than silently sharing this key.

## Knock-on

- `-ffast-math` / `-ffunction-sections` were stale "unmodeled codegen flag" examples in the refusal docs/tests (both now modeled) → repointed those and the `e2e-c-passthrough` fixture to `-funroll-loops`, exactly as that fixture's docstring anticipated.

## New regression fixture

`e2e-cc-bench-flags` (gate tier, clang-pinned — `CapturedByProbe` needs the resolved `-###` invocation kache parses for clang not gcc, mirroring `e2e-cc-cl-xclang-deps`): compiles the exact Firefox+LLVM flag set and asserts **cold-miss → warm-hit (no passthrough)** + relocate-modified invalidation.

## Validation

- 1024 unit tests pass (incl. updated refusal tests + unchanged `-Xclang -ffast-math` still-refuses boundary), clippy clean.
- `e2e-cc-bench-flags` + full gate green on **macOS** and **Linux** (`just e2e-docker`).

## ⚠️ Important: the LLVM bench needs a clang pin to actually benefit

The first LLVM bench run built with **gcc** (CMake's `/usr/bin/cc` default), and kache resolves `-###` only for clang (`extract_cc1_line` keys on the `-cc1` token). So on that bench these `CapturedByProbe` flags will *still* passthrough until `scenarios/bench-llvm` pins clang (`-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++`). That bench-config change is intentionally **not** in this PR — it's a separate decision (pin clang vs. surface kache's gcc codegen-flag limitation).

Cross-family: classification independently corroborated by codex + the `clang -###` oracle.