### PR TITLE
docs: stop claiming bare `kache` opens the TUI

### DIFF
--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -13,7 +13,7 @@ When invoked without arguments, kache prints `--help` and exits — it does not 
 |---|---|
 | `kache` | Print `--help` and exit (use `kache monitor` for the live TUI) |
 | `kache init [-y] [--no-service] [--check]` | Interactive setup: cargo wrapper + service install + daemon start |
-| `kache monitor [--since <dur>]` | Same as bare `kache`, with optional time window |
+| `kache monitor [--since <dur>]` | Open the live TUI dashboard, optionally scoped to a time window |
 | `kache stats [--since <dur>]` | One-shot stats snapshot, no interactive UI |
 | `kache list [<crate>] [--sort <field>]` | List cache entries or show details for one crate |
 | `kache why-miss <crate>` | Diagnose why a crate keeps missing the cache |

--- a/docs/monitor.mdx
+++ b/docs/monitor.mdx
@@ -5,7 +5,7 @@ description: Reading and using the live TUI dashboard.
 
 # Monitor
 
-Running `kache` with no arguments (or `kache monitor`) opens a live TUI dashboard that shows what's happening in your cache in real time. It refreshes automatically and doesn't require the daemon to be running: the monitor makes a best-effort attempt to start one in the background for richer stats, but still works via direct store and event-log reads if the daemon is unavailable (the Transfer line then reads `n/a (daemon offline)`).
+`kache monitor` opens a live TUI dashboard that shows what's happening in your cache in real time. It refreshes automatically and doesn't require the daemon to be running: the monitor makes a best-effort attempt to start one in the background for richer stats, but still works via direct store and event-log reads if the daemon is unavailable (the Transfer line then reads `n/a (daemon offline)`).
 
 ![kache monitor TUI cycling through Build, Projects, Store, Transfer, and Passthrough tabs against a populated cache](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/monitor.gif)
 


### PR DESCRIPTION
## Summary

Bare `kache` prints help and exits — it has not opened the TUI for a while. The `None` arm in `src/main.rs` records the intent:

> No subcommand — print help. New users often find an unexpected TUI disorienting; they can still launch it explicitly with `kache monitor`.

Two documentation claims never caught up. Notably `docs/commands/reference.mdx` **contradicted itself**: its intro paragraph and its `kache` row both state the correct behavior, while the `kache monitor` row two lines later still described the monitor as "Same as bare `kache`" — so the stale row was a leftover from a partial update, not a considered claim.

| File | Was | Now |
|---|---|---|
| `docs/commands/reference.mdx` | `kache monitor` — "Same as bare `kache`, with optional time window" | "Open the live TUI dashboard, optionally scoped to a time window" |
| `docs/monitor.mdx` | "Running `kache` with no arguments (or `kache monitor`) opens a live TUI dashboard…" | "`kache monitor` opens a live TUI dashboard…" |

Deliberately **not** touched, because they are already correct: `reference.mdx`'s intro and `kache` row, and `docs/getting-started/quick-start.mdx:85` ("Running bare `kache` prints help; use `kache monitor` to open the dashboard").

## Test plan

- [x] Swept the full docs surface for every assertion tying bare `kache` / "no arguments" to the TUI; the two above were the only stale ones, and the sweep is clean afterwards.
- [x] Confirmed the real behavior against the built binary: bare `kache` prints `Usage: kache [COMMAND]` and exits 0.
- [x] Docs-only diff (2 `.mdx` lines) — no Rust, Cargo, or workflow surface, so the CI code matrix is expected to skip.

## Checklist

- [ ] `just check` passes locally (fmt + clippy + tests) — n/a, docs-only diff with no Rust surface
- [ ] New behaviour is covered by tests where it makes sense — n/a, no behavior change
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] User-visible changes (CLI, config, output) are reflected in the README or relevant docs

---

Found while reviewing #522 (which is unrelated and not the cause). No behavior change here — this only makes the docs match what the code already does.