### PR TITLE
fix(wrapper): avoid following symlinks for warning marker files

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2211,10 +2211,17 @@ fn maybe_trigger_prefetch(config: &Config, args: &RustcArgs) {
 /// non-regular files up front, and opens with `O_NOFOLLOW` on Unix to prevent
 /// symlink attacks and arbitrary file truncation in shared temporary directories.
 fn open_marker_for_lock(marker: &Path) -> Option<std::fs::File> {
-    if let Ok(metadata) = std::fs::symlink_metadata(marker)
-        && (metadata.file_type().is_symlink() || !metadata.file_type().is_file())
-    {
-        return None;
+    if let Ok(metadata) = std::fs::symlink_metadata(marker) {
+        if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
+            return None;
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::MetadataExt;
+            if (metadata.file_attributes() & 0x400) != 0 {
+                return None; // Refuse reparse points explicitly
+            }
+        }
     }
 
     let mut options = std::fs::OpenOptions::new();
@@ -2237,10 +2244,16 @@ fn open_marker_for_lock(marker: &Path) -> Option<std::fs::File> {
     let file = options.open(marker).ok()?;
 
     // Post-open verification: ensure the opened file handle itself is a regular file.
-    if let Ok(meta) = file.metadata()
-        && !meta.file_type().is_file()
-    {
+    let meta = file.metadata().ok()?;
+    if !meta.file_type().is_file() {
         return None;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        if (meta.file_attributes() & 0x400) != 0 {
+            return None; // Refuse reparse points explicitly
+        }
     }
 
     Some(file)
@@ -2519,6 +2532,37 @@ mod tests {
         // Verify target file remains completely untouched
         let content = std::fs::read_to_string(&target).unwrap();
         assert_eq!(content, "sensitive target content");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn maybe_trigger_prefetch_refuses_symlinked_build_session() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let target = temp.path().join("target_file");
+        std::fs::write(&target, "target content").unwrap();
+
+        let marker = temp.path().join(".build-session");
+        std::os::unix::fs::symlink(&target, &marker).unwrap();
+
+        let mut config = test_config(temp.path().to_path_buf());
+        // Enable remote so prefetch actually triggers its path
+        config.remote = Some(crate::config::RemoteConfig {
+            bucket: "test-bucket".to_string(),
+            endpoint: Some("http://localhost".to_string()),
+            region: "us-east-1".to_string(),
+            prefix: "kache/".to_string(),
+            profile: None,
+        });
+
+        // Use dummy args
+        let args = rustc_args(&["rustc", "foo.rs"]);
+
+        // This must NOT modify the target file
+        super::maybe_trigger_prefetch(&config, &args);
+
+        // Verify target file remains completely untouched
+        let content = std::fs::read_to_string(&target).unwrap();
+        assert_eq!(content, "target content");
     }
 
     // ── Opportunistic size-pressure GC (kunobi-ninja/kache#497) ─────────────

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -132,16 +132,16 @@ pub(crate) fn warn_marker_path(kind: &str, cache_dir: &Path) -> PathBuf {
 ///
 /// Returns whether this call actually emitted the message (for tests).
 pub(crate) fn warn_once_per_session(marker: &Path, session_secs: u64, message: &str) -> bool {
+    if let Ok(metadata) = std::fs::symlink_metadata(marker)
+        && metadata.file_type().is_symlink()
+    {
+        eprintln!("{message}");
+        return true;
+    }
     if marker_is_fresh(marker, session_secs) {
         return false; // already warned this session
     }
-    let Ok(lock_file) = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(marker)
-    else {
+    let Some(lock_file) = open_marker_for_lock(marker) else {
         eprintln!("{message}");
         return true;
     };
@@ -2158,12 +2158,7 @@ fn maybe_trigger_prefetch(config: &Config, args: &RustcArgs) {
     // Marker is stale or missing — try to acquire an exclusive lock so only
     // one process does the (expensive) cargo-metadata + daemon RPC.
     let _ = std::fs::create_dir_all(&config.cache_dir);
-    let Ok(lock_file) = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(&marker)
-    else {
+    let Some(lock_file) = open_marker_for_lock(&marker) else {
         return;
     };
     // std::fs::File::try_lock (1.89+) is cross-platform: flock(2) on Unix,
@@ -2174,7 +2169,7 @@ fn maybe_trigger_prefetch(config: &Config, args: &RustcArgs) {
 
     // Re-check under the lock — another process may have updated the marker
     // between our first check and acquiring the lock.
-    if marker_is_fresh(&marker, session_timeout_secs) {
+    if marker_file_is_fresh(&lock_file, session_timeout_secs) {
         return;
     }
 
@@ -2212,8 +2207,54 @@ fn maybe_trigger_prefetch(config: &Config, args: &RustcArgs) {
     write_marker_timestamp(&lock_file);
 }
 
+/// Open a marker file safely for locking and updating. Refuses symlinks and
+/// non-regular files up front, and opens with `O_NOFOLLOW` on Unix to prevent
+/// symlink attacks and arbitrary file truncation in shared temporary directories.
+fn open_marker_for_lock(marker: &Path) -> Option<std::fs::File> {
+    if let Ok(metadata) = std::fs::symlink_metadata(marker)
+        && (metadata.file_type().is_symlink() || !metadata.file_type().is_file())
+    {
+        return None;
+    }
+
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true).write(true).create(true).truncate(false);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        // FILE_FLAG_OPEN_REPARSE_POINT (0x00200000) opens the reparse point itself
+        // without following it to the target file.
+        options.custom_flags(0x0020_0000);
+    }
+
+    let file = options.open(marker).ok()?;
+
+    // Post-open verification: ensure the opened file handle itself is a regular file.
+    if let Ok(meta) = file.metadata()
+        && !meta.file_type().is_file()
+    {
+        return None;
+    }
+
+    Some(file)
+}
+
 /// Check if the marker file contains a timestamp within `timeout_secs` of now.
+/// Returns `false` if the marker does not exist, contains a stale/corrupt
+/// timestamp, or is a symlink/non-regular file.
 fn marker_is_fresh(marker: &std::path::Path, timeout_secs: u64) -> bool {
+    if let Ok(metadata) = std::fs::symlink_metadata(marker)
+        && (metadata.file_type().is_symlink() || !metadata.file_type().is_file())
+    {
+        return false;
+    }
     let content = match std::fs::read_to_string(marker) {
         Ok(c) if !c.is_empty() => c,
         _ => return false,
@@ -2440,6 +2481,44 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(&marker);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn warn_once_per_session_refuses_symlink() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let target = temp.path().join("target_file");
+        std::fs::write(&target, "some sensitive content").unwrap();
+
+        let marker = temp.path().join("marker_symlink");
+        std::os::unix::fs::symlink(&target, &marker).unwrap();
+
+        // If we call warn_once_per_session, it should print the message,
+        // but it MUST NOT truncate or modify the target file!
+        let warned = warn_once_per_session(&marker, 300, "warning message");
+        assert!(warned);
+
+        // Verify target file is untouched.
+        let content = std::fs::read_to_string(&target).unwrap();
+        assert_eq!(content, "some sensitive content");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn open_marker_for_lock_refuses_symlink_target() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let target = temp.path().join("target_file");
+        std::fs::write(&target, "sensitive target content").unwrap();
+
+        let marker = temp.path().join("marker_symlink");
+        std::os::unix::fs::symlink(&target, &marker).unwrap();
+
+        // open_marker_for_lock must refuse symlink targets up front
+        assert!(open_marker_for_lock(&marker).is_none());
+
+        // Verify target file remains completely untouched
+        let content = std::fs::read_to_string(&target).unwrap();
+        assert_eq!(content, "sensitive target content");
     }
 
     // ── Opportunistic size-pressure GC (kunobi-ninja/kache#497) ─────────────


### PR DESCRIPTION
## Summary

Prevent `warn_once_per_session` from following symbolic links when accessing warning marker files.

Warning marker files are stored under `std::env::temp_dir()` and are used to deduplicate warning messages across a session. This change adds defensive checks to ensure that symlinked marker paths are not followed when reading or updating marker files.

## Changes

- Detect symlinked marker paths using `std::fs::symlink_metadata`.
- Skip reading timestamp data from symlinked marker files.
- On Unix, open marker files with `O_NOFOLLOW` to prevent following symbolic links during `open`.
- Add a regression test verifying that symlinked marker paths do not modify the target file.

### Before

```text
warn_once_per_session()
    ↓
Open marker file
    ↓
Follow symlinks if present
    ↓
Update marker timestamp
```

### After

```text
warn_once_per_session()
    ↓
Reject symlinked marker paths
    ↓
Open with O_NOFOLLOW (Unix)
    ↓
Update timestamp only for regular marker files
```