### PR TITLE
fix(rustc): detect unrecognized RUSTC_WORKSPACE_WRAPPER drivers by inner rustc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -2692,7 +2692,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32 0.2.1",
  "rustc_version",
- "spin 0.9.8",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -3612,7 +3612,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -6105,18 +6105,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -1074,7 +1074,7 @@ fn inspect_binary(run_cmd: &str, cwd: &Path, forbidden: &[String]) -> Option<Str
                 "binary contains forbidden substring `{}` in {}: ...{}...",
                 needle,
                 bin_path.display(),
-                &haystack[start..end].replace('\n', " ")
+                haystack[start..end].replace('\n', " ")
             ));
         }
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -984,6 +984,39 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_double_wrapper_unrecognized_driver() {
+        // Issue #505: dylint-driver (or any future RUSTC_WORKSPACE_WRAPPER
+        // tool) in the double-wrapper chain. The split keys off the inner
+        // rustc, so an unrecognized workspace wrapper is forwarded correctly.
+        let args: Vec<String> = vec![
+            "/Users/dev/.dylint_drivers/nightly/dylint-driver",
+            "/home/user/.rustup/toolchains/stable/bin/rustc",
+            "--crate-name",
+            "foo",
+            "src/lib.rs",
+            "--crate-type",
+            "lib",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let parsed = RustcArgs::parse(&args).unwrap();
+        assert_eq!(
+            parsed.rustc,
+            PathBuf::from("/Users/dev/.dylint_drivers/nightly/dylint-driver")
+        );
+        assert_eq!(
+            parsed.inner_rustc,
+            Some(PathBuf::from(
+                "/home/user/.rustup/toolchains/stable/bin/rustc"
+            ))
+        );
+        assert_eq!(parsed.crate_name.as_deref(), Some("foo"));
+        assert!(!parsed.all_args.iter().any(|a| a.contains("rustc")));
+    }
+
+    #[test]
     fn test_parse_single_wrapper_unchanged() {
         // Normal case: kache /path/to/rustc --crate-name foo src/lib.rs
         // After main.rs strips argv[0], parse receives: [/path/to/rustc, ...]

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -586,6 +586,18 @@ pub fn detect_compiler(args: &[String]) -> Option<&'static CompilerAdapter> {
         .find(|adapter| adapter.recognizes(args))
 }
 
+/// Detect a `RUSTC_WRAPPER` + `RUSTC_WORKSPACE_WRAPPER` chain where the
+/// workspace wrapper is not a known compiler basename. Cargo resolves
+/// the workspace wrapper to an absolute path, and the next positional arg
+/// is the real `rustc`. We recognize the chain by the inner compiler
+/// rather than the wrapper's name, so any future workspace-wrapper tool
+/// works without per-tool patches.
+pub fn is_workspace_wrapper_chain(args: &[String]) -> bool {
+    args.len() >= 2
+        && (args[0].contains('/') || args[0].contains('\\'))
+        && rustc::RustcCompiler::recognizes(&args[1..])
+}
+
 /// Extract the bare command name from an `argv[0]`, splitting on both Unix
 /// (`/`) and Windows (`\`) separators regardless of host OS.
 ///
@@ -692,6 +704,37 @@ mod tests {
         assert!(detect_compiler(&s(&["make"])).is_none());
         assert!(detect_compiler(&s(&["ld"])).is_none());
         assert!(detect_compiler(&s(&["--crate-name"])).is_none());
+    }
+
+    #[test]
+    fn workspace_wrapper_chain_detects_unrecognized_drivers() {
+        // Issue #505: dylint-driver and any future RUSTC_WORKSPACE_WRAPPER
+        // tool. Cargo passes `kache <wrapper-path> rustc <args>`.
+        assert!(is_workspace_wrapper_chain(&s(&[
+            "/Users/dev/.dylint_drivers/nightly/dylint-driver",
+            "rustc",
+            "--crate-name",
+        ])));
+        assert!(is_workspace_wrapper_chain(&s(&[
+            "/usr/local/bin/some-future-tool",
+            "rustc",
+        ])));
+        // Windows backslash path (host-OS-independent).
+        assert!(is_workspace_wrapper_chain(&s(&[
+            r"C:\tools\custom-driver.exe",
+            "rustc",
+        ])));
+    }
+
+    #[test]
+    fn workspace_wrapper_chain_rejects_non_paths() {
+        // No path separator → CLI subcommand, not a wrapper path.
+        assert!(!is_workspace_wrapper_chain(&s(&["init", "rustc-project"])));
+        assert!(!is_workspace_wrapper_chain(&s(&["stats"])));
+        // Inner arg not rustc.
+        assert!(!is_workspace_wrapper_chain(&s(&["/usr/bin/cc", "file.c"])));
+        // Too few args.
+        assert!(!is_workspace_wrapper_chain(&s(&["/usr/bin/rustc"])));
     }
 
     #[test]

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -728,14 +728,29 @@ mod tests {
     fn workspace_wrapper_chain_detects_bare_name_via_env() {
         // Cargo may pass a bare wrapper name (resolved via PATH) when
         // RUSTC_WORKSPACE_WRAPPER is set without a path separator.
-        let prev = std::env::var_os("RUSTC_WORKSPACE_WRAPPER");
-        unsafe { std::env::set_var("RUSTC_WORKSPACE_WRAPPER", "mydriver") };
-        assert!(is_workspace_wrapper_chain(&s(&["mydriver", "rustc"])));
-        // Restore: clear or reinstate previous value.
-        match prev {
-            Some(v) => unsafe { std::env::set_var("RUSTC_WORKSPACE_WRAPPER", v) },
-            None => unsafe { std::env::remove_var("RUSTC_WORKSPACE_WRAPPER") },
+        struct EnvGuard {
+            key: &'static str,
+            prev: Option<std::ffi::OsString>,
         }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                unsafe {
+                    match &self.prev {
+                        Some(v) => std::env::set_var(self.key, v),
+                        None => std::env::remove_var(self.key),
+                    }
+                }
+            }
+        }
+        let _guard = {
+            let prev = std::env::var_os("RUSTC_WORKSPACE_WRAPPER");
+            unsafe { std::env::set_var("RUSTC_WORKSPACE_WRAPPER", "mydriver") };
+            EnvGuard {
+                key: "RUSTC_WORKSPACE_WRAPPER",
+                prev,
+            }
+        };
+        assert!(is_workspace_wrapper_chain(&s(&["mydriver", "rustc"])));
     }
 
     #[test]

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -586,16 +586,18 @@ pub fn detect_compiler(args: &[String]) -> Option<&'static CompilerAdapter> {
         .find(|adapter| adapter.recognizes(args))
 }
 
-/// Detect a `RUSTC_WRAPPER` + `RUSTC_WORKSPACE_WRAPPER` chain where the
-/// workspace wrapper is not a known compiler basename. Cargo resolves
-/// the workspace wrapper to an absolute path, and the next positional arg
-/// is the real `rustc`. We recognize the chain by the inner compiler
-/// rather than the wrapper's name, so any future workspace-wrapper tool
-/// works without per-tool patches.
+/// Detect a `RUSTC_WRAPPER` + `RUSTC_WORKSPACE_WRAPPER` chain with an
+/// unrecognized workspace wrapper. Cargo passes `<wrapper> rustc <args>`;
+/// the wrapper may be an absolute path or a bare name resolved via PATH.
+/// We match the inner rustc, not the wrapper name.
 pub fn is_workspace_wrapper_chain(args: &[String]) -> bool {
-    args.len() >= 2
-        && (args[0].contains('/') || args[0].contains('\\'))
-        && rustc::RustcCompiler::recognizes(&args[1..])
+    if args.len() < 2 || !rustc::RustcCompiler::recognizes(&args[1..]) {
+        return false;
+    }
+    args[0].contains('/')
+        || args[0].contains('\\')
+        || std::env::var_os("RUSTC_WORKSPACE_WRAPPER")
+            .is_some_and(|w| w == std::ffi::OsStr::new(&args[0]))
 }
 
 /// Extract the bare command name from an `argv[0]`, splitting on both Unix
@@ -715,10 +717,6 @@ mod tests {
             "rustc",
             "--crate-name",
         ])));
-        assert!(is_workspace_wrapper_chain(&s(&[
-            "/usr/local/bin/some-future-tool",
-            "rustc",
-        ])));
         // Windows backslash path (host-OS-independent).
         assert!(is_workspace_wrapper_chain(&s(&[
             r"C:\tools\custom-driver.exe",
@@ -727,10 +725,23 @@ mod tests {
     }
 
     #[test]
+    fn workspace_wrapper_chain_detects_bare_name_via_env() {
+        // Cargo may pass a bare wrapper name (resolved via PATH) when
+        // RUSTC_WORKSPACE_WRAPPER is set without a path separator.
+        let prev = std::env::var_os("RUSTC_WORKSPACE_WRAPPER");
+        unsafe { std::env::set_var("RUSTC_WORKSPACE_WRAPPER", "mydriver") };
+        assert!(is_workspace_wrapper_chain(&s(&["mydriver", "rustc"])));
+        // Restore: clear or reinstate previous value.
+        match prev {
+            Some(v) => unsafe { std::env::set_var("RUSTC_WORKSPACE_WRAPPER", v) },
+            None => unsafe { std::env::remove_var("RUSTC_WORKSPACE_WRAPPER") },
+        }
+    }
+
+    #[test]
     fn workspace_wrapper_chain_rejects_non_paths() {
-        // No path separator → CLI subcommand, not a wrapper path.
+        // No path separator and not RUSTC_WORKSPACE_WRAPPER → CLI subcommand.
         assert!(!is_workspace_wrapper_chain(&s(&["init", "rustc-project"])));
-        assert!(!is_workspace_wrapper_chain(&s(&["stats"])));
         // Inner arg not rustc.
         assert!(!is_workspace_wrapper_chain(&s(&["/usr/bin/cc", "file.c"])));
         // Too few args.

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,6 +295,7 @@ fn detect_log_mode(env_args: &[String]) -> LogMode {
         // stderr as a stale compiler diagnostic).
         if compiler::detect_compiler(after).is_some()
             || compiler::cc::CcCompiler::recognizes_family_probe(after)
+            || compiler::is_workspace_wrapper_chain(after)
         {
             return LogMode::Wrapper;
         }
@@ -618,9 +619,20 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
         std::process::exit(wrapper::run_cc_probe(args)?);
     }
 
-    // Dispatch by detected adapter. detect_log_mode already verified there's
-    // a recognized compiler at args[0], so the None branch is defensive.
-    let Some(adapter) = compiler::detect_compiler(args) else {
+    // Dispatch by detected adapter. detect_log_mode may have routed here
+    // via is_workspace_wrapper_chain (unrecognized workspace wrapper),
+    // in which case detect_compiler returns None and we fall back to the
+    // rustc adapter — the double-wrapper split in RustcArgs::parse handles
+    // inner-rustc forwarding, and the cache key probes the wrapper's -vV
+    // so different wrappers (clippy-driver, dylint-driver, …) get distinct keys.
+    let adapter = compiler::detect_compiler(args).or_else(|| {
+        if compiler::is_workspace_wrapper_chain(args) {
+            Some(&compiler::rustc::ADAPTER)
+        } else {
+            None
+        }
+    });
+    let Some(adapter) = adapter else {
         anyhow::bail!(
             "wrapper-mode dispatched but no compiler adapter matched argv[0] = {:?}",
             args.first()
@@ -764,6 +776,24 @@ mod tests {
                 "--crate-name".into(),
             ]),
             LogMode::Wrapper
+        );
+        // Issue #505: unrecognized RUSTC_WORKSPACE_WRAPPER tools like
+        // dylint-driver. Cargo passes `kache <wrapper-path> rustc <args>`.
+        // Detection keys off the inner rustc (position 2), not the
+        // wrapper's name — so any workspace-wrapper tool works.
+        assert_eq!(
+            detect_log_mode(&[
+                "kache".into(),
+                "/Users/dev/.dylint_drivers/nightly/dylint-driver".into(),
+                "rustc".into(),
+                "--crate-name".into(),
+            ]),
+            LogMode::Wrapper
+        );
+        // Negative: no path separator in arg[1] → CLI subcommand, not a wrapper.
+        assert_eq!(
+            detect_log_mode(&["kache".into(), "init".into(), "rustc-project".into(),]),
+            LogMode::Cli
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -619,20 +619,10 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
         std::process::exit(wrapper::run_cc_probe(args)?);
     }
 
-    // Dispatch by detected adapter. detect_log_mode may have routed here
-    // via is_workspace_wrapper_chain (unrecognized workspace wrapper),
-    // in which case detect_compiler returns None and we fall back to the
-    // rustc adapter — the double-wrapper split in RustcArgs::parse handles
-    // inner-rustc forwarding, and the cache key probes the wrapper's -vV
-    // so different wrappers (clippy-driver, dylint-driver, …) get distinct keys.
-    let adapter = compiler::detect_compiler(args).or_else(|| {
+    let Some(adapter) = compiler::detect_compiler(args) else {
         if compiler::is_workspace_wrapper_chain(args) {
-            Some(&compiler::rustc::ADAPTER)
-        } else {
-            None
+            std::process::exit(run_compiler_directly(args)?);
         }
-    });
-    let Some(adapter) = adapter else {
         anyhow::bail!(
             "wrapper-mode dispatched but no compiler adapter matched argv[0] = {:?}",
             args.first()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -747,3 +747,75 @@ fn test_cc_depinfo_restore_preserves_parent_relative_deps() {
     let report = kache_report(cache_dir.path());
     assert_cc_report_counts(&report, 1, 1);
 }
+
+/// Issue #505: unrecognized RUSTC_WORKSPACE_WRAPPER tools must pass through
+/// uncached — the wrapper must execute on every build, not just the first.
+/// If someone routes unknown wrappers back through the cache, the second
+/// invocation would be a cache hit and the wrapper would NOT execute,
+/// failing the marker-count assertion.
+#[cfg(unix)]
+#[test]
+fn workspace_wrapper_passthrough_executes_every_time() {
+    use std::os::unix::fs::PermissionsExt;
+
+    build_kache();
+    let cache_dir = TempDir::new().unwrap();
+    let marker = cache_dir.path().join("wrapper-runs.log");
+
+    // Fake workspace wrapper: records each execution, then forwards to rustc.
+    let wrapper = cache_dir.path().join("fake-driver");
+    std::fs::write(
+        &wrapper,
+        format!("#!/bin/sh\necho ran >> {}\nexec \"$@\"\n", marker.display()),
+    )
+    .unwrap();
+    std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let src = cache_dir.path().join("lib.rs");
+    std::fs::write(&src, "pub fn foo() -> u32 { 42 }\n").unwrap();
+    let out = cache_dir.path().join("out.rlib");
+
+    let run = || {
+        std::process::Command::new(kache_binary())
+            .arg(&wrapper)
+            .arg("rustc")
+            .args([
+                "--edition",
+                "2024",
+                "--crate-type",
+                "lib",
+                "--crate-name",
+                "fakedriver",
+                "-o",
+                out.to_str().unwrap(),
+                src.to_str().unwrap(),
+            ])
+            .env("KACHE_CACHE_DIR", cache_dir.path())
+            .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
+            .env_remove("RUSTC_WRAPPER")
+            .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+            .output()
+            .expect("failed to run kache")
+    };
+
+    let out1 = run();
+    assert!(
+        out1.status.success(),
+        "first build failed\nstderr: {}",
+        String::from_utf8_lossy(&out1.stderr)
+    );
+    let count1 = std::fs::read_to_string(&marker).unwrap().lines().count();
+    assert_eq!(count1, 1);
+
+    let out2 = run();
+    assert!(
+        out2.status.success(),
+        "second build failed\nstderr: {}",
+        String::from_utf8_lossy(&out2.stderr)
+    );
+    let count2 = std::fs::read_to_string(&marker).unwrap().lines().count();
+    assert_eq!(
+        count2, 2,
+        "wrapper must execute on every build (uncached passthrough)"
+    );
+}


### PR DESCRIPTION
## What

When `RUSTC_WRAPPER=kache` and a tool also sets `RUSTC_WORKSPACE_WRAPPER` (e.g. `cargo dylint`), cargo invokes the wrapper chain as `kache <workspace-wrapper> rustc <args>` for workspace-member crates.

kache's `RustcCompiler::recognizes` only matched `rustc`, `rustc*`, and `clippy-driver` basenames. Any other workspace wrapper — like `dylint-driver` — fell through to clap CLI parsing and errored:

```
error: unrecognized subcommand '/Users/…/.dylint_drivers/…/dylint-driver'
```

Same class of bug as #287 (clippy-driver, fixed in #289 by adding the name to the list).

## Fix

Rather than extending the hardcoded basename list, this PR detects the double-wrapper chain structurally: if `args[0]` is a path (contains a separator) and `args[1]` is recognized as rustc, it's a `RUSTC_WRAPPER + RUSTC_WORKSPACE_WRAPPER` chain — regardless of the workspace wrapper's name.

New helper `is_workspace_wrapper_chain` in `compiler/mod.rs` is wired into two call sites:

1. **`detect_log_mode`** (main.rs) — entry gate: routes the invocation to Wrapper mode instead of falling through to clap.
2. **`run_wrapper_mode`** (main.rs) — adapter fallback: when `detect_compiler` returns None but the chain matches, falls back to the rustc adapter.

The path-separator constraint on `args[0]` prevents false positives on CLI subcommands (cargo always resolves wrappers to absolute paths).

No changes to `recognizes`, `RustcArgs::parse`, `compile.rs`, or `wrapper.rs` — the existing double-wrapper infrastructure (inner-rustc split at args.rs:155, inner-rustc forwarding at compile.rs:44-48) handles the rest unchanged.

## Why caching is safe

The cache key probes `<compiler> -vV` and hashes the version string (cache_key.rs:360). Different workspace wrappers (dylint-driver, clippy-driver, plain rustc) produce different `-vV` output, so cache keys are naturally differentiated.

## Testing

- Unit tests for `is_workspace_wrapper_chain` (positive: dylint-driver path, Windows backslash path; negative: no path separator, inner arg not rustc, too few args)
- `detect_log_mode` test: dylint-driver chain routes to Wrapper; negative case (CLI subcommand with `rustc` in position 2 but no path separator) stays Cli
- `RustcArgs::parse` double-wrapper test with dylint-driver path

All tests are pure string-logic — run on every host OS, no fixtures.

Closes #505