### PR TITLE
fix(cc): cache -Xclang-forwarded modeled codegen knobs (#428, -ffp-contract=off)

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2664,7 +2664,7 @@ fn classify_and_trace_cc_flags<'a>(
                 idx += 1;
                 continue;
             };
-            let class = classify_xclang_forwarded(inner);
+            let class = classify_xclang_forwarded(inner, dialect);
             summary.record(class);
             match class {
                 Some(class) => tracing::trace!(
@@ -2880,26 +2880,58 @@ const XCLANG_INERT_CC1_FLAGS: &[&str] = &[
 /// Returns `NoObjectEffect` for an allow-listed inert cc1 flag
 /// ([`XCLANG_INERT_CC1_FLAGS`]) or for a bare value token — e.g. the
 /// dependency-file path, itself forwarded as its own `-Xclang <value>`
-/// pair. Returns `None` for any other forwarded flag so it refuses: an
-/// `-Xclang`-wrapped codegen flag (`-Xclang -ffast-math`, …) must not be
-/// cached blindly.
-fn classify_xclang_forwarded(inner: &str) -> Option<FlagClass> {
+/// pair.
+///
+/// A forwarded flag that matches a modeled `CapturedByProbe` codegen knob
+/// (`-Xclang -ffp-contract=off`, the Firefox/Windows clang-cl shape of #428)
+/// is allowed and keyed via the probe: `-Xclang` forwards it to cc1, where the
+/// `cc -###` resolved cc1 line records it (verified: `-Xclang -ffp-contract=off`
+/// appends `-ffp-contract=off` to the dump), so the cache key already
+/// differentiates it from the default. This is safe, NOT "blind": the bare
+/// operand token also classifies as `ProbeKeyed` at the driver level, so
+/// `cc_flags_need_resolved_invocation` forces the probe and refuses to cache if
+/// it cannot resolve — there is no under-keying path. An UNMODELED `-Xclang`
+/// codegen flag (not in `CC_FLAGS`) still returns `None` and refuses.
+fn classify_xclang_forwarded(inner: &str, dialect: Dialect) -> Option<FlagClass> {
     if !inner.starts_with('-') {
         // A value token (e.g. the dependency-file path). No object effect;
         // its content is irrelevant to the resulting `.obj`.
         return Some(FlagClass::NoObjectEffect);
     }
-    XCLANG_INERT_CC1_FLAGS
-        .contains(&inner)
-        .then_some(FlagClass::NoObjectEffect)
+    // Inert cc1 flags FIRST: a forwarded `-MT`/`-MP`/… is the cc1 dep-info flag,
+    // which must NOT be confused with the clang-cl driver flag of the same
+    // spelling (`/MT` = CRT selection, a CapturedByProbe codegen knob). The
+    // driver-level `classify_cc_flag` below would misread the cc1 spelling as
+    // the driver flag, so the forwarded-position allow-list wins.
+    if XCLANG_INERT_CC1_FLAGS.contains(&inner) {
+        return Some(FlagClass::NoObjectEffect);
+    }
+    if classify_cc_flag(inner, dialect) == Some(FlagClass::CapturedByProbe) {
+        return Some(FlagClass::CapturedByProbe);
+    }
+    None
 }
 
 fn cc_flags_need_resolved_invocation(parsed: &CcArgs) -> bool {
     let dialect = parsed.family.dialect();
-    parsed
+    // Any driver-level probe-keyed flag forces the resolved `cc -###`
+    // invocation so the key captures its codegen effect.
+    if parsed
         .rest
         .iter()
         .any(|arg| analyze_cc_arg(arg, dialect).bucket == CcArgBucket::ProbeKeyed)
+    {
+        return true;
+    }
+    // A `-Xclang`-forwarded CapturedByProbe knob is keyed via the resolved cc1
+    // line too (#428), so it must force the probe as well. The flat scan above
+    // already catches self-contained shapes whose operand also matches a driver
+    // row (e.g. `-ffp-contract=`), but a cc1-only forwarded knob would slip
+    // past it — without the probe its codegen effect would not be keyed.
+    parsed.rest.windows(2).any(|w| {
+        w[0] == "-Xclang"
+            && classify_xclang_forwarded(&w[1], dialect) == Some(FlagClass::CapturedByProbe)
+    })
 }
 
 /// MSVC debug-info markers that embed absolute CodeView paths into the
@@ -6019,16 +6051,17 @@ mod tests {
     /// `-Xclang`-wrapped codegen flag can't slip past.
     #[test]
     fn xclang_forwarded_classifier_issue_411() {
+        let cl = Dialect::Cl;
         assert_eq!(
-            classify_xclang_forwarded("-MP"),
+            classify_xclang_forwarded("-MP", cl),
             Some(FlagClass::NoObjectEffect)
         );
         assert_eq!(
-            classify_xclang_forwarded("-dependency-file"),
+            classify_xclang_forwarded("-dependency-file", cl),
             Some(FlagClass::NoObjectEffect)
         );
         assert_eq!(
-            classify_xclang_forwarded("-fansi-escape-codes"),
+            classify_xclang_forwarded("-fansi-escape-codes", cl),
             Some(FlagClass::NoObjectEffect)
         );
         // The dep-target flags that MUST accompany `-dependency-file` (cc1
@@ -6036,26 +6069,39 @@ mod tests {
         // the bare `-MT` token collided with the clang-cl CRT row; the
         // forwarding path must classify them on their own merits.
         assert_eq!(
-            classify_xclang_forwarded("-MT"),
+            classify_xclang_forwarded("-MT", cl),
             Some(FlagClass::NoObjectEffect)
         );
         assert_eq!(
-            classify_xclang_forwarded("-MQ"),
+            classify_xclang_forwarded("-MQ", cl),
             Some(FlagClass::NoObjectEffect)
         );
         assert_eq!(
-            classify_xclang_forwarded("-sys-header-deps"),
+            classify_xclang_forwarded("-sys-header-deps", cl),
             Some(FlagClass::NoObjectEffect)
         );
         // A bare value (e.g. the dependency-file path, itself forwarded as
         // its own `-Xclang <path>`) is inert.
         assert_eq!(
-            classify_xclang_forwarded("dom/ipc/Unified_cpp_dom_ipc5.cpp.pp"),
+            classify_xclang_forwarded("dom/ipc/Unified_cpp_dom_ipc5.cpp.pp", cl),
             Some(FlagClass::NoObjectEffect)
         );
-        // An unmodeled forwarded flag must refuse — not be swallowed.
-        assert_eq!(classify_xclang_forwarded("-ffast-math"), None);
-        assert_eq!(classify_xclang_forwarded("-mllvm"), None);
+        // #428: a forwarded flag that matches a modeled CapturedByProbe codegen
+        // knob is allowed and keyed via the resolved cc1 probe (the bare operand
+        // also forces the probe), so `-Xclang -ffp-contract=off` / `-ffast-math`
+        // cache instead of passing through.
+        assert_eq!(
+            classify_xclang_forwarded("-ffp-contract=off", cl),
+            Some(FlagClass::CapturedByProbe)
+        );
+        assert_eq!(
+            classify_xclang_forwarded("-ffast-math", cl),
+            Some(FlagClass::CapturedByProbe)
+        );
+        // An UNMODELED forwarded flag (not in CC_FLAGS) must still refuse —
+        // not be swallowed blindly.
+        assert_eq!(classify_xclang_forwarded("-mllvm", cl), None);
+        assert_eq!(classify_xclang_forwarded("-fnot-a-real-flag", cl), None);
     }
 
     /// Issue #411 — a full Firefox/Windows clang-cl invocation: `-TP`,
@@ -6104,26 +6150,43 @@ mod tests {
         );
     }
 
-    /// Issue #411 safety boundary: a codegen flag wrapped in `-Xclang` must
-    /// still refuse. The forwarding handler classifies the inner token; it
-    /// never blindly consumes whatever follows `-Xclang`.
+    /// Issue #428: a `-Xclang`-forwarded flag that matches a modeled
+    /// `CapturedByProbe` codegen knob now CACHES — Firefox's Windows clang-cl
+    /// build passes `-Xclang -ffp-contract=off` on ~every TU, and the resolved
+    /// cc1 probe records the forwarded flag, so the key differentiates it. An
+    /// UNMODELED `-Xclang` codegen flag still refuses (the #411 boundary holds
+    /// for anything not in `CC_FLAGS` — the relaxation is principled, not blind).
     #[test]
-    fn xclang_wrapped_codegen_flag_still_refuses_issue_411() {
-        let descs = refuse_descriptions(&[
+    fn xclang_forwarded_modeled_knob_caches_unmodeled_refuses_issue_428() {
+        // Modeled knob via -Xclang: must NOT refuse.
+        let ok = refuse_descriptions(&[
             "clang-cl",
             "-c",
             "-Xclang",
-            "-ffast-math",
+            "-ffp-contract=off",
             "-Foa.obj",
             "a.cpp",
         ]);
-        let detail = descs
+        assert!(
+            !ok.iter().any(|d| d.contains("unsupported flag")),
+            "-Xclang -ffp-contract=off must classify (cache), got: {ok:?}"
+        );
+        // Unmodeled forwarded flag: must still refuse, naming the flag.
+        let bad = refuse_descriptions(&[
+            "clang-cl",
+            "-c",
+            "-Xclang",
+            "-fnot-a-real-codegen-flag",
+            "-Foa.obj",
+            "a.cpp",
+        ]);
+        let detail = bad
             .iter()
             .find(|d| d.contains("unsupported flag"))
-            .expect("an -Xclang-wrapped codegen flag must still refuse");
+            .expect("an UNMODELED -Xclang flag must still refuse");
         assert!(
-            detail.contains("-ffast-math"),
-            "reason should name the forwarded codegen flag: {detail}"
+            detail.contains("-fnot-a-real-codegen-flag"),
+            "reason should name the unmodeled forwarded flag: {detail}"
         );
     }
 


### PR DESCRIPTION
Fixes #428.

## What broke

Firefox's Windows clang-cl build passes clang codegen flags through clang-cl as `-Xclang -ffp-contract=off`, and kache passed those TUs through uncached — **322** in the reporter's run:

```
cc unsupported flag(s): -ffp-contract=off — not yet
```

`-ffp-contract=` is *already* modeled (`CapturedByProbe`), so the reporter's "I think AI hallucinated when it argued it's already supported" is half-right: the **bare** flag caches, but the **`-Xclang`-forwarded** shape Firefox actually uses did not. kache's `-Xclang` handler (added in #411) only allowed an inert dep-info/diagnostics cc1 allow-list and refused everything else — including a forwarded flag that *is* a modeled, probe-captured codegen knob.

## Fix

`classify_xclang_forwarded` now also accepts an inner flag that `classify_cc_flag` reports as `CapturedByProbe`. It's keyed via the resolved `cc -###` cc1 line.

**Verified safe (no false hit)** — the cc1 dump appends the forwarded flag and the keys are distinct:
```
baseline (no flag):        3e58506a…
-Xclang -ffp-contract=off: 3fd7cbba…   ← differs from baseline
-Xclang -ffp-contract=on:  9b0f12b5…   ← differs from off
```

Not blind: an **unmodeled** `-Xclang` codegen flag still refuses, so the #411 boundary holds for anything not in `CC_FLAGS`.

Two subtleties (both caught by the codex cross-check):
- **Inert-list-first ordering**: a forwarded cc1 `-MT`/`-MP` stays `NoObjectEffect` and is *not* misread as the clang-cl driver's `/MT` CRT-selection flag (a `CapturedByProbe` row of the same spelling).
- **`cc_flags_need_resolved_invocation`** now also forces the probe for a `-Xclang`-forwarded `CapturedByProbe` knob — for `-ffp-contract=` the bare operand already triggered it, but a cc1-only forwarded knob would have slipped past, leaving its effect unkeyed.

## Tests

Updated the #411 tests: `-Xclang -ffast-math`/`-ffp-contract=off` now classify (modeled + probe-keyed); an unmodeled `-Xclang -f…` still refuses. 1035 tests + clippy clean.

## Related, not in this PR

`/clang:-ffp-contract=off` is a sibling shape that also refuses, but it forwards to the clang **driver** (not cc1) — different semantics that need separate handling (driver-level unwrap + probe requirement). Left as a follow-up; the reporter's failure is the `-Xclang` form.

> Cross-family: codex independently agreed the relaxation is safe for modeled `CapturedByProbe` knobs *given the probe is forced*, and flagged the two subtleties above — both fixed here. The distinct-key oracle is the family-neutral confirmation.