### PR TITLE
Update ammonia to 4.1.4 (RUSTSEC-2026-0213) and drop a stale advisory ignore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
  "cssparser",
  "html5ever",

--- a/deny.toml
+++ b/deny.toml
@@ -16,12 +16,6 @@ ignore = [
   # `kache-service`, so cargo-deny must be run per workspace member (a
   # root-only invocation graphs the `kache` bin alone and misses it).
   "RUSTSEC-2023-0071",
-
-  # RUSTSEC-2023-0089 — atomic-polyfill unmaintained (warning, not a CVE).
-  # Transitive via surrealdb -> geo -> rstar -> heapless 0.7. surrealdb is
-  # several hops from heapless 0.8 (which drops this dep). Low risk;
-  # re-evaluate on surrealdb major upgrades.
-  "RUSTSEC-2023-0089",
 ]
 
 [bans]


### PR DESCRIPTION
`just audit` fails on RUSTSEC-2026-0213: ammonia 4.1.3 does not sanitize `to`/`from`/`values` attributes on SVG `set`/`animate` tags as URLs, allowing a `javascript:` link through. Reachable via surrealdb-core -> surrealdb -> kache-service. Lockfile-only bump to the fixed 4.1.4; no other dependencies change.

Also removes the RUSTSEC-2023-0089 (atomic-polyfill unmaintained) ignore from deny.toml: cargo deny now reports it as unmatched in all four workspace members, so it no longer suppresses anything.

After this, `just audit` passes clean for `.`, `kache-core`, `kache-service`, and `kache-e2e`. The remaining warnings (unmatched surrealdb license exceptions in members that do not pull surrealdb, duplicate-version notes) are expected: the shared deny.toml serves all members, and bans are configured warn-only.