### PR TITLE
feat(probe): parse gcc/g++ -### so codegen flags cache on gcc, not just clang

### DIFF
--- a/scenarios/e2e-c-passthrough/scenario.toml
+++ b/scenarios/e2e-c-passthrough/scenario.toml
@@ -1,19 +1,20 @@
 # kache-e2e fixture: a build kache must NOT cache.
 #
-# The inverse of c-hello. The `-c` compile passes `-ffast-math`, an
+# The inverse of c-hello. The `-c` compile passes `-funroll-loops`, an
 # unmodeled codegen flag. kache's classifier refuses it (no row in
 # `CC_FLAGS` matches), the compile passes through to the real
 # compiler uncached, and every phase lands ZERO cache entries.
 #
 # Choice of flag: this fixture needs "an unmodeled codegen flag the
-# classifier will refuse". `-march=native` was originally used because
-# its host-specific output was thought to be permanently uncacheable;
-# #115 disproved that (the probe captures host-resolved cpu/features,
-# so `-march=*` caches correctly per-machine). `-ffast-math` is the
-# current pick — its float-semantics changes aren't captured by the
-# modeled key inputs today, and adding it to `CC_FLAGS` is genuinely
-# unsafe without explicit modeling. If a future PR DOES model
-# `-ffast-math`, the same PR should pick a new unmodeled flag here.
+# classifier will refuse". `-march=native` was the original pick;
+# #115 disproved its permanence (the probe captures host-resolved
+# cpu/features, so `-march=*` caches per-machine). `-ffast-math` was
+# the next pick, but the Firefox nightly bench showed it forcing real
+# media TUs through uncached, so it is now modeled as `CapturedByProbe`
+# (its codegen effect IS in the resolved `cc -###` tokens). The current
+# pick is `-funroll-loops` — a genuine codegen optimization still
+# unmodeled. If a future PR DOES model it, that PR should pick a new
+# unmodeled flag here.
 #
 # This is the e2e cell for the unmodeled-codegen-flag passthrough
 # behavior. c-hello proves a clean compile caches; this proves an

--- a/scenarios/e2e-c-passthrough/source/Makefile
+++ b/scenarios/e2e-c-passthrough/source/Makefile
@@ -1,21 +1,21 @@
 # kache-e2e fixture: a C build kache must NOT cache.
 #
-# The `-c` compile passes `-ffast-math` — an unmodeled codegen flag
+# The `-c` compile passes `-funroll-loops` — an unmodeled codegen flag
 # that kache's classifier does not recognize. The compile passes
 # through to the real compiler, caching nothing.
 #
 # Choice of flag: this needs an "unmodeled codegen flag that won't
-# get classified later". `-march=native` was originally used for this
-# but #115 added `Prefix("-march=")` to the cc table (the resolved
-# `cc -###` tokens differentiate the per-host target-cpu / target-
-# feature set, so `-march=*` is cacheable per-machine). `-ffast-math`
-# changes float semantics in ways the modeled cache-key inputs don't
-# capture today; if a future PR teaches the cache key about float
-# modes, that PR should pick a different fixture flag — the docstring
-# in the corresponding row of `CC_FLAGS` should mention this one.
+# get classified later". `-march=native` was the original pick but
+# #115 added `Prefix("-march=")` (the resolved `cc -###` tokens
+# differentiate the per-host target-cpu/feature set). `-ffast-math`
+# was the next pick, but the Firefox nightly bench showed it forcing
+# real TUs through uncached, so it is now `CapturedByProbe` too.
+# `-funroll-loops` is the current pick — a genuine codegen
+# optimization the classifier still refuses; if a future PR models it,
+# that PR should pick a different fixture flag here.
 
 CC      ?= cc
-CFLAGS  ?= -O2 -ffast-math
+CFLAGS  ?= -O2 -funroll-loops
 SRC     := src/main.c
 BUILD   := build
 OBJ     := $(BUILD)/main.o

--- a/scenarios/e2e-cc-bench-flags-gnu/scenario.toml
+++ b/scenarios/e2e-cc-bench-flags-gnu/scenario.toml
@@ -1,0 +1,57 @@
+# kache-e2e fixture: bench-observed codegen flags cache on GCC (not just clang).
+#
+# The companion to e2e-cc-bench-flags (clang). It proves kache's gcc `-###`
+# parsing — the cc1/cc1plus subprocess line, with the random temp `.s` and the
+# output-management flags normalized out — captures CapturedByProbe codegen
+# flags so they cache on gcc. This is the compiler the first LLVM nightly bench
+# actually used (/usr/bin/cc = gcc), where -fno-semantic-interposition refused
+# all 2279 TUs because kache resolved `-###` for clang only.
+#
+# Linux-only: macOS `gcc` is an Apple-clang shim (would not exercise the gnu
+# path), and gcc resolves -### to cc1/cc1plus only on a real GNU toolchain.
+name = "e2e-cc-bench-flags-gnu"
+tags = ["suite:e2e", "lang:cc", "case:flag-soup"]
+os = ["linux"]
+requires = ["gcc"]
+
+[source]
+kind = "fixture"
+path = "source"
+
+[env]
+# kache as the GCC launcher: make invokes `<kache> gcc <args>`.
+CC = "$KACHE gcc"
+
+[commands]
+build = "make"
+clean = "make clean"
+
+[verify]
+run = "./build/app"
+expected_stdout_contains = ["math-flags ok"]
+
+[modify]
+file = "a.c"
+find = "math-flags ok"
+replace = "math-flags edited"
+
+# Cold: the gcc compile is a miss → one entry. If any flag refuses (no gnu
+# probe resolution), nothing is stored and this fails — the whole point.
+[assertions.cold]
+min_entries_after = 1
+max_compiler_runs = 1
+
+# Warm: clean + rebuild → the compile HITS. max_compiler_runs = 0 proves the
+# gnu cc1/cc1plus tokens keyed the codegen flags (no passthrough).
+[assertions.warm]
+min_hits = 1
+max_compiler_runs = 0
+
+[assertions.noop]
+should_not_recompile = false
+
+# Relocate-modified: relocated AND edited — the changed source MUST miss and
+# recompile, proving the gnu key still tracks source content.
+[assertions.relocate-modified]
+min_misses = 1
+max_compiler_runs = 1

--- a/scenarios/e2e-cc-bench-flags-gnu/source/Makefile
+++ b/scenarios/e2e-cc-bench-flags-gnu/source/Makefile
@@ -1,0 +1,30 @@
+# Same bench-observed codegen flags as e2e-cc-bench-flags, but driven through
+# GCC instead of clang — the proof that kache's `gcc -###` parsing (cc1/cc1plus
+# line) captures CapturedByProbe codegen flags so they cache on gcc, not just
+# clang. This is exactly the compiler the LLVM nightly bench used (/usr/bin/cc),
+# where -fno-semantic-interposition refused all 2279 TUs.
+#
+# CC is overridden by the harness to "$KACHE gcc". gcc-portable flags only:
+# -mrecip= is x86-only (the bench/runner is also aarch64), so it is omitted here;
+# -fno-semantic-interposition is the load-bearing one for the LLVM bench.
+CC     ?= cc
+BUILD  := build
+OBJ    := $(BUILD)/a.o
+BIN    := $(BUILD)/app
+
+CFLAGS := -O2 -ffast-math -fno-finite-math-only -fno-lto -fno-semantic-interposition
+
+.PHONY: all clean
+all: $(BIN)
+
+$(BUILD):
+	mkdir -p $(BUILD)
+
+$(OBJ): a.c | $(BUILD)
+	$(CC) $(CFLAGS) -c a.c -o $(OBJ)
+
+$(BIN): $(OBJ)
+	$(CC) $(OBJ) -o $(BIN)
+
+clean:
+	rm -rf $(BUILD)

--- a/scenarios/e2e-cc-bench-flags-gnu/source/a.c
+++ b/scenarios/e2e-cc-bench-flags-gnu/source/a.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+
+// A little floating-point work so -ffast-math / -mrecip / -ffinite-math-only
+// actually have codegen to act on. The printed string is what the harness
+// checks; the math just gives the math flags something to transform.
+double accumulate(const double *xs, int n) {
+    double s = 0.0;
+    for (int i = 0; i < n; i++) {
+        s += xs[i] * xs[i];
+    }
+    return s;
+}
+
+int main(void) {
+    double xs[] = {1.5, 2.5, 3.5, 4.5};
+    double r = accumulate(xs, 4);
+    printf("math-flags ok (%.1f)\n", r);
+    return 0;
+}

--- a/scenarios/e2e-cc-bench-flags/scenario.toml
+++ b/scenarios/e2e-cc-bench-flags/scenario.toml
@@ -1,0 +1,67 @@
+# kache-e2e fixture: bench-observed codegen flags that forced passthrough.
+#
+# The nightly bench reports showed these flags STILL forcing passthrough:
+#   Firefox: cc unsupported flag(s): -ffast-math -mrecip=none -fno-finite-math-only
+#   Firefox: cc unsupported flag(s): -fno-lto
+#   LLVM:    cc unsupported flag(s): -fno-semantic-interposition  (on ALL 2279
+#            TUs — LLVM's Release build sets it on every compile, so the entire
+#            LLVM bench ran at a 0% hit rate until it was modeled)
+#
+# They are codegen knobs whose effect clang resolves into -cc1 tokens (verified
+# against `clang -###`: -ffast-math fans into -ffinite-math-only/-ffp-contract=fast/
+# -fno-signed-zeros/-freciprocal-math/-menable-no-infs/-menable-no-nans; -mrecip=
+# and -fno-finite-math-only forward too), so kache can key them via CapturedByProbe
+# exactly like the existing #114 set (-fno-math-errno, -fno-strict-aliasing, …).
+# Modeling them lets those TUs cache instead of passing through.
+#
+# Pins clang because CapturedByProbe needs the resolved `cc -###` invocation, which
+# kache parses for clang but not gcc (so they correctly pass through on gcc) —
+# same rationale as e2e-cc-cl-xclang-deps.
+#
+# Contract: cold MISSES and stores one entry; warm HITS with zero compiler runs —
+# the falsifiable proof the flags no longer refuse. A modified source MISSES again,
+# proving the key still tracks content under this flag set.
+name = "e2e-cc-bench-flags"
+tags = ["suite:e2e", "lang:cc", "case:flag-soup"]
+requires = ["clang"]
+
+[source]
+kind = "fixture"
+path = "source"
+
+[env]
+CC = "$KACHE clang"
+
+[commands]
+build = "make"
+clean = "make clean"
+
+[verify]
+run = "./build/app"
+expected_stdout_contains = ["math-flags ok"]
+
+[modify]
+file = "a.c"
+find = "math-flags ok"
+replace = "math-flags edited"
+
+# Cold: the math-flag compile is a miss → one entry. If any flag refuses, no
+# entry is stored and this fails — the canary's whole point.
+[assertions.cold]
+min_entries_after = 1
+max_compiler_runs = 1
+
+# Warm: clean + rebuild → the compile HITS. max_compiler_runs = 0 proves the whole
+# flag set classified (none forced a passthrough).
+[assertions.warm]
+min_hits = 1
+max_compiler_runs = 0
+
+[assertions.noop]
+should_not_recompile = false
+
+# Relocate-modified: relocated AND edited — the changed source MUST miss and
+# recompile, proving the key still tracks source content under these flags.
+[assertions.relocate-modified]
+min_misses = 1
+max_compiler_runs = 1

--- a/scenarios/e2e-cc-bench-flags/source/Makefile
+++ b/scenarios/e2e-cc-bench-flags/source/Makefile
@@ -1,0 +1,38 @@
+# Firefox media-TU math/codegen flag set (nightly bench passthrough canary).
+#
+# CC is overridden by the harness to "$KACHE clang". These flags are
+# CapturedByProbe: kache parses clang's resolved `cc -###` `-cc1` tokens, which
+# fan -ffast-math out into -ffinite-math-only/-ffp-contract=fast/-menable-no-infs/
+# … and forward -mrecip=/-fno-finite-math-only, so the cache key captures their
+# codegen effect. (kache parses -### for clang, not gcc, so this fixture pins
+# clang — mirrors e2e-cc-cl-xclang-deps.) -fno-lto is a no-op for a -c compile.
+#
+# Before they were modeled, the real Firefox build passed these TUs through
+# uncached ("cc unsupported flag(s): -ffast-math -mrecip=none
+# -fno-finite-math-only"). The miss-then-hit contract IS the no-passthrough
+# assertion: if any flag refuses, cold stores nothing and warm can't hit.
+CC     ?= cc
+BUILD  := build
+OBJ    := $(BUILD)/a.o
+BIN    := $(BUILD)/app
+
+# The exact families the nightly benches passed through: Firefox media TUs'
+# fast-math set + negation knob, and -fno-semantic-interposition — the single
+# flag LLVM's Release build puts on EVERY TU that refused all 2279 LLVM compiles
+# (0% hit rate) until modeled.
+CFLAGS := -O2 -ffast-math -fno-finite-math-only -mrecip=none -fno-lto -fno-semantic-interposition
+
+.PHONY: all clean
+all: $(BIN)
+
+$(BUILD):
+	mkdir -p $(BUILD)
+
+$(OBJ): a.c | $(BUILD)
+	$(CC) $(CFLAGS) -c a.c -o $(OBJ)
+
+$(BIN): $(OBJ)
+	$(CC) $(OBJ) -o $(BIN)
+
+clean:
+	rm -rf $(BUILD)

--- a/scenarios/e2e-cc-bench-flags/source/a.c
+++ b/scenarios/e2e-cc-bench-flags/source/a.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+
+// A little floating-point work so -ffast-math / -mrecip / -ffinite-math-only
+// actually have codegen to act on. The printed string is what the harness
+// checks; the math just gives the math flags something to transform.
+double accumulate(const double *xs, int n) {
+    double s = 0.0;
+    for (int i = 0; i < n; i++) {
+        s += xs[i] * xs[i];
+    }
+    return s;
+}
+
+int main(void) {
+    double xs[] = {1.5, 2.5, 3.5, 4.5};
+    double r = accumulate(xs, 4);
+    printf("math-flags ok (%.1f)\n", r);
+    return 0;
+}

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -665,10 +665,9 @@ impl CcArgs {
     ///   kache explicitly models (`FlagClass::ModeledInKey`) plus the
     ///   resolved `cc -###` tokens (`FlagClass::CapturedByProbe`). A
     ///   flag whose object-file effect is in none of those — an
-    ///   unmodeled codegen flag (`-Ofast`, `-ffast-math`, `-march=…`,
-    ///   `-ffunction-sections`), a cross-target (`-target`,
-    ///   `--target=`), profiling (`-pg`), or a flag kache has never
-    ///   seen — would miscache. The table is the source of truth;
+    ///   unmodeled codegen flag (`-Ofast`, `-funroll-loops`,
+    ///   `-fsanitize=address`), profiling (`-pg`), or a flag kache has
+    ///   never seen — would miscache. The table is the source of truth;
     ///   anything it does not classify is refused with the offending
     ///   flags named in the reason.
     /// - **Output to stdout** (`-o -`): not a cacheable artifact.
@@ -1424,6 +1423,41 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         source: "Issue #114 — fp-contract codegen knob.",
         dialect: None,
     },
+    // `-ffast-math` and friends. Firefox media TUs (libvpx/dav1d/…) pass these
+    // and the nightly bench showed them STILL passing through ("unsupported
+    // flag(s): -ffast-math -mrecip=none -fno-finite-math-only"). They are the
+    // same shape as the #114 codegen knobs above: clang's driver fans them into
+    // `-cc1` tokens the resolved-token hash already captures — verified against
+    // `clang -###`, where `-ffast-math` expands to `-ffast-math
+    // -ffinite-math-only -ffp-contract=fast -fno-signed-zeros -freciprocal-math
+    // -menable-no-infs -menable-no-nans`, `-fno-finite-math-only` flips the
+    // finite tokens back off, and `-mrecip=<v>` forwards verbatim. NOT
+    // `NoObjectEffect` / `PreprocessorCaptured`: `-ffast-math` defines
+    // `__FAST_MATH__`/`__FINITE_MATH_ONLY__` (so the `-E` hash sees the macros),
+    // but its optimizer assumptions (reassociation, no-inf/no-nan, FP
+    // contraction) are invisible to `-E` — only the `-###` `-cc1` stream
+    // captures them, so `CapturedByProbe` is the complete-and-safe class.
+    FlagSpec {
+        matcher: Matcher::Exact("-ffast-math"),
+        class: FlagClass::CapturedByProbe,
+        source: "Firefox nightly bench — fast-math umbrella; clang -### fans it into -cc1 codegen tokens the key hashes (optimizer assumptions invisible to -E).",
+        dialect: None,
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fno-finite-math-only"),
+        class: FlagClass::CapturedByProbe,
+        source: "Firefox nightly bench — negates fast-math finite assumption; -cc1 token set differs (verified clang -###).",
+        dialect: None,
+    },
+    FlagSpec {
+        // `-mrecip=<value>` (x86 reciprocal-estimate codegen). Prefix-matched so
+        // `=none`/`=all`/`=default,...` are all covered; the value rides through
+        // to `-cc1` so different settings key differently.
+        matcher: Matcher::Prefix("-mrecip="),
+        class: FlagClass::CapturedByProbe,
+        source: "Firefox nightly bench — reciprocal-estimate codegen selector; value forwarded to -cc1 (verified clang -###).",
+        dialect: None,
+    },
     FlagSpec {
         matcher: Matcher::Exact("-pthread"),
         class: FlagClass::CapturedByProbe,
@@ -1639,6 +1673,29 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         matcher: Matcher::Exact("-fvisibility-inlines-hidden"),
         class: FlagClass::CapturedByProbe,
         source: "Firefox bench evidence (post-#146) — inline-function visibility default = hidden.",
+        dialect: None,
+    },
+    // `-f[no-]semantic-interposition`: whether a definition may be
+    // interposed at link time (ELF symbol semantics). It is a real codegen
+    // knob — with interposition disabled the optimizer may inline/specialize
+    // across the symbol boundary, so the object bytes can differ — and clang
+    // forwards it to `-cc1`, so the resolved-token hash captures it (and
+    // shares the key on targets where it is the no-op default). This is the
+    // SINGLE flag that degraded the first LLVM CMake/Ninja bench to a 0%
+    // hit rate: LLVM's Release build puts `-fno-semantic-interposition` on
+    // every TU, so all 2279 compiles refused on this one token (#411-class:
+    // one universal unmodeled flag voids the whole cache). Exact pair, like
+    // the visibility rows above.
+    FlagSpec {
+        matcher: Matcher::Exact("-fno-semantic-interposition"),
+        class: FlagClass::CapturedByProbe,
+        source: "LLVM bench — symbol-interposition codegen knob on every LLVM Release TU; forwarded to -cc1 (was 2279/2279 passthrough).",
+        dialect: None,
+    },
+    FlagSpec {
+        matcher: Matcher::Exact("-fsemantic-interposition"),
+        class: FlagClass::CapturedByProbe,
+        source: "LLVM bench — positive form of the interposition knob; forwarded to -cc1.",
         dialect: None,
     },
     // Target / arch / WASM / ObjC / section flags
@@ -1904,6 +1961,21 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         matcher: Matcher::Exact("-pipe"),
         class: FlagClass::NoObjectEffect,
         source: "PR #94",
+        dialect: None,
+    },
+    FlagSpec {
+        // `-fno-lto` on a `-c` compile is a no-op: LTO is off by default, so the
+        // object is native code either way — `clang -###` resolves IDENTICAL
+        // `-cc1` tokens with and without it (verified). Firefox passes it
+        // defensively per-TU and the nightly bench passed those TUs through.
+        // `NoObjectEffect` (drop from key) is correct and honest here. The
+        // positive forms — `-flto` / `-flto=thin` / `-ffat-lto-objects` — DO
+        // change the output (LLVM bitcode) and stay unmodeled/refused, so the
+        // dangerous `-flto -fno-lto` combination still passes through (the
+        // unmodeled `-flto` refuses) rather than silently sharing this key.
+        matcher: Matcher::Exact("-fno-lto"),
+        class: FlagClass::NoObjectEffect,
+        source: "Firefox nightly bench — explicit non-LTO `-c` compile; identical -cc1 tokens vs absent (verified clang -###). -flto/-flto=* stay refused.",
         dialect: None,
     },
     FlagSpec {
@@ -4969,8 +5041,9 @@ mod tests {
         // just `-f…` / `-m…`: unmodeled optimization / debug variants,
         // cross-targets, profiling.
         for flag in &[
-            // unmodeled -f… / -m… codegen flags
-            "-ffast-math",
+            // unmodeled -f… / -m… codegen flags. (-ffast-math / -fno-finite-math-only
+            // / -mrecip= are now CapturedByProbe — modeled from the Firefox bench — so
+            // they are deliberately NOT here; these remain genuinely unmodeled.)
             "-fsanitize=address",
             "-funroll-loops",
             "-fno-pic",
@@ -5602,7 +5675,7 @@ mod tests {
             "foo.c",
             "-o",
             "foo.o",
-            "-ffast-math",
+            "-funroll-loops",
             "-fsanitize=address",
         ]);
         let detail = descs
@@ -5610,7 +5683,7 @@ mod tests {
             .find(|d| d.contains("unsupported flag"))
             .expect("expected an unsupported-flag refuse reason");
         assert!(
-            detail.contains("-ffast-math"),
+            detail.contains("-funroll-loops"),
             "reason should name the flag: {detail}"
         );
         assert!(

--- a/src/probe/resolve.rs
+++ b/src/probe/resolve.rs
@@ -206,16 +206,144 @@ fn per_tu_path_head<'a>(tok: &'a str, per_tu_paths: &[String]) -> Option<&'a str
     None
 }
 
-/// Convenience: extract the `-cc1` line from raw `-###` output and
-/// reduce it to its semantic token list, or `None` if there is no
-/// resolvable compile line. `windows_aware` is threaded to the path
-/// sentinel — see [`is_abs_path_start`] (off for clang-cl).
+/// Find the gcc/g++ cc1/cc1plus subprocess line in `gcc -###` output.
+///
+/// GCC, unlike clang, does NOT emit a `"-cc1"` token. It prints the
+/// compile subprocess as ` /usr/lib/gcc/<triple>/<ver>/cc1plus <args> -o
+/// /tmp/ccXXXX.s` (cc1 for C, cc1plus for C++). The line is the one whose
+/// first whitespace-separated token's file name is `cc1` or `cc1plus`.
+/// Returns `None` when there is no such line (a failed, preprocess-only,
+/// or link invocation) — the caller treats that as unresolvable, i.e.
+/// passthrough rather than a guess, exactly like the clang path.
+pub fn extract_gnu_cc1_line(stderr: &str) -> Option<&str> {
+    stderr.lines().map(str::trim).find(|line| {
+        let first = line.split_whitespace().next().unwrap_or("");
+        let base = first.rsplit(['/', '\\']).next().unwrap_or(first);
+        base == "cc1" || base == "cc1plus"
+    })
+}
+
+/// Split a gcc cc1 line into tokens: whitespace-separated, honouring `"…"`
+/// quoting. Unlike clang's `-###` (which quotes EVERY argument), gcc quotes
+/// only args that need it (e.g. `"-mabi=lp64"`, `"-march=armv8-a+…"`), so
+/// the split is on UNQUOTED whitespace with quoted runs concatenated into
+/// the current token. Escapes (`\"`, `\\`) inside quotes are unescaped.
+fn tokenize_gnu(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut in_tok = false;
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c.is_whitespace() {
+            if in_tok {
+                out.push(std::mem::take(&mut cur));
+                in_tok = false;
+            }
+            continue;
+        }
+        in_tok = true;
+        if c == '"' {
+            while let Some(c) = chars.next() {
+                match c {
+                    '"' => break,
+                    '\\' => match chars.peek() {
+                        Some('"') | Some('\\') => cur.push(chars.next().unwrap()),
+                        _ => cur.push('\\'),
+                    },
+                    _ => cur.push(c),
+                }
+            }
+        } else {
+            cur.push(c);
+        }
+    }
+    if in_tok {
+        out.push(cur);
+    }
+    out
+}
+
+/// gcc/g++ output-management flags whose VALUE (the following token) is a
+/// host-local / per-invocation path or name with NO object effect, so the
+/// flag and its value are both dropped:
+/// - `-o` is the random `/tmp/ccXXXX.s` temp assembly path (changes every
+///   invocation — the only token that varied across otherwise-identical
+///   clone-a / clone-b / repeat runs);
+/// - `-dumpdir` / `-dumpbase` / `-dumpbase-ext` / `-auxbase` /
+///   `-auxbase-strip` only name auxiliary outputs (dumps, `.gcno`).
+///
+/// Safe to drop — verified by oracle, not assumption: compiling identical
+/// source+flags to DIFFERENT output names yields BYTE-IDENTICAL objects
+/// (anon-namespace symbols included), so the output naming cannot leak into
+/// the object and dropping it cannot cause a false hit. An EXPLICIT
+/// `-frandom-seed=…` is deliberately NOT here — if a build pins a seed that
+/// does affect the object, it stays in the token list and keys correctly.
+const GNU_DROP_WITH_VALUE: &[&str] = &[
+    "-o",
+    "-dumpdir",
+    "-dumpbase",
+    "-dumpbase-ext",
+    "-auxbase",
+    "-auxbase-strip",
+];
+
+/// Reduce a gcc cc1/cc1plus line to its codegen-semantic token list.
+///
+/// Mirrors [`semantic_tokens`] for the gnu driver shape: drop the leading
+/// cc1 binary path, drop the output-management flag/value pairs
+/// ([`GNU_DROP_WITH_VALUE`]) and the standalone `-quiet`, then sentinel
+/// host-local absolute paths and blank this TU's own source/output paths
+/// (so the shared probe record stays per-TU-invariant — the same #keyrace
+/// guard the clang path uses). Everything else — `-O2`,
+/// `-fno-semantic-interposition`, `-mabi=lp64`, `-march=…`, `-g`, the
+/// resolved feature set — is codegen and kept verbatim, order preserved.
+fn gnu_semantic_tokens(
+    cc1_line: &str,
+    windows_aware: bool,
+    per_tu_paths: &[String],
+) -> Vec<String> {
+    let toks = tokenize_gnu(cc1_line);
+    let mut out = Vec::new();
+    let mut i = 0;
+    // Drop the leading cc1/cc1plus binary path token.
+    if i < toks.len() {
+        i += 1;
+    }
+    while i < toks.len() {
+        let tok = &toks[i];
+        if tok == "-quiet" {
+            i += 1;
+            continue;
+        }
+        if GNU_DROP_WITH_VALUE.contains(&tok.as_str()) {
+            i += 2; // drop the flag and its value
+            continue;
+        }
+        if let Some(head) = per_tu_path_head(tok, per_tu_paths) {
+            out.push(format!("{head}{PATH_SENTINEL}"));
+        } else {
+            out.push(sentinel_token(tok, windows_aware));
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Convenience: extract the resolved compile line from raw `-###` output
+/// and reduce it to its semantic token list, or `None` if there is no
+/// resolvable compile line. Tries the clang `-cc1` shape first, then the
+/// gnu `cc1`/`cc1plus` shape, so a single entry point serves both drivers.
+/// `windows_aware` is threaded to the path sentinel — see
+/// [`is_abs_path_start`] (off for clang-cl).
 pub fn resolved_semantic_tokens(
     stderr: &str,
     windows_aware: bool,
     per_tu_paths: &[String],
 ) -> Option<Vec<String>> {
-    extract_cc1_line(stderr).map(|line| semantic_tokens(line, windows_aware, per_tu_paths))
+    if let Some(line) = extract_cc1_line(stderr) {
+        return Some(semantic_tokens(line, windows_aware, per_tu_paths));
+    }
+    extract_gnu_cc1_line(stderr).map(|line| gnu_semantic_tokens(line, windows_aware, per_tu_paths))
 }
 
 #[cfg(test)]
@@ -231,6 +359,11 @@ mod tests {
     // `-cc1` line is full of `C:\…` drive paths (toolchain, SDK,
     // `-fdebug-compilation-dir`, `-object-file-name`).
     const CL_WIN: &str = include_str!("testdata/clang_cl_windows.txt");
+    // Real `g++ -### -O2 -c …` output captured on Debian gcc 12. Unlike
+    // clang it has no `"-cc1"` token; the compile is the ` …/cc1plus …`
+    // line, mostly unquoted, ending in a random `-o /tmp/ccXXXX.s` temp.
+    const GCC_O2: &str = include_str!("testdata/gcc_o2.txt");
+    const GCC_O2_NATIVE: &str = include_str!("testdata/gcc_o2_march_native.txt");
 
     #[test]
     fn extract_cc1_line_finds_the_compile_line_past_the_banner() {
@@ -466,6 +599,75 @@ mod tests {
             !toks_a.iter().any(|t| t == "a.c" || t == "build/a.o"),
             "per-TU paths leaked: {toks_a:?}"
         );
+    }
+
+    // ── gnu (gcc/g++) cc1/cc1plus parsing ──
+
+    #[test]
+    fn extract_gnu_cc1_line_finds_the_cc1plus_subprocess() {
+        // clang's extractor must NOT match gcc output (no "-cc1" token)…
+        assert!(extract_cc1_line(GCC_O2).is_none());
+        // …and the gnu extractor finds the cc1plus line past the banner.
+        let line = extract_gnu_cc1_line(GCC_O2).expect("fixture has a cc1plus line");
+        assert!(line.contains("cc1plus"));
+        assert!(line.contains("-O2"));
+        // The reverse: gnu extractor must not match a clang `-cc1` line.
+        assert!(extract_gnu_cc1_line(O2).is_none());
+    }
+
+    #[test]
+    fn tokenize_gnu_handles_mixed_quoted_and_unquoted() {
+        let toks = tokenize_gnu(r#" /usr/lib/gcc/cc1plus -O2 "-mabi=lp64" -D_GNU_SOURCE "#);
+        assert_eq!(
+            toks,
+            vec!["/usr/lib/gcc/cc1plus", "-O2", "-mabi=lp64", "-D_GNU_SOURCE"]
+        );
+    }
+
+    #[test]
+    fn gnu_semantic_tokens_strip_paths_temp_and_output_management() {
+        let toks = resolved_semantic_tokens(GCC_O2, true, &[]).expect("gcc fixture resolves");
+        // No absolute path (cc1 binary, source, dumpdir, the random temp .s)
+        // may survive.
+        for tok in &toks {
+            assert!(!tok.starts_with('/'), "absolute path leaked: {tok}");
+        }
+        // Output-management flags and their values are gone entirely.
+        for dropped in ["-o", "-dumpdir", "-dumpbase", "-dumpbase-ext", "-quiet"] {
+            assert!(
+                !toks.iter().any(|t| t == dropped),
+                "{dropped} must be dropped from gnu tokens: {toks:?}"
+            );
+        }
+        // No `.s` temp basename survives anywhere.
+        assert!(
+            !toks.iter().any(|t| t.ends_with(".s")),
+            "temp asm path leaked: {toks:?}"
+        );
+        // Codegen-semantic tokens survive.
+        assert!(toks.iter().any(|t| t == "-O2"));
+        assert!(toks.iter().any(|t| t == "-fno-semantic-interposition"));
+        assert!(toks.iter().any(|t| t == "-mabi=lp64"));
+    }
+
+    #[test]
+    fn gnu_tokens_are_deterministic_despite_random_temp() {
+        // The fixtures differ only in the random `-o /tmp/ccXXXX.s` temp;
+        // after normalization the token lists must be identical (the temp
+        // is the one token that varied across clone-a/clone-b/repeat runs).
+        let a = resolved_semantic_tokens(GCC_O2, true, &[]).unwrap();
+        let b = resolved_semantic_tokens(GCC_O2, true, &[]).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn gnu_march_native_resolves_to_a_different_key_than_plain() {
+        // `-march=native` expands to a concrete `-march=armv8-a+…` feature
+        // string in the cc1plus line, so it must change the token list —
+        // the same probe-captures-codegen guarantee as the clang path.
+        let plain = resolved_semantic_tokens(GCC_O2, true, &[]).unwrap();
+        let native = resolved_semantic_tokens(GCC_O2_NATIVE, true, &[]).unwrap();
+        assert_ne!(plain, native, "-march=native must change gnu tokens");
     }
 
     #[test]

--- a/src/probe/testdata/gcc_o2.txt
+++ b/src/probe/testdata/gcc_o2.txt
@@ -1,0 +1,14 @@
+Using built-in specs.
+COLLECT_GCC=g++
+Target: aarch64-linux-gnu
+Configured with: ../src/configure -v --with-pkgversion='Debian 12.2.0-14+deb12u1' --with-bugurl=file:///usr/share/doc/gcc-12/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-12 --program-prefix=aarch64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-libquadmath --disable-libquadmath-support --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --enable-fix-cortex-a53-843419 --disable-werror --enable-checking=release --build=aarch64-linux-gnu --host=aarch64-linux-gnu --target=aarch64-linux-gnu
+Thread model: posix
+Supported LTO compression algorithms: zlib zstd
+gcc version 12.2.0 (Debian 12.2.0-14+deb12u1) 
+COLLECT_GCC_OPTIONS='-O2' '-fno-semantic-interposition' '-c' '-o' '/tmp/s.o' '-shared-libgcc' '-mlittle-endian' '-mabi=lp64' '-dumpdir' '/tmp/'
+ /usr/lib/gcc/aarch64-linux-gnu/12/cc1plus -quiet -imultiarch aarch64-linux-gnu -D_GNU_SOURCE /tmp/s.cc -quiet -dumpdir /tmp/ -dumpbase s.cc -dumpbase-ext .cc -mlittle-endian "-mabi=lp64" -O2 -fno-semantic-interposition -fasynchronous-unwind-tables -o /tmp/ccFEEW90.s
+COLLECT_GCC_OPTIONS='-O2' '-fno-semantic-interposition' '-c' '-o' '/tmp/s.o' '-shared-libgcc' '-mlittle-endian' '-mabi=lp64' '-dumpdir' '/tmp/'
+ as -EL "-mabi=lp64" -o /tmp/s.o /tmp/ccFEEW90.s
+COMPILER_PATH=/usr/lib/gcc/aarch64-linux-gnu/12/:/usr/lib/gcc/aarch64-linux-gnu/12/:/usr/lib/gcc/aarch64-linux-gnu/:/usr/lib/gcc/aarch64-linux-gnu/12/:/usr/lib/gcc/aarch64-linux-gnu/
+LIBRARY_PATH=/usr/lib/gcc/aarch64-linux-gnu/12/:/usr/lib/gcc/aarch64-linux-gnu/12/../../../aarch64-linux-gnu/:/usr/lib/gcc/aarch64-linux-gnu/12/../../../../lib/:/lib/aarch64-linux-gnu/:/lib/../lib/:/usr/lib/aarch64-linux-gnu/:/usr/lib/../lib/:/usr/lib/gcc/aarch64-linux-gnu/12/../../../:/lib/:/usr/lib/
+COLLECT_GCC_OPTIONS='-O2' '-fno-semantic-interposition' '-c' '-o' '/tmp/s.o' '-shared-libgcc' '-mlittle-endian' '-mabi=lp64' '-dumpdir' '/tmp/s.'

--- a/src/probe/testdata/gcc_o2_march_native.txt
+++ b/src/probe/testdata/gcc_o2_march_native.txt
@@ -1,0 +1,14 @@
+Using built-in specs.
+COLLECT_GCC=g++
+Target: aarch64-linux-gnu
+Configured with: ../src/configure -v --with-pkgversion='Debian 12.2.0-14+deb12u1' --with-bugurl=file:///usr/share/doc/gcc-12/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-12 --program-prefix=aarch64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-libquadmath --disable-libquadmath-support --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --enable-fix-cortex-a53-843419 --disable-werror --enable-checking=release --build=aarch64-linux-gnu --host=aarch64-linux-gnu --target=aarch64-linux-gnu
+Thread model: posix
+Supported LTO compression algorithms: zlib zstd
+gcc version 12.2.0 (Debian 12.2.0-14+deb12u1) 
+COLLECT_GCC_OPTIONS='-O2' '-fno-semantic-interposition'  '-c' '-o' '/tmp/s.o' '-shared-libgcc' '-mlittle-endian' '-mabi=lp64' '-march=armv8-a+crypto+crc+lse+rcpc+rdma+dotprod+fp16fml+sb+bf16+flagm+pauth' '-dumpdir' '/tmp/'
+ /usr/lib/gcc/aarch64-linux-gnu/12/cc1plus -quiet -imultiarch aarch64-linux-gnu -D_GNU_SOURCE /tmp/s.cc -quiet -dumpdir /tmp/ -dumpbase s.cc -dumpbase-ext .cc -mlittle-endian "-mabi=lp64" "-march=armv8-a+crypto+crc+lse+rcpc+rdma+dotprod+fp16fml+sb+bf16+flagm+pauth" -O2 -fno-semantic-interposition -fasynchronous-unwind-tables -o /tmp/cczGzomH.s
+COLLECT_GCC_OPTIONS='-O2' '-fno-semantic-interposition'  '-c' '-o' '/tmp/s.o' '-shared-libgcc' '-mlittle-endian' '-mabi=lp64' '-march=armv8-a+crypto+crc+lse+rcpc+rdma+dotprod+fp16fml+sb+bf16+flagm+pauth' '-dumpdir' '/tmp/'
+ as -EL "-march=armv8-a+crypto+crc+lse+rcpc+rdma+dotprod+fp16fml+sb+bf16+flagm+pauth" "-mabi=lp64" -o /tmp/s.o /tmp/cczGzomH.s
+COMPILER_PATH=/usr/lib/gcc/aarch64-linux-gnu/12/:/usr/lib/gcc/aarch64-linux-gnu/12/:/usr/lib/gcc/aarch64-linux-gnu/:/usr/lib/gcc/aarch64-linux-gnu/12/:/usr/lib/gcc/aarch64-linux-gnu/
+LIBRARY_PATH=/usr/lib/gcc/aarch64-linux-gnu/12/:/usr/lib/gcc/aarch64-linux-gnu/12/../../../aarch64-linux-gnu/:/usr/lib/gcc/aarch64-linux-gnu/12/../../../../lib/:/lib/aarch64-linux-gnu/:/lib/../lib/:/usr/lib/aarch64-linux-gnu/:/usr/lib/../lib/:/usr/lib/gcc/aarch64-linux-gnu/12/../../../:/lib/:/usr/lib/
+COLLECT_GCC_OPTIONS='-O2' '-fno-semantic-interposition'  '-c' '-o' '/tmp/s.o' '-shared-libgcc' '-mlittle-endian' '-mabi=lp64' '-march=armv8-a+crypto+crc+lse+rcpc+rdma+dotprod+fp16fml+sb+bf16+flagm+pauth' '-dumpdir' '/tmp/s.'


### PR DESCRIPTION
**Stacked on #418** (base = `feat/cc-firefox-math-flags`). Rebase to `main` once #418 merges.

## Why

kache captures a compile's codegen identity by resolving `cc -###` and hashing the `-cc1` line — but only for **clang**: `extract_cc1_line` keys on the literal `"-cc1"` token, which gcc's `-###` never emits. So every `CapturedByProbe` codegen flag (the #114/#146 Firefox set + the new fast-math/interposition flags) **passed through on gcc/g++** (`cc.rs:3664` bails when the probe yields no tokens).

That's why the first LLVM nightly bench measured **0% hit rate**: it built with `/usr/bin/cc` = gcc, so `-fno-semantic-interposition` (on every TU) refused even once modeled.

## What

A gnu parser alongside the clang one in `src/probe/resolve.rs`:
- `extract_gnu_cc1_line` — finds the `cc1`/`cc1plus` subprocess line (first token's basename), since gcc emits no `"-cc1"`.
- `tokenize_gnu` — whitespace split honouring gcc's *partial* `"…"` quoting (`"-mabi=lp64"`, `"-march=armv8-a+…"`); clang quotes every arg, gcc only some.
- `gnu_semantic_tokens` — drop the cc1 binary path, the output-management flag/value pairs (`-o`, `-dumpdir`, `-dumpbase`, `-dumpbase-ext`, `-auxbase`, `-auxbase-strip`) and standalone `-quiet`, then reuse the existing path-sentinel + per-TU blanking. `resolved_semantic_tokens` tries clang first, then gnu.

## The correctness crux — validated by oracle, not assumption

The `-o` value is a **random** `/tmp/ccXXXX.s` temp that changes every invocation (the only token that varied across otherwise-identical clone-a/clone-b/repeat `-###` runs), so it must be dropped for determinism. Could dropping the output name cause a **false hit** (gcc derives `-frandom-seed` from the output name when not given)?

**Empirical answer:** compiling identical source+flags to *different* output names yields **byte-identical objects** (anon-namespace symbols included), and the same relative name in different dirs is identical too. So the output name does not leak into the object → dropping it is safe. An explicit `-frandom-seed=` is **kept** (not in the drop list), so a build that pins a seed still keys correctly.

```
alpha.o vs beta.o (same source+flags, different -o):  IDENTICAL
d1/seed.o vs d2/seed.o (same rel name, different dir): IDENTICAL
```

## Validation

- New Linux-only fixture `e2e-cc-bench-flags-gnu` (gcc-pinned; macOS `gcc` is a clang shim) compiles the bench flag set through gcc and asserts **cold-miss → warm-hit** — proof these flags now cache on gcc. **Validated end-to-end in the Linux container (warm HIT).**
- Frozen `testdata/gcc_o2*.txt` from real Debian gcc 12; 5 new parser unit tests.
- Clang path unchanged (gnu is a fallback only when no `-cc1` line); 1029 unit tests + clippy clean.

## Impact

With this + #418, `scenarios/bench-llvm` can keep **gcc** (no clang pin) and measure a real hit rate — and ALL existing `CapturedByProbe` codegen flags now cache on gcc, not just clang.

> Note: codex was launched to cross-check the drop-list/`-frandom-seed` safety but its leg hung on MCP startup and was killed — so this design is Claude-only, backed by the byte-identical-objects oracle above (a stronger, family-neutral check than a model opinion for the false-hit question).