### PR TITLE
chore(release): bump kache to v0.9.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more. No copies, no wasted disk — just hardlinks locally and S3 for sharing."
 license = "Apache-2.0"
@@ -45,7 +45,7 @@ aws-smithy-http-client = { version = "1", features = ["rustls-ring"] }
 # Direct dep so we can install ring as the process-wide rustls crypto
 # provider (reqwest uses `rustls-no-provider`, so one must be installed).
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.8.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.9.0-rc.1", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bumps the kache workspace version to **v0.9.0-rc.1** (unstable prerelease).

## Context
First release cut with **GitHub immutable releases enabled** (#481). The release job now runs `_release-rust@v10`'s draft→upload→publish flow, so this prerelease should publish with `immutable: true` and show the **Immutable** badge on its release page.

## Release plan
- Squash this PR after CI is green.
- From synced `main`, run `just release` (reads the merged manifest version, cuts `v0.9.0-rc.1`).
- Monitor CI (gated release job), Service Image, Publish crates, Package Publish, then Homebrew + Winget downstream PRs.