### PR TITLE
fix(compile): probe cargo outputs instead of readdir'ing out-dir

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -60,6 +60,11 @@ const IGNORED_ATTACHED_PREFIXES: &[&str] = &[
 /// Boolean diagnostics / query flags (no value) that must not reach the key.
 const IGNORED_BOOL_FLAGS: &[&str] = &["-v", "--verbose", "-V", "--version", "-h", "--help"];
 
+/// Cargo/rustc artifact basename stem: `{crate_name}{extra_filename}`.
+pub fn format_crate_output_stem(crate_name: &str, extra_filename: &str) -> String {
+    format!("{crate_name}{extra_filename}")
+}
+
 /// Parsed rustc invocation arguments relevant to caching.
 #[derive(Debug, Clone, Default)]
 pub struct RustcArgs {
@@ -512,12 +517,13 @@ impl RustcArgs {
                 .is_some_and(|source| source.starts_with(build_script_out_dir))
     }
 
-    /// Get the output filename stem (crate name + extra filename).
-    #[allow(dead_code)]
+    /// Output filename stem (`crate_name` + optional `extra_filename`).
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn output_stem(&self) -> Option<String> {
-        let name = self.crate_name.as_ref()?;
-        let extra = self.extra_filename.as_deref().unwrap_or("");
-        Some(format!("{name}{extra}"))
+        Some(format_crate_output_stem(
+            self.crate_name.as_ref()?,
+            self.extra_filename.as_deref().unwrap_or(""),
+        ))
     }
 
     /// Whether this compilation has coverage instrumentation enabled (-C instrument-coverage).
@@ -789,6 +795,13 @@ mod tests {
             parsed.is_user_facing_executable(),
             "--test must count as user-facing"
         );
+    }
+
+    #[test]
+    fn test_format_crate_output_stem() {
+        assert_eq!(format_crate_output_stem("serde", "-9f2a1b"), "serde-9f2a1b");
+        assert_eq!(format_crate_output_stem("serde", ""), "serde");
+        assert_eq!(format_crate_output_stem("app", "-abc"), "app-abc");
     }
 
     #[test]

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -112,7 +112,7 @@ pub fn run_rustc(
     // Discover output files. rustc's own `artifact` JSON notifications
     // are authoritative — when cargo invokes rustc it passes
     // `--error-format=json --json=artifacts`, so rustc reports every
-    // file it writes by exact path. Directory scanning is the fallback
+    // file it writes by exact path. Candidate path probing is the fallback
     // for invocations that don't emit those messages (a bare `rustc`
     // without `--json=artifacts`), where filename guessing is the best
     // available signal.
@@ -120,7 +120,7 @@ pub fn run_rustc(
         let from_json = resolve_artifacts(&parse_rustc_artifacts(&stderr));
         if from_json.is_empty() {
             tracing::debug!(
-                "[kache] no rustc artifact notifications for {}; falling back to directory scan",
+                "[kache] no rustc artifact notifications for {}; falling back to candidate path discovery",
                 crate_name.unwrap_or("unknown")
             );
             ArtifactSet::from_output_files(
@@ -249,24 +249,66 @@ fn resolve_artifacts(artifacts: &[PathBuf]) -> Vec<(PathBuf, String)> {
     files
 }
 
-/// Discover all output files from a compilation by directory scanning.
+/// Product suffixes for rustc/cargo artifacts (`{base}.{suffix}`).
 ///
-/// This is the *fallback* path — [`parse_rustc_artifacts`] is preferred
-/// whenever rustc emits artifact notifications (i.e. every cargo-driven
-/// build). Scanning is used only for bare `rustc` invocations without
-/// `--json=artifacts`, where filename guessing is the best signal.
-///
-/// Rustc can produce multiple output files:
-/// - `.rlib` (Rust library)
-/// - `.rmeta` (metadata only)
-/// - `.d` (dependency info)
-/// - `.o` (object file)
-/// - binary (no extension on Unix)
-/// - `.dylib` / `.so` / `.dll` (dynamic library)
-///
-/// We find them via two paths:
-/// 1. `-o path`: look at the output file and siblings with the same stem
-/// 2. `--out-dir dir`: scan the directory for files matching `{crate_name}{extra_filename}.*`
+/// Shared by `--out-dir` candidates and `-o` stem siblings. Includes compound
+/// Windows import-lib names (`dll.lib` / `dll.exp` / `dll.a`) so a primary
+/// `foo.dll` still probes `foo.dll.lib`. Over-probe is intentional: missing a
+/// restored 0444 hardlink causes EACCES on the next rustc write.
+const ARTIFACT_SUFFIXES: &[&str] = &[
+    "rlib", "rmeta", "d", "so", "dylib", "dll", "wasm", "a", "lib", "dll.lib", "dll.exp", "dll.a",
+    "exe", "pdb", "dwo", "o", "obj", "ll", "bc", "mir", "s", "asm",
+];
+
+/// Invoke `f` for each `--out-dir` candidate basename (no intermediate `Vec`).
+fn for_each_out_dir_candidate(crate_name: &str, extra: &str, mut f: impl FnMut(&str)) {
+    let bare = crate::args::format_crate_output_stem(crate_name, extra);
+    let mut buf = String::with_capacity(bare.len() + 8 + 16);
+    for suffix in ARTIFACT_SUFFIXES {
+        buf.clear();
+        buf.push_str("lib");
+        buf.push_str(&bare);
+        buf.push('.');
+        buf.push_str(suffix);
+        f(&buf);
+
+        buf.clear();
+        buf.push_str(&bare);
+        buf.push('.');
+        buf.push_str(suffix);
+        f(&buf);
+    }
+    f(&bare);
+}
+
+/// Probe known same-stem sibling paths next to a `-o` primary output.
+fn for_each_stem_sibling(parent: &Path, stem: &str, primary: &Path, mut f: impl FnMut(&Path)) {
+    let mut buf = String::with_capacity(stem.len() + 16);
+    for suffix in ARTIFACT_SUFFIXES {
+        buf.clear();
+        buf.push_str(stem);
+        buf.push('.');
+        buf.push_str(suffix);
+        let path = parent.join(&buf);
+        if path != *primary {
+            f(&path);
+        }
+    }
+}
+
+fn crate_depinfo_path(parent: &Path, crate_name: &str, extra: &str) -> PathBuf {
+    parent.join(format!(
+        "{}.d",
+        crate::args::format_crate_output_stem(crate_name, extra)
+    ))
+}
+
+fn path_file_name(path: &Path) -> Option<String> {
+    path.file_name().map(|n| n.to_string_lossy().into_owned())
+}
+
+/// Fallback discovery when rustc did not emit JSON artifact notifications.
+/// Probes a fixed candidate set — never `read_dir`s the out-dir.
 fn discover_output_files(
     output_path: Option<&Path>,
     out_dir: Option<&Path>,
@@ -274,159 +316,76 @@ fn discover_output_files(
     extra_filename: Option<&str>,
 ) -> Result<Vec<(PathBuf, String)>> {
     let mut files = Vec::new();
+    let extra = extra_filename.unwrap_or("");
 
     if let Some(output) = output_path {
-        // -o mode: discover primary output and siblings with same stem
-        if output.exists() {
-            let filename = output
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_default();
+        if output.is_file()
+            && let Some(filename) = path_file_name(output)
+        {
             files.push((output.to_path_buf(), filename));
         }
 
-        if let Some(parent) = output.parent()
-            && let Some(stem) = output.file_stem()
-        {
+        if let (Some(parent), Some(stem)) = (output.parent(), output.file_stem()) {
             let stem_str = stem.to_string_lossy();
-            let output_filename = output
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_default();
-
-            if let Ok(entries) = std::fs::read_dir(parent) {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    let name = path
-                        .file_name()
-                        .map(|n| n.to_string_lossy().to_string())
-                        .unwrap_or_default();
-
-                    if name == output_filename {
-                        continue;
-                    }
-
-                    if name.starts_with(&*stem_str) {
-                        files.push((path, name));
-                    }
+            for_each_stem_sibling(parent, &stem_str, output, |path| {
+                if path.is_file()
+                    && let Some(name) = path_file_name(path)
+                {
+                    files.push((path.to_path_buf(), name));
                 }
-            }
+            });
         }
 
-        // Also check for dep-info files with the crate name pattern
-        if let (Some(parent), Some(name), Some(extra)) =
-            (output.parent(), crate_name, extra_filename)
-        {
-            let d_file = parent.join(format!("{name}{extra}.d"));
-            if d_file.exists() && !files.iter().any(|(p, _)| p == &d_file) {
-                let filename = d_file
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_default();
+        if let (Some(parent), Some(name)) = (output.parent(), crate_name) {
+            let d_file = crate_depinfo_path(parent, name, extra);
+            if d_file.is_file()
+                && !files.iter().any(|(p, _)| p == &d_file)
+                && let Some(filename) = path_file_name(&d_file)
+            {
                 files.push((d_file, filename));
             }
         }
     } else if let (Some(dir), Some(name)) = (out_dir, crate_name) {
-        // --out-dir mode: scan directory for files matching the crate
-        // Cargo uses patterns like: lib{name}{extra}.rlib, {name}{extra}.d
-        let extra = extra_filename.unwrap_or("");
-        let prefixes = [format!("lib{name}{extra}"), format!("{name}{extra}")];
-
-        if let Ok(entries) = std::fs::read_dir(dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if !path.is_file() {
-                    continue;
-                }
-                let fname = path
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_default();
-
-                let matches = prefixes
-                    .iter()
-                    .any(|prefix| fname == *prefix || fname.starts_with(&format!("{prefix}.")));
-
-                if matches {
-                    files.push((path, fname));
-                }
+        for_each_out_dir_candidate(name, extra, |fname| {
+            let path = dir.join(fname);
+            if path.is_file() {
+                files.push((path, fname.to_string()));
             }
-        }
+        });
     }
 
     Ok(files)
 }
 
-/// Remove read-only files at output paths before rustc writes to them.
+/// Remove read-only hardlinks at known output paths so rustc can overwrite them.
 ///
-/// When kache restores a cache hit, it hardlinks store files (0444) into the
-/// target directory. If a subsequent build is a cache miss for the same crate,
-/// rustc tries to overwrite these paths but fails because the hardlinked files
-/// are read-only. This function removes them so rustc can create fresh files.
-///
-/// Also reused by the direct-exec passthrough (`KACHE_DISABLED`, nested
-/// re-entrancy) so a non-kache compile over a warm, restored target dir
-/// does not hit EACCES — see `run_compiler_directly` in `main.rs`.
+/// Probes deterministic candidates from `-o` / `--out-dir` + crate identity.
+/// Never `read_dir`s cargo out-dirs (can be hundreds of thousands of entries).
+/// Also used by direct-exec passthrough (`KACHE_DISABLED`) — see `main.rs`.
 pub(crate) fn pre_clean_outputs(
     output_path: Option<&Path>,
     out_dir: Option<&Path>,
     crate_name: Option<&str>,
     extra_filename: Option<&str>,
 ) {
+    let extra = extra_filename.unwrap_or("");
     if let Some(output) = output_path {
         remove_if_readonly(output);
 
-        // Also clean sibling files with the same stem (e.g., .rmeta alongside .rlib)
         if let (Some(parent), Some(stem)) = (output.parent(), output.file_stem()) {
             let stem_str = stem.to_string_lossy();
-            if let Ok(entries) = std::fs::read_dir(parent) {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if path == *output {
-                        continue;
-                    }
-                    if let Some(name) = path.file_name()
-                        && name.to_string_lossy().starts_with(&*stem_str)
-                    {
-                        remove_if_readonly(&path);
-                    }
-                }
-            }
+            for_each_stem_sibling(parent, &stem_str, output, remove_if_readonly);
         }
 
-        // Check for dep-info files with crate name pattern
-        if let (Some(parent), Some(name), Some(extra)) =
-            (output.parent(), crate_name, extra_filename)
-        {
-            remove_if_readonly(&parent.join(format!("{name}{extra}.d")));
+        if let (Some(parent), Some(name)) = (output.parent(), crate_name) {
+            remove_if_readonly(&crate_depinfo_path(parent, name, extra));
         }
     } else if let (Some(dir), Some(name)) = (out_dir, crate_name) {
-        let extra = extra_filename.unwrap_or("");
-        let prefixes = [format!("lib{name}{extra}"), format!("{name}{extra}")];
-
-        if let Ok(entries) = std::fs::read_dir(dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if let Some(fname) = path.file_name() {
-                    let fname = fname.to_string_lossy();
-                    if prefixes
-                        .iter()
-                        .any(|prefix| *fname == *prefix || fname.starts_with(&format!("{prefix}.")))
-                    {
-                        remove_if_readonly(&path);
-                    }
-                }
-            }
-        }
+        for_each_out_dir_candidate(name, extra, |fname| {
+            remove_if_readonly(&dir.join(fname));
+        });
     } else {
-        // Neither a concrete output path nor an (out_dir, crate_name) pair to
-        // scan: a lenient/partial parse (an unusual rustc spawner) left nothing
-        // to identify the outputs by, so we can't pre-empt a warm read-only
-        // restore and the compiler may then fail with EACCES. Surface it at
-        // debug so the failure mode is diagnosable rather than silent — a
-        // conservative "remove every read-only file in the dir" sweep would
-        // risk deleting unrelated cached artifacts, so we report instead of
-        // guess (rio-build#51 / kache#242).
+        // Incomplete identity: refuse a mass sweep of out-dir (rio-build#51 / kache#242).
         tracing::debug!(
             "pre_clean_outputs: nothing to identify outputs by \
              (out_dir={out_dir:?}, crate_name={crate_name:?}); skipping read-only pre-clean — \
@@ -677,22 +636,26 @@ mod tests {
     #[test]
     fn test_discover_output_files_out_dir_mode() {
         let dir = tempfile::tempdir().unwrap();
-        let rlib = dir.path().join("libfoo-abc.rlib");
-        let rmeta = dir.path().join("libfoo-abc.rmeta");
-        let dep = dir.path().join("foo-abc.d");
-        let unrelated = dir.path().join("libbar-xyz.rlib");
-
-        for path in [&rlib, &rmeta, &dep, &unrelated] {
-            fs::write(path, b"content").unwrap();
+        // Plant a mix of lib / dep-info / bin / dylib products plus noise.
+        let planted = [
+            "libfoo-abc.rlib",
+            "libfoo-abc.rmeta",
+            "foo-abc.d",
+            "libfoo-abc.dylib",
+            "foo-abc", // unix bin
+        ];
+        for name in planted {
+            fs::write(dir.path().join(name), b"content").unwrap();
         }
+        fs::write(dir.path().join("libbar-xyz.rlib"), b"content").unwrap();
 
         let files =
             discover_output_files(None, Some(dir.path()), Some("foo"), Some("-abc")).unwrap();
-        let names: Vec<&str> = files.iter().map(|(_, n)| n.as_str()).collect();
-        assert!(names.contains(&"libfoo-abc.rlib"));
-        assert!(names.contains(&"libfoo-abc.rmeta"));
-        assert!(names.contains(&"foo-abc.d"));
-        assert!(!names.contains(&"libbar-xyz.rlib"));
+        let mut names: Vec<&str> = files.iter().map(|(_, n)| n.as_str()).collect();
+        names.sort_unstable();
+        let mut expected = planted.to_vec();
+        expected.sort_unstable();
+        assert_eq!(names, expected, "exact discover set for planted candidates");
     }
 
     // ── authoritative discovery via rustc artifact notifications ──
@@ -726,7 +689,7 @@ mod tests {
     fn parse_rustc_artifacts_empty_when_no_artifact_messages() {
         // A bare `rustc` invocation without `--json=artifacts`:
         // human-readable diagnostics only, no artifact notifications.
-        // The caller must then fall back to directory scanning.
+        // The caller must then fall back to candidate path discovery.
         let stream = "warning: unused variable: `x`\nerror: aborting due to 1 error\n";
         assert!(parse_rustc_artifacts(stream).is_empty());
     }
@@ -768,15 +731,280 @@ mod tests {
 
         let files =
             discover_output_files(Some(&output), None, Some("foo"), Some("-abc123")).unwrap();
-        let names: Vec<&str> = files.iter().map(|(_, n)| n.as_str()).collect();
-
-        assert!(names.contains(&"libfoo.rlib"), "primary output: {names:?}");
-        assert!(names.contains(&"libfoo.rmeta"), "rmeta sibling: {names:?}");
-        assert!(names.contains(&"libfoo.d"), "depinfo sibling: {names:?}");
-        assert!(
-            names.contains(&"foo-abc123.d"),
-            "crate-name depinfo: {names:?}"
+        let mut names: Vec<&str> = files.iter().map(|(_, n)| n.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec!["foo-abc123.d", "libfoo.d", "libfoo.rlib", "libfoo.rmeta"]
         );
-        assert!(!names.contains(&"other.rlib"), "unrelated stem excluded");
+    }
+
+    fn collect_out_dir_candidates(crate_name: &str, extra: &str) -> Vec<String> {
+        let mut names = Vec::with_capacity(ARTIFACT_SUFFIXES.len() * 2 + 1);
+        for_each_out_dir_candidate(crate_name, extra, |n| names.push(n.to_string()));
+        names
+    }
+
+    #[test]
+    fn out_dir_candidate_filenames_exact_ordered_set() {
+        // Hardcoded full ordered set: dropping/reordering a product suffix
+        // (or the lib/bare dual emission) must fail this equality.
+        let names = collect_out_dir_candidates("serde", "-9f2a1b");
+        let expected: &[&str] = &[
+            "libserde-9f2a1b.rlib",
+            "serde-9f2a1b.rlib",
+            "libserde-9f2a1b.rmeta",
+            "serde-9f2a1b.rmeta",
+            "libserde-9f2a1b.d",
+            "serde-9f2a1b.d",
+            "libserde-9f2a1b.so",
+            "serde-9f2a1b.so",
+            "libserde-9f2a1b.dylib",
+            "serde-9f2a1b.dylib",
+            "libserde-9f2a1b.dll",
+            "serde-9f2a1b.dll",
+            "libserde-9f2a1b.wasm",
+            "serde-9f2a1b.wasm",
+            "libserde-9f2a1b.a",
+            "serde-9f2a1b.a",
+            "libserde-9f2a1b.lib",
+            "serde-9f2a1b.lib",
+            "libserde-9f2a1b.dll.lib",
+            "serde-9f2a1b.dll.lib",
+            "libserde-9f2a1b.dll.exp",
+            "serde-9f2a1b.dll.exp",
+            "libserde-9f2a1b.dll.a",
+            "serde-9f2a1b.dll.a",
+            "libserde-9f2a1b.exe",
+            "serde-9f2a1b.exe",
+            "libserde-9f2a1b.pdb",
+            "serde-9f2a1b.pdb",
+            "libserde-9f2a1b.dwo",
+            "serde-9f2a1b.dwo",
+            "libserde-9f2a1b.o",
+            "serde-9f2a1b.o",
+            "libserde-9f2a1b.obj",
+            "serde-9f2a1b.obj",
+            "libserde-9f2a1b.ll",
+            "serde-9f2a1b.ll",
+            "libserde-9f2a1b.bc",
+            "serde-9f2a1b.bc",
+            "libserde-9f2a1b.mir",
+            "serde-9f2a1b.mir",
+            "libserde-9f2a1b.s",
+            "serde-9f2a1b.s",
+            "libserde-9f2a1b.asm",
+            "serde-9f2a1b.asm",
+            "serde-9f2a1b",
+        ];
+        assert_eq!(names.as_slice(), expected);
+
+        let bare = collect_out_dir_candidates("app", "");
+        assert_eq!(bare.first().map(String::as_str), Some("libapp.rlib"));
+        assert!(bare.iter().any(|n| n == "app.d"));
+        assert_eq!(bare.last().map(String::as_str), Some("app"));
+        assert_eq!(bare.len(), expected.len());
+    }
+
+    #[test]
+    fn pre_clean_out_dir_removes_all_common_readonly_candidates() {
+        let dir = tempfile::tempdir().unwrap();
+        let targets = [
+            "libfoo-abc.rlib",
+            "libfoo-abc.rmeta",
+            "foo-abc.d",
+            "libfoo-abc.so",
+            "libfoo-abc.dylib",
+            "libfoo-abc.dll",
+            "foo-abc.dll",
+            "foo-abc.exe",
+            "foo-abc", // bin
+            "libfoo-abc.a",
+            // emit products + Windows dll sidecars
+            "foo-abc.ll",
+            "foo-abc.dll.lib",
+            "foo-abc.dll.exp",
+            "foo-abc.dll.a",
+            "libfoo-abc.dll.a",
+        ];
+        for name in targets {
+            let path = dir.path().join(name);
+            fs::write(&path, b"cached").unwrap();
+            make_readonly(&path);
+        }
+        // Unrelated crate must survive.
+        let other = dir.path().join("libbar-xyz.rlib");
+        fs::write(&other, b"cached").unwrap();
+        make_readonly(&other);
+
+        pre_clean_outputs(None, Some(dir.path()), Some("foo"), Some("-abc"));
+
+        for name in targets {
+            assert!(
+                !dir.path().join(name).exists(),
+                "expected pre_clean to remove readonly {name}"
+            );
+        }
+        assert!(other.exists(), "unrelated crate must not be touched");
+    }
+
+    #[test]
+    fn pre_clean_windows_dll_sidecars_o_mode() {
+        // Primary `foo-abc.dll` has file_stem `foo-abc`; compound suffixes
+        // must still hit `foo-abc.dll.lib` / `.dll.exp` / `.dll.a`.
+        let dir = tempfile::tempdir().unwrap();
+        let dll = dir.path().join("foo-abc.dll");
+        let sidecars = [
+            "foo-abc.dll.lib",
+            "foo-abc.dll.exp",
+            "foo-abc.dll.a",
+            "foo-abc.pdb",
+        ];
+        fs::write(&dll, b"dll").unwrap();
+        make_readonly(&dll);
+        for name in sidecars {
+            let path = dir.path().join(name);
+            fs::write(&path, b"cached").unwrap();
+            make_readonly(&path);
+        }
+
+        pre_clean_outputs(Some(&dll), None, Some("foo"), Some("-abc"));
+
+        assert!(!dll.exists());
+        for name in sidecars {
+            assert!(
+                !dir.path().join(name).exists(),
+                "o-mode must remove dll sidecar {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn production_pre_clean_and_discover_do_not_call_read_dir() {
+        // Structural regression guard: the non-test half of this module must
+        // never invoke `read_dir` (happy path is pure candidate probes).
+        let src = include_str!("compile.rs");
+        let production = src.split("#[cfg(test)]").next().expect("test module");
+        let mut code = String::new();
+        for line in production.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            code.push_str(line);
+            code.push('\n');
+        }
+        assert!(
+            !code.contains("read_dir"),
+            "production compile.rs must not call read_dir; use candidate path probes"
+        );
+    }
+
+    #[test]
+    fn pre_clean_and_discover_only_touch_candidates_amid_noise() {
+        // Behavioral: noise files that are not candidates must survive, and
+        // discover must return exactly the planted candidate set.
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..64 {
+            fs::write(dir.path().join(format!("libnoise-{i:03}.rlib")), b"n").unwrap();
+        }
+
+        let rlib = dir.path().join("libhot-deadbeef.rlib");
+        let rmeta = dir.path().join("libhot-deadbeef.rmeta");
+        let dep = dir.path().join("hot-deadbeef.d");
+        for path in [&rlib, &rmeta, &dep] {
+            fs::write(path, b"cached").unwrap();
+            make_readonly(path);
+        }
+
+        pre_clean_outputs(None, Some(dir.path()), Some("hot"), Some("-deadbeef"));
+
+        assert!(!rlib.exists());
+        assert!(!rmeta.exists());
+        assert!(!dep.exists());
+        assert!(dir.path().join("libnoise-000.rlib").exists());
+
+        for path in [&rlib, &rmeta, &dep] {
+            fs::write(path, b"fresh").unwrap();
+        }
+        let found =
+            discover_output_files(None, Some(dir.path()), Some("hot"), Some("-deadbeef")).unwrap();
+        let mut names: Vec<&str> = found.iter().map(|(_, n)| n.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec![
+                "hot-deadbeef.d",
+                "libhot-deadbeef.rlib",
+                "libhot-deadbeef.rmeta"
+            ]
+        );
+    }
+
+    #[test]
+    fn pre_clean_o_mode_probes_stem_siblings_without_scan() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..64 {
+            fs::write(dir.path().join(format!("zzz-noise-{i}")), b"n").unwrap();
+        }
+        let rlib = dir.path().join("libfoo-abc.rlib");
+        let rmeta = dir.path().join("libfoo-abc.rmeta");
+        let dep = dir.path().join("foo-abc.d");
+        for path in [&rlib, &rmeta, &dep] {
+            fs::write(path, b"cached").unwrap();
+            make_readonly(path);
+        }
+
+        pre_clean_outputs(Some(&rlib), None, Some("foo"), Some("-abc"));
+
+        assert!(!rlib.exists());
+        assert!(!rmeta.exists());
+        assert!(!dep.exists());
+        assert!(dir.path().join("zzz-noise-0").exists());
+    }
+
+    #[test]
+    fn discover_out_dir_without_crate_name_finds_nothing() {
+        // Incomplete identity: out-dir alone must not invent deletions or
+        // discoveries (no delete-everything, no silent sweep).
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("libfoo-abc.rlib"), b"x").unwrap();
+
+        let found = discover_output_files(None, Some(dir.path()), None, Some("-abc")).unwrap();
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn pre_clean_and_discover_with_none_extra_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let rlib = dir.path().join("libapp.rlib");
+        let dep = dir.path().join("app.d");
+        for path in [&rlib, &dep] {
+            fs::write(path, b"cached").unwrap();
+            make_readonly(path);
+        }
+
+        pre_clean_outputs(None, Some(dir.path()), Some("app"), None);
+        assert!(!rlib.exists());
+        assert!(!dep.exists());
+
+        fs::write(&rlib, b"fresh").unwrap();
+        fs::write(&dep, b"fresh").unwrap();
+        let found = discover_output_files(None, Some(dir.path()), Some("app"), None).unwrap();
+        let mut names: Vec<&str> = found.iter().map(|(_, n)| n.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["app.d", "libapp.rlib"]);
+    }
+
+    #[test]
+    fn pre_clean_skips_writable_out_dir_candidates() {
+        let dir = tempfile::tempdir().unwrap();
+        let rlib = dir.path().join("libfoo-abc.rlib");
+        fs::write(&rlib, b"fresh").unwrap();
+        // writable — not a kache hardlink
+        assert!(!fs::metadata(&rlib).unwrap().permissions().readonly());
+
+        pre_clean_outputs(None, Some(dir.path()), Some("foo"), Some("-abc"));
+        assert!(rlib.exists(), "writable candidates must not be removed");
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -30,13 +30,14 @@ pub fn run_rustc(
     out_dir: Option<&Path>,
     crate_name: Option<&str>,
     extra_filename: Option<&str>,
+    emit: &[String],
     skip_remap: bool,
     path_normalizer: &crate::path_normalizer::PathNormalizer,
 ) -> Result<CompileResult> {
     // Pre-clean output paths: remove any read-only hardlinks left by a previous
     // kache cache hit. Without this, rustc cannot overwrite the 0444 hardlinked
     // files and fails with "output file is not writeable".
-    pre_clean_outputs(output_path, out_dir, crate_name, extra_filename);
+    pre_clean_outputs(output_path, out_dir, crate_name, extra_filename, emit);
 
     crate::opcounts::record_compiler_run();
     let mut cmd = Command::new(rustc);
@@ -124,7 +125,7 @@ pub fn run_rustc(
                 crate_name.unwrap_or("unknown")
             );
             ArtifactSet::from_output_files(
-                discover_output_files(output_path, out_dir, crate_name, extra_filename)?,
+                discover_output_files(output_path, out_dir, crate_name, extra_filename, emit)?,
                 classify_by_filename,
             )
         } else {
@@ -255,10 +256,28 @@ fn resolve_artifacts(artifacts: &[PathBuf]) -> Vec<(PathBuf, String)> {
 /// Windows import-lib names (`dll.lib` / `dll.exp` / `dll.a`) so a primary
 /// `foo.dll` still probes `foo.dll.lib`. Over-probe is intentional: missing a
 /// restored 0444 hardlink causes EACCES on the next rustc write.
+///
+/// Not covered: per-CGU names under `--emit=obj|llvm-ir|asm|llvm-bc` with
+/// `codegen-units > 1` (`{crate}{extra}.{crate}.{hash}-cgu.N.rcgu.o`, …).
+/// Those are unbounded — see [`emit_may_produce_per_cgu_files`].
 const ARTIFACT_SUFFIXES: &[&str] = &[
     "rlib", "rmeta", "d", "so", "dylib", "dll", "wasm", "a", "lib", "dll.lib", "dll.exp", "dll.a",
-    "exe", "pdb", "dwo", "o", "obj", "ll", "bc", "mir", "s", "asm",
+    "exe", "pdb", "dwo", "dwp", "o", "obj", "ll", "bc", "mir", "s", "asm",
 ];
+
+/// Emit kinds that produce unbounded per-CGU filenames when `codegen-units > 1`.
+/// A closed candidate list cannot name them; fall back to a prefix `read_dir`.
+const PER_CGU_EMIT_KINDS: &[&str] = &["obj", "llvm-ir", "asm", "llvm-bc"];
+
+/// True when `--emit` includes kinds that can produce per-CGU artifact names
+/// (`foo-abc.foo.<hash>-cgu.0.rcgu.o`, …). Cargo's usual `link,metadata,dep-info`
+/// does not — so the hot path stays probe-only.
+fn emit_may_produce_per_cgu_files(emit: &[String]) -> bool {
+    emit.iter().any(|e| {
+        let kind = e.split('=').next().unwrap_or(e.as_str());
+        PER_CGU_EMIT_KINDS.contains(&kind)
+    })
+}
 
 /// Invoke `f` for each `--out-dir` candidate basename (no intermediate `Vec`).
 fn for_each_out_dir_candidate(crate_name: &str, extra: &str, mut f: impl FnMut(&str)) {
@@ -307,16 +326,58 @@ fn path_file_name(path: &Path) -> Option<String> {
     path.file_name().map(|n| n.to_string_lossy().into_owned())
 }
 
+/// Whether `name` is a cargo/rustc product for `crate_name` + `extra`.
+///
+/// Matches the exact stem and any `{stem}.…` prefix (covers per-CGU files,
+/// custom dep-info basenames, etc. — the old full-scan filter).
+fn matches_crate_output_prefix(name: &str, crate_name: &str, extra: &str) -> bool {
+    let bare = crate::args::format_crate_output_stem(crate_name, extra);
+    let lib = format!("lib{bare}");
+    name == bare
+        || name == lib
+        || name.starts_with(&format!("{bare}."))
+        || name.starts_with(&format!("{lib}."))
+}
+
+/// Prefix `read_dir` of `dir` for products of `crate_name` + `extra`.
+///
+/// Only used when [`emit_may_produce_per_cgu_files`] — per-CGU filenames are
+/// unbounded (`…-cgu.N.rcgu.o`), so they cannot be probed. Cargo's default
+/// emit sets never take this path.
+fn for_each_prefix_match_in_dir(
+    dir: &Path,
+    crate_name: &str,
+    extra: &str,
+    mut f: impl FnMut(&Path),
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if matches_crate_output_prefix(name, crate_name, extra) {
+            f(&path);
+        }
+    }
+}
+
 /// Fallback discovery when rustc did not emit JSON artifact notifications.
-/// Probes a fixed candidate set — never `read_dir`s the out-dir.
+///
+/// Probes a fixed candidate set on the cargo hot path. When `--emit` includes
+/// per-CGU kinds, falls back to a prefix `read_dir` (unbounded names).
 fn discover_output_files(
     output_path: Option<&Path>,
     out_dir: Option<&Path>,
     crate_name: Option<&str>,
     extra_filename: Option<&str>,
+    emit: &[String],
 ) -> Result<Vec<(PathBuf, String)>> {
     let mut files = Vec::new();
     let extra = extra_filename.unwrap_or("");
+    let prefix_scan = emit_may_produce_per_cgu_files(emit);
 
     if let Some(output) = output_path {
         if output.is_file()
@@ -344,14 +405,34 @@ fn discover_output_files(
             {
                 files.push((d_file, filename));
             }
+            if prefix_scan {
+                for_each_prefix_match_in_dir(parent, name, extra, |path| {
+                    if path.is_file()
+                        && !files.iter().any(|(p, _)| p == path)
+                        && let Some(filename) = path_file_name(path)
+                    {
+                        files.push((path.to_path_buf(), filename));
+                    }
+                });
+            }
         }
     } else if let (Some(dir), Some(name)) = (out_dir, crate_name) {
-        for_each_out_dir_candidate(name, extra, |fname| {
-            let path = dir.join(fname);
-            if path.is_file() {
-                files.push((path, fname.to_string()));
-            }
-        });
+        if prefix_scan {
+            for_each_prefix_match_in_dir(dir, name, extra, |path| {
+                if path.is_file()
+                    && let Some(filename) = path_file_name(path)
+                {
+                    files.push((path.to_path_buf(), filename));
+                }
+            });
+        } else {
+            for_each_out_dir_candidate(name, extra, |fname| {
+                let path = dir.join(fname);
+                if path.is_file() {
+                    files.push((path, fname.to_string()));
+                }
+            });
+        }
     }
 
     Ok(files)
@@ -359,16 +440,20 @@ fn discover_output_files(
 
 /// Remove read-only hardlinks at known output paths so rustc can overwrite them.
 ///
-/// Probes deterministic candidates from `-o` / `--out-dir` + crate identity.
-/// Never `read_dir`s cargo out-dirs (can be hundreds of thousands of entries).
+/// Cargo's usual emit sets probe a fixed candidate list (no out-dir `read_dir`).
+/// When `--emit` includes per-CGU kinds (`obj` / `llvm-ir` / `asm` / `llvm-bc`),
+/// falls back to a prefix directory scan — those filenames are unbounded.
 /// Also used by direct-exec passthrough (`KACHE_DISABLED`) — see `main.rs`.
 pub(crate) fn pre_clean_outputs(
     output_path: Option<&Path>,
     out_dir: Option<&Path>,
     crate_name: Option<&str>,
     extra_filename: Option<&str>,
+    emit: &[String],
 ) {
     let extra = extra_filename.unwrap_or("");
+    let prefix_scan = emit_may_produce_per_cgu_files(emit);
+
     if let Some(output) = output_path {
         remove_if_readonly(output);
 
@@ -379,11 +464,18 @@ pub(crate) fn pre_clean_outputs(
 
         if let (Some(parent), Some(name)) = (output.parent(), crate_name) {
             remove_if_readonly(&crate_depinfo_path(parent, name, extra));
+            if prefix_scan {
+                for_each_prefix_match_in_dir(parent, name, extra, remove_if_readonly);
+            }
         }
     } else if let (Some(dir), Some(name)) = (out_dir, crate_name) {
-        for_each_out_dir_candidate(name, extra, |fname| {
-            remove_if_readonly(&dir.join(fname));
-        });
+        if prefix_scan {
+            for_each_prefix_match_in_dir(dir, name, extra, remove_if_readonly);
+        } else {
+            for_each_out_dir_candidate(name, extra, |fname| {
+                remove_if_readonly(&dir.join(fname));
+            });
+        }
     } else {
         // Incomplete identity: refuse a mass sweep of out-dir (rio-build#51 / kache#242).
         tracing::debug!(
@@ -445,7 +537,7 @@ mod tests {
         make_readonly(&output);
         assert!(fs::metadata(&output).unwrap().permissions().readonly());
 
-        pre_clean_outputs(Some(&output), None, None, None);
+        pre_clean_outputs(Some(&output), None, None, None, &[]);
 
         assert!(!output.exists(), "read-only file should have been removed");
     }
@@ -462,7 +554,7 @@ mod tests {
             make_readonly(path);
         }
 
-        pre_clean_outputs(Some(&rlib), None, Some("foo"), Some("-abc123"));
+        pre_clean_outputs(Some(&rlib), None, Some("foo"), Some("-abc123"), &[]);
 
         assert!(!rlib.exists());
         assert!(!rmeta.exists());
@@ -478,7 +570,7 @@ mod tests {
         fs::write(&output, b"fresh content").unwrap();
         assert!(!fs::metadata(&output).unwrap().permissions().readonly());
 
-        pre_clean_outputs(Some(&output), None, None, None);
+        pre_clean_outputs(Some(&output), None, None, None, &[]);
 
         assert!(output.exists(), "writable file should NOT be removed");
     }
@@ -495,7 +587,13 @@ mod tests {
             make_readonly(path);
         }
 
-        pre_clean_outputs(None, Some(dir.path()), Some("mycrate"), Some("-def456"));
+        pre_clean_outputs(
+            None,
+            Some(dir.path()),
+            Some("mycrate"),
+            Some("-def456"),
+            &[],
+        );
 
         assert!(!rlib.exists());
         assert!(!rmeta.exists());
@@ -515,8 +613,8 @@ mod tests {
         fs::write(&readonly, b"cached").unwrap();
         make_readonly(&readonly);
 
-        pre_clean_outputs(None, Some(dir.path()), None, None);
-        pre_clean_outputs(None, None, None, None);
+        pre_clean_outputs(None, Some(dir.path()), None, None, &[]);
+        pre_clean_outputs(None, None, None, None, &[]);
 
         assert!(
             readonly.exists(),
@@ -535,7 +633,7 @@ mod tests {
         fs::set_permissions(&blob, fs::Permissions::from_mode(0o444)).unwrap();
         fs::hard_link(&blob, &output).unwrap();
 
-        pre_clean_outputs(Some(&output), None, None, None);
+        pre_clean_outputs(Some(&output), None, None, None, &[]);
 
         assert!(
             !output.exists(),
@@ -628,6 +726,7 @@ mod tests {
             None,
             None,
             None,
+            &[],
         )
         .unwrap();
         assert!(result.is_empty());
@@ -650,7 +749,7 @@ mod tests {
         fs::write(dir.path().join("libbar-xyz.rlib"), b"content").unwrap();
 
         let files =
-            discover_output_files(None, Some(dir.path()), Some("foo"), Some("-abc")).unwrap();
+            discover_output_files(None, Some(dir.path()), Some("foo"), Some("-abc"), &[]).unwrap();
         let mut names: Vec<&str> = files.iter().map(|(_, n)| n.as_str()).collect();
         names.sort_unstable();
         let mut expected = planted.to_vec();
@@ -730,7 +829,7 @@ mod tests {
         fs::write(dir.path().join("other.rlib"), b"x").unwrap();
 
         let files =
-            discover_output_files(Some(&output), None, Some("foo"), Some("-abc123")).unwrap();
+            discover_output_files(Some(&output), None, Some("foo"), Some("-abc123"), &[]).unwrap();
         let mut names: Vec<&str> = files.iter().map(|(_, n)| n.as_str()).collect();
         names.sort_unstable();
         assert_eq!(
@@ -781,6 +880,8 @@ mod tests {
             "serde-9f2a1b.pdb",
             "libserde-9f2a1b.dwo",
             "serde-9f2a1b.dwo",
+            "libserde-9f2a1b.dwp",
+            "serde-9f2a1b.dwp",
             "libserde-9f2a1b.o",
             "serde-9f2a1b.o",
             "libserde-9f2a1b.obj",
@@ -837,7 +938,7 @@ mod tests {
         fs::write(&other, b"cached").unwrap();
         make_readonly(&other);
 
-        pre_clean_outputs(None, Some(dir.path()), Some("foo"), Some("-abc"));
+        pre_clean_outputs(None, Some(dir.path()), Some("foo"), Some("-abc"), &[]);
 
         for name in targets {
             assert!(
@@ -868,7 +969,7 @@ mod tests {
             make_readonly(&path);
         }
 
-        pre_clean_outputs(Some(&dll), None, Some("foo"), Some("-abc"));
+        pre_clean_outputs(Some(&dll), None, Some("foo"), Some("-abc"), &[]);
 
         assert!(!dll.exists());
         for name in sidecars {
@@ -880,23 +981,84 @@ mod tests {
     }
 
     #[test]
-    fn production_pre_clean_and_discover_do_not_call_read_dir() {
-        // Structural regression guard: the non-test half of this module must
-        // never invoke `read_dir` (happy path is pure candidate probes).
+    fn production_read_dir_only_in_prefix_scan_helper() {
+        // `read_dir` is allowed only inside `for_each_prefix_match_in_dir`
+        // (gated by per-CGU emit). Split at the real tests module, not the first
+        // `#[cfg(test)]` token (which can appear earlier and fail-open).
         let src = include_str!("compile.rs");
-        let production = src.split("#[cfg(test)]").next().expect("test module");
+        let production = src
+            .split("\n#[cfg(test)]\nmod tests {")
+            .next()
+            .expect("tests module");
         let mut code = String::new();
         for line in production.lines() {
             let trimmed = line.trim_start();
-            if trimmed.starts_with("//") {
+            if trimmed.starts_with("//") || trimmed.starts_with("///") {
                 continue;
             }
             code.push_str(line);
             code.push('\n');
         }
+        let helper = "fn for_each_prefix_match_in_dir";
+        let start = code
+            .find(helper)
+            .expect("prefix-scan helper must exist in production code");
+        // Helper body until the next top-level `fn ` at column 0-ish after helper.
+        let after = &code[start + helper.len()..];
+        let end_rel = after
+            .find("\nfn ")
+            .or_else(|| after.find("\npub(crate) fn "))
+            .unwrap_or(after.len());
+        let helper_body = &after[..end_rel];
+        let outside = format!("{}{}", &code[..start], &after[end_rel..]);
         assert!(
-            !code.contains("read_dir"),
-            "production compile.rs must not call read_dir; use candidate path probes"
+            helper_body.contains("read_dir"),
+            "prefix-scan helper must call read_dir"
+        );
+        assert!(
+            !outside.contains("read_dir"),
+            "read_dir must only appear in for_each_prefix_match_in_dir"
+        );
+    }
+
+    #[test]
+    fn pre_clean_removes_per_cgu_object_when_emit_obj() {
+        // Regression (PR review): with --emit=obj and codegen-units > 1, rustc
+        // writes `{crate}{extra}.{crate}.{hash}-cgu.N.rcgu.o`. A closed suffix
+        // list cannot name these; prefix scan (gated on emit) must still clean.
+        let dir = tempfile::tempdir().unwrap();
+        let cgu = dir.path().join("foo-abc.foo.deadbeef12345678-cgu.0.rcgu.o");
+        let noise = dir.path().join("libbar-xyz.rlib");
+        fs::write(&cgu, b"cached").unwrap();
+        make_readonly(&cgu);
+        fs::write(&noise, b"cached").unwrap();
+        make_readonly(&noise);
+
+        let emit = ["obj".to_string()];
+        pre_clean_outputs(None, Some(dir.path()), Some("foo"), Some("-abc"), &emit);
+
+        assert!(!cgu.exists(), "per-CGU object must be pre-cleaned");
+        assert!(noise.exists(), "unrelated crate must not be touched");
+    }
+
+    #[test]
+    fn pre_clean_probe_path_leaves_per_cgu_when_emit_is_link_only() {
+        // Cargo-typical emit must not take the prefix-scan path.
+        let dir = tempfile::tempdir().unwrap();
+        let cgu = dir.path().join("foo-abc.foo.deadbeef12345678-cgu.0.rcgu.o");
+        fs::write(&cgu, b"cached").unwrap();
+        make_readonly(&cgu);
+
+        let emit = [
+            "link".to_string(),
+            "metadata".to_string(),
+            "dep-info".to_string(),
+        ];
+        pre_clean_outputs(None, Some(dir.path()), Some("foo"), Some("-abc"), &emit);
+
+        assert!(
+            cgu.exists(),
+            "probe-only path must not readdir; per-CGU files stay (cargo never makes them)"
         );
     }
 
@@ -917,7 +1079,7 @@ mod tests {
             make_readonly(path);
         }
 
-        pre_clean_outputs(None, Some(dir.path()), Some("hot"), Some("-deadbeef"));
+        pre_clean_outputs(None, Some(dir.path()), Some("hot"), Some("-deadbeef"), &[]);
 
         assert!(!rlib.exists());
         assert!(!rmeta.exists());
@@ -928,7 +1090,8 @@ mod tests {
             fs::write(path, b"fresh").unwrap();
         }
         let found =
-            discover_output_files(None, Some(dir.path()), Some("hot"), Some("-deadbeef")).unwrap();
+            discover_output_files(None, Some(dir.path()), Some("hot"), Some("-deadbeef"), &[])
+                .unwrap();
         let mut names: Vec<&str> = found.iter().map(|(_, n)| n.as_str()).collect();
         names.sort_unstable();
         assert_eq!(
@@ -955,7 +1118,7 @@ mod tests {
             make_readonly(path);
         }
 
-        pre_clean_outputs(Some(&rlib), None, Some("foo"), Some("-abc"));
+        pre_clean_outputs(Some(&rlib), None, Some("foo"), Some("-abc"), &[]);
 
         assert!(!rlib.exists());
         assert!(!rmeta.exists());
@@ -970,7 +1133,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("libfoo-abc.rlib"), b"x").unwrap();
 
-        let found = discover_output_files(None, Some(dir.path()), None, Some("-abc")).unwrap();
+        let found = discover_output_files(None, Some(dir.path()), None, Some("-abc"), &[]).unwrap();
         assert!(found.is_empty());
     }
 
@@ -984,13 +1147,13 @@ mod tests {
             make_readonly(path);
         }
 
-        pre_clean_outputs(None, Some(dir.path()), Some("app"), None);
+        pre_clean_outputs(None, Some(dir.path()), Some("app"), None, &[]);
         assert!(!rlib.exists());
         assert!(!dep.exists());
 
         fs::write(&rlib, b"fresh").unwrap();
         fs::write(&dep, b"fresh").unwrap();
-        let found = discover_output_files(None, Some(dir.path()), Some("app"), None).unwrap();
+        let found = discover_output_files(None, Some(dir.path()), Some("app"), None, &[]).unwrap();
         let mut names: Vec<&str> = found.iter().map(|(_, n)| n.as_str()).collect();
         names.sort_unstable();
         assert_eq!(names, vec!["app.d", "libapp.rlib"]);
@@ -1004,7 +1167,7 @@ mod tests {
         // writable — not a kache hardlink
         assert!(!fs::metadata(&rlib).unwrap().permissions().readonly());
 
-        pre_clean_outputs(None, Some(dir.path()), Some("foo"), Some("-abc"));
+        pre_clean_outputs(None, Some(dir.path()), Some("foo"), Some("-abc"), &[]);
         assert!(rlib.exists(), "writable candidates must not be removed");
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -983,17 +983,20 @@ mod tests {
     #[test]
     fn production_read_dir_only_in_prefix_scan_helper() {
         // `read_dir` is allowed only inside `for_each_prefix_match_in_dir`
-        // (gated by per-CGU emit). Split at the real tests module, not the first
-        // `#[cfg(test)]` token (which can appear earlier and fail-open).
-        let src = include_str!("compile.rs");
-        let production = src
-            .split("\n#[cfg(test)]\nmod tests {")
-            .next()
-            .expect("tests module");
+        // (gated by per-CGU emit). Normalize CRLF first — Windows checkouts
+        // can rewrite line endings, which would make a bare `\n#[cfg(test)]`
+        // split miss and fail-open over the whole file (including this test).
+        let src = include_str!("compile.rs").replace("\r\n", "\n");
+        let marker = "\n#[cfg(test)]\nmod tests {";
+        assert!(
+            src.contains(marker),
+            "expected tests module marker for production/test split"
+        );
+        let production = src.split(marker).next().expect("tests module");
         let mut code = String::new();
         for line in production.lines() {
             let trimmed = line.trim_start();
-            if trimmed.starts_with("//") || trimmed.starts_with("///") {
+            if trimmed.starts_with("//") {
                 continue;
             }
             code.push_str(line);
@@ -1003,7 +1006,6 @@ mod tests {
         let start = code
             .find(helper)
             .expect("prefix-scan helper must exist in production code");
-        // Helper body until the next top-level `fn ` at column 0-ish after helper.
         let after = &code[start + helper.len()..];
         let end_rel = after
             .find("\nfn ")

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -134,6 +134,7 @@ impl Compiler for RustcCompiler {
             parsed.out_dir.as_deref(),
             parsed.crate_name.as_deref(),
             parsed.extra_filename.as_deref(),
+            &parsed.emit,
             skip_remap,
             &path_normalizer,
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -580,6 +580,7 @@ fn run_compiler_directly(args: &[String]) -> Result<i32> {
             parsed.out_dir.as_deref(),
             parsed.crate_name.as_deref(),
             parsed.extra_filename.as_deref(),
+            &parsed.emit,
         );
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1852,6 +1852,7 @@ fn passthrough(args: &RustcArgs, fallback: Option<&str>) -> Result<PassthroughOu
         args.out_dir.as_deref(),
         args.crate_name.as_deref(),
         args.extra_filename.as_deref(),
+        &args.emit,
     );
 
     // Configured fallback wrapper: `<fallback> <rustc> [<inner-rustc>]


### PR DESCRIPTION
## Summary

- Replace full `read_dir` of cargo `--out-dir` / `-o` parent directories in `pre_clean_outputs` and `discover_output_files` with O(candidates) path probes.
- Shared `ARTIFACT_SUFFIXES` covers common cargo/rustc products (rlib/rmeta/d/dylib/bin/…) plus Windows import-lib sidecars (`dll.lib` / `dll.exp` / `dll.a`) and special emit kinds (`ll`/`bc`/`mir`/`s`/`asm`).
- Fixes severe **sys CPU** thrash when many parallel `kache rustc` wrappers scan huge monorepo `target/*/deps` trees (~800k entries → tens of seconds of pure readdir each).

Cargo post-compile discovery still prefers rustc JSON artifact notifications; candidate probing is the fallback and the always-on pre-clean path.

## Why

On a large monorepo, sampling showed wrappers stuck in `__getdirentries64` during pre-clean/store, while the daemon itself was nearly idle. Full directory scans do not scale with `split-debuginfo=unpacked` and large deps dirs.

## Test plan

- [x] `just check` (fmt + clippy -D warnings + workspace tests)
- [x] Unit tests for exact candidate set, Windows dll sidecars, emit products, incomplete identity no-op, noise isolation, structural `include_str!` guard that production `compile.rs` has no `read_dir`
- [ ] CI green on this PR