### PR TITLE
ci(windows): point runner-provisioning refs at the real ans-runners path

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -247,17 +247,17 @@ jobs:
       # missing. MozillaBuild provides mach's bash/python env; clang-cl (cc/c++),
       # nasm, and MSVC + Windows SDK back the compile. clang/rust are pulled by
       # `./mach bootstrap`, so they are NOT pre-required here. Keep in sync with
-      # ans-runners/tasks/setup_windows.yml.
+      # ans-runners/tasks/windows/setup_packages.yml.
       - name: Verify Firefox/Windows build prerequisites
         run: |
           missing=
           if [ -z "${MOZILLABUILD:-}" ] && [ ! -d "/c/mozilla-build" ]; then
-            echo "MISSING: MozillaBuild (set MOZILLABUILD or install to C:\\mozilla-build) — provision it (ans-runners/tasks/setup_windows.yml)"
+            echo "MISSING: MozillaBuild (set MOZILLABUILD or install to C:\\mozilla-build) — provision it (ans-runners/tasks/windows/setup_packages.yml)"
             missing=1
           fi
           for t in cc c++ nasm; do
             if ! command -v "$t" >/dev/null 2>&1; then
-              echo "MISSING on runner PATH: $t — provision it (ans-runners/tasks/setup_windows.yml)"
+              echo "MISSING on runner PATH: $t — provision it (ans-runners/tasks/windows/setup_packages.yml)"
               missing=1
             fi
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
       # Fail fast with an explicit checklist if the self-hosted Windows runner
       # is missing a build/fixture tool, instead of an opaque failure deep in
       # the cargo build or a fixture's `make`. Mirrors the verification step in
-      # ans-runners/tasks/setup_windows.yml — keep the two tool lists in sync.
+      # ans-runners/tasks/windows/setup_packages.yml — keep the two tool lists in sync.
       #   cc/c++/make  -> C/C++ fixtures (harness sets CC="$KACHE cc")
       #   nasm         -> ring's x86_64 `.asm` (the rustls crypto provider).
       #                   perl/cmake are no longer needed: they were aws-lc-sys
@@ -246,7 +246,7 @@ jobs:
           missing=
           for t in cc c++ make nasm; do
             if ! command -v "$t" >/dev/null 2>&1; then
-              echo "MISSING on runner PATH: $t — provision it (see ans-runners/tasks/setup_windows.yml)"
+              echo "MISSING on runner PATH: $t — provision it (see ans-runners/tasks/windows/setup_packages.yml)"
               missing=1
             fi
           done
@@ -584,7 +584,7 @@ jobs:
           missing=
           for t in cc c++ make nasm; do
             if ! command -v "$t" >/dev/null 2>&1; then
-              echo "MISSING on runner PATH: $t — provision it (see ans-runners/tasks/setup_windows.yml)"
+              echo "MISSING on runner PATH: $t — provision it (see ans-runners/tasks/windows/setup_packages.yml)"
               missing=1
             fi
           done


### PR DESCRIPTION
## Summary

The Windows runner-provisioning pointers in `bench.yml` and `ci.yml` referenced **`ans-runners/tasks/setup_windows.yml`**, which is a *stale untracked draft*. The maintained Windows provisioning lives in **`tasks/windows/setup_packages.yml`** (Zondax/ans-runners#2; MozillaBuild for the Firefox/Windows bench arm added in Zondax/ans-runners#8).

This corrects **all six** references so they send people to the file that actually exists:

- `bench.yml` — the `bench-firefox-windows` precheck "keep in sync" comment + the two operator-facing `provision it (...)` messages.
- `ci.yml` — the Windows-toolchain preflight comment + the two `provision it (see ...)` messages (test-windows + e2e).

Comment / echo-string only — **no behavioral change** (both files still parse).

Follow-up to #446 (closed once the runner was provisioned via ans-runners#8).