### PR TITLE
docs: drop failing Docs.rs badge from kache README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # kache
 
 [![Crates.io](https://img.shields.io/crates/v/kache.svg)](https://crates.io/crates/kache)
-[![Docs.rs](https://img.shields.io/docsrs/kache)](https://docs.rs/kache)
 [![CI](https://github.com/kunobi-ninja/kache/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/kunobi-ninja/kache/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue.svg)](Cargo.toml)


### PR DESCRIPTION
Follow-up to #488.

kache is a **binary-only crate** (no `lib` target). docs.rs runs `cargo rustdoc --lib` and fails with:

```
error: no library targets found in package `kache`
```

so the Docs.rs badge is permanently red. This removes it and keeps the Crates.io badge (still useful for `cargo install kache`).

Row is now: **Crates.io → CI → License → MSRV**.