### PR TITLE
refactor(store,events): extract shared atomic replace helper

### DIFF
--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -1,0 +1,297 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static ATOMIC_TMP_NONCE: AtomicU64 = AtomicU64::new(0);
+
+/// fsync a directory so a rename/create into it survives a crash. Without it,
+/// a file's contents can be durable while its directory entry is not. No-op on non-Unix:
+/// Windows has no directory-handle fsync and `File::open` on a directory fails.
+#[cfg(unix)]
+fn fsync_dir(dir: &Path) -> std::io::Result<()> {
+    fs::File::open(dir)?.sync_all()
+}
+#[cfg(not(unix))]
+fn fsync_dir(_dir: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// fsync a file so its bytes are durable on disk.
+/// On Windows, FlushFileBuffers requires write access.
+pub(crate) fn fsync_file(path: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    let file = fs::OpenOptions::new().write(true).open(path)?;
+    #[cfg(not(windows))]
+    let file = fs::File::open(path)?;
+    file.sync_all()
+}
+
+/// Whether a failed rename is a transient Windows state worth retrying.
+/// ERROR_ACCESS_DENIED (5) and ERROR_SHARING_VIOLATION (32) surface when a
+/// concurrent put/remove leaves the destination delete-pending or open; both
+/// clear on their own. No such transient rename error exists off Windows.
+fn is_transient_rename_error(e: &std::io::Error) -> bool {
+    #[cfg(windows)]
+    {
+        matches!(e.raw_os_error(), Some(5) | Some(32))
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = e;
+        false
+    }
+}
+
+/// Backoff before the next rename retry: 1, 2, 4, … ms capped at 64 ms
+/// (≈0.3 s total across the retry budget), bounding how long a wedged Windows
+/// destination can delay a write.
+fn rename_backoff_ms(attempt: u32) -> u64 {
+    (1u64 << attempt.min(6)).min(64)
+}
+
+/// Remove a file, clearing the read-only attribute first to ensure deletion
+/// succeeds even on Windows when the file was marked read-only.
+fn remove_file_robust(path: &Path) -> std::io::Result<()> {
+    if let Ok(meta) = fs::metadata(path) {
+        let mut perms = meta.permissions();
+        if perms.readonly() {
+            perms.set_readonly(false);
+            let _ = fs::set_permissions(path, perms);
+        }
+    }
+    fs::remove_file(path)
+}
+
+/// Perform an atomic file replacement. This creates a temporary file beside the
+/// destination path, executes `write_fn` to populate it, flushes it (`fsync_file`),
+/// copies permissions from the original destination (if it exists) to preserve file
+/// modes, and atomic renames it with transient error retries on Windows.
+///
+/// Returns `Ok(true)` if the rename succeeded.
+/// If `allow_concurrent_winner` is `true`, a concurrent writer winning the race to create
+/// the file is treated as a benign lost race and returns `Ok(false)`. If `allow_concurrent_winner`
+/// is `false`, it retries or errors out on conflicts.
+pub(crate) fn atomic_write_and_replace<F>(
+    dest_path: &Path,
+    allow_concurrent_winner: bool,
+    write_fn: F,
+) -> Result<bool>
+where
+    F: FnOnce(&Path) -> Result<()>,
+{
+    let nonce = ATOMIC_TMP_NONCE.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let file_name = dest_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("file");
+    let temp_path = dest_path.with_file_name(format!(".{file_name}.{pid}.{nonce}.tmp"));
+
+    let res = (|| -> Result<()> {
+        write_fn(&temp_path)?;
+        fsync_file(&temp_path).context("flushing temp file")?;
+        Ok(())
+    })();
+
+    if let Err(e) = res {
+        let _ = remove_file_robust(&temp_path);
+        return Err(e);
+    }
+
+    // Preserve the destination's permissions so atomic replacement does not widen them.
+    // Setting permissions is best-effort (e.g. read-only mounts or filesystem limitations).
+    if let Ok(meta) = fs::metadata(dest_path) {
+        let _ = fs::set_permissions(&temp_path, meta.permissions());
+    }
+
+    const MAX_ATTEMPTS: u32 = 10;
+    let mut last_err = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match fs::rename(&temp_path, dest_path) {
+            Ok(()) => {
+                if let Some(parent) = dest_path.parent() {
+                    let _ = fsync_dir(parent);
+                }
+                return Ok(true);
+            }
+            Err(e) => {
+                if allow_concurrent_winner && dest_path.is_file() {
+                    let _ = remove_file_robust(&temp_path);
+                    return Ok(false);
+                }
+                if dest_path.is_dir() || !is_transient_rename_error(&e) {
+                    let _ = remove_file_robust(&temp_path);
+                    return Err(e).context("atomic rename");
+                }
+                last_err = Some(e);
+                std::thread::sleep(std::time::Duration::from_millis(rename_backoff_ms(attempt)));
+            }
+        }
+    }
+
+    let _ = remove_file_robust(&temp_path);
+    if allow_concurrent_winner && dest_path.is_file() {
+        return Ok(false);
+    }
+    let err = last_err.unwrap_or_else(|| std::io::Error::other("atomic rename failed"));
+    Err(anyhow::Error::new(err).context("atomic rename failed after retries"))
+}
+
+pub(crate) fn atomic_replace(dest_path: &Path, bytes: &[u8]) -> Result<()> {
+    atomic_write_and_replace(dest_path, false, |temp_path| {
+        fs::write(temp_path, bytes)?;
+        Ok(())
+    })?;
+    Ok(())
+}
+
+pub(crate) fn cleanup_temp_files(
+    dir: &Path,
+    prefix: &str,
+    min_age: std::time::Duration,
+) -> Result<()> {
+    if let Ok(entries) = fs::read_dir(dir) {
+        let now = std::time::SystemTime::now();
+        let expected_prefix = format!(".{prefix}.");
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Some(name) = path.file_name().and_then(|n| n.to_str())
+                && name.starts_with(&expected_prefix)
+                && name.ends_with(".tmp")
+                && let Ok(meta) = entry.metadata()
+                && let Ok(modified) = meta.modified()
+                && let Ok(age) = now.duration_since(modified)
+                && age > min_age
+            {
+                let _ = remove_file_robust(&path);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rename_backoff_ms_caps_at_64() {
+        assert_eq!(rename_backoff_ms(0), 1);
+        assert_eq!(rename_backoff_ms(1), 2);
+        assert_eq!(rename_backoff_ms(5), 32);
+        assert_eq!(rename_backoff_ms(6), 64);
+        assert_eq!(rename_backoff_ms(9), 64);
+    }
+
+    #[test]
+    fn is_transient_rename_error_only_flags_windows_race_codes() {
+        use std::io::Error;
+        let access_denied = Error::from_raw_os_error(5);
+        let sharing_violation = Error::from_raw_os_error(32);
+        let other = Error::from_raw_os_error(2);
+        #[cfg(windows)]
+        {
+            assert!(is_transient_rename_error(&access_denied));
+            assert!(is_transient_rename_error(&sharing_violation));
+            assert!(!is_transient_rename_error(&other));
+        }
+        #[cfg(not(windows))]
+        {
+            assert!(!is_transient_rename_error(&access_denied));
+            assert!(!is_transient_rename_error(&sharing_violation));
+            assert!(!is_transient_rename_error(&other));
+        }
+    }
+
+    #[test]
+    fn test_atomic_replace_writes_content_and_syncs() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("dest.txt");
+
+        atomic_replace(&dest, b"hello world").unwrap();
+        assert_eq!(fs::read(&dest).unwrap(), b"hello world");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_atomic_replace_preserves_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("dest.txt");
+
+        // Write initial file and set permissions to 0o600
+        fs::write(&dest, b"initial").unwrap();
+        fs::set_permissions(&dest, fs::Permissions::from_mode(0o600)).unwrap();
+
+        // Do atomic replacement
+        atomic_replace(&dest, b"new content").unwrap();
+
+        // Verify content and that mode 0o600 was preserved
+        assert_eq!(fs::read(&dest).unwrap(), b"new content");
+        let meta = fs::metadata(&dest).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+    }
+
+    #[test]
+    fn test_cleanup_temp_files_only_removes_matching_stale_temps() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Pattern: .<prefix>.<pid>.<nonce>.tmp
+        let temp_live = dir.path().join(".testfile.1234.0.tmp");
+        let temp_stale = dir.path().join(".testfile.5678.1.tmp");
+        let other_file = dir.path().join(".otherfile.1234.0.tmp");
+        let unrelated = dir.path().join("unrelated.txt");
+
+        fs::write(&temp_live, b"live temp").unwrap();
+        fs::write(&temp_stale, b"stale temp").unwrap();
+        fs::write(&other_file, b"other temp").unwrap();
+        fs::write(&unrelated, b"unrelated").unwrap();
+
+        // Adjust mtimes so only temp_stale and other_file are older than 5 minutes
+        let stale_time = std::time::SystemTime::now() - std::time::Duration::from_secs(400);
+        filetime::set_file_mtime(
+            &temp_stale,
+            filetime::FileTime::from_system_time(stale_time),
+        )
+        .unwrap();
+        filetime::set_file_mtime(
+            &other_file,
+            filetime::FileTime::from_system_time(stale_time),
+        )
+        .unwrap();
+
+        // Run cleanup with prefix "testfile" and min_age 5 minutes (300 secs)
+        cleanup_temp_files(dir.path(), "testfile", std::time::Duration::from_secs(300)).unwrap();
+
+        // stale temp must be deleted
+        assert!(!temp_stale.exists());
+        // live temp must still exist (not old enough)
+        assert!(temp_live.exists());
+        // other temp must still exist (prefix is different)
+        assert!(other_file.exists());
+        // unrelated file must still exist
+        assert!(unrelated.exists());
+    }
+
+    // Regression guard for #196: `fsync_file` must durably flush a freshly
+    // written (writable) file. The bug was a read-only handle — fine for Unix
+    // `fsync(2)`, but Windows `FlushFileBuffers` rejects it with
+    // ERROR_ACCESS_DENIED, so every blob store failed ("flushing blob to disk").
+    // Passes on Unix before and after; the real failing→passing signal is on
+    // Windows, where the old read-only-handle form errored here.
+    #[test]
+    fn fsync_file_flushes_a_writable_blob() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob = dir.path().join("blob.bin");
+        fs::write(&blob, b"some bytes").unwrap();
+        fsync_file(&blob).expect("fsync of a writable file must succeed on all platforms");
+    }
+
+    #[test]
+    fn fsync_dir_succeeds_on_a_real_directory() {
+        // On Unix this exercises the open+sync_all path; elsewhere it's a no-op.
+        let dir = tempfile::tempdir().unwrap();
+        fsync_dir(dir.path()).expect("fsync of a directory must not error");
+    }
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -389,22 +389,13 @@ fn rotate_log_impl(
 
         // Clean up stale temp files in the same directory (older than 5 minutes)
         if let Some(parent) = log_path.parent()
-            && let Ok(entries) = fs::read_dir(parent)
+            && let Some(file_prefix) = log_path.file_name().and_then(|n| n.to_str())
         {
-            let file_prefix = log_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            let temp_marker = format!("{}.tmp.", file_prefix);
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if let Some(name) = path.file_name().and_then(|n| n.to_str())
-                    && name.starts_with(&temp_marker)
-                    && let Ok(meta) = fs::metadata(&path)
-                    && let Ok(modified) = meta.modified()
-                    && let Ok(age) = modified.elapsed()
-                    && age > std::time::Duration::from_secs(300)
-                {
-                    let _ = fs::remove_file(&path);
-                }
-            }
+            let _ = crate::atomic::cleanup_temp_files(
+                parent,
+                file_prefix,
+                std::time::Duration::from_secs(300),
+            );
         }
 
         let content = fs::read_to_string(log_path)?;
@@ -419,69 +410,9 @@ fn rotate_log_impl(
             total_bytes -= (removed.len() + 1) as u64;
         }
 
-        // Generate unique temp file path using PID
-        let pid = std::process::id();
-        let mut temp_name = log_path
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("invalid log path"))?
-            .to_owned();
-        temp_name.push(format!(".tmp.{pid}"));
-        let temp_path = log_path.with_file_name(temp_name);
-
-        // Write to temp file, fsync, and close
-        let mut file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&temp_path)
-            .context("opening temp log file")?;
         let output = kept.join("\n") + "\n";
-        file.write_all(output.as_bytes())
-            .context("writing kept lines to temp file")?;
-        file.sync_all().context("flushing log temp file")?;
-        drop(file); // Close temp file
-
-        // Platform-robust atomic rename with retry on Windows transient sharing/access errors
-        const MAX_RETRY_ATTEMPTS: u32 = 10;
-        let mut rename_ok = false;
-        for attempt in 0..MAX_RETRY_ATTEMPTS {
-            match fs::rename(&temp_path, log_path) {
-                Ok(()) => {
-                    rename_ok = true;
-                    break;
-                }
-                Err(e) => {
-                    // Check if it's a transient rename error (Access Denied / Sharing Violation on Windows)
-                    #[cfg(windows)]
-                    let is_transient = matches!(e.raw_os_error(), Some(5) | Some(32));
-                    #[cfg(not(windows))]
-                    let is_transient = false;
-
-                    if !is_transient {
-                        let _ = fs::remove_file(&temp_path);
-                        return Err(e).context("renaming log file");
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(
-                        (1u64 << attempt.min(6)).min(64),
-                    ));
-                }
-            }
-        }
-
-        if !rename_ok {
-            let _ = fs::remove_file(&temp_path);
-            anyhow::bail!("failed to rename temp log file after retries");
-        }
-
-        // On Unix, fsync the parent directory to guarantee rename durability
-        #[cfg(unix)]
-        {
-            if let Some(parent) = log_path.parent()
-                && let Ok(dir) = File::open(parent)
-            {
-                let _ = dir.sync_all();
-            }
-        }
+        crate::atomic::atomic_replace(log_path, output.as_bytes())
+            .context("writing and replacing log file atomically")?;
 
         tracing::info!(
             "rotated {}: kept {} of {} lines",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod args;
+mod atomic;
 mod build_intent;
 mod cache_key;
 mod cli;

--- a/src/store.rs
+++ b/src/store.rs
@@ -8,9 +8,6 @@ use std::time::Duration;
 
 use crate::config::Config;
 
-/// Process-local counter for unique blob temp-file names.
-static BLOB_TMP_NONCE: AtomicU64 = AtomicU64::new(0);
-
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct StorePutResult {
     pub output_blobs: u32,
@@ -22,46 +19,6 @@ impl StorePutResult {
     pub fn is_full_dup(self) -> bool {
         self.output_blobs > 0 && self.duplicate_blobs == self.output_blobs
     }
-}
-
-/// fsync a file so its bytes are durable on disk before we rename it into the
-/// content-addressed store or reference it from a committed entry.
-///
-/// On Unix, `fsync(2)` works on a read-only fd, so we keep opening read-only —
-/// byte-identical to before, and it even flushes files that are already
-/// read-only. On Windows, `sync_all` maps to `FlushFileBuffers`, which requires
-/// a handle with *write* access and fails with `ERROR_ACCESS_DENIED` on a
-/// read-only handle (#196) — so open writable there. Every caller fsyncs
-/// *before* `set_blob_readonly`, so the file is writable on Windows;
-/// `write(true)` does not truncate.
-fn fsync_file(path: &Path) -> std::io::Result<()> {
-    #[cfg(windows)]
-    let file = fs::OpenOptions::new().write(true).open(path)?;
-    #[cfg(not(windows))]
-    let file = fs::File::open(path)?;
-    file.sync_all()
-}
-
-/// fsync a directory so a rename/create into it survives a crash. Without it,
-/// a blob's contents can be durable while its directory entry is not, leaving a
-/// committed entry pointing at a phantom-missing blob. No-op on non-Unix:
-/// Windows has no directory-handle fsync and `File::open` on a directory fails.
-#[cfg(unix)]
-fn fsync_dir(dir: &Path) -> std::io::Result<()> {
-    fs::File::open(dir)?.sync_all()
-}
-#[cfg(not(unix))]
-fn fsync_dir(_dir: &Path) -> std::io::Result<()> {
-    Ok(())
-}
-
-/// A unique temp path beside the destination blob. Concurrent writers of the
-/// same hash must not share a temp file (a fixed `<hash>.tmp` lets one truncate
-/// the other mid-copy), so we disambiguate by pid + a process-local counter.
-fn blob_tmp_path(blob: &Path, hash: &str) -> PathBuf {
-    let pid = std::process::id();
-    let nonce = BLOB_TMP_NONCE.fetch_add(1, Ordering::Relaxed);
-    blob.with_file_name(format!(".{hash}.{pid}.{nonce}.tmp"))
 }
 
 /// Mark a blob read-only so accidental writes can't corrupt the shared,
@@ -109,113 +66,30 @@ fn unlink_blob(blob: &Path) {
 /// Whichever path runs is recorded (`record_store_reflinked` /
 /// `record_store_copied`) so `kache report` can account for disk honestly,
 /// mirroring the restore side in `link.rs`.
-fn materialize_blob(source: &Path, blob: &Path, hash: &str) -> Result<()> {
+fn materialize_blob(source: &Path, blob: &Path, _hash: &str) -> Result<()> {
     if blob.is_file() {
         return Ok(());
     }
     fs::create_dir_all(blob.parent().unwrap()).context("creating blob shard directory")?;
-    let tmp = blob_tmp_path(blob, hash);
     let bytes = fs::metadata(source).map(|m| m.len()).unwrap_or(0);
-    // CoW reflink first (zero physical bytes on APFS/btrfs/XFS-with-reflink);
-    // fall back to a real copy where the filesystem has no CoW.
-    if crate::link::try_reflink(source, &tmp).is_ok() {
-        crate::opcounts::record_store_reflinked(bytes);
-    } else {
-        fs::copy(source, &tmp)
-            .with_context(|| format!("copying {} to blob store", source.display()))?;
-        crate::opcounts::record_store_copied(bytes);
-    }
-    if let Err(e) = fsync_file(&tmp) {
-        let _ = fs::remove_file(&tmp);
-        return Err(e).context("flushing blob to disk");
-    }
-    // Publish the blob with an atomic rename, tolerating a concurrent winner
-    // (content-addressed → byte-identical content) and transient Windows
-    // sharing / delete-pending states (#441).
-    if commit_blob_rename(&tmp, blob)? {
-        // We performed the rename: finalize it.
+
+    let renamed = crate::atomic::atomic_write_and_replace(blob, true, |tmp| {
+        // CoW reflink first (zero physical bytes on APFS/btrfs/XFS-with-reflink);
+        // fall back to a real copy where the filesystem has no CoW.
+        if crate::link::try_reflink(source, tmp).is_ok() {
+            crate::opcounts::record_store_reflinked(bytes);
+        } else {
+            fs::copy(source, tmp)
+                .with_context(|| format!("copying {} to blob store", source.display()))?;
+            crate::opcounts::record_store_copied(bytes);
+        }
+        Ok(())
+    })?;
+
+    if renamed {
         set_blob_readonly(blob);
-        // Flush the shard directory so the rename is durable across a power loss;
-        // best-effort, since the blob bytes are already fsynced and a missing dir
-        // entry self-heals to a cache miss rather than corruption.
-        if let Some(parent) = blob.parent() {
-            let _ = fsync_dir(parent);
-        }
     }
-    // else: a concurrent winner already published + marked the blob read-only
-    // and flushed the shard dir — nothing more for us to do.
     Ok(())
-}
-
-/// Atomically publish a content-addressed blob by renaming `tmp` onto `blob`.
-/// Returns `Ok(true)` when this call performed the rename (the caller finalizes
-/// it), `Ok(false)` when a concurrent writer already published the identical
-/// blob — a benign lost race, since the blob is content-addressed so the winner
-/// wrote byte-identical content. `tmp` is always removed on a non-rename exit.
-///
-/// On Windows the rename (MoveFileExW with REPLACE_EXISTING) can return
-/// ERROR_ACCESS_DENIED / ERROR_SHARING_VIOLATION *transiently* while puts and
-/// removes race on the same blob path: a destination left delete-pending by a
-/// concurrent `remove_entry`, an open reader handle, or a winner that marked the
-/// blob read-only just before a remove unlinked it. Those states clear on their
-/// own, so retry with a short backoff, re-checking for a concurrent winner
-/// between attempts. Unix has no such transient rename state (rename-over and
-/// delete-while-open both succeed), so there it takes a single attempt (#441).
-fn commit_blob_rename(tmp: &Path, blob: &Path) -> Result<bool> {
-    const MAX_ATTEMPTS: u32 = 10;
-    let mut last_err = None;
-    for attempt in 0..MAX_ATTEMPTS {
-        match fs::rename(tmp, blob) {
-            Ok(()) => return Ok(true),
-            Err(e) => {
-                // A concurrent writer published the identical blob first.
-                if blob.is_file() {
-                    let _ = fs::remove_file(tmp);
-                    return Ok(false);
-                }
-                // Only a transient Windows race is worth retrying; a directory
-                // (or any other non-transient) destination is a genuine error on
-                // every platform — fail it immediately with the original error.
-                if blob.is_dir() || !is_transient_rename_error(&e) {
-                    let _ = fs::remove_file(tmp);
-                    return Err(e).context("atomic rename of blob");
-                }
-                last_err = Some(e);
-                std::thread::sleep(std::time::Duration::from_millis(rename_backoff_ms(attempt)));
-            }
-        }
-    }
-    // Exhausted the retries: one last concurrent-winner check, else surface the
-    // most recent transient error.
-    let _ = fs::remove_file(tmp);
-    if blob.is_file() {
-        return Ok(false);
-    }
-    Err(last_err.unwrap_or_else(|| std::io::Error::other("blob rename failed")))
-        .context("atomic rename of blob after retries")
-}
-
-/// Whether a failed blob rename is a transient Windows state worth retrying.
-/// ERROR_ACCESS_DENIED (5) and ERROR_SHARING_VIOLATION (32) surface when a
-/// concurrent put/remove leaves the destination delete-pending or open; both
-/// clear on their own. No such transient rename error exists off Windows.
-fn is_transient_rename_error(e: &std::io::Error) -> bool {
-    #[cfg(windows)]
-    {
-        matches!(e.raw_os_error(), Some(5) | Some(32))
-    }
-    #[cfg(not(windows))]
-    {
-        let _ = e;
-        false
-    }
-}
-
-/// Backoff before the next blob-rename retry: 1, 2, 4, … ms capped at 64 ms
-/// (≈0.3 s total across the retry budget), bounding how long a wedged Windows
-/// destination can delay a store.
-fn rename_backoff_ms(attempt: u32) -> u64 {
-    (1u64 << attempt.min(6)).min(64)
 }
 
 fn blob_path_in_store_dir(store_dir: &Path, hash: &str) -> PathBuf {
@@ -1113,7 +987,7 @@ impl Store {
             serde_json::to_string_pretty(&meta).context("serializing entry metadata")?;
         let meta_path = entry_dir.join("meta.json");
         fs::write(&meta_path, meta_json)?;
-        fsync_file(&meta_path).context("flushing entry metadata")?;
+        crate::atomic::fsync_file(&meta_path).context("flushing entry metadata")?;
 
         // Phase 2: register the entry and all of its blob references in a single
         // transaction, flipping `committed = 1` only once every blob is durable
@@ -1243,7 +1117,7 @@ impl Store {
                         file_path.display()
                     )
                 })?;
-                fsync_file(&blob).context("flushing downloaded blob to disk")?;
+                crate::atomic::fsync_file(&blob).context("flushing downloaded blob to disk")?;
                 set_blob_readonly(&blob);
             }
         }
@@ -1289,7 +1163,7 @@ impl Store {
                         file_path.display()
                     )
                 })?;
-                fsync_file(&blob).context("flushing downloaded blob to disk")?;
+                crate::atomic::fsync_file(&blob).context("flushing downloaded blob to disk")?;
                 set_blob_readonly(&blob);
             }
         }
@@ -2195,27 +2069,6 @@ mod tests {
         );
     }
 
-    // Regression guard for #196: `fsync_file` must durably flush a freshly
-    // written (writable) file. The bug was a read-only handle — fine for Unix
-    // `fsync(2)`, but Windows `FlushFileBuffers` rejects it with
-    // ERROR_ACCESS_DENIED, so every blob store failed ("flushing blob to disk").
-    // Passes on Unix before and after; the real failing→passing signal is on
-    // Windows, where the old read-only-handle form errored here.
-    #[test]
-    fn fsync_file_flushes_a_writable_blob() {
-        let dir = tempfile::tempdir().unwrap();
-        let blob = dir.path().join("blob.bin");
-        fs::write(&blob, b"some bytes").unwrap();
-        fsync_file(&blob).expect("fsync of a writable file must succeed on all platforms");
-    }
-
-    #[test]
-    fn fsync_dir_succeeds_on_a_real_directory() {
-        // On Unix this exercises the open+sync_all path; elsewhere it's a no-op.
-        let dir = tempfile::tempdir().unwrap();
-        fsync_dir(dir.path()).expect("fsync of a directory must not error");
-    }
-
     #[test]
     fn materialize_blob_errors_when_source_cannot_be_copied() {
         // Covers materialize_blob copy-fallback error branch.
@@ -2246,7 +2099,7 @@ mod tests {
         let err = materialize_blob(&source, &blob, &hash).unwrap_err();
 
         assert!(
-            err.to_string().contains("atomic rename of blob"),
+            err.to_string().contains("atomic rename"),
             "expected rename context, got: {err:#}"
         );
         let tmp_left = fs::read_dir(blob.parent().unwrap())
@@ -2256,37 +2109,6 @@ mod tests {
             .count();
         assert_eq!(tmp_left, 0, "failed rename must remove its temp file");
         assert!(blob.is_dir(), "the conflicting destination dir remains");
-    }
-
-    #[test]
-    fn rename_backoff_ms_caps_at_64() {
-        assert_eq!(rename_backoff_ms(0), 1);
-        assert_eq!(rename_backoff_ms(1), 2);
-        assert_eq!(rename_backoff_ms(5), 32);
-        assert_eq!(rename_backoff_ms(6), 64);
-        assert_eq!(rename_backoff_ms(9), 64, "backoff is capped, not unbounded");
-    }
-
-    #[test]
-    fn is_transient_rename_error_only_flags_windows_race_codes() {
-        use std::io::Error;
-        let access_denied = Error::from_raw_os_error(5);
-        let sharing_violation = Error::from_raw_os_error(32);
-        let other = Error::from_raw_os_error(2);
-        #[cfg(windows)]
-        {
-            // ACCESS_DENIED / SHARING_VIOLATION are the retryable race states.
-            assert!(is_transient_rename_error(&access_denied));
-            assert!(is_transient_rename_error(&sharing_violation));
-            assert!(!is_transient_rename_error(&other));
-        }
-        #[cfg(not(windows))]
-        {
-            // No transient rename state off Windows: every error is genuine.
-            assert!(!is_transient_rename_error(&access_denied));
-            assert!(!is_transient_rename_error(&sharing_violation));
-            assert!(!is_transient_rename_error(&other));
-        }
     }
 
     fn test_config(dir: &Path) -> Config {


### PR DESCRIPTION
## Motivation

`src/store.rs` and `src/events.rs` each implemented their own version of the same atomic file replacement logic:

- unique temporary file creation
- writing and `sync_all()`
- Windows transient rename retries with exponential backoff
- atomic `rename()`
- parent directory `fsync` on Unix

This duplicated the platform-specific behavior introduced for the Windows rename fixes and made the implementations susceptible to drifting over time.

## Solution

Extract the shared implementation into a new `src/atomic.rs` module.

The new helper provides:

- `atomic_write_and_replace(...)`
  - unique `.<file>.<pid>.<nonce>.tmp` naming
  - callback-based writing
  - `sync_all()` before publish
  - destination permission preservation before replacement
  - Windows transient rename retry with exponential backoff
  - optional concurrent-writer handling
  - parent directory `fsync` on Unix

- `atomic_replace(...)` convenience wrapper for byte slices.
- `cleanup_temp_files(...)` for removing stale temporary files using the shared naming convention.

`store.rs` now uses `atomic_write_and_replace(...)` for blob materialization, while `events.rs` uses `atomic_replace(...)` during log rotation. This removes the duplicated atomic publish implementation and centralizes the platform-specific behavior in one place.

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test`

Added unit tests covering:

- atomic replacement
- destination permission preservation
- temporary file cleanup

Closes #525.
Closes #526.