### PR TITLE
refactor(remote): extract RemoteBackend trait for transport-specific concerns (#414)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ resolver = "3"
 
 [dependencies]
 blake3 = "1"
+# Already transitive via aws-sdk-s3; declared for RemoteBackend's body type.
+bytes = "1"
 # TLS provider: `ring`, NOT aws-lc-rs. We avoid `aws-lc-sys` entirely
 # because its cmake/NASM C build hangs when cross-compiling to
 # `aarch64-pc-windows-msvc` under cargo-xwin; `ring` ships prebuilt asm

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,8 @@ use bytesize::ByteSize;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 
+use std::sync::Arc;
+
 use crate::config::Config;
 use crate::daemon;
 use crate::events;
@@ -2587,11 +2589,11 @@ async fn sync_inner(
     lock_crates: Option<&std::collections::HashSet<String>>,
     pull_workspace: bool,
 ) -> Result<()> {
-    let client = crate::remote::create_s3_client(remote, config.s3_pool_idle_secs)
+    let backend = crate::remote_backend::create_backend(remote, config.s3_pool_idle_secs)
         .await
-        .context("connecting to S3 — check credentials and endpoint")?;
+        .context("connecting to the remote — check credentials and endpoint")?;
     sync_with_client(
-        &client,
+        backend.as_ref(),
         config,
         store,
         remote,
@@ -2606,12 +2608,12 @@ async fn sync_inner(
     .await
 }
 
-/// The S3-driven body of `sync`, with the client injected so tests can drive it
-/// against a mock S3 server. Lists remote keys, diffs against the local store,
+/// The remote-driven body of `sync`, with the backend injected so tests can
+/// drive it against a mock. Lists remote keys, diffs against the local store,
 /// then (unless `dry_run`) pulls missing artifacts and pushes local-only ones.
 #[allow(clippy::too_many_arguments)]
 async fn sync_with_client(
-    client: &aws_sdk_s3::Client,
+    backend: &dyn crate::remote_backend::RemoteBackend,
     config: &Config,
     store: &Store,
     remote: &crate::config::RemoteConfig,
@@ -2646,7 +2648,7 @@ async fn sync_with_client(
             eprint!("Listing S3 keys for {} workspace crates...", crates.len());
             let keys = planner
                 .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
-                .layout(client, remote)
+                .layout(backend, remote)
                 .list_keys_for_crates(crates)
                 .await
                 .context("listing S3 keys for workspace crates")?;
@@ -2659,7 +2661,7 @@ async fn sync_with_client(
             eprint!("Listing S3 keys for {} crates...", crates.len());
             let keys = planner
                 .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
-                .layout(client, remote)
+                .layout(backend, remote)
                 .list_keys_for_crates(crates)
                 .await
                 .context("listing S3 keys for dependency crates")?;
@@ -2669,7 +2671,7 @@ async fn sync_with_client(
             eprint!("Listing S3 keys...");
             let keys = planner
                 .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
-                .layout(client, remote)
+                .layout(backend, remote)
                 .list_keys()
                 .await
                 .context("listing S3 keys")?;
@@ -2681,7 +2683,7 @@ async fn sync_with_client(
         eprint!("Listing S3 keys...");
         let keys = planner
             .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
-            .layout(client, remote)
+            .layout(backend, remote)
             .list_keys()
             .await
             .context("listing S3 keys")?;
@@ -2772,7 +2774,6 @@ async fn sync_with_client(
                 );
             }
 
-            let client = client.clone();
             let remote_cfg = remote.clone();
             let cfg = config.clone();
             let download_plan = planner.plan(crate::remote_plan::RemoteWorkload::SyncPull);
@@ -2791,7 +2792,7 @@ async fn sync_with_client(
 
                 let blobs_dir = cfg.store_dir().join("blobs");
                 let result = download_plan
-                    .layout(&client, &remote_cfg)
+                    .layout(backend, &remote_cfg)
                     .download_entry(&key, &crate_name, &entry_dir, &blobs_dir)
                     .await;
                 match result {
@@ -2854,7 +2855,6 @@ async fn sync_with_client(
                 );
             }
 
-            let client = client.clone();
             let remote_cfg = remote.clone();
             let cfg = config.clone();
             let upload_plan = planner.plan(crate::remote_plan::RemoteWorkload::SyncPush);
@@ -2871,7 +2871,7 @@ async fn sync_with_client(
 
                 let blobs_dir = cfg.store_dir().join("blobs");
                 match upload_plan
-                    .layout(&client, &remote_cfg)
+                    .layout(backend, &remote_cfg)
                     .upload_entry(
                         &key,
                         &crate_name,
@@ -2967,9 +2967,9 @@ pub fn save_manifest(
     let pool_idle_secs = config.s3_pool_idle_secs;
     let entry_count = entries.len();
     rt.block_on(async {
-        let client = crate::remote::create_s3_client(remote, pool_idle_secs).await?;
+        let backend = crate::remote_backend::create_backend(remote, pool_idle_secs).await?;
         upload_manifest_and_shards(
-            &client,
+            &backend,
             remote,
             &key,
             effective_namespace.as_deref(),
@@ -3030,10 +3030,10 @@ fn manifest_entries_from_events(
 /// Upload the monolithic build manifest and, when a namespace is given and a
 /// `Cargo.lock` exists at `lock_path`, the content-addressed shard indexes.
 ///
-/// Takes the S3 client by reference so tests can drive it against a mock S3
-/// server (the production caller injects a real client from `create_s3_client`).
+/// Takes the backend by reference so tests can drive it against a mock (the
+/// production caller injects a real one from `create_backend`).
 async fn upload_manifest_and_shards(
-    client: &aws_sdk_s3::Client,
+    backend: &Arc<dyn crate::remote_backend::RemoteBackend>,
     remote: &crate::config::RemoteConfig,
     key: &str,
     namespace: Option<&str>,
@@ -3048,20 +3048,13 @@ async fn upload_manifest_and_shards(
     };
 
     // Always upload the monolithic build manifest.
-    crate::remote::upload_manifest(client, &remote.bucket, &remote.prefix, key, &manifest).await?;
+    crate::remote::upload_manifest(backend.as_ref(), &remote.prefix, key, &manifest).await?;
 
     // Upload sharded build-manifest indexes if a namespace is provided and Cargo.lock exists.
     if let Some(ns) = namespace {
         if lock_path.exists() {
-            let shard_count = upload_shards(
-                client,
-                &remote.bucket,
-                &remote.prefix,
-                ns,
-                lock_path,
-                &entries,
-            )
-            .await?;
+            let shard_count =
+                upload_shards(backend, &remote.prefix, ns, lock_path, &entries).await?;
             eprintln!("Uploaded {shard_count} shards for namespace '{ns}'");
         } else {
             eprintln!("No Cargo.lock found, skipping shard upload");
@@ -3077,8 +3070,7 @@ async fn upload_manifest_and_shards(
 ///
 /// Returns the number of shards uploaded.
 async fn upload_shards(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
+    backend: &Arc<dyn crate::remote_backend::RemoteBackend>,
     prefix: &str,
     namespace: &str,
     lock_path: &std::path::Path,
@@ -3123,14 +3115,13 @@ async fn upload_shards(
     let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(16));
     let mut handles = Vec::new();
     for (hash, shard) in uploads {
-        let client = client.clone();
-        let bucket = bucket.to_string();
+        let backend = Arc::clone(backend);
         let prefix = prefix.to_string();
         let namespace = namespace.to_string();
         let permit = sem.clone().acquire_owned().await?;
         handles.push(tokio::spawn(async move {
             let result =
-                crate::remote::upload_shard(&client, &bucket, &prefix, &namespace, &hash, &shard)
+                crate::remote::upload_shard(backend.as_ref(), &prefix, &namespace, &hash, &shard)
                     .await;
             drop(permit);
             result
@@ -4197,7 +4188,12 @@ mod tests {
     // ── upload_shards against a mock S3 ──────────────────────────────────────
     use aws_smithy_http_client::test_util::wire::{ReplayedEvent, WireMockServer};
 
-    async fn mock_s3(events: Vec<ReplayedEvent>) -> (WireMockServer, aws_sdk_s3::Client) {
+    async fn mock_s3(
+        events: Vec<ReplayedEvent>,
+    ) -> (
+        WireMockServer,
+        Arc<dyn crate::remote_backend::RemoteBackend>,
+    ) {
         let server = WireMockServer::start(events).await;
         let conf = aws_sdk_s3::config::Builder::new()
             .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
@@ -4209,7 +4205,11 @@ mod tests {
             .http_client(server.http_client())
             .force_path_style(true)
             .build();
-        (server, aws_sdk_s3::Client::from_conf(conf))
+        let backend = crate::remote_backend::S3Backend::new(
+            aws_sdk_s3::Client::from_conf(conf),
+            "bucket".to_string(),
+        );
+        (server, Arc::new(backend))
     }
 
     #[tokio::test]
@@ -4252,7 +4252,7 @@ mod tests {
             .collect();
         let (server, client) = mock_s3(events).await;
 
-        let uploaded = upload_shards(&client, "bucket", "prefix", "ns", &lock, &entries)
+        let uploaded = upload_shards(&client, "prefix", "ns", &lock, &entries)
             .await
             .expect("upload_shards should succeed");
         assert_eq!(uploaded, expected);
@@ -4272,7 +4272,7 @@ mod tests {
         .unwrap();
 
         let (server, client) = mock_s3(vec![]).await;
-        let uploaded = upload_shards(&client, "bucket", "prefix", "ns", &lock, &[])
+        let uploaded = upload_shards(&client, "prefix", "ns", &lock, &[])
             .await
             .expect("should succeed with nothing to upload");
         assert_eq!(uploaded, 0);
@@ -4294,9 +4294,13 @@ mod tests {
             .endpoint_url("http://127.0.0.1:1")
             .force_path_style(true)
             .build();
-        let client = aws_sdk_s3::Client::from_conf(conf);
+        let client: Arc<dyn crate::remote_backend::RemoteBackend> =
+            Arc::new(crate::remote_backend::S3Backend::new(
+                aws_sdk_s3::Client::from_conf(conf),
+                "bucket".to_string(),
+            ));
 
-        let err = upload_shards(&client, "bucket", "prefix", "ns", &lock, &[])
+        let err = upload_shards(&client, "prefix", "ns", &lock, &[])
             .await
             .expect_err("bad lockfile should error");
         assert!(
@@ -5147,7 +5151,17 @@ mod tests {
 
         let (server, client) = mock_s3(vec![ReplayedEvent::with_body(list_bucket_xml(&[]))]).await;
         sync_with_client(
-            &client, &config, &store, &remote, None, false, false, true, false, None, false,
+            client.as_ref(),
+            &config,
+            &store,
+            &remote,
+            None,
+            false,
+            false,
+            true,
+            false,
+            None,
+            false,
         )
         .await
         .expect("dry-run sync over empty remote should succeed");
@@ -5175,7 +5189,7 @@ mod tests {
         // One LIST response (workspace path = exactly one LIST, for `wsfoo`).
         let (server, client) = mock_s3(vec![ReplayedEvent::with_body(list_bucket_xml(&[]))]).await;
         sync_with_client(
-            &client,
+            client.as_ref(),
             &config,
             &store,
             &remote,
@@ -5211,7 +5225,7 @@ mod tests {
             let (server, client) =
                 mock_s3(vec![ReplayedEvent::with_body(list_bucket_xml(&[]))]).await;
             let err = sync_with_client(
-                &client,
+                client.as_ref(),
                 &config,
                 &store,
                 &remote,
@@ -5268,7 +5282,17 @@ mod tests {
         let (server, client) = mock_s3(events).await;
 
         sync_with_client(
-            &client, &config, &store, &remote, None, false, true, false, false, None, false,
+            client.as_ref(),
+            &config,
+            &store,
+            &remote,
+            None,
+            false,
+            true,
+            false,
+            false,
+            None,
+            false,
         )
         .await
         .expect("push sync should succeed");
@@ -5311,7 +5335,17 @@ mod tests {
         let (server, client) = mock_s3(events).await;
 
         sync_with_client(
-            &client, &config, &store, &remote, None, false, true, false, false, None, false,
+            client.as_ref(),
+            &config,
+            &store,
+            &remote,
+            None,
+            false,
+            true,
+            false,
+            false,
+            None,
+            false,
         )
         .await
         .expect("throttled push sync should succeed");
@@ -5330,7 +5364,17 @@ mod tests {
         let xml = list_bucket_xml(&["prefix/v3/manifests/serde/abc123def456.json"]);
         let (server, client) = mock_s3(vec![ReplayedEvent::with_body(xml)]).await;
         sync_with_client(
-            &client, &config, &store, &remote, None, false, false, true, false, None, false,
+            client.as_ref(),
+            &config,
+            &store,
+            &remote,
+            None,
+            false,
+            false,
+            true,
+            false,
+            None,
+            false,
         )
         .await
         .expect("dry-run sync planning a pull should succeed");
@@ -5357,7 +5401,17 @@ mod tests {
         let (server, client) = mock_s3(events).await;
 
         sync_with_client(
-            &client, &config, &store, &remote, None, true, false, false, false, None, false,
+            client.as_ref(),
+            &config,
+            &store,
+            &remote,
+            None,
+            true,
+            false,
+            false,
+            false,
+            None,
+            false,
         )
         .await
         .expect("pull sync should complete Ok even when a download fails");
@@ -5400,7 +5454,17 @@ mod tests {
         let (server, client) = mock_s3(events).await;
 
         sync_with_client(
-            &client, &config, &store, &remote, None, false, true, false, false, None, false,
+            client.as_ref(),
+            &config,
+            &store,
+            &remote,
+            None,
+            false,
+            true,
+            false,
+            false,
+            None,
+            false,
         )
         .await
         .expect("push sync should complete Ok even when an upload fails");
@@ -5429,7 +5493,17 @@ mod tests {
         let (server, client) = mock_s3(events).await;
 
         sync_with_client(
-            &client, &config, &store, &remote, None, true, false, false, false, None, false,
+            client.as_ref(),
+            &config,
+            &store,
+            &remote,
+            None,
+            true,
+            false,
+            false,
+            false,
+            None,
+            false,
         )
         .await
         .expect("throttled pull sync should complete Ok");
@@ -5489,7 +5563,17 @@ mod tests {
         let (server, client) = mock_s3(events).await;
 
         sync_with_client(
-            &client, &config, &store, &remote, None, true, false, false, false, None, false,
+            client.as_ref(),
+            &config,
+            &store,
+            &remote,
+            None,
+            true,
+            false,
+            false,
+            false,
+            None,
+            false,
         )
         .await
         .expect("pull sync should succeed");
@@ -5731,7 +5815,17 @@ mod tests {
         let (server, client) = mock_s3(vec![ReplayedEvent::with_body(xml)]).await;
 
         sync_with_client(
-            &client, &config, &store, &remote, None, false, true, false, false, None, false,
+            client.as_ref(),
+            &config,
+            &store,
+            &remote,
+            None,
+            false,
+            true,
+            false,
+            false,
+            None,
+            false,
         )
         .await
         .expect("push sync should succeed (by skipping pushes)");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2090,7 +2090,7 @@ impl Daemon {
         };
 
         if self.get_remote_backend().await.is_err() {
-            return Response::err("S3 client init failed");
+            return Response::err("remote backend init failed");
         }
 
         // Filter to keys that need downloading: (cache_key, crate_name, entry_dir)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1012,7 +1012,7 @@ impl S3KeyCache {
 pub(crate) struct Daemon {
     config: Config,
     store: OnceLock<Mutex<Store>>,
-    s3_client: tokio::sync::OnceCell<aws_sdk_s3::Client>,
+    remote_backend: tokio::sync::OnceCell<Arc<dyn crate::remote_backend::RemoteBackend>>,
     key_cache: Arc<S3KeyCache>,
     remote_health: Arc<RemoteHealth>,
     s3_semaphore: Arc<tokio::sync::Semaphore>,
@@ -1076,7 +1076,7 @@ impl Daemon {
         Self {
             store: OnceLock::new(),
             s3_semaphore: Arc::new(tokio::sync::Semaphore::new(permits)),
-            s3_client: tokio::sync::OnceCell::new(),
+            remote_backend: tokio::sync::OnceCell::new(),
             key_cache: Arc::new(S3KeyCache::new()),
             remote_health: Arc::new(RemoteHealth::new()),
             upload_tx: Mutex::new(None),
@@ -1195,16 +1195,18 @@ impl Daemon {
             .take();
     }
 
-    /// Lazy-init the S3 client (requires remote config).
-    pub(crate) async fn get_s3_client(&self) -> Result<&aws_sdk_s3::Client> {
-        self.s3_client
+    /// Lazy-init the remote backend (requires remote config).
+    pub(crate) async fn get_remote_backend(
+        &self,
+    ) -> Result<&Arc<dyn crate::remote_backend::RemoteBackend>> {
+        self.remote_backend
             .get_or_try_init(|| async {
                 let remote = self
                     .config
                     .remote
                     .as_ref()
                     .ok_or_else(|| anyhow::anyhow!("no remote configured"))?;
-                crate::remote::create_s3_client(remote, self.config.s3_pool_idle_secs).await
+                crate::remote_backend::create_backend(remote, self.config.s3_pool_idle_secs).await
             })
             .await
     }
@@ -1535,20 +1537,20 @@ impl Daemon {
             return Response::err("no remote configured");
         };
 
-        let client = match self.get_s3_client().await {
-            Ok(c) => c,
+        let backend = match self.get_remote_backend().await {
+            Ok(b) => b,
             Err(e) => {
                 tracing::warn!(
                     crate_name = job.crate_name,
                     key = key_short,
-                    "S3 client init failed: {e:#}"
+                    "remote backend init failed: {e:#}"
                 );
-                return Response::err(format!("S3 client init failed: {e:#}"));
+                return Response::err(format!("remote backend init failed: {e:#}"));
             }
         };
         let plan = crate::remote_plan::RemotePlanner::new(&self.config)
             .plan(crate::remote_plan::RemoteWorkload::BackgroundUpload);
-        let layout = plan.layout(client, remote);
+        let layout = plan.layout(backend.as_ref(), remote);
 
         let already_exists = layout
             .exists_entry(&job.key, &job.crate_name)
@@ -1773,13 +1775,13 @@ impl Daemon {
             }
         }
 
-        let client = match self.get_s3_client().await {
-            Ok(c) => c,
-            Err(e) => return Response::err(format!("S3 client init failed: {e}")),
+        let backend = match self.get_remote_backend().await {
+            Ok(b) => b,
+            Err(e) => return Response::err(format!("remote backend init failed: {e}")),
         };
         let plan = crate::remote_plan::RemotePlanner::new(&self.config)
             .plan(crate::remote_plan::RemoteWorkload::RestoreCheck);
-        let layout = plan.layout(client, remote);
+        let layout = plan.layout(backend.as_ref(), remote);
 
         if needs_head_probe {
             let semaphore_start = Instant::now();
@@ -2087,7 +2089,7 @@ impl Daemon {
             return Response::err("no remote configured");
         };
 
-        if self.get_s3_client().await.is_err() {
+        if self.get_remote_backend().await.is_err() {
             return Response::err("S3 client init failed");
         }
 
@@ -2120,10 +2122,10 @@ impl Daemon {
 
         // If empty keys were sent, fetch all S3 keys missing locally
         if req.keys.is_empty()
-            && let Ok(client) = self.get_s3_client().await
+            && let Ok(backend) = self.get_remote_backend().await
             && let Ok(s3_keys) = crate::remote_plan::RemotePlanner::new(&self.config)
                 .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
-                .layout(client, remote)
+                .layout(backend.as_ref(), remote)
                 .list_keys()
                 .await
         {
@@ -2242,8 +2244,8 @@ impl Daemon {
                         return;
                     };
                     let semaphore_wait_ms = semaphore_start.elapsed().as_millis() as u64;
-                    let client = match d.get_s3_client().await {
-                        Ok(c) => c,
+                    let backend = match d.get_remote_backend().await {
+                        Ok(b) => b,
                         Err(_) => {
                             return;
                         }
@@ -2258,7 +2260,7 @@ impl Daemon {
                         profile,
                     };
                     let download_result = download_plan
-                        .layout(client, &remote_cfg)
+                        .layout(backend.as_ref(), &remote_cfg)
                         .download_entry(&key, &crate_name, &entry_dir, &blobs_dir)
                         .await;
 
@@ -3165,9 +3167,9 @@ async fn accept_loop(
     }
 }
 
-/// Populate the S3 key cache by listing all keys in the bucket.
+/// Populate the key cache by listing every key in the remote.
 async fn populate_key_cache(daemon: &Daemon) -> Result<usize> {
-    let client = daemon.get_s3_client().await?;
+    let backend = daemon.get_remote_backend().await?;
     let remote = daemon
         .config
         .remote
@@ -3177,7 +3179,7 @@ async fn populate_key_cache(daemon: &Daemon) -> Result<usize> {
     let list_start = Instant::now();
     let keys = crate::remote_plan::RemotePlanner::new(&daemon.config)
         .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
-        .layout(client, remote)
+        .layout(backend.as_ref(), remote)
         .list_keys()
         .await?;
     // Phase-0 telemetry (#485): the LIST cost the coordination service exists
@@ -3206,10 +3208,10 @@ async fn manifest_prefetch(daemon: &Arc<Daemon>) {
         return;
     };
 
-    let client = match daemon.get_s3_client().await {
-        Ok(c) => c,
+    let backend = match daemon.get_remote_backend().await {
+        Ok(b) => b,
         Err(e) => {
-            tracing::warn!("manifest prefetch: S3 client init failed: {e}");
+            tracing::warn!("manifest prefetch: remote backend init failed: {e}");
             return;
         }
     };
@@ -3218,16 +3220,7 @@ async fn manifest_prefetch(daemon: &Arc<Daemon>) {
     if let Ok(namespace) = std::env::var("KACHE_NAMESPACE") {
         let lock_path = std::path::Path::new("Cargo.lock");
         if lock_path.exists() {
-            match shard_prefetch(
-                daemon,
-                client,
-                &remote.bucket,
-                &remote.prefix,
-                &namespace,
-                lock_path,
-            )
-            .await
-            {
+            match shard_prefetch(daemon, backend, &remote.prefix, &namespace, lock_path).await {
                 Ok(n) => {
                     tracing::info!("shard prefetch: queued {n} keys from shards");
                     return;
@@ -3245,27 +3238,25 @@ async fn manifest_prefetch(daemon: &Arc<Daemon>) {
         }
     }
 
-    monolithic_manifest_prefetch(daemon, client, remote).await;
+    monolithic_manifest_prefetch(daemon, backend.as_ref(), remote).await;
 }
 
 /// Shard-based prefetch: compute shard hashes from Cargo.lock, download matching shards
-/// from S3 in parallel, collect cache keys.
+/// from the remote in parallel, collect cache keys.
 async fn shard_prefetch(
     daemon: &Arc<Daemon>,
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
+    backend: &Arc<dyn crate::remote_backend::RemoteBackend>,
     prefix: &str,
     namespace: &str,
     lock_path: &std::path::Path,
 ) -> anyhow::Result<usize> {
     let deps = crate::shards::parse_cargo_lock(lock_path)?;
-    shard_prefetch_for_deps(daemon, client, bucket, prefix, namespace, &deps).await
+    shard_prefetch_for_deps(daemon, backend, prefix, namespace, &deps).await
 }
 
 async fn shard_prefetch_for_deps(
     daemon: &Arc<Daemon>,
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
+    backend: &Arc<dyn crate::remote_backend::RemoteBackend>,
     prefix: &str,
     namespace: &str,
     deps: &[(String, String)],
@@ -3281,13 +3272,12 @@ async fn shard_prefetch_for_deps(
     // Download all shards in parallel
     let mut handles = Vec::new();
     for (hash, _entries) in &shard_set.shards {
-        let c = client.clone();
-        let b = bucket.to_string();
+        let b = Arc::clone(backend);
         let p = prefix.to_string();
         let ns = namespace.to_string();
         let h = hash.clone();
         handles.push(tokio::spawn(async move {
-            crate::remote::download_shard(&c, &b, &p, &ns, &h).await
+            crate::remote::download_shard(b.as_ref(), &p, &ns, &h).await
         }));
     }
 
@@ -3335,7 +3325,7 @@ async fn shard_prefetch_for_deps(
 /// Monolithic build-manifest prefetch: download the manifest and filter by compile cost.
 async fn monolithic_manifest_prefetch(
     daemon: &Arc<Daemon>,
-    client: &aws_sdk_s3::Client,
+    backend: &dyn crate::remote_backend::RemoteBackend,
     remote: &crate::config::RemoteConfig,
 ) {
     let manifest_key =
@@ -3346,13 +3336,8 @@ async fn monolithic_manifest_prefetch(
         .and_then(|s| s.parse().ok())
         .unwrap_or(1000);
 
-    let manifest = match crate::remote::download_manifest(
-        client,
-        &remote.bucket,
-        &remote.prefix,
-        &manifest_key,
-    )
-    .await
+    let manifest = match crate::remote::download_manifest(backend, &remote.prefix, &manifest_key)
+        .await
     {
         Ok(m) => m,
         Err(e) => {
@@ -6820,7 +6805,12 @@ mod tests {
         }
     }
 
-    async fn mock_s3_client(events: Vec<ReplayedEvent>) -> (WireMockServer, aws_sdk_s3::Client) {
+    async fn mock_s3_client(
+        events: Vec<ReplayedEvent>,
+    ) -> (
+        WireMockServer,
+        Arc<dyn crate::remote_backend::RemoteBackend>,
+    ) {
         let server = WireMockServer::start(events).await;
         let conf = aws_sdk_s3::config::Builder::new()
             .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
@@ -6832,7 +6822,11 @@ mod tests {
             .http_client(server.http_client())
             .force_path_style(true)
             .build();
-        (server, aws_sdk_s3::Client::from_conf(conf))
+        let backend = crate::remote_backend::S3Backend::new(
+            aws_sdk_s3::Client::from_conf(conf),
+            "bucket".to_string(),
+        );
+        (server, Arc::new(backend))
     }
 
     #[tokio::test]
@@ -6848,7 +6842,10 @@ mod tests {
 
         let (server, client) = mock_s3_client(vec![ReplayedEvent::status(404)]).await;
         let daemon = Arc::new(Daemon::new(config));
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         let resp = one_shot_request(
             &daemon,
@@ -6884,7 +6881,10 @@ mod tests {
             </ListBucketResult>";
         let (server, client) = mock_s3_client(vec![ReplayedEvent::with_body(empty_list)]).await;
         let daemon = Arc::new(Daemon::new(config));
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         let resp = one_shot_request(
             &daemon,
@@ -6908,7 +6908,10 @@ mod tests {
 
         let (server, client) = mock_s3_client(vec![ReplayedEvent::ok()]).await; // 200 HEAD
         let daemon = Arc::new(Daemon::new(config));
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         let resp = daemon
             .do_upload(&UploadJob {
@@ -6942,7 +6945,10 @@ mod tests {
         events.extend(std::iter::repeat_with(ReplayedEvent::ok).take(4)); // pack + manifest PUTs
         let (server, client) = mock_s3_client(events).await;
         let daemon = Arc::new(Daemon::new(config));
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         let resp = daemon
             .do_upload(&UploadJob {
@@ -6972,7 +6978,10 @@ mod tests {
         events.extend(std::iter::repeat_with(|| ReplayedEvent::status(403)).take(4)); // PUTs denied
         let (server, client) = mock_s3_client(events).await;
         let daemon = Arc::new(Daemon::new(config));
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         let resp = daemon
             .do_upload(&UploadJob {
@@ -7007,7 +7016,10 @@ mod tests {
 
         let (server, client) = mock_s3_client(vec![ReplayedEvent::status(404)]).await;
         let daemon = Arc::new(Daemon::new(config));
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         let req = BuildStartedRequest {
             intent: kache_core::BuildIntent {
@@ -7041,7 +7053,10 @@ mod tests {
             .collect();
         let (server, client) = mock_s3_client(events).await;
         let daemon = Arc::new(Daemon::new(config));
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         let resp = daemon
             .handle_batch_remote_check(&BatchRemoteCheckRequest {
@@ -7081,7 +7096,10 @@ mod tests {
         events.extend(std::iter::repeat_with(|| ReplayedEvent::with_body(b"not a pack")).take(4));
         let (server, client) = mock_s3_client(events).await;
         let daemon = Arc::new(Daemon::new(config));
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         let resp = daemon
             .handle_remote_check(&RemoteCheckRequest {
@@ -7132,7 +7150,10 @@ mod tests {
         // Only event: the GET answers 404 (no HEAD happens — key cache says positive).
         let (server, client) = mock_s3_client(vec![ReplayedEvent::status(404)]).await;
         let daemon = Arc::new(Daemon::new(config));
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         // Fresh, authoritative-positive key cache entry for the key.
         let key = "gone01gone02gone03";
@@ -7212,7 +7233,10 @@ mod tests {
         let (server, client) =
             mock_s3_client(vec![ReplayedEvent::ok(), ReplayedEvent::with_body(&pack)]).await;
         let daemon = Arc::new(Daemon::new(config.clone()));
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         let resp = daemon
             .handle_remote_check(&RemoteCheckRequest {
@@ -7251,7 +7275,10 @@ mod tests {
             .collect();
         let (server, client) = mock_s3_client(events).await;
         let daemon = Arc::new(Daemon::new(config.clone()));
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         let resp = daemon
             .handle_prefetch(&PrefetchRequest {
@@ -7294,7 +7321,10 @@ mod tests {
             .collect();
         let (server, client) = mock_s3_client(events).await;
         let daemon = Arc::new(Daemon::new(config.clone()));
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         let resp = daemon
             .handle_prefetch(&PrefetchRequest {
@@ -7356,7 +7386,10 @@ mod tests {
         ]);
         let (server, client) = mock_s3_client(vec![ReplayedEvent::with_body(xml)]).await;
         let daemon = Daemon::new(config);
-        daemon.s3_client.set(client).expect("inject mock S3 client");
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
 
         let count = populate_key_cache(&daemon)
             .await
@@ -7394,7 +7427,7 @@ mod tests {
         let daemon = Arc::new(Daemon::new(config));
 
         // Should complete without panicking and without queuing the cheap crate.
-        monolithic_manifest_prefetch(&daemon, &client, &remote).await;
+        monolithic_manifest_prefetch(&daemon, client.as_ref(), &remote).await;
         server.shutdown();
     }
 
@@ -7411,7 +7444,7 @@ mod tests {
         let (server, client) = mock_s3_client(vec![ReplayedEvent::status(404)]).await;
         let daemon = Arc::new(Daemon::new(config));
 
-        monolithic_manifest_prefetch(&daemon, &client, &remote).await; // must not panic
+        monolithic_manifest_prefetch(&daemon, client.as_ref(), &remote).await; // must not panic
         server.shutdown();
     }
 
@@ -7446,7 +7479,7 @@ mod tests {
         let (server, client) = mock_s3_client(events).await;
         let daemon = Arc::new(Daemon::new(config));
 
-        monolithic_manifest_prefetch(&daemon, &client, &remote).await; // dispatches + returns
+        monolithic_manifest_prefetch(&daemon, client.as_ref(), &remote).await; // dispatches + returns
         server.shutdown();
     }
 
@@ -7478,7 +7511,7 @@ mod tests {
         let (server, client) = mock_s3_client(events).await;
         let daemon = Arc::new(Daemon::new(config));
 
-        let count = shard_prefetch(&daemon, &client, "bucket", "prefix", "ns", &lock)
+        let count = shard_prefetch(&daemon, &client, "prefix", "ns", &lock)
             .await
             .expect("shard prefetch should succeed");
         assert_eq!(count, 0, "no shards matched -> nothing queued");

--- a/src/fallback_planner.rs
+++ b/src/fallback_planner.rs
@@ -33,7 +33,7 @@ impl PlannerDataSource for LocalPlannerSource<'_> {
             .daemon
             .remote_config()
             .ok_or_else(|| anyhow::anyhow!("no remote configured"))?;
-        let client = self.daemon.get_s3_client().await?;
+        let backend = self.daemon.get_remote_backend().await?;
         let shard_set = crate::shards::compute_shards(namespace, deps);
 
         tracing::info!(
@@ -43,7 +43,7 @@ impl PlannerDataSource for LocalPlannerSource<'_> {
         );
 
         let shard_fetches = shard_set.shards.iter().map(|(hash, _entries)| {
-            crate::remote::download_shard(client, &remote.bucket, &remote.prefix, namespace, hash)
+            crate::remote::download_shard(backend.as_ref(), &remote.prefix, namespace, hash)
         });
         let shard_results = join_all(shard_fetches).await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod planner_client;
 mod platform;
 mod probe;
 mod remote;
+mod remote_backend;
 mod remote_layout;
 mod remote_plan;
 mod report;

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 use crate::config::RemoteConfig;
+use crate::remote_backend::RemoteBackend;
 
 /// Result of a download operation with timing breakdown.
 pub struct DownloadResult {
@@ -150,47 +151,26 @@ pub struct Shard {
 /// memory by serving a giant object on the prefetch/plan path, where many of
 /// these are fetched concurrently. Guards the honest-`Content-Length` case;
 /// a remote that lies about its length is already an integrity problem.
-const MAX_METADATA_BYTES: i64 = 64 * 1024 * 1024; // 64 MiB
-
-fn reject_oversized_metadata(kind: &str, content_length: Option<i64>) -> Result<()> {
-    if let Some(len) = content_length
-        && len > MAX_METADATA_BYTES
-    {
-        anyhow::bail!("{kind} object too large: {len} bytes (max {MAX_METADATA_BYTES})");
-    }
-    Ok(())
-}
+const MAX_METADATA_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
 
 pub async fn download_manifest(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
+    backend: &dyn RemoteBackend,
     prefix: &str,
     manifest_key: &str,
 ) -> Result<BuildManifest> {
     let object_key = format!("{prefix}/{MANIFEST_PREFIX}/{manifest_key}.json");
 
-    let resp = client
-        .get_object()
-        .bucket(bucket)
-        .key(&object_key)
-        .send()
+    let fetched = backend
+        .get(&object_key, Some(MAX_METADATA_BYTES))
         .await
-        .context("downloading manifest from S3")?;
+        .context("downloading manifest")?
+        .with_context(|| format!("manifest not found: {}", backend.describe(&object_key)))?;
 
-    reject_oversized_metadata("manifest", resp.content_length())?;
-    let body = resp
-        .body
-        .collect()
-        .await
-        .context("reading manifest response body")?;
-    let bytes = body.into_bytes();
-
-    serde_json::from_slice(&bytes).context("parsing manifest JSON")
+    serde_json::from_slice(&fetched.body).context("parsing manifest JSON")
 }
 
 pub async fn upload_manifest(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
+    backend: &dyn RemoteBackend,
     prefix: &str,
     manifest_key: &str,
     manifest: &BuildManifest,
@@ -198,15 +178,10 @@ pub async fn upload_manifest(
     let object_key = format!("{prefix}/{MANIFEST_PREFIX}/{manifest_key}.json");
     let body = serde_json::to_vec_pretty(manifest).context("serializing manifest")?;
 
-    client
-        .put_object()
-        .bucket(bucket)
-        .key(&object_key)
-        .body(body.into())
-        .content_type("application/json")
-        .send()
+    backend
+        .put(&object_key, body, Some("application/json"))
         .await
-        .context("uploading manifest to S3")?;
+        .context("uploading manifest")?;
 
     Ok(())
 }
@@ -217,46 +192,27 @@ pub fn shard_object_key(prefix: &str, namespace: &str, shard_hash: &str) -> Stri
 }
 
 pub async fn download_shard(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
+    backend: &dyn RemoteBackend,
     prefix: &str,
     namespace: &str,
     shard_hash: &str,
 ) -> Result<Option<Shard>> {
     let object_key = shard_object_key(prefix, namespace, shard_hash);
 
-    match client
-        .get_object()
-        .bucket(bucket)
-        .key(&object_key)
-        .send()
+    let Some(fetched) = backend
+        .get(&object_key, Some(MAX_METADATA_BYTES))
         .await
-    {
-        Ok(resp) => {
-            reject_oversized_metadata("shard", resp.content_length())?;
-            let body = resp
-                .body
-                .collect()
-                .await
-                .context("reading shard response body")?;
-            let bytes = body.into_bytes();
-            let shard: Shard = serde_json::from_slice(&bytes).context("parsing shard JSON")?;
-            Ok(Some(shard))
-        }
-        Err(e) => {
-            let err = e.into_service_error();
-            if err.is_no_such_key() {
-                Ok(None)
-            } else {
-                Err(anyhow::anyhow!("S3 get shard error: {err}"))
-            }
-        }
-    }
+        .context("downloading shard")?
+    else {
+        return Ok(None);
+    };
+
+    let shard: Shard = serde_json::from_slice(&fetched.body).context("parsing shard JSON")?;
+    Ok(Some(shard))
 }
 
 pub async fn upload_shard(
-    client: &aws_sdk_s3::Client,
-    bucket: &str,
+    backend: &dyn RemoteBackend,
     prefix: &str,
     namespace: &str,
     shard_hash: &str,
@@ -265,15 +221,10 @@ pub async fn upload_shard(
     let object_key = shard_object_key(prefix, namespace, shard_hash);
     let body = serde_json::to_vec_pretty(shard).context("serializing shard")?;
 
-    client
-        .put_object()
-        .bucket(bucket)
-        .key(&object_key)
-        .body(body.into())
-        .content_type("application/json")
-        .send()
+    backend
+        .put(&object_key, body, Some("application/json"))
         .await
-        .context("uploading shard to S3")?;
+        .context("uploading shard")?;
 
     Ok(())
 }
@@ -395,28 +346,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn reject_oversized_metadata_allows_small_and_absent_lengths() {
-        // No advertised length -> can't pre-check, allow.
-        assert!(reject_oversized_metadata("manifest", None).is_ok());
-        // Small object, well under the 64 MiB cap.
-        assert!(reject_oversized_metadata("manifest", Some(1024)).is_ok());
-        // Exactly at the cap is still allowed (the guard is strictly greater).
-        assert!(reject_oversized_metadata("shard", Some(MAX_METADATA_BYTES)).is_ok());
-    }
-
-    #[test]
-    fn reject_oversized_metadata_rejects_over_cap() {
-        let err = reject_oversized_metadata("manifest", Some(MAX_METADATA_BYTES + 1))
-            .expect_err("over-cap length must be rejected");
-        let msg = err.to_string();
-        assert!(msg.contains("too large"), "unexpected message: {msg}");
-        assert!(
-            msg.contains("manifest"),
-            "should name the object kind: {msg}"
-        );
-    }
-
     // ── Mock-S3 round-trips ─────────────────────────────────────────────────
     //
     // These drive the real aws-sdk-s3 client against an in-process wire mock
@@ -426,7 +355,9 @@ mod tests {
 
     /// Build an S3 client whose HTTP traffic is served by `server`, replaying
     /// the canned `events` in request order.
-    async fn mock_client(events: Vec<ReplayedEvent>) -> (WireMockServer, aws_sdk_s3::Client) {
+    async fn mock_client(
+        events: Vec<ReplayedEvent>,
+    ) -> (WireMockServer, crate::remote_backend::S3Backend) {
         let server = WireMockServer::start(events).await;
         let conf = aws_sdk_s3::config::Builder::new()
             .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
@@ -438,7 +369,11 @@ mod tests {
             .http_client(server.http_client())
             .force_path_style(true)
             .build();
-        (server, aws_sdk_s3::Client::from_conf(conf))
+        let backend = crate::remote_backend::S3Backend::new(
+            aws_sdk_s3::Client::from_conf(conf),
+            "bucket".to_string(),
+        );
+        (server, backend)
     }
 
     fn sample_manifest() -> BuildManifest {
@@ -460,7 +395,7 @@ mod tests {
         let body = serde_json::to_vec(&sample_manifest()).unwrap();
         let (server, client) = mock_client(vec![ReplayedEvent::with_body(&body)]).await;
 
-        let got = download_manifest(&client, "bucket", "prefix", "key")
+        let got = download_manifest(&client, "prefix", "key")
             .await
             .expect("download should succeed");
         assert_eq!(got.entries.len(), 1);
@@ -475,7 +410,7 @@ mod tests {
         // connection/response events, not the request URI, so we assert on the
         // operation result rather than the path.)
         let (server, client) = mock_client(vec![ReplayedEvent::ok()]).await;
-        upload_manifest(&client, "bucket", "prefix", "mykey", &sample_manifest())
+        upload_manifest(&client, "prefix", "mykey", &sample_manifest())
             .await
             .expect("upload should succeed");
         assert_eq!(server.events().len(), 3, "one request round-trip expected");
@@ -494,7 +429,7 @@ mod tests {
         let body = serde_json::to_vec(&shard).unwrap();
         let (server, client) = mock_client(vec![ReplayedEvent::with_body(&body)]).await;
 
-        let got = download_shard(&client, "bucket", "prefix", "ns", "hash")
+        let got = download_shard(&client, "prefix", "ns", "hash")
             .await
             .expect("download should succeed")
             .expect("shard should be present");
@@ -513,7 +448,7 @@ mod tests {
             ),
         };
         let (server, client) = mock_client(vec![not_found]).await;
-        let got = download_shard(&client, "bucket", "prefix", "ns", "missing")
+        let got = download_shard(&client, "prefix", "ns", "missing")
             .await
             .expect("a 404 NoSuchKey must not be an error");
         assert!(got.is_none());

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -1,0 +1,366 @@
+//! Transport abstraction for the remote cache.
+//!
+//! The remote layout ([`crate::remote_layout`]) and the manifest/shard sync
+//! ([`crate::remote`]) speak in opaque byte objects addressed by key. This
+//! module is the seam between that key/bytes vocabulary and whatever actually
+//! stores the bytes — today S3, next a plain shared folder (#414).
+//!
+//! Everything above the trait (pack framing, zstd, blake3 validation, key
+//! naming) is transport-independent and stays shared.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use aws_sdk_s3::error::ProvideErrorMetadata;
+use aws_sdk_s3::operation::head_object::HeadObjectError;
+use std::sync::Arc;
+
+use crate::config::RemoteConfig;
+
+/// A fetched object plus the timing split callers report as transfer telemetry.
+#[derive(Debug)]
+pub struct GetObject {
+    pub body: Vec<u8>,
+    /// Time to response headers, ms.
+    pub request_ms: u64,
+    /// Time spent reading the body, ms.
+    pub body_ms: u64,
+}
+
+/// Byte-object transport backing the remote cache.
+///
+/// Absence is not an error: `head` answers `false` and `get` answers `None`, so
+/// callers can take a clean miss path without inspecting transport-specific
+/// error codes.
+#[async_trait]
+pub trait RemoteBackend: Send + Sync {
+    /// Whether `key` exists.
+    async fn head(&self, key: &str) -> Result<bool>;
+
+    /// Fetch `key`, or `None` when it is absent.
+    ///
+    /// `max_bytes` is refused *before* the body is buffered, so a hostile or
+    /// corrupt object can't force an unbounded allocation.
+    async fn get(&self, key: &str, max_bytes: Option<u64>) -> Result<Option<GetObject>>;
+
+    /// Store `body` at `key`.
+    async fn put(&self, key: &str, body: Vec<u8>, content_type: Option<&str>) -> Result<()>;
+
+    /// Keys under `prefix`.
+    async fn list(&self, prefix: &str) -> Result<Vec<String>>;
+
+    /// Where `key` lives, for logs and errors (e.g. `s3://bucket/key`).
+    fn describe(&self, key: &str) -> String;
+}
+
+/// S3 (and S3-compatible: MinIO, Ceph RGW, R2) transport.
+pub struct S3Backend {
+    client: aws_sdk_s3::Client,
+    bucket: String,
+}
+
+impl S3Backend {
+    pub fn new(client: aws_sdk_s3::Client, bucket: String) -> Self {
+        Self { client, bucket }
+    }
+}
+
+/// True when a GetObject failure means "no such object" rather than a
+/// transport/service error. Checks the service-error code (AWS, MinIO) AND the
+/// raw HTTP status, because some S3 clones answer a GET for a missing key with
+/// a bare 404 and no XML error body, which parses to a code-less unhandled
+/// service error.
+fn is_missing_get_object(
+    err: &aws_sdk_s3::error::SdkError<
+        aws_sdk_s3::operation::get_object::GetObjectError,
+        aws_smithy_runtime_api::client::orchestrator::HttpResponse,
+    >,
+) -> bool {
+    if err
+        .raw_response()
+        .is_some_and(|r| r.status().as_u16() == 404)
+    {
+        return true;
+    }
+    match err.as_service_error() {
+        Some(se) => {
+            se.is_no_such_key()
+                || matches!(
+                    se.code(),
+                    Some("NotFound" | "NoSuchKey" | "404" | "NoSuchObject")
+                )
+        }
+        None => false,
+    }
+}
+
+fn is_missing_head_object(err: &HeadObjectError) -> bool {
+    err.is_not_found()
+        || matches!(
+            err.code(),
+            Some("NotFound" | "NoSuchKey" | "404" | "NoSuchObject")
+        )
+}
+
+fn describe_head_object_error(err: &HeadObjectError, http_status: Option<u16>) -> String {
+    let mut details = Vec::new();
+
+    if let Some(status) = http_status {
+        details.push(format!("HTTP {status}"));
+    }
+    if let Some(code) = err.code() {
+        details.push(format!("code={code}"));
+    }
+    if let Some(message) = err.message() {
+        details.push(format!("message={message}"));
+    }
+    if details.is_empty() {
+        details.push(format!("{err:?}"));
+    }
+
+    details.join(", ")
+}
+
+#[async_trait]
+impl RemoteBackend for S3Backend {
+    async fn head(&self, key: &str) -> Result<bool> {
+        match self
+            .client
+            .head_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(e) => {
+                let http_status = e.raw_response().map(|r| r.status().as_u16());
+                let err = e.into_service_error();
+                if is_missing_head_object(&err) {
+                    Ok(false)
+                } else {
+                    Err(anyhow::anyhow!(
+                        "S3 head_object error for {}: {}",
+                        self.describe(key),
+                        describe_head_object_error(&err, http_status)
+                    ))
+                }
+            }
+        }
+    }
+
+    async fn get(&self, key: &str, max_bytes: Option<u64>) -> Result<Option<GetObject>> {
+        let request_start = std::time::Instant::now();
+        let resp = match self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) if is_missing_get_object(&e) => return Ok(None),
+            Err(e) => {
+                return Err(anyhow::Error::new(e))
+                    .with_context(|| format!("GET {}", self.describe(key)));
+            }
+        };
+        let request_ms = request_start.elapsed().as_millis() as u64;
+
+        // Refuse before collecting: the point of the cap is to not buffer the
+        // body at all.
+        if let Some(max) = max_bytes
+            && let Some(len) = resp.content_length()
+            && len as u64 > max
+        {
+            anyhow::bail!("{} too large: {len} bytes (max {max})", self.describe(key));
+        }
+
+        let body_start = std::time::Instant::now();
+        let body = resp
+            .body
+            .collect()
+            .await
+            .with_context(|| format!("reading body of {}", self.describe(key)))?;
+        let body_ms = body_start.elapsed().as_millis() as u64;
+
+        Ok(Some(GetObject {
+            body: body.into_bytes().to_vec(),
+            request_ms,
+            body_ms,
+        }))
+    }
+
+    async fn put(&self, key: &str, body: Vec<u8>, content_type: Option<&str>) -> Result<()> {
+        let mut req = self
+            .client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .body(body.into());
+
+        if let Some(ct) = content_type {
+            req = req.content_type(ct);
+        }
+
+        req.send()
+            .await
+            .with_context(|| format!("PUT {}", self.describe(key)))?;
+
+        Ok(())
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>> {
+        let mut keys = Vec::new();
+        let mut continuation_token: Option<String> = None;
+
+        loop {
+            let mut req = self
+                .client
+                .list_objects_v2()
+                .bucket(&self.bucket)
+                .prefix(prefix);
+
+            if let Some(token) = &continuation_token {
+                req = req.continuation_token(token);
+            }
+
+            let resp = req
+                .send()
+                .await
+                .with_context(|| format!("listing s3://{}/{prefix}", self.bucket))?;
+
+            keys.extend(
+                resp.contents()
+                    .iter()
+                    .filter_map(|o| o.key())
+                    .map(String::from),
+            );
+
+            // A truncated response must carry a continuation token. Some
+            // non-AWS S3 implementations (MinIO/Ceph RGW/R2/proxies) have
+            // emitted is_truncated=true with a missing/empty token; treat that
+            // as end-of-pagination rather than looping forever re-listing page 1.
+            match resp.next_continuation_token() {
+                Some(token) if resp.is_truncated == Some(true) && !token.is_empty() => {
+                    continuation_token = Some(token.to_string());
+                }
+                _ => break,
+            }
+        }
+
+        Ok(keys)
+    }
+
+    fn describe(&self, key: &str) -> String {
+        format!("s3://{}/{}", self.bucket, key)
+    }
+}
+
+/// Build the backend named by `remote`.
+///
+/// `Arc` rather than `Box`: the prefetch path fans shard downloads out across
+/// `tokio::spawn`, which needs an owned `'static` handle per task.
+pub async fn create_backend(
+    remote: &RemoteConfig,
+    pool_idle_secs: u64,
+) -> Result<Arc<dyn RemoteBackend>> {
+    let client = crate::remote::create_s3_client(remote, pool_idle_secs).await?;
+    Ok(Arc::new(S3Backend::new(client, remote.bucket.clone())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_s3::error::ErrorMetadata;
+    use aws_smithy_http_client::test_util::wire::{ReplayedEvent, WireMockServer};
+
+    async fn mock_backend(events: Vec<ReplayedEvent>) -> (WireMockServer, S3Backend) {
+        let server = WireMockServer::start(events).await;
+        let conf = aws_sdk_s3::config::Builder::new()
+            .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
+            .region(aws_sdk_s3::config::Region::new("us-east-1"))
+            .credentials_provider(aws_sdk_s3::config::Credentials::new(
+                "AK", "SK", None, None, "test",
+            ))
+            .endpoint_url(server.endpoint_url())
+            .http_client(server.http_client())
+            .force_path_style(true)
+            .build();
+        let backend = S3Backend::new(aws_sdk_s3::Client::from_conf(conf), "bucket".to_string());
+        (server, backend)
+    }
+
+    #[tokio::test]
+    async fn get_under_the_cap_is_allowed() {
+        let (_server, backend) = mock_backend(vec![ReplayedEvent::with_body("hello")]).await;
+
+        let fetched = backend
+            .get("k", Some(MAX_METADATA_BYTES_TEST))
+            .await
+            .expect("under-cap GET succeeds")
+            .expect("object is present");
+        assert_eq!(fetched.body, b"hello");
+    }
+
+    #[tokio::test]
+    async fn get_over_the_cap_is_refused() {
+        // The cap is checked against the advertised Content-Length before the
+        // body is buffered, so a 5-byte body still trips a 1-byte cap.
+        let (_server, backend) = mock_backend(vec![ReplayedEvent::with_body("hello")]).await;
+
+        let err = backend
+            .get("k", Some(1))
+            .await
+            .expect_err("over-cap length must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("too large"), "unexpected message: {msg}");
+        assert!(
+            msg.contains("s3://bucket/k"),
+            "should name the object: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_without_a_cap_is_unbounded() {
+        let (_server, backend) = mock_backend(vec![ReplayedEvent::with_body("hello")]).await;
+
+        let fetched = backend
+            .get("k", None)
+            .await
+            .expect("uncapped GET succeeds")
+            .expect("object is present");
+        assert_eq!(fetched.body, b"hello");
+    }
+
+    #[tokio::test]
+    async fn get_absent_object_is_none_not_an_error() {
+        let (_server, backend) = mock_backend(vec![ReplayedEvent::status(404)]).await;
+
+        let fetched = backend.get("k", None).await.expect("404 is a clean miss");
+        assert!(fetched.is_none());
+    }
+
+    /// Mirrors `remote::MAX_METADATA_BYTES`; the cap under test is the
+    /// backend's `max_bytes` argument, not that specific constant.
+    const MAX_METADATA_BYTES_TEST: u64 = 64 * 1024 * 1024;
+
+    #[test]
+    fn generic_head_object_not_found_codes_are_treated_as_misses() {
+        let err = HeadObjectError::generic(ErrorMetadata::builder().code("NotFound").build());
+        assert!(is_missing_head_object(&err));
+
+        let err = HeadObjectError::generic(ErrorMetadata::builder().code("NoSuchKey").build());
+        assert!(is_missing_head_object(&err));
+    }
+
+    #[test]
+    fn generic_head_object_non_miss_code_is_not_treated_as_missing() {
+        let err = HeadObjectError::generic(
+            ErrorMetadata::builder()
+                .code("SignatureDoesNotMatch")
+                .build(),
+        );
+        assert!(!is_missing_head_object(&err));
+    }
+}

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -12,6 +12,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use aws_sdk_s3::error::ProvideErrorMetadata;
 use aws_sdk_s3::operation::head_object::HeadObjectError;
+use bytes::Bytes;
 use std::sync::Arc;
 
 use crate::config::RemoteConfig;
@@ -19,7 +20,8 @@ use crate::config::RemoteConfig;
 /// A fetched object plus the timing split callers report as transfer telemetry.
 #[derive(Debug)]
 pub struct GetObject {
-    pub body: Vec<u8>,
+    /// `Bytes` so a restore doesn't copy the whole pack a second time.
+    pub body: Bytes,
     /// Time to response headers, ms.
     pub request_ms: u64,
     /// Time spent reading the body, ms.
@@ -38,8 +40,8 @@ pub trait RemoteBackend: Send + Sync {
 
     /// Fetch `key`, or `None` when it is absent.
     ///
-    /// `max_bytes` is refused *before* the body is buffered, so a hostile or
-    /// corrupt object can't force an unbounded allocation.
+    /// `max_bytes` checks the object's *advertised* size before the body is
+    /// buffered. A remote that advertises no size is not bounded.
     async fn get(&self, key: &str, max_bytes: Option<u64>) -> Result<Option<GetObject>>;
 
     /// Store `body` at `key`.
@@ -65,31 +67,29 @@ impl S3Backend {
 }
 
 /// True when a GetObject failure means "no such object" rather than a
-/// transport/service error. Checks the service-error code (AWS, MinIO) AND the
-/// raw HTTP status, because some S3 clones answer a GET for a missing key with
-/// a bare 404 and no XML error body, which parses to a code-less unhandled
-/// service error.
+/// transport/service error.
+///
+/// A structured code is authoritative: `NoSuchBucket` is also a 404, and
+/// treating it as absence would turn a misconfigured bucket into a cache miss.
+/// The raw status is consulted only when there is no code, because some S3
+/// clones answer a missing key with a bare 404 and no XML error body.
 fn is_missing_get_object(
     err: &aws_sdk_s3::error::SdkError<
         aws_sdk_s3::operation::get_object::GetObjectError,
         aws_smithy_runtime_api::client::orchestrator::HttpResponse,
     >,
 ) -> bool {
-    if err
-        .raw_response()
-        .is_some_and(|r| r.status().as_u16() == 404)
-    {
-        return true;
-    }
     match err.as_service_error() {
-        Some(se) => {
+        Some(se) if se.code().is_some() || se.is_no_such_key() => {
             se.is_no_such_key()
                 || matches!(
                     se.code(),
                     Some("NotFound" | "NoSuchKey" | "404" | "NoSuchObject")
                 )
         }
-        None => false,
+        _ => err
+            .raw_response()
+            .is_some_and(|r| r.status().as_u16() == 404),
     }
 }
 
@@ -113,8 +113,9 @@ fn describe_head_object_error(err: &HeadObjectError, http_status: Option<u16>) -
     if let Some(message) = err.message() {
         details.push(format!("message={message}"));
     }
-    if details.is_empty() {
-        details.push(format!("{err:?}"));
+    // Fallback: if no structured info, include Display output
+    if details.is_empty() || (http_status.is_none() && err.code().is_none()) {
+        details.push(err.to_string());
     }
 
     details.join(", ")
@@ -185,7 +186,7 @@ impl RemoteBackend for S3Backend {
         let body_ms = body_start.elapsed().as_millis() as u64;
 
         Ok(Some(GetObject {
-            body: body.into_bytes().to_vec(),
+            body: body.into_bytes(),
             request_ms,
             body_ms,
         }))
@@ -300,7 +301,7 @@ mod tests {
             .await
             .expect("under-cap GET succeeds")
             .expect("object is present");
-        assert_eq!(fetched.body, b"hello");
+        assert_eq!(fetched.body, "hello");
     }
 
     #[tokio::test]
@@ -330,7 +331,7 @@ mod tests {
             .await
             .expect("uncapped GET succeeds")
             .expect("object is present");
-        assert_eq!(fetched.body, b"hello");
+        assert_eq!(fetched.body, "hello");
     }
 
     #[tokio::test]
@@ -339,6 +340,86 @@ mod tests {
 
         let fetched = backend.get("k", None).await.expect("404 is a clean miss");
         assert!(fetched.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_at_exactly_the_cap_is_allowed() {
+        // The guard is strictly greater, so a body equal to the cap passes.
+        let (_server, backend) = mock_backend(vec![ReplayedEvent::with_body("hello")]).await;
+
+        let fetched = backend
+            .get("k", Some(5))
+            .await
+            .expect("at-cap GET succeeds")
+            .expect("object is present");
+        assert_eq!(fetched.body, "hello");
+    }
+
+    /// A 404 carrying a structured S3 error code.
+    fn s3_error(code: &str) -> ReplayedEvent {
+        ReplayedEvent::HttpResponse {
+            status: 404,
+            body: format!(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+                 <Error><Code>{code}</Code><Message>test</Message></Error>"
+            )
+            .into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_no_such_key_is_a_miss() {
+        let (_server, backend) = mock_backend(vec![s3_error("NoSuchKey")]).await;
+
+        let fetched = backend.get("k", None).await.expect("NoSuchKey is a miss");
+        assert!(fetched.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_no_such_bucket_is_an_error_not_a_miss() {
+        // NoSuchBucket is also a 404. Reporting it as absence would turn a
+        // misconfigured bucket into an ordinary cache miss.
+        let (_server, backend) = mock_backend(vec![s3_error("NoSuchBucket")]).await;
+
+        backend
+            .get("k", None)
+            .await
+            .expect_err("NoSuchBucket must not classify as absence");
+    }
+
+    #[tokio::test]
+    async fn get_bare_404_without_a_code_is_a_miss() {
+        // Some S3 clones answer a missing key with a bare 404 and no XML body.
+        let (_server, backend) = mock_backend(vec![ReplayedEvent::status(404)]).await;
+
+        let fetched = backend.get("k", None).await.expect("bare 404 is a miss");
+        assert!(fetched.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_follows_the_continuation_token_across_pages() {
+        fn page(key: &str, next: Option<&str>) -> ReplayedEvent {
+            let (truncated, token) = match next {
+                Some(t) => (
+                    "true",
+                    format!("<NextContinuationToken>{t}</NextContinuationToken>"),
+                ),
+                None => ("false", String::new()),
+            };
+            ReplayedEvent::with_body(format!(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+                 <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+                 <Name>bucket</Name><KeyCount>1</KeyCount><MaxKeys>1</MaxKeys>\
+                 <IsTruncated>{truncated}</IsTruncated>{token}\
+                 <Contents><Key>{key}</Key><Size>10</Size></Contents></ListBucketResult>"
+            ))
+        }
+
+        let (_server, backend) =
+            mock_backend(vec![page("a.json", Some("tok")), page("b.json", None)]).await;
+
+        let keys = backend.list("p/").await.expect("paginated LIST succeeds");
+        assert_eq!(keys, vec!["a.json".to_string(), "b.json".to_string()]);
     }
 
     /// Mirrors `remote::MAX_METADATA_BYTES`; the cap under test is the

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -1,12 +1,11 @@
 use anyhow::{Context, Result, bail};
-use aws_sdk_s3::error::ProvideErrorMetadata;
-use aws_sdk_s3::operation::head_object::HeadObjectError;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::config::RemoteConfig;
 use crate::remote::{DownloadResult, UploadResult};
+use crate::remote_backend::RemoteBackend;
 use crate::store::EntryMeta;
 
 const V3_ROOT: &str = "v3";
@@ -44,7 +43,7 @@ struct V3Manifest {
 /// The local store stays content-addressed; remote transport is optimized for
 /// cold object-store restores with low request fan-out.
 pub struct RemoteLayout<'a> {
-    client: &'a aws_sdk_s3::Client,
+    backend: &'a dyn RemoteBackend,
     remote: &'a RemoteConfig,
 }
 
@@ -54,36 +53,13 @@ pub struct RemoteUploadResult {
 }
 
 impl<'a> RemoteLayout<'a> {
-    pub fn new(client: &'a aws_sdk_s3::Client, remote: &'a RemoteConfig) -> Self {
-        Self { client, remote }
+    pub fn new(backend: &'a dyn RemoteBackend, remote: &'a RemoteConfig) -> Self {
+        Self { backend, remote }
     }
 
     pub async fn exists_entry(&self, cache_key: &str, crate_name: &str) -> Result<bool> {
         let object_key = v3_manifest_key(&self.remote.prefix, cache_key, crate_name);
-        match self
-            .client
-            .head_object()
-            .bucket(&self.remote.bucket)
-            .key(&object_key)
-            .send()
-            .await
-        {
-            Ok(_) => Ok(true),
-            Err(e) => {
-                let http_status = e.raw_response().map(|r| r.status().as_u16());
-                let err = e.into_service_error();
-                if is_missing_head_object(&err) {
-                    Ok(false)
-                } else {
-                    Err(anyhow::anyhow!(
-                        "S3 head_object error for s3://{}/{}: {}",
-                        self.remote.bucket,
-                        object_key,
-                        describe_head_object_error(&err, http_status)
-                    ))
-                }
-            }
-        }
+        self.backend.head(&object_key).await
     }
 
     pub async fn download_entry(
@@ -95,44 +71,26 @@ impl<'a> RemoteLayout<'a> {
     ) -> Result<DownloadResult> {
         let object_key = v3_pack_key(&self.remote.prefix, cache_key, crate_name);
 
-        tracing::debug!(
-            "downloading v3 pack s3://{}/{}",
-            self.remote.bucket,
-            object_key
-        );
+        tracing::debug!("downloading v3 pack {}", self.backend.describe(&object_key));
 
-        let request_start = std::time::Instant::now();
-        let resp = self
-            .client
-            .get_object()
-            .bucket(&self.remote.bucket)
-            .key(&object_key)
-            .send()
+        // A missing object is a clean miss, not a transfer failure. Callers
+        // downcast to `EntryNotFound` to take the miss path (#485 Phase 0):
+        // likely-present keys go straight to GET, and a stale key-cache
+        // positive degrades to a miss, not an error.
+        let fetched = self
+            .backend
+            .get(&object_key, None)
             .await
-            .map_err(|e| {
-                // A missing object is a clean miss, not a transfer failure.
-                // Callers downcast to `EntryNotFound` to take the miss path
-                // (#485 Phase 0): likely-present keys go straight to GET, and
-                // a stale key-cache positive degrades to a miss, not an error.
-                if is_missing_get_object(&e) {
-                    anyhow::Error::new(EntryNotFound).context(format!(
-                        "v3 pack not found (GET 404): s3://{}/{}",
-                        self.remote.bucket, object_key
-                    ))
-                } else {
-                    anyhow::Error::new(e).context("downloading v3 pack from S3")
-                }
+            .context("downloading v3 pack")?
+            .ok_or_else(|| {
+                anyhow::Error::new(EntryNotFound).context(format!(
+                    "v3 pack not found: {}",
+                    self.backend.describe(&object_key)
+                ))
             })?;
-        let request_ms = request_start.elapsed().as_millis() as u64;
-
-        let body_start = std::time::Instant::now();
-        let body = resp
-            .body
-            .collect()
-            .await
-            .context("reading v3 pack response body")?;
-        let body_ms = body_start.elapsed().as_millis() as u64;
-        let compressed = body.into_bytes();
+        let request_ms = fetched.request_ms;
+        let body_ms = fetched.body_ms;
+        let compressed = fetched.body;
         let compressed_len = compressed.len() as u64;
 
         let extract_start = std::time::Instant::now();
@@ -185,14 +143,10 @@ impl<'a> RemoteLayout<'a> {
 
         let pack_key = v3_pack_key(&self.remote.prefix, cache_key, crate_name);
         let put_pack_start = std::time::Instant::now();
-        self.client
-            .put_object()
-            .bucket(&self.remote.bucket)
-            .key(&pack_key)
-            .body(packed.into())
-            .send()
+        self.backend
+            .put(&pack_key, packed, None)
             .await
-            .context("uploading v3 pack to S3")?;
+            .context("uploading v3 pack")?;
         let mut network_ms = put_pack_start.elapsed().as_millis() as u64;
 
         let manifest = V3Manifest {
@@ -209,15 +163,10 @@ impl<'a> RemoteLayout<'a> {
         let manifest_key = v3_manifest_key(&self.remote.prefix, cache_key, crate_name);
 
         let put_manifest_start = std::time::Instant::now();
-        self.client
-            .put_object()
-            .bucket(&self.remote.bucket)
-            .key(&manifest_key)
-            .body(manifest_body.into())
-            .content_type("application/json")
-            .send()
+        self.backend
+            .put(&manifest_key, manifest_body, Some("application/json"))
             .await
-            .context("uploading v3 manifest to S3")?;
+            .context("uploading v3 manifest")?;
         network_ms += put_manifest_start.elapsed().as_millis() as u64;
 
         Ok(RemoteUploadResult {
@@ -232,44 +181,22 @@ impl<'a> RemoteLayout<'a> {
     }
 
     pub async fn list_keys(&self) -> Result<HashMap<String, String>> {
-        let mut keys = HashMap::new();
-        let mut continuation_token: Option<String> = None;
         let manifest_prefix = format!("{}/{V3_ROOT}/{V3_MANIFESTS}/", self.remote.prefix);
+        let objects = self
+            .backend
+            .list(&manifest_prefix)
+            .await
+            .context("listing v3 manifests")?;
 
-        loop {
-            let mut req = self
-                .client
-                .list_objects_v2()
-                .bucket(&self.remote.bucket)
-                .prefix(&manifest_prefix);
-
-            if let Some(token) = &continuation_token {
-                req = req.continuation_token(token);
-            }
-
-            let resp = req.send().await.context("listing v3 manifests")?;
-
-            for obj in resp.contents() {
-                if let Some(key) = obj.key()
-                    && let Some(stripped) = key.strip_prefix(&manifest_prefix)
-                    && let Some(without_ext) = stripped.strip_suffix(".json")
-                    && let Some((crate_name, cache_key)) = without_ext.rsplit_once('/')
-                {
-                    keys.insert(cache_key.to_string(), crate_name.to_string());
-                }
-            }
-
-            // A truncated response must carry a continuation token. Some
-            // non-AWS S3 implementations (MinIO/Ceph RGW/R2/proxies) have
-            // emitted is_truncated=true with a missing/empty token; treat that
-            // as end-of-pagination rather than looping forever re-listing page 1.
-            match resp.next_continuation_token() {
-                Some(token) if resp.is_truncated == Some(true) && !token.is_empty() => {
-                    continuation_token = Some(token.to_string());
-                }
-                _ => break,
-            }
-        }
+        let keys = objects
+            .iter()
+            .filter_map(|key| {
+                let stripped = key.strip_prefix(&manifest_prefix)?;
+                let without_ext = stripped.strip_suffix(".json")?;
+                let (crate_name, cache_key) = without_ext.rsplit_once('/')?;
+                Some((cache_key.to_string(), crate_name.to_string()))
+            })
+            .collect();
 
         Ok(keys)
     }
@@ -281,47 +208,21 @@ impl<'a> RemoteLayout<'a> {
         let mut keys = HashMap::new();
 
         for crate_name in crate_names {
-            let mut continuation_token: Option<String> = None;
             let manifest_prefix = format!(
                 "{}/{V3_ROOT}/{V3_MANIFESTS}/{crate_name}/",
                 self.remote.prefix
             );
+            let objects = self
+                .backend
+                .list(&manifest_prefix)
+                .await
+                .with_context(|| format!("listing v3 manifests for crate {crate_name}"))?;
 
-            loop {
-                let mut req = self
-                    .client
-                    .list_objects_v2()
-                    .bucket(&self.remote.bucket)
-                    .prefix(&manifest_prefix);
-
-                if let Some(token) = &continuation_token {
-                    req = req.continuation_token(token);
-                }
-
-                let resp = req
-                    .send()
-                    .await
-                    .with_context(|| format!("listing v3 manifests for crate {crate_name}"))?;
-
-                for obj in resp.contents() {
-                    if let Some(key) = obj.key()
-                        && let Some(stripped) = key.strip_prefix(&manifest_prefix)
-                        && let Some(cache_key) = stripped.strip_suffix(".json")
-                    {
-                        keys.insert(cache_key.to_string(), crate_name.clone());
-                    }
-                }
-
-                // See list_keys: guard against a truncated response with no
-                // usable continuation token (non-AWS S3) to avoid an infinite
-                // re-list of page 1.
-                match resp.next_continuation_token() {
-                    Some(token) if resp.is_truncated == Some(true) && !token.is_empty() => {
-                        continuation_token = Some(token.to_string());
-                    }
-                    _ => break,
-                }
-            }
+            keys.extend(objects.iter().filter_map(|key| {
+                let stripped = key.strip_prefix(&manifest_prefix)?;
+                let cache_key = stripped.strip_suffix(".json")?;
+                Some((cache_key.to_string(), crate_name.clone()))
+            }));
         }
 
         Ok(keys)
@@ -349,64 +250,6 @@ impl std::fmt::Display for EntryNotFound {
 }
 
 impl std::error::Error for EntryNotFound {}
-
-/// GET-side twin of [`is_missing_head_object`]: true when a GetObject failure
-/// means "no such object" rather than a transport/service error. Checks the
-/// service-error code (AWS, MinIO) AND the raw HTTP status, because some S3
-/// clones answer a GET for a missing key with a bare 404 and no XML error
-/// body, which parses to a code-less unhandled service error.
-fn is_missing_get_object(
-    err: &aws_sdk_s3::error::SdkError<
-        aws_sdk_s3::operation::get_object::GetObjectError,
-        aws_smithy_runtime_api::client::orchestrator::HttpResponse,
-    >,
-) -> bool {
-    if err
-        .raw_response()
-        .is_some_and(|r| r.status().as_u16() == 404)
-    {
-        return true;
-    }
-    match err.as_service_error() {
-        Some(se) => {
-            se.is_no_such_key()
-                || matches!(
-                    se.code(),
-                    Some("NotFound" | "NoSuchKey" | "404" | "NoSuchObject")
-                )
-        }
-        None => false,
-    }
-}
-
-fn is_missing_head_object(err: &HeadObjectError) -> bool {
-    err.is_not_found()
-        || matches!(
-            err.code(),
-            Some("NotFound" | "NoSuchKey" | "404" | "NoSuchObject")
-        )
-}
-
-fn describe_head_object_error(err: &HeadObjectError, http_status: Option<u16>) -> String {
-    let mut details = Vec::new();
-
-    if let Some(status) = http_status {
-        details.push(format!("HTTP {status}"));
-    }
-    if let Some(code) = err.code() {
-        details.push(format!("code={code}"));
-    }
-    if let Some(message) = err.message() {
-        details.push(format!("message={message}"));
-    }
-
-    // Fallback: if no structured info, include Display output
-    if details.is_empty() || (http_status.is_none() && err.code().is_none()) {
-        details.push(err.to_string());
-    }
-
-    details.join(", ")
-}
 
 // pub(crate) so other modules' tests can build a valid entry pack fixture to
 // drive the S3 download-success paths against the mock (sync pull, daemon
@@ -648,8 +491,6 @@ mod tests {
     };
     use crate::config::{Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS, DEFAULT_S3_POOL_IDLE_SECS};
     use crate::store::{EntryMeta, Store};
-    use aws_sdk_s3::error::ErrorMetadata;
-    use aws_sdk_s3::operation::head_object::HeadObjectError;
     use std::path::Path;
 
     #[test]
@@ -959,25 +800,6 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("path traversal"));
     }
 
-    #[test]
-    fn generic_head_object_not_found_codes_are_treated_as_misses() {
-        let err = HeadObjectError::generic(ErrorMetadata::builder().code("NotFound").build());
-        assert!(super::is_missing_head_object(&err));
-
-        let err = HeadObjectError::generic(ErrorMetadata::builder().code("NoSuchKey").build());
-        assert!(super::is_missing_head_object(&err));
-    }
-
-    #[test]
-    fn generic_head_object_non_miss_code_is_not_treated_as_missing() {
-        let err = HeadObjectError::generic(
-            ErrorMetadata::builder()
-                .code("SignatureDoesNotMatch")
-                .build(),
-        );
-        assert!(!super::is_missing_head_object(&err));
-    }
-
     // ── Mock-S3 round-trips for the v3 RemoteLayout ─────────────────────────
     //
     // Drive RemoteLayout against an in-process wire mock (no network) to cover
@@ -1021,7 +843,9 @@ mod tests {
         }
     }
 
-    async fn mock_client(events: Vec<ReplayedEvent>) -> (WireMockServer, aws_sdk_s3::Client) {
+    async fn mock_client(
+        events: Vec<ReplayedEvent>,
+    ) -> (WireMockServer, crate::remote_backend::S3Backend) {
         let server = WireMockServer::start(events).await;
         let conf = aws_sdk_s3::config::Builder::new()
             .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
@@ -1033,7 +857,11 @@ mod tests {
             .http_client(server.http_client())
             .force_path_style(true)
             .build();
-        (server, aws_sdk_s3::Client::from_conf(conf))
+        let backend = crate::remote_backend::S3Backend::new(
+            aws_sdk_s3::Client::from_conf(conf),
+            "bucket".to_string(),
+        );
+        (server, backend)
     }
 
     /// Build a one-file store entry and return (tmpdir, store, entry_dir).

--- a/src/remote_plan.rs
+++ b/src/remote_plan.rs
@@ -1,4 +1,5 @@
 use crate::config::{Config, RemoteConfig};
+use crate::remote_backend::RemoteBackend;
 use crate::remote_layout::RemoteLayout;
 
 /// The kind of remote workload being planned.
@@ -31,11 +32,11 @@ pub struct RemotePlan {
 impl RemotePlan {
     pub fn layout<'a>(
         &self,
-        client: &'a aws_sdk_s3::Client,
+        backend: &'a dyn RemoteBackend,
         remote: &'a RemoteConfig,
     ) -> RemoteLayout<'a> {
         match self.layout {
-            RemoteLayoutKind::V3 => RemoteLayout::new(client, remote),
+            RemoteLayoutKind::V3 => RemoteLayout::new(backend, remote),
         }
     }
 


### PR DESCRIPTION
Phase 1 of #414 opens with:

> - Introduce a backend trait over the four operations and move the current S3 path onto it.

This is that bullet on its own. The `std::fs` backend — the second bullet — follows in a separate PR: CONTRIBUTING asks to keep PRs focused, and splitting here means the folder backend arrives as a pure addition rather than a rewrite tangled up with a refactor. Structurally a refactor; `S3Backend` is the only implementor. Not *bit-for-bit* no-op, though: a few things are observable, and they are called out inline below — GET miss-classification for shards, the pack body no longer being copied, and some error/log strings that promised S3.

## Why this has to come first

`aws_sdk_s3::Client` was the concrete type threaded through `remote.rs`, `remote_layout.rs`, `remote_plan.rs`, `daemon.rs`, `cli.rs` and `fallback_planner.rs`. `RemoteLayout` held one directly, and four manifest/shard functions in `remote.rs` took one by argument alongside `bucket`. A second transport had nowhere to attach.

## The seam

The trait sits at the object level #414 describes — `head` / `get` / `put` / `list`-by-prefix — rather than at the entry level. That keeps pack framing, zstd, blake3 validation and key naming above it, shared by every transport; a folder backend only has to answer four questions about bytes. `bucket` moves inside the backend and off the call signatures.

`RemotePlan::layout()` and the daemon's `OnceCell` now speak `RemoteBackend`, so the plumbing is transport-agnostic end to end.

## Design notes

- **Absence is not an error.** `head` answers `false`, `get` answers `None`. The `NoSuchKey`/`404`/`NoSuchObject` spread of AWS and its clones stays inside the backend, where it belongs. `EntryNotFound` is still minted by the layout, so the #485 Phase 0 miss path is untouched.
- **`get` takes `max_bytes`.** The metadata cap has to be a pre-buffering guard — checking the length after the body is collected would defeat the point. Letting callers check afterwards would have quietly dropped that protection, so the cap crosses the trait.
- **`get` returns the request/body timing split** that `DownloadResult` reports, so transfer telemetry keeps its resolution instead of collapsing to one number.
- **`Arc<dyn RemoteBackend>`, not `Box`.** Shard prefetch and shard upload fan out over `tokio::spawn`, which needs an owned `'static` handle. The alternative — `join_all` — would have quietly serialized them onto one task.
- **Naming.** Where the code is transport-agnostic, messages that promised S3 now say remote; "S3 client init failed" would be a lie over a folder. Internals still named for S3 (`s3_semaphore`, `S3KeyCache`, `s3_concurrency`) are left alone — renaming those is churn that belongs with the backend that makes them wrong.

## Tests

The mock-injection points that already existed (`sync_with_client`, `upload_manifest_and_shards`, the daemon's `OnceCell`) now take the trait, so every existing wire-mock round-trip — remote-check hit/miss, GET-404-as-clean-miss, prefetch, upload-skip — still exercises the S3 path, just through the seam.

Two test groups moved with the code they cover:

- head-miss classification (`NotFound`/`NoSuchKey` → miss, `SignatureDoesNotMatch` → not a miss) → `remote_backend.rs`.
- the metadata cap: `reject_oversized_metadata` was unit-tested directly; the equivalent now drives a real GET against the mock (under cap, over cap, uncapped, absent), which covers the guard on the path it actually protects.

## Verification

`just check` is green: fmt, `clippy --workspace --all-targets -- -D warnings`, and the full
`cargo test --workspace` including the integration suite (1182 unit + integration all passing).

Correcting something from the first revision of this description: I had flagged
`cargo test --workspace` as flaky here and on `main`. That was wrong. The integration tests build
into `/tmp`, which is a 16G tmpfs on my machine, and my own repeated runs had filled it — the
failures were `No space left on device`, not test interference. With space free, the suite is
green on both.
