### PR TITLE
feat(cli): add shell completions from clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,6 +3405,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "clap",
+ "clap_complete",
  "crossterm",
  "dirs",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 rusqlite = { version = "0.40", features = ["bundled"] }
 ratatui = "0.30"
 crossterm = "0.29"

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
 | `kache purge [--crate-name <name>]` | Wipe entire cache or entries for a specific crate |
 | `kache clean [--dry-run]` | Find and delete `target/` directories with cache breakdown |
 | `kache config` | Open the TUI configuration editor |
+| `kache completions <shell>` | Print shell completion script (bash, zsh, fish, elvish, powershell) |
 | `kache daemon` | Show daemon and service status |
 | `kache daemon run` | Start the persistent background daemon (foreground) |
 | `kache daemon start` | Start daemon in background (returns immediately) |

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -25,6 +25,7 @@ When invoked without arguments, kache prints `--help` and exits — it does not 
 | `kache save-manifest [--manifest-key <key>] [--namespace <ns>]` | Save a build manifest for future prefetch warming |
 | `kache doctor [--fix [--purge-sccache]] [--verify] [--checksums] [--repair]` | Diagnose and fix setup issues; verify cache integrity |
 | `kache config` | Open the TUI configuration editor |
+| `kache completions <shell>` | Print shell completion script (bash, zsh, fish, elvish, powershell) |
 | `kache daemon [subcommand]` | Manage the background daemon |
 
 Duration arguments accept days or hours: `7d`, `24h`, or a bare number of hours like `48`. Minutes are not supported — a value like `30m` fails to parse and silently falls back to the default.
@@ -317,6 +318,39 @@ kache config
 ```
 
 Opens the TUI configuration editor. Shows all config fields, their current values, and which ones are overridden by environment variables. Saves changes to the active config file: `$KACHE_CONFIG` if set, else the nearest `.kache.toml` in a parent directory, else the global `~/.config/kache/config.toml` (`$XDG_CONFIG_HOME/kache/config.toml`).
+
+---
+
+## `kache completions`
+
+```sh
+kache completions <shell>
+```
+
+Prints a completion script for the given shell to stdout. Supported shells: `bash`, `zsh`, `fish`, `elvish`, `powershell`. Does not require a valid kache config.
+
+Install examples:
+
+```sh
+# zsh — write to a directory on fpath, then restart the shell
+mkdir -p ~/.zfunc
+kache completions zsh > ~/.zfunc/_kache
+# ensure fpath+=(~/.zfunc) before compinit, then: exec zsh
+
+# bash
+kache completions bash > ~/.local/share/bash-completion/completions/kache
+
+# fish
+kache completions fish > ~/.config/fish/completions/kache.fish
+```
+
+Alternatively, load completions for the current session:
+
+```sh
+eval "$(kache completions bash)"  # bash
+eval "$(kache completions zsh)"   # zsh (compinit must already be active)
+kache completions fish | source   # fish
+```
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,6 +232,13 @@ enum Commands {
 
     /// Open the configuration editor
     Config,
+
+    /// Generate shell completion scripts
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
 }
 
 #[derive(Subcommand)]
@@ -395,10 +402,18 @@ fn main() -> Result<()> {
     // CLI mode: parse subcommands
     let cli = Cli::parse();
 
-    // Config command loads its own raw config — handle before Config::load()
-    // so a broken config file can still be fixed via the editor.
-    if matches!(cli.command, Some(Commands::Config)) {
-        return config_tui::run_config_editor();
+    // Config and Completions run before Config::load() (broken/missing config).
+    match &cli.command {
+        Some(Commands::Config) => return config_tui::run_config_editor(),
+        Some(Commands::Completions { shell }) => {
+            use clap::CommandFactory;
+            use clap_complete::generate;
+            let mut cmd = Cli::command();
+            let name = cmd.get_name().to_string();
+            generate(*shell, &mut cmd, name, &mut std::io::stdout());
+            return Ok(());
+        }
+        _ => {}
     }
 
     let config = config::Config::load()?;
@@ -509,6 +524,7 @@ fn main() -> Result<()> {
             tui::run_monitor(&config, hours)
         }
         Some(Commands::Config) => unreachable!(),
+        Some(Commands::Completions { .. }) => unreachable!(),
         None => {
             // No subcommand — print help. New users often find an unexpected TUI
             // disorienting; they can still launch it explicitly with `kache monitor`.

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -128,7 +128,8 @@ fn help_lists_subcommands() {
         .success()
         .stdout(predicates::str::contains("list"))
         .stdout(predicates::str::contains("report"))
-        .stdout(predicates::str::contains("doctor"));
+        .stdout(predicates::str::contains("doctor"))
+        .stdout(predicates::str::contains("completions"));
 }
 
 #[test]
@@ -143,7 +144,16 @@ fn unknown_subcommand_is_a_usage_error() {
 
 #[test]
 fn subcommand_help_is_available() {
-    for sub in ["list", "report", "gc", "purge", "doctor", "stats", "sync"] {
+    for sub in [
+        "list",
+        "report",
+        "gc",
+        "purge",
+        "doctor",
+        "stats",
+        "sync",
+        "completions",
+    ] {
         let e = env();
         e.cmd()
             .args([sub, "--help"])
@@ -151,6 +161,62 @@ fn subcommand_help_is_available() {
             .success()
             .stdout(predicates::str::contains("Usage"));
     }
+}
+
+// ── shell completions ───────────────────────────────────────────────────────
+
+#[test]
+fn completions_zsh_emits_script() {
+    let e = env();
+    e.cmd()
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("#compdef"))
+        .stdout(predicates::str::contains("kache"));
+}
+
+#[test]
+fn completions_bash_emits_script() {
+    let e = env();
+    e.cmd()
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("complete"))
+        .stdout(predicates::str::contains("kache"));
+}
+
+#[test]
+fn completions_fish_emits_script() {
+    let e = env();
+    e.cmd()
+        .args(["completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("complete"))
+        .stdout(predicates::str::contains("kache"));
+}
+
+#[test]
+fn completions_invalid_shell_is_a_usage_error() {
+    let e = env();
+    e.cmd()
+        .args(["completions", "not-a-shell"])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn completions_work_with_broken_config() {
+    let e = env();
+    std::fs::write(e.cache.join("config.toml"), "{{{{ not toml").unwrap();
+    e.cmd()
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("#compdef"));
 }
 
 // ── empty-cache behavior ────────────────────────────────────────────────────


### PR DESCRIPTION
<!--
Thanks for sending a PR! Keep it focused on a single change — unrelated
refactors are easier to review separately. See CONTRIBUTING.md for the
full process.
-->

## Summary

<!-- What does this PR change and why? Link related issues. -->
I wrote [#493](https://github.com/kunobi-ninja/kache/issues/493) and decided to implement for fun. Happy to close/change/etc the PR however y'all see fit! 

This adds `clap`'s completions to `kache` so users can get shell completions via:
```bash
kache completions <shell>   # bash | zsh | fish | elvish | powershell
```

## Test plan

<!-- How did you verify the change? Commands run, scenarios covered.
Include before/after numbers for performance changes. -->

- [x] Add tests to `tests/cli_commands_test.rs`
- [x] Ran `just check`

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [x] User-visible changes (CLI, config, output) are reflected in the README or relevant docs
