### PR TITLE
ci(package-publish): trigger Scoop bucket autoupdate on release

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -36,6 +36,7 @@ on:
           - apt
           - brew
           - winget
+          - scoop
         default: 'all'
 
 # OIDC for GCP WIF (KMS PGP signing); read-only repo contents.
@@ -330,3 +331,28 @@ jobs:
             --version "$VERSION" \
             --release-notes-url "$NOTES_URL" \
             --submit
+
+  # ---------------------------------------------------------------------------
+  # scoop — kick the self-hosted Scoop bucket (kunobi-ninja/scoop-bucket) to
+  # autoupdate. The bucket's Excavator workflow runs checkver + autoupdate: it
+  # discovers the new version from GitHub Releases and pulls hashes from the
+  # .sha256 sidecars, so no version/hash payload is needed here — just the kick.
+  # One dispatch re-excavates every manifest; only the one whose version changed
+  # is committed, so this covers both the stable (kache) and unstable
+  # (kache-unstable) manifests regardless of channel.
+  # ---------------------------------------------------------------------------
+  scoop:
+    needs: [resolve, gate]
+    if: ${{ github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'scoop' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger Scoop bucket autoupdate
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          # SCOOP_DISPATCH_TOKEN: PAT with contents:write on kunobi-ninja/scoop-bucket
+          # (classic `repo`, or a fine-grained token scoped to that repo). Distinct
+          # from HOMEBREW_DISPATCH_TOKEN — this one targets the Scoop bucket.
+          token: ${{ secrets.SCOOP_DISPATCH_TOKEN }}
+          repository: kunobi-ninja/scoop-bucket
+          event-type: release

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -333,7 +333,7 @@ jobs:
             --submit
 
   # ---------------------------------------------------------------------------
-  # scoop — kick the self-hosted Scoop bucket (kunobi-ninja/scoop-bucket) to
+  # scoop — kick the self-hosted Scoop bucket (kunobi-ninja/scoop-kunobi) to
   # autoupdate. The bucket's Excavator workflow runs checkver + autoupdate: it
   # discovers the new version from GitHub Releases and pulls hashes from the
   # .sha256 sidecars, so no version/hash payload is needed here — just the kick.
@@ -350,9 +350,9 @@ jobs:
       - name: Trigger Scoop bucket autoupdate
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
-          # SCOOP_DISPATCH_TOKEN: PAT with contents:write on kunobi-ninja/scoop-bucket
+          # SCOOP_DISPATCH_TOKEN: PAT with contents:write on kunobi-ninja/scoop-kunobi
           # (classic `repo`, or a fine-grained token scoped to that repo). Distinct
           # from HOMEBREW_DISPATCH_TOKEN — this one targets the Scoop bucket.
           token: ${{ secrets.SCOOP_DISPATCH_TOKEN }}
-          repository: kunobi-ninja/scoop-bucket
+          repository: kunobi-ninja/scoop-kunobi
           event-type: release


### PR DESCRIPTION
Adds a `scoop` job to `package-publish.yml` that fires a `repository_dispatch` (event `release`) to **`kunobi-ninja/scoop-bucket`** after a release, so the bucket's Excavator runs `checkver` + `autoupdate` immediately instead of waiting for its 4-hourly schedule.

Unlike the brew job, no version/sha payload is computed here — Excavator discovers the new version from GitHub Releases and pulls hashes from the `.sha256` sidecars itself. One dispatch re-excavates every manifest; only the changed one commits, so it covers both `kache` (stable) and `kache-unstable`.

Also adds `scoop` to the `only` `workflow_dispatch` input for manual re-runs.

### ⚠️ Requires a new secret
`SCOOP_DISPATCH_TOKEN` — a PAT with `contents:write` on `kunobi-ninja/scoop-bucket` (classic `repo`, or a fine-grained token scoped to that repo). Deliberately **separate** from `HOMEBREW_DISPATCH_TOKEN`. Until it's set, the scoop job will fail (the other tracks are unaffected).

Bucket side already merged: `scoop-bucket` `excavator.yml` now accepts `repository_dispatch: types: [release]`.