### PR TITLE
test(events): fix flaky concurrent tailer assertion on Windows

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -1219,13 +1219,25 @@ mod tests {
             ids
         );
 
-        // 4. Verify that the EventTailer observed EVERY single event (0..=200) without loss
-        for expected_id in 0..=200 {
-            assert!(
-                polled_ids.contains(&expected_id),
-                "EventTailer missed event ID {}",
-                expected_id
-            );
-        }
+        // 4. The tailer must still be following the log after rotations — i.e. it
+        // observed the final event.
+        //
+        // It may legitimately miss earlier events: the rotator trims to `keep_lines`
+        // concurrently, so an event appended and then rotated away before the tailer
+        // next polled was never observable. That is rotation working, not event loss —
+        // asserting the tailer sees *every* id makes this test a race it can only win
+        // when the tailer happens to outrun the rotator (it flaked on Windows CI).
+        //
+        // What must hold is that rotation never leaves the tailer stranded on the old
+        // inode (kunobi-ninja/kache#518): if it did, it would stop seeing new events
+        // entirely and never reach the last one. The deterministic inode-swap guard is
+        // `test_event_tailer_handles_rename_rotation`; this is its concurrent analogue.
+        assert!(
+            polled_ids.contains(&200),
+            "EventTailer stopped following the log across rotation: never observed the \
+             final event (saw {} ids, max {:?})",
+            polled_ids.len(),
+            polled_ids.iter().max()
+        );
     }
 }


### PR DESCRIPTION
## Summary

`events::tests::test_concurrent_log_append_and_rotate` (added in #518) is flaky on Windows and is currently reddening unrelated PRs — it blocked #520, whose own change is fine.

## The bug in the test

The test runs three threads against one log:

- **appender** — writes ids `1..=200`, sleeping 1ms between each
- **tailer** — polls every 2ms (half the appender's rate, so it falls behind by construction)
- **rotator** — spins continuously, trimming the log to `keep_lines`

…and then asserted the tailer observed **every** id `0..=200`.

That can't hold. The rotator deletes events before the tailer's next poll, so those events were never observable. The assertion only passes when the tailer happens to outrun the rotator — it's a race, and a loaded Windows runner loses it. It failed on `EventTailer missed event ID 1`: the oldest id, i.e. the first one rotation trims.

A tailer missing an already-rotated event is rotation working correctly, not event loss.

## The fix

Assert the property that must actually hold: the tailer is never left stranded on the pre-rotation inode (the #518 regression), so it still observes the **final** event. Earlier ids may legitimately be gone.

Parts 1–3 of the test (trailing-newline invariant, and no gaps in the *surviving log*) are unchanged — those are sound and remain the real no-loss check.

## Verification

The replacement is still a genuine guard, not a weaker no-op. Neutering the reopen-on-rotation fix (simulating the #518 regression) makes it fail:

```
EventTailer stopped following the log across rotation: never observed the
final event (saw 8 ids, max Some(7))
```

…and it passes with the fix restored. Ran it 5x locally — green each time. `cargo fmt` / `cargo clippy -D warnings` clean.

The deterministic inode-swap guard remains `test_event_tailer_handles_rename_rotation`, which is unaffected by this PR.

## Notes

The over-strict assertion traces back to my review comment on #518 asking for a test that exercises the real `EventTailer` across a rotation — the intent was right, the assertion was stronger than reality allows. Cleaning up after myself.
