### PR TITLE
Reuse known hashes after exact artifact restores

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -657,6 +657,16 @@ impl Store {
         self.file_hasher().record_cached(fingerprint, hash);
     }
 
+    /// Associate a file just materialized from a verified blob with that blob's
+    /// known content hash, avoiding a redundant read when it becomes a compiler input.
+    pub fn record_known_file_hash(&self, path: &Path, hash: &str) {
+        if let crate::cache_key::FileHashLookup::NeedsHash(fingerprint) =
+            self.file_hasher().lookup_cached(path)
+        {
+            self.file_hasher().record_cached(&fingerprint, hash);
+        }
+    }
+
     /// Check if a committed entry exists for this cache key.
     pub fn contains(&self, cache_key: &str) -> bool {
         let entry_dir = self.entry_dir(cache_key);
@@ -2186,6 +2196,21 @@ mod tests {
         let unicode = "wörning: ".repeat(20);
         let capped = cap_diagnostics(&unicode, Some(5));
         assert!(std::str::from_utf8(capped.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn record_known_file_hash_avoids_reading_materialized_blob() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&test_config(dir.path())).unwrap();
+        let artifact = dir.path().join("artifact.rlib");
+        std::fs::write(&artifact, vec![b'x'; 64 * 1024]).unwrap();
+        let expected = crate::cache_key::hash_file(&artifact).unwrap();
+
+        store.record_known_file_hash(&artifact, &expected);
+        assert!(matches!(
+            store.file_hash_lookup(&artifact),
+            crate::cache_key::FileHashLookup::Hit(hash) if hash == expected
+        ));
     }
 
     #[test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1660,6 +1660,10 @@ fn materialize_cached_artifact(
         }
     }
 
+    if plan.is_empty() {
+        store.record_known_file_hash(target_path, &cached_file.hash);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Human context

<!-- Written by the submitter. -->

## AI summary

### Summary

Seed the existing file-hash memo after an exact cache restore so downstream wrappers reuse the blob's verified digest instead of rereading the restored artifact.

Closes #540.

### Changed

- Associated exactly restored files with their already-known content hash and fresh filesystem fingerprint.
- Limited reuse to artifacts with no post-restore transformation plan.
- Preserved fail-closed behaviour: any fingerprint change returns to normal content hashing.
- Added focused coverage proving the memo returns the known digest after materialization.

### Why

A local hit already verifies and materializes a content-addressed blob. Reading the resulting `.rlib`, `.rmeta`, or proc-macro artifact again to calculate the same digest adds avoidable work to warm cross-worktree builds.

### Evidence

- Focused A/B: 13.3% fewer warm bytes hashed; warm wall median improved 7.1% in that sample.
- Three quiet-host native `kache-scenario` pairs for the complete hash-reuse stack: median warm build 24s → 23s and median key-hash input 225.9 MB → 171.5 MB.
- Native verdict `ok`, 203 hits/0 misses, 180/180 stable keys, zero path leaks, and full APFS reflink restore.

### Validation

- `just check`
- Native cross-clone `kache-scenario` benchmark on a real Rust workspace

### Checklist

- [x] Targeted test covers the new behaviour
- [x] Full `just check` passes
- [x] Cross-clone correctness and path-leak checks pass
- [x] No transformed artifact reuses a pre-transform hash

Implementation, benchmarking, and this summary were prepared with AI assistance and reviewed by the submitter.
