### PR TITLE
Reuse known hashes after storing compiler outputs

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -1240,7 +1240,9 @@ impl Store {
     }
 
     /// Associate a stable file with its already-known content hash, avoiding a
-    /// redundant read when it becomes a compiler input.
+    /// redundant read when it becomes a compiler input. Call this only after
+    /// every store-side operation that may change the file's fingerprint and
+    /// while the compiler-owned output is stable.
     pub fn record_known_file_hash(&self, path: &Path, hash: &str) {
         if let crate::cache_key::FileHashLookup::NeedsHash(fingerprint) =
             self.file_hasher().lookup_cached(path)
@@ -1620,7 +1622,6 @@ impl Store {
         for (source_path, store_name) in output_files {
             let hash = crate::cache_key::hash_file(source_path)?;
             let metadata = fs::metadata(source_path)?;
-            self.record_known_file_hash(source_path, &hash);
             let size = metadata.len();
             let executable = is_executable(&metadata);
             if size == 0 && !zero_byte_is_valid_output(store_name, crate_types) {
@@ -1713,6 +1714,23 @@ impl Store {
             params![cache_key, crate_name, crate_type_str, profile, num_features, total_size as i64, content_hash, compile_time_ms as i64],
         )?;
         tx.commit()?;
+
+        // Both ingest phases may hardlink a compiler output to the immutable
+        // blob and mark the shared inode read-only, changing ctime. Seed only
+        // after the transaction's final rematerialization. Independent (C/C++)
+        // puts use disposable staging paths and deliberately do not seed them.
+        if allow_source_hardlinks {
+            for (file, (source, _)) in meta.files.iter().zip(&sources) {
+                // The Rust wrapper expands dep-info back to absolute paths
+                // immediately after `put`, so it is not stable here.
+                if !matches!(
+                    crate::compiler::classify_by_filename(&file.name),
+                    crate::compiler::ArtifactKind::DepInfo
+                ) {
+                    self.record_known_file_hash(source, &file.hash);
+                }
+            }
+        }
 
         Ok(put_result)
     }
@@ -3635,17 +3653,72 @@ mod tests {
     }
 
     #[test]
-    fn record_known_file_hash_returns_memoized_digest() {
+    fn put_records_known_hash_only_for_stable_outputs() {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open(&test_config(dir.path())).unwrap();
         let artifact = dir.path().join("artifact.rlib");
         std::fs::write(&artifact, vec![b'x'; 64 * 1024]).unwrap();
         let expected = crate::cache_key::hash_file(&artifact).unwrap();
 
-        store.record_known_file_hash(&artifact, &expected);
+        store
+            .put(
+                "known-hash-stable",
+                "artifact",
+                &["rlib".to_string()],
+                &[],
+                "host",
+                "dev",
+                &[(artifact.clone(), "libartifact.rlib".to_string())],
+                "",
+                "",
+            )
+            .unwrap();
+        let hasher = store.file_hasher();
+        assert_eq!(hasher.hash(&artifact).unwrap(), expected);
+        let stats = hasher.stats();
+        assert_eq!(stats.cache_hits, 1);
+        assert_eq!(stats.cache_misses, 0);
+        assert_eq!(stats.bytes_hashed, 0);
+
+        let dep_info = dir.path().join("artifact.d");
+        std::fs::write(&dep_info, vec![b'd'; 64 * 1024]).unwrap();
+        store
+            .put(
+                "known-hash-dep-info",
+                "artifact",
+                &[],
+                &[],
+                "host",
+                "dev",
+                &[(dep_info.clone(), "artifact.d".to_string())],
+                "",
+                "",
+            )
+            .unwrap();
         assert!(matches!(
-            store.file_hash_lookup(&artifact),
-            crate::cache_key::FileHashLookup::Hit(hash) if hash == expected
+            store.file_hash_lookup(&dep_info),
+            crate::cache_key::FileHashLookup::NeedsHash(_)
+        ));
+
+        let independent = dir.path().join("independent.o");
+        std::fs::write(&independent, vec![b'o'; 64 * 1024]).unwrap();
+        store
+            .put_with_compile_time_independent(
+                "known-hash-independent",
+                "artifact.c",
+                &[],
+                &[],
+                "host",
+                "dev",
+                &[(independent.clone(), "independent.o".to_string())],
+                "",
+                "",
+                1,
+            )
+            .unwrap();
+        assert!(matches!(
+            store.file_hash_lookup(&independent),
+            crate::cache_key::FileHashLookup::NeedsHash(_)
         ));
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1239,6 +1239,16 @@ impl Store {
         self.file_hasher().record_cached(fingerprint, hash);
     }
 
+    /// Associate a stable file with its already-known content hash, avoiding a
+    /// redundant read when it becomes a compiler input.
+    pub fn record_known_file_hash(&self, path: &Path, hash: &str) {
+        if let crate::cache_key::FileHashLookup::NeedsHash(fingerprint) =
+            self.file_hasher().lookup_cached(path)
+        {
+            self.file_hasher().record_cached(&fingerprint, hash);
+        }
+    }
+
     /// Check if a committed entry exists for this cache key.
     pub fn contains(&self, cache_key: &str) -> bool {
         let entry_dir = self.entry_dir(cache_key);
@@ -1610,6 +1620,7 @@ impl Store {
         for (source_path, store_name) in output_files {
             let hash = crate::cache_key::hash_file(source_path)?;
             let metadata = fs::metadata(source_path)?;
+            self.record_known_file_hash(source_path, &hash);
             let size = metadata.len();
             let executable = is_executable(&metadata);
             if size == 0 && !zero_byte_is_valid_output(store_name, crate_types) {
@@ -3621,6 +3632,21 @@ mod tests {
         let unicode = "wörning: ".repeat(20);
         let capped = cap_diagnostics(&unicode, Some(5));
         assert!(std::str::from_utf8(capped.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn record_known_file_hash_returns_memoized_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&test_config(dir.path())).unwrap();
+        let artifact = dir.path().join("artifact.rlib");
+        std::fs::write(&artifact, vec![b'x'; 64 * 1024]).unwrap();
+        let expected = crate::cache_key::hash_file(&artifact).unwrap();
+
+        store.record_known_file_hash(&artifact, &expected);
+        assert!(matches!(
+            store.file_hash_lookup(&artifact),
+            crate::cache_key::FileHashLookup::Hit(hash) if hash == expected
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Human context

<!-- Written by the submitter. -->

## AI summary

### Summary

Seed the existing file-hash memo after storing fresh, stable Rust compiler outputs so downstream wrappers reuse the digest kache already calculated instead of rereading the artifact.

Closes #541.

### Changed

- Seeded memo entries only after final blob materialization and the store transaction commit, so hardlink/readonly fingerprint changes are captured.
- Limited seeding to normal Rust output ingestion; dep-info and independent C/C++ staging paths remain unseeded because those source paths are mutated or disposable.
- Reused the existing fingerprint validation path and documented the compiler-output stability assumption.
- Added store-level coverage proving a real `put` yields a memo hit with zero bytes rehashed, while dep-info and independent puts do not.

### Why

`Store::put` already reads and hashes every fresh output before content-addressed storage. Repeating that full-file read when the output becomes a downstream `--extern` input is redundant I/O along the normal Rust dependency graph.

### Evidence

- Focused fresh-cache A/B: cold key-hash input fell from 239.5 MB to 129.6 MB in every paired run; aggregate key time fell 12.1% in that sample.
- Three quiet-host native `kache-scenario` pairs for the complete hash-reuse stack: median key-hash input 225.9 MB → 171.5 MB with native verdict `ok` and unchanged correctness.
- Cold wall median remained tied at 33s because rustc compilation dominates; this PR claims deterministic work reduction, not a stable cold wall-time speedup.

### Validation

- `just check`
- `cargo test put_records_known_hash_only_for_stable_outputs`
- Native cross-clone `kache-scenario` benchmark on a real Rust workspace

### Checklist

- [x] Product-level test covers post-ingest memo reuse
- [x] Full `just check` passes
- [x] Cross-clone correctness and path-leak checks pass
- [x] Mutable/disposable outputs are excluded

Implementation, benchmarking, and this summary were prepared with AI assistance and reviewed by the submitter.
