### PR TITLE
fix(link): show affected path in Windows no-CoW copy-restore warning (#490)

### DIFF
--- a/src/link.rs
+++ b/src/link.rs
@@ -100,7 +100,7 @@ pub fn link_to_target(store_path: &Path, target_path: &Path, strategy: LinkStrat
                 // trade the read-only-output risk for working-tree dedup.
                 hardlink_or_copy(store_path, target_path, bytes)
             } else {
-                warn_no_cow_restore_once();
+                warn_no_cow_restore_once(store_path, target_path);
                 copy_file(store_path, target_path, false)?;
                 crate::opcounts::record_copied(bytes);
                 Ok(())
@@ -144,26 +144,86 @@ fn hardlink_or_copy(store_path: &Path, target_path: &Path, bytes: u64) -> Result
     Ok(())
 }
 
-/// Warn ONCE per process that cache hits are being restored by copy on this
-/// non-CoW Windows volume (NTFS), so the cache and build tree don't share
-/// storage. One warning per compilation (each TU is its own process); it fires
-/// only when a hit is actually copy-restored, so a compile that misses stays
-/// silent. ReFS (a Dev Drive) block-clones instead and never reaches here, and
-/// `[cache] windows_hardlink = true` opts back into hardlinking.
+/// Warn ONCE per process that cache hits are being restored by copy because
+/// this Windows restore couldn't block-clone, so the cache and build tree don't
+/// share storage. One warning per compilation (each TU is its own process); it
+/// fires only when a hit is actually copy-restored, so a compile that misses
+/// stays silent.
+///
+/// The reflink that just failed (`FSCTL_DUPLICATE_EXTENTS_TO_FILE`) fails for
+/// two distinct reasons, and the fix differs, so we tell them apart from the
+/// cache-blob and build-output paths (#490):
+///
+/// - **Cross-volume**: the cache blob and the build output live on different
+///   volumes. Block-cloning cannot span volumes (nor can hardlinks), so even on
+///   two ReFS Dev Drives this copies. This is the likely case for a Dev Drive
+///   user who still sees the warning — the fix is to co-locate cache + build on
+///   the *same* volume, not to touch the filesystem.
+/// - **Same volume, no CoW (NTFS)**: the volume simply has no block-cloning.
+///   Move both onto a ReFS Dev Drive, or opt into `[cache] windows_hardlink`.
+///
+/// Including the paths lets the user see *which* file and *which* volumes are
+/// involved instead of guessing.
 #[cfg(windows)]
-fn warn_no_cow_restore_once() {
+fn warn_no_cow_restore_once(store_path: &Path, target_path: &Path) {
     use std::sync::Once;
     static WARNED: Once = Once::new();
     WARNED.call_once(|| {
-        eprintln!(
-            "kache: this volume has no copy-on-write (NTFS), so cache hits are \
-             restored by COPY — the cache and build tree do not share storage, \
-             roughly doubling disk for cached content. For zero-copy dedup put \
-             the cache + build dir on a ReFS Dev Drive, or set \
-             `[cache] windows_hardlink = true` (only if your build never \
-             deletes or rewrites an object output)."
-        );
+        let cache_vol = windows_volume_root(store_path);
+        let build_vol = windows_volume_root(target_path);
+        let cross_volume = match (&cache_vol, &build_vol) {
+            (Some(a), Some(b)) => !a.eq_ignore_ascii_case(b),
+            // If we can't resolve a volume for either side, don't assert
+            // cross-volume — fall back to the NTFS wording.
+            _ => false,
+        };
+
+        if cross_volume {
+            eprintln!(
+                "kache: cache hits are restored by COPY because the cache and build \
+                 tree are on different volumes ({cache_vol} vs {build_vol}), and \
+                 copy-on-write block-cloning cannot span volumes — so they do not \
+                 share storage, roughly doubling disk for cached content. Put the \
+                 cache and build dir on the SAME volume (ideally a ReFS Dev Drive) \
+                 for zero-copy dedup.\n         cache blob:   {store}\n         \
+                 build output: {target}",
+                cache_vol = cache_vol.as_deref().unwrap_or("?"),
+                build_vol = build_vol.as_deref().unwrap_or("?"),
+                store = store_path.display(),
+                target = target_path.display(),
+            );
+        } else {
+            eprintln!(
+                "kache: this volume ({vol}) has no copy-on-write, so cache hits are \
+                 restored by COPY — the cache and build tree do not share storage, \
+                 roughly doubling disk for cached content. For zero-copy dedup put \
+                 the cache + build dir on a ReFS Dev Drive, or set \
+                 `[cache] windows_hardlink = true` (only if your build never \
+                 deletes or rewrites an object output).\n         affected output: \
+                 {target}",
+                vol = build_vol.as_deref().unwrap_or("NTFS"),
+                target = target_path.display(),
+            );
+        }
     });
+}
+
+/// Volume mount root (e.g. `C:\` or `D:\`) that holds `path`, or `None` if it
+/// can't be resolved. `path` need not exist; its nearest existing parent volume
+/// is used. Used to tell a cross-volume copy-restore from a no-CoW one (#490).
+#[cfg(windows)]
+fn windows_volume_root(path: &Path) -> Option<String> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::GetVolumePathNameW;
+
+    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    let mut root = [0u16; 260];
+    let ok = unsafe { GetVolumePathNameW(wide.as_ptr(), root.as_mut_ptr(), root.len() as u32) };
+    if ok == 0 {
+        return None;
+    }
+    let len = root.iter().position(|&c| c == 0).unwrap_or(root.len());
+    Some(String::from_utf16_lossy(&root[..len]))
 }
 
 /// Set 0o755 on a file. Applied after a successful reflink for the Copy


### PR DESCRIPTION
## Problem

Closes #490.

On Windows, when a cache hit can't be block-cloned it's restored by COPY and kache prints a warning. The message never said *which* path or volume was involved, so it was hard to act on — especially confusing for the reporter, who was building Firefox on a **ReFS Dev Drive** yet still saw the "no copy-on-write (NTFS)" warning.

The reason a Dev Drive user still hits the copy path is almost always **cross-volume**: `FSCTL_DUPLICATE_EXTENTS_TO_FILE` (and hardlinks) cannot span volumes, so if the cache dir and the build tree live on different drives the restore copies regardless of filesystem. The old message misattributed that to NTFS and gave advice (`windows_hardlink = true`) that wouldn't have helped.

## Change

`warn_no_cow_restore_once` now takes the cache-blob and build-output paths and resolves each side's volume root (`GetVolumePathNameW`, same helper pattern as `windows_cluster_size`) to distinguish the two real causes:

- **Cross-volume** — cache and build on different volumes. Reports both volume roots and both paths, and advises co-locating them on the same volume (block-cloning can't span volumes; `windows_hardlink` wouldn't help here, so it's not offered).
- **Same volume, no CoW (NTFS)** — reports the volume and the affected output path, keeping the ReFS Dev Drive / `windows_hardlink` guidance.

Still one warning per process (`Once`), still only when a hit is actually copy-restored.

### Example

Before:
```
kache: this volume has no copy-on-write (NTFS), so cache hits are restored by COPY — ...
```

After (cross-volume):
```
kache: cache hits are restored by COPY because the cache and build tree are on
different volumes (C:\ vs D:\), and copy-on-write block-cloning cannot span
volumes — ... Put the cache and build dir on the SAME volume (ideally a ReFS Dev Drive) ...
         cache blob:   C:\Users\...\.cache\kache\objects\1f\6c39...
         build output: D:\firefox\obj-x86_64-pc-windows-msvc\dom\...\Foo.o
```

## Testing

- `cargo check`, `cargo fmt`, `cargo clippy -p kache` clean on macOS.
- All changed code is `#[cfg(windows)]`; the LAN Windows box was offline, so Windows compilation is covered by CI's `cargo build --release -p kache` job on the Windows runner. The logic mirrors the existing `windows_cluster_size` / `GetVolumePathNameW` usage already in this file.