### PR TITLE
fix(link): stop blaming the filesystem for sub-cluster copy-restores (#508)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -2692,7 +2692,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32 0.2.1",
  "rustc_version",
- "spin 0.9.8",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -3612,7 +3612,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -6105,18 +6105,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,9 @@ windows-sys = { version = "0.61", features = [
     # write-isolated restore on a Dev Drive — see link::try_reflink (#429).
     "Win32_System_IO",
     "Win32_System_Ioctl",
+    # FILE_SUPPORTS_BLOCK_REFCOUNTING — ask the volume whether it block-clones
+    # instead of inferring "no CoW" from one failed clone (#508).
+    "Win32_System_SystemServices",
 ] }
 
 [dev-dependencies]

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -1083,7 +1083,7 @@ fn inspect_binary(run_cmd: &str, cwd: &Path, forbidden: &[String]) -> Option<Str
                 "binary contains forbidden substring `{}` in {}: ...{}...",
                 needle,
                 bin_path.display(),
-                &haystack[start..end].replace('\n', " ")
+                haystack[start..end].replace('\n', " ")
             ));
         }
     }

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,6 +1,10 @@
 use anyhow::{Context, Result};
 use std::fs;
 use std::path::Path;
+#[cfg(windows)]
+use std::path::PathBuf;
+#[cfg(windows)]
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Process-global: restore via hardlink on a non-CoW Windows volume (NTFS)
@@ -8,10 +12,24 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// at wrapper entry; read on the Windows restore path. Off everywhere else.
 static WINDOWS_HARDLINK_RESTORE: AtomicBool = AtomicBool::new(false);
 
+/// Process-global: marker file used to dedup the no-CoW advisory across the
+/// hundreds of wrapper processes a single build spawns (#508). Set at wrapper
+/// entry; if unset the advisory falls back to once-per-process.
+#[cfg(windows)]
+static COW_WARN_MARKER: OnceLock<PathBuf> = OnceLock::new();
+
 /// Set the Windows hardlink-restore opt-in (from `Config::windows_hardlink`).
 /// Call once per process before restoring. No effect off Windows.
 pub fn set_windows_hardlink_restore(enabled: bool) {
     WINDOWS_HARDLINK_RESTORE.store(enabled, Ordering::Relaxed);
+}
+
+/// Set the cross-process dedup marker for the no-CoW advisory. Call once per
+/// process before restoring. No effect off Windows.
+#[cfg_attr(not(windows), allow(unused_variables))]
+pub fn set_cow_warn_marker(path: std::path::PathBuf) {
+    #[cfg(windows)]
+    let _ = COW_WARN_MARKER.set(path);
 }
 
 /// Strategy for restoring a cached file to a build output path.
@@ -61,20 +79,27 @@ pub fn link_to_target(store_path: &Path, target_path: &Path, strategy: LinkStrat
     // Try reflink first. CoW gives us zero-copy *and* mutations don't
     // propagate to the cache blob — strictly better than hardlink when
     // available (APFS, btrfs, XFS-with-reflink).
-    if try_reflink(store_path, target_path).is_ok() {
-        if matches!(strategy, LinkStrategy::Copy) {
-            // Reflink preserves source mode (0o444 for stored blobs);
-            // executables/dylibs need 0o755 so cargo can run/load them.
-            set_executable_perms(target_path)?;
+    // Keep the failure reason: on Windows it separates "this volume can't
+    // block-clone" from "this one file couldn't be cloned" (#508).
+    let reflink_err = match try_reflink(store_path, target_path) {
+        Ok(()) => {
+            if matches!(strategy, LinkStrategy::Copy) {
+                // Reflink preserves source mode (0o444 for stored blobs);
+                // executables/dylibs need 0o755 so cargo can run/load them.
+                set_executable_perms(target_path)?;
+            }
+            tracing::debug!(
+                "reflinked {} -> {}",
+                store_path.display(),
+                target_path.display()
+            );
+            crate::opcounts::record_reflinked(bytes);
+            return Ok(());
         }
-        tracing::debug!(
-            "reflinked {} -> {}",
-            store_path.display(),
-            target_path.display()
-        );
-        crate::opcounts::record_reflinked(bytes);
-        return Ok(());
-    }
+        Err(e) => e,
+    };
+    #[cfg(not(windows))]
+    let _ = &reflink_err;
 
     // Reflink unsupported on this filesystem — strategy-specific fallback.
     match strategy {
@@ -100,7 +125,7 @@ pub fn link_to_target(store_path: &Path, target_path: &Path, strategy: LinkStrat
                 // trade the read-only-output risk for working-tree dedup.
                 hardlink_or_copy(store_path, target_path, bytes)
             } else {
-                warn_no_cow_restore_once(store_path, target_path);
+                warn_no_cow_restore_once(store_path, target_path, bytes, &reflink_err);
                 copy_file(store_path, target_path, false)?;
                 crate::opcounts::record_copied(bytes);
                 Ok(())
@@ -144,68 +169,210 @@ fn hardlink_or_copy(store_path: &Path, target_path: &Path, bytes: u64) -> Result
     Ok(())
 }
 
-/// Warn ONCE per process that cache hits are being restored by copy because
-/// this Windows restore couldn't block-clone, so the cache and build tree don't
-/// share storage. One warning per compilation (each TU is its own process); it
-/// fires only when a hit is actually copy-restored, so a compile that misses
-/// stays silent.
+/// Why a Windows cache hit was restored by COPY instead of a block-clone.
 ///
-/// The reflink that just failed (`FSCTL_DUPLICATE_EXTENTS_TO_FILE`) fails for
-/// two distinct reasons, and the fix differs, so we tell them apart from the
-/// cache-blob and build-output paths (#490):
+/// A failed `FSCTL_DUPLICATE_EXTENTS_TO_FILE` does NOT imply the volume lacks
+/// copy-on-write, and conflating the two is what made kache cry wolf at every
+/// Dev Drive user (#508). The three causes need three different responses:
 ///
-/// - **Cross-volume**: the cache blob and the build output live on different
-///   volumes. Block-cloning cannot span volumes (nor can hardlinks), so even on
-///   two ReFS Dev Drives this copies. This is the likely case for a Dev Drive
-///   user who still sees the warning — the fix is to co-locate cache + build on
-///   the *same* volume, not to touch the filesystem.
-/// - **Same volume, no CoW (NTFS)**: the volume simply has no block-cloning.
-///   Move both onto a ReFS Dev Drive, or opt into `[cache] windows_hardlink`.
-///
-/// Including the paths lets the user see *which* file and *which* volumes are
-/// involved instead of guessing.
-#[cfg(windows)]
-fn warn_no_cow_restore_once(store_path: &Path, target_path: &Path) {
-    use std::sync::Once;
-    static WARNED: Once = Once::new();
-    WARNED.call_once(|| {
-        let cache_vol = windows_volume_root(store_path);
-        let build_vol = windows_volume_root(target_path);
-        let cross_volume = match (&cache_vol, &build_vol) {
-            (Some(a), Some(b)) => !a.eq_ignore_ascii_case(b),
-            // If we can't resolve a volume for either side, don't assert
-            // cross-volume — fall back to the NTFS wording.
-            _ => false,
-        };
+/// - **`CrossVolume`**: cache blob and build output are on different volumes.
+///   Block-cloning cannot span volumes (nor can hardlinks), so even two ReFS Dev
+///   Drives copy. Fix: co-locate cache + build on one volume — not a filesystem
+///   problem, so this is worth saying (#490).
+/// - **`NoCow`**: the volume genuinely has no block-cloning (NTFS). Fix: move
+///   both onto a ReFS Dev Drive, or opt into `[cache] windows_hardlink`. Worth
+///   saying — this is the case that really does double disk usage.
+/// - **`SubClusterOnCowVolume`**: the volume DOES block-clone, and this file is
+///   smaller than one cluster, so it has no cluster-aligned range (ReFS clones
+///   whole clusters; cloning past EOF is undefined). Every `.d` under ~4 KB hits
+///   this on a healthy Dev Drive: all 670 warnings in #508 were sub-cluster `.d`
+///   files while the `.rlib`/`.rmeta` beside them block-cloned fine. Saying
+///   nothing is right — the volume is healthy and there is no advice to give.
+/// - **`UnexpectedOnCowVolume`**: the volume block-clones and the file was big
+///   enough to clone, yet the clone still failed. That is NOT benign — a filter
+///   driver, an integrity-stream mismatch, or a kache bug could silently demote
+///   every large artifact to a copy. Surface it (with the OS error) rather than
+///   hiding it behind the #508 fix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(windows), allow(dead_code))]
+enum CopyRestoreCause {
+    CrossVolume,
+    NoCow,
+    SubClusterOnCowVolume,
+    UnexpectedOnCowVolume,
+}
 
-        if cross_volume {
-            eprintln!(
-                "kache: cache hits are restored by COPY because the cache and build \
-                 tree are on different volumes ({cache_vol} vs {build_vol}), and \
-                 copy-on-write block-cloning cannot span volumes — so they do not \
-                 share storage, roughly doubling disk for cached content. Put the \
-                 cache and build dir on the SAME volume (ideally a ReFS Dev Drive) \
-                 for zero-copy dedup.\n         cache blob:   {store}\n         \
-                 build output: {target}",
-                cache_vol = cache_vol.as_deref().unwrap_or("?"),
-                build_vol = build_vol.as_deref().unwrap_or("?"),
-                store = store_path.display(),
-                target = target_path.display(),
-            );
+/// Classify a copy-restore from the two volume roots, the build volume's
+/// block-cloning capability, and whether the file was too small to clone. Pure —
+/// kept platform-independent so the decision table is unit-testable off Windows.
+///
+/// `build_vol_has_cow == None` means the capability probe failed; we then fall
+/// back to the historical assumption (no CoW) rather than going silent, so a
+/// real NTFS user still gets told. Likewise an unknown `file_is_sub_cluster`
+/// resolves to "unexpected" — we'd rather say too much than hide a real fault.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn classify_copy_restore(
+    cache_vol: Option<&str>,
+    build_vol: Option<&str>,
+    build_vol_has_cow: Option<bool>,
+    file_is_sub_cluster: Option<bool>,
+) -> CopyRestoreCause {
+    // If we can't resolve a volume for either side, don't assert cross-volume.
+    if let (Some(cache), Some(build)) = (cache_vol, build_vol)
+        && !cache.eq_ignore_ascii_case(build)
+    {
+        return CopyRestoreCause::CrossVolume;
+    }
+    if build_vol_has_cow == Some(true) {
+        // Same volume, and it block-clones — the other files in this same build
+        // reflink fine. Expected only when the file had no clonable range.
+        return if file_is_sub_cluster == Some(true) {
+            CopyRestoreCause::SubClusterOnCowVolume
         } else {
-            eprintln!(
-                "kache: this volume ({vol}) has no copy-on-write, so cache hits are \
-                 restored by COPY — the cache and build tree do not share storage, \
-                 roughly doubling disk for cached content. For zero-copy dedup put \
-                 the cache + build dir on a ReFS Dev Drive, or set \
-                 `[cache] windows_hardlink = true` (only if your build never \
-                 deletes or rewrites an object output).\n         affected output: \
-                 {target}",
-                vol = build_vol.as_deref().unwrap_or("NTFS"),
-                target = target_path.display(),
+            CopyRestoreCause::UnexpectedOnCowVolume
+        };
+    }
+    CopyRestoreCause::NoCow
+}
+
+/// Tell the user their cache hits are being restored by COPY — but only when
+/// that is actually a problem, and at most once per warn-session window across
+/// all wrapper processes (#508).
+///
+/// Every restored file that can't block-clone lands here, so both gates matter:
+/// a sub-cluster file on a working Dev Drive says nothing at all, and the real
+/// advisories dedup through a marker file rather than a per-process `Once` —
+/// each rustc is its own process, which is why a single build used to emit the
+/// same warning hundreds of times.
+///
+/// `bytes` is the blob's size and `reflink_err` the clone failure, so a file
+/// that was big enough to clone but failed anyway can still be surfaced instead
+/// of being swallowed along with the benign sub-cluster case.
+#[cfg(windows)]
+fn warn_no_cow_restore_once(
+    store_path: &Path,
+    target_path: &Path,
+    bytes: u64,
+    reflink_err: &anyhow::Error,
+) {
+    let cache_vol = windows_volume_root(store_path);
+    let build_vol = windows_volume_root(target_path);
+    // A file with no cluster-aligned range can't be block-cloned on ANY volume.
+    // If the cluster size can't be read, leave it unknown rather than guessing.
+    let sub_cluster = windows_cluster_size(target_path)
+        .ok()
+        .map(|cluster| bytes > 0 && bytes < cluster);
+    let cause = classify_copy_restore(
+        cache_vol.as_deref(),
+        build_vol.as_deref(),
+        windows_volume_supports_block_clone(target_path),
+        sub_cluster,
+    );
+
+    let message = match cause {
+        CopyRestoreCause::SubClusterOnCowVolume => {
+            // Not a filesystem problem: the volume block-clones, this file is
+            // just smaller than a cluster. Debug-log it and stay quiet.
+            tracing::debug!(
+                "copy-restored {} — {} bytes is smaller than one cluster, so it has \
+                 no cluster-aligned range to block-clone; volume {} does support \
+                 copy-on-write",
+                target_path.display(),
+                bytes,
+                build_vol.as_deref().unwrap_or("?"),
+            );
+            return;
+        }
+        CopyRestoreCause::UnexpectedOnCowVolume => format!(
+            "kache: this volume ({vol}) supports copy-on-write and this file is \
+             large enough to block-clone, but the clone FAILED — so the cache hit \
+             was restored by COPY and does not share storage with the cache. This \
+             is unexpected; please report it with the error below.\n         \
+             error:           {err:#}\n         affected output: {target} \
+             ({bytes} bytes)",
+            vol = build_vol.as_deref().unwrap_or("?"),
+            err = reflink_err,
+            target = target_path.display(),
+            bytes = bytes,
+        ),
+        CopyRestoreCause::CrossVolume => format!(
+            "kache: cache hits are restored by COPY because the cache and build \
+             tree are on different volumes ({cache_vol} vs {build_vol}), and \
+             copy-on-write block-cloning cannot span volumes — so they do not \
+             share storage, roughly doubling disk for cached content. Put the \
+             cache and build dir on the SAME volume (ideally a ReFS Dev Drive) \
+             for zero-copy dedup.\n         cache blob:   {store}\n         \
+             build output: {target}",
+            cache_vol = cache_vol.as_deref().unwrap_or("?"),
+            build_vol = build_vol.as_deref().unwrap_or("?"),
+            store = store_path.display(),
+            target = target_path.display(),
+        ),
+        CopyRestoreCause::NoCow => format!(
+            "kache: this volume ({vol}) has no copy-on-write, so cache hits are \
+             restored by COPY — the cache and build tree do not share storage, \
+             roughly doubling disk for cached content. For zero-copy dedup put \
+             the cache + build dir on a ReFS Dev Drive, or set \
+             `[cache] windows_hardlink = true` (only if your build never \
+             deletes or rewrites an object output).\n         affected output: \
+             {target}",
+            vol = build_vol.as_deref().unwrap_or("NTFS"),
+            target = target_path.display(),
+        ),
+    };
+
+    match COW_WARN_MARKER.get() {
+        Some(marker) => {
+            let _warned = crate::wrapper::warn_once_per_session(
+                marker,
+                crate::wrapper::WARN_SESSION_SECS,
+                &message,
             );
         }
-    });
+        // No marker configured (unit tests, non-wrapper entrypoints): fall back
+        // to once-per-process rather than going silent.
+        None => {
+            use std::sync::Once;
+            static WARNED: Once = Once::new();
+            WARNED.call_once(|| eprintln!("{message}"));
+        }
+    }
+}
+
+/// Does the volume holding `path` support ReFS block-cloning (copy-on-write)?
+/// `None` if the capability can't be determined.
+///
+/// This is the question `warn_no_cow_restore_once` actually needs answered —
+/// asking the volume directly, rather than inferring "no CoW" from one failed
+/// clone of one file (#508).
+#[cfg(windows)]
+fn windows_volume_supports_block_clone(path: &Path) -> Option<bool> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::GetVolumeInformationW;
+    use windows_sys::Win32::System::SystemServices::FILE_SUPPORTS_BLOCK_REFCOUNTING;
+
+    let root = windows_volume_root(path)?;
+    let wide: Vec<u16> = std::ffi::OsStr::new(&root)
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    let mut flags: u32 = 0;
+    let ok = unsafe {
+        GetVolumeInformationW(
+            wide.as_ptr(),
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut flags,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ok == 0 {
+        return None;
+    }
+    Some(flags & FILE_SUPPORTS_BLOCK_REFCOUNTING != 0)
 }
 
 /// Volume mount root (e.g. `C:\` or `D:\`) that holds `path`, or `None` if it
@@ -345,16 +512,19 @@ fn reflink_windows(src: &Path, dst: &Path) -> Result<()> {
         .open(dst)?;
 
     if len == 0 {
-        return Ok(()); // empty file: dst already created empty
+        return Ok(()); // empty file: dst already created empty, nothing to clone
     }
 
-    // Cluster size of the destination volume; clone ranges must be aligned to it.
+    // Cluster size of the destination volume; clone ranges must be aligned to
+    // it. A file smaller than one cluster has no aligned range at all, so bail
+    // before the FSCTL rather than issuing a call that cannot succeed — this is
+    // the common case for the many small `.d` files restored here (#508).
     let cluster = windows_cluster_size(dst)?;
-    let clone_len = (len / cluster) * cluster;
-    if clone_len == 0 {
-        // Smaller than a cluster — no aligned range to clone. Copy instead.
-        anyhow::bail!("file smaller than ReFS cluster; fall back to copy");
+    if len < cluster {
+        anyhow::bail!("file smaller than one cluster; fall back to copy");
     }
+
+    let clone_len = (len / cluster) * cluster;
 
     // Allocate the destination clusters and set EOF to the cloned prefix.
     dst_file.set_len(clone_len)?;
@@ -618,6 +788,71 @@ pub enum DepInfoMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The regression from #508: on a ReFS Dev Drive that DOES block-clone, a
+    /// sub-cluster file (every `.d` under ~4 KB) falls back to copy — and kache
+    /// used to blame the filesystem, once per rustc process, hundreds of times
+    /// per build. A healthy volume must produce no advisory at all.
+    #[test]
+    fn sub_cluster_copy_on_a_cow_volume_is_not_a_no_cow_problem() {
+        assert_eq!(
+            classify_copy_restore(Some("G:\\"), Some("G:\\"), Some(true), Some(true)),
+            CopyRestoreCause::SubClusterOnCowVolume,
+        );
+    }
+
+    /// But silence must not extend to a file that COULD have been cloned and
+    /// wasn't — that would hide a filter driver or a kache bug quietly demoting
+    /// every large artifact to a copy.
+    #[test]
+    fn a_clonable_file_that_fails_to_clone_is_still_surfaced() {
+        assert_eq!(
+            classify_copy_restore(Some("G:\\"), Some("G:\\"), Some(true), Some(false)),
+            CopyRestoreCause::UnexpectedOnCowVolume,
+        );
+        assert_eq!(
+            classify_copy_restore(Some("G:\\"), Some("G:\\"), Some(true), None),
+            CopyRestoreCause::UnexpectedOnCowVolume,
+            "an unknown size must not be assumed benign",
+        );
+    }
+
+    #[test]
+    fn same_volume_without_block_cloning_is_a_real_no_cow_warning() {
+        assert_eq!(
+            classify_copy_restore(Some("C:\\"), Some("C:\\"), Some(false), Some(true)),
+            CopyRestoreCause::NoCow,
+        );
+    }
+
+    /// Cross-volume wins over capability: two Dev Drives still can't clone
+    /// across the volume boundary, so the co-locate advice is the useful one.
+    #[test]
+    fn different_volumes_report_cross_volume_even_when_both_support_cow() {
+        assert_eq!(
+            classify_copy_restore(Some("C:\\"), Some("G:\\"), Some(true), Some(false)),
+            CopyRestoreCause::CrossVolume,
+        );
+        assert_eq!(
+            classify_copy_restore(Some("c:\\"), Some("C:\\"), Some(false), Some(true)),
+            CopyRestoreCause::NoCow,
+            "volume roots compare case-insensitively",
+        );
+    }
+
+    /// If the capability probe fails we must not go silent on a genuinely
+    /// broken setup: fall back to the historical "no CoW" advisory.
+    #[test]
+    fn unknown_capability_falls_back_to_warning() {
+        assert_eq!(
+            classify_copy_restore(Some("C:\\"), Some("C:\\"), None, Some(true)),
+            CopyRestoreCause::NoCow,
+        );
+        assert_eq!(
+            classify_copy_restore(None, None, None, None),
+            CopyRestoreCause::NoCow,
+        );
+    }
 
     #[test]
     fn test_hardlink_strategy_restores_content() {

--- a/src/link.rs
+++ b/src/link.rs
@@ -125,7 +125,7 @@ pub fn link_to_target(store_path: &Path, target_path: &Path, strategy: LinkStrat
                 // trade the read-only-output risk for working-tree dedup.
                 hardlink_or_copy(store_path, target_path, bytes)
             } else {
-                warn_no_cow_restore_once(store_path, target_path, bytes, &reflink_err);
+                warn_no_cow_restore_once(store_path, target_path, bytes, &reflink_err, true);
                 copy_file(store_path, target_path, false)?;
                 crate::opcounts::record_copied(bytes);
                 Ok(())
@@ -134,6 +134,12 @@ pub fn link_to_target(store_path: &Path, target_path: &Path, strategy: LinkStrat
         #[cfg(not(windows))]
         LinkStrategy::Hardlink => hardlink_or_copy(store_path, target_path, bytes),
         LinkStrategy::Copy => {
+            // Copying here is by design (executables/dylibs may be mutated after
+            // the build), so no storage-layout advice — but a large artifact that
+            // failed to block-clone on a CoW volume is still a real fault and is
+            // reported rather than swallowed.
+            #[cfg(windows)]
+            warn_no_cow_restore_once(store_path, target_path, bytes, &reflink_err, false);
             copy_file(store_path, target_path, true)?;
             crate::opcounts::record_copied(bytes);
             Ok(())
@@ -188,6 +194,16 @@ fn hardlink_or_copy(store_path: &Path, target_path: &Path, bytes: u64) -> Result
 ///   this on a healthy Dev Drive: all 670 warnings in #508 were sub-cluster `.d`
 ///   files while the `.rlib`/`.rmeta` beside them block-cloned fine. Saying
 ///   nothing is right — the volume is healthy and there is no advice to give.
+/// - **`UnknownCow`**: the capability probe itself failed, so we do NOT know
+///   whether this volume block-clones. Still worth saying — a copy-restore is
+///   happening either way — but say it *honestly*: asserting "no copy-on-write"
+///   from a failed probe would repeat the very mistake #508 is about.
+/// - **`SubClusterOnCowVolume`**: the volume DOES block-clone, and this file is
+///   smaller than one cluster, so it has no cluster-aligned range (ReFS clones
+///   whole clusters; cloning past EOF is undefined). Every `.d` under ~4 KB hits
+///   this on a healthy Dev Drive: all 670 warnings in #508 were sub-cluster `.d`
+///   files while the `.rlib`/`.rmeta` beside them block-cloned fine. Saying
+///   nothing is right — the volume is healthy and there is no advice to give.
 /// - **`UnexpectedOnCowVolume`**: the volume block-clones and the file was big
 ///   enough to clone, yet the clone still failed. That is NOT benign — a filter
 ///   driver, an integrity-stream mismatch, or a kache bug could silently demote
@@ -198,18 +214,35 @@ fn hardlink_or_copy(store_path: &Path, target_path: &Path, bytes: u64) -> Result
 enum CopyRestoreCause {
     CrossVolume,
     NoCow,
+    UnknownCow,
     SubClusterOnCowVolume,
     UnexpectedOnCowVolume,
+}
+
+impl CopyRestoreCause {
+    /// Which dedup bucket this advisory belongs to.
+    ///
+    /// A storage-*layout* advisory ("no CoW", "cross-volume") must NOT be able
+    /// to mute a *fault* ("the clone failed unexpectedly") — they have different
+    /// severities and different audiences, so they get separate markers. Sharing
+    /// one bucket would let a benign cross-volume note swallow the report of a
+    /// filter driver silently demoting every large artifact to a copy.
+    #[cfg_attr(not(windows), allow(dead_code))]
+    fn warn_bucket(self) -> &'static str {
+        match self {
+            CopyRestoreCause::UnexpectedOnCowVolume => "cow-fault",
+            _ => "cow",
+        }
+    }
 }
 
 /// Classify a copy-restore from the two volume roots, the build volume's
 /// block-cloning capability, and whether the file was too small to clone. Pure —
 /// kept platform-independent so the decision table is unit-testable off Windows.
 ///
-/// `build_vol_has_cow == None` means the capability probe failed; we then fall
-/// back to the historical assumption (no CoW) rather than going silent, so a
-/// real NTFS user still gets told. Likewise an unknown `file_is_sub_cluster`
-/// resolves to "unexpected" — we'd rather say too much than hide a real fault.
+/// Unknowns are never resolved *toward silence*: a failed capability probe warns
+/// as `UnknownCow` (hedged) rather than asserting NTFS, and an unknown size
+/// resolves to "unexpected" rather than assuming the benign sub-cluster case.
 #[cfg_attr(not(windows), allow(dead_code))]
 fn classify_copy_restore(
     cache_vol: Option<&str>,
@@ -223,37 +256,47 @@ fn classify_copy_restore(
     {
         return CopyRestoreCause::CrossVolume;
     }
-    if build_vol_has_cow == Some(true) {
+    match build_vol_has_cow {
         // Same volume, and it block-clones — the other files in this same build
         // reflink fine. Expected only when the file had no clonable range.
-        return if file_is_sub_cluster == Some(true) {
-            CopyRestoreCause::SubClusterOnCowVolume
-        } else {
-            CopyRestoreCause::UnexpectedOnCowVolume
-        };
+        Some(true) => {
+            if file_is_sub_cluster == Some(true) {
+                CopyRestoreCause::SubClusterOnCowVolume
+            } else {
+                CopyRestoreCause::UnexpectedOnCowVolume
+            }
+        }
+        Some(false) => CopyRestoreCause::NoCow,
+        None => CopyRestoreCause::UnknownCow,
     }
-    CopyRestoreCause::NoCow
 }
 
 /// Tell the user their cache hits are being restored by COPY — but only when
-/// that is actually a problem, and at most once per warn-session window across
-/// all wrapper processes (#508).
+/// that is actually a problem, and at most once per warn-session window per
+/// [bucket](CopyRestoreCause::warn_bucket) across all wrapper processes (#508).
 ///
-/// Every restored file that can't block-clone lands here, so both gates matter:
-/// a sub-cluster file on a working Dev Drive says nothing at all, and the real
-/// advisories dedup through a marker file rather than a per-process `Once` —
-/// each rustc is its own process, which is why a single build used to emit the
-/// same warning hundreds of times.
+/// Both gates matter: a sub-cluster file on a working Dev Drive says nothing at
+/// all, and the real advisories dedup through a marker file rather than a
+/// per-process `Once` — each rustc is its own process, which is why a single
+/// build used to emit the same warning hundreds of times.
 ///
 /// `bytes` is the blob's size and `reflink_err` the clone failure, so a file
 /// that was big enough to clone but failed anyway can still be surfaced instead
 /// of being swallowed along with the benign sub-cluster case.
+///
+/// `layout_advice` gates the *configuration* advisories ("no CoW", "cross
+/// volume"). The `Copy` strategy (executables, dylibs) always intended to copy,
+/// so it passes `false`: it must not start nagging about storage layout. But it
+/// still routes through here, because a LARGE artifact that fails to clone on a
+/// CoW volume is a genuine fault that must not pass silently just because the
+/// restore strategy happened to be `Copy`.
 #[cfg(windows)]
 fn warn_no_cow_restore_once(
     store_path: &Path,
     target_path: &Path,
     bytes: u64,
     reflink_err: &anyhow::Error,
+    layout_advice: bool,
 ) {
     let cache_vol = windows_volume_root(store_path);
     let build_vol = windows_volume_root(target_path);
@@ -319,12 +362,40 @@ fn warn_no_cow_restore_once(
             vol = build_vol.as_deref().unwrap_or("NTFS"),
             target = target_path.display(),
         ),
+        // Probe failed: we do NOT know what this volume supports. Say exactly
+        // that — claiming "no copy-on-write" here would be the same unfounded
+        // assertion that produced #508 in the first place.
+        CopyRestoreCause::UnknownCow => format!(
+            "kache: cache hits are restored by COPY, so the cache and build tree \
+             do not share storage. kache could not determine whether this volume \
+             ({vol}) supports copy-on-write — the capability probe failed. For \
+             zero-copy dedup the cache + build dir must be on the same ReFS Dev \
+             Drive.\n         probe error:     {err:#}\n         affected output: \
+             {target}",
+            vol = build_vol.as_deref().unwrap_or("?"),
+            err = reflink_err,
+            target = target_path.display(),
+        ),
     };
 
+    // The Copy strategy always meant to copy — it must not nag about storage
+    // layout. It DOES still report a genuine clone fault (see `layout_advice`).
+    if !layout_advice && cause != CopyRestoreCause::UnexpectedOnCowVolume {
+        tracing::debug!(
+            "copy-restored {} (copy strategy; {:?})",
+            target_path.display(),
+            cause
+        );
+        return;
+    }
+
     match COW_WARN_MARKER.get() {
-        Some(marker) => {
+        Some(base) => {
+            // Separate bucket per severity: a layout advisory must never mute a
+            // fault report (and vice versa).
+            let marker = bucket_marker(base, cause.warn_bucket());
             let _warned = crate::wrapper::warn_once_per_session(
-                marker,
+                &marker,
                 crate::wrapper::WARN_SESSION_SECS,
                 &message,
             );
@@ -337,6 +408,17 @@ fn warn_no_cow_restore_once(
             WARNED.call_once(|| eprintln!("{message}"));
         }
     }
+}
+
+/// Derive a per-bucket marker path from the base marker (`…/kache-cow-warn-<hash>`
+/// → `…/kache-cow-warn-<hash>.<bucket>`), so advisories of different severity
+/// dedup independently.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn bucket_marker(base: &Path, bucket: &str) -> std::path::PathBuf {
+    let mut name = base.as_os_str().to_os_string();
+    name.push(".");
+    name.push(bucket);
+    std::path::PathBuf::from(name)
 }
 
 /// Does the volume holding `path` support ReFS block-cloning (copy-on-write)?
@@ -840,17 +922,42 @@ mod tests {
         );
     }
 
-    /// If the capability probe fails we must not go silent on a genuinely
-    /// broken setup: fall back to the historical "no CoW" advisory.
+    /// A failed probe must still warn (a copy-restore IS happening) — but as
+    /// "unknown", not as "no copy-on-write". Asserting NTFS from a failed probe
+    /// would be the same unfounded claim that produced #508.
     #[test]
-    fn unknown_capability_falls_back_to_warning() {
+    fn a_failed_capability_probe_warns_without_claiming_no_cow() {
         assert_eq!(
             classify_copy_restore(Some("C:\\"), Some("C:\\"), None, Some(true)),
-            CopyRestoreCause::NoCow,
+            CopyRestoreCause::UnknownCow,
         );
         assert_eq!(
             classify_copy_restore(None, None, None, None),
+            CopyRestoreCause::UnknownCow,
+        );
+    }
+
+    /// A benign storage-layout advisory must not be able to mute a genuine clone
+    /// FAULT: they dedup in separate buckets, so one can't swallow the other.
+    #[test]
+    fn a_layout_advisory_cannot_mute_a_clone_fault() {
+        let fault = CopyRestoreCause::UnexpectedOnCowVolume.warn_bucket();
+        for benign in [
             CopyRestoreCause::NoCow,
+            CopyRestoreCause::CrossVolume,
+            CopyRestoreCause::UnknownCow,
+        ] {
+            assert_ne!(
+                benign.warn_bucket(),
+                fault,
+                "{benign:?} must not share a dedup marker with a clone fault",
+            );
+        }
+
+        let base = Path::new("/tmp/kache-cow-warn-abc123");
+        assert_ne!(
+            bucket_marker(base, CopyRestoreCause::NoCow.warn_bucket()),
+            bucket_marker(base, fault),
         );
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -94,16 +94,83 @@ fn store_unavailable_message(err: &anyhow::Error) -> String {
     )
 }
 
-/// Dedup-marker path for the "store unavailable" warning.
+/// How long a one-shot warning stays "already emitted" for. Matches the
+/// prefetch session window: the hundreds of wrapper processes a build spawns
+/// all fall inside one window, so only the first of them warns, while a fresh
+/// `cargo` command after a gap this long warns again. It is a sliding window,
+/// not true build identity — a build that keeps hitting the cache for longer
+/// than this re-warns once per window rather than exactly once. That is the
+/// same trade-off `maybe_trigger_prefetch` and the store advisory already make,
+/// and it still turns #508's 670 lines into a handful.
+pub(crate) const WARN_SESSION_SECS: u64 = 300;
+
+/// Dedup-marker path for a warn-once-per-build-session message of `kind`
+/// (`"store"`, `"cow"`, …).
 ///
 /// Lives in the **OS temp dir**, keyed by a hash of the cache directory — NOT
-/// under the cache dir itself. When the index can't be opened the cache dir is
-/// exactly the filesystem we can't rely on (broken locking / shared across
-/// machines), so the marker that coordinates "warn only once" must live on a
-/// local, writable filesystem instead.
-fn store_warn_marker_path(cache_dir: &Path) -> PathBuf {
+/// under the cache dir itself. For the store warning the cache dir is exactly
+/// the filesystem we can't rely on (broken locking / shared across machines),
+/// so the marker that coordinates "warn only once" must live on a local,
+/// writable filesystem instead. Keying by cache dir keeps two builds against
+/// two different caches from silencing each other.
+pub(crate) fn warn_marker_path(kind: &str, cache_dir: &Path) -> PathBuf {
     let hash = blake3::hash(cache_dir.as_os_str().as_encoded_bytes()).to_hex();
-    std::env::temp_dir().join(format!("kache-store-warn-{}", &hash[..16]))
+    std::env::temp_dir().join(format!("kache-{kind}-warn-{}", &hash[..16]))
+}
+
+/// Print `message` to stderr at most once per [`WARN_SESSION_SECS`] window,
+/// even across the hundreds of parallel wrapper processes a single build spawns.
+///
+/// Each wrapper is its own process, so a `static Once` only dedups within one
+/// compilation — a build then repeats the same advisory hundreds of times
+/// (kunobi-ninja/kache#508). Dedup therefore has to be cross-process: a marker
+/// file holding a timestamp, guarded by an flock so two wrappers can't decide
+/// to warn simultaneously.
+///
+/// Best-effort by construction: if the marker can't be created we warn rather
+/// than go silent — a duplicated advisory beats a swallowed one.
+///
+/// Returns whether this call actually emitted the message (for tests).
+pub(crate) fn warn_once_per_session(marker: &Path, session_secs: u64, message: &str) -> bool {
+    if marker_is_fresh(marker, session_secs) {
+        return false; // already warned this session
+    }
+    let Ok(lock_file) = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(marker)
+    else {
+        eprintln!("{message}");
+        return true;
+    };
+    match lock_file.try_lock() {
+        Ok(()) => {}
+        // Contended: another wrapper is emitting this warning right now.
+        Err(std::fs::TryLockError::WouldBlock) => return false,
+        // The lock itself is broken — NOT contention (e.g. a filesystem with no
+        // working locks). Treating that as "someone else is warning" would
+        // silence the advisory forever, so warn best-effort instead.
+        Err(std::fs::TryLockError::Error(e)) => {
+            tracing::debug!("warn-once marker lock failed ({e}); warning anyway");
+            eprintln!("{message}");
+            return true;
+        }
+    }
+    // Re-check under the lock — another wrapper may have warned between our
+    // first check and acquiring the lock. Read through the handle that OWNS the
+    // lock: on Windows the lock is mandatory (`LockFileEx`) and blocks
+    // cross-handle reads, so `marker_is_fresh` (which opens its own handle)
+    // would always read "stale" here and let a second wrapper warn again — on
+    // the very platform this advisory targets. Same reason
+    // `write_marker_timestamp` writes through the locked handle (#348).
+    if marker_file_is_fresh(&lock_file, session_secs) {
+        return false;
+    }
+    eprintln!("{message}");
+    write_marker_timestamp(&lock_file);
+    true
 }
 
 /// Emit the `store_unavailable_message` to stderr **at most once per build
@@ -112,40 +179,13 @@ fn store_warn_marker_path(cache_dir: &Path) -> PathBuf {
 ///
 /// Cross-process dedup uses the same flock-on-a-marker pattern as
 /// `maybe_trigger_prefetch`, but the marker lives locally (see
-/// `store_warn_marker_path`) because the cache dir can't be trusted here.
+/// `warn_marker_path`) because the cache dir can't be trusted here.
 fn warn_store_unavailable_once(config: &Config, err: &anyhow::Error) {
     // Full detail always goes to the debug log for `KACHE_LOG` users.
     tracing::warn!("failed to open store: {:#}", err);
 
-    // Re-warn at most once per build session — matches the prefetch session
-    // window so a fresh `cargo` command after a gap warns again.
-    const STORE_WARN_SESSION_SECS: u64 = 300;
-    let marker = store_warn_marker_path(&config.cache_dir);
-
-    if marker_is_fresh(&marker, STORE_WARN_SESSION_SECS) {
-        return; // already warned this session
-    }
-    let Ok(lock_file) = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(&marker)
-    else {
-        // Can't even create a local marker (very unusual): warn rather than go
-        // silent — a duplicated warning is better than a silent cache miss.
-        eprintln!("{}", store_unavailable_message(err));
-        return;
-    };
-    if lock_file.try_lock().is_err() {
-        return; // another wrapper is emitting the warning right now
-    }
-    // Re-check under the lock — another process may have warned between our
-    // first check and acquiring the lock.
-    if marker_is_fresh(&marker, STORE_WARN_SESSION_SECS) {
-        return;
-    }
-    eprintln!("{}", store_unavailable_message(err));
-    write_marker_timestamp(&lock_file);
+    let marker = warn_marker_path("store", &config.cache_dir);
+    warn_once_per_session(&marker, WARN_SESSION_SECS, &store_unavailable_message(err));
 }
 
 fn event_result_for_store_put(put: StorePutResult) -> EventResult {
@@ -232,6 +272,7 @@ fn probe_forward_compiler() -> String {
 pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let start = std::time::Instant::now();
     crate::link::set_windows_hardlink_restore(config.windows_hardlink);
+    crate::link::set_cow_warn_marker(warn_marker_path("cow", &config.cache_dir));
     let compiler = CcCompiler::with_extra_allowlist_flags(config.cc_extra_allowlist_flags.clone());
     let parsed = compiler
         .parse(wrapper_args)
@@ -735,6 +776,7 @@ fn restore_cc_from_cache(
 pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let start = std::time::Instant::now();
     crate::link::set_windows_hardlink_restore(config.windows_hardlink);
+    crate::link::set_cow_warn_marker(warn_marker_path("cow", &config.cache_dir));
     // Wall-clock build-start (ns since epoch) for the optional too-new-input
     // guard; compared against keyed inputs' mtime/ctime (kunobi-ninja/kache#324).
     let invocation_start_ns = std::time::SystemTime::now()
@@ -2030,6 +2072,24 @@ fn marker_is_fresh(marker: &std::path::Path, timeout_secs: u64) -> bool {
         Ok(c) if !c.is_empty() => c,
         _ => return false,
     };
+    timestamp_is_fresh(&content, timeout_secs)
+}
+
+/// Marker freshness read through an ALREADY-OPEN handle. A caller holding the
+/// exclusive lock must use this rather than [`marker_is_fresh`]: on Windows the
+/// lock is mandatory and blocks reads from any other handle (#348).
+fn marker_file_is_fresh(mut file: &std::fs::File, timeout_secs: u64) -> bool {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let mut content = String::new();
+    if file.seek(SeekFrom::Start(0)).is_err() || file.read_to_string(&mut content).is_err() {
+        return false;
+    }
+    timestamp_is_fresh(&content, timeout_secs)
+}
+
+/// Is a marker's Unix-epoch timestamp within `timeout_secs` of now?
+fn timestamp_is_fresh(content: &str, timeout_secs: u64) -> bool {
     let stamp: u64 = match content.trim().parse() {
         Ok(s) => s,
         Err(_) => return false, // legacy "1" marker or corrupt — treat as stale
@@ -2127,6 +2187,32 @@ mod tests {
         RustcCompiler::new().parse(&s(args)).unwrap()
     }
 
+    /// A build spawns hundreds of wrapper processes, so "warn once" has to hold
+    /// ACROSS processes, not just within one (#508). The marker is the only
+    /// thing carrying that state — a second wrapper hitting a fresh marker must
+    /// stay quiet, and a stale marker must let the advisory through again.
+    #[test]
+    fn warn_once_per_session_dedups_across_processes_via_the_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("cow-warn");
+
+        assert!(
+            warn_once_per_session(&marker, 300, "advisory"),
+            "first wrapper in the session must warn"
+        );
+        assert!(
+            !warn_once_per_session(&marker, 300, "advisory"),
+            "a later wrapper in the same session must stay quiet"
+        );
+
+        // A session window of 0 makes any marker stale — a fresh `cargo` command
+        // after a gap warns again rather than staying silent forever.
+        assert!(
+            warn_once_per_session(&marker, 0, "advisory"),
+            "a stale marker must let the advisory through again"
+        );
+    }
+
     #[test]
     fn store_unavailable_message_is_actionable() {
         let err = anyhow::anyhow!("disk I/O error")
@@ -2160,8 +2246,8 @@ mod tests {
 
     #[test]
     fn store_warn_marker_is_local_and_keyed_by_cache_dir() {
-        let a = store_warn_marker_path(Path::new("/mnt/c/Users/x/kache"));
-        let b = store_warn_marker_path(Path::new("/home/y/.cache/kache"));
+        let a = warn_marker_path("store", Path::new("/mnt/c/Users/x/kache"));
+        let b = warn_marker_path("store", Path::new("/home/y/.cache/kache"));
         let tmp = std::env::temp_dir();
 
         // Lives in the OS temp dir (local), NOT under the (possibly broken)
@@ -2176,7 +2262,10 @@ mod tests {
         assert_ne!(a, b);
         // Same cache dir is stable across calls, so the 300+ parallel wrapper
         // processes all agree on one marker and only one of them warns.
-        assert_eq!(a, store_warn_marker_path(Path::new("/mnt/c/Users/x/kache")));
+        assert_eq!(
+            a,
+            warn_marker_path("store", Path::new("/mnt/c/Users/x/kache"))
+        );
     }
 
     #[test]
@@ -2185,7 +2274,7 @@ mod tests {
         // other tests running in the same binary. The dir need not exist — the
         // warning only ever touches the local marker, never the cache dir.
         let cache_dir = PathBuf::from("/nonexistent/kache-469-dedup-test-cache-dir-7f3a2b1c");
-        let marker = store_warn_marker_path(&cache_dir);
+        let marker = warn_marker_path("store", &cache_dir);
         let _ = std::fs::remove_file(&marker);
         assert!(
             !marker_is_fresh(&marker, 300),


### PR DESCRIPTION
Fixes #508.

## What's wrong

On a Windows **ReFS Dev Drive — which does support copy-on-write** — kache prints:

> kache: this volume (G:\) has no copy-on-write, so cache hits are restored by COPY …

once per rustc process. One reporter's build emitted it **670 times**; both reporters were on genuine Dev Drives, and [#490](https://github.com/kunobi-ninja/kache/issues/490) was the same user hitting the same false alarm (it only added paths to the message, never diagnosed it).

## Root cause

`link_to_target` treated **any** reflink failure as "this volume has no CoW".

ReFS block-cloning (`FSCTL_DUPLICATE_EXTENTS_TO_FILE`) can only clone **cluster-aligned ranges**. A file smaller than one cluster (4 KiB) therefore has *no* clonable range and necessarily falls back to a copy — on a perfectly healthy Dev Drive. `reflink_windows` bails out for exactly that case:

```rust
let clone_len = (len / cluster) * cluster;
if clone_len == 0 { anyhow::bail!("file smaller than ReFS cluster; fall back to copy"); }
```

…and the caller then blamed the filesystem.

The reporter's debug log confirms it: **184 files reflinked, 35 copied — and every copied file was a `.d`**. All 670 warned outputs were `.d` files. The reflinked `.d` files belong to big crates (tokio, hyper, axum, boa_engine → dep-info over 4 KiB); every copied one belongs to a small crate (`tauri_plugin_*`, `tracing_error`, `tokio_rustls` → dep-info under 4 KiB). Size is the discriminating variable, exactly as the code predicts. Because each rustc is its own process, the per-process `Once` guard couldn't dedup any of it.

## The fix

Ask the volume instead of inferring from one failed clone:

- **Probe** `GetVolumeInformationW` / `FILE_SUPPORTS_BLOCK_REFCOUNTING`, and only warn when the volume genuinely can't block-clone (or when cache and build tree are on different volumes — no filesystem clones across those, so #490's advice is kept).
- **Sub-cluster files are silent.** They could never have been cloned, the volume is healthy, and there's no advice to give. The FSCTL is now skipped for them outright instead of creating a destination just to delete it again.
- **A file that *could* have been cloned but failed anyway is still surfaced**, with the OS error — that would be a real fault (filter driver, integrity stream, kache bug) and must not hide behind this fix.
- **Cross-process dedup**: the remaining advisories go through the existing flock'd marker (the one `warn_store_unavailable_once` already uses) rather than a per-process `Once`, so a build emits one line, not hundreds. Two pre-existing bugs in that helper are fixed along the way: the under-lock recheck now reads through the **locked handle** (Windows locks are mandatory and block cross-handle reads, so the recheck silently always read "stale" — see #348), and a genuine lock **error** is no longer mistaken for contention (which would have silenced the advisory forever).

## Verification — on a real Windows 11 ReFS Dev Drive

Not just unit tests: a ReFS Dev Drive was created on a Windows 11 box and the reporters' scenario replayed against the **released v0.9.0** binary and this branch. Every row is 3/3 cache hits, so the restore path really ran:

| Scenario | hits | reflinked | copied | no-CoW warning | cross-volume warning |
|---|---|---|---|---|---|
| **v0.9.0**, Dev Drive `G:` | 3 | 6 | 3 | **3** ❌ false | 0 |
| **this PR**, Dev Drive `G:` | 3 | 6 | 3 | **0** ✅ | 0 |
| **this PR**, NTFS `C:` | 3 | 0 | 9 | **1 per build** ✅ | 0 |
| **this PR**, NTFS `C:`, 2nd build | 3 | 0 | 9 | **0** (throttled) | 0 |
| **this PR**, cache `C:` + build `G:` | 3 | 0 | 9 | 0 | **1** ✅ |

Block-cloning is unchanged (6 reflinked either way) — only the false alarm goes away. The NTFS advisory still fires (once per build instead of once per compile), and the cross-volume advice still fires.

`cargo test` (1178 unit tests) and `cargo clippy -D warnings` are green; the classifier's decision table is unit-tested off-Windows.

## Note on wording

The advisory is deduped over a 300-second sliding window (the same window `maybe_trigger_prefetch` and the store advisory already use), not true build identity — a build that keeps hitting the cache for longer than that re-warns once per window rather than exactly once. The docs say so rather than overclaiming.