### PR TITLE
fix(bench): disambiguate firefox profile by exact name; drop misleading os:linux tag (#458)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -77,12 +77,13 @@ jobs:
           #
           # Smaller than Firefox but still tens of minutes cold.
           substrate='{"name":"substrate","cmd":"bench substrate","dir":"bench-substrate","timeout":180,"min_free_gb":60}'
-          # Full cold Firefox build is the long pole — hours. `--select os:linux`
-          # disambiguates: `--profile firefox` is a name SUBSTRING match, so it
-          # also matches `bench-firefox-windows`; the os tag pins this Linux arm
-          # to `bench-firefox`. (The Windows variant runs in its own job below,
-          # on the self-hosted Windows runner.)
-          firefox='{"name":"firefox","cmd":"bench firefox --select os:linux","dir":"bench-firefox","timeout":360,"min_free_gb":120}'
+          # Full cold Firefox build is the long pole — hours. `bench firefox`
+          # resolves to the exact `bench-firefox` scenario: `--profile firefox`
+          # is a name SUBSTRING match that also catches `bench-firefox-windows`,
+          # but discovery prefers the exact-name hit (#458), so no `os:` tag is
+          # needed to pin this host-native arm. (The Windows variant runs in its
+          # own job below, on the self-hosted Windows runner.)
+          firefox='{"name":"firefox","cmd":"bench firefox","dir":"bench-firefox","timeout":360,"min_free_gb":120}'
           # Same Firefox shape through sccache for a side-by-side comparison.
           firefox_sccache='{"name":"firefox-sccache","cmd":"bench-sccache firefox","dir":"bench-firefox-sccache","timeout":360,"min_free_gb":120}'
           # Almost-pure C/C++ CMake build (X86-only Release) — lighter than Firefox.
@@ -313,12 +314,12 @@ jobs:
           reshim: false
 
       - name: Run bench (firefox-windows)
-        # `--select os:windows` pins selection to bench-firefox-windows (the
-        # `bench` recipe already ANDs suite:bench + backend:kache + the firefox
-        # name filter; the os tag disambiguates from the Linux scenario).
+        # The fuller `firefox-windows` profile is a unique substring, so it
+        # selects bench-firefox-windows directly — no `os:` workaround needed
+        # (the `bench` recipe already ANDs suite:bench + backend:kache).
         run: |
           rustc --version && cargo --version && just --version
-          just bench firefox --select os:windows
+          just bench firefox-windows
         env:
           # The bench measures kache itself; it must not run under a wrapper.
           RUSTC_WRAPPER: ""

--- a/crates/kache-e2e/src/bench_profile.rs
+++ b/crates/kache-e2e/src/bench_profile.rs
@@ -153,6 +153,30 @@ impl BenchProfile {
             }
             profiles.push(Self::load(&metadata.toml_path)?);
         }
+        // `name:` is a substring match, so a short profile like `firefox` also
+        // catches `bench-firefox-windows`. When several scenarios match but
+        // exactly one carries the name the profile names (`<needle>` or
+        // `bench-<needle>`), prefer that single scenario. This lets
+        // `just bench firefox` resolve unambiguously to `bench-firefox` without
+        // an `os:`-flavored discriminator tag (#458). A genuinely ambiguous
+        // substring with no exact hit is left untouched for the caller's
+        // "matched multiple scenarios" guard to report.
+        if profiles.len() > 1 {
+            let needles = selectors.name_needles();
+            let exact: Vec<String> = profiles
+                .iter()
+                .map(|p| p.name.clone())
+                .filter(|name| {
+                    let name = name.as_str();
+                    needles
+                        .iter()
+                        .any(|&n| name == n || name == format!("bench-{n}").as_str())
+                })
+                .collect();
+            if exact.len() == 1 {
+                profiles.retain(|p| p.name == exact[0]);
+            }
+        }
         Ok(profiles)
     }
 
@@ -613,39 +637,43 @@ setup_marker = "{}"
     }
 
     #[test]
-    fn discover_filters_bench_scenarios_by_tags_and_name() {
+    fn discover_disambiguates_short_profile_to_exact_name() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scenarios");
-        // `name:firefox` is a SUBSTRING match, so it catches both the Linux
-        // (`bench-firefox`) and Windows (`bench-firefox-windows`) kache
-        // scenarios. The bench workflow relies on the `os:` tag to disambiguate
-        // which arm runs which — guard that contract here.
-        let base = [
-            "suite:bench".to_string(),
-            "backend:kache".to_string(),
-            "name:firefox".to_string(),
-        ];
+        let base = ["suite:bench".to_string(), "backend:kache".to_string()];
 
-        let both = Selectors::parse_many(&base).unwrap();
-        let mut names: Vec<String> = BenchProfile::discover(&root, &both)
-            .unwrap()
-            .into_iter()
-            .map(|p| p.name)
-            .collect();
-        names.sort();
-        assert_eq!(names, ["bench-firefox", "bench-firefox-windows"]);
+        // `name:firefox` is a SUBSTRING match, so it catches both the
+        // host-native (`bench-firefox`) and Windows (`bench-firefox-windows`)
+        // kache scenarios. Discovery then disambiguates to the scenario whose
+        // exact name the profile names (`bench-firefox`), so `just bench
+        // firefox` resolves to a single scenario without an `os:`-flavored
+        // discriminator tag (#458).
+        let mut firefox_sel = base.to_vec();
+        firefox_sel.push("name:firefox".to_string());
+        let firefox =
+            BenchProfile::discover(&root, &Selectors::parse_many(&firefox_sel).unwrap()).unwrap();
+        assert_eq!(
+            firefox.len(),
+            1,
+            "short `firefox` profile resolves to exactly one scenario"
+        );
+        assert_eq!(firefox[0].name, "bench-firefox");
 
-        let mut linux_sel = base.to_vec();
-        linux_sel.push("os:linux".to_string());
-        let linux =
-            BenchProfile::discover(&root, &Selectors::parse_many(&linux_sel).unwrap()).unwrap();
-        assert_eq!(linux.len(), 1);
-        assert_eq!(linux[0].name, "bench-firefox");
-
+        // The fuller `firefox-windows` profile is already a unique substring.
         let mut win_sel = base.to_vec();
-        win_sel.push("os:windows".to_string());
+        win_sel.push("name:firefox-windows".to_string());
         let win = BenchProfile::discover(&root, &Selectors::parse_many(&win_sel).unwrap()).unwrap();
         assert_eq!(win.len(), 1);
         assert_eq!(win[0].name, "bench-firefox-windows");
+
+        // `os:windows` is accurate metadata and still selects the Windows
+        // variant; it is no longer a *required* disambiguator.
+        let mut os_win_sel = base.to_vec();
+        os_win_sel.push("name:firefox".to_string());
+        os_win_sel.push("os:windows".to_string());
+        let os_win =
+            BenchProfile::discover(&root, &Selectors::parse_many(&os_win_sel).unwrap()).unwrap();
+        assert_eq!(os_win.len(), 1);
+        assert_eq!(os_win[0].name, "bench-firefox-windows");
     }
 
     fn repo_profile(name: &str) -> PathBuf {

--- a/crates/kache-e2e/src/scenario.rs
+++ b/crates/kache-e2e/src/scenario.rs
@@ -122,6 +122,17 @@ impl Selectors {
     pub fn matches_metadata(&self, metadata: &ScenarioMetadata) -> bool {
         self.matches(&metadata.name, metadata.source_kind, &metadata.tags)
     }
+
+    /// Needles from any `name:<needle>` selectors. `name:` is a substring
+    /// filter, so callers that must resolve to a single scenario (the bench
+    /// runner) use these to prefer an exact-name match when the substring is
+    /// ambiguous — e.g. `firefox` also catches `bench-firefox-windows`.
+    pub fn name_needles(&self) -> Vec<&str> {
+        self.items
+            .iter()
+            .filter_map(|s| s.raw().strip_prefix("name:"))
+            .collect()
+    }
 }
 
 /// Tags used for matching. Source kind is always implicit, and the default

--- a/scenarios/bench-firefox-windows/scenario.toml
+++ b/scenarios/bench-firefox-windows/scenario.toml
@@ -3,8 +3,11 @@
 # Same project, ref, and build driver as `bench-firefox`, but tuned for the
 # self-hosted `kunobi-windows` runner where Firefox builds with clang-cl + MSVC
 # under MozillaBuild. It exists as its OWN scenario (bench profiles have no
-# per-OS `[windows]` override, unlike e2e fixtures), selected with the
-# `os:windows` tag so the Linux nightly's `--profile firefox` never picks it up.
+# per-OS `[windows]` override, unlike e2e fixtures). It is reached by its fuller
+# `firefox-windows` profile name, so the host-native nightly's `bench firefox`
+# (which disambiguates to the exact `bench-firefox` scenario) never picks it up.
+# The `os:windows` tag below is accurate metadata (this scenario genuinely
+# requires Windows), not a selection workaround.
 #
 # v1 scope: a single reference clone + two git worktrees (the harness default),
 # i.e. cold in clone-a then warm in clone-b. Cross-clone cache-key CONVERGENCE

--- a/scenarios/bench-firefox/scenario.toml
+++ b/scenarios/bench-firefox/scenario.toml
@@ -1,6 +1,11 @@
 # Firefox compile-cache benchmark scenario for kache-scenario.
 name     = "bench-firefox"
-tags     = ["suite:bench", "project:firefox", "backend:kache", "lang:cc", "lang:cpp", "lang:rust", "os:linux"]
+# No `os:` tag: this scenario builds natively on whatever host runs it
+# (Linux or macOS in CI), so an `os:linux` discriminator would lie about the
+# build target. `just bench firefox` resolves to this scenario via exact-name
+# disambiguation, not an OS tag (#458). The Windows variant is a separate
+# scenario reached by its fuller `firefox-windows` profile name.
+tags     = ["suite:bench", "project:firefox", "backend:kache", "lang:cc", "lang:cpp", "lang:rust"]
 
 # No `requires`: it's a PATH check for external tools the harness needs
 # around the checkout (cf. substrate's cargo/rustc). Firefox's build


### PR DESCRIPTION
Closes #458.

## Problem
`just bench firefox` matched **both** `bench-firefox` and `bench-firefox-windows` and failed with "matched multiple scenarios", because `--profile firefox` is a name SUBSTRING match. The workaround `--select os:linux` then *looked* like it forced a Linux build, when `bench-firefox` actually builds natively on whatever host runs it (macOS in recent runs). The `os:linux` tag was a selection discriminator masquerading as a build target.

## Fix
- `BenchProfile::discover` now disambiguates: when a substring `name:` profile matches several scenarios but exactly one carries the named scenario (`<needle>` or `bench-<needle>`), it prefers that one. So `bench firefox` → `bench-firefox` and `bench firefox-windows` → `bench-firefox-windows`, no `os:` workaround needed. A genuinely ambiguous substring with no exact hit is left for the existing "matched multiple scenarios" guard.
- Dropped the misleading `os:linux` tag from `bench-firefox`. Kept the **accurate** `os:windows` on `bench-firefox-windows` (it genuinely requires Windows) — now metadata, not a required disambiguator.
- Updated `bench.yml`: the Linux arm runs `bench firefox` (no `--select os:linux`); the Windows arm runs `bench firefox-windows` (no `--select os:windows`).

## Acceptance (from the issue)
- ✅ `just bench firefox` selects exactly one scenario without an `os:`-flavored workaround.
- ✅ No tag implies a build OS the scenario does not actually require.

## Tests
Rewrote `discover_disambiguates_short_profile_to_exact_name`: asserts `name:firefox` resolves to exactly `bench-firefox`, `name:firefox-windows` to the Windows variant, and `os:windows` still selects the Windows variant.