### PR TITLE
chore(nix): drop flake-utils input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1773597492,
@@ -36,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
@@ -58,21 +39,6 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,27 +3,44 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    flake-utils,
-    rust-overlay,
-  }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      rust-overlay,
+    }:
     let
-      kacheOverlay = final: _prev: let
-        rustToolchain = final.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-        rustPlatform = final.makeRustPlatform {
-          cargo = rustToolchain;
-          rustc = rustToolchain;
-        };
-      in
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f (
+            import nixpkgs {
+              inherit system;
+              overlays = [ self.overlays.default ];
+            }
+          )
+        );
+      kacheOverlay =
+        final: _prev:
+        let
+          rustToolchain = final.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          rustPlatform = final.makeRustPlatform {
+            cargo = rustToolchain;
+            rustc = rustToolchain;
+          };
+        in
         {
           kache = final.callPackage ./nix/package.nix {
             inherit rustPlatform;
@@ -49,16 +66,10 @@
           kacheOverlay
         ];
       };
-    }
-    // flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [self.overlays.default];
-      };
-    in {
-      packages = {
+
+      packages = forAllSystems (pkgs: {
         kache = pkgs.kache;
         default = pkgs.kache;
-      };
-    });
+      });
+    };
 }


### PR DESCRIPTION
<!--
Thanks for sending a PR! Keep it focused on a single change — unrelated
refactors are easier to review separately. See CONTRIBUTING.md for the
full process.
-->

## Summary

<!-- What does this PR change and why? Link related issues. -->
Remove `flake-utils` input from flake.nix and replace it with inline function to generate output.

The `flake-utils` is outdated and contains deprecated entry for `x86_64-darwin` that breaks newer nixos builds.

## Test plan

<!-- How did you verify the change? Commands run, scenarios covered.
Include before/after numbers for performance changes. -->

My nixos build passes fine with updated nixpkgs from the new branch
