### PR TITLE
Fix rustc cache key ordering and key locking

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -3,14 +3,10 @@ use std::path::{Path, PathBuf};
 
 use crate::compiler::rustc::RustcCompiler;
 
-/// rustc flags that affect only diagnostics, lint levels, queries, or carry a
-/// path already reflected in the key elsewhere — never the emitted artifact
-/// bytes. Their separated value (`--flag value`) is skipped during parsing so
-/// neither the flag nor its value reaches the `residual_args` catch-all and
-/// over-keys the result (kunobi-ninja/kache#324).
-///
-/// `--remap-path-prefix` is path-bearing but already reflected in the key via
-/// the remap-sentinel set, so it is dropped here as well.
+/// rustc flags that affect only diagnostics, lint levels, or queries — never
+/// the emitted artifact bytes. Their separated value (`--flag value`) is
+/// skipped during parsing so neither the flag nor its value reaches the
+/// `residual_args` catch-all and over-keys the result (kunobi-ninja/kache#324).
 const IGNORED_VALUE_FLAGS: &[&str] = &[
     "--error-format",
     "--json",
@@ -18,7 +14,6 @@ const IGNORED_VALUE_FLAGS: &[&str] = &[
     "--diagnostic-width",
     "--cap-lints",
     "--check-cfg",
-    "--remap-path-prefix",
     "--print",
     "--explain",
     "-W",
@@ -43,7 +38,6 @@ const IGNORED_ATTACHED_PREFIXES: &[&str] = &[
     "--diagnostic-width=",
     "--cap-lints=",
     "--check-cfg=",
-    "--remap-path-prefix=",
     "--print=",
     "--explain=",
     "--warn=",
@@ -114,6 +108,10 @@ pub struct RustcArgs {
     /// Unstable `-Z` flags. Can change codegen (e.g. `-Zsanitizer`,
     /// `-Zshare-generics`) and arrive on argv outside RUSTFLAGS.
     pub unstable_flags: Vec<String>,
+    /// Direct rustc `--remap-path-prefix FROM=TO` values in argv order.
+    /// The key normalizes known machine-local FROM prefixes while retaining
+    /// unrelated FROM values, TO values, and occurrence order.
+    pub remap_path_prefixes: Vec<String>,
     /// Inner rustc path for double-wrapper case (RUSTC_WRAPPER + RUSTC_WORKSPACE_WRAPPER).
     /// When both wrappers are active, cargo passes: wrapper workspace_wrapper rustc <args>.
     /// This field holds the rustc path that the workspace wrapper expects as its first arg.
@@ -184,6 +182,7 @@ impl RustcArgs {
             link_search: Vec::new(),
             link_libs: Vec::new(),
             unstable_flags: Vec::new(),
+            remap_path_prefixes: Vec::new(),
             inner_rustc,
             all_args: rustc_args.to_vec(),
             residual_args: Vec::new(),
@@ -284,29 +283,30 @@ impl RustcArgs {
                         parsed.features.push(feat);
                     }
                 }
-                "-C" => {
+                "-C" | "--codegen" => {
                     i += 1;
                     if let Some(val) = rustc_args.get(i) {
-                        let (key, value) = parse_codegen_opt(val);
-                        if key == "extra-filename" {
-                            parsed.extra_filename = value.clone();
-                        }
-                        if key == "incremental" {
-                            parsed.incremental = value.as_ref().map(PathBuf::from);
-                        }
-                        parsed.codegen_opts.push((key, value));
+                        record_codegen_opt(&mut parsed, val);
                     }
                 }
                 _ if arg.starts_with("-C") && arg.len() > 2 => {
-                    let val = &arg[2..];
-                    let (key, value) = parse_codegen_opt(val);
-                    if key == "extra-filename" {
-                        parsed.extra_filename = value.clone();
-                    }
-                    if key == "incremental" {
-                        parsed.incremental = value.as_ref().map(PathBuf::from);
-                    }
-                    parsed.codegen_opts.push((key, value));
+                    record_codegen_opt(&mut parsed, &arg[2..]);
+                }
+                _ if arg.starts_with("--codegen=") => {
+                    record_codegen_opt(&mut parsed, &arg["--codegen=".len()..]);
+                }
+                // rustc defines these shorthands as exact -C aliases. Model
+                // them in the same ordered bucket so last-wins combinations
+                // such as `-O -Copt-level=0` cannot collide with the reverse.
+                "-O" => {
+                    parsed
+                        .codegen_opts
+                        .push(("opt-level".to_string(), Some("3".to_string())));
+                }
+                "-g" => {
+                    parsed
+                        .codegen_opts
+                        .push(("debuginfo".to_string(), Some("2".to_string())));
                 }
                 "--sysroot" => {
                     i += 1;
@@ -347,9 +347,20 @@ impl RustcArgs {
                 _ if arg.starts_with("-Z") && arg.len() > 2 => {
                     parsed.unstable_flags.push(arg["-Z".len()..].to_string());
                 }
-                // Diagnostics / lint / query / already-keyed path flags: never
-                // change the artifact, so drop them (and their separated value)
-                // before the residual catch-all (kunobi-ninja/kache#324).
+                "--remap-path-prefix" => {
+                    i += 1;
+                    if let Some(value) = rustc_args.get(i) {
+                        parsed.remap_path_prefixes.push(value.clone());
+                    }
+                }
+                _ if arg.starts_with("--remap-path-prefix=") => {
+                    parsed
+                        .remap_path_prefixes
+                        .push(arg["--remap-path-prefix=".len()..].to_string());
+                }
+                // Diagnostics / lint / query flags: never change the artifact,
+                // so drop them (and their separated value) before the residual
+                // catch-all (kunobi-ninja/kache#324).
                 _ if IGNORED_VALUE_FLAGS.contains(&arg.as_str()) => {
                     i += 1; // skip the value argument
                 }
@@ -363,9 +374,9 @@ impl RustcArgs {
                     parsed.source_file = Some(PathBuf::from(arg));
                 }
                 // Anything else is an argv token kache does not model. It may
-                // affect codegen (e.g. `-O`, `-g`), so keep it for the cache key
-                // (folded normalized + sorted in `cache_key.rs`) rather than
-                // dropping it silently (kunobi-ninja/kache#324).
+                // affect codegen, so keep it for the cache key (folded
+                // normalized + sorted in `cache_key.rs`) rather than dropping
+                // it silently (kunobi-ninja/kache#324).
                 _ => {
                     parsed.residual_args.push(arg.clone());
                 }
@@ -552,6 +563,7 @@ impl RustcArgs {
     pub fn get_codegen_opt(&self, key: &str) -> Option<&str> {
         self.codegen_opts
             .iter()
+            .rev()
             .find(|(k, _)| k == key)
             .and_then(|(_, v)| v.as_deref())
     }
@@ -590,6 +602,17 @@ fn parse_codegen_opt(s: &str) -> (String, Option<String>) {
     } else {
         (s.to_string(), None)
     }
+}
+
+fn record_codegen_opt(parsed: &mut RustcArgs, value: &str) {
+    let (key, value) = parse_codegen_opt(value);
+    if key == "extra-filename" {
+        parsed.extra_filename = value.clone();
+    }
+    if key == "incremental" {
+        parsed.incremental = value.as_ref().map(PathBuf::from);
+    }
+    parsed.codegen_opts.push((key, value));
 }
 
 #[cfg(test)]
@@ -718,6 +741,57 @@ mod tests {
         assert_eq!(parsed.get_codegen_opt("opt-level"), Some("3"));
         assert_eq!(parsed.get_codegen_opt("metadata"), Some("abc123"));
         assert_eq!(parsed.get_codegen_opt("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_parse_codegen_shorthands_preserves_override_order() {
+        let args: Vec<String> = vec![
+            "rustc",
+            "src/lib.rs",
+            "-O",
+            "--codegen=opt-level=0",
+            "--codegen",
+            "debuginfo=0",
+            "-g",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        let parsed = RustcArgs::parse(&args).unwrap();
+
+        assert_eq!(
+            parsed.codegen_opts,
+            vec![
+                ("opt-level".to_string(), Some("3".to_string())),
+                ("opt-level".to_string(), Some("0".to_string())),
+                ("debuginfo".to_string(), Some("0".to_string())),
+                ("debuginfo".to_string(), Some("2".to_string())),
+            ]
+        );
+        assert_eq!(parsed.get_codegen_opt("opt-level"), Some("0"));
+        assert_eq!(parsed.get_codegen_opt("debuginfo"), Some("2"));
+        assert!(parsed.residual_args.is_empty());
+    }
+
+    #[test]
+    fn test_parse_direct_remap_path_prefixes() {
+        let args: Vec<String> = vec![
+            "rustc",
+            "src/lib.rs",
+            "--remap-path-prefix",
+            "/work/a=/src",
+            "--remap-path-prefix=/work/b=/generated",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        let parsed = RustcArgs::parse(&args).unwrap();
+
+        assert_eq!(
+            parsed.remap_path_prefixes,
+            vec!["/work/a=/src".to_string(), "/work/b=/generated".to_string()]
+        );
+        assert!(parsed.residual_args.is_empty());
     }
 
     #[test]

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -5494,7 +5494,8 @@ pub fn value() -> (&'static str, u8) {
         let dir = tempfile::tempdir().unwrap();
         let workspace = dir.path().join("workspace");
         std::fs::create_dir_all(&workspace).unwrap();
-        let workspace = workspace.canonicalize().unwrap();
+        let workspace =
+            PathBuf::from(crate::path_normalizer::canonical_string(&workspace).unwrap());
         let normalizer = PathNormalizer::from_env(Some(&workspace));
         let from = workspace.join("dir=with=equals");
         let to = workspace.join("literal-to");

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -242,6 +242,17 @@ fn scrub_remap_value(value: &str) -> String {
     }
 }
 
+/// Normalize only machine-local prefixes known to [`PathNormalizer`] on the
+/// FROM side of a direct rustc remap. Unlike environment-provided build-system
+/// remaps, an arbitrary direct FROM may not match this invocation at all, so
+/// erasing it unconditionally would collide with a mapping that does match.
+fn normalize_direct_remap_value(value: &str, path_normalizer: &PathNormalizer) -> String {
+    match value.rsplit_once('=') {
+        Some((from, to)) => format!("{}={to}", path_normalizer.normalize(from)),
+        None => value.to_string(),
+    }
+}
+
 /// Fold a user-declared salt into an already-computed cache key.
 ///
 /// The salt captures toolchain divergence kache cannot observe from the
@@ -456,7 +467,9 @@ pub fn compute_cache_key(
         tracing::trace!("[key:{}] emit:{}", crate_name, kind);
     }
 
-    // codegen options (sorted for determinism)
+    // Codegen options grouped by name for determinism. This is a stable sort,
+    // so repeated last-wins options retain argv order. Rustc's `-O` and `-g`
+    // shorthands are normalized into this same list during parsing.
     let mut codegen_opts: Vec<_> = args
         .codegen_opts
         .iter()
@@ -671,6 +684,26 @@ pub fn compute_cache_key(
         );
     }
 
+    // Direct argv remaps are codegen inputs too: they alter `file!()`, panic
+    // locations, and debug paths. Normalize known machine-local prefixes on
+    // FROM, but retain unrelated FROM values because matching vs non-matching
+    // mappings are semantically different. Keep TO verbatim because it is
+    // embedded in the artifact, and preserve order because overlapping remaps
+    // are order-sensitive.
+    for value in &args.remap_path_prefixes {
+        let normalized = normalize_direct_remap_value(value, path_normalizer);
+        fold_field(
+            &mut hasher,
+            b"argv_remap_path_prefix.v1:",
+            normalized.as_bytes(),
+        );
+        tracing::trace!(
+            "[key:{}] argv --remap-path-prefix={}",
+            crate_name,
+            normalized
+        );
+    }
+
     // RUSTC_BOOTSTRAP changes what rustc accepts — nightly-only
     // `#![feature(...)]` and unstable `-Z` flags on a stable/beta toolchain —
     // so byte-identical source can compile differently (or succeed vs fail)
@@ -787,7 +820,7 @@ pub fn compute_cache_key(
     }
 
     // Residual argv tokens (kunobi-ninja/kache#324): flags kache does not model
-    // explicitly still reach rustc and can affect codegen (`-O`, `-g`, or a
+    // explicitly still reach rustc and can affect codegen (for example a
     // future flag), yet were previously invisible to the key — the `_ => {}`
     // catch-all in `args.rs` dropped them. Fold the NORMALIZED, sorted residual
     // under a versioned tag so an unmodeled codegen-affecting flag changes the
@@ -2969,11 +3002,10 @@ mod tests {
         );
     }
 
-    /// kunobi-ninja/kache#324: an unmodeled argv flag that can affect codegen
-    /// (`-g`, `-O`) used to land in the `_ => {}` catch-all and never enter the
-    /// key. It must now change the key via the residual-args fold.
+    /// Rustc's `-O` / `-g` shorthands must share keys with their exact `-C`
+    /// equivalents rather than living in the unmodeled residual bucket.
     #[test]
-    fn residual_unmodeled_flag_changes_key() {
+    fn codegen_shorthands_match_explicit_forms() {
         let _lock = key_test_lock();
         let dir = tempfile::tempdir().unwrap();
         let source = dir.path().join("lib.rs");
@@ -2982,9 +3014,35 @@ mod tests {
         let base = key_of_flags(&flag_base(&source, &[]));
         let debug = key_of_flags(&flag_base(&source, &["-g"]));
         let opt = key_of_flags(&flag_base(&source, &["-O"]));
-        assert_ne!(base, debug, "an unmodeled `-g` must change the key");
-        assert_ne!(base, opt, "an unmodeled `-O` must change the key");
+        let explicit_debug = key_of_flags(&flag_base(&source, &["-Cdebuginfo=2"]));
+        let explicit_opt = key_of_flags(&flag_base(&source, &["-Copt-level=3"]));
+        let long_debug = key_of_flags(&flag_base(&source, &["--codegen=debuginfo=2"]));
+        let long_opt = key_of_flags(&flag_base(&source, &["--codegen", "opt-level=3"]));
+        assert_ne!(base, debug, "`-g` must change the key");
+        assert_ne!(base, opt, "`-O` must change the key");
         assert_ne!(debug, opt, "`-g` and `-O` must produce distinct keys");
+        assert_eq!(debug, explicit_debug, "`-g` is `-Cdebuginfo=2`");
+        assert_eq!(opt, explicit_opt, "`-O` is `-Copt-level=3`");
+        assert_eq!(debug, long_debug, "`--codegen` is the long `-C` alias");
+        assert_eq!(opt, long_opt, "separated `--codegen` must match `-C`");
+    }
+
+    #[test]
+    fn codegen_shorthand_override_order_changes_key() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+
+        let shorthand_then_explicit =
+            key_of_flags(&flag_base(&source, &["-O", "--codegen=opt-level=0"]));
+        let explicit_then_shorthand =
+            key_of_flags(&flag_base(&source, &["--codegen", "opt-level=0", "-O"]));
+
+        assert_ne!(
+            shorthand_then_explicit, explicit_then_shorthand,
+            "rustc applies optimization flags last-wins, so opposite orders must not collide"
+        );
     }
 
     /// kunobi-ninja/kache#324: residual tokens are sorted before folding, so
@@ -5428,6 +5486,96 @@ pub fn value() -> (&'static str, u8) {
         assert_eq!(
             scrub("--remap-path-prefix=garbage"),
             "--remap-path-prefix=garbage"
+        );
+    }
+
+    #[test]
+    fn normalize_direct_remap_normalizes_known_from_but_keeps_to() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let workspace = workspace.canonicalize().unwrap();
+        let normalizer = PathNormalizer::from_env(Some(&workspace));
+        let from = workspace.join("dir=with=equals");
+        let to = workspace.join("literal-to");
+        let value = format!("{}={}", from.display(), to.display());
+
+        assert_eq!(
+            normalize_direct_remap_value(&value, &normalizer),
+            format!(
+                "{}={}",
+                Path::new("<WORKSPACE>").join("dir=with=equals").display(),
+                to.display()
+            ),
+            "only FROM is normalized; TO remains verbatim"
+        );
+        assert_eq!(
+            normalize_direct_remap_value("malformed", &normalizer),
+            "malformed"
+        );
+    }
+
+    #[test]
+    fn key_matrix_direct_remap_path_prefix_is_keyed_portably_and_in_order() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+
+        let none = key_of_flags(&flag_base(&source, &[]));
+        let separated = key_of_flags(&flag_base(
+            &source,
+            &["--remap-path-prefix", "/work/clone-a=/virtual/src"],
+        ));
+        let attached = key_of_flags(&flag_base(
+            &source,
+            &["--remap-path-prefix=/work/clone-a=/virtual/src"],
+        ));
+        let unrelated_from = key_of_flags(&flag_base(
+            &source,
+            &["--remap-path-prefix=/work/clone-b=/virtual/src"],
+        ));
+        let other_target = key_of_flags(&flag_base(
+            &source,
+            &["--remap-path-prefix=/work/clone-a=/virtual/other"],
+        ));
+        let remap_root = format!("--remap-path-prefix={}=/virtual/root", dir.path().display());
+        let remap_source = format!("--remap-path-prefix={}=/virtual/source", source.display());
+        let order_ab = key_of_flags(&flag_base(&source, &[&remap_root, &remap_source]));
+        let order_ba = key_of_flags(&flag_base(&source, &[&remap_source, &remap_root]));
+
+        assert_ne!(none, separated, "adding a direct remap must change the key");
+        assert_eq!(separated, attached, "both rustc spellings are equivalent");
+        assert_ne!(
+            separated, unrelated_from,
+            "without a matching normalization rule, FROM remains semantic"
+        );
+        assert_ne!(
+            separated, other_target,
+            "the remap target is embedded in artifacts and must remain key-visible"
+        );
+        assert_ne!(order_ab, order_ba, "overlapping remap order is semantic");
+
+        let clone_a = dir.path().join("clone-a");
+        let clone_b = dir.path().join("clone-b");
+        std::fs::create_dir_all(&clone_a).unwrap();
+        std::fs::create_dir_all(&clone_b).unwrap();
+        let portable_key = |workspace: &Path| {
+            let workspace = workspace.canonicalize().unwrap();
+            let remap = format!("--remap-path-prefix={}=/virtual/src", workspace.display());
+            let mut parsed = RustcArgs::parse(&flag_base(&source, &[&remap])).unwrap();
+            parsed.source_file = None;
+            compute_cache_key(
+                &parsed,
+                &FileHasher::new(),
+                &PathNormalizer::from_env(Some(&workspace)),
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            portable_key(&clone_a),
+            portable_key(&clone_b),
+            "known workspace prefixes normalize portably across checkouts"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -425,6 +425,36 @@ pub struct KeyLock {
     path: PathBuf,
 }
 
+/// A fully-written key lock waiting to be published at its canonical path.
+/// Keeping preparation separate from publication prevents contenders from
+/// observing an empty lock file and mistaking an in-progress owner for stale.
+struct PreparedKeyLock {
+    path: PathBuf,
+    temp: tempfile::NamedTempFile,
+}
+
+impl PreparedKeyLock {
+    fn new(path: PathBuf) -> Result<Self> {
+        let parent = path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("key lock has no parent: {}", path.display()))?;
+        fs::create_dir_all(parent)?;
+        let mut temp = tempfile::NamedTempFile::new_in(parent)?;
+        use std::io::Write;
+        write!(temp, "{}", std::process::id())?;
+        Ok(Self { path, temp })
+    }
+
+    /// Atomically publish without replacing an existing owner.
+    fn publish(self) -> Result<Option<KeyLock>> {
+        match self.temp.persist_noclobber(&self.path) {
+            Ok(_) => Ok(Some(KeyLock { path: self.path })),
+            Err(e) if e.error.kind() == std::io::ErrorKind::AlreadyExists => Ok(None),
+            Err(e) => Err(e.error.into()),
+        }
+    }
+}
+
 /// Lock guard for store-wide GC. Dropping it releases the OS lock.
 pub struct GcLock {
     file: Option<fs::File>,
@@ -987,44 +1017,58 @@ impl Store {
         self.try_acquire_file_lock(self.config.store_dir().join("gc.lock"))
     }
 
-    /// Create `lock_path` exclusively (writing the holder PID for debugging),
-    /// stale-recovering a lock left by a dead process. `None` means another live
-    /// process holds it.
+    /// Publish a fully-written `lock_path` exclusively, stale-recovering a lock
+    /// left by a dead process. `None` means another live process holds it.
     fn try_acquire_lock(&self, lock_path: PathBuf) -> Result<Option<KeyLock>> {
-        fs::create_dir_all(lock_path.parent().unwrap())?;
-        match fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&lock_path)
-        {
-            Ok(mut f) => {
-                use std::io::Write;
-                let _ = write!(f, "{}", std::process::id());
-                Ok(Some(KeyLock { path: lock_path }))
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                // Check if the lock is stale (process died)
-                if self.is_lock_stale(&lock_path)? {
-                    fs::remove_file(&lock_path)?;
-                    // Retry once
-                    match fs::OpenOptions::new()
-                        .write(true)
-                        .create_new(true)
-                        .open(&lock_path)
-                    {
-                        Ok(mut f) => {
-                            use std::io::Write;
-                            let _ = write!(f, "{}", std::process::id());
-                            Ok(Some(KeyLock { path: lock_path }))
-                        }
-                        Err(_) => Ok(None),
-                    }
-                } else {
-                    Ok(None)
-                }
-            }
-            Err(e) => Err(e.into()),
+        if let Some(lock) = PreparedKeyLock::new(lock_path.clone())?.publish()? {
+            return Ok(Some(lock));
         }
+
+        // Avoid the recovery lock on the ordinary live-owner contention path.
+        if !self.is_lock_stale(&lock_path)? {
+            return Ok(None);
+        }
+
+        // Serialize the rare stale check/remove/publish sequence. Without this,
+        // two reclaimers can both approve removal of the old marker; the second
+        // can then delete the first reclaimer's newly-published live marker.
+        // The per-key build lock itself remains PID-file based.
+        let _recovery_guard =
+            self.acquire_file_lock(self.config.store_dir().join("build-lock-recovery.lock"))?;
+
+        // The previous owner may have exited while we waited. Acquire directly
+        // if the canonical path is now free, or re-check the current marker so
+        // a reclaimer that won before us cannot be mistaken for the stale one.
+        if let Some(lock) = PreparedKeyLock::new(lock_path.clone())?.publish()? {
+            return Ok(Some(lock));
+        }
+        if !self.is_lock_stale(&lock_path)? {
+            return Ok(None);
+        }
+
+        match fs::remove_file(&lock_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.into()),
+        }
+        PreparedKeyLock::new(lock_path)?.publish()
+    }
+
+    /// Block until an OS-backed coordination lock is held.
+    fn acquire_file_lock(&self, lock_path: PathBuf) -> Result<GcLock> {
+        fs::create_dir_all(lock_path.parent().unwrap())?;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        file.lock()?;
+
+        use std::io::{Seek, SeekFrom, Write};
+        file.set_len(0)?;
+        file.seek(SeekFrom::Start(0))?;
+        write!(file, "{}", std::process::id())?;
+        Ok(GcLock { file: Some(file) })
     }
 
     /// Acquire an exclusive OS lock on `lock_path` and write the holder PID for
@@ -3158,6 +3202,72 @@ mod tests {
         // Now should succeed
         let lock3 = store.try_lock("testkey").unwrap();
         assert!(lock3.is_some());
+    }
+
+    #[test]
+    fn prepared_key_lock_is_complete_before_atomic_publication() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("entry.lock");
+        let first = PreparedKeyLock::new(lock_path.clone()).unwrap();
+
+        assert!(
+            !lock_path.exists(),
+            "the canonical path must stay absent while PID metadata is prepared"
+        );
+        assert_eq!(
+            fs::read_to_string(first.temp.path()).unwrap(),
+            std::process::id().to_string()
+        );
+
+        let winner = PreparedKeyLock::new(lock_path.clone())?
+            .publish()?
+            .expect("one prepared contender should publish");
+        assert_eq!(
+            fs::read_to_string(&lock_path).unwrap(),
+            std::process::id().to_string(),
+            "a visible lock must already contain a complete PID"
+        );
+        assert!(
+            first.publish()?.is_none(),
+            "noclobber publication must preserve the existing owner"
+        );
+
+        drop(winner);
+        assert!(!lock_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn concurrent_stale_lock_recovery_has_one_winner() {
+        const CONTENDERS: usize = 16;
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let lock_path = store.entry_dir("stale-race").with_extension("lock");
+        fs::create_dir_all(lock_path.parent().unwrap()).unwrap();
+        fs::write(&lock_path, b"not-a-pid").unwrap();
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(CONTENDERS));
+        let mut handles = Vec::new();
+        for _ in 0..CONTENDERS {
+            let config = test_config(dir.path());
+            let barrier = barrier.clone();
+            handles.push(std::thread::spawn(move || {
+                let store = Store::open(&config).unwrap();
+                barrier.wait();
+                store.try_lock("stale-race").unwrap()
+            }));
+        }
+
+        let guards: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect();
+        assert_eq!(
+            guards.iter().filter(|guard| guard.is_some()).count(),
+            1,
+            "serialized stale recovery must publish exactly one live guard"
+        );
     }
 
     #[test]

--- a/tests/cache_key_underkeying_test.rs
+++ b/tests/cache_key_underkeying_test.rs
@@ -14,6 +14,9 @@
 //!   - `-l` / `-L native=` — build-script `cargo:rustc-link-lib` /
 //!     `cargo:rustc-link-search` reach rustc on argv, not via RUSTFLAGS.
 //!   - `--sysroot` — selects which std rustc links against.
+//!   - `-O` / `-g` — shorthand codegen flags whose order relative to explicit
+//!     `-C` overrides is last-wins.
+//!   - direct `--remap-path-prefix` — changes embedded source/debug paths.
 //!
 //! `-L dependency=` (cargo's rlib search, redundant with the content-hashed
 //! `--extern`) must NOT affect the key, or every target-dir move would bust
@@ -151,6 +154,89 @@ fn fresh_src() -> (TempDir, PathBuf) {
     let src = dir.path().join("lib.rs");
     std::fs::write(&src, b"pub fn f() -> u32 { 42 }\n").unwrap();
     (dir, src)
+}
+
+/// Rustc applies `-O` and `-Copt-level` in argv order. Reversing them must
+/// miss rather than restore the artifact compiled under the opposite winner.
+#[test]
+fn codegen_shorthand_override_order_changes_cache_key() {
+    build_kache();
+    let cache_dir = TempDir::new().unwrap();
+    let out = TempDir::new().unwrap();
+    let (_src_dir, src) = fresh_src();
+
+    run_kache_rustc(
+        cache_dir.path(),
+        out.path(),
+        &src,
+        &["-O", "--codegen=opt-level=0"],
+    ); // miss
+    run_kache_rustc(
+        cache_dir.path(),
+        out.path(),
+        &src,
+        &["-O", "--codegen=opt-level=0"],
+    ); // hit
+    run_kache_rustc(
+        cache_dir.path(),
+        out.path(),
+        &src,
+        &["--codegen", "opt-level=0", "-O"],
+    ); // miss
+
+    assert_eq!(
+        compiled_hit_counts(cache_dir.path()),
+        (2, 1),
+        "reversing last-wins optimization flags must produce a new cache key"
+    );
+}
+
+/// Direct remaps alter `file!()` and debug paths. Equivalent spelling and a
+/// relocated matching FROM must hit; a non-matching FROM or changed TO misses.
+#[test]
+fn direct_remap_path_prefix_changes_cache_key() {
+    build_kache();
+    let cache_dir = TempDir::new().unwrap();
+    let workspace_a = TempDir::new().unwrap();
+    let workspace_b = TempDir::new().unwrap();
+    let root_a = workspace_a.path().canonicalize().unwrap();
+    let root_b = workspace_b.path().canonicalize().unwrap();
+    let layout = |root: &Path| {
+        let src = root.join("src/lib.rs");
+        let out = root.join("target/debug/deps");
+        std::fs::create_dir_all(src.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&out).unwrap();
+        std::fs::write(&src, b"pub const SOURCE: &str = file!();\n").unwrap();
+        (src, out)
+    };
+    let (src_a, out_a) = layout(&root_a);
+    let (src_b, out_b) = layout(&root_b);
+
+    let map_a = format!("{}=/virtual/a", root_a.display());
+    let attached_a = format!("--remap-path-prefix={map_a}");
+    let nonmatching_a = format!(
+        "--remap-path-prefix={}=/virtual/a",
+        root_a.join("not-the-source-prefix").display()
+    );
+    let portable_b = format!("--remap-path-prefix={}=/virtual/a", root_b.display());
+    let different_target_b = format!("--remap-path-prefix={}=/virtual/b", root_b.display());
+
+    run_kache_rustc(
+        cache_dir.path(),
+        &out_a,
+        &src_a,
+        &["--remap-path-prefix", &map_a],
+    ); // miss
+    run_kache_rustc(cache_dir.path(), &out_a, &src_a, &[&attached_a]); // hit
+    run_kache_rustc(cache_dir.path(), &out_a, &src_a, &[&nonmatching_a]); // miss
+    run_kache_rustc(cache_dir.path(), &out_b, &src_b, &[&portable_b]); // hit
+    run_kache_rustc(cache_dir.path(), &out_b, &src_b, &[&different_target_b]); // miss
+
+    assert_eq!(
+        compiled_hit_counts(cache_dir.path()),
+        (3, 2),
+        "spelling and relocated FROM must hit; non-matching FROM or changed TO must miss"
+    );
 }
 
 /// H1: a build-script `-l <lib>` reaches rustc on argv. A different native


### PR DESCRIPTION
## Summary

- normalize `-O`, `-g`, `-C`, and `--codegen` into one ordered cache-key stream so rustc's last-wins semantics are preserved
- key direct `--remap-path-prefix` arguments in order, preserving semantic FROM/TO differences while retaining cross-worktree portability
- publish fully written PID lock markers atomically and serialize stale-marker recovery

This addresses code-review findings 1, 3, and 10.

## Root cause

Equivalent rustc codegen spellings were split across differently ordered key buckets, direct remaps were omitted from argv keying, and build locks became visible before their PID contents were complete. Concurrent stale reclaimers could also remove a newly published live marker.

## Impact

The cache no longer aliases compilations whose effective codegen or path remapping differs, while equivalent portable invocations continue to share entries. Per-key build locks retain their PID-file behavior without exposing partial markers or allowing two same-version stale reclaimers to win.

## Validation

- `env CARGO_TARGET_DIR=/private/tmp/kache-fix-target just check`
- focused codegen/remap cache-key tests
- real wrapper miss/hit regressions across relocated worktrees
- 16-way concurrent stale-lock recovery regression
