### PR TITLE
chore: bump kache to v0.11.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more. No copies, no wasted disk — just hardlinks locally and S3 for sharing."
 license = "Apache-2.0"
@@ -50,7 +50,7 @@ aws-smithy-runtime-api = "1"
 # Direct dep so we can install ring as the process-wide rustls crypto
 # provider (reqwest uses `rustls-no-provider`, so one must be installed).
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.10.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.11.0-rc.1", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Bumps the workspace version `0.10.0` → `0.11.0-rc.1` via `just bump 0.11.0-rc.1`.

Touches the four member manifests, the `kache-core` dep-pin, and `Cargo.lock`. The recipe uses `cargo set-version` + a plain `cargo check` rather than a broad `cargo update`, so the pinned `kunobi-*` git deps and the hand-maintained nix `outputHashes` stay valid; the flake derives `version` from `Cargo.toml`, so no hash change is needed.

Dotted prerelease (`-rc.1`, not `-rc1`): crates.io is permanent and semver orders the no-dot form lexically.

## Test plan

- [x] `just bump 0.11.0-rc.1` — version consistency gate passes: `kache == kache-core == kache-core dep-pin == 0.11.0-rc.1`
- [x] `just fmt-check` + `just lint` clean
- [x] `Cargo.lock` diff contains only the four local crates — no dependency drift

After merge, cut the tag from the merged commit with `just release` (never re-typed).