### PR TITLE
fix(link): copy on Windows restore so consumers can delete/rewrite output (#429)

### DIFF
--- a/src/link.rs
+++ b/src/link.rs
@@ -66,6 +66,27 @@ pub fn link_to_target(store_path: &Path, target_path: &Path, strategy: LinkStrat
 
     // Reflink unsupported on this filesystem — strategy-specific fallback.
     match strategy {
+        // Windows has no reflink on NTFS, so the Hardlink strategy would
+        // hardlink the read-only store blob. NTFS stores FILE_ATTRIBUTE_READONLY
+        // in the shared MFT record, so EVERY hardlink to a read-only blob is
+        // itself read-only — and Windows refuses to delete or rewrite a
+        // read-only file (WinError 5). A consumer that owns its output and
+        // deletes/rewrites it — e.g. mozbuild's configure `ar_supports_response_files`
+        // conftest (#429) — then breaks. There is no way on NTFS to give a
+        // hardlink a different read-only state than its blob, so restore via an
+        // independent COPY instead: the output is writable and deletable while
+        // the store blob stays read-only (integrity preserved). This mirrors
+        // `write_restored`, already the proven-safe independent-file path, and
+        // costs only working-tree↔store block sharing (LRU is index-based, not
+        // mtime-based, so eviction is unaffected). gnu/clang restores keep
+        // hardlinking — reflink/hardlink there are writable or CoW-isolated.
+        #[cfg(windows)]
+        LinkStrategy::Hardlink => {
+            copy_file(store_path, target_path, false)?;
+            crate::opcounts::record_copied(bytes);
+            Ok(())
+        }
+        #[cfg(not(windows))]
         LinkStrategy::Hardlink => hardlink_or_copy(store_path, target_path, bytes),
         LinkStrategy::Copy => {
             copy_file(store_path, target_path, true)?;
@@ -77,6 +98,11 @@ pub fn link_to_target(store_path: &Path, target_path: &Path, strategy: LinkStrat
 
 /// Hardlink fallback for the `Hardlink` strategy when reflink is unavailable.
 /// Falls back to a plain copy on hardlink failure (cross-filesystem).
+///
+/// Not used on Windows: there the Hardlink strategy restores via copy, because
+/// a hardlink to a read-only store blob is itself read-only (shared MFT
+/// attribute) and breaks consumers that delete/rewrite their output (#429).
+#[cfg(not(windows))]
 fn hardlink_or_copy(store_path: &Path, target_path: &Path, bytes: u64) -> Result<()> {
     if let Err(e) = fs::hard_link(store_path, target_path) {
         tracing::debug!(
@@ -373,6 +399,38 @@ mod tests {
         // independent inode) on APFS/btrfs/XFS-with-reflink, or hardlink
         // (shared inode) as fallback. We don't assert which mechanism was
         // used — either satisfies the contract.
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_hardlink_restore_yields_writable_deletable_output() {
+        // #429: on Windows a Hardlink-strategy restore must NOT leave the
+        // output read-only (a hardlink to the read-only store blob would be),
+        // or a consumer that owns its output — mozbuild's configure conftest —
+        // cannot delete/rewrite it (WinError 5). The output must be writable
+        // and deletable, while the store blob stays read-only (integrity).
+        let dir = tempfile::tempdir().unwrap();
+        let blob = dir.path().join("deadbeef");
+        fs::write(&blob, b"obj bytes").unwrap();
+        let mut p = fs::metadata(&blob).unwrap().permissions();
+        p.set_readonly(true);
+        fs::set_permissions(&blob, p).unwrap();
+
+        let out = dir.path().join("conftest.o");
+        link_to_target(&blob, &out, LinkStrategy::Hardlink).unwrap();
+
+        assert_eq!(fs::read(&out).unwrap(), b"obj bytes");
+        assert!(
+            !fs::metadata(&out).unwrap().permissions().readonly(),
+            "restored output must be writable on Windows (#429)"
+        );
+        // The consumer must be able to delete its own output.
+        fs::remove_file(&out).expect("consumer must be able to delete its output (#429)");
+        // ...without the store blob losing its read-only integrity guard.
+        assert!(
+            fs::metadata(&blob).unwrap().permissions().readonly(),
+            "store blob must stay read-only after a restore"
+        );
     }
 
     #[test]

--- a/src/opcounts.rs
+++ b/src/opcounts.rs
@@ -79,6 +79,12 @@ pub fn record_reflinked(bytes: u64) {
 }
 
 /// Record `bytes` restored by a hardlink (reflink unavailable).
+///
+/// Unused on Windows: there the Hardlink strategy restores via copy (a hardlink
+/// to a read-only store blob is itself read-only and breaks consumers — #429),
+/// so no restore is ever accounted as hardlinked. The `cfg_attr` keeps the
+/// `-D warnings` build green without dropping the counter on other platforms.
+#[cfg_attr(windows, allow(dead_code))]
 pub fn record_hardlinked(bytes: u64) {
     HARDLINKED_BYTES.fetch_add(bytes, Ordering::Relaxed);
 }


### PR DESCRIPTION
Fixes #429.

## What broke

Firefox's `./mach build` fails at the configure step on Windows. mozbuild's `ar_supports_response_files` check creates a temp `conftest.c`, kache gets a cache **hit** and restores `conftest.o`, then mozbuild's context manager does `os.remove(conftest.o)`:

```
PermissionError: [WinError 5] Access is denied: '...\conftest0yx4x5m3.o'
```

The debug log shows the cause: `kache::link: hardlinked …\store\blobs\… -> …\conftest…o`.

## Root cause

kache restores a hit by **hardlinking** the content-addressed store blob, which is marked **read-only** (`FILE_ATTRIBUTE_READONLY`, for integrity). On NTFS that attribute lives in the **shared MFT record**, so *every* hardlink to a read-only blob is itself read-only — and Windows refuses to delete or rewrite a read-only file. Any consumer that owns its output (the conftest, or an in-place `strip`/`objcopy`) breaks. NTFS has no reflink (CoW) to hand out an independent writable link, and a hardlink **cannot** have a different read-only state than its blob.

## Fix

On Windows, when reflink is unavailable, the `Hardlink` strategy restores via an independent **copy** (`copy_file` already clears read-only on non-Unix). The output is writable and deletable; **the store blob stays read-only** (integrity preserved). This mirrors `write_restored` — already the proven-safe independent-file path on Windows — and is the model **sccache** uses (extract to a temp file in the output dir, not a hardlink to a cache blob).

- Cost: working-tree↔store block sharing on **Windows only**. LRU is index-based (`last_accessed`), not blob-mtime, so eviction is unaffected. gnu/clang restores keep hardlinking/reflinking.
- **Rejected alternative:** making store blobs writable on Windows to keep dedup — an in-place `strip`/`objcopy` or a later miss overwriting the same output would then corrupt the *shared* blob, which `KACHE_VERIFY_RESTORES` only catches after the fact.

## Validation

- Windows-gated regression test: a `Hardlink`-strategy restore yields a **writable, deletable** output while the store blob **stays read-only**.
- `hardlink_or_copy` is now `cfg(not(windows))`. 1035 tests + clippy clean on the host; the Windows path is exercised in CI.

> Cross-family: a second model (codex) independently chose this option over the writable-blob alternative, citing the same `strip`/`objcopy` corruption risk and that sccache does the same.