### PR TITLE
fix(compiler): detect bare workspace wrappers configured by Cargo

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -590,14 +590,90 @@ pub fn detect_compiler(args: &[String]) -> Option<&'static CompilerAdapter> {
 /// unrecognized workspace wrapper. Cargo passes `<wrapper> rustc <args>`;
 /// the wrapper may be an absolute path or a bare name resolved via PATH.
 /// We match the inner rustc, not the wrapper name.
+#[cfg(unix)]
+fn is_executable(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &std::path::Path) -> bool {
+    path.is_file()
+}
+
+pub(crate) fn is_kache_subcommand_or_flag(s: &str) -> bool {
+    if s.starts_with('-') {
+        return true;
+    }
+    use clap::CommandFactory;
+    let mut cmd = crate::Cli::command();
+    cmd.build();
+    cmd.find_subcommand(s).is_some()
+}
+
+pub(crate) fn resolve_program_on_path(program: &str) -> Option<std::path::PathBuf> {
+    if program.contains('/') || program.contains('\\') {
+        return Some(std::path::PathBuf::from(program));
+    }
+    let path = std::env::var_os("PATH")?;
+    let dirs: Vec<std::path::PathBuf> = std::env::split_paths(&path).collect();
+
+    let extensions: Vec<String> = if cfg!(windows) {
+        if let Some(pathext) = std::env::var_os("PATHEXT") {
+            std::env::split_paths(&pathext)
+                .filter_map(|p| p.to_str().map(|s| s.to_string()))
+                .collect()
+        } else {
+            vec![
+                ".exe".to_string(),
+                ".bat".to_string(),
+                ".cmd".to_string(),
+                ".com".to_string(),
+            ]
+        }
+    } else {
+        vec!["".to_string()]
+    };
+
+    for dir in dirs {
+        let p = dir.join(program);
+        if is_executable(&p) {
+            return Some(p);
+        }
+        for ext in &extensions {
+            if ext.is_empty() {
+                continue;
+            }
+            let mut suffixed = p.clone().into_os_string();
+            suffixed.push(ext);
+            let suffixed_path = std::path::PathBuf::from(suffixed);
+            if is_executable(&suffixed_path) {
+                return Some(suffixed_path);
+            }
+        }
+    }
+    None
+}
+
+fn is_program_on_path(program: &str) -> bool {
+    resolve_program_on_path(program).is_some()
+}
+
 pub fn is_workspace_wrapper_chain(args: &[String]) -> bool {
     if args.len() < 2 || !rustc::RustcCompiler::recognizes(&args[1..]) {
         return false;
     }
-    args[0].contains('/')
-        || args[0].contains('\\')
-        || std::env::var_os("RUSTC_WORKSPACE_WRAPPER")
-            .is_some_and(|w| w == std::ffi::OsStr::new(&args[0]))
+    if args[0].contains('/') || args[0].contains('\\') {
+        return true;
+    }
+    if std::env::var_os("RUSTC_WORKSPACE_WRAPPER")
+        .is_some_and(|w| w == std::ffi::OsStr::new(&args[0]))
+    {
+        return true;
+    }
+    !is_kache_subcommand_or_flag(&args[0]) && is_program_on_path(&args[0])
 }
 
 /// Extract the bare command name from an `argv[0]`, splitting on both Unix
@@ -629,6 +705,18 @@ pub(crate) fn strip_windows_exe_suffix(name: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_is_kache_subcommand_or_flag() {
+        assert!(is_kache_subcommand_or_flag("help"));
+        assert!(is_kache_subcommand_or_flag("-h"));
+        assert!(is_kache_subcommand_or_flag("--help"));
+        assert!(is_kache_subcommand_or_flag("-V"));
+        assert!(is_kache_subcommand_or_flag("--version"));
+        assert!(is_kache_subcommand_or_flag("gc"));
+        assert!(is_kache_subcommand_or_flag("list"));
+        assert!(!is_kache_subcommand_or_flag("not-a-subcommand"));
+    }
 
     fn s(args: &[&str]) -> Vec<String> {
         args.iter().map(|a| a.to_string()).collect()
@@ -754,11 +842,73 @@ mod tests {
     }
 
     #[test]
+    fn workspace_wrapper_chain_detects_bare_name_via_path() {
+        use std::fs::File;
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let wrapper_name = "custom-wrapper-test-executable";
+        #[cfg(windows)]
+        {
+            let wrapper_path_exe = temp_dir.path().join(format!("{}.exe", wrapper_name));
+            File::create(&wrapper_path_exe).unwrap();
+        }
+        #[cfg(not(windows))]
+        {
+            let wrapper_path = temp_dir.path().join(wrapper_name);
+            File::create(&wrapper_path).unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = std::fs::metadata(&wrapper_path).unwrap().permissions();
+                perms.set_mode(0o755);
+                std::fs::set_permissions(&wrapper_path, perms).unwrap();
+            }
+        }
+
+        struct PathGuard {
+            prev: Option<std::ffi::OsString>,
+        }
+        impl Drop for PathGuard {
+            fn drop(&mut self) {
+                unsafe {
+                    match &self.prev {
+                        Some(v) => std::env::set_var("PATH", v),
+                        None => std::env::remove_var("PATH"),
+                    }
+                }
+            }
+        }
+        let prev = std::env::var_os("PATH");
+        let mut new_path = std::ffi::OsString::new();
+        new_path.push(temp_dir.path());
+        if let Some(ref p) = prev {
+            new_path.push(if cfg!(windows) { ";" } else { ":" });
+            new_path.push(p);
+        }
+        unsafe { std::env::set_var("PATH", new_path) };
+        let _guard = PathGuard { prev };
+
+        assert!(is_workspace_wrapper_chain(&s(&[wrapper_name, "rustc"])));
+    }
+
+    #[test]
     fn workspace_wrapper_chain_rejects_non_paths() {
         // No path separator and not RUSTC_WORKSPACE_WRAPPER → CLI subcommand.
         assert!(!is_workspace_wrapper_chain(&s(&["init", "rustc-project"])));
+        assert!(!is_workspace_wrapper_chain(&s(&["gc", "rustc"])));
+        assert!(!is_workspace_wrapper_chain(&s(&["doctor", "rustc"])));
+        assert!(!is_workspace_wrapper_chain(&s(&["config", "rustc"])));
+        assert!(!is_workspace_wrapper_chain(&s(&["report", "rustc"])));
+
+        // Non-existent executable name
+        assert!(!is_workspace_wrapper_chain(&s(&[
+            "nonexistentwrappername12345",
+            "rustc"
+        ])));
+
         // Inner arg not rustc.
         assert!(!is_workspace_wrapper_chain(&s(&["/usr/bin/cc", "file.c"])));
+        assert!(!is_workspace_wrapper_chain(&s(&["cargo", "build"])));
+
         // Too few args.
         assert!(!is_workspace_wrapper_chain(&s(&["/usr/bin/rustc"])));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,9 +58,9 @@ pub const VERSION: &str = {
 /// transparent build cache. Otherwise, it provides CLI commands for cache management.
 #[derive(Parser)]
 #[command(name = "kache", version = VERSION, about)]
-struct Cli {
+pub(crate) struct Cli {
     #[command(subcommand)]
-    command: Option<Commands>,
+    pub(crate) command: Option<Commands>,
 }
 
 #[derive(Subcommand)]
@@ -579,7 +579,9 @@ fn run_compiler_directly(args: &[String]) -> Result<i32> {
     }
 
     let filtered = compile::strip_incremental_flags(&args[1..]);
-    let status = std::process::Command::new(&args[0])
+    let program = compiler::resolve_program_on_path(&args[0])
+        .unwrap_or_else(|| std::path::PathBuf::from(&args[0]));
+    let status = std::process::Command::new(program)
         .args(&filtered)
         .status()?;
     Ok(status.code().unwrap_or(1))

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -1019,3 +1019,117 @@ fn gc_max_age_runs_eviction_sweep_on_populated_cache() {
         .success()
         .stdout(predicates::str::contains("Store:"));
 }
+
+fn create_wrapper_script(dir: &Path, name: &str) -> std::path::PathBuf {
+    if cfg!(windows) {
+        let script_path = dir.join(format!("{}.bat", name));
+        std::fs::write(&script_path, "@%*\n").unwrap();
+        script_path
+    } else {
+        let script_path = dir.join(name);
+        std::fs::write(&script_path, "#!/bin/sh\nexec \"$@\"\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script_path, perms).unwrap();
+        }
+        script_path
+    }
+}
+
+#[test]
+fn workspace_wrapper_via_cargo_build_env_and_path() {
+    let e = env();
+    let project = scaffold_lib("kachewrap1", "pub fn w() -> u8 { 1 }\n");
+    let target_dir = project.path().join("target");
+
+    // Create a bare wrapper script on PATH
+    let path_dir = TempDir::new().unwrap();
+    let _script = create_wrapper_script(path_dir.path(), "mydriver");
+
+    let prev_path = std::env::var_os("PATH");
+    let mut new_path = std::ffi::OsString::new();
+    new_path.push(path_dir.path());
+    if let Some(ref p) = prev_path {
+        new_path.push(if cfg!(windows) { ";" } else { ":" });
+        new_path.push(p);
+    }
+
+    let build = std::process::Command::new(env!("CARGO"))
+        .args(["build", "--lib"])
+        .current_dir(project.path())
+        .env("PATH", new_path)
+        .env("RUSTC_WRAPPER", KACHE_BIN)
+        .env("CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER", "mydriver")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .env("KACHE_CACHE_DIR", &e.cache)
+        .env("KACHE_CONFIG", e.cache.join("config.toml"))
+        .env("KACHE_LOG", "off")
+        .env("HOME", &e.home)
+        .env("KACHE_DAEMON_IDLE_TIMEOUT", "3")
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .env("CARGO_INCREMENTAL", "0")
+        .output()
+        .expect("run cargo build");
+
+    assert!(
+        build.status.success(),
+        "build failed with stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+}
+
+#[test]
+fn workspace_wrapper_via_cargo_config_and_path() {
+    let e = env();
+    let project = scaffold_lib("kachewrap2", "pub fn w() -> u8 { 2 }\n");
+    let target_dir = project.path().join("target");
+
+    // Create a bare wrapper script on PATH
+    let path_dir = TempDir::new().unwrap();
+    let _script = create_wrapper_script(path_dir.path(), "mydriver");
+
+    // Add .cargo/config.toml to project
+    let cargo_dir = project.path().join(".cargo");
+    std::fs::create_dir_all(&cargo_dir).unwrap();
+    std::fs::write(
+        cargo_dir.join("config.toml"),
+        "[build]\nrustc-workspace-wrapper = \"mydriver\"\n",
+    )
+    .unwrap();
+
+    let prev_path = std::env::var_os("PATH");
+    let mut new_path = std::ffi::OsString::new();
+    new_path.push(path_dir.path());
+    if let Some(ref p) = prev_path {
+        new_path.push(if cfg!(windows) { ";" } else { ":" });
+        new_path.push(p);
+    }
+
+    let build = std::process::Command::new(env!("CARGO"))
+        .args(["build", "--lib"])
+        .current_dir(project.path())
+        .env("PATH", new_path)
+        .env("RUSTC_WRAPPER", KACHE_BIN)
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .env_remove("CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER")
+        .env("KACHE_CACHE_DIR", &e.cache)
+        .env("KACHE_CONFIG", e.cache.join("config.toml"))
+        .env("KACHE_LOG", "off")
+        .env("HOME", &e.home)
+        .env("KACHE_DAEMON_IDLE_TIMEOUT", "3")
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .env("CARGO_INCREMENTAL", "0")
+        .output()
+        .expect("run cargo build");
+
+    assert!(
+        build.status.success(),
+        "build failed with stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

Closes #516.

This PR extends workspace-wrapper chain detection to support bare (separator-free) wrapper names configured through Cargo, not just `RUSTC_WORKSPACE_WRAPPER`.

Previously, bare wrapper names were only recognized when they matched the `RUSTC_WORKSPACE_WRAPPER` environment variable. As a result, wrappers configured through `CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER` or `.cargo/config.toml` (`build.rustc-workspace-wrapper`) were misidentified and treated as `kache` subcommands.

## What changed

### Compiler detection

- Keep the existing absolute/relative path detection.
- Keep the existing `RUSTC_WORKSPACE_WRAPPER` environment matching.
- Add detection for bare wrapper names by:
  - ignoring known `kache` subcommands and global flags,
  - resolving the wrapper executable on `PATH` (including Windows `PATHEXT` handling),
  - verifying that the remaining arguments form a recognized `rustc` compiler invocation.

### Compiler execution

- Update `run_compiler_directly` to execute the resolved wrapper path, allowing Windows batch-script wrappers (`.bat` / `.cmd`) to work correctly.
- Add a regression test to ensure the hardcoded subcommand list stays synchronized with the Clap command definitions.

### Tests

Added coverage for:

- PATH-resolved bare wrapper detection.
- `CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER`.
- `.cargo/config.toml` (`build.rustc-workspace-wrapper`).
- Negative cases to ensure unrelated commands are not misidentified as wrapper chains.