### PR TITLE
chore(release): kache v0.9.0 (+ RUSTSEC-2026-0204 fix, SHA-pin CI actions)

### DIFF
--- a/.github/actions/setup-pgp-kms-signing/action.yml
+++ b/.github/actions/setup-pgp-kms-signing/action.yml
@@ -41,7 +41,7 @@ runs:
   using: 'composite'
   steps:
     - name: Authenticate with GCP (WIF)
-      uses: zondax/actions/gcp-wif-auth@v1
+      uses: zondax/actions/gcp-wif-auth@d31a633e95842c4c41534a30ffce8c57aed9d64a # v1.2.0
       with:
         workload_identity_provider: ${{ inputs.workload-identity-provider }}
         project_id: ${{ inputs.gcp-project-id }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -128,7 +128,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         timeout-minutes: 10
 
       # The ARC runner image is minimal. Install the base toolchain the bench
@@ -159,7 +159,7 @@ jobs:
       # mise-action puts the tools on PATH directly — none of the macOS
       # isolation/PATH workarounds from ci.yml are needed.
       - name: Install tools via mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           # Pin mise CLI — see ci.yml (v2026.6.10 regression).
           version: 2026.6.9
@@ -213,7 +213,7 @@ jobs:
         # upload even on a valid run and discarded build-cold.log. `if-no-files-found:
         # warn` already makes an empty match (e.g. after a precheck failure) a no-op.
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-${{ matrix.name }}
           # Reports, per-phase JSON/MD, key-diff, ALL top-level logs
@@ -256,7 +256,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         timeout-minutes: 10
 
       # Fail fast with an explicit checklist if a Firefox build prerequisite is
@@ -314,7 +314,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Install tools via mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           # Pin mise CLI — see ci.yml (v2026.6.10 regression).
           version: 2026.6.9
@@ -345,7 +345,7 @@ jobs:
 
       - name: Upload bench reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-firefox-windows
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,11 @@ jobs:
           # and stays Linux-only. macOS gets a dedicated, lighter `test-macos`
           # job below — see that job for the rationale.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # mise installs everything in mise.toml: rust (with rustfmt +
       # clippy via the rust tool-options block), just, helm, sccache,
       # cargo-llvm-cov.
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           # Pin the mise CLI. v2026.6.10 (2026-06-14) regressed binary
           # resolution ("mise ERROR cannot find binary path"), reddening every
@@ -81,8 +81,8 @@ jobs:
           # upstream fixes it.
           version: 2026.6.9
           cache: false
-      - uses: docker/setup-buildx-action@v4
-      - uses: kunobi-ninja/kache-action@v1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: kunobi-ninja/kache-action@49398d37113c616fdb61be434cb497e3c2c8f3e6 # v1
         with:
           github-cache: "true"
           cache-executables: "false"
@@ -122,7 +122,7 @@ jobs:
           print(f'OK: >= {threshold}%')
           "
       - name: Upload HTML coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # Skip on tag/release runs: the shared release workflow downloads *all*
         # run artifacts and `gh release upload artifacts/*` chokes on directory
         # artifacts like this one. Coverage HTML is only useful on PR/branch runs.
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Manifests agree (and match the tag on a v* tag)
         # Pass the ref via a quoted env var (not `${{ }}` interpolated into the
         # script) — a tag name can legally contain shell metacharacters.
@@ -182,13 +182,13 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # Install only what `just audit` needs — rust (for cargo), just, and
       # cargo-deny — via scoped install_args, so the rest of mise.toml (helm,
       # cmake, sccache, llvm-cov) doesn't build on this job. Tool names must
       # match the mise.toml keys. cargo-deny ships prebuilt via the aqua backend
       # (no from-source compile).
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           # Pin mise CLI — see the `check` job's note (v2026.6.10 regression).
           version: 2026.6.9
@@ -204,8 +204,8 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - name: Check flake evaluation
         run: nix flake check --no-build
       - name: Build flake package
@@ -262,7 +262,7 @@ jobs:
             runner: ${{ fromJSON('["self-hosted", "Windows", "X64", "kunobi-windows"]') }}
             exe_suffix: ".exe"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         # Checkout has hung on the persistent self-hosted runners' stale git
         # state (#208); a checkout never legitimately runs this long, so fail
         # fast rather than waiting out the whole job timeout.
@@ -337,7 +337,7 @@ jobs:
       # the github backend, so the full `github:mozilla/sccache`
       # identifier is required.
       - name: Install tools via mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         env:
           # jdx/mise-action extracts into `$TMPDIR/mise` before moving
           # the binary. On the shared macOS host, parallel runner
@@ -479,7 +479,7 @@ jobs:
         # artifact: the shared release workflow's `gh release upload
         # artifacts/*` would try to upload this directory as a release asset.
         if: always() && github.ref_type != 'tag'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-results-${{ matrix.os }}
           path: tmp/e2e/
@@ -505,7 +505,7 @@ jobs:
     # additionally capped at 30m); catches checkout/mise hangs.
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         # See the e2e job: checkout can hang on this persistent runner's stale
         # git state, so cap it well under the job timeout.
         timeout-minutes: 10
@@ -547,7 +547,7 @@ jobs:
       # Same setup as the `e2e` job — see that block for the
       # `cache: false` + `reshim: false` rationale.
       - name: Install Rust via mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         env:
           # See the e2e job: isolate mise's download/extract scratch
           # without changing TMPDIR for the later Cargo test process.
@@ -611,7 +611,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         timeout-minutes: 10
       # Fail fast if the runner is missing a build tool the dep graph needs
       # (ring → nasm, *-sys → cc). Mirrors the e2e job's check.
@@ -650,7 +650,7 @@ jobs:
           echo "MISE_CACHE_DIR=$RUNNER_TEMP/mise-cache" >> "$GITHUB_ENV"
           echo "MISE_STATE_DIR=$RUNNER_TEMP/mise-state" >> "$GITHUB_ENV"
       - name: Install Rust via mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         env:
           TMPDIR: ${{ env.MISE_DL_TMPDIR }}
           TEMP: ${{ env.MISE_DL_TMPDIR }}
@@ -691,7 +691,7 @@ jobs:
     # disagrees with the manifest BEFORE any binary builds; `e2e` includes the
     # (blocking) Windows arm, so a tag won't release unless Windows e2e is green.
     needs: [check, nix-package, e2e, test-macos, test-windows, version-consistency]
-    uses: zondax/_workflows/.github/workflows/_release-rust.yml@v10
+    uses: zondax/_workflows/.github/workflows/_release-rust.yml@7f61511b59d2b86454e65a6bbf48f14469692324 # v11
     with:
       binary_name: kache
       # Build .deb assets (kache_<version>_{amd64,arm64}.deb) for the apt repo,

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -60,7 +60,7 @@ jobs:
       channel: ${{ steps.resolve.outputs.channel }}
     steps:
       - name: Checkout (for scripts)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Resolve version and channel
         id: resolve
@@ -87,7 +87,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout (for scripts)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Wait for the release build to finish uploading assets
         if: github.event_name == 'release'
         env:
@@ -108,7 +108,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install apt-repo tooling
         # On the GitHub-hosted runner reprepro + rclone aren't preinstalled (gpg
@@ -223,7 +223,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Trigger Homebrew formula update
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.HOMEBREW_DISPATCH_TOKEN }}
           repository: kunobi-ninja/homebrew-kunobi

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -36,13 +36,17 @@ jobs:
       CARGO_TERM_COLOR: always
       RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned to the `stable` branch tip; the action reads the toolchain from
+      # the ref name, so a SHA pin needs the explicit `toolchain:` input below.
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: stable
 
-      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Check release tag matches Cargo manifests (and dep-pin)
         # The version gate: tag version (prerelease suffix included) == kache ==
@@ -89,7 +93,7 @@ jobs:
         id: auth
         # Pinned to v1.0.4: the floating @v1 tag still runs on the deprecated
         # Node 20 runtime; v1.0.4 is the first node24 release.
-        uses: rust-lang/crates-io-auth-action@v1.0.4
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
 
       - name: Publish kache-core
         env:

--- a/.github/workflows/service-image.yml
+++ b/.github/workflows/service-image.yml
@@ -33,8 +33,8 @@ jobs:
     name: Build Service Image (Dry Run)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build image (dry-run, no cache)
         run: docker buildx bake -f docker-bake.hcl --set '*.cache-from=' service
 
@@ -46,7 +46,7 @@ jobs:
       contents: read
       actions: read # read CI job conclusions for the pushed commit (gate below)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check tag matches manifest (tag builds)
         # A versioned image tag is derived from the git tag (see "Derive release
@@ -65,15 +65,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: ./scripts/require-ci-green.sh "$(git rev-parse HEAD)" "Check (Linux)"
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+# Config for `just pin-actions` / `just pin-actions-check`. Every GitHub Action
+# in .github/ is pinned to a full commit SHA; this file records the deliberate
+# exceptions so the check recipe stays green.
+version: 3
+rules:
+  # `dtolnay/rust-toolchain` has no semver tags — it's published only as branch
+  # refs (`stable`, `master`, `1.xx.0`). We DO pin it to a commit SHA (with a
+  # `# stable` comment + an explicit `toolchain: stable` input, since the action
+  # reads the toolchain from the ref name), but pinact can neither resolve a
+  # branch to pin it automatically nor `--verify` a non-semver `# stable`
+  # comment. So it's hand-managed: ignore it here and bump the SHA manually when
+  # you want a newer action release.
+  - ignore: true
+    conditions:
+      - expr: |
+          ActionName == "dtolnay/rust-toolchain"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,23 @@ just coverage-open  # coverage with HTML report
 just clean          # remove build artifacts
 ```
 
+### Hardening GitHub Actions
+
+Every action in `.github/` is pinned to a full commit SHA rather than a mutable
+`@vN` tag, so a compromised or repointed tag can't inject code into CI or the
+release pipeline. When you add or bump an action, run:
+
+```sh
+just pin-actions        # rewrite uses: owner/repo@vN -> @<sha> # vN, then commit
+just pin-actions-check  # verify everything is pinned (no edits); used to guard it
+```
+
+Both use [pinact](https://github.com/suzuki-shunsuke/pinact) (pinned in
+`mise.toml`) and need a GitHub token to resolve tags — they fall back to
+`gh auth token`. `dtolnay/rust-toolchain` has no semver tags, so it's pinned to
+a commit SHA by hand (with a `toolchain: stable` input) and excluded from pinact
+in `.pinact.yaml`; bump its SHA manually when you want a newer release.
+
 ## Code style
 
 - **Edition**: Rust 2024

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.9.0-rc.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3436,7 +3436,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.9.0-rc.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.9.0-rc.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.9.0-rc.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.9.0-rc.2"
+version = "0.9.0"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more. No copies, no wasted disk — just hardlinks locally and S3 for sharing."
 license = "Apache-2.0"
@@ -45,7 +45,7 @@ aws-smithy-http-client = { version = "1", features = ["rustls-ring"] }
 # Direct dep so we can install ring as the process-wide rustls crypto
 # provider (reqwest uses `rustls-no-provider`, so one must be installed).
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.9.0-rc.2", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.9.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/Justfile
+++ b/Justfile
@@ -78,6 +78,24 @@ audit:
         && cargo deny check --config "{{justfile_directory()}}/deny.toml" )
   done
 
+# Pin every GitHub Actions `uses:` to a full 40-char commit SHA (supply-chain
+# hardening — a mutable `@vN` tag can be repointed at malicious code). Runs
+# pinact, which rewrites `uses: owner/repo@vN` to `@<sha> # vN` in place across
+# .github/. Run it after adding or bumping any action, then commit the result.
+# Everything is SHA-pinned, including `dtolnay/rust-toolchain` (hand-managed —
+# it has no semver tags, see `.pinact.yaml`). Needs a GitHub token to resolve
+# tags → SHAs; falls back to `gh auth token` if GITHUB_TOKEN is unset.
+[group('dev')]
+pin-actions:
+  GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token)}" pinact run
+
+# Verify every action is already SHA-pinned (and the `# vN` comment matches the
+# SHA) WITHOUT editing files — exits non-zero if anything is unpinned or drifted.
+# Use in CI or before a release to guard the pinning.
+[group('dev')]
+pin-actions-check:
+  GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token)}" pinact run --check --verify
+
 # Run the end-to-end harness against every e2e scenario in scenarios/.
 # Builds kache + harness in release mode, drives each fixture through
 # cold → warm → noop, asserts per-fixture contracts against

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.9.0-rc.2"
+version = "0.9.0"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.9.0-rc.2"
+version = "0.9.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.9.0-rc.2"
+version = "0.9.0"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"

--- a/mise.toml
+++ b/mise.toml
@@ -26,6 +26,10 @@ cmake = "4.3.4"
 # binaries (no from-source compile, unlike the old cargo-audit pin).
 # Pinned to the same version the kunobi repos use.
 "aqua:EmbarkStudios/cargo-deny" = "0.19.4"
+# GitHub Actions SHA-pinning — `just pin-actions` / `pin-actions-check`. pinact
+# rewrites each `uses: owner/repo@vN` to a full commit SHA (supply-chain
+# hardening) and can verify the pins in CI. Prebuilt via the `aqua:` backend.
+"aqua:suzuki-shunsuke/pinact" = "4.1.0"
 # NOTE: `cargo-edit` (for `just bump`) is deliberately NOT listed here. It is a
 # local, maintainer-only tool used to cut a release; CI never bumps, so pinning
 # it would make every `mise install` compile it from source (it pulls in gix


### PR DESCRIPTION
## Summary

Cuts the **v0.9.0** stable release, and bundles two CI/supply-chain items that were needed/opportune alongside it.

### 1. Version bump → v0.9.0
- `0.9.0-rc.2` → `0.9.0` (stable) via `just bump 0.9.0`.
- Version consistency OK: kache == kache-core == kache-core dep-pin == 0.9.0.

### 2. Security: RUSTSEC-2026-0204 (required for green CI)
- Newly-published advisory — invalid pointer deref in `crossbeam-epoch`'s `fmt::Display` for `Atomic`/`Shared`. Transitive via `surrealdb` (kache-service). It was failing the `Dependency audit` (`cargo deny`) job.
- Fix: lockfile-only bump `crossbeam-epoch 0.9.18 → 0.9.20`. `just audit` green across all 4 workspace members.

### 3. Supply-chain hardening: SHA-pin all GitHub Actions
- Every action in `.github/` is pinned from a mutable `@vN` tag to a full 40-char commit SHA (`@<sha> # vN`), via [pinact](https://github.com/suzuki-shunsuke/pinact). A mutable tag can be repointed at malicious code; a SHA can't.
- Adds **`just pin-actions`** (apply) and **`just pin-actions-check`** (verify, no edits) — pinact pinned in `mise.toml`, config in `.pinact.yaml`, documented in `CONTRIBUTING.md` — so pins are easy to refresh going forward.
- `dtolnay/rust-toolchain` has no semver tags, so it's SHA-pinned by hand with an explicit `toolchain: stable` input and excluded from pinact in `.pinact.yaml`.
- Note: `zondax/_workflows/_release-rust.yml@v10` resolves to the same commit as `v11`, so pinact labels its `# v11` — same code, no behavior change.

## Release plan
- Squash after CI is green.
- From synced main, run `just release` (cuts + pushes the `v0.9.0` tag).
- Monitor CI, Service Image, Publish crates, Package Publish, then Homebrew + Winget downstream PRs.