### PR TITLE
feat(daemon): prefetch Phase 0 — baseline telemetry + scheduling fixes (#485)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,6 +3400,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "aws-smithy-http-client",
+ "aws-smithy-runtime-api",
  "blake3",
  "bytes",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ blake3 = "1"
 aws-sdk-s3 = { version = "1", default-features = false, features = ["sigv4a", "http-1x", "rt-tokio"] }
 aws-config = { version = "1", default-features = false, features = ["rt-tokio", "credentials-process", "sso"] }
 aws-smithy-http-client = { version = "1", features = ["rustls-ring"] }
+# Already in-tree via aws-sdk-s3; direct dep only to name the concrete HTTP
+# response type in SdkError so a raw GET 404 is detectable (#485 Phase 0).
+aws-smithy-runtime-api = "1"
 # Direct dep so we can install ring as the process-wide rustls crypto
 # provider (reqwest uses `rustls-no-provider`, so one must be installed).
 rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,9 @@ pub(crate) struct StatsSnapshot {
     pub bytes_downloaded: u64,
     pub recent_transfers: Vec<daemon::TransferEvent>,
     pub blob_stats: Option<crate::store::BlobStats>,
+    /// Phase-0 prefetch/planning observability (#485); zeroed when the daemon
+    /// is unreachable.
+    pub prefetch: daemon::PrefetchStatsSnapshot,
 }
 
 impl Default for StatsSnapshot {
@@ -75,6 +78,7 @@ impl Default for StatsSnapshot {
             bytes_downloaded: 0,
             recent_transfers: Vec::new(),
             blob_stats: None,
+            prefetch: daemon::PrefetchStatsSnapshot::default(),
         }
     }
 }
@@ -137,6 +141,7 @@ pub(crate) fn fetch_stats_snapshot(
             bytes_downloaded: resp.bytes_downloaded,
             recent_transfers: resp.recent_transfers,
             blob_stats: blob_stats(),
+            prefetch: resp.prefetch,
         };
     }
 
@@ -168,6 +173,7 @@ pub(crate) fn fetch_stats_snapshot(
             bytes_downloaded: resp.bytes_downloaded,
             recent_transfers: resp.recent_transfers,
             blob_stats: blob_stats(),
+            prefetch: resp.prefetch,
         };
     }
 
@@ -258,6 +264,7 @@ pub(crate) fn snapshot_from_direct_reads(
         bytes_downloaded: 0,
         recent_transfers: Vec::new(),
         blob_stats: store.as_ref().and_then(|s| s.blob_stats().ok()),
+        prefetch: daemon::PrefetchStatsSnapshot::default(),
     }
 }
 
@@ -372,6 +379,47 @@ pub(crate) fn render_stats(
         lines.push("Remote:     local-only mode (remote + planner ignored)".to_string());
     } else {
         lines.push("Remote:     not configured".to_string());
+    }
+
+    // Prefetch/planning baseline (#485 Phase 0). Shown only when the daemon
+    // has something to report, so local-only output stays unchanged.
+    let pf = &snap.prefetch;
+    if snap.daemon_connected
+        && (pf.downloads_completed > 0
+            || pf.plans_advisory + pf.plans_fallback > 0
+            || pf.last_list_key_count > 0)
+    {
+        let used_pct = if pf.downloads_completed > 0 {
+            (pf.keys_used as f64 / pf.downloads_completed as f64) * 100.0
+        } else {
+            0.0
+        };
+        let cancelled = if pf.cancelled { ", CANCELLED" } else { "" };
+        lines.push(format!(
+            "Prefetch:   {} downloads ({}), {} used ({:.0}%), {} cancelled{}",
+            pf.downloads_completed,
+            ByteSize(pf.bytes_downloaded),
+            pf.keys_used,
+            used_pct,
+            pf.keys_cancelled,
+            cancelled,
+        ));
+        lines.push(format!(
+            "Planning:   {} advisory / {} fallback plans (last: {} candidates)",
+            pf.plans_advisory, pf.plans_fallback, pf.last_plan_candidates,
+        ));
+        if pf.last_list_key_count > 0 {
+            lines.push(format!(
+                "Key LIST:   {} keys in {} ms (refreshes every 60s)",
+                pf.last_list_key_count, pf.last_list_duration_ms,
+            ));
+        }
+        if pf.dedup_join_waits > 0 {
+            lines.push(format!(
+                "Join-wait:  {} waits, {} ms total (in-flight download dedup)",
+                pf.dedup_join_waits, pf.dedup_join_wait_ms,
+            ));
+        }
     }
 
     lines
@@ -4550,6 +4598,49 @@ mod tests {
             "matching epoch -> no mismatch tag"
         );
         assert!(out.contains("Remote:     s3://"));
+    }
+
+    /// The #485 Phase-0 prefetch section renders when the daemon reports
+    /// activity and stays absent for a quiet/offline daemon, so local-only
+    /// `kache stats` output is unchanged.
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn render_stats_prefetch_section_gated_on_activity() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = save_manifest_config(dir.path().join("cache"), Some(test_remote_cfg()));
+        let blobs = crate::store::BlobStats::default();
+
+        // Quiet daemon: no prefetch lines at all.
+        let mut quiet = StatsSnapshot::default();
+        quiet.daemon_connected = true;
+        let out = render_stats(&quiet, &blobs, &config, 24).join("\n");
+        assert!(!out.contains("Prefetch:"));
+        assert!(!out.contains("Planning:"));
+
+        // Active daemon: all lines present with the right arithmetic.
+        let mut snap = StatsSnapshot::default();
+        snap.daemon_connected = true;
+        snap.prefetch = crate::daemon::PrefetchStatsSnapshot {
+            downloads_completed: 4,
+            bytes_downloaded: 2048,
+            keys_used: 2,
+            keys_cancelled: 3,
+            cancelled: true,
+            plans_advisory: 1,
+            plans_fallback: 2,
+            last_plan_candidates: 7,
+            dedup_join_waits: 5,
+            dedup_join_wait_ms: 1234,
+            last_list_duration_ms: 88,
+            last_list_key_count: 250_000,
+        };
+        let out = render_stats(&snap, &blobs, &config, 24).join("\n");
+        assert!(out.contains("Prefetch:   4 downloads"));
+        assert!(out.contains("2 used (50%)"));
+        assert!(out.contains("CANCELLED"));
+        assert!(out.contains("Planning:   1 advisory / 2 fallback plans (last: 7 candidates)"));
+        assert!(out.contains("Key LIST:   250000 keys in 88 ms"));
+        assert!(out.contains("Join-wait:  5 waits, 1234 ms total"));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -480,6 +480,41 @@ pub struct StatsResponse {
     pub bytes_downloaded: u64,
     #[serde(default)]
     pub recent_transfers: Vec<TransferEvent>,
+    /// Phase-0 prefetch/planning observability (#485). Defaulted so old
+    /// clients reading a new daemon (and vice versa) keep working.
+    #[serde(default)]
+    pub prefetch: PrefetchStatsSnapshot,
+}
+
+/// Point-in-time view of [`PrefetchStats`] (+ the cancel latch) carried in
+/// [`StatsResponse`]. See the field docs on `PrefetchStats` for semantics.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct PrefetchStatsSnapshot {
+    #[serde(default)]
+    pub downloads_completed: u64,
+    #[serde(default)]
+    pub bytes_downloaded: u64,
+    #[serde(default)]
+    pub keys_used: u64,
+    #[serde(default)]
+    pub keys_cancelled: u64,
+    /// Whether the daemon-lifetime adaptive cancel latch has fired.
+    #[serde(default)]
+    pub cancelled: bool,
+    #[serde(default)]
+    pub plans_advisory: u64,
+    #[serde(default)]
+    pub plans_fallback: u64,
+    #[serde(default)]
+    pub last_plan_candidates: u64,
+    #[serde(default)]
+    pub dedup_join_waits: u64,
+    #[serde(default)]
+    pub dedup_join_wait_ms: u64,
+    #[serde(default)]
+    pub last_list_duration_ms: u64,
+    #[serde(default)]
+    pub last_list_key_count: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -776,6 +811,57 @@ impl TransferCounters {
     }
 }
 
+/// Daemon-lifetime prefetch/planning observability counters (#485 Phase 0).
+///
+/// Telemetry only — nothing here feeds a decision. The adaptive cancellation
+/// keeps its own `prefetch_checks`/`prefetch_hits` pair untouched so behavior
+/// is unchanged while the baseline is being measured; these counters exist so
+/// `kache stats` can show planner source, plan size, downloaded-vs-used
+/// prefetch volume, cancellation, dedup join-waits, and LIST cost — the
+/// numbers the prefetch-coordination work is judged against.
+pub(crate) struct PrefetchStats {
+    /// Downloads completed by the speculative prefetch pipeline (a subset of
+    /// `TransferCounters::downloads_completed`, which also counts on-demand).
+    pub downloads_completed: std::sync::atomic::AtomicU64,
+    /// Compressed bytes downloaded by prefetch (subset of `bytes_downloaded`).
+    pub bytes_downloaded: std::sync::atomic::AtomicU64,
+    /// Distinct prefetched keys later requested by a wrapper. Together with
+    /// `downloads_completed` this gives the used-vs-wasted split.
+    pub keys_used: std::sync::atomic::AtomicU64,
+    /// Keys dropped un-downloaded by an adaptive cancellation.
+    pub keys_cancelled: std::sync::atomic::AtomicU64,
+    /// BuildStarted sessions planned by the advisory service vs locally.
+    pub plans_advisory: std::sync::atomic::AtomicU64,
+    pub plans_fallback: std::sync::atomic::AtomicU64,
+    /// Candidate count of the most recent plan (either source).
+    pub last_plan_candidates: std::sync::atomic::AtomicU64,
+    /// RemoteCheck handlers that waited on another task's in-flight download
+    /// of the same key (the dedup join-wait), and their cumulative wait.
+    pub dedup_join_waits: std::sync::atomic::AtomicU64,
+    pub dedup_join_wait_ms: std::sync::atomic::AtomicU64,
+    /// Most recent key-cache LIST refresh: wall time and key count.
+    pub last_list_duration_ms: std::sync::atomic::AtomicU64,
+    pub last_list_key_count: std::sync::atomic::AtomicU64,
+}
+
+impl PrefetchStats {
+    fn new() -> Self {
+        Self {
+            downloads_completed: 0.into(),
+            bytes_downloaded: 0.into(),
+            keys_used: 0.into(),
+            keys_cancelled: 0.into(),
+            plans_advisory: 0.into(),
+            plans_fallback: 0.into(),
+            last_plan_candidates: 0.into(),
+            dedup_join_waits: 0.into(),
+            dedup_join_wait_ms: 0.into(),
+            last_list_duration_ms: 0.into(),
+            last_list_key_count: 0.into(),
+        }
+    }
+}
+
 const RECENT_TRANSFERS_CAP: usize = 50;
 
 // ── S3 Key Cache ─────────────────────────────────────────────────
@@ -916,6 +1002,13 @@ pub(crate) struct Daemon {
     prefetch_hits: Arc<AtomicU32>,
     /// Signals remaining prefetch downloads to stop when hit rate is too low.
     prefetch_cancel: tokio::sync::watch::Sender<bool>,
+    /// Phase-0 observability counters (#485). Telemetry only.
+    prefetch_stats: PrefetchStats,
+    /// Prefetched keys that a wrapper later requested — the distinct-"used"
+    /// side of `PrefetchStats::keys_used`. Separate from `prefetched_keys`
+    /// (which must keep every key for PrefetchHit labeling) so counting a use
+    /// doesn't disturb labels. Bounded alongside `prefetched_keys`.
+    prefetch_used_keys: Arc<RwLock<HashSet<String>>>,
     version: String,
     build_epoch: u64,
     transfer_counters: TransferCounters,
@@ -952,6 +1045,8 @@ impl Daemon {
             prefetch_checks: Arc::new(AtomicU32::new(0)),
             prefetch_hits: Arc::new(AtomicU32::new(0)),
             prefetch_cancel,
+            prefetch_stats: PrefetchStats::new(),
+            prefetch_used_keys: Arc::new(RwLock::new(HashSet::new())),
             version: VERSION.to_string(),
             build_epoch: build_epoch(),
             transfer_counters: TransferCounters::new(),
@@ -1134,6 +1229,7 @@ impl Daemon {
         let active_downloads = self.downloading.try_read().map(|g| g.len()).unwrap_or(0);
 
         let tc = &self.transfer_counters;
+        let ps = &self.prefetch_stats;
         let s3_total = self.config.s3_concurrency.max(1) as usize;
         let s3_used = s3_total - self.s3_semaphore.available_permits();
 
@@ -1179,6 +1275,20 @@ impl Daemon {
             bytes_uploaded: tc.bytes_uploaded.load(Ordering::Relaxed),
             bytes_downloaded: tc.bytes_downloaded.load(Ordering::Relaxed),
             recent_transfers,
+            prefetch: PrefetchStatsSnapshot {
+                downloads_completed: ps.downloads_completed.load(Ordering::Relaxed),
+                bytes_downloaded: ps.bytes_downloaded.load(Ordering::Relaxed),
+                keys_used: ps.keys_used.load(Ordering::Relaxed),
+                keys_cancelled: ps.keys_cancelled.load(Ordering::Relaxed),
+                cancelled: *self.prefetch_cancel.borrow(),
+                plans_advisory: ps.plans_advisory.load(Ordering::Relaxed),
+                plans_fallback: ps.plans_fallback.load(Ordering::Relaxed),
+                last_plan_candidates: ps.last_plan_candidates.load(Ordering::Relaxed),
+                dedup_join_waits: ps.dedup_join_waits.load(Ordering::Relaxed),
+                dedup_join_wait_ms: ps.dedup_join_wait_ms.load(Ordering::Relaxed),
+                last_list_duration_ms: ps.last_list_duration_ms.load(Ordering::Relaxed),
+                last_list_key_count: ps.last_list_key_count.load(Ordering::Relaxed),
+            },
         })
     }
 
@@ -1546,6 +1656,18 @@ impl Daemon {
                 self.prefetch_checks.fetch_add(1, Ordering::Relaxed);
                 // This is a hit — the wrapper is requesting a key that was prefetched
                 self.prefetch_hits.fetch_add(1, Ordering::Relaxed);
+                // Phase-0 telemetry: count each prefetched key as "used" once
+                // (distinct keys, unlike the per-check counters above).
+                if self
+                    .prefetch_used_keys
+                    .write()
+                    .await
+                    .insert(req.key.clone())
+                {
+                    self.prefetch_stats
+                        .keys_used
+                        .fetch_add(1, Ordering::Relaxed);
+                }
             }
             let checks = self.prefetch_checks.load(Ordering::Relaxed);
             let hits = self.prefetch_hits.load(Ordering::Relaxed);
@@ -1674,12 +1796,22 @@ impl Daemon {
         if !self.downloading.write().await.insert(req.key.clone()) {
             tracing::debug!("already downloading {}, waiting for completion", &req.key);
             // Poll until the in-flight download finishes (up to 30s).
+            let join_start = Instant::now();
             for _ in 0..300 {
                 tokio::time::sleep(Duration::from_millis(100)).await;
                 if !self.downloading.read().await.contains(&req.key) {
                     break;
                 }
             }
+            // Phase-0 telemetry: how often and how long RemoteCheck blocks
+            // behind another task's in-flight download (the join-wait the
+            // notify-based dedup redesign will attack).
+            self.prefetch_stats
+                .dedup_join_waits
+                .fetch_add(1, Ordering::Relaxed);
+            self.prefetch_stats
+                .dedup_join_wait_ms
+                .fetch_add(join_start.elapsed().as_millis() as u64, Ordering::Relaxed);
             // If the other task succeeded, the entry is on disk — done.
             let entry_dir = PathBuf::from(&req.entry_dir);
             if entry_dir.join("meta.json").exists() {
@@ -1910,10 +2042,16 @@ impl Daemon {
                     // Remove this key + all remaining keys from downloading set
                     let mut guard = daemon.downloading.write().await;
                     guard.remove(&key);
+                    let mut cancelled: u64 = 1;
                     for (k, _, _) in keys_iter {
                         guard.remove(&k);
+                        cancelled += 1;
                     }
                     drop(guard);
+                    daemon
+                        .prefetch_stats
+                        .keys_cancelled
+                        .fetch_add(cancelled, Ordering::Relaxed);
                     break;
                 }
 
@@ -1979,6 +2117,14 @@ impl Daemon {
                             d.transfer_counters
                                 .bytes_downloaded
                                 .fetch_add(dl.compressed_bytes, Ordering::Relaxed);
+                            // Phase-0 telemetry: the prefetch-attributed subset
+                            // of the transfer counters above.
+                            d.prefetch_stats
+                                .downloads_completed
+                                .fetch_add(1, Ordering::Relaxed);
+                            d.prefetch_stats
+                                .bytes_downloaded
+                                .fetch_add(dl.compressed_bytes, Ordering::Relaxed);
                             d.push_transfer_event(TransferEvent {
                                 schema: default_transfer_schema(),
                                 crate_name: crate_name.clone(),
@@ -2021,6 +2167,10 @@ impl Daemon {
                                 let mut pf = d.prefetched_keys.write().await;
                                 if pf.len() >= MAX_PREFETCHED_KEYS {
                                     pf.clear();
+                                    // Keep the used-key set consistent with the
+                                    // attribution set it mirrors (the counter
+                                    // keeps its lifetime total).
+                                    d.prefetch_used_keys.write().await.clear();
                                 }
                                 pf.insert(key.clone());
                             }
@@ -2100,6 +2250,12 @@ impl Daemon {
                         let prefetch_req = PrefetchRequest::from_plan(plan);
                         let resp = self.handle_prefetch(&prefetch_req).await;
                         if resp.ok {
+                            self.prefetch_stats
+                                .plans_advisory
+                                .fetch_add(1, Ordering::Relaxed);
+                            self.prefetch_stats
+                                .last_plan_candidates
+                                .store(prefetch_req.keys.len() as u64, Ordering::Relaxed);
                             tracing::info!(
                                 plan_id = ?plan_id,
                                 planner = ?planner,
@@ -2158,6 +2314,12 @@ impl Daemon {
             fallback_plan.candidates.len(),
             req.intent.crate_names.len()
         );
+        self.prefetch_stats
+            .plans_fallback
+            .fetch_add(1, Ordering::Relaxed);
+        self.prefetch_stats
+            .last_plan_candidates
+            .store(fallback_plan.candidates.len() as u64, Ordering::Relaxed);
 
         let prefetch_req = PrefetchRequest::from_plan(fallback_plan);
         self.handle_prefetch(&prefetch_req).await
@@ -2804,11 +2966,22 @@ async fn populate_key_cache(daemon: &Daemon) -> Result<usize> {
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("no remote configured"))?;
 
+    let list_start = Instant::now();
     let keys = crate::remote_plan::RemotePlanner::new(&daemon.config)
         .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
         .layout(client, remote)
         .list_keys()
         .await?;
+    // Phase-0 telemetry (#485): the LIST cost the coordination service exists
+    // to retire. Duration + key count of the most recent refresh.
+    daemon
+        .prefetch_stats
+        .last_list_duration_ms
+        .store(list_start.elapsed().as_millis() as u64, Ordering::Relaxed);
+    daemon
+        .prefetch_stats
+        .last_list_key_count
+        .store(keys.len() as u64, Ordering::Relaxed);
     let count = keys.len();
     daemon.key_cache.populate(keys).await;
     Ok(count)
@@ -4906,6 +5079,40 @@ mod tests {
         assert_eq!(json, r#"{"ok":true,"found":true,"prefetched":true}"#);
     }
 
+    /// A StatsResponse serialized by an OLD daemon (no `prefetch` field) must
+    /// deserialize on a new client, and the new nested snapshot round-trips.
+    /// Pins the #[serde(default)] compatibility contract for #485 Phase 0.
+    #[test]
+    fn test_stats_response_prefetch_field_is_backward_compatible() {
+        // Old-daemon shape: no `prefetch` key at all.
+        let old_json = r#"{"total_size":0,"max_size":0,"entry_count":0,"entries":null,
+            "events":{"local_hits":0,"prefetch_hits":0,"remote_hits":0,"dups":0,
+            "misses":0,"errors":0,"total_elapsed_ms":0,"hit_elapsed_ms":0,
+            "miss_elapsed_ms":0,"hit_compile_time_ms":0,"miss_compile_time_ms":0,
+            "store_output_blobs":0,"store_duplicate_blobs":0,"store_new_blobs":0}}"#;
+        let parsed: StatsResponse = serde_json::from_str(old_json).unwrap();
+        assert_eq!(parsed.prefetch, PrefetchStatsSnapshot::default());
+
+        // New shape round-trips.
+        let snap = PrefetchStatsSnapshot {
+            downloads_completed: 3,
+            bytes_downloaded: 1024,
+            keys_used: 2,
+            keys_cancelled: 1,
+            cancelled: true,
+            plans_advisory: 1,
+            plans_fallback: 4,
+            last_plan_candidates: 17,
+            dedup_join_waits: 2,
+            dedup_join_wait_ms: 250,
+            last_list_duration_ms: 42,
+            last_list_key_count: 9001,
+        };
+        let json = serde_json::to_string(&snap).unwrap();
+        let back: PrefetchStatsSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, snap);
+    }
+
     #[test]
     fn test_response_err_serde() {
         let resp = Response::err("something broke");
@@ -5557,6 +5764,7 @@ mod tests {
             bytes_uploaded: 0,
             bytes_downloaded: 0,
             recent_transfers: Vec::new(),
+            prefetch: PrefetchStatsSnapshot::default(),
         };
         let resp = Response::ok_stats(stats.clone());
         let json = serde_json::to_string(&resp).unwrap();
@@ -5627,6 +5835,7 @@ mod tests {
             bytes_uploaded: 0,
             bytes_downloaded: 0,
             recent_transfers: Vec::new(),
+            prefetch: PrefetchStatsSnapshot::default(),
         };
         let resp = Response::ok_stats(stats);
         let json = serde_json::to_string(&resp).unwrap();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -811,6 +811,19 @@ impl TransferCounters {
     }
 }
 
+/// Max concurrent speculative prefetch downloads for an S3 permit pool of
+/// `s3_concurrency` (#485 Phase 0): total minus a reserve of 1/4 of the pool
+/// (at least 1, at most 4), never below 1. Because every prefetch task holds
+/// at most one permit and at most this many run at once, at least `reserve`
+/// permits stay available to interactive RemoteCheck and uploads — prefetch
+/// can slow them but never starve them. A 1-permit pool degrades to no
+/// reservation rather than disabling prefetch.
+fn prefetch_concurrency_cap(s3_concurrency: u32) -> usize {
+    let total = s3_concurrency.max(1) as usize;
+    let reserve = (total / 4).clamp(1, 4).min(total.saturating_sub(1));
+    (total - reserve).max(1)
+}
+
 /// Daemon-lifetime prefetch/planning observability counters (#485 Phase 0).
 ///
 /// Telemetry only — nothing here feeds a decision. The adaptive cancellation
@@ -825,8 +838,13 @@ pub(crate) struct PrefetchStats {
     pub downloads_completed: std::sync::atomic::AtomicU64,
     /// Compressed bytes downloaded by prefetch (subset of `bytes_downloaded`).
     pub bytes_downloaded: std::sync::atomic::AtomicU64,
-    /// Distinct prefetched keys later requested by a wrapper. Together with
-    /// `downloads_completed` this gives the used-vs-wasted split.
+    /// Distinct prefetched keys later requested by a wrapper THROUGH the
+    /// daemon (RemoteCheck). A LOWER BOUND on real usage: a completed
+    /// prefetch is normally consumed via the wrapper's local store path,
+    /// which never reaches the daemon (cross-family review, #485). Full
+    /// per-build attribution lives in the events log (`kache report`,
+    /// PrefetchHit); this counter mainly captures joins on in-flight
+    /// prefetch downloads.
     pub keys_used: std::sync::atomic::AtomicU64,
     /// Keys dropped un-downloaded by an adaptive cancellation.
     pub keys_cancelled: std::sync::atomic::AtomicU64,
@@ -974,6 +992,19 @@ impl S3KeyCache {
             }
         }
     }
+
+    /// Remove a key whose positive turned out stale (a GET returned 404, so
+    /// the object is gone from the remote). Forward set and reverse index are
+    /// updated under one lock, mirroring [`Self::insert`] (#485 Phase 0).
+    pub async fn remove(&self, key: &str) {
+        let mut guard = self.index.write().await;
+        if let Some(index) = guard.as_mut() {
+            index.keys.remove(key);
+            for keys in index.by_crate.values_mut() {
+                keys.retain(|k| k != key);
+            }
+        }
+    }
 }
 
 // ── Daemon (the "lib" — all business logic, no I/O) ─────────────
@@ -1004,6 +1035,15 @@ pub(crate) struct Daemon {
     prefetch_cancel: tokio::sync::watch::Sender<bool>,
     /// Phase-0 observability counters (#485). Telemetry only.
     prefetch_stats: PrefetchStats,
+    /// DAEMON-WIDE cap on concurrent speculative prefetch downloads, sized by
+    /// [`prefetch_concurrency_cap`]. Each prefetch task holds one gate permit
+    /// for its whole S3-permit tenure, so across ALL coordinators (startup
+    /// manifest/shard prefetch overlapping a BuildStarted plan) prefetch can
+    /// never occupy more than `cap` of the `s3_concurrency` pool — the reserve
+    /// stays available to interactive RemoteCheck. Gate is always acquired
+    /// BEFORE the S3 permit and only by prefetch tasks, so no lock-order cycle
+    /// with interactive paths exists (cross-family review finding, #485).
+    prefetch_gate: Arc<tokio::sync::Semaphore>,
     /// Prefetched keys that a wrapper later requested — the distinct-"used"
     /// side of `PrefetchStats::keys_used`. Separate from `prefetched_keys`
     /// (which must keep every key for PrefetchHit labeling) so counting a use
@@ -1046,6 +1086,9 @@ impl Daemon {
             prefetch_hits: Arc::new(AtomicU32::new(0)),
             prefetch_cancel,
             prefetch_stats: PrefetchStats::new(),
+            prefetch_gate: Arc::new(tokio::sync::Semaphore::new(prefetch_concurrency_cap(
+                config.s3_concurrency,
+            ))),
             prefetch_used_keys: Arc::new(RwLock::new(HashSet::new())),
             version: VERSION.to_string(),
             build_epoch: build_epoch(),
@@ -1890,6 +1933,19 @@ impl Daemon {
                 });
                 Response::found(true)
             }
+            Err(e)
+                if e.downcast_ref::<crate::remote_layout::EntryNotFound>()
+                    .is_some() =>
+            {
+                // GET 404 = clean miss (#485 Phase 0). Reached when a
+                // key-cache positive was stale (upload evicted/GC'd) or the
+                // direct-GET path raced an upload. Correct the cache so the
+                // next check doesn't repeat the GET, and report a miss — the
+                // wrapper compiles as usual. Not a transfer failure.
+                tracing::debug!("remote GET 404 for {} — treating as miss", &req.key);
+                self.key_cache.remove(&req.key).await;
+                Response::found(false)
+            }
             Err(e) => {
                 let elapsed_ms = start.elapsed().as_millis() as u64;
                 self.transfer_counters
@@ -2032,7 +2088,15 @@ impl Daemon {
         let cancel_rx = self.prefetch_cancel.subscribe();
         tokio::spawn(async move {
             let mut in_flight = futures::stream::FuturesUnordered::new();
-            let max_concurrent = daemon.s3_semaphore.available_permits().max(1);
+            // Speculative prefetch is capped BELOW the S3 permit pool so an
+            // interactive RemoteCheck can always acquire a permit without
+            // queueing behind a wall of prefetch downloads (#485 Phase 0).
+            // A fixed cap (not an available_permits snapshot, which raced
+            // whatever happened to be free at spawn time): total minus a
+            // reserve of 1/4 of the pool, at least 1, at most 4. With the
+            // default 16 permits prefetch uses at most 12, leaving 4 for
+            // on-demand traffic; a 1-permit pool degrades to no reservation.
+            let max_concurrent = prefetch_concurrency_cap(daemon.config.s3_concurrency);
 
             let mut keys_iter = keys_to_fetch.into_iter().peekable();
             while let Some((key, crate_name, entry_dir)) = keys_iter.next() {
@@ -2073,6 +2137,14 @@ impl Daemon {
                 in_flight.push(tokio::spawn(async move {
                     // Released on every exit path below (including panic) by Drop.
                     let _dl_guard = DownloadingGuard::new(d.downloading.clone(), key.clone());
+                    // Daemon-wide speculative gate FIRST, then the shared S3
+                    // permit: bounds prefetch across ALL coordinators so the
+                    // interactive reserve holds even when startup prefetch
+                    // overlaps a BuildStarted plan (#485, cross-family review).
+                    let Ok(_gate) = d.prefetch_gate.clone().acquire_owned().await else {
+                        tracing::warn!("prefetch: gate closed for {}", key);
+                        return;
+                    };
                     let semaphore_start = Instant::now();
                     let Ok(_permit) = sem.acquire().await else {
                         tracing::warn!("prefetch: semaphore closed for {}", key);
@@ -6889,6 +6961,72 @@ mod tests {
             "download failure should surface as an error: {resp:?}"
         );
         assert!(resp.error.is_some());
+        server.shutdown();
+    }
+
+    /// The prefetch cap must always leave head-room in the permit pool for
+    /// interactive traffic (#485 Phase 0), across pool sizes.
+    #[test]
+    fn test_prefetch_concurrency_cap_reserves_interactive_permits() {
+        assert_eq!(prefetch_concurrency_cap(16), 12); // default: 4 reserved
+        assert_eq!(prefetch_concurrency_cap(8), 6); // 2 reserved
+        assert_eq!(prefetch_concurrency_cap(4), 3); // 1 reserved
+        assert_eq!(prefetch_concurrency_cap(2), 1); // 1 reserved
+        assert_eq!(prefetch_concurrency_cap(1), 1); // degenerate: no reserve
+        assert_eq!(prefetch_concurrency_cap(0), 1); // clamped like the pool
+        assert_eq!(prefetch_concurrency_cap(64), 60); // reserve capped at 4
+        for n in 2..=64u32 {
+            assert!(
+                prefetch_concurrency_cap(n) < n as usize,
+                "pool {n}: prefetch must never be able to hold every permit"
+            );
+        }
+    }
+
+    /// GET 404 = clean miss (#485 Phase 0): a stale key-cache positive sends
+    /// the check straight to GET (no HEAD); when the object is gone the
+    /// response must be a miss (found=false), NOT an error, and the stale key
+    /// must be evicted from the key cache so the next check doesn't repeat it.
+    #[tokio::test]
+    async fn test_remote_check_known_positive_get_404_is_clean_miss() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+
+        // Only event: the GET answers 404 (no HEAD happens — key cache says positive).
+        let (server, client) = mock_s3_client(vec![ReplayedEvent::status(404)]).await;
+        let daemon = Arc::new(Daemon::new(config));
+        daemon.s3_client.set(client).expect("inject mock S3 client");
+
+        // Fresh, authoritative-positive key cache entry for the key.
+        let key = "gone01gone02gone03";
+        let mut keys = HashMap::new();
+        keys.insert(key.to_string(), "serde".to_string());
+        daemon.key_cache.populate(keys).await;
+
+        let resp = daemon
+            .handle_remote_check(&RemoteCheckRequest {
+                key: key.into(),
+                entry_dir: dir.path().join("entry").to_string_lossy().into_owned(),
+                crate_name: "serde".into(),
+            })
+            .await;
+
+        assert!(
+            resp.ok,
+            "GET 404 must be a clean miss, not an error: {resp:?}"
+        );
+        assert_eq!(resp.found, Some(false));
+        // The stale positive was evicted.
+        assert_eq!(daemon.key_cache.check(key).await, Some(false));
+        // Not counted as a failed transfer.
+        assert_eq!(
+            daemon
+                .transfer_counters
+                .downloads_failed
+                .load(Ordering::Relaxed),
+            0
+        );
         server.shutdown();
     }
 

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -109,7 +109,20 @@ impl<'a> RemoteLayout<'a> {
             .key(&object_key)
             .send()
             .await
-            .context("downloading v3 pack from S3")?;
+            .map_err(|e| {
+                // A missing object is a clean miss, not a transfer failure.
+                // Callers downcast to `EntryNotFound` to take the miss path
+                // (#485 Phase 0): likely-present keys go straight to GET, and
+                // a stale key-cache positive degrades to a miss, not an error.
+                if is_missing_get_object(&e) {
+                    anyhow::Error::new(EntryNotFound).context(format!(
+                        "v3 pack not found (GET 404): s3://{}/{}",
+                        self.remote.bucket, object_key
+                    ))
+                } else {
+                    anyhow::Error::new(e).context("downloading v3 pack from S3")
+                }
+            })?;
         let request_ms = request_start.elapsed().as_millis() as u64;
 
         let body_start = std::time::Instant::now();
@@ -321,6 +334,49 @@ fn v3_manifest_key(prefix: &str, cache_key: &str, crate_name: &str) -> String {
 
 fn v3_pack_key(prefix: &str, cache_key: &str, crate_name: &str) -> String {
     format!("{prefix}/{V3_ROOT}/{V3_PACKS}/{crate_name}/{cache_key}.tar.zst")
+}
+
+/// Marker error: the requested entry does not exist in the remote (GET 404).
+/// Downcast target for callers that treat absence as a clean miss rather than
+/// a transfer failure (#485 Phase 0).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EntryNotFound;
+
+impl std::fmt::Display for EntryNotFound {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("remote entry not found")
+    }
+}
+
+impl std::error::Error for EntryNotFound {}
+
+/// GET-side twin of [`is_missing_head_object`]: true when a GetObject failure
+/// means "no such object" rather than a transport/service error. Checks the
+/// service-error code (AWS, MinIO) AND the raw HTTP status, because some S3
+/// clones answer a GET for a missing key with a bare 404 and no XML error
+/// body, which parses to a code-less unhandled service error.
+fn is_missing_get_object(
+    err: &aws_sdk_s3::error::SdkError<
+        aws_sdk_s3::operation::get_object::GetObjectError,
+        aws_smithy_runtime_api::client::orchestrator::HttpResponse,
+    >,
+) -> bool {
+    if err
+        .raw_response()
+        .is_some_and(|r| r.status().as_u16() == 404)
+    {
+        return true;
+    }
+    match err.as_service_error() {
+        Some(se) => {
+            se.is_no_such_key()
+                || matches!(
+                    se.code(),
+                    Some("NotFound" | "NoSuchKey" | "404" | "NoSuchObject")
+                )
+        }
+        None => false,
+    }
 }
 
 fn is_missing_head_object(err: &HeadObjectError) -> bool {


### PR DESCRIPTION
## What

Phase 0 of #485, in two commits:

**Baseline telemetry (no behavior change).** New daemon-side `PrefetchStats` (prefetch-attributed downloads/bytes, distinct keys later used via the daemon, adaptive-cancellation drops, advisory-vs-fallback plan counts + last plan size, dedup join-waits, LIST duration/key count), carried in `StatsResponse` as a serde-defaulted nested snapshot and rendered by `kache stats` only when the daemon reports activity. This is the baseline the coordination service will be judged against.

**Scheduling fixes (service-independent, called out in the design note).**
- Speculative prefetch is bounded by a daemon-wide gate semaphore below the S3 permit pool (default 16 permits -> 12 for prefetch), acquired before and held throughout each task's S3 permit tenure. Across all coordinators, interactive `RemoteCheck` always finds head-room; the old per-coordinator `available_permits()` snapshot was racy and, with overlapping coordinators, could occupy every permit.
- GET 404 is a clean miss: `download_entry` returns a typed `EntryNotFound` (service-error codes and bare-404 clones), `handle_remote_check` reports found=false, evicts the stale key-cache positive, and doesn't count a failed transfer. Previously a stale positive on the direct-GET path surfaced as a hard error.

## Notes

- `keys_used` is documented as a lower bound: prefetches consumed via the wrapper's local store path never reach the daemon; full attribution stays in the events log (`kache report`).
- The notify-based download dedup (replacing the 300x100ms poll) is deliberately NOT here; it lands as its own PR — it also needs to fix the existing double-claim race when two waiters time out simultaneously.
- The design critique this implements against, and the cross-model review that reshaped the permit fix (per-coordinator -> daemon-wide), are recorded in #485.

## Tests

1169 unit tests green; new: permit-cap arithmetic across pool sizes, GET-404-as-miss end to end on a mocked S3 (found=false, cache evicted, no failed-transfer count), stats serde back-compat (old daemon JSON without the new field), and the gated `kache stats` render section.