### PR TITLE
docs: add Chocolatey (Windows) install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ scoop install kunobi/kache
 scoop install kunobi/kache-unstable
 ```
 
+**Chocolatey (Windows):**
+
+```powershell
+# Stable
+choco install kache
+
+# Pre-release channel (RC/beta)
+choco install kache --pre
+```
+
 **AUR (Arch Linux):**
 
 ```sh

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: How to install kache — mise, cargo-binstall, source, or an OS package manager (Homebrew, APT, winget, AUR).
+description: How to install kache — mise, cargo-binstall, source, or an OS package manager (Homebrew, APT, winget, Scoop, Chocolatey, AUR).
 ---
 
 # Installation
@@ -62,9 +62,9 @@ kache requires Rust 1.95 or later and is built with the 2024 edition (`Cargo.tom
 
 ## OS package managers
 
-kache is also published to Homebrew, APT, winget, and the AUR. Homebrew, APT, and winget each have a **stable** channel and an **unstable** channel (release-candidates / betas).
+kache is also published to Homebrew, APT, winget, Scoop, Chocolatey, and the AUR. Most have both a **stable** channel and an **unstable** channel (release-candidates / betas).
 
-<Tabs items={["Homebrew (macOS)", "APT (Debian/Ubuntu)", "winget (Windows)", "Scoop (Windows)", "AUR (Arch Linux)"]}>
+<Tabs items={["Homebrew (macOS)", "APT (Debian/Ubuntu)", "winget (Windows)", "Scoop (Windows)", "Chocolatey (Windows)", "AUR (Arch Linux)"]}>
   <Tab value="Homebrew (macOS)">
     ```sh
     # Stable
@@ -123,6 +123,15 @@ kache is also published to Homebrew, APT, winget, and the AUR. Homebrew, APT, an
     <Callout type="info">
       `kache` and `kache-unstable` both provide a `kache` command. With both installed, run `scoop reset kache-unstable` (or `scoop reset kache`) to choose which one the `kache` shim points at.
     </Callout>
+  </Tab>
+  <Tab value="Chocolatey (Windows)">
+    ```powershell
+    # Stable
+    choco install kache
+
+    # Unstable (RC/beta) — same package, pre-release versions
+    choco install kache --pre
+    ```
   </Tab>
   <Tab value="AUR (Arch Linux)">
     kache is on the [AUR](https://aur.archlinux.org/packages/kache). Install it with your preferred AUR helper:


### PR DESCRIPTION
Adds Chocolatey to the install docs, alongside the other Windows managers.

```powershell
choco install kache          # stable
choco install kache --pre    # pre-release (RC/beta)
```

- README: `**Chocolatey (Windows):**` block after Scoop.
- docs/getting-started/installation.mdx: new `Chocolatey (Windows)` tab + manager list updated.

Package: https://community.chocolatey.org/packages/kache (0.11.0 pending Chocolatey moderation). Docs-only.