### PR TITLE
feat(clean): non-interactive `kache clean -y` + `-n` dry-run alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
 | `kache save-manifest [--manifest-key <key>] [--namespace <ns>]` | Save a build manifest for future prefetch warming; `--manifest-key` overrides the default host-target-triple key |
 | `kache gc [--max-age <dur>]` | Garbage collect — LRU eviction or age-based cleanup |
 | `kache purge [--crate-name <name>]` | Wipe entire cache or entries for a specific crate |
-| `kache clean [--dry-run]` | Find and delete `target/` directories with cache breakdown |
+| `kache clean [-n \| --dry-run] [-y \| --yes]` | Find and delete `target/` directories with cache breakdown (interactive; `-n` previews, `-y` removes all non-interactively for scripts/cron) |
 | `kache config` | Open the TUI configuration editor |
 | `kache completions <shell>` | Print shell completion script (bash, zsh, fish, elvish, powershell) |
 | `kache daemon` | Show daemon and service status |

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -20,7 +20,7 @@ When invoked without arguments, kache prints `--help` and exits — it does not 
 | `kache report [--format <fmt>] [--since <dur>] [--root <path>] [--output <path>] [--top <n>]` | Build report in text / json / trace / markdown / github format |
 | `kache gc [--max-age <dur>]` | Evict entries by LRU or age |
 | `kache purge [--crate-name <name>]` | Wipe entire cache or entries for one crate |
-| `kache clean [--dry-run]` | Find and remove `target/` directories |
+| `kache clean [-n \| --dry-run] [-y \| --yes]` | Find and remove `target/` directories (interactive; `-n` previews, `-y` removes all non-interactively) |
 | `kache sync [flags]` | Sync local cache with S3 remote |
 | `kache save-manifest [--manifest-key <key>] [--namespace <ns>]` | Save a build manifest for future prefetch warming |
 | `kache doctor [--fix [--purge-sccache]] [--verify] [--checksums] [--repair]` | Diagnose and fix setup issues; verify cache integrity |
@@ -192,10 +192,12 @@ kache purge --crate-name tokio     # remove all tokio entries
 ## `kache clean`
 
 ```sh
-kache clean [--dry-run]
+kache clean [-n | --dry-run] [-y | --yes]
 ```
 
 Recursively finds all `target/` directories under the current directory and removes them. Reports disk usage per directory before deleting, including how much of each `target/` is already cached in kache's store — so you can see at a glance which projects are safe to wipe.
+
+With no flags, `clean` opens an interactive selector (shown below). For scripts and cron, pass `-y`/`--yes` to skip the selector and remove **every** `target/` directory found, or `-n`/`--dry-run` to preview what would be removed without deleting. If both are given, `--dry-run` wins.
 
 ![kache clean TUI listing target/ dirs with cached percentages and per-directory breakdown](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/clean.gif)
 
@@ -238,8 +240,9 @@ Static layout for reference:
 ```
 
 ```sh
-kache clean --dry-run    # preview what would be deleted
-kache clean              # delete all target/ directories
+kache clean              # interactive selector
+kache clean -n           # preview what would be deleted (alias: --dry-run)
+kache clean -y           # non-interactive: delete all target/ dirs (alias: --yes)
 ```
 
 This is useful for freeing disk space when you're done with a project or before a fresh build.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1443,7 +1443,7 @@ fn draw_clean(
 }
 
 /// Recursively find and remove target/ directories (TUI selector).
-pub fn clean(dry_run: bool) -> Result<()> {
+pub fn clean(dry_run: bool, yes: bool) -> Result<()> {
     use crossterm::ExecutableCommand;
     use crossterm::event::{self, Event, KeyEventKind};
     use crossterm::terminal::{
@@ -1465,10 +1465,23 @@ pub fn clean(dry_run: bool) -> Result<()> {
     // Sort by size descending
     targets.sort_by_key(|entry| std::cmp::Reverse(entry.size));
 
+    // `--dry-run` takes precedence over `--yes`: preview only, never delete.
     if dry_run {
         for line in render_clean_dry_run(&targets, &root) {
             println!("{line}");
         }
+        return Ok(());
+    }
+
+    // `--yes`: non-interactive, remove every discovered target/ dir. Meant for
+    // scripts and cron where the interactive selector cannot run.
+    if yes {
+        let to_remove: Vec<_> = targets.iter().map(|t| (t.path.clone(), t.size)).collect();
+        let (removed, freed) = remove_targets(&to_remove, &root);
+        println!(
+            "\nRemoved {removed} target/ dirs, freed {}",
+            ByteSize(freed)
+        );
         return Ok(());
     }
 
@@ -1517,21 +1530,7 @@ pub fn clean(dry_run: bool) -> Result<()> {
             println!("Nothing selected.");
         }
         Some(to_remove) => {
-            let mut freed = 0u64;
-            let mut removed = 0usize;
-            for (path, size) in &to_remove {
-                let rel = path.strip_prefix(&root).unwrap_or(path);
-                match std::fs::remove_dir_all(path) {
-                    Ok(()) => {
-                        freed += size;
-                        removed += 1;
-                        println!("  removed {}", rel.display());
-                    }
-                    Err(e) => {
-                        println!("  failed  {} — {e}", rel.display());
-                    }
-                }
-            }
+            let (removed, freed) = remove_targets(&to_remove, &root);
             println!(
                 "\nRemoved {removed} target/ dirs, freed {}",
                 ByteSize(freed)
@@ -1540,6 +1539,30 @@ pub fn clean(dry_run: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Delete each `(path, size)` target/ dir, printing a per-directory `removed` /
+/// `failed` line (paths shown relative to `root`). A failure on one directory is
+/// reported and skipped, never aborting the rest. Returns `(removed_count,
+/// freed_bytes)` — bytes are only counted for directories that were actually
+/// removed. Shared by the interactive TUI path and the non-interactive `--yes` path.
+fn remove_targets(to_remove: &[(std::path::PathBuf, u64)], root: &std::path::Path) -> (usize, u64) {
+    let mut freed = 0u64;
+    let mut removed = 0usize;
+    for (path, size) in to_remove {
+        let rel = path.strip_prefix(root).unwrap_or(path);
+        match std::fs::remove_dir_all(path) {
+            Ok(()) => {
+                freed += size;
+                removed += 1;
+                println!("  removed {}", rel.display());
+            }
+            Err(e) => {
+                println!("  failed  {} — {e}", rel.display());
+            }
+        }
+    }
+    (removed, freed)
 }
 
 fn render_clean_dry_run(targets: &[TargetEntry], root: &std::path::Path) -> Vec<String> {
@@ -5506,6 +5529,40 @@ mod tests {
         cursor = 10;
         clean_handle_key(KeyCode::Char(' '), &mut selected, &mut cursor, 2);
         assert_eq!(cursor, 10, "out-of-range cursor is ignored");
+    }
+
+    #[test]
+    fn remove_targets_deletes_all_and_reports_freed_bytes() {
+        // Two real target/ dirs under a root; --yes removes every one.
+        let root = tempfile::tempdir().unwrap();
+        let a = root.path().join("proj-a/target");
+        let b = root.path().join("proj-b/target");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+
+        let to_remove = vec![(a.clone(), 100u64), (b.clone(), 200u64)];
+        let (removed, freed) = remove_targets(&to_remove, root.path());
+
+        assert_eq!(removed, 2, "both target/ dirs removed");
+        assert_eq!(freed, 300, "freed bytes sum the sizes of removed dirs");
+        assert!(!a.exists() && !b.exists(), "directories are gone from disk");
+    }
+
+    #[test]
+    fn remove_targets_skips_failures_without_aborting() {
+        // A missing path fails to remove; a real one after it still succeeds and
+        // only the removed dir's bytes are counted.
+        let root = tempfile::tempdir().unwrap();
+        let missing = root.path().join("gone/target");
+        let real = root.path().join("proj/target");
+        std::fs::create_dir_all(&real).unwrap();
+
+        let to_remove = vec![(missing, 100u64), (real.clone(), 200u64)];
+        let (removed, freed) = remove_targets(&to_remove, root.path());
+
+        assert_eq!(removed, 1, "only the existing dir counts as removed");
+        assert_eq!(freed, 200, "failed dir's bytes are not counted");
+        assert!(!real.exists(), "the reachable dir was still removed");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,9 +90,14 @@ enum Commands {
 
     /// Recursively find and remove target/ directories under the current directory
     Clean {
-        /// Preview what would be removed without deleting
-        #[arg(long)]
+        /// Preview what would be removed without deleting (pairs with --yes)
+        #[arg(long, short = 'n')]
         dry_run: bool,
+
+        /// Non-interactive: remove all target/ directories without the selector.
+        /// For scripts and cron. Preview first with --dry-run.
+        #[arg(long, short = 'y')]
+        yes: bool,
     },
 
     /// Interactive setup: configure cargo wrapper, install and start the daemon
@@ -427,7 +432,7 @@ fn main() -> Result<()> {
             cli::gc(&config, hours)
         }
         Some(Commands::Purge { crate_name }) => cli::purge(&config, crate_name.as_deref()),
-        Some(Commands::Clean { dry_run }) => cli::clean(dry_run),
+        Some(Commands::Clean { dry_run, yes }) => cli::clean(dry_run, yes),
         Some(Commands::Init {
             yes,
             no_service,


### PR DESCRIPTION
## Summary

Closes #498 — makes `kache clean` runnable unattended (scripts, cron).

- **`-y` / `--yes`**: skips the interactive TUI and removes **all** discovered `target/` directories, printing the existing per-dir `removed`/`failed` lines and `Removed N target/ dirs, freed X` summary.
- **`-n`**: short alias for the existing `--dry-run`, giving a symmetric pair — `-n` previews, `-y` applies.
- **Precedence**: if both are passed, `--dry-run` wins (preview only, never deletes).
- Empty case still prints `No target/ directories found.` and exits 0 — no false error under cron.
- Bare `kache clean` is unchanged (interactive TUI).

The `-y` short flag mirrors the existing `Init` command's precedent. The deletion loop is extracted into a shared `remove_targets` helper used by both the TUI-confirm and `-y` paths (no behavior change to the TUI).

## Testing

- Unit tests for `remove_targets`: removes all + sums freed bytes; skips failures without aborting and counts only successfully-removed bytes.
- Manual end-to-end: verified `-n` previews without deleting, `-n -y` lets dry-run win, `-y` removes all with the correct summary, and the empty case exits cleanly. `cargo fmt`, `cargo clippy -D warnings`, and the `clean` test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)