### PR TITLE
fix(sync): fail --workspace fast when workspace is unresolved (follow-up to #416)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
 | `kache list [<crate>] [--sort name\|size\|hits\|age]` | List cached entries, or show details for a specific crate |
 | `kache why-miss <crate>` | Explain why a specific crate missed the cache |
 | `kache report [--format text\|json\|markdown\|github\|perfetto\|chrome-trace] [--since <dur>] [--top <n>] [--output <path>]` | Generate a detailed hit/dup/miss build report or Perfetto/Chrome trace (`--top` defaults to 10) |
-| `kache sync [--manifest-path <path>] [--pull] [--push] [--all] [--dry-run]` | Synchronize local cache with S3 remote (pull + push); `--manifest-path` points the Cargo.lock pull filter at a non-cwd manifest |
+| `kache sync [--manifest-path <path>] [--pull] [--push] [--all] [--workspace] [--dry-run]` | Synchronize local cache with S3 remote (pull + push); `--manifest-path` points the Cargo.lock pull filter at a non-cwd manifest; `--workspace` scopes the pull to workspace members only (one LIST per member) |
 | `kache save-manifest [--manifest-key <key>] [--namespace <ns>]` | Save a build manifest for future prefetch warming; `--manifest-key` overrides the default host-target-triple key |
 | `kache gc [--max-age <dur>]` | Garbage collect — LRU eviction or age-based cleanup |
 | `kache purge [--crate-name <name>]` | Wipe entire cache or entries for a specific crate |

--- a/docs/remote-cache/sync.mdx
+++ b/docs/remote-cache/sync.mdx
@@ -14,6 +14,7 @@ kache sync              # pull missing artifacts + push new local artifacts
 kache sync --pull       # download only
 kache sync --push       # upload only
 kache sync --all        # pull all artifacts, ignoring Cargo.lock filtering
+kache sync --workspace  # pull scope = workspace members only (one LIST per member)
 kache sync --dry-run    # preview what would transfer, make no changes
 ```
 
@@ -33,6 +34,19 @@ kache sync --pull --all
 ```
 
 If kache can't find a `Cargo.lock`, it falls back to pulling everything. The same full-bucket fallback applies if `Cargo.lock` is present but yields no package names.
+
+### `--workspace`: scope the pull to workspace members
+
+By default the pull issues one `ListObjectsV2` per crate in the `Cargo.lock` dependency set — often hundreds to thousands of LIST calls. `--workspace` instead scopes discovery to the **workspace members** (the same `cargo metadata --no-deps` set used by the push filter), issuing one LIST per member (typically tens). It conflicts with `--all`.
+
+This only narrows the up-front batch pull — dependency artifacts are still resolved on demand during the build (the rustc wrapper fetches a local miss from S3 via the daemon, and the daemon prefetches by build intent), so deps are not recompiled. It's most useful when the dependency artifacts are already present locally — e.g. a prebuilt `cargo chef` deps image whose compiled deps sit in `target/` — where they're local hits that never need an S3 round-trip.
+
+```sh
+# discovery issues one LIST per workspace member instead of one per dependency
+kache sync --pull --workspace
+```
+
+Unlike the default pull, `--workspace` does **not** fall back to a full-bucket scan: if the workspace set can't be resolved (`cargo metadata` failed, or you're not in a Cargo workspace), the command errors rather than silently listing the entire bucket.
 
 <Callout type="warn">
 `--manifest-path` controls the **push-side** workspace filter only (which local crates get uploaded). The pull filter always reads `Cargo.lock` from the current working directory and ignores `--manifest-path`, so to pull for a different project, run `kache sync` from that project's directory.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2468,10 +2468,19 @@ async fn sync_with_client(
     // otherwise it's the Cargo.lock dep set; `--all` (or no filter) lists the
     // whole bucket.
     let s3_keys = if !push_only {
-        if pull_workspace
-            && let Some(crates) = workspace_crates
-            && !crates.is_empty()
-        {
+        if pull_workspace {
+            // `--workspace` must resolve to a non-empty workspace set. If cargo
+            // metadata failed or this isn't a Cargo workspace, refuse to fall
+            // back to a full-bucket scan — that's the exact opposite of what the
+            // flag asks for (and `lock_crates` is None here, so the dep path
+            // can't catch it either).
+            let crates = workspace_crates.filter(|c| !c.is_empty()).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "--workspace: no workspace members resolved (cargo metadata \
+                     failed or this is not a Cargo workspace); refusing to fall \
+                     back to a full-bucket S3 scan"
+                )
+            })?;
             eprint!("Listing S3 keys for {} workspace crates...", crates.len());
             let keys = planner
                 .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
@@ -4548,6 +4557,47 @@ mod tests {
         .await
         .expect("workspace-scoped pull should list only the workspace member(s)");
         server.shutdown();
+    }
+
+    #[tokio::test]
+    async fn sync_with_client_workspace_pull_errors_when_no_workspace_resolved() {
+        // `--workspace` with an unresolved (None) or empty workspace set must
+        // error, NOT silently fall back to a full-bucket scan. We hand the mock
+        // a valid full-bucket LIST response: if the guard were missing, the
+        // fallback `list_keys()` would consume it and return Ok — so an Err here
+        // proves the guard fired before any S3 round-trip.
+        let dir = tempfile::tempdir().unwrap();
+        let config = save_manifest_config(dir.path().to_path_buf(), Some(test_remote_cfg()));
+        let store = Store::open(&config).unwrap();
+        let remote = test_remote_cfg();
+
+        let empty: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let cases: [Option<&std::collections::HashSet<String>>; 2] = [None, Some(&empty)];
+
+        for workspace_crates in cases {
+            let (server, client) =
+                mock_s3(vec![ReplayedEvent::with_body(list_bucket_xml(&[]))]).await;
+            let err = sync_with_client(
+                &client,
+                &config,
+                &store,
+                &remote,
+                workspace_crates, // None or empty → cannot scope to workspace
+                true,             // pull_only
+                false,            // push_only
+                true,             // dry_run
+                false,            // pull_all
+                None,             // lock_crates (always None under --workspace)
+                true,             // pull_workspace
+            )
+            .await
+            .expect_err("--workspace with no resolved members must error, not scan the bucket");
+            assert!(
+                err.to_string().contains("no workspace members resolved"),
+                "unexpected error: {err}"
+            );
+            server.shutdown();
+        }
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,10 @@ enum Commands {
         /// prebuilt `cargo chef` deps image whose compiled deps sit in target/),
         /// where they're local hits and never need an S3 round-trip; in a plain
         /// setup deps are fetched lazily during the build rather than pre-warmed.
+        ///
+        /// Errors out if the workspace set can't be resolved (cargo metadata
+        /// failed or this isn't a Cargo workspace) rather than silently falling
+        /// back to a full-bucket scan.
         #[arg(long, conflicts_with = "all")]
         workspace: bool,
     },


### PR DESCRIPTION
## Summary

Follow-up to #416. That PR added `--workspace` to scope `sync --pull` discovery to workspace members. During review we flagged one sharp edge: if `--workspace` is passed but the workspace set **can't be resolved** — `cargo metadata` fails, or sync is run outside a Cargo workspace — `sync_with_client` silently fell through to `list_keys()`, a **full-bucket S3 scan**. That's the exact opposite of what the flag asks for, and because `lock_crates` is `None` under `--workspace`, the dependency-listing path couldn't catch it either.

This PR makes `--workspace` **fail fast** with a clear error instead of degrading to the most expensive listing.

## Changes

- `sync_with_client`: when `pull_workspace` is set, the workspace set must resolve to a non-empty set or the call errors (`--workspace: no workspace members resolved …; refusing to fall back to a full-bucket S3 scan`). No silent fallback.
- New test `sync_with_client_workspace_pull_errors_when_no_workspace_resolved`: asserts the guard fires for **both** `None` and empty workspace sets, *even when a valid full-bucket LIST response is queued* — so it genuinely proves the guard runs before any S3 round-trip (a missing guard would consume the mock and return `Ok`).
- Help-text note on the `--workspace` flag documenting the fail-fast behavior.

## Verification

- `cargo test --bin kache sync_with_client` → 10 passed (9 existing + 1 new)
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

No change to existing default-path or `--all` behavior; the guard only affects the new opt-in `--workspace` flag.