### PR TITLE
fix(cc): re-add bare -fansi-escape-codes row dropped by #430 refactor

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1900,6 +1900,19 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         dialect: None,
     },
     FlagSpec {
+        // Forces ANSI color escapes in diagnostics regardless of TTY
+        // detection — terminal coloring only, no object effect. A real
+        // clang driver flag in both dialects (Firefox's Windows clang-cl
+        // build passes it bare, not just `-Xclang` forwarded as #411
+        // covered), with no clang-cl spelling collision. Same family as
+        // `-fcolor-diagnostics` above. (Re-added after the #430 refactor
+        // dropped the #425 row — see issue #438.)
+        matcher: Matcher::Exact("-fansi-escape-codes"),
+        class: FlagClass::NoObjectEffect,
+        source: "Issue #424/#438 — Firefox/Windows bare diagnostics flag; ANSI color escapes only, no object effect.",
+        dialect: None,
+    },
+    FlagSpec {
         // Dep-info generation: -MD, -MMD, -MF, -MT, -MQ, -MP, -MG.
         // All write the `.d` sidecar; none affect the object. Regex
         // captures the family; alternatives are equally tight in this
@@ -6015,6 +6028,45 @@ mod tests {
         assert!(
             cc_flags_need_resolved_invocation(&parsed),
             "probe-captured flags must force the resolved invocation"
+        );
+    }
+
+    /// Issue #438 (regression of #424/#425): Firefox's Windows clang-cl build
+    /// passes `-fansi-escape-codes` as a *bare* driver flag, not just `-Xclang`
+    /// forwarded. It only forces ANSI color escapes in diagnostics, so it has
+    /// no object effect and must classify as `NoObjectEffect` in both dialects
+    /// — exactly like its sibling `-fcolor-diagnostics`. The bare-flag row was
+    /// added by #425 but dropped by the #430 refactor; this pins it so it
+    /// cannot silently regress again.
+    #[test]
+    fn bare_fansi_escape_codes_is_inert_issue_438() {
+        assert_eq!(
+            classify_cc_flag("-fansi-escape-codes", Dialect::Gnu),
+            Some(FlagClass::NoObjectEffect)
+        );
+        assert_eq!(
+            classify_cc_flag("-fansi-escape-codes", Dialect::Cl),
+            Some(FlagClass::NoObjectEffect)
+        );
+    }
+
+    /// Issue #438 — a representative Firefox/Windows clang-cl TU from the bug
+    /// report (`Unified_cpp_dom_ipc0.cpp` passing bare `-fansi-escape-codes`)
+    /// must classify so the compile caches instead of passing through as
+    /// "unsupported flag(s)".
+    #[test]
+    fn firefox_windows_bare_fansi_escape_codes_is_cacheable_issue_438() {
+        let descs = refuse_descriptions(&[
+            "clang-cl",
+            "-c",
+            "-TP",
+            "-fansi-escape-codes",
+            "-FoUnified_cpp_dom_ipc0.obj",
+            "Unified_cpp_dom_ipc0.cpp",
+        ]);
+        assert!(
+            !descs.iter().any(|d| d.contains("unsupported flag")),
+            "bare -fansi-escape-codes must classify; got: {descs:?}"
         );
     }
 


### PR DESCRIPTION
## What

Re-add the bare `-fansi-escape-codes` `FlagSpec` row (as `NoObjectEffect`, `dialect: None`, beside `-fcolor-diagnostics`) plus two regression tests.

Closes #438.

## Root cause — a post-v0.7.0 regression

`-fansi-escape-codes` was fixed in **#425** (added the bare-flag row + tests). The **#430** "polarity-aware codegen-knob stems" refactor then **accidentally deleted that row and both tests** — almost certainly a merge-collision (it branched before #425 landed). So on `main` the flag refuses again, and every Firefox/Windows media/dom TU passes through as `unsupported flag(s)` → cache miss.

Timeline (verified with `git merge-base`):

| Commit | Effect |
|--------|--------|
| `f134b92` #425 | adds the row — **this is what the `v0.7.0` tag points to** |
| `f1e6519` #430 | refactor **drops** the row + tests (lands after v0.7.0) |
| `c415a37` #435 | the reporter's build (`kache --version` in #438) — downstream of #430, hence the bug |

So **v0.7.0 itself is unaffected** (it carries the working #425 fix); the regression exists only on `main` after #430. The reporter built from `main` (`cargo install` at sha `c415a37`), not the release.

## The flag

`-fansi-escape-codes` forces ANSI color escapes in diagnostics regardless of TTY detection — terminal coloring only, no object effect; a real clang driver flag in both GNU and clang-cl modes with no spelling collision.

## Tests

- `bare_fansi_escape_codes_is_inert_issue_438` — bare flag → `NoObjectEffect` in both `Gnu` and `Cl`.
- `firefox_windows_bare_fansi_escape_codes_is_cacheable_issue_438` — a clang-cl TU from the bug report produces no `unsupported flag` refusal.

Both written failing first (reproduced #438), then green. Full `compiler::cc` suite: 157 passed. `just fmt` + `just lint` clean.

The regression tests pin the row so a future refactor can't silently drop it a third time.