### PR TITLE
bench(surrealdb): byte-reproducible native libs across clones (partial #471)

### DIFF
--- a/scenarios/bench-surrealdb/scenario.toml
+++ b/scenarios/bench-surrealdb/scenario.toml
@@ -42,6 +42,42 @@ if [ "$(uname)" = Darwin ]; then
     fi
   done
 fi
+
+# Cross-clone cache-key portability (the headline metric this bench measures).
+# Each clone builds at a different absolute path; without help a few EXPENSIVE
+# crates re-key across clones and tank the compile-time-WEIGHTED warm hit rate
+# (~47%) even though count hit rate is ~97%. These knobs make the native build
+# byte-reproducible across clones. They change build PATHS and determinism, not
+# WHAT is built — the feature set stays exactly what SurrealDB ships, so the
+# workload remains faithful (mirrors bench-firefox's KACHE_BASE_DIR usage).
+#
+# What this recovers (validated by --trace-keys, run 28462889652):
+#   - tikv-jemalloc-sys / libjemalloc_pic.a becomes byte-identical -> warm HIT
+#     (autotools build with path-stable object names; only the timestamp/path
+#     reproducibility axes diverged, which these flags pin).
+#
+# Known residuals it does NOT fix (root-caused; tracked in #471):
+#   - rquickjs-sys / libquickjs.a (and wasm-opt-cc): the .o CONTENT is identical
+#     across clones, but the `cc` crate names each archive MEMBER with a hash
+#     derived from the absolute build path (cafca65b…-quickjs.o vs 4af22b2a…),
+#     and kache content-hashes the .a including those names. -ffile-prefix-map
+#     can't touch member names — needs an upstream cc/rquickjs path-stable-name
+#     fix, or a kache-core "hash static= members by content, ignore name" change
+#     (safe: member names don't affect linking). This cascades into the big
+#     surrealdb_core/server crates via scripting.
+#   - DEBUG_OUTPUT_DIR (wasmtime/wiggle) and OUT_DIR (cxx `scratch`): kache keeps
+#     these ABSOLUTE because they fail its include-only / no-runtime-value gate
+#     (genuine runtime value use). KACHE_PATH_ONLY_ENV_VARS=DEBUG_OUTPUT_DIR was
+#     tried and confirmed a NO-OP (the gate still kept it absolute, as it must to
+#     avoid miscaching), so it is intentionally NOT set here.
+src="$(pwd -P)"
+prefix_map="-ffile-prefix-map=$src=. -fdebug-prefix-map=$src=. -fmacro-prefix-map=$src=."
+export CFLAGS="${CFLAGS:-} $prefix_map"
+export CXXFLAGS="${CXXFLAGS:-} $prefix_map"
+export SOURCE_DATE_EPOCH=1735689600
+export ZERO_AR_DATE=1
+export KACHE_BASE_DIR="$src"
+
 cargo build --release -p surreal
 """
 


### PR DESCRIPTION
Partial fix for #471 (cross-clone weighted hit-rate gap). Adds scenario-side reproducibility knobs to `bench-surrealdb`; **no kache core change** (a core path-invariant `.a` *content* digest would restore wrong bytes — verified hazard).

## What it does

Exports into the build: `-ffile-prefix-map`/`-fdebug-prefix-map`/`-fmacro-prefix-map`, `SOURCE_DATE_EPOCH`, `ZERO_AR_DATE`, `KACHE_BASE_DIR`. These change build *paths*/determinism, not *what* is built — feature set stays exactly what SurrealDB ships (mirrors `bench-firefox`).

## Result (validated by `--trace-keys`, run 28462889652)

| | before | after |
|---|---|---|
| weighted warm hit rate | 47.5% | **49.9%** |
| key stability | 96.9% | **97.1%** |
| verdict | ok | **ok** |

✅ **`tikv-jemalloc-sys`/`libjemalloc_pic.a` is now byte-identical across clones → warm HIT.**

## Root-caused residuals (NOT fixed here — tracked in #471)

A local two-path repro (`ar`/`cmp`/`xxd`) pinned the remaining `quickjs` miss precisely:

- **`rquickjs-sys`/`libquickjs.a` + `wasm-opt-cc`**: the `.o` content is **byte-identical** across clones; only the archive **member names** differ — the `cc` crate names each object with a hash of the absolute build path (`cafca65b…-quickjs.o` vs `4af22b2a…-quickjs.o`), and kache content-hashes the `.a` including names. `-ffile-prefix-map` can't touch member names (confirmed: applied, still differs). Needs upstream `cc`/rquickjs path-stable names, **or** a kache-core change to hash `static=` members by *content* ignoring the name (safe — member names don't affect linking). Cascades into `surrealdb_core`/`server` via scripting.
- **`DEBUG_OUTPUT_DIR` / `OUT_DIR`** (wasmtime/wiggle, cxx `scratch`): kache keeps them absolute because they fail its include-only / no-runtime-value gate (genuine runtime value use). Forcing normalization would miscache; `KACHE_PATH_ONLY_ENV_VARS=DEBUG_OUTPUT_DIR` was tried and confirmed a **no-op**, so it's not set.

## Notes

- Cross-family (codex) review shaped the plan and safety boundaries. The jemalloc-vs-quickjs fixability split was settled by the `.a`-member experiment — which **flipped** both lineages' prediction (they expected quickjs easy / jemalloc hard; reality was the reverse, for the member-name reason above).
- Stacked on #472 (now merged), rebased onto `main` — single-commit diff.

Refs #471 (kept open for the remaining cc-member-name root).