### PR TITLE
docs(ci): note immutable-release dependency on the release job (#481)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,6 +655,14 @@ jobs:
     # disagrees with the manifest BEFORE any binary builds; `e2e` includes the
     # (blocking) Windows arm, so a tag won't release unless Windows e2e is green.
     needs: [check, nix-package, e2e, test-macos, test-windows, version-consistency]
+    # This repo has GitHub immutable releases ENABLED: publishing a release locks
+    # its tag + assets (they can't be added/modified/deleted afterward). That
+    # REQUIRES the reusable workflow to create the release as a draft, attach all
+    # assets, then publish as the final step — which @v10 does (see
+    # Zondax/_workflows#110). Do NOT pin back to a tag predating that change, or
+    # the post-publish asset uploads will be rejected and releases will break. The
+    # `release: published` event package-publish.yml triggers on still fires (from
+    # the publish transition at the end of the `Upload release assets` job).
     uses: zondax/_workflows/.github/workflows/_release-rust.yml@v10
     with:
       binary_name: kache


### PR DESCRIPTION
## Goal — closes #481

Enable **immutable releases** so the signed binaries we ship on GitHub can't be altered or replaced after publish (supply-chain hardening; `kache-action` and the package managers pull from these releases).

## The problem

Binaries are already **signed** (Authenticode + macOS notarization + PGP via `_release-rust.yml`), but releases are **not immutable** — confirmed off:
```
GET /repos/kunobi-ninja/kache/immutable-releases → {"enabled":false}
```
We can't just flip the switch. Immutability locks the tag + assets **at publish time**, but the old release flow *published first, then uploaded assets* — which immutability would reject, breaking every release. Fix: **draft → upload → publish** (Zondax/_workflows#110).

## This PR

Since Zondax/_workflows#110 is **backward-compatible** (identical final state), the `v10` tag is moved forward to include it rather than split — so **kache stays pinned to `@v10`** and needs no functional change. This PR is **doc-only**: it records the immutable-release constraint on the release job so the pin isn't later rolled back to a tag predating the draft→publish flow.

## Rollout / merge order ⚠️

1. Merge **Zondax/_workflows#110**, then advance **both `v10` and `v11`** tags to that commit (no split; both carry the backward-compatible flow).
2. Merge this PR.
3. Enable the setting: `gh api -X PUT /repos/kunobi-ninja/kache/immutable-releases` (reversible via `DELETE`) — must come **after** the tag move, or the next release breaks.