### PR TITLE
feat(daemon): prefetch P0.5 measurement closure (#583)

### DIFF
--- a/src/build_intent.rs
+++ b/src/build_intent.rs
@@ -42,10 +42,12 @@ pub fn discover(args: Option<&RustcArgs>) -> Option<BuildIntent> {
 pub fn into_build_started_request(
     intent: BuildIntent,
     client_epoch: u64,
+    session_id: String,
 ) -> crate::daemon::BuildStartedRequest {
     crate::daemon::BuildStartedRequest {
         intent,
         client_epoch,
+        session_id,
     }
 }
 
@@ -402,7 +404,7 @@ edition = "2021"
             cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
         };
 
-        let req = into_build_started_request(intent, 42);
+        let req = into_build_started_request(intent, 42, "sess-test".into());
         assert_eq!(req.intent.crate_names, vec!["serde", "tokio"]);
         assert_eq!(req.intent.namespace.as_deref(), Some("x86_64/hash/release"));
         assert_eq!(req.intent.cargo_lock_deps.len(), 1);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -282,6 +282,35 @@ pub fn stats(config: &Config, hours: Option<u64>) -> Result<()> {
     for line in render_stats(&snap, &blob_stats, config, hours) {
         println!("{line}");
     }
+
+    // Recent per-session prefetch summaries (#583 P0.5): the durable record
+    // (survives daemon restarts) behind the live snapshot above. Keys/bytes
+    // are daemon-visible lower bounds; join events.jsonl by session_id for
+    // full attribution.
+    let summaries = crate::events::read_summaries(&config.summary_log_path()).unwrap_or_default();
+    if !summaries.is_empty() {
+        println!("Sessions (last {}):", summaries.len().min(5));
+        for s in summaries.iter().rev().take(5) {
+            let cancelled = if s.cancelled { ", CANCELLED" } else { "" };
+            println!(
+                "  {} [{}] {}: {}/{} candidates downloaded ({}), {} used, {} demanded ({}){}",
+                s.ts.format("%m-%d %H:%M"),
+                if s.session_id.is_empty() {
+                    "legacy"
+                } else {
+                    &s.session_id
+                },
+                s.plan_source,
+                s.downloaded_keys,
+                s.candidate_keys,
+                ByteSize(s.downloaded_bytes),
+                s.used_keys,
+                s.demanded_keys,
+                s.closure_reason,
+                cancelled,
+            );
+        }
+    }
     Ok(())
 }
 
@@ -414,6 +443,17 @@ pub(crate) fn render_stats(
             lines.push(format!(
                 "Key LIST:   {} keys in {} ms (refreshes every 60s)",
                 pf.last_list_key_count, pf.last_list_duration_ms,
+            ));
+        }
+        // Cumulative LIST cost (#583 P0.5): the totals the P3 decision gate
+        // reads. Rendered only once refreshes have happened.
+        if pf.list_requests_total > 0 {
+            lines.push(format!(
+                "LIST total: {} requests ({} failed), {} ms, {} keys returned",
+                pf.list_requests_total,
+                pf.list_failures_total,
+                pf.list_duration_ms_total,
+                pf.list_keys_total,
             ));
         }
         if pf.dedup_join_waits > 0 {
@@ -4697,6 +4737,10 @@ mod tests {
             dedup_join_wait_ms: 1234,
             last_list_duration_ms: 88,
             last_list_key_count: 250_000,
+            list_requests_total: 0,
+            list_failures_total: 0,
+            list_duration_ms_total: 0,
+            list_keys_total: 0,
         };
         let out = render_stats(&snap, &blobs, &config, 24).join("\n");
         assert!(out.contains("Prefetch:   4 downloads"));
@@ -4971,6 +5015,7 @@ mod tests {
     ) -> crate::events::BuildEvent {
         crate::events::BuildEvent {
             ts: chrono::Utc::now(),
+            session_id: String::new(),
             crate_name: crate_name.to_string(),
             version: "0.1.0".to_string(),
             result,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1002,6 +1002,12 @@ impl Config {
         self.cache_dir.join("transfers.jsonl")
     }
 
+    /// Per-session prefetch summaries appended by the daemon on session
+    /// finalization (kunobi-ninja/kache#583 P0.5).
+    pub fn summary_log_path(&self) -> PathBuf {
+        self.cache_dir.join("summaries.jsonl")
+    }
+
     pub fn socket_path(&self) -> PathBuf {
         self.cache_dir.join("daemon.sock")
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -430,6 +430,10 @@ pub struct BuildStartedRequest {
     /// Client binary mtime — lets the daemon detect when it's running stale code.
     #[serde(default)]
     pub client_epoch: u64,
+    /// Build session id minted by the wrapper that won the session-marker
+    /// lock (kunobi-ninja/kache#583 P0.5). Empty from legacy wrappers.
+    #[serde(default)]
+    pub session_id: String,
 }
 
 #[allow(dead_code)]
@@ -515,6 +519,14 @@ pub struct PrefetchStatsSnapshot {
     pub last_list_duration_ms: u64,
     #[serde(default)]
     pub last_list_key_count: u64,
+    #[serde(default)]
+    pub list_requests_total: u64,
+    #[serde(default)]
+    pub list_failures_total: u64,
+    #[serde(default)]
+    pub list_duration_ms_total: u64,
+    #[serde(default)]
+    pub list_keys_total: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -826,9 +838,8 @@ fn prefetch_concurrency_cap(s3_concurrency: u32) -> usize {
 
 /// Daemon-lifetime prefetch/planning observability counters (#485 Phase 0).
 ///
-/// Telemetry only — nothing here feeds a decision. The adaptive cancellation
-/// keeps its own `prefetch_checks`/`prefetch_hits` pair untouched so behavior
-/// is unchanged while the baseline is being measured; these counters exist so
+/// Telemetry only — nothing here feeds a decision. Adaptive cancellation is
+/// driven by the per-plan [`ActivePlan`] counters (#581); these exist so
 /// `kache stats` can show planner source, plan size, downloaded-vs-used
 /// prefetch volume, cancellation, dedup join-waits, and LIST cost — the
 /// numbers the prefetch-coordination work is judged against.
@@ -860,6 +871,14 @@ pub(crate) struct PrefetchStats {
     /// Most recent key-cache LIST refresh: wall time and key count.
     pub last_list_duration_ms: std::sync::atomic::AtomicU64,
     pub last_list_key_count: std::sync::atomic::AtomicU64,
+    /// Cumulative key-cache LIST telemetry (#583 P0.5). The "last" gauges
+    /// above show current behavior; deciding whether LIST replacement (plan
+    /// P3) is worth building needs totals — count, failures, total wall time,
+    /// total keys returned — and per-session deltas of these.
+    pub list_requests_total: std::sync::atomic::AtomicU64,
+    pub list_failures_total: std::sync::atomic::AtomicU64,
+    pub list_duration_ms_total: std::sync::atomic::AtomicU64,
+    pub list_keys_total: std::sync::atomic::AtomicU64,
 }
 
 impl PrefetchStats {
@@ -876,11 +895,159 @@ impl PrefetchStats {
             dedup_join_wait_ms: 0.into(),
             last_list_duration_ms: 0.into(),
             last_list_key_count: 0.into(),
+            list_requests_total: 0.into(),
+            list_failures_total: 0.into(),
+            list_duration_ms_total: 0.into(),
+            list_keys_total: 0.into(),
         }
     }
 }
 
 const RECENT_TRANSFERS_CAP: usize = 50;
+
+// ── Active prefetch plan (per-session attribution, #583 P0.5) ───────────────
+
+/// Per-plan prefetch bookkeeping. One plan is active at a time (the daemon
+/// serves one build session per cache dir); a new BuildStarted supersedes and
+/// finalizes the previous plan, and an inactivity sweep finalizes an
+/// abandoned one. Fixes #581: the adaptive-cancel counters live HERE, reset
+/// per plan, instead of daemon-lifetime atomics whose ratio was 100% by
+/// construction.
+///
+/// KNOWN LIMITS (P0.5 scope, accepted in cross-family review): concurrent
+/// builds from different roots share this single slot — their demands are
+/// coalesced because RemoteCheck carries no session id yet (a P2a feedback
+/// concern); and a superseded plan's still-in-flight downloads record into
+/// the superseding plan (brief window, inflates its potential-hit upper
+/// bound, i.e. errs toward NOT cancelling — the safe direction).
+#[derive(Debug)]
+pub(crate) struct ActivePlan {
+    pub session_id: String,
+    pub plan_id: String,
+    /// `advisory` | `fallback`.
+    pub plan_source: &'static str,
+    pub candidates: HashSet<String>,
+    /// Distinct keys demanded via RemoteCheck while this plan was active —
+    /// candidate or not. The denominator of the adaptive-cancel ratio.
+    pub demanded: HashSet<String>,
+    /// Demanded ∩ candidates: the numerator.
+    pub demanded_candidates: HashSet<String>,
+    /// Prefetch downloads completed under this plan: key → compressed bytes.
+    pub downloaded: HashMap<String, u64>,
+    /// Demanded ∩ downloaded — daemon-visible use (lower bound; a completed
+    /// prefetch consumed via the wrapper's local store path never gets here).
+    pub used: HashSet<String>,
+    pub cancelled: bool,
+    pub started_at_ms: u64,
+    pub last_activity_ms: u64,
+    /// Cumulative LIST counters at install time, for per-session deltas.
+    pub list_requests_at_install: u64,
+    pub list_duration_ms_at_install: u64,
+}
+
+impl ActivePlan {
+    fn new(
+        session_id: String,
+        plan_id: String,
+        plan_source: &'static str,
+        candidates: HashSet<String>,
+        list_requests_at_install: u64,
+        list_duration_ms_at_install: u64,
+    ) -> Self {
+        let now = epoch_ms();
+        Self {
+            session_id,
+            plan_id,
+            plan_source,
+            candidates,
+            demanded: HashSet::new(),
+            demanded_candidates: HashSet::new(),
+            downloaded: HashMap::new(),
+            used: HashSet::new(),
+            cancelled: false,
+            started_at_ms: now,
+            last_activity_ms: now,
+            list_requests_at_install,
+            list_duration_ms_at_install,
+        }
+    }
+
+    /// Record a demanded key; returns true when adaptive cancellation should
+    /// fire NOW (single false→true transition of the latch).
+    fn record_demand(&mut self, key: &str) -> bool {
+        self.last_activity_ms = epoch_ms();
+        if self.demanded.insert(key.to_string()) {
+            if self.candidates.contains(key) {
+                self.demanded_candidates.insert(key.to_string());
+            }
+            if self.downloaded.contains_key(key) {
+                self.used.insert(key.to_string());
+            }
+        }
+        if self.cancelled {
+            return false;
+        }
+        let downloaded_not_demanded = self
+            .downloaded
+            .keys()
+            .filter(|k| !self.demanded.contains(*k))
+            .count() as u64;
+        if should_cancel_prefetch(
+            self.demanded.len() as u64,
+            self.demanded_candidates.len() as u64,
+            downloaded_not_demanded,
+        ) {
+            self.cancelled = true;
+            return true;
+        }
+        false
+    }
+
+    fn record_download(&mut self, key: &str, compressed_bytes: u64) {
+        self.last_activity_ms = epoch_ms();
+        self.downloaded.insert(key.to_string(), compressed_bytes);
+        if self.demanded.contains(key) {
+            self.used.insert(key.to_string());
+        }
+    }
+
+    fn used_bytes(&self) -> u64 {
+        self.used
+            .iter()
+            .filter_map(|k| self.downloaded.get(k))
+            .sum()
+    }
+}
+
+/// Should adaptive prefetch cancellation fire? (#581)
+///
+/// `demanded` = distinct keys the build has asked for while the plan is
+/// active (candidate or not); `demanded_candidates` = the subset that were
+/// plan candidates; `downloaded_not_demanded` = completed prefetch downloads
+/// the daemon has NOT seen demanded — these may already have been consumed
+/// through the wrapper's local store path without reaching the daemon, so
+/// they count as potential hits (conservative upper bound, cross-family
+/// review). Cancel only when even the upper-bound hit rate is below 30%
+/// after 10+ distinct demands: wasting a plan is cheaper than cancelling a
+/// good one on biased evidence.
+pub(crate) fn should_cancel_prefetch(
+    demanded: u64,
+    demanded_candidates: u64,
+    downloaded_not_demanded: u64,
+) -> bool {
+    if demanded < 10 {
+        return false;
+    }
+    let upper_bound_hits = demanded_candidates + downloaded_not_demanded;
+    (upper_bound_hits as f64 / demanded as f64) < 0.3
+}
+
+fn epoch_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
 
 // ── S3 Key Cache ─────────────────────────────────────────────────
 
@@ -1030,11 +1197,9 @@ pub(crate) struct Daemon {
     /// Keys downloaded during manifest/shard prefetch. Used to distinguish
     /// PrefetchHit from LocalHit in wrapper event logging.
     prefetched_keys: Arc<RwLock<HashSet<String>>>,
-    /// Counters for adaptive prefetch cancellation: number of remote checks
-    /// against prefetched keys (checks) vs how many were actually used (hits).
-    prefetch_checks: Arc<AtomicU32>,
-    prefetch_hits: Arc<AtomicU32>,
     /// Signals remaining prefetch downloads to stop when hit rate is too low.
+    /// Reset to `false` on every plan install; the per-plan counters that
+    /// drive it live in [`ActivePlan`] (#581).
     prefetch_cancel: tokio::sync::watch::Sender<bool>,
     /// Phase-0 observability counters (#485). Telemetry only.
     prefetch_stats: PrefetchStats,
@@ -1052,6 +1217,9 @@ pub(crate) struct Daemon {
     /// (which must keep every key for PrefetchHit labeling) so counting a use
     /// doesn't disturb labels. Bounded alongside `prefetched_keys`.
     prefetch_used_keys: Arc<RwLock<HashSet<String>>>,
+    /// The active per-session prefetch plan (#583 P0.5). Std mutex: every
+    /// critical section is a short map/set operation, never held across await.
+    active_plan: Arc<std::sync::Mutex<Option<ActivePlan>>>,
     version: String,
     build_epoch: u64,
     transfer_counters: TransferCounters,
@@ -1085,14 +1253,13 @@ impl Daemon {
             downloading: Arc::new(RwLock::new(HashMap::new())),
             warming_tx,
             prefetched_keys: Arc::new(RwLock::new(HashSet::new())),
-            prefetch_checks: Arc::new(AtomicU32::new(0)),
-            prefetch_hits: Arc::new(AtomicU32::new(0)),
             prefetch_cancel,
             prefetch_stats: PrefetchStats::new(),
             prefetch_gate: Arc::new(tokio::sync::Semaphore::new(prefetch_concurrency_cap(
                 config.s3_concurrency,
             ))),
             prefetch_used_keys: Arc::new(RwLock::new(HashSet::new())),
+            active_plan: Arc::new(std::sync::Mutex::new(None)),
             version: VERSION.to_string(),
             build_epoch: build_epoch(),
             transfer_counters: TransferCounters::new(),
@@ -1336,6 +1503,10 @@ impl Daemon {
                 dedup_join_wait_ms: ps.dedup_join_wait_ms.load(Ordering::Relaxed),
                 last_list_duration_ms: ps.last_list_duration_ms.load(Ordering::Relaxed),
                 last_list_key_count: ps.last_list_key_count.load(Ordering::Relaxed),
+                list_requests_total: ps.list_requests_total.load(Ordering::Relaxed),
+                list_failures_total: ps.list_failures_total.load(Ordering::Relaxed),
+                list_duration_ms_total: ps.list_duration_ms_total.load(Ordering::Relaxed),
+                list_keys_total: ps.list_keys_total.load(Ordering::Relaxed),
             },
         })
     }
@@ -1696,16 +1867,19 @@ impl Daemon {
             );
         }
 
-        // Adaptive prefetch cancellation: track whether prefetched keys are being used.
-        // After enough checks, if hit rate is too low, cancel remaining prefetch downloads.
+        // Adaptive prefetch cancellation (#581, #583 P0.5): per-plan demand
+        // tracking. Every distinct demanded key counts (candidate or not) —
+        // the old daemon-lifetime counters only incremented on prefetched
+        // keys, making the hit ratio 100% by construction so cancellation
+        // never fired. The decision itself is `should_cancel_prefetch`,
+        // which counts downloaded-but-not-yet-demanded keys as potential
+        // hits (they may have been consumed via the wrapper's local store
+        // path without reaching the daemon).
         {
             let is_prefetched = self.prefetched_keys.read().await.contains(&req.key);
             if is_prefetched {
-                self.prefetch_checks.fetch_add(1, Ordering::Relaxed);
-                // This is a hit — the wrapper is requesting a key that was prefetched
-                self.prefetch_hits.fetch_add(1, Ordering::Relaxed);
                 // Phase-0 telemetry: count each prefetched key as "used" once
-                // (distinct keys, unlike the per-check counters above).
+                // (distinct keys; daemon-visible lower bound).
                 if self
                     .prefetch_used_keys
                     .write()
@@ -1717,13 +1891,23 @@ impl Daemon {
                         .fetch_add(1, Ordering::Relaxed);
                 }
             }
-            let checks = self.prefetch_checks.load(Ordering::Relaxed);
-            let hits = self.prefetch_hits.load(Ordering::Relaxed);
-            if checks >= 10 && (hits as f64 / checks as f64) < 0.3 {
-                // Hit rate below 30% after 10+ checks — cancel remaining prefetch
+            let fire_cancel = {
+                let mut plan = self.active_plan.lock().unwrap_or_else(|p| p.into_inner());
+                match plan.as_mut() {
+                    Some(p) => p.record_demand(&req.key),
+                    None => false,
+                }
+            };
+            if fire_cancel {
                 let _ = self.prefetch_cancel.send(true);
+                let (demanded, hits) = {
+                    let plan = self.active_plan.lock().unwrap_or_else(|p| p.into_inner());
+                    plan.as_ref()
+                        .map(|p| (p.demanded.len(), p.demanded_candidates.len()))
+                        .unwrap_or((0, 0))
+                };
                 tracing::info!(
-                    "adaptive prefetch cancel: {hits}/{checks} hit rate, cancelling remaining downloads"
+                    "adaptive prefetch cancel: {hits}/{demanded} demanded keys were plan candidates, cancelling remaining downloads"
                 );
             }
         }
@@ -2290,6 +2474,15 @@ impl Daemon {
                             d.prefetch_stats
                                 .bytes_downloaded
                                 .fetch_add(dl.compressed_bytes, Ordering::Relaxed);
+                            // Per-plan attribution (#583 P0.5): byte-accurate
+                            // downloaded set for the session summary.
+                            {
+                                let mut plan =
+                                    d.active_plan.lock().unwrap_or_else(|p| p.into_inner());
+                                if let Some(p) = plan.as_mut() {
+                                    p.record_download(&key, dl.compressed_bytes);
+                                }
+                            }
                             d.push_transfer_event(TransferEvent {
                                 schema: default_transfer_schema(),
                                 crate_name: crate_name.clone(),
@@ -2394,10 +2587,117 @@ impl Daemon {
     /// Handle a build-started hint by asking the advisory remote planner first,
     /// then falling back to the in-process planner that matches the daemon's
     /// current shard/history/key-cache heuristics.
+    /// Install a new active plan, finalizing (and summarizing) any previous
+    /// one as `superseded`, and reset the adaptive-cancel latch so one bad
+    /// build can't poison the next (#581).
+    fn install_plan(
+        &self,
+        session_id: &str,
+        plan_id: &str,
+        plan_source: &'static str,
+        candidates: impl Iterator<Item = String>,
+    ) {
+        let _ = self.prefetch_cancel.send(false);
+        let plan = ActivePlan::new(
+            session_id.to_string(),
+            plan_id.to_string(),
+            plan_source,
+            candidates.collect(),
+            self.prefetch_stats
+                .list_requests_total
+                .load(Ordering::Relaxed),
+            self.prefetch_stats
+                .list_duration_ms_total
+                .load(Ordering::Relaxed),
+        );
+        let prev = {
+            let mut slot = self.active_plan.lock().unwrap_or_else(|p| p.into_inner());
+            slot.replace(plan)
+        };
+        if let Some(prev) = prev {
+            self.emit_plan_summary(prev, "superseded");
+        }
+    }
+
+    /// Finalize the active plan if it has been inactive for `inactivity_ms`.
+    /// Called from the periodic sweep; cargo gives no positive end-of-build
+    /// signal, so inactivity IS the end signal (#583 P0.5).
+    pub(crate) fn finalize_inactive_plan(&self, inactivity_ms: u64) {
+        let prev = {
+            let mut slot = self.active_plan.lock().unwrap_or_else(|p| p.into_inner());
+            match slot.as_ref() {
+                Some(p) if epoch_ms().saturating_sub(p.last_activity_ms) >= inactivity_ms => {
+                    slot.take()
+                }
+                _ => None,
+            }
+        };
+        if let Some(prev) = prev {
+            self.emit_plan_summary(prev, "inactivity");
+        }
+    }
+
+    /// Append the per-session summary to `summaries.jsonl`. Best-effort:
+    /// telemetry must never fail the daemon.
+    fn emit_plan_summary(&self, plan: ActivePlan, closure_reason: &str) {
+        let used_bytes = plan.used_bytes();
+        let downloaded_bytes: u64 = plan.downloaded.values().sum();
+        let event = crate::events::BuildSummaryEvent {
+            ts: chrono::Utc::now(),
+            schema: 1,
+            session_id: plan.session_id,
+            root: String::new(),
+            plan_source: plan.plan_source.to_string(),
+            plan_id: plan.plan_id,
+            closure_reason: closure_reason.to_string(),
+            started_at_ms: plan.started_at_ms,
+            last_activity_ms: plan.last_activity_ms,
+            candidate_keys: plan.candidates.len() as u64,
+            downloaded_keys: plan.downloaded.len() as u64,
+            downloaded_bytes,
+            used_keys: plan.used.len() as u64,
+            used_bytes,
+            demanded_keys: plan.demanded.len() as u64,
+            demanded_candidate_keys: plan.demanded_candidates.len() as u64,
+            cancelled: plan.cancelled,
+            list_requests: self
+                .prefetch_stats
+                .list_requests_total
+                .load(Ordering::Relaxed)
+                .saturating_sub(plan.list_requests_at_install),
+            list_duration_ms: self
+                .prefetch_stats
+                .list_duration_ms_total
+                .load(Ordering::Relaxed)
+                .saturating_sub(plan.list_duration_ms_at_install),
+        };
+        let path = self.config.summary_log_path();
+        if let Err(e) = crate::events::log_summary(&path, &event) {
+            tracing::debug!("failed to write build summary: {e}");
+        }
+    }
+
     pub async fn handle_build_started(self: &Arc<Self>, req: &BuildStartedRequest) -> Response {
         let Some(_remote) = &self.config.remote else {
             return Response::err("no remote configured");
         };
+
+        // A new session supersedes the previous plan even when THIS build ends
+        // up with no plan (DoNothing, empty candidates, planning failure) —
+        // otherwise the old plan would keep absorbing the new build's demands,
+        // never go inactive, and never finalize (cross-family review finding).
+        {
+            let prev = {
+                let mut slot = self.active_plan.lock().unwrap_or_else(|p| p.into_inner());
+                match slot.as_ref() {
+                    Some(p) if p.session_id != req.session_id => slot.take(),
+                    _ => None,
+                }
+            };
+            if let Some(prev) = prev {
+                self.emit_plan_summary(prev, "superseded");
+            }
+        }
 
         match crate::planner_client::resolve_prefetch_plan(&req.intent).await {
             Ok(Some(plan)) => {
@@ -2413,6 +2713,12 @@ impl Daemon {
                     }
                     PrefetchDisposition::Execute => {
                         let prefetch_req = PrefetchRequest::from_plan(plan);
+                        self.install_plan(
+                            &req.session_id,
+                            plan_id.as_deref().unwrap_or(""),
+                            "advisory",
+                            prefetch_req.keys.iter().map(|(k, _)| k.clone()),
+                        );
                         let resp = self.handle_prefetch(&prefetch_req).await;
                         if resp.ok {
                             self.prefetch_stats
@@ -2487,6 +2793,12 @@ impl Daemon {
             .store(fallback_plan.candidates.len() as u64, Ordering::Relaxed);
 
         let prefetch_req = PrefetchRequest::from_plan(fallback_plan);
+        self.install_plan(
+            &req.session_id,
+            "",
+            "fallback",
+            prefetch_req.keys.iter().map(|(k, _)| k.clone()),
+        );
         self.handle_prefetch(&prefetch_req).await
     }
 
@@ -2775,6 +3087,21 @@ async fn server_main(config: &Config, coord: DaemonCoordFile) -> Result<()> {
 
     // Periodic GC task: run immediately on startup, then every 6 hours
     let gc_daemon = daemon.clone();
+    // Session-summary sweep (#583 P0.5): finalize an active prefetch plan
+    // once its build session has gone quiet. 60s granularity against a
+    // 5-minute inactivity window is plenty; the summary lands in
+    // `summaries.jsonl` where `kache report` joins it with per-crate events.
+    let sweep_daemon = daemon.clone();
+    tokio::spawn(async move {
+        const SESSION_INACTIVITY_MS: u64 = 300_000;
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            sweep_daemon.finalize_inactive_plan(SESSION_INACTIVITY_MS);
+        }
+    });
+
     let gc_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(6 * 3600));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -3177,21 +3504,51 @@ async fn populate_key_cache(daemon: &Daemon) -> Result<usize> {
         .ok_or_else(|| anyhow::anyhow!("no remote configured"))?;
 
     let list_start = Instant::now();
-    let keys = crate::remote_plan::RemotePlanner::new(&daemon.config)
+    daemon
+        .prefetch_stats
+        .list_requests_total
+        .fetch_add(1, Ordering::Relaxed);
+    let keys = match crate::remote_plan::RemotePlanner::new(&daemon.config)
         .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
         .layout(backend.as_ref(), remote)
         .list_keys()
-        .await?;
-    // Phase-0 telemetry (#485): the LIST cost the coordination service exists
-    // to retire. Duration + key count of the most recent refresh.
+        .await
+    {
+        Ok(keys) => keys,
+        Err(e) => {
+            // Failures still cost wall time; count both (#583 P0.5).
+            daemon
+                .prefetch_stats
+                .list_failures_total
+                .fetch_add(1, Ordering::Relaxed);
+            daemon
+                .prefetch_stats
+                .list_duration_ms_total
+                .fetch_add(list_start.elapsed().as_millis() as u64, Ordering::Relaxed);
+            return Err(e);
+        }
+    };
+    // Phase-0 telemetry (#485/#583): the LIST cost the coordination service
+    // exists to retire. Last-refresh gauges plus cumulative totals — the
+    // totals (and their per-session deltas in the build summary) are what
+    // the P3-vs-P4a decision gate reads.
+    let list_elapsed_ms = list_start.elapsed().as_millis() as u64;
     daemon
         .prefetch_stats
         .last_list_duration_ms
-        .store(list_start.elapsed().as_millis() as u64, Ordering::Relaxed);
+        .store(list_elapsed_ms, Ordering::Relaxed);
     daemon
         .prefetch_stats
         .last_list_key_count
         .store(keys.len() as u64, Ordering::Relaxed);
+    daemon
+        .prefetch_stats
+        .list_duration_ms_total
+        .fetch_add(list_elapsed_ms, Ordering::Relaxed);
+    daemon
+        .prefetch_stats
+        .list_keys_total
+        .fetch_add(keys.len() as u64, Ordering::Relaxed);
     let count = keys.len();
     daemon.key_cache.populate(keys).await;
     Ok(count)
@@ -4560,6 +4917,90 @@ mod tests {
     use super::*;
     use std::sync::mpsc;
 
+    /// #581: the old counters incremented checks and hits in the same branch,
+    /// so the ratio was 100% by construction and cancellation never fired.
+    /// The rework counts EVERY distinct demanded key; these pin the decision
+    /// function's semantics.
+    #[test]
+    fn should_cancel_prefetch_fires_on_low_candidate_share() {
+        // 12 distinct demands, only 1 was a plan candidate, nothing else
+        // downloaded — a plainly bad plan.
+        assert!(should_cancel_prefetch(12, 1, 0));
+    }
+
+    #[test]
+    fn should_cancel_prefetch_holds_below_min_demands() {
+        // Never cancel on thin evidence, however bad the ratio looks.
+        assert!(!should_cancel_prefetch(9, 0, 0));
+    }
+
+    #[test]
+    fn should_cancel_prefetch_holds_when_plan_is_good() {
+        assert!(!should_cancel_prefetch(20, 15, 0));
+    }
+
+    #[test]
+    fn should_cancel_prefetch_counts_undmanded_downloads_as_potential_hits() {
+        // The local-consumption blind spot: completed prefetches consumed via
+        // the wrapper's local store never reach the daemon as demands. They
+        // count toward the upper bound, so a plan whose downloads are being
+        // silently consumed is NOT cancelled.
+        assert!(should_cancel_prefetch(20, 2, 0));
+        assert!(!should_cancel_prefetch(20, 2, 8));
+    }
+
+    /// Per-plan lifecycle: demand/download bookkeeping and the single-fire
+    /// cancel latch.
+    #[test]
+    fn active_plan_tracks_demand_download_and_use() {
+        let mut plan = ActivePlan::new(
+            "sess-1".into(),
+            "plan-1".into(),
+            "fallback",
+            ["a", "b"].into_iter().map(String::from).collect(),
+            0,
+            0,
+        );
+        // Candidate demanded before download: counted, not yet used.
+        assert!(!plan.record_demand("a"));
+        assert_eq!(plan.demanded.len(), 1);
+        assert_eq!(plan.demanded_candidates.len(), 1);
+        assert!(plan.used.is_empty());
+        // Download lands after demand → used.
+        plan.record_download("a", 100);
+        assert!(plan.used.contains("a"));
+        // Download-then-demand also counts as used.
+        plan.record_download("b", 50);
+        assert!(!plan.record_demand("b"));
+        assert!(plan.used.contains("b"));
+        assert_eq!(plan.used_bytes(), 150);
+        // Duplicate demand of the same key doesn't inflate the sets.
+        assert!(!plan.record_demand("a"));
+        assert_eq!(plan.demanded.len(), 2);
+    }
+
+    #[test]
+    fn active_plan_cancel_latch_fires_once() {
+        let mut plan = ActivePlan::new(
+            "sess-2".into(),
+            String::new(),
+            "advisory",
+            ["only-candidate".to_string()].into_iter().collect(),
+            0,
+            0,
+        );
+        // Demand 9 non-candidate keys: below the floor, no fire.
+        for i in 0..9 {
+            assert!(!plan.record_demand(&format!("k{i}")));
+        }
+        // The 10th distinct non-candidate demand crosses the floor with a
+        // 0/10 candidate share → fires exactly once...
+        assert!(plan.record_demand("k9"));
+        assert!(plan.cancelled);
+        // ...and never again for the same plan.
+        assert!(!plan.record_demand("k10"));
+    }
+
     // Tests use the same cross-platform transport as production. On Unix
     // this resolves to UDS; on Windows (when tests are eventually enabled
     // there) it resolves to named pipes.
@@ -5303,6 +5744,10 @@ mod tests {
             dedup_join_wait_ms: 250,
             last_list_duration_ms: 42,
             last_list_key_count: 9001,
+            list_requests_total: 7,
+            list_failures_total: 1,
+            list_duration_ms_total: 900,
+            list_keys_total: 63007,
         };
         let json = serde_json::to_string(&snap).unwrap();
         let back: PrefetchStatsSnapshot = serde_json::from_str(&json).unwrap();
@@ -6499,6 +6944,7 @@ mod tests {
                     cargo_lock_deps: vec![],
                 },
                 client_epoch: 0,
+                session_id: String::new(),
             }),
         )
         .await;
@@ -7031,6 +7477,7 @@ mod tests {
                 cargo_lock_deps: vec![],
             },
             client_epoch: 0,
+            session_id: String::new(),
         };
         let resp = daemon.handle_build_started(&req).await;
         assert!(
@@ -8047,6 +8494,7 @@ mod tests {
                 cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
             },
             client_epoch: 0,
+            session_id: String::new(),
         });
         let json = serde_json::to_string(&req).unwrap();
         let parsed: Request = serde_json::from_str(&json).unwrap();
@@ -8063,6 +8511,7 @@ mod tests {
         let req = Request::BuildStarted(BuildStartedRequest {
             intent: kache_core::BuildIntent::default(),
             client_epoch: 0,
+            session_id: String::new(),
         });
         let json = serde_json::to_string(&req).unwrap();
         let parsed: Request = serde_json::from_str(&json).unwrap();
@@ -8098,6 +8547,7 @@ mod tests {
                         ..Default::default()
                     },
                     client_epoch: 0,
+                    session_id: String::new(),
                 },
             )
         })
@@ -8178,6 +8628,7 @@ mod tests {
                 ..Default::default()
             },
             client_epoch: 0,
+            session_id: String::new(),
         };
         let resp = daemon.handle_build_started(&req).await;
         assert!(!resp.ok);
@@ -8201,6 +8652,7 @@ mod tests {
                 ..Default::default()
             },
             client_epoch: 0,
+            session_id: String::new(),
         });
         let resp = daemon.handle_request_sync(&req);
         assert!(!resp.ok);

--- a/src/events.rs
+++ b/src/events.rs
@@ -34,9 +34,18 @@ pub struct BuildEvent {
     /// 2 = compile-cost-aware, 3 = op-count-aware, 4 = probe-count-aware,
     /// 5 = passthrough details, 6 = file-hash cache metrics,
     /// 7 = restore-method bytes, 8 = dup outcome + store blob counters,
-    /// 9 = event root.
+    /// 9 = event root, 10 = build session id.
     #[serde(default)]
     pub schema: u32,
+    /// Build session this event belongs to (kunobi-ninja/kache#583 P0.5).
+    ///
+    /// Minted once per build by the wrapper that wins the session-marker
+    /// lock (see `wrapper::build_session_id`) and read back by every other
+    /// wrapper in the same build, so per-crate events can be joined with the
+    /// daemon's per-plan prefetch summary. Empty = legacy wrapper or no
+    /// session marker (never fails a build).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub session_id: String,
     /// Cache key computation time (ms).
     #[serde(default)]
     pub key_ms: u64,
@@ -154,18 +163,68 @@ impl std::fmt::Display for EventResult {
     }
 }
 
-/// Summary event logged once per build session with prefetch metrics.
-#[allow(dead_code)]
+/// Per-session prefetch summary, appended to `summaries.jsonl` by the daemon
+/// when a build session is finalized (kunobi-ninja/kache#583 P0.5).
+///
+/// Finalization happens on session inactivity, supersession by a newer
+/// session, or daemon shutdown — cargo gives no positive end-of-build signal,
+/// so closure is always inferred (`closure_reason` says how). Counts are kept
+/// as raw numerators/denominators; consumers derive ratios (key precision =
+/// `used_keys / downloaded_keys`, byte precision = `used_bytes /
+/// downloaded_bytes`) so mixed-version or partial sessions stay auditable.
+///
+/// `used_keys`/`used_bytes` are a LOWER BOUND: a completed prefetch is
+/// imported into the local store and consumed as a `LocalHit` without
+/// contacting the daemon, so daemon-side demand misses it. Join per-crate
+/// events by `session_id` + `cache_key` for full attribution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BuildSummaryEvent {
     pub ts: DateTime<Utc>,
     pub schema: u32,
-    pub warming_wait_ms: u64,
-    pub prefetch_duration_ms: u64,
-    pub prefetch_requested: usize,
-    pub prefetch_downloaded: usize,
-    pub shards_matched: usize,
-    pub shards_total: usize,
+    #[serde(default)]
+    pub session_id: String,
+    #[serde(default)]
+    pub root: String,
+    /// `advisory` | `fallback` | `none` — which planner produced the plan.
+    #[serde(default)]
+    pub plan_source: String,
+    #[serde(default)]
+    pub plan_id: String,
+    /// `inactivity` | `superseded` | `shutdown`.
+    #[serde(default)]
+    pub closure_reason: String,
+    #[serde(default)]
+    pub started_at_ms: u64,
+    #[serde(default)]
+    pub last_activity_ms: u64,
+    /// Plan candidates offered for prefetch.
+    #[serde(default)]
+    pub candidate_keys: u64,
+    /// Prefetch downloads completed (distinct keys / compressed wire bytes).
+    #[serde(default)]
+    pub downloaded_keys: u64,
+    #[serde(default)]
+    pub downloaded_bytes: u64,
+    /// Daemon-visible consumption of downloaded keys (lower bound, see above).
+    #[serde(default)]
+    pub used_keys: u64,
+    #[serde(default)]
+    pub used_bytes: u64,
+    /// Distinct keys demanded via RemoteCheck while the plan was active.
+    #[serde(default)]
+    pub demanded_keys: u64,
+    /// Distinct demanded keys that were plan candidates.
+    #[serde(default)]
+    pub demanded_candidate_keys: u64,
+    /// Whether adaptive cancellation fired for this plan.
+    #[serde(default)]
+    pub cancelled: bool,
+    /// Key-cache LIST refreshes attributed to this session (delta of the
+    /// daemon-lifetime counters between plan install and finalization).
+    #[serde(default)]
+    pub list_requests: u64,
+    #[serde(default)]
+    pub list_duration_ms: u64,
 }
 
 /// Append a build event to the event log file.
@@ -440,6 +499,61 @@ pub fn rotate_if_needed(event_log_path: &Path, max_size: u64, keep_lines: usize)
     rotate_log_impl(event_log_path, max_size, keep_lines, "event log")
 }
 
+// ── Summary log ─────────────────────────────────────────────────────────────
+
+/// Append a per-session build summary to the summary log (`summaries.jsonl`).
+/// Own file rather than `events.jsonl` so `read_events` never has to skip
+/// foreign lines; same locking discipline as the other logs.
+pub fn log_summary(summary_log_path: &Path, event: &BuildSummaryEvent) -> Result<()> {
+    if let Some(parent) = summary_log_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let lock = open_log_lock(summary_log_path).context("opening summary log lock")?;
+    lock.lock().context("locking summary log")?;
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(summary_log_path)
+        .context("opening summary log")?;
+    let line = serde_json::to_string(event).context("serializing summary event")?;
+    let mut bytes = line.into_bytes();
+    bytes.push(b'\n');
+    file.write_all(&bytes)
+        .context("writing summary event to log")?;
+    lock.unlock().context("unlocking summary log")?;
+    Ok(())
+}
+
+/// Read all build summaries from the summary log. Invalid lines are skipped
+/// (schema evolution / partial writes must not poison reporting).
+pub fn read_summaries(summary_log_path: &Path) -> Result<Vec<BuildSummaryEvent>> {
+    if !summary_log_path.exists() {
+        return Ok(Vec::new());
+    }
+    let lock = open_log_lock(summary_log_path).context("opening summary log lock")?;
+    lock.lock_shared().context("locking summary log for read")?;
+
+    let file = File::open(summary_log_path).context("opening summary log")?;
+    let reader = BufReader::new(&file);
+    let mut events = Vec::new();
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<BuildSummaryEvent>(&line) {
+            Ok(event) => events.push(event),
+            Err(e) => {
+                tracing::debug!("skipping invalid summary line: {}", e);
+            }
+        }
+    }
+
+    lock.unlock().context("unlocking summary log")?;
+    Ok(events)
+}
+
 // ── Transfer log ────────────────────────────────────────────────────────────
 
 use crate::daemon::TransferEvent;
@@ -686,6 +800,7 @@ mod tests {
             crate_name: crate_name.to_string(),
             root: String::new(),
             version: "0.0.0".to_string(),
+            session_id: String::new(),
             result,
             elapsed_ms,
             compile_time_ms,
@@ -727,6 +842,7 @@ mod tests {
             crate_name: "serde".to_string(),
             root: "/work/tree".to_string(),
             version: "1.0.210".to_string(),
+            session_id: String::new(),
             result: EventResult::LocalHit,
             elapsed_ms: 2,
             compile_time_ms: 250,

--- a/src/report.rs
+++ b/src/report.rs
@@ -2778,6 +2778,7 @@ mod tests {
     ) -> BuildEvent {
         BuildEvent {
             ts: Utc::now(),
+            session_id: String::new(),
             crate_name: crate_name.to_string(),
             root: String::new(),
             version: "0.1.0".to_string(),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1972,6 +1972,7 @@ mod tests {
     ) -> events::BuildEvent {
         events::BuildEvent {
             ts: chrono::Utc::now(),
+            session_id: String::new(),
             crate_name: crate_name.to_string(),
             version: "0.1.0".to_string(),
             result,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2084,6 +2084,12 @@ fn log_event_details(
     fallback: bool,
     exit_code: Option<i32>,
 ) {
+    // Session attribution (#583 P0.5): read the root-scoped session id and
+    // refresh the marker so the 5-minute window measures inactivity. Both are
+    // best-effort; an empty id just means a legacy or session-less build.
+    let session_id = current_session_id(config, root);
+    refresh_session_marker(config, root, &session_id);
+
     let event = BuildEvent {
         ts: Utc::now(),
         crate_name: crate_name.to_string(),
@@ -2094,7 +2100,8 @@ fn log_event_details(
         compile_time_ms,
         size,
         cache_key: cache_key.to_string(),
-        schema: 9,
+        schema: 10,
+        session_id,
         key_ms,
         key_hash_hits: key_hash_stats.cache_hits,
         key_hash_misses: key_hash_stats.cache_misses,
@@ -2142,13 +2149,25 @@ fn maybe_trigger_prefetch(config: &Config, args: &RustcArgs) {
         return;
     }
 
-    let marker = config.cache_dir.join(".build-session");
+    // Root-scoped marker (#583 P0.5): parallel repos sharing a cache dir get
+    // independent sessions instead of suppressing each other's plans. Falls
+    // back to the legacy cache-global path when no workspace root is known.
+    let root = args
+        .workspace_root()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let marker = if root.is_empty() {
+        config.cache_dir.join(".build-session")
+    } else {
+        session_marker_path(config, &root)
+    };
     // 5 minutes: long enough to span gaps between sequential cargo commands
     // in CI (check → clippy → test → tarpaulin are ~2 min apart), short
     // enough that a new `cargo test` after an edit still triggers a fresh
     // prefetch.  The BFS prefetch sends ALL crates, so re-triggering within
-    // the same session provides no benefit.
-    let session_timeout_secs: u64 = 300;
+    // the same session provides no benefit. Event logging refreshes the
+    // marker, so this measures INACTIVITY, not build age.
+    let session_timeout_secs: u64 = BUILD_SESSION_SECS;
 
     // Fast non-blocking check: if the marker contains a fresh timestamp, skip.
     // We store a Unix epoch inside the file instead of relying on filesystem
@@ -2159,7 +2178,13 @@ fn maybe_trigger_prefetch(config: &Config, args: &RustcArgs) {
 
     // Marker is stale or missing — try to acquire an exclusive lock so only
     // one process does the (expensive) cargo-metadata + daemon RPC.
-    let _ = std::fs::create_dir_all(&config.cache_dir);
+    // Create the marker's parent (`.build-sessions/` for root-scoped markers,
+    // the cache dir itself for the legacy path) — without this a fresh cache
+    // dir would fail the marker open and never establish a session
+    // (cross-family review finding).
+    if let Some(parent) = marker.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
     let Some(lock_file) = open_marker_for_lock(&marker) else {
         return;
     };
@@ -2196,17 +2221,25 @@ fn maybe_trigger_prefetch(config: &Config, args: &RustcArgs) {
         }
     );
 
+    // Mint the session id here — this wrapper won the marker lock, so it is
+    // the one process per build that establishes session identity (#583).
+    let session_id = mint_session_id(&root);
+
     crate::daemon::send_build_started(
         config,
-        crate::build_intent::into_build_started_request(build_intent, crate::daemon::build_epoch()),
+        crate::build_intent::into_build_started_request(
+            build_intent,
+            crate::daemon::build_epoch(),
+            session_id.clone(),
+        ),
     );
 
-    // Write current epoch AFTER the prefetch succeeds so a failed/hung attempt
+    // Write the marker AFTER the prefetch send so a failed/hung attempt
     // (e.g. cargo metadata hangs on a git dep) doesn't block retries for the
     // full session timeout. Write through `lock_file` — the handle that owns
-    // the exclusive lock — so the timestamp lands even on Windows, where the
+    // the exclusive lock — so the record lands even on Windows, where the
     // lock is mandatory and a second handle could not write (kache #348).
-    write_marker_timestamp(&lock_file);
+    write_session_marker(&lock_file, &session_id);
 }
 
 /// Open a marker file safely for locking and updating. Refuses symlinks and
@@ -2264,6 +2297,137 @@ fn open_marker_for_lock(marker: &Path) -> Option<std::fs::File> {
 /// Check if the marker file contains a timestamp within `timeout_secs` of now.
 /// Returns `false` if the marker does not exist, contains a stale/corrupt
 /// timestamp, or is a symlink/non-regular file.
+/// Root-scoped session-marker path: `.build-sessions/<hash(root)>` under the
+/// cache dir (kunobi-ninja/kache#583 P0.5).
+///
+/// Scoping by build root (not one cache-global `.build-session`) stops
+/// parallel repositories sharing a cache dir from suppressing each other's
+/// prefetch plans. The legacy `.build-session` file is left alone: old
+/// wrappers keep using it independently; the worst mixed-fleet outcome is a
+/// redundant BuildStarted, which the daemon coalesces.
+pub(crate) fn session_marker_path(config: &Config, root: &str) -> std::path::PathBuf {
+    let hash = blake3::hash(root.as_bytes()).to_hex();
+    config
+        .cache_dir
+        .join(".build-sessions")
+        .join(&hash.as_str()[..16])
+}
+
+/// Parse a session marker: `v1 <unix-epoch-secs> <session_id>`, or the legacy
+/// bare `<unix-epoch-secs>` (empty session id). Returns `(timestamp, id)`.
+fn parse_session_marker(content: &str) -> Option<(u64, String)> {
+    let content = content.trim();
+    if let Some(rest) = content.strip_prefix("v1 ") {
+        let mut parts = rest.splitn(2, ' ');
+        let ts: u64 = parts.next()?.parse().ok()?;
+        let id = parts.next().unwrap_or("").trim().to_string();
+        return Some((ts, id));
+    }
+    content.parse().ok().map(|ts| (ts, String::new()))
+}
+
+/// The current build session id for `root`, or empty when no session marker
+/// exists. Best-effort by design — session attribution must never fail a
+/// build.
+///
+/// Deliberately does NOT check freshness: freshness gates the TRIGGER (should
+/// a new session start?), not attribution. A single crate compiling longer
+/// than the inactivity window (LLVM-sized) must not fragment its session —
+/// any newer build would have re-minted the marker under the trigger lock, so
+/// whatever id is present is the most recent session for this root
+/// (cross-family review finding).
+pub(crate) fn current_session_id(config: &Config, root: &str) -> String {
+    if root.is_empty() {
+        return String::new();
+    }
+    let marker = session_marker_path(config, root);
+    if let Ok(metadata) = std::fs::symlink_metadata(&marker)
+        && (metadata.file_type().is_symlink() || !metadata.file_type().is_file())
+    {
+        return String::new();
+    }
+    let Ok(content) = std::fs::read_to_string(&marker) else {
+        return String::new();
+    };
+    match parse_session_marker(&content) {
+        Some((_, id)) => id,
+        None => String::new(),
+    }
+}
+
+/// Refresh the session marker's timestamp so the 5-minute window measures
+/// INACTIVITY, not age since the first crate — a long build must not have its
+/// session expire mid-way.
+///
+/// Atomic replace (write temp + rename), not truncate-in-place: readers must
+/// never observe an empty/partial marker (cross-family review finding), and
+/// rename is best-effort on Windows where the destination may be locked by a
+/// concurrent trigger. Guarded on the id still matching — if a newer build
+/// re-minted the marker between our read and this refresh, we must not
+/// resurrect the old session over it.
+pub(crate) fn refresh_session_marker(config: &Config, root: &str, session_id: &str) {
+    if root.is_empty() || session_id.is_empty() {
+        return;
+    }
+    let marker = session_marker_path(config, root);
+    match std::fs::read_to_string(&marker) {
+        Ok(content) => match parse_session_marker(&content) {
+            Some((_, id)) if id == session_id => {}
+            _ => return, // superseded or unreadable — never clobber
+        },
+        Err(_) => return,
+    }
+    let tmp = marker.with_extension(format!("tmp.{}", std::process::id()));
+    let record = format!("v1 {} {}", now_epoch_secs(), session_id);
+    if std::fs::write(&tmp, record).is_err() {
+        return;
+    }
+    if std::fs::rename(&tmp, &marker).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
+/// Write a `v1 <now> <session_id>` record through the caller's locked handle
+/// (same Windows mandatory-lock rationale as [`write_marker_timestamp`]).
+fn write_session_marker(mut file: &std::fs::File, session_id: &str) {
+    use std::io::{Seek, SeekFrom, Write};
+    let record = format!("v1 {} {}", now_epoch_secs(), session_id);
+    let _ = file.set_len(0);
+    let _ = file.seek(SeekFrom::Start(0));
+    let _ = file.write_all(record.as_bytes());
+    let _ = file.flush();
+}
+
+/// Mint a new session id: hex(blake3(root, pid, nanos))[..16]. Opaque and
+/// dependency-free; uniqueness only needs to hold per cache dir per window.
+fn mint_session_id(root: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(root.as_bytes());
+    hasher.update(&std::process::id().to_le_bytes());
+    hasher.update(&nanos.to_le_bytes());
+    hasher.finalize().to_hex().as_str()[..16].to_string()
+}
+
+fn now_epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// The build-session inactivity window (shared by trigger + attribution).
+pub(crate) const BUILD_SESSION_SECS: u64 = 300;
+
+/// Is `ts` within `timeout_secs` of `now`? Extracted (with an injectable
+/// `now`) so freshness is unit-testable without clock races.
+fn timestamp_is_fresh_at(ts: u64, timeout_secs: u64, now: u64) -> bool {
+    now.saturating_sub(ts) < timeout_secs
+}
+
 fn marker_is_fresh(marker: &std::path::Path, timeout_secs: u64) -> bool {
     if let Ok(metadata) = std::fs::symlink_metadata(marker)
         && (metadata.file_type().is_symlink() || !metadata.file_type().is_file())
@@ -2290,17 +2454,14 @@ fn marker_file_is_fresh(mut file: &std::fs::File, timeout_secs: u64) -> bool {
     timestamp_is_fresh(&content, timeout_secs)
 }
 
-/// Is a marker's Unix-epoch timestamp within `timeout_secs` of now?
+/// Is a marker's timestamp within `timeout_secs` of now? Accepts both the
+/// legacy bare-epoch format and the v1 session record (`v1 <ts> <id>`), so
+/// freshness checks work across marker generations.
 fn timestamp_is_fresh(content: &str, timeout_secs: u64) -> bool {
-    let stamp: u64 = match content.trim().parse() {
-        Ok(s) => s,
-        Err(_) => return false, // legacy "1" marker or corrupt — treat as stale
-    };
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    now.saturating_sub(stamp) < timeout_secs
+    match parse_session_marker(content) {
+        Some((ts, _)) => timestamp_is_fresh_at(ts, timeout_secs, now_epoch_secs()),
+        None => false, // legacy "1" marker or corrupt — treat as stale
+    }
 }
 
 /// Write the current Unix epoch to the marker file, reusing the caller's
@@ -3356,7 +3517,7 @@ mod tests {
         assert_eq!(event.compile_time_ms, 20);
         assert_eq!(event.size, 30);
         assert_eq!(event.cache_key, "cache-key");
-        assert_eq!(event.schema, 9);
+        assert_eq!(event.schema, 10);
         assert_eq!(event.key_ms, 40);
         assert_eq!(event.key_hash_hits, 4);
         assert_eq!(event.key_hash_misses, 5);
@@ -3569,6 +3730,99 @@ mod tests {
 
         std::fs::write(&marker, (now + 60).to_string()).unwrap();
         assert!(marker_is_fresh(&marker, 300));
+    }
+
+    #[test]
+    fn session_marker_roundtrip_carries_id_and_freshness() {
+        // v1 record: fresh timestamp + id parse back out.
+        let now = now_epoch_secs();
+        let content = format!("v1 {now} abcd1234efgh5678");
+        let (ts, id) = parse_session_marker(&content).expect("v1 record parses");
+        assert_eq!(ts, now);
+        assert_eq!(id, "abcd1234efgh5678");
+        assert!(timestamp_is_fresh(&content, BUILD_SESSION_SECS));
+    }
+
+    #[test]
+    fn session_marker_accepts_legacy_bare_timestamp() {
+        // Old wrappers wrote a bare epoch; it parses with an empty id, so
+        // freshness checks work across marker generations (mixed fleets).
+        let now = now_epoch_secs();
+        let (ts, id) = parse_session_marker(&now.to_string()).expect("legacy parses");
+        assert_eq!(ts, now);
+        assert!(id.is_empty());
+        // Corrupt / non-numeric stays stale.
+        assert!(parse_session_marker("garbage").is_none());
+        assert!(parse_session_marker("v1 notanumber id").is_none());
+    }
+
+    #[test]
+    fn session_marker_paths_differ_per_root() {
+        // Root-scoped markers: parallel repos sharing one cache dir must not
+        // suppress each other's sessions (#583 P0.5).
+        let dir = tempfile::TempDir::new().unwrap();
+        let config = test_config(dir.path().to_path_buf());
+        let a = session_marker_path(&config, "/repo/a");
+        let b = session_marker_path(&config, "/repo/b");
+        assert_ne!(a, b);
+        assert!(a.parent().unwrap().ends_with(".build-sessions"));
+    }
+
+    #[test]
+    fn current_session_id_reads_marker_regardless_of_age() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config = test_config(dir.path().to_path_buf());
+        let root = "/some/workspace";
+        let marker = session_marker_path(&config, root);
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+
+        // Fresh marker → id comes back.
+        std::fs::write(&marker, format!("v1 {} sess42", now_epoch_secs())).unwrap();
+        assert_eq!(current_session_id(&config, root), "sess42");
+
+        // STALE marker still yields the id: freshness gates the trigger, not
+        // attribution — a >5-minute crate compile must not fragment its
+        // session (any newer build would have re-minted the marker).
+        std::fs::write(&marker, "v1 1000 sess42").unwrap();
+        assert_eq!(current_session_id(&config, root), "sess42");
+
+        // Corrupt marker → empty.
+        std::fs::write(&marker, "garbage").unwrap();
+        assert_eq!(current_session_id(&config, root), "");
+
+        // Empty root → always empty, never panics.
+        assert_eq!(current_session_id(&config, ""), "");
+    }
+
+    #[test]
+    fn refresh_session_marker_extends_own_session_but_never_clobbers_newer() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config = test_config(dir.path().to_path_buf());
+        let root = "/ws";
+        let marker = session_marker_path(&config, root);
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+
+        // Refreshing our own (stale) session bumps the timestamp.
+        std::fs::write(&marker, "v1 1000 mine").unwrap();
+        refresh_session_marker(&config, root, "mine");
+        let (ts, id) = parse_session_marker(&std::fs::read_to_string(&marker).unwrap()).unwrap();
+        assert_eq!(id, "mine");
+        assert!(ts > 1000, "timestamp must be refreshed");
+
+        // A newer session re-minted the marker: our refresh must not
+        // resurrect the old id over it.
+        std::fs::write(&marker, format!("v1 {} newer", now_epoch_secs())).unwrap();
+        refresh_session_marker(&config, root, "mine");
+        let (_, id) = parse_session_marker(&std::fs::read_to_string(&marker).unwrap()).unwrap();
+        assert_eq!(id, "newer");
+    }
+
+    #[test]
+    fn mint_session_id_is_opaque_and_distinct() {
+        let a = mint_session_id("/repo");
+        let b = mint_session_id("/repo");
+        assert_eq!(a.len(), 16);
+        assert_ne!(a, b, "nanos+pid make consecutive ids distinct");
     }
 
     #[test]


### PR DESCRIPTION
## What

P0.5 of the prefetch coordination plan (#583): close the measurement and attribution gaps so per-plan prefetch precision and build-level timing become computable before any service work starts. Fixes #581.

- **Session identity.** The wrapper winning the session-marker lock mints a session id; markers are root-scoped (`.build-sessions/<hash(root)>`, so parallel repos sharing a cache dir stop suppressing each other) with the legacy `.build-session` left for old wrappers. Every per-crate event carries the id (schema 10); marker refresh is an atomic rename and freshness gates only the trigger, so a >5-minute crate compile does not fragment its session. All wire changes are serde-defaulted; mixed fleets keep working.
- **Adaptive cancellation fixed (#581).** The old counters incremented checks and hits in the same branch (ratio 100% by construction, cancel never fired). Counters now live in a per-plan `ActivePlan`: checks = distinct demanded keys, hits = the candidate subset, per-plan reset and single-fire latch. Downloaded-but-not-demanded keys count as potential hits (completed prefetches are consumed via the wrapper's local store without reaching the daemon), so cancellation fires only when even that upper bound is under 30% after 10+ distinct demands.
- **Per-session summaries.** On inactivity (5 min) or supersession (including a new session whose planning yields no plan) the daemon appends a `BuildSummaryEvent` to `summaries.jsonl`: numerators/denominators only (candidates, downloaded keys/bytes, daemon-visible used, demanded, LIST deltas, closure reason), joinable with `events.jsonl` by session id. Shown in `kache stats`.
- **Cumulative LIST telemetry** (requests/failures/duration/keys) alongside the last-refresh gauges — the input for the P3-vs-P4a decision gate in #583.

## Known P0.5 limits (documented in code)

- Concurrent builds from different roots share the single active-plan slot; RemoteCheck carries no session id yet (P2a feedback territory).
- A superseded plan's still-in-flight downloads attribute to its successor — brief window, inflates the successor's potential-hit upper bound, i.e. errs toward not cancelling.
- Summaries are lost on daemon crash (per-crate events persist); no crash checkpoint in P0.5.

## Tests

1275 unit tests green; new coverage: cancel-decision semantics (floor, good plan, upper-bound blind-spot rule), ActivePlan demand/download/use bookkeeping and single-fire latch, marker parse/roundtrip/legacy formats, root-scoped path separation, stale-marker attribution, refresh-never-clobbers-newer-session, LIST/snapshot serde back-compat. clippy + fmt clean.