### PR TITLE
test(bench): add SurrealDB compile-cache scenario to the bench suite

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,8 @@
 name: Bench
 
 # Clone benchmark — builds kache from THIS ref and runs the cross-clone
-# cold/warm scenarios (Firefox, Substrate) against one shared cache, then
+# cold/warm scenarios (Firefox, Substrate, SurrealDB, LLVM) against one shared
+# cache, then
 # uploads the reports. This is the heavy, hours-long, tens-of-GB-disk job the
 # bench engine's doc-comment says is "intentionally NOT wired into [PR] CI": it
 # lives in its own workflow so it never blocks a push/PR.
@@ -30,7 +31,7 @@ on:
       scenario:
         description: "Which scenario(s) to run"
         type: choice
-        options: [all, substrate, firefox, firefox-sccache, llvm, firefox-windows]
+        options: [all, substrate, surrealdb, firefox, firefox-sccache, llvm, firefox-windows]
         default: all
       extra_args:
         description: "Extra args appended to `just bench <profile>` (e.g. --skip-clone, --retry)"
@@ -77,6 +78,11 @@ jobs:
           #
           # Smaller than Firefox but still tens of minutes cold.
           substrate='{"name":"substrate","cmd":"bench substrate","dir":"bench-substrate","timeout":180,"min_free_gb":60}'
+          # SurrealDB's `surreal` server binary at default features — a large
+          # pure-Rust workspace whose default features also drag in native C/C++
+          # deps (rocksdb, grpcio, quickjs) that build outside kache. Comparable
+          # weight to substrate; same native-prereq set (already installed below).
+          surrealdb='{"name":"surrealdb","cmd":"bench surrealdb","dir":"bench-surrealdb","timeout":180,"min_free_gb":80}'
           # Full cold Firefox build is the long pole — hours. `bench firefox`
           # resolves to the exact `bench-firefox` scenario: `--profile firefox`
           # is a name SUBSTRING match that also catches `bench-firefox-windows`,
@@ -90,10 +96,11 @@ jobs:
           llvm='{"name":"llvm","cmd":"bench llvm","dir":"bench-llvm","timeout":240,"min_free_gb":100}'
           case "$SCENARIO" in
             substrate)       inc="[$substrate]" ;;
+            surrealdb)       inc="[$surrealdb]" ;;
             firefox)         inc="[$firefox]" ;;
             firefox-sccache) inc="[$firefox_sccache]" ;;
             llvm)            inc="[$llvm]" ;;
-            *)               inc="[$substrate,$firefox,$firefox_sccache,$llvm]" ;;
+            *)               inc="[$substrate,$surrealdb,$firefox,$firefox_sccache,$llvm]" ;;
           esac
           echo "matrix={\"include\":$inc}" >> "$GITHUB_OUTPUT"
 
@@ -126,7 +133,9 @@ jobs:
 
       # The ARC runner image is minimal. Install the base toolchain the bench
       # needs around the build: substrate links rocksdb/secp256k1 and needs
-      # protoc + clang + cmake + openssl headers; Firefox's `./mach bootstrap`
+      # protoc + clang + cmake + openssl headers (SurrealDB's default features
+      # need the same set — rocksdb bindgen wants libclang, storage-tikv/grpcio
+      # wants protoc); Firefox's `./mach bootstrap`
       # pulls its own clang/rust toolchain but still needs python3 + common
       # archive/file utilities present first; the LLVM scenario drives CMake
       # with the Ninja generator, so it needs ninja-build. git/curl are needed by

--- a/scenarios/bench-surrealdb/scenario.toml
+++ b/scenarios/bench-surrealdb/scenario.toml
@@ -1,0 +1,59 @@
+# SurrealDB compile-cache benchmark scenario for kache-scenario.
+# A large pure-Rust Cargo workspace — kache wires in via RUSTC_WRAPPER only
+# (set by the engine), caching every crate compile in the `surreal` server
+# binary's dependency graph. Like substrate, the native C/C++ deps that the
+# default features pull in — rocksdb (storage-rocksdb), grpcio (storage-tikv),
+# and quickjs (scripting) — compile OUTSIDE kache by design (no CC/CXX wrapper
+# here); only their Rust crates are cached.
+name = "bench-surrealdb"
+tags = ["suite:bench", "project:surrealdb", "backend:kache", "lang:rust"]
+
+requires = ["cargo", "rustc"]
+
+# SurrealDB ships a rust-toolchain.toml (channel = "1.95"), so — unlike
+# substrate — there is NOTHING to pin here: rustup auto-installs and selects
+# that toolchain on the first cargo invocation in the tree, and the bench
+# workflow clears RUSTUP_TOOLCHAIN so the file is honoured (a forced pin would
+# override it). The only out-of-band need is native system deps for the default
+# storage/scripting features; they are NOT auto-installed — the bench runner
+# already provisions them (see .github/workflows/bench.yml), and the echo below
+# documents them for a local run.
+setup = [
+  "echo '[bench] surrealdb default features need system deps: clang + libclang (rocksdb bindgen), cmake, protoc (storage-tikv/grpcio), pkg-config, openssl headers, a C/C++ compiler. macOS: brew install protobuf cmake llvm. Debian: apt install build-essential protobuf-compiler clang libclang-dev cmake pkg-config libssl-dev.'",
+]
+
+# Build the `surreal` server binary with its DEFAULT features (storage-mem,
+# storage-surrealkv, storage-rocksdb, storage-tikv, scripting, http, graphql,
+# mcp, cli, allocator, …) — i.e. what SurrealDB actually ships, the fairest
+# representative workload for the cache. macOS prelude mirrors substrate:
+# librocksdb-sys's bindgen build script links @rpath/libclang.dylib with no
+# embedded rpath, so point the loader (and clang-sys via LIBCLANG_PATH) at the
+# active Xcode/CLT lib — no-op off macOS or when LIBCLANG_PATH is already set.
+# No RUSTUP_TOOLCHAIN pin: the tree's rust-toolchain.toml drives toolchain
+# selection. This shell lives in config rather than Rust, which is the whole
+# point of scenarios.
+build = """
+if [ "$(uname)" = Darwin ]; then
+  for d in "$(xcode-select -p 2>/dev/null)/Toolchains/XcodeDefault.xctoolchain/usr/lib" /Library/Developer/CommandLineTools/usr/lib; do
+    if [ -f "$d/libclang.dylib" ]; then
+      [ -n "${LIBCLANG_PATH:-}" ] || export LIBCLANG_PATH="$d"
+      export DYLD_FALLBACK_LIBRARY_PATH="$d${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+      break
+    fi
+  done
+fi
+cargo build --release -p surreal
+"""
+
+[source]
+kind = "clone"
+repo = "https://github.com/surrealdb/surrealdb.git"
+# Latest stable release as of 2026-06-29. This tag pins Rust via
+# rust-toolchain.toml (channel "1.95"), honoured automatically (see setup note).
+ref    = "v3.1.5"
+objdir = "target"
+
+[checks.assert.warm]
+min_key_stability_pct = 50.0
+max_passthrough_pct = 40.0
+max_errors = 0


### PR DESCRIPTION
## What

Adds **`bench-surrealdb`** as a new compile-cache benchmark scenario, alongside the existing substrate / firefox / llvm scenarios. It clones `surrealdb/surrealdb@v3.1.5` (latest stable) and runs the cross-clone cold/warm benchmark over `cargo build --release -p surreal` at **default features** — a large pure-Rust Cargo workspace driven through `RUSTC_WRAPPER`.

## Why

SurrealDB is a big, real-world Rust workspace that exercises exactly what kache caches: a deep crate graph, plus default features that drag in native C/C++ deps (rocksdb, grpcio, quickjs) which build *outside* kache by design. It complements substrate (Polkadot) and broadens the nightly bench's real-project coverage.

## Changes

- **`scenarios/bench-surrealdb/scenario.toml`** — mirrors `bench-substrate`.
  - No toolchain pin needed: the tree ships `rust-toolchain.toml` (channel `1.95`) and the bench workflow clears `RUSTUP_TOOLCHAIN`, so it is honored automatically.
  - Native C/C++ deps from default features compile outside kache; only their Rust crates are cached. macOS `libclang` prelude matches substrate (rocksdb bindgen).
- **`.github/workflows/bench.yml`** — adds `surrealdb` to the dispatch menu, a matrix arm (`timeout 180m`, `min_free_gb 80`), the case branch, and the nightly `all` set. **No apt changes**: SurrealDB's native deps (libclang, cmake, protoc, openssl) are already installed for substrate.

## Verification

- `kache-scenario --list` discovers `surrealdb`; `bench surrealdb` resolves uniquely (no substring collision).
- YAML + TOML parse; dispatch options correct.
- `v3.1.5` confirmed to pin Rust 1.95 and carry the same default features (rocksdb + tikv).
- No new `actionlint` warnings (the 2 reported pre-exist on `main`).

**Not** run here: the full cold+warm bench (multi-hour, ~80 GB build of SurrealDB twice) — that's what the nightly CI on the `kunobi-runners` scale-set is for. This PR is verified-as-wired, to be exercised by the nightly (or a manual `workflow_dispatch` → scenario `surrealdb`).