### PR TITLE
feat(store): hardlink immutable blobs when CoW reflink is unavailable

### DIFF
--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -308,7 +308,7 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
 
     // Snapshot the volume's free space before any build runs, so the real
     // footprint of the cold+warm builds can be measured (free-space delta) and
-    // used to VERIFY the CoW-corrected disk-layout estimate. Only on a full
+    // used to VERIFY the sharing-corrected disk-layout estimate. Only on a full
     // run: on `--retry` cold is restored from a snapshot rather than built, so
     // the delta would not cover the cold pool. Clones already exist at this
     // point; the cache and objdirs do not (cold wipes the cache first).
@@ -426,20 +426,29 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     let cold_objdir_bytes = dir_size_kb(&clone_a.join(&objdir)).saturating_mul(1024);
     let warm_objdir_bytes = dir_size_kb(&clone_b.join(&objdir)).saturating_mul(1024);
 
-    // Verify: the measured free-space delta should land near the CoW-corrected
-    // estimate of the three-pool footprint. They agree on any filesystem — on
-    // a CoW one because the shared bytes are subtracted, on a non-CoW one
-    // because nothing is shared and the estimate stays at the apparent sum. A
-    // gap therefore means the storage byte accounting is off (not merely "no
-    // CoW"), which is worth surfacing. A 20% band absorbs the cache snapshot,
-    // logs, and df noise.
+    // Verify: the measured free-space delta should land near the
+    // sharing-corrected estimate of the three-pool footprint. They agree on
+    // any filesystem — on a CoW one because the shared bytes are subtracted,
+    // on a non-CoW one because hardlinked shared bytes are subtracted the same
+    // way (or nothing is shared and the estimate stays at the apparent sum).
+    // A gap therefore means the storage byte accounting is off (not merely
+    // "no CoW"), which is worth surfacing. A 20% band absorbs the cache
+    // snapshot, logs, and df noise.
     if let Some(measured) = disk_measured_bytes {
         let warm_st = &warm_metrics.storage;
+        // Hardlinked bytes (store ingest and warm restore) are one inode in
+        // two pools, exactly like reflinked bytes — both are sharing, not a
+        // second copy, so both are subtracted from the apparent sum.
         let store_shared = cold_metrics
             .storage
             .store_reflinked_bytes
-            .saturating_add(warm_st.store_reflinked_bytes);
-        let shared_total = warm_st.reflinked_bytes.saturating_add(store_shared);
+            .saturating_add(cold_metrics.storage.store_hardlinked_bytes)
+            .saturating_add(warm_st.store_reflinked_bytes)
+            .saturating_add(warm_st.store_hardlinked_bytes);
+        let shared_total = warm_st
+            .reflinked_bytes
+            .saturating_add(warm_st.hardlinked_bytes)
+            .saturating_add(store_shared);
         let sum_apparent = cold_objdir_bytes
             .saturating_add(warm_objdir_bytes)
             .saturating_add(warm_st.blob_bytes);
@@ -448,7 +457,7 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
             && measured >= estimate.saturating_mul(4) / 5;
         if estimate > 0 && !within_band {
             measure_warnings.push(format!(
-                "disk: measured on-disk {} diverges from the CoW-corrected estimate {} \
+                "disk: measured on-disk {} diverges from the sharing-corrected estimate {} \
                  (apparent {}) — storage byte accounting may be off",
                 human_bytes(measured),
                 human_bytes(estimate),
@@ -2392,37 +2401,46 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
 
     // ── disk layout: the three pools and what sharing buys ──
     // Apparent = sum of file lengths. The same physical blocks appear in more
-    // than one pool's apparent size whenever kache CoW-reflinked them, so the
-    // naive sum triple-counts shared content. Three distinct sharings exist,
-    // and each is now a measured byte count (not an untallied side effect):
-    //   • warm RESTORE reflink  — clone-b/obj bytes that share with the cache
-    //   • cold STORE reflink    — cache blobs that share with clone-a/obj (the
-    //                             blob was cloned from the cold build's output)
-    //   • warm STORE reflink    — cache blobs from warm misses that share with
-    //                             clone-b/obj
+    // than one pool's apparent size whenever kache CoW-reflinked (or, on a
+    // non-CoW filesystem, hardlinked) them, so the naive sum triple-counts
+    // shared content. Three distinct sharings exist, and each is now a
+    // measured byte count (not an untallied side effect):
+    //   • warm RESTORE reflink/hardlink — clone-b/obj bytes that share with
+    //                             the cache
+    //   • cold STORE reflink/hardlink — cache blobs that share with
+    //                             clone-a/obj (the blob was cloned or linked
+    //                             from the cold build's output)
+    //   • warm STORE reflink/hardlink — cache blobs from warm misses that
+    //                             share with clone-b/obj
     // Subtracting all three from the apparent sum yields the real footprint.
     let cold_st = &r.cold.storage;
     let store_shared = cold_st
         .store_reflinked_bytes
-        .saturating_add(st.store_reflinked_bytes);
-    let shared_total = st.reflinked_bytes.saturating_add(store_shared);
+        .saturating_add(cold_st.store_hardlinked_bytes)
+        .saturating_add(st.store_reflinked_bytes)
+        .saturating_add(st.store_hardlinked_bytes);
+    let shared_total = st
+        .reflinked_bytes
+        .saturating_add(st.hardlinked_bytes)
+        .saturating_add(store_shared);
     let sum_apparent = r
         .cold_objdir_bytes
         .saturating_add(r.warm_objdir_bytes)
         .saturating_add(st.blob_bytes);
     let approx_on_disk = sum_apparent.saturating_sub(shared_total);
-    eprintln!("  disk layout — three pools, sharing blocks via CoW reflinks");
+    let restore_shared = st.reflinked_bytes.saturating_add(st.hardlinked_bytes);
+    eprintln!("  disk layout — three pools, sharing via reflink/hardlink");
     eprintln!(
         "    clone-a/obj   {:>10}   cold-built objdir",
         human_bytes(r.cold_objdir_bytes)
     );
     eprintln!(
-        "    clone-b/obj   {:>10}   warm-built; {} reflinked from cache",
+        "    clone-b/obj   {:>10}   warm-built; {} shared from cache",
         human_bytes(r.warm_objdir_bytes),
-        human_bytes(st.reflinked_bytes),
+        human_bytes(restore_shared),
     );
     eprintln!(
-        "    kache cache   {:>10}   {} blobs; {} reflinked from build output, {} copied",
+        "    kache cache   {:>10}   {} blobs; {} shared from build output, {} copied",
         human_bytes(st.blob_bytes),
         st.store_blobs,
         human_bytes(store_shared),
@@ -2444,10 +2462,10 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
         human_bytes(sum_apparent),
     );
     eprintln!(
-        "    ≈ on disk    ~{:>10}   CoW sharing saves {} ({} restore + {} store)",
+        "    ≈ on disk    ~{:>10}   zero-copy sharing saves {} ({} restore + {} store)",
         human_bytes(approx_on_disk),
         human_bytes(shared_total),
-        human_bytes(st.reflinked_bytes),
+        human_bytes(restore_shared),
         human_bytes(store_shared),
     );
     if let Some(measured) = r.disk_measured_bytes {
@@ -2757,6 +2775,11 @@ struct StorageInfo {
     /// The disk-layout estimate subtracts these (they're double-counted in the
     /// apparent objdir + cache sum).
     store_reflinked_bytes: u64,
+    /// Bytes that entered the store by a hardlink (non-CoW filesystem,
+    /// immutable artifact kinds) — one inode appearing in both the objdir and
+    /// the store, so like reflinked bytes they are subtracted from the
+    /// estimate.
+    store_hardlinked_bytes: u64,
     /// Bytes that entered the store by a full copy (no CoW) — a genuine second
     /// copy, so they are NOT subtracted from the on-disk estimate.
     store_copied_bytes: u64,
@@ -2784,6 +2807,7 @@ impl StorageInfo {
             restored_bytes: u("restored_bytes"),
             zero_copy_pct: st["zero_copy_pct"].as_f64().unwrap_or(0.0),
             store_reflinked_bytes: u("store_reflinked_bytes"),
+            store_hardlinked_bytes: u("store_hardlinked_bytes"),
             store_copied_bytes: u("store_copied_bytes"),
             store_blobs: u("store_blobs"),
             logical_bytes: u("logical_bytes"),
@@ -3405,6 +3429,7 @@ mod tests {
                 restored_bytes: 0,
                 zero_copy_pct: 0.0,
                 store_reflinked_bytes: 0,
+                store_hardlinked_bytes: 0,
                 store_copied_bytes: 0,
                 store_blobs: 0,
                 logical_bytes: 0,

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -52,10 +52,22 @@ fn rename_backoff_ms(attempt: u32) -> u64 {
 
 /// Remove a file, clearing the read-only attribute first to ensure deletion
 /// succeeds even on Windows when the file was marked read-only.
+///
+/// On Unix, when the path is one of several hardlinks (`nlink > 1`), the RO bit
+/// is left alone: clearing it would make every name on the shared inode
+/// writable (including a published content-addressed blob the temp still
+/// shares). Unlink alone is enough — the remaining names keep their mode.
 fn remove_file_robust(path: &Path) -> std::io::Result<()> {
     if let Ok(meta) = fs::metadata(path) {
         let mut perms = meta.permissions();
         if perms.readonly() {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::MetadataExt;
+                if meta.nlink() > 1 {
+                    return fs::remove_file(path);
+                }
+            }
             perms.set_readonly(false);
             let _ = fs::set_permissions(path, perms);
         }
@@ -80,6 +92,23 @@ pub(crate) fn atomic_write_and_replace<F>(
 where
     F: FnOnce(&Path) -> Result<()>,
 {
+    atomic_write_and_replace_with(dest_path, allow_concurrent_winner, write_fn, |_| Ok(()))
+}
+
+/// Like [`atomic_write_and_replace`], but runs `after_fsync` on the temp path
+/// after the durable flush and before the rename. Used by store hardlink ingest
+/// to enforce the read-only guard on a shared inode only once fsync has
+/// finished (Windows `FlushFileBuffers` needs a writable handle, #196).
+pub(crate) fn atomic_write_and_replace_with<F, A>(
+    dest_path: &Path,
+    allow_concurrent_winner: bool,
+    write_fn: F,
+    after_fsync: A,
+) -> Result<bool>
+where
+    F: FnOnce(&Path) -> Result<()>,
+    A: FnOnce(&Path) -> Result<()>,
+{
     let nonce = ATOMIC_TMP_NONCE.fetch_add(1, Ordering::Relaxed);
     let pid = std::process::id();
     let file_name = dest_path
@@ -91,6 +120,7 @@ where
     let res = (|| -> Result<()> {
         write_fn(&temp_path)?;
         fsync_file(&temp_path).context("flushing temp file")?;
+        after_fsync(&temp_path)?;
         Ok(())
     })();
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4994,6 +4994,7 @@ mod tests {
             hardlinked_bytes: 0,
             copied_bytes: 0,
             store_reflinked_bytes: 0,
+            store_hardlinked_bytes: 0,
             store_copied_bytes: 0,
             root: String::new(),
             passthrough_reason: String::new(),

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -3660,19 +3660,35 @@ where
 /// MISS for the same translation unit (e.g. the source was edited), the
 /// compiler tries to overwrite these paths in place and fails with
 /// EACCES / "operation not permitted" (observed with gcc, clang, and
-/// clang-cl on Windows).  A chmod cannot help because the inode is
-/// shared: making it writable would mutate the store blob. The correct
-/// fix is to unlink the file first: a plain `remove_file` breaks the
-/// hardlink and leaves the store blob untouched, exactly as
-/// `compile::pre_clean_outputs` does for the rustc path.
+/// clang-cl on Windows).  A chmod-to-writable cannot substitute for the
+/// unlink because the inode is shared: writing through it would mutate
+/// the store blob. The correct fix is to unlink the file first: a
+/// `remove_file` breaks the hardlink and leaves the store blob
+/// untouched, exactly as `compile::pre_clean_outputs` does for the
+/// rustc path. On Windows a read-only file cannot be deleted at all, so
+/// the read-only attribute is cleared immediately before the unlink
+/// (same as `remove_if_readonly` on the rustc path and `clear_target`
+/// on restore) — under the `windows_hardlink` opt-in both hit and miss
+/// outputs can be read-only hardlinks.
 ///
 /// Best-effort: a missing file is fine; errors are silently ignored.
 pub(crate) fn pre_clean_cc_outputs(parsed: &CcArgs) {
+    fn remove_output(path: &std::path::Path) {
+        #[cfg(windows)]
+        if let Ok(meta) = std::fs::metadata(path)
+            && meta.permissions().readonly()
+        {
+            let mut perms = meta.permissions();
+            perms.set_readonly(false);
+            let _ = std::fs::set_permissions(path, perms);
+        }
+        let _ = std::fs::remove_file(path);
+    }
     if let Some(obj) = parsed.object_output_path() {
-        let _ = std::fs::remove_file(&obj);
+        remove_output(&obj);
     }
     if let Some(dep) = parsed.depinfo_output_path() {
-        let _ = std::fs::remove_file(&dep);
+        remove_output(&dep);
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -99,8 +99,14 @@ pub struct BuildEvent {
     /// disk (APFS / btrfs / XFS-with-reflink).
     #[serde(default)]
     pub store_reflinked_bytes: u64,
+    /// Bytes ingested into the store by a hardlink on a miss — the blob
+    /// shares an inode with the build's own output, zero-copy on filesystems
+    /// without CoW (immutable artifact kinds only).
+    #[serde(default)]
+    pub store_hardlinked_bytes: u64,
     /// Bytes ingested into the store by a full physical copy on a miss — a
-    /// genuine second copy, the fallback on a filesystem without CoW.
+    /// genuine second copy, the fallback when neither reflink nor hardlink
+    /// is available.
     #[serde(default)]
     pub store_copied_bytes: u64,
     /// Why kache passed the invocation through instead of caching it.
@@ -568,6 +574,9 @@ pub struct EventStats {
     /// Bytes ingested into the store by a CoW reflink (shares blocks with the
     /// build's output — not a second physical copy).
     pub store_reflinked_bytes: u64,
+    /// Bytes ingested into the store by a hardlink (shares an inode with the
+    /// build's output — not a second physical copy).
+    pub store_hardlinked_bytes: u64,
     /// Bytes ingested into the store by a full physical copy (a real second copy).
     pub store_copied_bytes: u64,
 }
@@ -598,6 +607,7 @@ pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
         hardlinked_bytes: 0,
         copied_bytes: 0,
         store_reflinked_bytes: 0,
+        store_hardlinked_bytes: 0,
         store_copied_bytes: 0,
     };
 
@@ -652,6 +662,7 @@ pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
         stats.hardlinked_bytes += event.hardlinked_bytes;
         stats.copied_bytes += event.copied_bytes;
         stats.store_reflinked_bytes += event.store_reflinked_bytes;
+        stats.store_hardlinked_bytes += event.store_hardlinked_bytes;
         stats.store_copied_bytes += event.store_copied_bytes;
     }
 
@@ -698,6 +709,7 @@ mod tests {
             hardlinked_bytes: 0,
             copied_bytes: 0,
             store_reflinked_bytes: 0,
+            store_hardlinked_bytes: 0,
             store_copied_bytes: 0,
             passthrough_reason: String::new(),
             fallback: false,
@@ -738,6 +750,7 @@ mod tests {
             hardlinked_bytes: 0,
             copied_bytes: 0,
             store_reflinked_bytes: 0,
+            store_hardlinked_bytes: 0,
             store_copied_bytes: 0,
             passthrough_reason: String::new(),
             fallback: false,

--- a/src/link.rs
+++ b/src/link.rs
@@ -24,6 +24,15 @@ pub fn set_windows_hardlink_restore(enabled: bool) {
     WINDOWS_HARDLINK_RESTORE.store(enabled, Ordering::Relaxed);
 }
 
+/// Is the `[cache] windows_hardlink` opt-in active for this process?
+/// The store's insert-side blob hardlinking keys off the same flag as
+/// restore: without it, a hardlink would propagate the blob's read-only
+/// attribute to the build's own output (shared MFT record, #429).
+#[cfg(windows)]
+pub(crate) fn windows_hardlink_enabled() -> bool {
+    WINDOWS_HARDLINK_RESTORE.load(Ordering::Relaxed)
+}
+
 /// Set the cross-process dedup marker for the no-CoW advisory. Call once per
 /// process before restoring. No effect off Windows.
 #[cfg_attr(not(windows), allow(unused_variables))]
@@ -839,10 +848,11 @@ pub fn rewrite_depinfo(depinfo_path: &Path, project_dir: &Path, mode: DepInfoMod
 
     // Defense-in-depth: if the file is hardlinked (nlink > 1), unlink
     // first so the in-place write can't mutate a shared inode. On the
-    // store side `Store::put` copies blobs rather than hardlinking, so
-    // this rarely fires — but it keeps `rewrite_depinfo` safe for any
-    // caller. Windows exposes no portable nlink count; remove
-    // unconditionally there.
+    // store side `Store::put` never hardlinks `.d` blobs (DepInfo is
+    // excluded from insert-side hardlinking precisely because of this
+    // post-put in-place rewrite), so this rarely fires — but it keeps
+    // `rewrite_depinfo` safe for any caller. Windows exposes no portable
+    // nlink count; remove unconditionally there.
     #[cfg(unix)]
     if let Ok(meta) = fs::metadata(depinfo_path) {
         use std::os::unix::fs::MetadataExt;

--- a/src/opcounts.rs
+++ b/src/opcounts.rs
@@ -109,15 +109,18 @@ pub fn copied_bytes() -> u64 {
 // artifact entered the content-addressed store on a miss. The store tries a
 // CoW reflink (clonefile / FICLONE) first, so on APFS / btrfs / XFS-with-reflink
 // the blob shares blocks with the build's own output file — storing costs
-// ~no physical bytes. It falls back to a full copy on a filesystem without CoW
-// (ext4 without reflink, tmpfs, a cross-volume store).
+// ~no physical bytes. Without CoW (ext4 without reflink, tmpfs) it hardlinks
+// immutable artifact kinds (shared inode, still zero-copy), and only falls
+// back to a full copy where neither is possible (mutable kinds, a
+// cross-volume store).
 //
 // Splitting store bytes by mechanism is what lets `kache report` (and the
-// clone benchmark) account for disk honestly: a blob reflinked from the
-// objdir is NOT a second physical copy, so a naive "objdir + store" sum
-// double-counts it. Deterministic given the same source + filesystem.
+// clone benchmark) account for disk honestly: a blob reflinked or hardlinked
+// from the objdir is NOT a second physical copy, so a naive "objdir + store"
+// sum double-counts it. Deterministic given the same source + filesystem.
 
 static STORE_REFLINKED_BYTES: AtomicU64 = AtomicU64::new(0);
+static STORE_HARDLINKED_BYTES: AtomicU64 = AtomicU64::new(0);
 static STORE_COPIED_BYTES: AtomicU64 = AtomicU64::new(0);
 
 /// Record `bytes` ingested into the store by a CoW reflink (shares blocks
@@ -126,8 +129,14 @@ pub fn record_store_reflinked(bytes: u64) {
     STORE_REFLINKED_BYTES.fetch_add(bytes, Ordering::Relaxed);
 }
 
-/// Record `bytes` ingested into the store by a full physical copy (the
-/// filesystem has no CoW, so the blob is a genuine second copy).
+/// Record `bytes` ingested into the store by a hardlink (shares an inode
+/// with the build's output file — zero-copy on filesystems without CoW).
+pub fn record_store_hardlinked(bytes: u64) {
+    STORE_HARDLINKED_BYTES.fetch_add(bytes, Ordering::Relaxed);
+}
+
+/// Record `bytes` ingested into the store by a full physical copy (no
+/// reflink, no hardlink — the blob is a genuine second copy).
 pub fn record_store_copied(bytes: u64) {
     STORE_COPIED_BYTES.fetch_add(bytes, Ordering::Relaxed);
 }
@@ -135,6 +144,11 @@ pub fn record_store_copied(bytes: u64) {
 /// Bytes ingested into the store by CoW reflink so far in this process.
 pub fn store_reflinked_bytes() -> u64 {
     STORE_REFLINKED_BYTES.load(Ordering::Relaxed)
+}
+
+/// Bytes ingested into the store by hardlink so far in this process.
+pub fn store_hardlinked_bytes() -> u64 {
+    STORE_HARDLINKED_BYTES.load(Ordering::Relaxed)
 }
 
 /// Bytes ingested into the store by a full copy so far in this process.
@@ -183,9 +197,13 @@ mod tests {
 
     #[test]
     fn store_byte_counters_increment_monotonically() {
-        let before = store_reflinked_bytes() + store_copied_bytes();
+        let before = store_reflinked_bytes() + store_hardlinked_bytes() + store_copied_bytes();
         record_store_reflinked(128);
+        record_store_hardlinked(32);
         record_store_copied(64);
-        assert!(store_reflinked_bytes() + store_copied_bytes() >= before + 192);
+        assert!(
+            store_reflinked_bytes() + store_hardlinked_bytes() + store_copied_bytes()
+                >= before + 224
+        );
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -159,9 +159,9 @@ pub struct TimingBreakdown {
 ///
 /// **Store side** — content-addressed dedup: an artifact whose content is
 /// already in the store is referenced, not stored a second time. And how a
-/// new blob entered the store: a CoW reflink (shares blocks with the build's
-/// own output — not a second physical copy) or a full copy on a filesystem
-/// without CoW.
+/// new blob entered the store: a CoW reflink first (shares blocks with the
+/// build's own output), then a hardlink for immutable kinds when CoW is
+/// unavailable (shared inode), then a full copy.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StorageBreakdown {
     /// Bytes restored by CoW reflink — zero physical copy.
@@ -177,8 +177,12 @@ pub struct StorageBreakdown {
     /// Bytes ingested into the store by a CoW reflink (shares blocks with the
     /// build's output — the store is not a second physical copy of these).
     pub store_reflinked_bytes: u64,
+    /// Bytes ingested into the store by a hardlink (shares an inode with the
+    /// build's output — zero-copy on filesystems without CoW).
+    #[serde(default)]
+    pub store_hardlinked_bytes: u64,
     /// Bytes ingested into the store by a full physical copy (a real second
-    /// copy — the fallback on a filesystem without CoW).
+    /// copy — the fallback when neither reflink nor hardlink is available).
     pub store_copied_bytes: u64,
     /// Unique content-addressed blobs in the local store.
     pub store_blobs: u64,
@@ -601,6 +605,7 @@ pub fn generate_report_with_filter(
             0.0
         },
         store_reflinked_bytes: stats.store_reflinked_bytes,
+        store_hardlinked_bytes: stats.store_hardlinked_bytes,
         store_copied_bytes: stats.store_copied_bytes,
         store_blobs: blob_stats.total_blobs as u64,
         logical_bytes: blob_stats.total_logical_size,
@@ -1510,6 +1515,7 @@ fn has_storage_data(storage: &StorageBreakdown) -> bool {
         || storage.blob_bytes > 0
         || storage.dedup_saved_bytes > 0
         || storage.store_reflinked_bytes > 0
+        || storage.store_hardlinked_bytes > 0
         || storage.store_copied_bytes > 0
 }
 
@@ -1538,16 +1544,20 @@ fn push_storage_table(lines: &mut Vec<String>, storage: &StorageBreakdown) {
         ));
         lines.push(format!("| Store blobs | {} |", storage.store_blobs));
     }
-    let ingested = storage.store_reflinked_bytes + storage.store_copied_bytes;
+    let ingested =
+        storage.store_reflinked_bytes + storage.store_hardlinked_bytes + storage.store_copied_bytes;
     if ingested > 0 {
-        // Reflinked ingest shares blocks with the build's own output, so it
-        // adds ~no physical disk; only copied ingest is a genuine second copy.
-        let reflink_pct = storage.store_reflinked_bytes as f64 / ingested as f64 * 100.0;
+        // Reflinked and hardlinked ingest share storage with the build's own
+        // output, so they add ~no physical disk; only copied ingest is a
+        // genuine second copy.
+        let zero_copy = storage.store_reflinked_bytes + storage.store_hardlinked_bytes;
+        let zero_copy_pct = zero_copy as f64 / ingested as f64 * 100.0;
         lines.push(format!(
-            "| Store ingest | {} reflinked (CoW), {} copied — {:.1}% shared with build output |",
+            "| Store ingest | {} reflinked (CoW), {} hardlinked, {} copied — {:.1}% shared with build output |",
             format_bytes(storage.store_reflinked_bytes),
+            format_bytes(storage.store_hardlinked_bytes),
             format_bytes(storage.store_copied_bytes),
-            (reflink_pct * 10.0).round() / 10.0,
+            (zero_copy_pct * 10.0).round() / 10.0,
         ));
     }
 }
@@ -2794,6 +2804,7 @@ mod tests {
             hardlinked_bytes: 0,
             copied_bytes: 0,
             store_reflinked_bytes: 0,
+            store_hardlinked_bytes: 0,
             store_copied_bytes: 0,
             passthrough_reason: String::new(),
             fallback: false,
@@ -3598,6 +3609,7 @@ mod tests {
             blob_bytes: 2048,
             dedup_saved_bytes: 2048,
             store_reflinked_bytes: 0,
+            store_hardlinked_bytes: 0,
             store_copied_bytes: 0,
         };
         report.gc = Some(GcSummary {
@@ -3907,6 +3919,7 @@ mod tests {
             blob_bytes: 3000,
             dedup_saved_bytes: 2000,
             store_reflinked_bytes: 0,
+            store_hardlinked_bytes: 0,
             store_copied_bytes: 0,
         };
         let mut lines = Vec::new();
@@ -3962,8 +3975,9 @@ mod tests {
 
     #[test]
     fn push_storage_table_renders_store_ingest_line() {
-        // Non-zero store ingest (reflinked + copied bytes from importing remote
-        // entries) renders the "Store ingest" line with a reflink-share %.
+        // Non-zero store ingest (reflinked + hardlinked + copied bytes)
+        // renders the "Store ingest" line with a zero-copy-share % that
+        // counts both reflinked and hardlinked bytes as shared.
         // Covers push_storage_table's ingest>0 branch.
         let storage = StorageBreakdown {
             reflinked_bytes: 0,
@@ -3975,7 +3989,8 @@ mod tests {
             logical_bytes: 4096,
             blob_bytes: 2048,
             dedup_saved_bytes: 0,
-            store_reflinked_bytes: 3000,
+            store_reflinked_bytes: 2000,
+            store_hardlinked_bytes: 1000,
             store_copied_bytes: 1000,
         };
         let mut lines = Vec::new();
@@ -3983,6 +3998,11 @@ mod tests {
         let joined = lines.join("\n");
         assert!(joined.contains("Store ingest"), "got: {joined}");
         assert!(joined.contains("reflinked (CoW)"));
+        assert!(joined.contains("hardlinked"), "got: {joined}");
+        assert!(
+            joined.contains("75.0% shared with build output"),
+            "hardlinked ingest must count toward the shared %: {joined}"
+        );
     }
 
     #[test]
@@ -4003,6 +4023,7 @@ mod tests {
             blob_bytes: 5000,
             dedup_saved_bytes: 4000,
             store_reflinked_bytes: 0,
+            store_hardlinked_bytes: 0,
             store_copied_bytes: 0,
         };
         let gh = format_github(&report);

--- a/src/store.rs
+++ b/src/store.rs
@@ -24,11 +24,17 @@ impl StorePutResult {
 /// Mark a blob read-only so accidental writes can't corrupt the shared,
 /// content-addressed copy. Best-effort.
 fn set_blob_readonly(blob: &Path) {
-    if let Ok(meta) = fs::metadata(blob) {
-        let mut perms = meta.permissions();
-        perms.set_readonly(true);
-        let _ = fs::set_permissions(blob, perms);
-    }
+    let _ = set_blob_readonly_checked(blob);
+}
+
+/// Mark a blob read-only, reporting failure. The hardlink ingest path needs
+/// the result: there the guard is a correctness requirement (the blob shares
+/// an inode with the build's own output), not a courtesy.
+fn set_blob_readonly_checked(blob: &Path) -> std::io::Result<()> {
+    let meta = fs::metadata(blob)?;
+    let mut perms = meta.permissions();
+    perms.set_readonly(true);
+    fs::set_permissions(blob, perms)
 }
 
 /// Is `name` exactly a content-blob filename: 64 lowercase hex chars (a
@@ -50,8 +56,63 @@ fn unlink_blob(blob: &Path) {
             perms.set_readonly(false);
             let _ = fs::set_permissions(blob, perms);
         }
-        let _ = fs::remove_file(blob);
+        if fs::remove_file(blob).is_err() && blob.exists() {
+            // Removal can fail transiently on Windows (sharing violation /
+            // delete-pending). The surviving blob may share an inode with a
+            // live build output (insert/restore hardlinks), so re-arm the
+            // read-only guard rather than leaving a writable blob behind.
+            set_blob_readonly(blob);
+        }
     }
+}
+
+/// May a freshly-compiled output be HARDLINKED into the blob store when the
+/// filesystem has no CoW reflink?
+///
+/// Mirrors the restore side's [`ArtifactKind::link_strategy`] reasoning:
+/// immutable kinds (`.rlib` / `.rmeta` / `.o` / …) may share an inode with the
+/// store blob because the build never mutates them in place — the same
+/// contract a warm restore already imposes, where these outputs *are*
+/// read-only hardlinks of blobs (and `prepare_output_paths` pre-cleans them
+/// before a recompile). Mutable kinds (executables, dylibs — codesigning,
+/// stripping) must stay independent so a post-build mutation can't reach the
+/// content-addressed blob.
+///
+/// Three insert-side tightenings versus restore:
+/// - `DepInfo` is excluded: the wrapper rewrites the build's `.d` in place
+///   *after* `put` (`DepInfoMode::Expand`), and restore never hardlinks `.d`
+///   either (it materializes via `write_restored`).
+/// - restore classifies with full compile context; here only the stored
+///   filename is available, so an extensionless name (a bin executable by
+///   rustc's Unix convention) or anything carrying an executable mode bit is
+///   excluded rather than defaulted to hardlink.
+/// - on Windows a hardlink would propagate the blob's read-only attribute to
+///   the build's own output (shared MFT record, #429), so insert hardlinks
+///   only under the same `[cache] windows_hardlink` opt-in as restore.
+fn hardlink_eligible(store_name: &str, executable: bool) -> bool {
+    use crate::compiler::{ArtifactKind, classify_by_filename};
+    if executable {
+        return false;
+    }
+    #[cfg(windows)]
+    if !crate::link::windows_hardlink_enabled() {
+        return false;
+    }
+    match classify_by_filename(store_name) {
+        ArtifactKind::DepInfo | ArtifactKind::Other("extensionless") => false,
+        kind => kind.link_strategy() == crate::link::LinkStrategy::Hardlink,
+    }
+}
+
+/// How a new blob was staged into the store before publish. Counters are
+/// recorded only when this call actually publishes (`atomic_write_and_replace`
+/// returns `true`); a concurrent winner already accounted for their ingest,
+/// and counting a discarded temp would over-claim zero-copy sharing.
+#[derive(Clone, Copy)]
+enum StoreIngest {
+    Reflink,
+    Hardlink,
+    Copy,
 }
 
 /// Durably materialize `source` into the content-addressed store at `blob`,
@@ -59,37 +120,159 @@ fn unlink_blob(blob: &Path) {
 /// atomic rename, mark read-only. Idempotent — when the blob is present this
 /// is just a `stat`.
 ///
-/// The temp is created by a CoW reflink first, falling back to a full byte
-/// copy on a filesystem without copy-on-write. On APFS / btrfs / XFS-with-
-/// reflink the blob then shares physical blocks with the build's own output
-/// file, so storing costs ~no extra disk — the store is not a second copy.
-/// Whichever path runs is recorded (`record_store_reflinked` /
-/// `record_store_copied`) so `kache report` can account for disk honestly,
-/// mirroring the restore side in `link.rs`.
-fn materialize_blob(source: &Path, blob: &Path, _hash: &str) -> Result<()> {
+/// The temp is created by a CoW reflink first. Where the filesystem has no
+/// copy-on-write (ext4 without reflink, tmpfs), `allow_hardlink` — decided
+/// per file by [`hardlink_eligible`] — permits a hardlink fallback: the blob
+/// then shares an inode with the build's own output, exactly the state a warm
+/// restore produces for these kinds, and `set_blob_readonly` below applies to
+/// both names. Only when neither zero-copy path is available (or allowed)
+/// does the blob become a genuine second physical copy. On APFS / btrfs /
+/// XFS-with-reflink the reflink wins and the blob shares physical blocks with
+/// the build's output — storing costs ~no extra disk. Whichever path runs is
+/// recorded **after a successful publish** (`record_store_reflinked` /
+/// `record_store_hardlinked` / `record_store_copied`) so `kache report` can
+/// account for disk honestly, mirroring the restore side in `link.rs`.
+/// Counters are best-effort under concurrent put/remove: a phase-2
+/// rematerialize after a reclaim may count the same logical ingest again.
+fn materialize_blob(source: &Path, blob: &Path, allow_hardlink: bool) -> Result<()> {
     if blob.is_file() {
         return Ok(());
     }
     fs::create_dir_all(blob.parent().unwrap()).context("creating blob shard directory")?;
     let bytes = fs::metadata(source).map(|m| m.len()).unwrap_or(0);
+    let ingest = std::cell::Cell::new(StoreIngest::Copy);
+    let ro_failed = std::cell::Cell::new(false);
 
-    let renamed = crate::atomic::atomic_write_and_replace(blob, true, |tmp| {
-        // CoW reflink first (zero physical bytes on APFS/btrfs/XFS-with-reflink);
-        // fall back to a real copy where the filesystem has no CoW.
-        if crate::link::try_reflink(source, tmp).is_ok() {
-            crate::opcounts::record_store_reflinked(bytes);
-        } else {
-            fs::copy(source, tmp)
-                .with_context(|| format!("copying {} to blob store", source.display()))?;
-            crate::opcounts::record_store_copied(bytes);
+    // CoW reflink first; then a hardlink where the artifact kind allows sharing
+    // an inode; only then a real copy. The hardlink is refused for a symlink
+    // source: hashing followed the link, but `hard_link` would link the symlink
+    // itself, and a blob must never be a pointer into mutable external state.
+    //
+    // Hardlink RO is applied in `after_fsync` (not in the write step): Windows
+    // needs a writable handle to flush (#196). On RO failure we demote to a
+    // full copy rather than publishing a writable shared inode.
+    let published = match crate::atomic::atomic_write_and_replace_with(
+        blob,
+        true,
+        |tmp| {
+            if crate::link::try_reflink(source, tmp).is_ok() {
+                ingest.set(StoreIngest::Reflink);
+            } else if allow_hardlink
+                && fs::symlink_metadata(source).is_ok_and(|m| m.file_type().is_file())
+                && fs::hard_link(source, tmp).is_ok()
+            {
+                ingest.set(StoreIngest::Hardlink);
+            } else {
+                fs::copy(source, tmp)
+                    .with_context(|| format!("copying {} to blob store", source.display()))?;
+                ingest.set(StoreIngest::Copy);
+            }
+            Ok(())
+        },
+        |tmp| {
+            if matches!(ingest.get(), StoreIngest::Hardlink)
+                && let Err(e) = set_blob_readonly_checked(tmp)
+            {
+                tracing::debug!(
+                    "read-only guard failed on hardlinked blob temp ({e}); \
+                     falling back to copy: {}",
+                    source.display()
+                );
+                ro_failed.set(true);
+                anyhow::bail!("read-only guard failed on hardlinked blob temp");
+            }
+            Ok(())
+        },
+    ) {
+        Ok(published) => published,
+        Err(_e) if ro_failed.get() => {
+            // Temp already cleaned by atomic_write_and_replace_with.
+            return materialize_blob(source, blob, false);
         }
-        Ok(())
-    })?;
+        Err(e) => {
+            // Hardlink path may have marked the source RO via the shared temp
+            // inode; undo that if we never published a blob that shares it.
+            // On Windows, remove_file_robust may also have cleared RO on a
+            // shared published blob — re-arm if the blob is present.
+            if matches!(ingest.get(), StoreIngest::Hardlink) {
+                if blob.is_file() {
+                    set_blob_readonly(blob);
+                } else {
+                    restore_source_writable_if_unshared(source, blob);
+                }
+            }
+            return Err(e);
+        }
+    };
 
-    if renamed {
+    if published {
+        match ingest.get() {
+            StoreIngest::Reflink => crate::opcounts::record_store_reflinked(bytes),
+            StoreIngest::Hardlink => crate::opcounts::record_store_hardlinked(bytes),
+            StoreIngest::Copy => crate::opcounts::record_store_copied(bytes),
+        }
         set_blob_readonly(blob);
+    } else if matches!(ingest.get(), StoreIngest::Hardlink) {
+        // Concurrent winner already published. Our temp was removed; if the
+        // published blob does not share the source inode, clear the provisional
+        // RO bit we applied before the race was lost. If it does share, re-arm
+        // RO in case Windows cleanup cleared the shared attribute.
+        if paths_share_inode(source, blob) {
+            set_blob_readonly(blob);
+        } else {
+            restore_source_writable_if_unshared(source, blob);
+        }
     }
     Ok(())
+}
+
+/// Whether `a` and `b` name the same inode (hardlinked). Used after a lost
+/// hardlink publish race to decide if the build output still shares the
+/// store blob (keep RO) or is an independent file we marked RO by mistake
+/// (restore writable).
+fn paths_share_inode(a: &Path, b: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        match (fs::metadata(a), fs::metadata(b)) {
+            (Ok(ma), Ok(mb)) => ma.dev() == mb.dev() && ma.ino() == mb.ino(),
+            _ => false,
+        }
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        match (fs::metadata(a), fs::metadata(b)) {
+            (Ok(ma), Ok(mb)) => {
+                ma.volume_serial_number().is_some()
+                    && ma.volume_serial_number() == mb.volume_serial_number()
+                    && ma.file_index().is_some()
+                    && ma.file_index() == mb.file_index()
+            }
+            _ => false,
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (a, b);
+        false
+    }
+}
+
+/// After a hardlink ingest that did not publish, clear read-only on `source`
+/// unless it still shares an inode with the published `blob` (in which case
+/// RO is the correct shared state, as on warm restore).
+fn restore_source_writable_if_unshared(source: &Path, blob: &Path) {
+    if paths_share_inode(source, blob) {
+        return;
+    }
+    if let Ok(meta) = fs::metadata(source) {
+        let mut perms = meta.permissions();
+        if perms.readonly() {
+            perms.set_readonly(false);
+            let _ = fs::set_permissions(source, perms);
+        }
+    }
 }
 
 fn blob_path_in_store_dir(store_dir: &Path, hash: &str) -> PathBuf {
@@ -945,7 +1128,11 @@ impl Store {
                 }
             }
 
-            materialize_blob(source_path, &self.blob_path(&hash), &hash)?;
+            materialize_blob(
+                source_path,
+                &self.blob_path(&hash),
+                hardlink_eligible(store_name, executable),
+            )?;
 
             cached_files.push(CachedFile {
                 name: store_name.clone(),
@@ -1012,7 +1199,11 @@ impl Store {
             // so a concurrent reclaim cannot interleave here. If a remove
             // unlinked this blob between Phase 1 and now, re-materialize it from
             // the source before we commit a reference to it.
-            materialize_blob(source, &self.blob_path(&file.hash), &file.hash)?;
+            materialize_blob(
+                source,
+                &self.blob_path(&file.hash),
+                hardlink_eligible(&file.name, file.executable),
+            )?;
         }
         tx.execute(
             "INSERT OR REPLACE INTO entries (cache_key, crate_name, crate_type, profile, num_features, size, content_hash, committed) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 1)",
@@ -2069,6 +2260,172 @@ mod tests {
         );
     }
 
+    /// Which stored filenames may share an inode with the store blob on
+    /// insert. Mirrors the restore-side `link_strategy` split, minus the
+    /// insert-only exclusions documented on `hardlink_eligible`.
+    #[test]
+    fn hardlink_eligibility_mirrors_restore_strategy_with_insert_exclusions() {
+        // On Windows the gate additionally requires the `windows_hardlink`
+        // opt-in, which is off in tests — eligibility is all-false there.
+        let gate_open = !cfg!(windows);
+
+        // Immutable kinds the restore side hardlinks: eligible.
+        for name in [
+            "libserde-abc123.rlib",
+            "libserde-abc123.rmeta",
+            "foo.rcgu.o",
+            "foo.obj",
+            "foo.dwo",
+        ] {
+            assert_eq!(
+                hardlink_eligible(name, false),
+                gate_open,
+                "{name} should be hardlink-eligible on insert (behind the Windows gate)"
+            );
+        }
+
+        // Mutable kinds (Copy strategy on restore): never eligible.
+        assert!(!hardlink_eligible("libfoo.dylib", false));
+        assert!(!hardlink_eligible("libfoo.so", false));
+        assert!(!hardlink_eligible("foo.exe", false));
+
+        // Insert-only exclusions: `.d` is rewritten in place after `put`
+        // (Expand), extensionless names are bin executables by rustc's Unix
+        // convention, and an executable mode bit wins over the filename.
+        assert!(!hardlink_eligible("serde-abc123.d", false));
+        assert!(!hardlink_eligible("my-binary", false));
+        assert!(!hardlink_eligible("libserde-abc123.rlib", true));
+    }
+
+    /// A mutable-kind blob must never share an inode with the build's output:
+    /// mutating the output post-put (codesigning, stripping) must not be able
+    /// to reach the content-addressed blob. Deterministic on every
+    /// filesystem — reflink yields an independent inode, and the copy
+    /// fallback trivially does; only a hardlink would fail this.
+    #[cfg(unix)]
+    #[test]
+    fn put_keeps_mutable_kind_blobs_inode_independent_from_the_source() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let source = dir.path().join("libfoo.dylib");
+        fs::write(&source, b"dylib bytes").unwrap();
+
+        store
+            .put(
+                "key-dylib",
+                "foo",
+                &["dylib".to_string()],
+                &[],
+                "host",
+                "dev",
+                &[(source.clone(), "libfoo.dylib".to_string())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        let hash = crate::cache_key::hash_file(&source).unwrap();
+        let blob = store.blob_path(&hash);
+        assert_ne!(
+            fs::metadata(&blob).unwrap().ino(),
+            fs::metadata(&source).unwrap().ino(),
+            "a mutable-kind blob must not share an inode with the build output"
+        );
+    }
+
+    /// Contract for immutable-kind ingest: the blob's content matches, the
+    /// blob is read-only, and IF the filesystem fell back to a hardlink
+    /// (no CoW — e.g. ext4 in CI) the build's own output is now the same
+    /// read-only inode, exactly the state a warm restore leaves behind.
+    /// Which zero-copy mechanism ran is filesystem-dependent, so the test
+    /// asserts the contract, not the mechanism.
+    #[cfg(unix)]
+    #[test]
+    fn put_ingests_immutable_kinds_zero_copy_where_the_filesystem_allows() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let source = dir.path().join("libfoo-abc.rlib");
+        fs::write(&source, b"rlib bytes").unwrap();
+
+        store
+            .put(
+                "key-rlib",
+                "foo",
+                &["rlib".to_string()],
+                &[],
+                "host",
+                "dev",
+                &[(source.clone(), "libfoo-abc.rlib".to_string())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        let hash = crate::cache_key::hash_file(&source).unwrap();
+        let blob = store.blob_path(&hash);
+        assert_eq!(fs::read(&blob).unwrap(), b"rlib bytes");
+        assert!(
+            fs::metadata(&blob).unwrap().permissions().readonly(),
+            "store blob must be read-only"
+        );
+        if fs::metadata(&blob).unwrap().ino() == fs::metadata(&source).unwrap().ino() {
+            // Hardlink fallback ran: the source shares the blob's inode and
+            // therefore its read-only mode — the same state a warm restore
+            // produces, handled by the pre-compile read-only clean.
+            assert!(
+                fs::metadata(&source).unwrap().permissions().readonly(),
+                "a hardlinked source must carry the blob's read-only mode"
+            );
+        }
+    }
+
+    /// A symlinked source must never produce a symlink "blob": hashing
+    /// follows the link, so the blob must hold the target's bytes as a
+    /// regular file. Reflink and copy both follow the link; only the
+    /// hardlink fallback could capture the symlink itself, and the
+    /// eligibility guard refuses it (`symlink_metadata` check).
+    #[cfg(unix)]
+    #[test]
+    fn put_never_stores_a_symlink_as_a_blob() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let target = dir.path().join("real-artifact.rlib");
+        fs::write(&target, b"real artifact bytes").unwrap();
+        let symlink = dir.path().join("linked.rlib");
+        std::os::unix::fs::symlink(&target, &symlink).unwrap();
+
+        store
+            .put(
+                "key-symlink",
+                "foo",
+                &["rlib".to_string()],
+                &[],
+                "host",
+                "dev",
+                &[(symlink.clone(), "linked.rlib".to_string())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        let hash = crate::cache_key::hash_file(&symlink).unwrap();
+        let blob = store.blob_path(&hash);
+        let meta = fs::symlink_metadata(&blob).unwrap();
+        assert!(
+            meta.file_type().is_file(),
+            "blob must be a regular file, not a symlink"
+        );
+        assert_eq!(fs::read(&blob).unwrap(), b"real artifact bytes");
+    }
+
     #[test]
     fn materialize_blob_errors_when_source_cannot_be_copied() {
         // Covers materialize_blob copy-fallback error branch.
@@ -2077,7 +2434,7 @@ mod tests {
         let source = dir.path().join("missing.rlib");
         let blob = dir.path().join("blobs").join("aa").join(&hash);
 
-        let err = materialize_blob(&source, &blob, &hash).unwrap_err();
+        let err = materialize_blob(&source, &blob, false).unwrap_err();
 
         assert!(
             err.to_string().contains("copying"),
@@ -2096,7 +2453,7 @@ mod tests {
         let blob = dir.path().join("blobs").join("bb").join(&hash);
         fs::create_dir_all(&blob).unwrap();
 
-        let err = materialize_blob(&source, &blob, &hash).unwrap_err();
+        let err = materialize_blob(&source, &blob, false).unwrap_err();
 
         assert!(
             err.to_string().contains("atomic rename"),
@@ -2109,6 +2466,32 @@ mod tests {
             .count();
         assert_eq!(tmp_left, 0, "failed rename must remove its temp file");
         assert!(blob.is_dir(), "the conflicting destination dir remains");
+    }
+
+    /// A failed publish after a provisional hardlink must not leave the
+    /// build's output read-only: the RO chmod was applied on the shared temp
+    /// inode before rename, and the temp is discarded on failure. (On CoW
+    /// filesystems the hardlink path is never taken — source stays writable
+    /// either way.)
+    #[test]
+    fn materialize_blob_failure_does_not_leave_source_readonly() {
+        let dir = tempfile::tempdir().unwrap();
+        let hash = "c".repeat(64);
+        let source = dir.path().join("source.rlib");
+        fs::write(&source, b"blob bytes").unwrap();
+        // Destination is a directory so rename fails after staging.
+        let blob = dir.path().join("blobs").join("cc").join(&hash);
+        fs::create_dir_all(&blob).unwrap();
+
+        let err = materialize_blob(&source, &blob, true).unwrap_err();
+        assert!(
+            err.to_string().contains("atomic rename"),
+            "expected rename context, got: {err:#}"
+        );
+        assert!(
+            !fs::metadata(&source).unwrap().permissions().readonly(),
+            "failed hardlink ingest must restore a writable build output"
+        );
     }
 
     fn test_config(dir: &Path) -> Config {
@@ -2286,12 +2669,12 @@ mod tests {
     }
 
     #[test]
-    fn store_ingest_accounts_new_blob_bytes_as_reflink_or_copy() {
+    fn store_ingest_accounts_new_blob_bytes_by_mechanism() {
         // A new-blob put must record the artifact's bytes against exactly one
-        // store-ingest counter — reflink on a CoW filesystem (APFS/btrfs),
-        // copy elsewhere. The counters are process-global and monotonic, so a
-        // delta of at least the artifact size is a safe assertion under
-        // parallel test execution.
+        // store-ingest counter — reflink, hardlink, or copy depending on the
+        // filesystem and artifact kind. The counters are process-global and
+        // monotonic, so a delta of at least the artifact size is a safe
+        // assertion under parallel test execution.
         let cache_dir = tempfile::tempdir().unwrap();
         let config = test_config(cache_dir.path());
         let store = Store::open(&config).unwrap();
@@ -2302,8 +2685,9 @@ mod tests {
         let output_file = cache_dir.path().join("output.rlib");
         std::fs::write(&output_file, &payload).unwrap();
 
-        let before =
-            crate::opcounts::store_reflinked_bytes() + crate::opcounts::store_copied_bytes();
+        let before = crate::opcounts::store_reflinked_bytes()
+            + crate::opcounts::store_hardlinked_bytes()
+            + crate::opcounts::store_copied_bytes();
         let put_result = store
             .put(
                 "ingest_key",
@@ -2319,8 +2703,9 @@ mod tests {
             .unwrap();
         assert_eq!(put_result.new_blobs, 1, "expected a genuinely new blob");
 
-        let after =
-            crate::opcounts::store_reflinked_bytes() + crate::opcounts::store_copied_bytes();
+        let after = crate::opcounts::store_reflinked_bytes()
+            + crate::opcounts::store_hardlinked_bytes()
+            + crate::opcounts::store_copied_bytes();
         assert!(
             after >= before + payload.len() as u64,
             "store ingest must account the new blob's bytes (delta {} < {})",
@@ -2870,7 +3255,7 @@ mod tests {
             )
             .unwrap();
 
-        std::fs::write(&output, b"data2").unwrap();
+        rewrite_source(&output, b"data2");
         store
             .put(
                 "k2",
@@ -3695,7 +4080,7 @@ mod tests {
             )
             .unwrap();
 
-        std::fs::write(&output, b"content2").unwrap();
+        rewrite_source(&output, b"content2");
         store
             .put(
                 "k2",
@@ -3940,7 +4325,7 @@ mod tests {
         let store = Store::open(&config).unwrap();
 
         let output = dir.path().join("lib.rlib");
-        fs::write(&output, b"same content").unwrap();
+        rewrite_source(&output, b"same content");
         store
             .put(
                 "k1",
@@ -3956,7 +4341,7 @@ mod tests {
             .unwrap();
 
         // Put again with same content but different cache key
-        fs::write(&output, b"same content").unwrap();
+        rewrite_source(&output, b"same content");
         store
             .put(
                 "k2",
@@ -4101,7 +4486,7 @@ mod tests {
         let store = Store::open(&config).unwrap();
 
         let output = dir.path().join("lib.rlib");
-        fs::write(&output, b"shared content").unwrap();
+        rewrite_source(&output, b"shared content");
         store
             .put(
                 "k1",
@@ -4115,7 +4500,7 @@ mod tests {
                 "",
             )
             .unwrap();
-        fs::write(&output, b"shared content").unwrap();
+        rewrite_source(&output, b"shared content");
         store
             .put(
                 "k2",
@@ -4562,7 +4947,7 @@ mod tests {
 
         // Add two entries with same content
         let output = dir.path().join("lib.rlib");
-        fs::write(&output, b"shared content!").unwrap();
+        rewrite_source(&output, b"shared content!");
         store
             .put(
                 "k1",
@@ -4576,7 +4961,7 @@ mod tests {
                 "",
             )
             .unwrap();
-        fs::write(&output, b"shared content!").unwrap();
+        rewrite_source(&output, b"shared content!");
         store
             .put(
                 "k2",
@@ -4604,8 +4989,17 @@ mod tests {
     /// Helper: create a temp file with given content and return its path.
     fn write_temp_file(dir: &Path, name: &str, content: &[u8]) -> PathBuf {
         let path = dir.join(name);
-        fs::write(&path, content).unwrap();
+        rewrite_source(&path, content);
         path
+    }
+
+    /// (Re)write a source file that an earlier `put` may have turned into a
+    /// read-only hardlink of a store blob (non-CoW filesystems): unlink
+    /// first, so the write neither fails with EACCES as an unprivileged user
+    /// nor reaches the blob through the shared inode.
+    fn rewrite_source(path: &Path, content: &[u8]) {
+        let _ = fs::remove_file(path);
+        fs::write(path, content).unwrap();
     }
 
     /// Helper: read meta.json for a cache key and return the EntryMeta.
@@ -4671,7 +5065,7 @@ mod tests {
             .unwrap();
 
         // Re-create shared file (put() reads from source path, content must exist)
-        fs::write(&shared, b"shared artifact data").unwrap();
+        rewrite_source(&shared, b"shared artifact data");
 
         // Put entry 2: shared + unique2
         store
@@ -5601,7 +5995,7 @@ mod tests {
         let dir = tmp.path().join("src");
         std::fs::create_dir_all(&dir).unwrap();
         let file = dir.join("lib.rlib");
-        std::fs::write(&file, b"same-content-for-corrupt-dedup").unwrap();
+        rewrite_source(&file, b"same-content-for-corrupt-dedup");
         store
             .put(
                 "dup_corrupt_old",
@@ -5624,7 +6018,7 @@ mod tests {
             )
             .unwrap();
 
-        std::fs::write(&file, b"same-content-for-corrupt-dedup").unwrap();
+        rewrite_source(&file, b"same-content-for-corrupt-dedup");
         store
             .put(
                 "dup_corrupt_new",

--- a/src/store.rs
+++ b/src/store.rs
@@ -241,14 +241,30 @@ fn paths_share_inode(a: &Path, b: &Path) -> bool {
     }
     #[cfg(windows)]
     {
-        use std::os::windows::fs::MetadataExt;
-        match (fs::metadata(a), fs::metadata(b)) {
-            (Ok(ma), Ok(mb)) => {
-                ma.volume_serial_number().is_some()
-                    && ma.volume_serial_number() == mb.volume_serial_number()
-                    && ma.file_index().is_some()
-                    && ma.file_index() == mb.file_index()
+        // `std::os::windows::fs::MetadataExt::{file_index,volume_serial_number}`
+        // are still unstable (`windows_by_handle`). Use the same stable
+        // `GetFileInformationByHandle` path as `events::get_file_identity`.
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Storage::FileSystem::{
+            BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+        };
+        fn identity(path: &Path) -> Option<(u32, u32, u32)> {
+            let file = fs::File::open(path).ok()?;
+            let handle = file.as_raw_handle();
+            let mut info: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+            let ok = unsafe { GetFileInformationByHandle(handle as _, &mut info) };
+            if ok != 0 {
+                Some((
+                    info.dwVolumeSerialNumber,
+                    info.nFileIndexHigh,
+                    info.nFileIndexLow,
+                ))
+            } else {
+                None
             }
+        }
+        match (identity(a), identity(b)) {
+            (Some(ia), Some(ib)) => ia == ib,
             _ => false,
         }
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1995,6 +1995,7 @@ mod tests {
             hardlinked_bytes: 0,
             copied_bytes: 0,
             store_reflinked_bytes: 0,
+            store_hardlinked_bytes: 0,
             store_copied_bytes: 0,
             root: String::new(),
             passthrough_reason: "linker invocation".to_string(),

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2110,6 +2110,7 @@ fn log_event_details(
         hardlinked_bytes: crate::opcounts::hardlinked_bytes(),
         copied_bytes: crate::opcounts::copied_bytes(),
         store_reflinked_bytes: crate::opcounts::store_reflinked_bytes(),
+        store_hardlinked_bytes: crate::opcounts::store_hardlinked_bytes(),
         store_copied_bytes: crate::opcounts::store_copied_bytes(),
         passthrough_reason,
         fallback,


### PR DESCRIPTION
## Summary

Add insert-side hardlink fallback for immutable store blobs when CoW reflink is unavailable (ext4 without reflink, tmpfs), mirroring restore. This keeps cold store ingest zero-copy on non-CoW filesystems instead of always making a second physical copy.

- **Ingest order**: reflink → hardlink (immutable kinds only) → full copy
- **Exclusions**: DepInfo (post-put in-place rewrite), executables, extensionless bins, symlinks; Windows behind the existing `[cache] windows_hardlink` opt-in
- **Correctness**: enforce RO on the shared inode after fsync (Windows needs a writable flush handle), demote to copy if RO fails, record ingest counters only after a successful publish, restore source writability on lost race/failure when the published blob does not share the inode
- **Accounting**: wire `store_hardlinked_bytes` through events, report, TUI, wrapper, and the e2e disk-layout estimate; printed bench summary labels now include hardlink sharing (not CoW-only)
- **Hardening**: CC pre-clean clears Windows RO before unlink; `remove_file_robust` does not clear RO on multi-hardlink Unix inodes; `atomic_write_and_replace_with` after-fsync hook for the hardlink RO guard

## Test plan

- [x] `cargo test --bin kache materialize_blob`
- [x] `cargo test --bin kache hardlink`
- [x] `cargo test --bin kache store_ingest`
- [x] `cargo test --bin kache put_ingests`
- [x] `cargo test --bin kache put_keeps`
- [x] `cargo test --bin kache put_never`
- [x] `cargo test --bin kache atomic`
- [x] `cargo check -p kache-e2e`
- [ ] CI full suite

## Checklist

- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [ ] `just check` passes locally (fmt + clippy + tests)
- [ ] User-visible report/bench wording updates (hardlink sharing) reflected where needed