### PR TITLE
fix(cc): restore bare -fansi-escape-codes classification (#438)

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1900,6 +1900,19 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         dialect: None,
     },
     FlagSpec {
+        // Forces ANSI color escapes in diagnostics regardless of TTY
+        // detection — terminal coloring only, no object effect. A real
+        // clang driver flag in both dialects (Firefox's Windows clang-cl
+        // build passes it bare, not just `-Xclang` forwarded as #411
+        // covered), with no clang-cl spelling collision. Same family as
+        // `-fcolor-diagnostics` above. Re-added after #430's codegen-knob
+        // refactor dropped it (issue #438; originally #425/#424).
+        matcher: Matcher::Exact("-fansi-escape-codes"),
+        class: FlagClass::NoObjectEffect,
+        source: "Issue #424/#438 — Firefox/Windows bare diagnostics flag; ANSI color escapes only, no object effect.",
+        dialect: None,
+    },
+    FlagSpec {
         // Dep-info generation: -MD, -MMD, -MF, -MT, -MQ, -MP, -MG.
         // All write the `.d` sidecar; none affect the object. Regex
         // captures the family; alternatives are equally tight in this
@@ -5121,6 +5134,45 @@ mod tests {
                 "{flag} is cache-safe and must NOT trip the classifier, got: {descs:?}"
             );
         }
+    }
+
+    /// Issue #424/#438 — Firefox's Windows clang-cl build passes
+    /// `-fansi-escape-codes` as a *bare* driver flag (not `-Xclang`
+    /// forwarded). It only forces ANSI color escapes in diagnostics, so it
+    /// has no object effect and must classify as `NoObjectEffect` in both
+    /// dialects — exactly like its sibling `-fcolor-diagnostics`. (#430's
+    /// codegen-knob refactor dropped this row; #438 restores it.)
+    #[test]
+    fn bare_fansi_escape_codes_is_inert_issue_424() {
+        assert_eq!(
+            classify_cc_flag("-fansi-escape-codes", Dialect::Gnu),
+            Some(FlagClass::NoObjectEffect)
+        );
+        assert_eq!(
+            classify_cc_flag("-fansi-escape-codes", Dialect::Cl),
+            Some(FlagClass::NoObjectEffect)
+        );
+    }
+
+    /// Issue #424/#438 — the remaining Firefox/Windows diagnostics + codegen
+    /// knobs surfaced in the bench log (`-fansi-escape-codes` bare alongside
+    /// `-ffp-contract=off`) must all classify so the TU caches instead of
+    /// passing through as "unsupported flag(s)".
+    #[test]
+    fn firefox_windows_remaining_flags_are_cacheable_issue_424() {
+        let descs = refuse_descriptions(&[
+            "clang-cl",
+            "-c",
+            "-TP",
+            "-ffp-contract=off",
+            "-fansi-escape-codes",
+            "-FoBasePrincipal.obj",
+            "caps/BasePrincipal.cpp",
+        ]);
+        assert!(
+            !descs.iter().any(|d| d.contains("unsupported flag")),
+            "issue #424 flags must all classify; got: {descs:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Re-add the `FlagSpec` row that classifies a **bare** `-fansi-escape-codes` driver flag as `NoObjectEffect`, plus its two regression tests.

## Why

This is a regression. #425 already fixed this exact flag (issue #424) by adding the row beside `-fcolor-diagnostics`. Then #430's polarity-aware codegen-knob refactor (`f1e6519`) **deleted that row and both tests** while consolidating codegen-knob rows into the sorted stem list. But `-fansi-escape-codes` is a *diagnostics* flag, not a codegen knob, so the new stem list never re-covered it and it silently reverted to passthrough.

As reported in #438 (build `c415a37`), Firefox's Windows clang-cl TUs pass it bare and fall through as `unsupported flag(s) — passthrough`, so nothing caches.

## Fix

- Restore `Matcher::Exact("-fansi-escape-codes")` → `NoObjectEffect` (`dialect: None`) next to `-fcolor-diagnostics`.
- Restore both regression tests:
  - `bare_fansi_escape_codes_is_inert_issue_424` — bare flag → `NoObjectEffect` in Gnu and Cl dialects.
  - `firefox_windows_remaining_flags_are_cacheable_issue_424` — clang-cl compile with bare `-fansi-escape-codes` + `-ffp-contract=off` produces no `unsupported flag` refusal.

## Tests

- Both restored tests pass; full `compiler::cc` suite (157 tests) green.
- `cargo fmt --check` clean.

Closes #438