### PR TITLE
chore: bump kache to v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more. No copies, no wasted disk — just hardlinks locally and S3 for sharing."
 license = "Apache-2.0"
@@ -48,7 +48,7 @@ aws-smithy-runtime-api = "1"
 # Direct dep so we can install ring as the process-wide rustls crypto
 # provider (reqwest uses `rustls-no-provider`, so one must be installed).
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.9.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.10.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bumps the kache workspace version to **v0.10.0**.

Minor (not a patch) because #503 is user-facing: it adds a Prefetch/Planning/Key-LIST section to `kache stats` and changes daemon S3 scheduling (interactive permit reservation, GET-404-as-miss).

## What's in v0.10.0 (since v0.9.0)

**Feature**
- `feat(daemon)`: prefetch Phase 0 — baseline telemetry + scheduling fixes (#503, part of #485)

**Fixes**
- `fix(link)`: stop blaming the filesystem for sub-cluster copy-restores — no more false "this volume has no copy-on-write" spam on ReFS Dev Drives (#512, fixes #508)
- `fix(daemon)`: notify-based download dedup replaces 30s polling (#504)
- `fix(cli)`: honor `CARGO_HOME` instead of hardcoding `~/.cargo` in `init` and `migrate` (#502)

Also folded in via #512: unbreak `cargo deny` (yanked `spin` 0.9.8/0.10.0) and clippy 1.97's `useless_borrows_in_formatting`.

## Release plan
- Squash this PR after CI is green.
- From synced `main`, run `just release`.
- Monitor CI, Service Image, Publish crates, Package Publish, Homebrew, and Winget.