### PR TITLE
refactor(gc): decouple eviction selection from removal mechanism

### DIFF
--- a/src/eviction.rs
+++ b/src/eviction.rs
@@ -1,0 +1,266 @@
+//! Eviction *selection*, decoupled from the removal *mechanism*
+//! (kunobi-ninja/kache#595).
+//!
+//! `Store` historically had three eviction entry points — size-pressure,
+//! age-based, and content-duplicate — each with its own hardcoded `SELECT`,
+//! all funnelling into the same `remove_entry_guarded`. Mechanism was already
+//! unified; selection was not.
+//!
+//! This module makes selection a pure function of observable per-entry
+//! features. Two consequences matter:
+//!
+//! - **Shadow evaluation.** A candidate policy can rank the same candidate set
+//!   and log what it *would* evict, while the live policy decides what actually
+//!   goes. That comparison is what #594 needs, and it is impractical while the
+//!   ranking is an `ORDER BY` clause inside the removal loop.
+//! - **Signals beyond SQL columns.** Selection written as SQL can only see
+//!   columns of `entries`; `compile_time_ms` lives in each entry's `meta.json`
+//!   and is therefore invisible to eviction today (#594). With features
+//!   assembled in Rust, adding a signal is a struct field.
+//!
+//! Policies never remove anything. The pin/grace check, blob refcount
+//! decrement, and refuse-on-corrupt-meta guard stay in
+//! `Store::remove_entry_guarded` — a policy that could bypass them would
+//! reintroduce the mid-restore eviction race (#326, #182).
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+/// The observable state of one cache entry, as seen by an eviction policy.
+///
+/// Deliberately small: it is materialized for every entry in the store on each
+/// sweep, so new fields should earn their bytes.
+#[derive(Debug, Clone)]
+pub(crate) struct EntryFeatures {
+    pub key: String,
+    pub size: i64,
+    pub hit_count: i64,
+    /// Hours since `last_accessed`. May be negative under clock skew; policies
+    /// are responsible for clamping (the previous SQL clamped at 0.01).
+    pub idle_hours: f64,
+    /// Content address of the entry's artifact set, when known.
+    pub content_hash: Option<String>,
+    pub committed: bool,
+}
+
+/// Ranks or filters eviction candidates. Pure: no I/O, no store mutation.
+pub(crate) trait EvictionPolicy {
+    /// Stable identifier, for logging and shadow-mode comparison.
+    fn name(&self) -> &'static str;
+
+    /// Candidates to evict, worst-first. The caller stops early when a size
+    /// budget is satisfied, so a policy may return more keys than are needed.
+    fn select(&self, candidates: &[EntryFeatures]) -> Vec<String>;
+}
+
+/// Priority score for size-pressure eviction; **lower is evicted first**.
+///
+/// `(hit_count + 1) / (idle_hours * size_mb)` — prefers evicting large, stale,
+/// rarely-hit entries, degrading to LRU with a size tiebreaker when ages are
+/// similar. The clamps reproduce the `MAX(..., 0.01)` / `MAX(..., 0.001)` of
+/// the SQL this replaced, which exist to keep a just-accessed or empty entry
+/// from dividing by zero.
+///
+/// Note this score has no notion of what an entry costs to *rebuild*; see #594.
+pub(crate) fn size_pressure_score(e: &EntryFeatures) -> f64 {
+    let idle = e.idle_hours.max(0.01);
+    let size_mb = (e.size as f64 / 1_048_576.0).max(0.001);
+    (e.hit_count as f64 + 1.0) / (idle * size_mb)
+}
+
+/// Size-pressure eviction: rank every entry by [`size_pressure_score`].
+pub(crate) struct SizePressurePolicy;
+
+impl EvictionPolicy for SizePressurePolicy {
+    fn name(&self) -> &'static str {
+        "size-pressure"
+    }
+
+    fn select(&self, candidates: &[EntryFeatures]) -> Vec<String> {
+        let mut ranked: Vec<&EntryFeatures> = candidates.iter().collect();
+        // Total order: NaN cannot arise from the clamped score, but sort_by
+        // demands a total comparator, so fall back to Equal rather than panic.
+        ranked.sort_by(|a, b| {
+            size_pressure_score(a)
+                .partial_cmp(&size_pressure_score(b))
+                .unwrap_or(Ordering::Equal)
+        });
+        ranked.into_iter().map(|e| e.key.clone()).collect()
+    }
+}
+
+/// Age-based eviction: every entry untouched for more than `hours`.
+///
+/// Replaces `WHERE last_accessed < datetime('now', '-N hours')`. One deliberate
+/// difference: `datetime()` compares at whole-second granularity, whereas
+/// `idle_hours` comes from `julianday()` and is sub-second. An entry sitting
+/// within the same second as the cutoff is therefore now selected where the
+/// old query kept it. Immaterial for a retention sweep measured in hours, and
+/// the finer comparison is the more truthful one, but it is a difference and
+/// not a pure refactor.
+pub(crate) struct OlderThanPolicy {
+    pub hours: u64,
+}
+
+impl EvictionPolicy for OlderThanPolicy {
+    fn name(&self) -> &'static str {
+        "older-than"
+    }
+
+    fn select(&self, candidates: &[EntryFeatures]) -> Vec<String> {
+        let cutoff = self.hours as f64;
+        candidates
+            .iter()
+            .filter(|e| e.idle_hours > cutoff)
+            .map(|e| e.key.clone())
+            .collect()
+    }
+}
+
+/// Content-duplicate eviction: when several committed entries share one
+/// `content_hash`, keep the most recently accessed and evict the rest.
+///
+/// Ties at the group maximum are all kept, reproducing the strict `<` of the
+/// previous `WHERE e.last_accessed < dups.newest_access`.
+pub(crate) struct DuplicatePolicy;
+
+impl EvictionPolicy for DuplicatePolicy {
+    fn name(&self) -> &'static str {
+        "duplicate"
+    }
+
+    fn select(&self, candidates: &[EntryFeatures]) -> Vec<String> {
+        // Group committed, content-addressed entries by content hash. Idle time
+        // is the inverse of recency, so the group's *minimum* idle is its most
+        // recently accessed member.
+        let mut newest: HashMap<&str, f64> = HashMap::new();
+        let mut counts: HashMap<&str, usize> = HashMap::new();
+        for e in candidates {
+            if !e.committed {
+                continue;
+            }
+            let Some(hash) = e.content_hash.as_deref() else {
+                continue;
+            };
+            *counts.entry(hash).or_insert(0) += 1;
+            newest
+                .entry(hash)
+                .and_modify(|m| *m = m.min(e.idle_hours))
+                .or_insert(e.idle_hours);
+        }
+
+        candidates
+            .iter()
+            .filter(|e| {
+                if !e.committed {
+                    return false;
+                }
+                let Some(hash) = e.content_hash.as_deref() else {
+                    return false;
+                };
+                // Only groups with a genuine duplicate, and only members
+                // strictly older than the group's newest access.
+                counts.get(hash).copied().unwrap_or(0) > 1
+                    && newest
+                        .get(hash)
+                        .is_some_and(|newest_idle| e.idle_hours > *newest_idle)
+            })
+            .map(|e| e.key.clone())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn feat(key: &str, size: i64, hits: i64, idle: f64) -> EntryFeatures {
+        EntryFeatures {
+            key: key.into(),
+            size,
+            hit_count: hits,
+            idle_hours: idle,
+            content_hash: None,
+            committed: true,
+        }
+    }
+
+    /// The score must rank a large, stale, unused entry below a small, fresh,
+    /// frequently-hit one — the ordering the size-pressure sweep depends on.
+    #[test]
+    fn size_pressure_ranks_large_stale_unused_first() {
+        let big_stale = feat("big", 600 * 1024 * 1024, 0, 15.0);
+        let small_hot = feat("small", 14 * 1024, 9, 0.1);
+        assert!(size_pressure_score(&big_stale) < size_pressure_score(&small_hot));
+
+        let order = SizePressurePolicy.select(&[small_hot, big_stale]);
+        assert_eq!(order, vec!["big", "small"]);
+    }
+
+    /// A just-accessed entry (idle ~0) and a zero-size entry must not produce a
+    /// division blow-up — the reason the SQL carried MAX() clamps.
+    #[test]
+    fn size_pressure_score_is_finite_at_the_clamps() {
+        assert!(size_pressure_score(&feat("fresh", 1024, 0, 0.0)).is_finite());
+        assert!(size_pressure_score(&feat("empty", 0, 0, 5.0)).is_finite());
+        // Clock skew must not invert the ordering into +inf.
+        assert!(size_pressure_score(&feat("skewed", 1024, 0, -3.0)).is_finite());
+    }
+
+    #[test]
+    fn older_than_selects_strictly_older_entries() {
+        let c = vec![
+            feat("old", 100, 0, 48.5),
+            feat("exactly", 100, 0, 24.0),
+            feat("fresh", 100, 0, 1.0),
+        ];
+        let picked = OlderThanPolicy { hours: 24 }.select(&c);
+        assert_eq!(
+            picked,
+            vec!["old"],
+            "boundary entry must be kept (strict >)"
+        );
+    }
+
+    /// Keep the most recently accessed member of each content group, evict the
+    /// rest, and never touch a group with only one member.
+    #[test]
+    fn duplicate_keeps_newest_and_ignores_singletons() {
+        let mut a = feat("dup_new", 100, 0, 1.0);
+        let mut b = feat("dup_old", 100, 0, 9.0);
+        let mut c = feat("dup_older", 100, 0, 20.0);
+        let mut lone = feat("lone", 100, 0, 99.0);
+        a.content_hash = Some("h1".into());
+        b.content_hash = Some("h1".into());
+        c.content_hash = Some("h1".into());
+        lone.content_hash = Some("h2".into());
+
+        let picked = DuplicatePolicy.select(&[a, b, c, lone]);
+        assert_eq!(picked, vec!["dup_old", "dup_older"]);
+    }
+
+    /// Uncommitted entries and entries without a content hash are invisible to
+    /// duplicate eviction — they may be mid-write.
+    #[test]
+    fn duplicate_ignores_uncommitted_and_hashless() {
+        let mut committed = feat("committed", 100, 0, 1.0);
+        let mut uncommitted = feat("uncommitted", 100, 0, 9.0);
+        committed.content_hash = Some("h".into());
+        uncommitted.content_hash = Some("h".into());
+        uncommitted.committed = false;
+
+        assert!(DuplicatePolicy.select(&[committed, uncommitted]).is_empty());
+    }
+
+    /// Ties at the group's newest access are all kept: the previous SQL used a
+    /// strict `<` against the group max, so two equally-fresh duplicates both
+    /// survive rather than one being arbitrarily dropped.
+    #[test]
+    fn duplicate_keeps_all_entries_tied_at_newest() {
+        let mut a = feat("tie_a", 100, 0, 5.0);
+        let mut b = feat("tie_b", 100, 0, 5.0);
+        a.content_hash = Some("h".into());
+        b.content_hash = Some("h".into());
+        assert!(DuplicatePolicy.select(&[a, b]).is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod config_tui;
 mod daemon;
 mod daemon_local;
 mod events;
+mod eviction;
 mod extra_inputs;
 mod fallback_planner;
 mod heartbeat;

--- a/src/store.rs
+++ b/src/store.rs
@@ -1751,62 +1751,127 @@ impl Store {
         Ok(cleaned)
     }
 
+    /// Materialize every entry's eviction-relevant features in one pass.
+    ///
+    /// Selection used to be three separate `SELECT`s embedded in three removal
+    /// loops; it is now a pure function over these features
+    /// (kunobi-ninja/kache#595). The size-pressure sweep already loaded every
+    /// row, so this is the same I/O shape it always had.
+    pub(crate) fn eviction_candidates(&self) -> Result<Vec<crate::eviction::EntryFeatures>> {
+        let mut stmt = self.db.prepare(
+            "SELECT cache_key, size, hit_count, content_hash, committed,
+                    (julianday('now') - julianday(last_accessed)) * 24.0
+             FROM entries",
+        )?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(crate::eviction::EntryFeatures {
+                    key: row.get(0)?,
+                    size: row.get(1)?,
+                    hit_count: row.get(2)?,
+                    content_hash: row.get(3)?,
+                    committed: row.get(4)?,
+                    // NULL/unparseable timestamps yield NULL from julianday();
+                    // treat those as "just accessed" so a malformed row is
+                    // never evicted ahead of a genuinely stale one.
+                    idle_hours: row.get::<_, Option<f64>>(5)?.unwrap_or(0.0),
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Remove a policy's selection, in order, under the active-pin guard.
+    ///
+    /// This is the *mechanism* half: the grace check, blob refcount decrement,
+    /// and refuse-on-corrupt-meta guard all live in `remove_entry_guarded` and
+    /// are deliberately not reachable from a policy. `stop_at` bounds a
+    /// size-driven sweep; `None` removes everything selected.
+    fn apply_eviction(
+        &self,
+        order: &[String],
+        sizes: &std::collections::HashMap<&str, i64>,
+        stop_at: Option<(u64, u64)>,
+    ) -> GcStats {
+        let mut stats = GcStats::default();
+        let (mut current_size, target) = match stop_at {
+            Some((current, target)) => (current, Some(target)),
+            None => (0, None),
+        };
+
+        for key in order {
+            if let Some(target) = target
+                && current_size <= target
+            {
+                break;
+            }
+            let size = sizes.get(key.as_str()).copied().unwrap_or(0);
+            match self.remove_entry_guarded(key, Some(EVICTION_IDLE_GRACE)) {
+                Ok(true) => {
+                    stats.entries_evicted += 1;
+                    stats.bytes_freed += size as u64;
+                    current_size = current_size.saturating_sub(size as u64);
+                }
+                // Pinned by a recent access — a live build may be mid-restore
+                // on it (kunobi-ninja/kache#326, #182). Leave it for next round.
+                Ok(false) => continue,
+                Err(e) => {
+                    // A corrupt entry (unloadable meta.json) refuses removal to
+                    // avoid leaking blob refcounts (#276); skip it and keep
+                    // evicting the rest rather than aborting the whole sweep.
+                    tracing::warn!("gc: skipping eviction of {key}: {e:#}");
+                    continue;
+                }
+            }
+        }
+        stats
+    }
+
+    /// Run one eviction policy over the current store.
+    ///
+    /// `stop_at` is `Some((current_size, target))` for size-driven sweeps and
+    /// `None` when the policy's whole selection should be removed.
+    fn evict_with(
+        &self,
+        policy: &dyn crate::eviction::EvictionPolicy,
+        stop_at: Option<(u64, u64)>,
+    ) -> Result<GcStats> {
+        let candidates = self.eviction_candidates()?;
+        let order = policy.select(&candidates);
+        if order.is_empty() {
+            return Ok(GcStats::default());
+        }
+        tracing::debug!(
+            policy = policy.name(),
+            candidates = candidates.len(),
+            selected = order.len(),
+            "gc: eviction selection"
+        );
+        let sizes: std::collections::HashMap<&str, i64> = candidates
+            .iter()
+            .map(|e| (e.key.as_str(), e.size))
+            .collect();
+        Ok(self.apply_eviction(&order, &sizes, stop_at))
+    }
+
     /// Weighted eviction: remove entries with lowest priority score until under the size limit.
     /// Prefers evicting large, old, rarely-accessed entries.
     /// Evicts down to 90% of max_size to create headroom and avoid boundary thrashing.
     pub fn evict(&self) -> Result<GcStats> {
-        let max_size = self.config.max_size;
-        let grace = EVICTION_IDLE_GRACE;
-        let target = max_size * 9 / 10; // evict to 90% — avoids boundary thrashing
+        let target = self.config.max_size * 9 / 10; // evict to 90% — avoids boundary thrashing
         let size_before = self.total_size()?;
-        let mut stats = GcStats::default();
-
-        // Fetch all eviction candidates once, worst-score first, then walk them
-        // decrementing a running total — instead of re-running SUM(size) plus a
-        // full scored sort on every iteration (was O(K*N) in store size). The
-        // per-entry score is independent of other rows, so the sort order is
-        // stable as we delete, and `total_size()` is SUM(entries.size), so
-        // subtracting each removed entry's `size` tracks it exactly.
-        let mut current_size = size_before;
-        if current_size > target {
-            // Score = (hit_count + 1) / (age_hours * size_mb); lower → evict first.
-            // Falls back to LRU with a size tiebreaker when ages are similar.
-            let victims: Vec<(String, i64)> = {
-                let mut stmt = self.db.prepare(
-                    "SELECT cache_key, size FROM entries
-                     ORDER BY
-                       CAST((hit_count + 1) AS REAL)
-                       / (MAX((julianday('now') - julianday(last_accessed)) * 24.0, 0.01)
-                          * MAX(size / 1048576.0, 0.001))
-                       ASC",
-                )?;
-                stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
-                    .collect::<Result<Vec<_>, _>>()?
-            };
-
-            for (key, size) in victims {
-                if current_size <= target {
-                    break;
-                }
-                match self.remove_entry_guarded(&key, Some(grace)) {
-                    Ok(true) => {
-                        stats.entries_evicted += 1;
-                        stats.bytes_freed += size as u64;
-                        current_size = current_size.saturating_sub(size as u64);
-                    }
-                    // Pinned by a recent access — a live build may be mid-restore
-                    // on it (kunobi-ninja/kache#326, #182). Leave it for next round.
-                    Ok(false) => continue,
-                    Err(e) => {
-                        // A corrupt entry (unloadable meta.json) refuses removal to
-                        // avoid leaking blob refcounts (#276); skip it and keep
-                        // evicting the rest rather than aborting the whole sweep.
-                        tracing::warn!("gc: skipping eviction of {key}: {e:#}");
-                        continue;
-                    }
-                }
-            }
+        if size_before <= target {
+            return Ok(GcStats::default());
         }
+
+        // The ranking is computed once and walked while deleting: each entry's
+        // score is independent of the others, so the order stays valid as rows
+        // disappear, and `total_size()` is SUM(entries.size) — subtracting each
+        // removed entry's size tracks it exactly without re-querying.
+        let mut stats = self.evict_with(
+            &crate::eviction::SizePressurePolicy,
+            Some((size_before, target)),
+        )?;
 
         // Count blobs removed (difference in blob count is not tracked per-eviction,
         // so we approximate from size freed)
@@ -1821,31 +1886,7 @@ impl Store {
 
     /// Evict entries older than the given duration.
     pub fn evict_older_than(&self, hours: u64) -> Result<GcStats> {
-        let rows: Vec<(String, i64)> = {
-            let mut stmt = self.db.prepare(
-                "SELECT cache_key, size FROM entries WHERE last_accessed < datetime('now', ?1)",
-            )?;
-
-            stmt.query_map(params![format!("-{hours} hours")], |row| {
-                Ok((row.get(0)?, row.get(1)?))
-            })?
-            .collect::<Result<Vec<_>, _>>()?
-        };
-
-        let mut stats = GcStats::default();
-        for (key, size) in &rows {
-            match self.remove_entry_guarded(key, Some(EVICTION_IDLE_GRACE)) {
-                Ok(true) => {
-                    stats.entries_evicted += 1;
-                    stats.bytes_freed += *size as u64;
-                }
-                Ok(false) => continue,
-                Err(e) => {
-                    tracing::warn!("gc: skipping eviction of {key}: {e:#}");
-                    continue;
-                }
-            }
-        }
+        let mut stats = self.evict_with(&crate::eviction::OlderThanPolicy { hours }, None)?;
         stats.blobs_removed = stats.entries_evicted;
         Ok(stats)
     }
@@ -1855,37 +1896,7 @@ impl Store {
     /// (consistent with LRU eviction policy).
     /// Returns GcStats with eviction metrics.
     pub fn evict_duplicate_entries(&self) -> Result<GcStats> {
-        let mut stmt = self.db.prepare(
-            "SELECT e.cache_key, e.size
-             FROM entries e
-             JOIN (
-                 SELECT content_hash, MAX(last_accessed) as newest_access
-                 FROM entries
-                 WHERE content_hash IS NOT NULL AND committed = 1
-                 GROUP BY content_hash
-                 HAVING COUNT(*) > 1
-             ) dups ON e.content_hash = dups.content_hash
-             WHERE e.last_accessed < dups.newest_access AND e.committed = 1",
-        )?;
-
-        let rows: Vec<(String, i64)> = stmt
-            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let mut stats = GcStats::default();
-        for (key, size) in &rows {
-            match self.remove_entry_guarded(key, Some(EVICTION_IDLE_GRACE)) {
-                Ok(true) => {
-                    stats.entries_evicted += 1;
-                    stats.bytes_freed += *size as u64;
-                }
-                Ok(false) => continue,
-                Err(e) => {
-                    tracing::warn!("gc: skipping eviction of {key}: {e:#}");
-                    continue;
-                }
-            }
-        }
+        let mut stats = self.evict_with(&crate::eviction::DuplicatePolicy, None)?;
         stats.blobs_removed = stats.entries_evicted;
         Ok(stats)
     }
@@ -2449,6 +2460,7 @@ pub struct EntryInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::eviction::EvictionPolicy as _;
 
     // Regression guard for #324: the local content-dedup hash must distinguish
     // entries that the old (bare-hash, 16-hex-truncated) fold could collide —
@@ -3254,6 +3266,166 @@ mod tests {
         let stats = store.evict().unwrap();
         assert!(stats.entries_evicted > 0);
         assert!(!store.contains("key1"));
+    }
+
+    /// #595 equivalence guard: the Rust `SizePressurePolicy` ranking must match
+    /// the SQL `ORDER BY` it replaced, entry for entry. This is the property
+    /// that makes the refactor a no-op — if someone later changes the scoring
+    /// formula, this test is what tells them they changed behavior, not just
+    /// structure. Deliberately uses awkward inputs (zero size, zero idle,
+    /// equal scores) since those are where the SQL's MAX() clamps mattered.
+    #[test]
+    fn size_pressure_policy_matches_the_sql_ordering_it_replaced() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        // (key, size, hit_count, hours idle)
+        let seed = [
+            ("huge_stale", 600 * 1024 * 1024_i64, 0_i64, 15.0_f64),
+            ("small_hot", 14 * 1024, 9, 0.1),
+            ("mid", 5 * 1024 * 1024, 2, 48.0),
+            ("zero_size", 0, 0, 3.0),
+            ("just_touched", 1024 * 1024, 1, 0.0),
+            ("ancient_tiny", 512, 0, 5000.0),
+            ("twin_a", 2 * 1024 * 1024, 3, 12.0),
+            ("twin_b", 2 * 1024 * 1024, 3, 12.0),
+        ];
+        for (key, size, hits, idle) in seed {
+            store
+                .db
+                .execute(
+                    "INSERT INTO entries (cache_key, crate_name, size, hit_count, committed, last_accessed)
+                     VALUES (?1, 'c', ?2, ?3, 1, datetime('now', ?4))",
+                    params![key, size, hits, format!("-{} seconds", (idle * 3600.0) as i64)],
+                )
+                .unwrap();
+        }
+
+        // The exact query this refactor removed from `evict()`.
+        let sql_order: Vec<String> = {
+            let mut stmt = store
+                .db
+                .prepare(
+                    "SELECT cache_key FROM entries
+                     ORDER BY
+                       CAST((hit_count + 1) AS REAL)
+                       / (MAX((julianday('now') - julianday(last_accessed)) * 24.0, 0.01)
+                          * MAX(size / 1048576.0, 0.001))
+                       ASC",
+                )
+                .unwrap();
+            stmt.query_map([], |r| r.get(0))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        };
+
+        let candidates = store.eviction_candidates().unwrap();
+        let policy_order = crate::eviction::SizePressurePolicy.select(&candidates);
+
+        // Compare by score rather than raw position: SQLite and Rust may break
+        // exact ties (twin_a/twin_b) in either order, and that is not a
+        // behavior difference. Any genuine ranking divergence still fails.
+        let score_of: std::collections::HashMap<&str, f64> = candidates
+            .iter()
+            .map(|e| (e.key.as_str(), crate::eviction::size_pressure_score(e)))
+            .collect();
+        let seq =
+            |order: &[String]| -> Vec<f64> { order.iter().map(|k| score_of[k.as_str()]).collect() };
+        assert_eq!(
+            seq(&sql_order),
+            seq(&policy_order),
+            "policy ranking diverged from the SQL it replaced\n  sql:    {sql_order:?}\n  policy: {policy_order:?}"
+        );
+        assert_eq!(policy_order.len(), seed.len(), "every entry must be ranked");
+    }
+
+    /// The other two policies must also agree with their former SQL: age uses a
+    /// strict cutoff, duplicates keep the newest of each content group.
+    #[test]
+    fn older_than_and_duplicate_policies_match_their_former_sql() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        for (key, idle_h, hash) in [
+            ("stale", 100.0_f64, Some("h1")),
+            ("fresh", 1.0, Some("h1")),
+            ("boundary", 24.0, None),
+            ("lonely", 200.0, Some("h2")),
+        ] {
+            store
+                .db
+                .execute(
+                    "INSERT INTO entries (cache_key, crate_name, size, committed, content_hash, last_accessed)
+                     VALUES (?1, 'c', 100, 1, ?2, datetime('now', ?3))",
+                    params![key, hash, format!("-{} seconds", (idle_h * 3600.0) as i64)],
+                )
+                .unwrap();
+        }
+
+        let candidates = store.eviction_candidates().unwrap();
+
+        let sql_old: Vec<String> = {
+            let mut stmt = store
+                .db
+                .prepare("SELECT cache_key FROM entries WHERE last_accessed < datetime('now', '-24 hours')")
+                .unwrap();
+            stmt.query_map([], |r| r.get(0))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        };
+        let mut policy_old = crate::eviction::OlderThanPolicy { hours: 24 }.select(&candidates);
+        policy_old.sort();
+
+        // Away from the cutoff the two agree exactly. `boundary` sits *on* the
+        // cutoff and is the one documented divergence: SQLite's `datetime()`
+        // compares whole seconds, so the old query kept it, while `julianday()`
+        // resolves sub-second and the policy evicts it. See `OlderThanPolicy`.
+        let unambiguous = |v: &[String]| -> Vec<String> {
+            let mut v: Vec<String> = v.iter().filter(|k| *k != "boundary").cloned().collect();
+            v.sort();
+            v
+        };
+        assert_eq!(
+            unambiguous(&policy_old),
+            unambiguous(&sql_old),
+            "older-than selection diverged away from the cutoff boundary"
+        );
+        assert!(
+            !sql_old.contains(&"boundary".to_string()),
+            "sanity: whole-second SQL should keep the on-cutoff entry"
+        );
+        assert!(
+            policy_old.contains(&"boundary".to_string()),
+            "sub-second comparison should evict the on-cutoff entry (documented difference)"
+        );
+
+        let sql_dup: Vec<String> = {
+            let mut stmt = store
+                .db
+                .prepare(
+                    "SELECT e.cache_key FROM entries e
+                     JOIN (SELECT content_hash, MAX(last_accessed) AS newest
+                           FROM entries WHERE content_hash IS NOT NULL AND committed = 1
+                           GROUP BY content_hash HAVING COUNT(*) > 1) d
+                       ON e.content_hash = d.content_hash
+                     WHERE e.last_accessed < d.newest AND e.committed = 1",
+                )
+                .unwrap();
+            stmt.query_map([], |r| r.get(0))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        };
+        let mut policy_dup = crate::eviction::DuplicatePolicy.select(&candidates);
+        let mut sql_dup_sorted = sql_dup.clone();
+        policy_dup.sort();
+        sql_dup_sorted.sort();
+        assert_eq!(policy_dup, sql_dup_sorted, "duplicate selection diverged");
+        assert_eq!(policy_dup, vec!["stale"], "expected the older twin evicted");
     }
 
     /// kunobi-ninja/kache#326, #182: size-pressure eviction must NOT delete an


### PR DESCRIPTION
Implements #595.

## What

`Store` had three eviction entry points — size-pressure, age-based, and content-duplicate — each with its own hardcoded `SELECT`, all funnelling into the same `remove_entry_guarded`. Mechanism was already unified; **selection** was not.

Selection now lives in `src/eviction.rs` as a pure function over per-entry features:

```rust
trait EvictionPolicy {
    fn name(&self) -> &'static str;
    fn select(&self, candidates: &[EntryFeatures]) -> Vec<String>;
}
```

`SizePressurePolicy`, `OlderThanPolicy`, and `DuplicatePolicy` are the three existing selectors; `Store::evict_with` drives any of them through the unchanged removal path. The three public entry points (`evict`, `evict_older_than`, `evict_duplicate_entries`) keep their signatures and semantics.

The pin/grace check, blob refcount decrement, and refuse-on-corrupt-meta guard (#276, #326, #182) stay in `remove_entry_guarded` and are deliberately unreachable from a policy.

## Why now

This is the enabling refactor for #594:

- **Shadow evaluation** — rank the same candidate set with a candidate policy, log what it *would* evict, keep evicting per the live one. Impractical while the ranking is an `ORDER BY` inside the removal loop; trivial once `select()` is a pure function.
- **Signals beyond SQL columns** — `compile_time_ms` is recorded per entry in `meta.json` and is invisible to eviction today partly *because* selection was SQL and could only see `entries` columns. Adding it is now a struct field.

## Behavior

Preserved, and pinned by equivalence tests that run the old SQL and the new policy over the same fixture and assert identical selection — using deliberately awkward inputs (zero size, zero idle time, tied scores, on-cutoff ages) since those are where the SQL's `MAX()` clamps mattered.

**One documented difference.** `OlderThanPolicy` compares sub-second `julianday` hours where the old query compared whole-second `datetime`, so an entry sitting within the same second as the cutoff is now selected where it previously wasn't. Immaterial for a retention sweep measured in hours, and the finer comparison is the more truthful one — but it is a difference, so it is called out in the type's docs and asserted by a test rather than left implicit. The equivalence test found this; I did not anticipate it.

I/O shape is unchanged: `evict()` already materialized every row before removing anything, so gathering features in one pass is what it was already doing.

## Testing

Full suite green (1297 unit + all integration). New: 6 policy unit tests (no `Store`, no SQLite) and 2 equivalence guards against the replaced SQL.

Live check on a real over-limit store: 330 entries / 1.09 GB → 251 / 188 MB, landing exactly on the 90% target, with the active-pin grace correctly refusing to evict entries younger than 120 s.

## Out of scope, noticed while testing

`kache gc` printed `Evicted 0 entries to stay under size limit` on that same run where 79 entries were demonstrably evicted. `cli.rs` and `daemon.rs` are untouched by this branch (empty diff) and `Store::evict` returns the correct count (asserted by the pre-existing `test_store_eviction`), so this is the reporting path — very likely #509. Not fixed here.
