### PR TITLE
fix(daemon): add `status` subcommand the help text already promised

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
 | `kache config` | Open the TUI configuration editor |
 | `kache completions <shell>` | Print shell completion script (bash, zsh, fish, elvish, powershell) |
 | `kache daemon` | Show daemon and service status |
+| `kache daemon status` | Show daemon and service status (explicit form) |
 | `kache daemon run` | Start the persistent background daemon (foreground) |
 | `kache daemon start` | Start daemon in background (returns immediately) |
 | `kache daemon stop` | Stop a running daemon |

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -361,6 +361,7 @@ kache completions fish | source   # fish
 
 ```sh
 kache daemon                  # show daemon status: service install state, running/offline, socket path, log location, daemon version/epoch
+kache daemon status           # same as above (explicit alias)
 kache daemon start            # start in background, wait until ready
 kache daemon stop             # graceful shutdown
 kache daemon restart          # restart (via launchd/systemd/Task Scheduler if installed, else manual)

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,7 @@ enum Commands {
         namespace: Option<String>,
     },
 
-    /// Daemon management (status, start, stop, install, uninstall, log)
+    /// Daemon management. With no subcommand, shows daemon status.
     #[command(subcommand_required = false)]
     Daemon {
         #[command(subcommand)]
@@ -249,6 +249,8 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum DaemonCommands {
+    /// Show daemon status (alias for bare `kache daemon`)
+    Status,
     /// Run the daemon server in the foreground
     Run,
     /// Start daemon in background (returns immediately)
@@ -474,6 +476,9 @@ fn main() -> Result<()> {
             namespace,
         }) => cli::save_manifest(&config, manifest_key.as_deref(), namespace.as_deref()),
         Some(Commands::Daemon { command: None }) => service::status(),
+        Some(Commands::Daemon {
+            command: Some(DaemonCommands::Status),
+        }) => service::status(),
         Some(Commands::Daemon {
             command: Some(DaemonCommands::Run),
         }) => daemon::run_server(&config),

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -598,6 +598,19 @@ fn daemon_without_subcommand_succeeds() {
     e.cmd().arg("daemon").assert().success();
 }
 
+#[test]
+fn daemon_status_subcommand_succeeds() {
+    // `kache daemon status` is the explicit alias for bare `kache daemon`.
+    // Pin the equivalence: both forms must exit identically and produce
+    // byte-identical stdout in the same environment.
+    let e = env();
+    let bare = e.cmd().arg("daemon").output().unwrap();
+    let explicit = e.cmd().args(["daemon", "status"]).output().unwrap();
+    assert!(bare.status.success(), "bare `kache daemon` failed");
+    assert_eq!(explicit.status, bare.status);
+    assert_eq!(explicit.stdout, bare.stdout);
+}
+
 // ── populated-cache behavior ────────────────────────────────────────────────
 
 /// Build a trivial library crate through the kache rustc wrapper so the cache


### PR DESCRIPTION
## Problem

`kache daemon --help` advertised `status` alongside the real subcommands:

> Daemon management (status, start, stop, install, uninstall, log)

…but no `status` subcommand existed, so `kache daemon status` failed with `unrecognized subcommand 'status'`. Status was only reachable via the bare `kache daemon` invocation, which the help text never mentioned.

## Fix

- Add a `Status` variant to `DaemonCommands` routing to the **existing** `service::status()` — the same function the bare command already uses. No logic duplicated.
- Rewrite the misleading `about` line; clap already enumerates the subcommands below it.
- Document `kache daemon status` as an explicit alias in `docs/commands/reference.mdx`.

Both `kache daemon` and `kache daemon status` now print the status block (service install state, running/offline, socket path, log location, version/epoch).

## Verification

- `just check` passes (fmt + clippy + tests).
- New test `daemon_status_subcommand_succeeds` mirrors the existing `daemon_without_subcommand_succeeds`.
