### PR TITLE
ci(aur): publish official kache-bin to the AUR

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -38,6 +38,7 @@ on:
           - winget
           - scoop
           - choco
+          - aur
         default: 'all'
 
 # OIDC for GCP WIF (KMS PGP signing); read-only repo contents.
@@ -412,3 +413,42 @@ jobs:
               "sha256_x64": "${{ steps.sha.outputs.x64 }}",
               "sha256_arm64": "${{ steps.sha.outputs.arm64 }}"
             }
+
+  # ---------------------------------------------------------------------------
+  # aur — publish the official `kache-bin` package to the Arch User Repository.
+  # An AUR package is a tiny git repo hosted by the AUR itself
+  # (ssh://aur@aur.archlinux.org/kache-bin.git) — NOT a GitHub repo; it holds
+  # just PKGBUILD + .SRCINFO. The recipe lives in-repo at aur/kache-bin/PKGBUILD;
+  # this job refreshes pkgver + checksums and pushes. STABLE only — AUR pkgver
+  # can't carry a pre-release '-' and AUR tracks the latest stable.
+  # Requires the AUR_SSH_KEY secret (private key of the key registered on the
+  # kunobi-ninja AUR account).
+  # ---------------------------------------------------------------------------
+  aur:
+    needs: [resolve, gate]
+    if: ${{ (github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'aur') && needs.resolve.outputs.channel == 'stable' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout (for the PKGBUILD)
+        uses: actions/checkout@v4
+
+      - name: Set pkgver in the PKGBUILD
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          sed -i -e "s/^pkgver=.*/pkgver=${VERSION}/" -e "s/^pkgrel=.*/pkgrel=1/" aur/kache-bin/PKGBUILD
+          echo "--- PKGBUILD (checksums refreshed by updpkgsums in the deploy step) ---"
+          cat aur/kache-bin/PKGBUILD
+
+      - name: Publish kache-bin to the AUR
+        uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
+        with:
+          pkgname: kache-bin
+          pkgbuild: aur/kache-bin/PKGBUILD
+          commit_username: kunobi-ninja
+          commit_email: feedback@kunobi.ninja
+          ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
+          commit_message: "kache-bin: update to ${{ needs.resolve.outputs.version }}"
+          updpkgsums: true

--- a/README.md
+++ b/README.md
@@ -112,12 +112,14 @@ choco install kache --pre
 
 **AUR (Arch Linux):**
 
+The official prebuilt-binary package is [`kache-bin`](https://aur.archlinux.org/packages/kache-bin):
+
 ```sh
 # paru
-paru -S kache
+paru -S kache-bin
 
 # yay
-yay -S kache
+yay -S kache-bin
 ```
 
 ## Quick start

--- a/aur/kache-bin/PKGBUILD
+++ b/aur/kache-bin/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Kunobi Ninja <feedback@kunobi.ninja>
+# This PKGBUILD is generated/updated by kunobi-ninja/kache CI on each stable
+# release (pkgver + checksums refreshed, then pushed to the AUR). It installs
+# the official prebuilt, statically linked musl binary from GitHub Releases.
+pkgname=kache-bin
+pkgver=0.11.0
+pkgrel=1
+pkgdesc='Content-addressed zero-copy build cache for Rust, C/C++ and more (prebuilt binary)'
+arch=('x86_64' 'aarch64')
+url='https://github.com/kunobi-ninja/kache'
+license=('Apache-2.0')
+provides=('kache')
+conflicts=('kache')
+source_x86_64=("kache-$pkgver-x86_64.tar.gz::https://github.com/kunobi-ninja/kache/releases/download/v$pkgver/kache-x86_64-unknown-linux-musl.tar.gz")
+source_aarch64=("kache-$pkgver-aarch64.tar.gz::https://github.com/kunobi-ninja/kache/releases/download/v$pkgver/kache-aarch64-unknown-linux-musl.tar.gz")
+sha256sums_x86_64=('6bedd0a5d6c7cbc27937000b9911c2897485b658f12636fc786890cf4dc23975')
+sha256sums_aarch64=('19566ba48f7ce36c0a1d6f6dce88e59ce4f24a162e1af566f5b24573eb04e98b')
+
+package() {
+  cd "$srcdir"
+
+  # Shell completions (kache ships a `completions` subcommand). Runs the
+  # freshly-extracted native binary on the matching-arch build host.
+  ./kache completions bash   > kache.bash
+  ./kache completions zsh    > kache.zsh
+  ./kache completions fish   > kache.fish
+  ./kache completions elvish > kache.elvish
+
+  install -Dm0755 kache        "$pkgdir/usr/bin/kache"
+  install -Dm0644 kache.bash   "$pkgdir/usr/share/bash-completion/completions/kache"
+  install -Dm0644 kache.zsh    "$pkgdir/usr/share/zsh/site-functions/_kache"
+  install -Dm0644 kache.fish   "$pkgdir/usr/share/fish/vendor_completions.d/kache.fish"
+  install -Dm0644 kache.elvish "$pkgdir/usr/share/elvish/lib/kache.elv"
+}

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -134,14 +134,14 @@ kache is also published to Homebrew, APT, winget, Scoop, Chocolatey, and the AUR
     ```
   </Tab>
   <Tab value="AUR (Arch Linux)">
-    kache is on the [AUR](https://aur.archlinux.org/packages/kache). Install it with your preferred AUR helper:
+    The official prebuilt-binary package is [`kache-bin`](https://aur.archlinux.org/packages/kache-bin) (statically linked, x86_64 + aarch64). Install it with your preferred AUR helper:
 
     ```sh
     # paru
-    paru -S kache
+    paru -S kache-bin
 
     # yay
-    yay -S kache
+    yay -S kache-bin
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
Stands up an **official, Zondax-owned** AUR package `kache-bin` (parallel to the community-maintained `kache` source package).

- **`aur/kache-bin/PKGBUILD`** — installs the prebuilt, statically-linked musl binary from GitHub Releases (x86_64 + aarch64), `provides`/`conflicts` `kache`, ships bash/zsh/fish/elvish completions. Pinned to v0.11.0.
- **`aur` job** in `package-publish.yml` — on each **stable** release, refreshes `pkgver` + checksums (`updpkgsums`) and pushes to `ssh://aur@aur.archlinux.org/kache-bin.git` via `KSXGitHub/github-actions-deploy-aur@v4.2.0` (SHA-pinned). Stable-only, since AUR `pkgver` can't carry a pre-release `-`.

### ⚠️ Prerequisite (one-time, yours)
An AUR package is a git repo hosted by the AUR — **not** a GitHub repo. You need:
1. A **kunobi-ninja account on aur.archlinux.org** with an **SSH key** registered.
2. That SSH **private** key stored as the **`AUR_SSH_KEY`** secret in this repo.
3. The first push (this job, or a manual `git push`) auto-creates `kache-bin` on the AUR.

Until the secret is set, only the `aur` job fails; every other track is unaffected.

Install (once live): `paru -S kache-bin` / `yay -S kache-bin`.