### PR TITLE
fix(cli): honor CARGO_HOME instead of hardcoding ~/.cargo in init and migrate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ just build
 ### Install locally
 
 ```sh
-just install   # installs to ~/.cargo/bin and registers the daemon service
+just install   # installs to $CARGO_HOME/bin (default ~/.cargo/bin) and registers the daemon service
 ```
 
 > **Note:** The `Justfile` exports `RUSTC_WRAPPER=` to avoid a bootstrapping loop (kache building itself through kache).

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ winget install kunobi-ninja.kache.Unstable
 ## Quick start
 
 ```sh
-# Interactive setup: configures ~/.cargo/config.toml, installs the
-# background daemon as a login service, and starts it.
+# Interactive setup: configures $CARGO_HOME/config.toml (default ~/.cargo),
+# installs the background daemon as a login service, and starts it.
 kache init
 
 # Or accept all defaults non-interactively:
@@ -102,7 +102,7 @@ kache init -y
 kache doctor
 ```
 
-`kache init` is idempotent — re-run it any time to repair configuration. Use `kache init --check` to preview the changes without touching any files. If you prefer to configure things by hand, just export `RUSTC_WRAPPER=kache` or add it to `~/.cargo/config.toml` under `[build]`.
+`kache init` is idempotent — re-run it any time to repair configuration. Use `kache init --check` to preview the changes without touching any files. If you prefer to configure things by hand, just export `RUSTC_WRAPPER=kache` or add it to `$CARGO_HOME/config.toml` (usually `~/.cargo`) under `[build]`.
 
 ## Use in CI
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2408,7 +2408,12 @@ fn migrate(purge_sccache: bool) -> Result<()> {
             && output.status.success()
         {
             let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if std::path::Path::new(&path).starts_with(cargo_dir.join("bin")) {
+            let sccache_path = std::path::PathBuf::from(&path);
+            let cargo_bin = cargo_dir.join("bin");
+            let resolved_sccache = sccache_path.canonicalize().unwrap_or(sccache_path);
+            let resolved_cargo_bin = cargo_bin.canonicalize().unwrap_or(cargo_bin);
+
+            if resolved_sccache.starts_with(resolved_cargo_bin) {
                 println!("Uninstalling sccache via cargo...");
                 let status = std::process::Command::new("cargo")
                     .args(["uninstall", "sccache"])

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2339,9 +2339,12 @@ fn migrate(purge_sccache: bool) -> Result<()> {
         actions.push("Stopped sccache daemon".into());
     }
 
-    // 2. Replace sccache in ~/.cargo/config.toml
+    // 2. Replace sccache in $CARGO_HOME/config.toml (fallback to ~/.cargo)
+    let cargo_dir = std::env::var_os("CARGO_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| home.join(".cargo"));
     for name in ["config.toml", "config"] {
-        let cargo_config = home.join(".cargo").join(name);
+        let cargo_config = cargo_dir.join(name);
         if let Ok(content) = std::fs::read_to_string(&cargo_config)
             && content.contains("sccache")
         {
@@ -2395,7 +2398,7 @@ fn migrate(purge_sccache: bool) -> Result<()> {
             && output.status.success()
         {
             let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if path.contains(".cargo/bin") {
+            if std::path::Path::new(&path).starts_with(cargo_dir.join("bin")) {
                 println!("Uninstalling sccache via cargo...");
                 let status = std::process::Command::new("cargo")
                     .args(["uninstall", "sccache"])
@@ -5660,7 +5663,8 @@ mod tests {
 // ── Init ──────────────────────────────────────────────────────────────────
 //
 // Interactive setup that resolves the common doctor issues:
-//   1. Writes `build.rustc-wrapper = "kache"` to ~/.cargo/config.toml
+//   1. Writes `build.rustc-wrapper = "kache"` to $CARGO_HOME/config.toml
+//      (fallback to ~/.cargo/config.toml)
 //   2. Installs the daemon as a login service (launchd/systemd)
 //   3. Starts the daemon
 //
@@ -5785,8 +5789,9 @@ fn backup_path_for(path: &std::path::Path) -> Option<std::path::PathBuf> {
 }
 
 fn cargo_config_target_path() -> std::path::PathBuf {
-    let home = dirs::home_dir().unwrap_or_default();
-    let cargo_dir = home.join(".cargo");
+    let cargo_dir = std::env::var_os("CARGO_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".cargo"));
     let with_ext = cargo_dir.join("config.toml");
     let legacy = cargo_dir.join("config");
     // Prefer the file that already exists; fall back to the canonical name.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1844,52 +1844,61 @@ pub fn doctor(
         fix: if bin_pass {
             None
         } else {
-            Some("cargo install --path . or add ~/.cargo/bin to PATH".into())
+            Some(format!(
+                "cargo install --path . or add {} to PATH",
+                cargo_home_dir().join("bin").display()
+            ))
         },
     });
 
     // 2. RUSTC_WRAPPER
-    let (wrapper_pass, wrapper_detail, wrapper_fix) = match crate::wrapper_config::resolve_wrapper_setting() {
-        Some(crate::wrapper_config::WrapperSetting::Environment { value }) if value.contains("kache") => {
-            (true, "kache via env".into(), None)
-        }
-        Some(crate::wrapper_config::WrapperSetting::Environment { value })
-            if value.contains("sccache") =>
-        {
-            (
+    let (wrapper_pass, wrapper_detail, wrapper_fix) =
+        match crate::wrapper_config::resolve_wrapper_setting() {
+            Some(crate::wrapper_config::WrapperSetting::Environment { value })
+                if value.contains("kache") =>
+            {
+                (true, "kache via env".into(), None)
+            }
+            Some(crate::wrapper_config::WrapperSetting::Environment { value })
+                if value.contains("sccache") =>
+            {
+                (
+                    false,
+                    format!("sccache ({value})"),
+                    Some("export RUSTC_WRAPPER=kache".into()),
+                )
+            }
+            Some(crate::wrapper_config::WrapperSetting::Environment { value }) => (
                 false,
-                format!("sccache ({value})"),
+                format!("{value} (not kache)"),
                 Some("export RUSTC_WRAPPER=kache".into()),
-            )
-        }
-        Some(crate::wrapper_config::WrapperSetting::Environment { value }) => (
-            false,
-            format!("{value} (not kache)"),
-            Some("export RUSTC_WRAPPER=kache".into()),
-        ),
-        Some(crate::wrapper_config::WrapperSetting::CargoConfig { value, path })
-            if value.contains("kache") =>
-        {
-            (
-                true,
-                format!("kache via {}", crate::wrapper_config::display_path(&path)),
-                None,
-            )
-        }
-        Some(crate::wrapper_config::WrapperSetting::CargoConfig { value, path }) => (
-            false,
-            format!("{value} in {}", crate::wrapper_config::display_path(&path)),
-            Some(format!(
-                "replace `rustc-wrapper = \"{value}\"` with `rustc-wrapper = \"kache\"` in {}",
-                path.display()
-            )),
-        ),
-        None => (
-            false,
-            "not set".into(),
-            Some("set `build.rustc-wrapper = \"kache\"` in ~/.cargo/config.toml or export RUSTC_WRAPPER=kache".into()),
-        ),
-    };
+            ),
+            Some(crate::wrapper_config::WrapperSetting::CargoConfig { value, path })
+                if value.contains("kache") =>
+            {
+                (
+                    true,
+                    format!("kache via {}", crate::wrapper_config::display_path(&path)),
+                    None,
+                )
+            }
+            Some(crate::wrapper_config::WrapperSetting::CargoConfig { value, path }) => (
+                false,
+                format!("{value} in {}", crate::wrapper_config::display_path(&path)),
+                Some(format!(
+                    "replace `rustc-wrapper = \"{value}\"` with `rustc-wrapper = \"kache\"` in {}",
+                    path.display()
+                )),
+            ),
+            None => (
+                false,
+                "not set".into(),
+                Some(format!(
+                    "set `build.rustc-wrapper = \"kache\"` in {} or export RUSTC_WRAPPER=kache",
+                    cargo_config_target_path().display()
+                )),
+            ),
+        };
     checks.push(Check {
         label: "RUSTC_WRAPPER",
         pass: wrapper_pass,
@@ -2340,9 +2349,7 @@ fn migrate(purge_sccache: bool) -> Result<()> {
     }
 
     // 2. Replace sccache in $CARGO_HOME/config.toml (fallback to ~/.cargo)
-    let cargo_dir = std::env::var_os("CARGO_HOME")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| home.join(".cargo"));
+    let cargo_dir = cargo_home_dir();
     for name in ["config.toml", "config"] {
         let cargo_config = cargo_dir.join(name);
         if let Ok(content) = std::fs::read_to_string(&cargo_config)
@@ -5788,10 +5795,15 @@ fn backup_path_for(path: &std::path::Path) -> Option<std::path::PathBuf> {
     Some(path.with_file_name(format!("{file_name}.kache-backup.{timestamp}")))
 }
 
-fn cargo_config_target_path() -> std::path::PathBuf {
-    let cargo_dir = std::env::var_os("CARGO_HOME")
+/// `$CARGO_HOME`, falling back to `~/.cargo` (cargo's documented default).
+fn cargo_home_dir() -> std::path::PathBuf {
+    std::env::var_os("CARGO_HOME")
         .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".cargo"));
+        .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".cargo"))
+}
+
+fn cargo_config_target_path() -> std::path::PathBuf {
+    let cargo_dir = cargo_home_dir();
     let with_ext = cargo_dir.join("config.toml");
     let legacy = cargo_dir.join("config");
     // Prefer the file that already exists; fall back to the canonical name.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5800,9 +5800,16 @@ fn backup_path_for(path: &std::path::Path) -> Option<std::path::PathBuf> {
 
 /// `$CARGO_HOME`, falling back to `~/.cargo` (cargo's documented default).
 fn cargo_home_dir() -> std::path::PathBuf {
-    std::env::var_os("CARGO_HOME")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".cargo"))
+    if let Some(cargo_home) = std::env::var_os("CARGO_HOME").filter(|value| !value.is_empty()) {
+        let cargo_home = std::path::PathBuf::from(cargo_home);
+        if cargo_home.is_absolute() {
+            cargo_home
+        } else {
+            std::env::current_dir().unwrap_or_default().join(cargo_home)
+        }
+    } else {
+        dirs::home_dir().unwrap_or_default().join(".cargo")
+    }
 }
 
 fn cargo_config_target_path() -> std::path::PathBuf {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2401,7 +2401,10 @@ fn migrate(purge_sccache: bool) -> Result<()> {
         }
 
         // Uninstall sccache binary if cargo-installed
-        if let Ok(output) = std::process::Command::new("which").arg("sccache").output()
+        if let Ok(output) =
+            std::process::Command::new(if cfg!(windows) { "where" } else { "which" })
+                .arg("sccache")
+                .output()
             && output.status.success()
         {
             let path = String::from_utf8_lossy(&output.stdout).trim().to_string();

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -514,6 +514,36 @@ fn doctor_fix_migrates_sccache_cargo_config_to_kache() {
 }
 
 #[test]
+fn doctor_fix_migrates_sccache_config_in_custom_cargo_home() {
+    // When $CARGO_HOME is set, migrate must rewrite the cargo config under it,
+    // not under the `~/.cargo` default.
+    let e = env();
+    let cargo_home = e.home.join("custom-cargo-home");
+    std::fs::create_dir_all(&cargo_home).unwrap();
+    std::fs::write(
+        cargo_home.join("config.toml"),
+        "[build]\nrustc-wrapper = \"sccache\"\n",
+    )
+    .unwrap();
+
+    e.cmd()
+        .env("CARGO_HOME", &cargo_home)
+        .args(["doctor", "--fix"])
+        .assert()
+        .success();
+
+    let rewritten = std::fs::read_to_string(cargo_home.join("config.toml")).unwrap();
+    assert!(
+        rewritten.contains("kache") && !rewritten.contains("sccache"),
+        "migrate should rewrite the $CARGO_HOME config: {rewritten}"
+    );
+    assert!(
+        !e.home.join(".cargo").join("config.toml").exists(),
+        "migrate must not touch ~/.cargo when CARGO_HOME points elsewhere"
+    );
+}
+
+#[test]
 fn init_check_is_a_dry_run() {
     // --check prints intended changes without modifying anything.
     let e = env();
@@ -540,6 +570,28 @@ fn init_noninteractive_writes_isolated_cargo_config() {
     assert!(
         cargo_home.join("config.toml").exists(),
         "init should have written an isolated cargo config"
+    );
+}
+
+#[test]
+fn init_writes_config_to_custom_cargo_home() {
+    // When $CARGO_HOME is set, init must write the wrapper config under it,
+    // not under the `~/.cargo` default.
+    let e = env();
+    let cargo_home = e.home.join("custom-cargo-home");
+    e.cmd()
+        .env("CARGO_HOME", &cargo_home)
+        .args(["init", "--no-service"])
+        .write_stdin("y\nn\n")
+        .assert()
+        .success();
+    assert!(
+        cargo_home.join("config.toml").exists(),
+        "init should write the wrapper config under $CARGO_HOME"
+    );
+    assert!(
+        !e.home.join(".cargo").join("config.toml").exists(),
+        "init must not touch ~/.cargo when CARGO_HOME points elsewhere"
     );
 }
 

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -479,7 +479,7 @@ fn doctor_fix_in_isolated_home_succeeds() {
     e.cmd().args(["doctor", "--fix"]).assert().success();
 }
 
-// Unix-only: migrate resolves `~/.cargo` via `dirs::home_dir()`, which on
+// Unix-only: migrate resolves `~/.zshrc` via `dirs::home_dir()`, which on
 // Windows reads the OS profile API and ignores the `HOME`/`CARGO_HOME` the test
 // helper sets — so the test couldn't isolate (and would mutate the runner's real
 // cargo config). The migration logic is platform-shared and covered here.
@@ -551,11 +551,6 @@ fn init_check_is_a_dry_run() {
     e.cmd().args(["init", "--check"]).assert().success();
 }
 
-// Unix-only: init resolves the cargo config path via `dirs::home_dir()`, which
-// on Windows reads the OS profile API and ignores the test's `HOME`/`CARGO_HOME`
-// — so the test couldn't isolate (and would mutate the runner's real cargo
-// config). The init logic is platform-shared and covered here.
-#[cfg(unix)]
 #[test]
 fn init_noninteractive_writes_isolated_cargo_config() {
     // Interactive init writes the wrapper config, then skips daemon start.


### PR DESCRIPTION
<!--
Thanks for sending a PR! Keep it focused on a single change — unrelated
refactors are easier to review separately. See CONTRIBUTING.md for the
full process.
-->

Closes #501 

## Summary

<!-- What does this PR change and why? Link related issues. -->
Honor `CARGO_HOME` instead of hardcoding `~/.cargo`.

### What changed

- In `cli.rs`, these will now use `$CARGO_HOME`, and fall back to `~/.cargo/` if env is missing.
  - kache init (`cargo_config_target_path()`)
  - kache doctor --fix (`migrate()`)
- Also changed README.md, CONTRIBUTING.md that refers `~/.cargo/`.
- Add two tests, enabled one existing test for windows, see **### Test code** below.

## Test plan

### Manual test

Tested `kache init`

<!-- How did you verify the change? Commands run, scenarios covered.
Include before/after numbers for performance changes. -->

<img width="997" height="373" alt="image" src="https://github.com/user-attachments/assets/a2b4a804-2bee-42c0-b1c6-7de99450fab3" />
<img width="990" height="372" alt="image" src="https://github.com/user-attachments/assets/2c2948e5-700b-45e7-a136-b90d1037fb19" />


### Test code

- Add two tests, which are nearly similar to existing tests but uses custom `CARGO_HOME`.
  - `doctor_fix_migrates_sccache_config_in_custom_cargo_home()`
  - `init_writes_config_to_custom_cargo_home()`
- **Enabled one existing test for windows**: `init_noninteractive_writes_isolated_cargo_config`
  - Now `kache init` use `CARGO_HOME` first, so this test can be enabled.

> [!NOTE]
> Theoretically, current `doctor_fix_migrates_sccache_cargo_config_to_kache()` works in windows.
> However, this is because current test doesn't checks whether `~/.zshrc` changed.
>
> Since `~/.zshrc` still have the same `dirs::home_dir()` issue, I didn't enabled it and just changed the comments.

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [x] User-visible changes (CLI, config, output) are reflected in the README or relevant docs
