### PR TITLE
fix(remote): never fail a build on remote config, restore legacy prefixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2945,7 +2945,6 @@ dependencies = [
  "ratatui",
  "regex",
  "reqsign-aws-v4",
- "reqsign-command-execute-tokio",
  "reqsign-core",
  "reqwest 0.13.4",
  "rusqlite",
@@ -4802,16 +4801,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sha1 0.11.0",
-]
-
-[[package]]
-name = "reqsign-command-execute-tokio"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf28fcf0aef694448cb235d393fbec7b5543d25050eacc0ccc2118596618c52"
-dependencies = [
- "reqsign-core",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ opendal-service-s3 = { version = "=0.58.0", default-features = false }
 # These published reqsign APIs preserve Kache's explicit profile selection
 # (including SSO and credential_process) without a git-only patch.
 reqsign-aws-v4 = { version = "=3.0.2", default-features = false }
-reqsign-command-execute-tokio = { version = "=3.0.2", default-features = false }
 reqsign-core = { version = "=3.1.0", default-features = false }
 # Direct dep so OpenDAL/reqwest can use ring without reintroducing aws-lc.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ bytes = "1"
 # supported backend set explicit and avoids compiling unused services.
 opendal = { package = "opendal-core", version = "=0.58.0", default-features = false, features = ["executors-tokio"] }
 opendal-http-transport-reqwest = { version = "=0.58.0", default-features = false, features = ["rustls-no-provider"] }
-opendal-layer-retry = "=0.58.0"
-opendal-service-fs = "=0.58.0"
-opendal-service-s3 = "=0.58.0"
+opendal-layer-retry = { version = "=0.58.0", default-features = false }
+opendal-service-fs = { version = "=0.58.0", default-features = false }
+opendal-service-s3 = { version = "=0.58.0", default-features = false }
 # OpenDAL exposes a custom credential chain but not a profile-name shortcut.
 # These published reqsign APIs preserve Kache's explicit profile selection
 # (including SSO and credential_process) without a git-only patch.

--- a/docs/remote-cache/filesystem-setup.mdx
+++ b/docs/remote-cache/filesystem-setup.mdx
@@ -52,7 +52,21 @@ atomic_write_dir = "/mnt/shared-kache/.staging"
   `atomic_write_dir` and `path` must be on the same filesystem. The final
   rename cannot be atomic across filesystems and will fail with a cross-device
   error. In particular, do not use the machine's `/tmp` unless it is on the
-  same filesystem as the shared cache.
+  same filesystem as the shared cache. kache checks this when it connects and
+  refuses the remote with an explicit message rather than failing every write.
+
+  It must also sit outside the object tree (`<prefix>/v3/...`); otherwise
+  in-progress staging files are listed as if they were cached objects. The
+  default `<path>/.kache-tmp` already satisfies both rules.
+</Callout>
+
+<Callout type="info">
+  A shared cache directory that other users can write is a trust boundary. kache
+  verifies that each write resolves inside the configured `path`, so a symlink
+  planted under the cache cannot redirect writes elsewhere, and it rejects keys
+  whose components end in a dot or space (Windows strips those, which would make
+  two distinct keys collide). This is defense in depth: provision the directory
+  with restrictive permissions rather than relying on it.
 </Callout>
 
 ## Directory layout

--- a/docs/remote-cache/s3-setup.mdx
+++ b/docs/remote-cache/s3-setup.mdx
@@ -126,11 +126,20 @@ endpoint.
   endpoints should also set `endpoint` explicitly.
 </Callout>
 
-OpenDAL normalizes object paths. To prevent a silent switch to different keys,
-`prefix` must now be a canonical relative path: no leading or trailing slash,
-backslashes, surrounding whitespace, `//`, `.` or `..` segments. If an older
-setup used a non-canonical prefix, migrate or copy those objects before
-upgrading.
+OpenDAL normalizes object paths, so kache stores objects under a canonical
+prefix. A non-canonical `prefix` is normalized rather than rejected: a leading or
+trailing slash, surrounding whitespace and `//` are collapsed, and kache logs a
+warning when that happens. An empty prefix is valid and stores objects at the
+bucket root.
+
+Normalization changes where objects live. `prefix = "team/"` previously wrote
+`team//v3/...` and now writes `team/v3/...`, so objects written by an older
+kache are no longer found and the remote cache repopulates once. Copy those
+objects first if you want to keep them.
+
+Backslashes and `.` / `..` segments are still rejected: there is no safe
+normalization for them. A rejected prefix does not fail your build — kache logs
+the reason, continues without a remote cache, and reports it in `kache status`.
 
 `AWS_ENDPOINT_URL_S3` remains supported when `endpoint` / `KACHE_S3_ENDPOINT`
 is unset. An `endpoint_url` stored only inside an AWS shared profile is not

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -410,6 +410,10 @@ pub(crate) fn render_stats(
         lines.push(format!("Remote:     {}", remote.describe()));
     } else if config.local_only {
         lines.push("Remote:     local-only mode (remote + planner ignored)".to_string());
+    } else if let Some(reason) = &config.remote_error {
+        // Configured but unusable: `Config::load` degraded to local-only so the
+        // build kept working. Say so rather than claiming nothing was configured.
+        lines.push(format!("Remote:     MISCONFIGURED — {reason}"));
     } else {
         lines.push("Remote:     not configured".to_string());
     }
@@ -2639,9 +2643,7 @@ pub fn sync(
     pull_all: bool,
     pull_workspace: bool,
 ) -> Result<()> {
-    let remote = config.remote.as_ref().ok_or_else(|| {
-        anyhow::anyhow!("No remote configured. Run `kache config` to set one up.")
-    })?;
+    let remote = config.require_remote()?;
 
     let store = Store::open(config)?;
     let workspace_crates = workspace_filter(manifest_path);
@@ -2687,6 +2689,17 @@ async fn sync_inner(
     lock_crates: Option<&std::collections::HashSet<String>>,
     pull_workspace: bool,
 ) -> Result<()> {
+    // Validate `--workspace` BEFORE connecting: `create_backend` resolves
+    // credentials, which can launch a `credential_process` or block on an SSO
+    // prompt. Failing after that for a reason knowable up front wastes the user's
+    // time and can leave an interactive prompt hanging.
+    if pull_workspace && workspace_crates.is_none_or(|crates| crates.is_empty()) {
+        anyhow::bail!(
+            "--workspace: no workspace members resolved (cargo metadata failed or this is not \
+             a Cargo workspace); refusing to fall back to a full remote scan"
+        );
+    }
+
     let backend = crate::remote_backend::create_backend(remote, config.s3_pool_idle_secs)
         .await
         .context("connecting to the remote — check its configuration and access")?;
@@ -4471,6 +4484,7 @@ mod tests {
     ) -> Config {
         use crate::config::{DEFAULT_DAEMON_IDLE_TIMEOUT_SECS, DEFAULT_S3_POOL_IDLE_SECS};
         Config {
+            remote_error: None,
             fallback: None,
             key_salt: None,
             cc_extra_allowlist_flags: Vec::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -272,6 +272,10 @@ impl RemoteConfig {
     }
 }
 
+/// Top-level directory the remote layout writes objects under. Kept here so the
+/// staging-directory check cannot drift from `remote_layout`'s actual layout.
+pub(crate) const V3_OBJECT_ROOT: &str = "v3";
+
 /// Canonicalize a configured remote prefix, tolerating the shapes the
 /// pre-OpenDAL loader accepted.
 ///
@@ -305,68 +309,33 @@ pub(crate) fn normalize_remote_prefix(prefix: &str) -> Result<String> {
     Ok(segments.join("/"))
 }
 
-/// Reject staging directories that cannot deliver the atomic-rename guarantee
-/// the filesystem remote is built on, or that would leak staging files into the
-/// object namespace.
+/// Reject a staging directory that would leak staging files into the object
+/// namespace.
 ///
-/// Two distinct failure modes, both silent until the remote is in use:
-/// * a staging dir on another filesystem makes every publish fail with `EXDEV`,
-///   because `rename(2)` cannot cross a mount point;
-/// * a staging dir *inside* the object prefix shows up in `list()` as if it were
-///   cached content, which confuses sync and GC.
+/// A staging dir inside the *object tree* shows up in `list()` as if it were
+/// cached content, which confuses sync and GC. Only the tree kache actually lists
+/// matters (`<prefix>/v3/...`), not the whole root — the documented default
+/// (`<path>/.kache-tmp`) deliberately sits beside it, and with an empty prefix the
+/// staging dir is necessarily under the root, so comparing against the root would
+/// reject the default configuration.
 ///
-/// The device check needs paths that exist, and neither is required to exist yet
-/// (OpenDAL creates the staging dir, not the root). Compare the nearest existing
-/// ancestor of each instead, and stay silent when that is not determinable —
-/// a missing root produces a clear error from the backend anyway.
+/// Purely lexical and I/O-free on purpose: this runs inside `Config::load`, which
+/// is on the rustc-wrapper hot path where touching an unavailable network mount
+/// could stall the compiler. The same-filesystem (`EXDEV`) check needs real
+/// syscalls and therefore lives in `remote_backend::create_filesystem_operator`,
+/// which only runs when the remote is actually used.
 fn filesystem_staging_problem(
     root: &std::path::Path,
     atomic_write_dir: &std::path::Path,
     prefix: &str,
 ) -> Option<String> {
-    let object_root = if prefix.is_empty() {
-        root.to_path_buf()
-    } else {
-        root.join(prefix)
-    };
-    if atomic_write_dir.starts_with(&object_root) {
+    let object_tree = join_remote_key(prefix, V3_OBJECT_ROOT);
+    let object_tree = root.join(object_tree);
+    if atomic_write_dir.starts_with(&object_tree) {
         return Some(format!(
-            "[cache.remote] atomic_write_dir {} is inside the object prefix {}; staging files \
-             would be listed as cached objects. Put it outside the prefix (the default is \
-             <path>/.kache-tmp).",
+            "[cache.remote] atomic_write_dir {} is inside the object tree {}; staging files would              be listed as cached objects. Put it outside it (the default is <path>/.kache-tmp).",
             atomic_write_dir.display(),
-            object_root.display()
-        ));
-    }
-
-    let device_of = |path: &std::path::Path| -> Option<u64> {
-        let existing = path.ancestors().find(|candidate| candidate.exists())?;
-        let metadata = std::fs::metadata(existing).ok()?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::MetadataExt;
-            Some(metadata.dev())
-        }
-        #[cfg(not(unix))]
-        {
-            // No portable device id on Windows without extra syscalls; the
-            // containment check above plus the backend's own error is enough.
-            let _ = metadata;
-            None
-        }
-    };
-
-    let (Some(root_device), Some(staging_device)) = (device_of(root), device_of(atomic_write_dir))
-    else {
-        return None;
-    };
-    if root_device != staging_device {
-        return Some(format!(
-            "[cache.remote] atomic_write_dir {} is on a different filesystem than path {}; \
-             publishing uses rename(2), which cannot cross filesystems and would fail with \
-             EXDEV on every write",
-            atomic_write_dir.display(),
-            root.display()
+            object_tree.display()
         ));
     }
     None
@@ -467,12 +436,12 @@ pub(crate) struct CacheFileConfig {
     pub(crate) path_only_env_vars: Option<Vec<String>>,
 }
 
-/// `deny_unknown_fields` so a typo (`bukcet = "..."`) is reported instead of
-/// silently ignored, which previously left the remote mysteriously unconfigured.
-/// Safe to be strict here now that `Config::load` degrades rather than failing the
-/// build.
+/// Deliberately NOT `deny_unknown_fields`. Rejecting an unknown key here fails the
+/// whole `FileConfig` parse, and every other setting (`key_salt`, `cache_dir`, ...)
+/// then silently reverts to its default — a cache-key shift is a much worse outcome
+/// than an ignored typo. Reporting unknown keys needs parsing that is isolated from
+/// the rest of the config.
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
-#[serde(deny_unknown_fields)]
 pub(crate) struct RemoteFileConfig {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub(crate) _type: Option<String>,
@@ -1150,18 +1119,18 @@ impl Config {
         // silently point that job at a different remote than it asked for, so an
         // explicit empty override disables the remote instead.
         let env_bucket = env_or_ignored("KACHE_S3_BUCKET", ignore_env).ok();
+        let file_bucket_is_usable = file_remote
+            .and_then(|r| r.bucket.as_deref())
+            .is_some_and(|bucket| !bucket.trim().is_empty());
         if let Some(env_bucket) = &env_bucket
             && env_bucket.trim().is_empty()
+            && file_bucket_is_usable
         {
-            // An explicit `type = "s3"` asked for S3, so an empty bucket is a
-            // misconfiguration worth reporting (Config::load degrades it to
-            // local-only rather than failing the build).
-            if configured_type.as_deref() == Some("s3") {
-                anyhow::bail!(
-                    "[cache.remote] type = \"s3\" requires a non-empty bucket, but KACHE_S3_BUCKET \
-                     is set to an empty value"
-                );
-            }
+            // Emptying the override is a deliberate operator action: disable the
+            // remote. Treating it as an error here would be inconsistent, since the
+            // build ends up local-only either way but remote-only commands would
+            // report a failure instead of an intentional disable. A config with no
+            // usable bucket anywhere falls through to the error below.
             tracing::warn!(
                 "KACHE_S3_BUCKET is set but empty — treating the remote cache as disabled rather \
                  than falling back to the configured bucket"
@@ -3036,15 +3005,49 @@ exclude = ["src/generated/**", "vendor/problem/**"]
     }
 
     #[test]
-    fn staging_dir_inside_the_object_prefix_is_rejected() {
+    fn staging_dir_inside_the_object_tree_is_rejected() {
         let root = std::path::Path::new("/tmp/kache-remote");
         let problem =
-            filesystem_staging_problem(root, &root.join("artifacts").join("staging"), "artifacts")
-                .expect("staging inside the prefix must be rejected");
-        assert!(problem.contains("inside the object prefix"), "{problem}");
+            filesystem_staging_problem(root, &root.join("artifacts/v3/staging"), "artifacts")
+                .expect("staging inside the object tree must be rejected");
+        assert!(problem.contains("inside the object tree"), "{problem}");
 
-        // The default lives beside the prefix, not inside it.
+        // The documented default sits beside the object tree, not inside it.
         assert!(filesystem_staging_problem(root, &root.join(".kache-tmp"), "artifacts").is_none());
+
+        // Regression: with an empty prefix the staging dir is NECESSARILY under the
+        // root, so comparing against the root rather than the object tree rejected
+        // the documented default and made empty-prefix filesystem remotes unusable.
+        assert!(
+            filesystem_staging_problem(root, &root.join(".kache-tmp"), "").is_none(),
+            "the default staging dir must be accepted with an empty prefix"
+        );
+        assert!(filesystem_staging_problem(root, &root.join("v3/staging"), "").is_some());
+    }
+
+    /// A filesystem remote with an empty prefix must resolve cleanly end to end.
+    #[test]
+    fn filesystem_remote_with_an_empty_prefix_resolves() {
+        let _guard = config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let file = FileConfig {
+            cc: None,
+            paths: None,
+            cache: Some(CacheFileConfig {
+                remote: Some(RemoteFileConfig {
+                    _type: Some("filesystem".to_string()),
+                    path: Some(dir.path().to_string_lossy().to_string()),
+                    prefix: Some(String::new()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        };
+
+        let remote = Config::load_remote_config(&Ok(file))
+            .expect("an empty prefix must be usable")
+            .expect("remote");
+        assert_eq!(remote.prefix, "");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2421,6 +2421,35 @@ exclude = ["src/generated/**", "vendor/problem/**"]
         }
     }
 
+    /// Clear an env var for the duration of a test, restoring it on drop.
+    ///
+    /// Tests that assert on *file* config must not inherit ambient `KACHE_*`
+    /// values: CI runs under kache-action, which exports `KACHE_S3_PREFIX` and
+    /// friends, and env overrides win over the file.
+    fn remove_env_var_for_test(key: &'static str) -> GenericEnvGuard {
+        let previous = std::env::var_os(key);
+        unsafe {
+            std::env::remove_var(key);
+        }
+        GenericEnvGuard { key, previous }
+    }
+
+    const S3_ENV_VARS: [&str; 5] = [
+        "KACHE_S3_BUCKET",
+        "KACHE_S3_ENDPOINT",
+        "KACHE_S3_REGION",
+        "KACHE_S3_PREFIX",
+        "KACHE_S3_PROFILE",
+    ];
+
+    /// Clear every `KACHE_S3_*` override, restoring them on drop.
+    fn isolate_s3_env() -> Vec<GenericEnvGuard> {
+        S3_ENV_VARS
+            .into_iter()
+            .map(remove_env_var_for_test)
+            .collect()
+    }
+
     struct GenericEnvGuard {
         key: &'static str,
         previous: Option<OsString>,
@@ -2919,6 +2948,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
     #[test]
     fn legacy_noncanonical_prefixes_normalize_instead_of_failing() {
         let _guard = config_path_lock();
+        let _isolated = isolate_s3_env();
         let _bucket = set_env_var_for_test("KACHE_S3_BUCKET", "legacy-bucket");
 
         for (configured, expected) in [("team/", "team"), ("/team", "team"), ("a//b", "a/b")] {
@@ -2942,6 +2972,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
     #[test]
     fn legacy_empty_env_prefix_means_the_bucket_root() {
         let _guard = config_path_lock();
+        let _isolated = isolate_s3_env();
         let _bucket = set_env_var_for_test("KACHE_S3_BUCKET", "legacy-bucket");
         let _prefix = set_env_var_for_test("KACHE_S3_PREFIX", "");
 
@@ -2956,6 +2987,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
     #[test]
     fn empty_env_bucket_disables_the_remote_instead_of_falling_back() {
         let _guard = config_path_lock();
+        let _isolated = isolate_s3_env();
         let _bucket = set_env_var_for_test("KACHE_S3_BUCKET", "");
         let file = FileConfig {
             cache: Some(CacheFileConfig {
@@ -2984,9 +3016,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
         let dir = tempfile::tempdir().unwrap();
         let cfg = dir.path().join("config.toml");
         let _g = set_kache_config_for_test(&cfg);
-        for var in ["KACHE_S3_BUCKET", "KACHE_S3_PREFIX"] {
-            unsafe { std::env::remove_var(var) };
-        }
+        let _isolated = isolate_s3_env();
 
         // `..` cannot be normalized, so this is a genuinely unusable remote.
         std::fs::write(
@@ -3034,6 +3064,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
     #[test]
     fn filesystem_remote_with_an_empty_prefix_resolves() {
         let _guard = config_path_lock();
+        let _isolated = isolate_s3_env();
         let dir = tempfile::tempdir().unwrap();
         let file = FileConfig {
             cc: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -436,10 +436,15 @@ pub(crate) struct CacheFileConfig {
     pub(crate) path_only_env_vars: Option<Vec<String>>,
 }
 
-/// Deliberately NOT `deny_unknown_fields`. Rejecting an unknown key here fails the
-/// whole `FileConfig` parse, and every other setting (`key_salt`, `cache_dir`, ...)
-/// then silently reverts to its default — a cache-key shift is a much worse outcome
-/// than an ignored typo. Reporting unknown keys needs parsing that is isolated from
+/// Deliberately NOT `deny_unknown_fields`.
+///
+/// Serde fails the *whole* `FileConfig` parse on one unknown key, so a typo takes
+/// every other setting with it. Measured with `key_salt = "from-file"` under
+/// `[cache]` and a typo'd `bukcet` under `[cache.remote]`: `key_salt` resolves to
+/// `None` (so the cache key shifts and the whole workspace rebuilds), the remote is
+/// dropped, and `remote_error` is `None` — there is not even a reason left to show
+/// in `kache status`. Silently rebuilding the world beats an ignored typo only if
+/// you never make typos. Reporting unknown keys needs remote parsing isolated from
 /// the rest of the config.
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub(crate) struct RemoteFileConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,12 @@ pub struct Config {
     pub cache_dir: PathBuf,
     pub max_size: u64,
     pub remote: Option<RemoteConfig>,
+    /// Why the remote is unavailable, when a remote *was* configured but could
+    /// not be resolved. Kept as a message rather than propagated out of
+    /// [`Config::load`] so a misconfigured remote degrades to local-only instead
+    /// of failing every compiler invocation; commands that exist to talk to the
+    /// remote surface it through [`Config::require_remote`].
+    pub remote_error: Option<String>,
     pub disabled: bool,
     pub cache_executables: bool,
     pub clean_incremental: bool,
@@ -209,7 +215,36 @@ pub struct FilesystemRemoteConfig {
     pub atomic_write_dir: PathBuf,
 }
 
+impl Config {
+    /// The configured remote, or an actionable error.
+    ///
+    /// For commands whose whole purpose is the remote (`sync`, `doctor`), a
+    /// misconfiguration must be loud. [`Config::load`] deliberately swallows it so
+    /// the compiler wrapper keeps working, so this is where that reason resurfaces
+    /// instead of being reported as a plain "not configured".
+    pub fn require_remote(&self) -> Result<&RemoteConfig> {
+        if let Some(remote) = &self.remote {
+            return Ok(remote);
+        }
+        if let Some(reason) = &self.remote_error {
+            anyhow::bail!("remote cache configuration is unusable: {reason}");
+        }
+        if self.local_only {
+            anyhow::bail!("local-only mode is enabled, so no remote cache is available");
+        }
+        anyhow::bail!("No remote configured. Run `kache config` to set one up.")
+    }
+}
+
 impl RemoteConfig {
+    /// Stable machine-readable backend name for the JSON report.
+    pub fn backend_kind(&self) -> &'static str {
+        match &self.backend {
+            RemoteBackendConfig::S3(_) => "s3",
+            RemoteBackendConfig::Filesystem(_) => "filesystem",
+        }
+    }
+
     /// Human-readable root used by status, doctor, and logs.
     pub fn describe(&self) -> String {
         let base = match &self.backend {
@@ -237,22 +272,134 @@ impl RemoteConfig {
     }
 }
 
-pub(crate) fn validate_remote_prefix(prefix: &str) -> Result<()> {
-    let canonical = !prefix.is_empty()
-        && prefix == prefix.trim()
-        && !prefix.starts_with('/')
-        && !prefix.ends_with('/')
-        && !prefix.contains('\\')
-        && prefix
-            .split('/')
-            .all(|segment| !segment.is_empty() && segment != "." && segment != "..");
-    if !canonical {
-        anyhow::bail!(
-            "remote prefix must be a canonical relative path without surrounding whitespace, \
-             leading/trailing slashes, backslashes, empty segments, '.' or '..': {prefix:?}"
+/// Canonicalize a configured remote prefix, tolerating the shapes the
+/// pre-OpenDAL loader accepted.
+///
+/// Empty prefixes and leading/trailing/duplicated slashes used to flow straight
+/// into object keys: `prefix = ""` stored at `/v3/...` and `prefix = "team/"` at
+/// `team//v3/...`. Neither shape survives the key canonicalization the transport
+/// now enforces, but *rejecting* them fails every compiler invocation for a
+/// config that worked before — the worst outcome for a build tool. Normalize
+/// instead, and let the caller warn: the objects move once, which costs a single
+/// cold cache rather than a broken build.
+///
+/// `.`/`..` segments and backslashes stay hard errors. There is no defensible
+/// normalization for them, and silently reinterpreting a traversal-shaped prefix
+/// is worse than refusing it.
+pub(crate) fn normalize_remote_prefix(prefix: &str) -> Result<String> {
+    let trimmed = prefix.trim();
+    if trimmed.contains('\\') {
+        anyhow::bail!("remote prefix must not contain backslashes: {prefix:?}");
+    }
+    let mut segments = Vec::new();
+    for segment in trimmed.split('/') {
+        if segment.is_empty() {
+            // Leading, trailing and duplicated slashes collapse.
+            continue;
+        }
+        if segment == "." || segment == ".." {
+            anyhow::bail!("remote prefix must not contain '.' or '..' path segments: {prefix:?}");
+        }
+        segments.push(segment);
+    }
+    Ok(segments.join("/"))
+}
+
+/// Reject staging directories that cannot deliver the atomic-rename guarantee
+/// the filesystem remote is built on, or that would leak staging files into the
+/// object namespace.
+///
+/// Two distinct failure modes, both silent until the remote is in use:
+/// * a staging dir on another filesystem makes every publish fail with `EXDEV`,
+///   because `rename(2)` cannot cross a mount point;
+/// * a staging dir *inside* the object prefix shows up in `list()` as if it were
+///   cached content, which confuses sync and GC.
+///
+/// The device check needs paths that exist, and neither is required to exist yet
+/// (OpenDAL creates the staging dir, not the root). Compare the nearest existing
+/// ancestor of each instead, and stay silent when that is not determinable —
+/// a missing root produces a clear error from the backend anyway.
+fn filesystem_staging_problem(
+    root: &std::path::Path,
+    atomic_write_dir: &std::path::Path,
+    prefix: &str,
+) -> Option<String> {
+    let object_root = if prefix.is_empty() {
+        root.to_path_buf()
+    } else {
+        root.join(prefix)
+    };
+    if atomic_write_dir.starts_with(&object_root) {
+        return Some(format!(
+            "[cache.remote] atomic_write_dir {} is inside the object prefix {}; staging files \
+             would be listed as cached objects. Put it outside the prefix (the default is \
+             <path>/.kache-tmp).",
+            atomic_write_dir.display(),
+            object_root.display()
+        ));
+    }
+
+    let device_of = |path: &std::path::Path| -> Option<u64> {
+        let existing = path.ancestors().find(|candidate| candidate.exists())?;
+        let metadata = std::fs::metadata(existing).ok()?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            Some(metadata.dev())
+        }
+        #[cfg(not(unix))]
+        {
+            // No portable device id on Windows without extra syscalls; the
+            // containment check above plus the backend's own error is enough.
+            let _ = metadata;
+            None
+        }
+    };
+
+    let (Some(root_device), Some(staging_device)) = (device_of(root), device_of(atomic_write_dir))
+    else {
+        return None;
+    };
+    if root_device != staging_device {
+        return Some(format!(
+            "[cache.remote] atomic_write_dir {} is on a different filesystem than path {}; \
+             publishing uses rename(2), which cannot cross filesystems and would fail with \
+             EXDEV on every write",
+            atomic_write_dir.display(),
+            root.display()
+        ));
+    }
+    None
+}
+
+/// Join a configured remote prefix with the rest of an object key.
+///
+/// The counterpart to [`normalize_remote_prefix`]: an empty prefix means "store at
+/// the root", so it must not contribute a leading `/`. Keys are validated as
+/// canonical relative paths at the transport boundary, which rejects both a
+/// leading slash and the empty segment that naive `{prefix}/{rest}` formatting
+/// produces.
+pub(crate) fn join_remote_key(prefix: &str, rest: &str) -> String {
+    if prefix.is_empty() {
+        rest.to_string()
+    } else {
+        format!("{prefix}/{rest}")
+    }
+}
+
+/// [`normalize_remote_prefix`] plus a one-line warning when normalization
+/// actually changed the prefix, because that moves where objects live.
+fn resolve_remote_prefix(configured: &str) -> Result<String> {
+    let normalized = normalize_remote_prefix(configured)?;
+    if normalized != configured {
+        tracing::warn!(
+            configured = %configured,
+            normalized = %normalized,
+            "remote prefix is not canonical; using the normalized form. Objects written under \
+             the previous prefix will not be found, so the remote cache repopulates once."
         );
     }
-    Ok(())
+    Ok(normalized)
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
@@ -320,7 +467,12 @@ pub(crate) struct CacheFileConfig {
     pub(crate) path_only_env_vars: Option<Vec<String>>,
 }
 
+/// `deny_unknown_fields` so a typo (`bukcet = "..."`) is reported instead of
+/// silently ignored, which previously left the remote mysteriously unconfigured.
+/// Safe to be strict here now that `Config::load` degrades rather than failing the
+/// build.
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct RemoteFileConfig {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub(crate) _type: Option<String>,
@@ -791,16 +943,33 @@ impl Config {
             })
             .unwrap_or(DEFAULT_HEARTBEAT_SECS);
         let explain_miss = Self::explain_miss_enabled(&file_config);
-        let remote = if local_only {
-            None
+        // A remote that cannot be resolved must NOT fail the build. `Config::load`
+        // runs on the rustc-wrapper hot path (`run_wrapper_mode`), where returning
+        // an error means the compiler never runs at all — a config typo would
+        // break every build instead of costing cache hits. Record the reason and
+        // continue local-only.
+        let (remote, remote_error) = if local_only {
+            (None, None)
         } else {
-            Self::load_remote_config(&file_config)?
+            match Self::load_remote_config(&file_config) {
+                Ok(remote) => (remote, None),
+                Err(error) => {
+                    let reason = format!("{error:#}");
+                    tracing::warn!(
+                        %reason,
+                        "remote cache configuration is unusable — continuing without a remote \
+                         cache. Run `kache doctor` for details."
+                    );
+                    (None, Some(reason))
+                }
+            }
         };
 
         Ok(Config {
             cache_dir,
             max_size,
             remote,
+            remote_error,
             disabled,
             local_only,
             remote_readonly,
@@ -955,12 +1124,16 @@ impl Config {
             let prefix = file_remote
                 .and_then(|r| r.prefix.clone())
                 .unwrap_or_else(|| "artifacts".to_string());
-            validate_remote_prefix(&prefix)?;
+            let prefix = resolve_remote_prefix(&prefix)?;
             if prefix.contains(':') {
                 anyhow::bail!(
                     "[cache.remote] filesystem prefix cannot contain ':' because it can escape \
                      the configured root or address an alternate data stream on Windows: {prefix:?}"
                 );
+            }
+
+            if let Some(problem) = filesystem_staging_problem(&root, &atomic_write_dir, &prefix) {
+                anyhow::bail!("{problem}");
             }
 
             return Ok(Some(RemoteConfig {
@@ -972,8 +1145,31 @@ impl Config {
             }));
         }
 
-        let bucket = env_or_ignored("KACHE_S3_BUCKET", ignore_env)
-            .ok()
+        // A *present but empty* KACHE_S3_BUCKET is how a job neutralizes an
+        // inherited remote. Falling through to the file-configured bucket would
+        // silently point that job at a different remote than it asked for, so an
+        // explicit empty override disables the remote instead.
+        let env_bucket = env_or_ignored("KACHE_S3_BUCKET", ignore_env).ok();
+        if let Some(env_bucket) = &env_bucket
+            && env_bucket.trim().is_empty()
+        {
+            // An explicit `type = "s3"` asked for S3, so an empty bucket is a
+            // misconfiguration worth reporting (Config::load degrades it to
+            // local-only rather than failing the build).
+            if configured_type.as_deref() == Some("s3") {
+                anyhow::bail!(
+                    "[cache.remote] type = \"s3\" requires a non-empty bucket, but KACHE_S3_BUCKET \
+                     is set to an empty value"
+                );
+            }
+            tracing::warn!(
+                "KACHE_S3_BUCKET is set but empty — treating the remote cache as disabled rather \
+                 than falling back to the configured bucket"
+            );
+            return Ok(None);
+        }
+
+        let bucket = env_bucket
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())
             .or_else(|| {
@@ -1004,7 +1200,7 @@ impl Config {
             .ok()
             .or_else(|| file_remote.and_then(|r| r.prefix.clone()))
             .unwrap_or_else(|| "artifacts".to_string());
-        validate_remote_prefix(&prefix)?;
+        let prefix = resolve_remote_prefix(&prefix)?;
 
         let profile = env_or_ignored("KACHE_S3_PROFILE", ignore_env)
             .ok()
@@ -1588,17 +1784,30 @@ mod tests {
 
     #[test]
     fn remote_prefix_is_backend_neutral() {
-        assert!(validate_remote_prefix("artifacts/team").is_ok());
-        for invalid in [
-            r"artifacts\team",
-            r"..\escape",
-            "/artifacts",
-            "artifacts/",
-            "artifacts//team",
-            "artifacts/../team",
+        assert_eq!(
+            normalize_remote_prefix("artifacts/team").unwrap(),
+            "artifacts/team"
+        );
+        // Shapes the pre-OpenDAL loader accepted normalize instead of failing the
+        // build. `""` is legitimate ("store at the root") and stays empty.
+        for (legacy, expected) in [
+            ("/artifacts", "artifacts"),
+            ("artifacts/", "artifacts"),
+            ("artifacts//team", "artifacts/team"),
+            ("  artifacts/team  ", "artifacts/team"),
+            ("/", ""),
+            ("", ""),
         ] {
+            assert_eq!(
+                normalize_remote_prefix(legacy).unwrap(),
+                expected,
+                "{legacy:?} must normalize, not fail"
+            );
+        }
+        // Traversal shapes have no defensible normalization.
+        for invalid in [r"artifacts\team", r"..\escape", "artifacts/../team", ".."] {
             assert!(
-                validate_remote_prefix(invalid).is_err(),
+                normalize_remote_prefix(invalid).is_err(),
                 "{invalid:?} must be rejected"
             );
         }
@@ -1957,6 +2166,7 @@ mod tests {
             cache_dir: PathBuf::from("/tmp/kache"),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -1990,6 +2200,7 @@ mod tests {
             cache_dir: PathBuf::from("/tmp/kache"),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -2023,6 +2234,7 @@ mod tests {
             cache_dir: PathBuf::from("/tmp/kache"),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -2059,6 +2271,7 @@ mod tests {
             cache_dir: PathBuf::from("/tmp/kache"),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -2724,6 +2937,114 @@ exclude = ["src/generated/**", "vendor/problem/**"]
             .expect_err("empty S3 bucket must be rejected")
             .to_string();
         assert!(error.contains("non-empty bucket"), "{error}");
+    }
+
+    /// Regression: `prefix = "team/"` and `KACHE_S3_PREFIX=""` were accepted by the
+    /// pre-OpenDAL loader. Rejecting them made `Config::load` fail, and because
+    /// `run_wrapper_mode` propagates that with `?`, every compiler invocation died.
+    #[test]
+    fn legacy_noncanonical_prefixes_normalize_instead_of_failing() {
+        let _guard = config_path_lock();
+        let _bucket = set_env_var_for_test("KACHE_S3_BUCKET", "legacy-bucket");
+
+        for (configured, expected) in [("team/", "team"), ("/team", "team"), ("a//b", "a/b")] {
+            let file = FileConfig {
+                cache: Some(CacheFileConfig {
+                    remote: Some(RemoteFileConfig {
+                        prefix: Some(configured.to_string()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            let remote = Config::load_remote_config(&Ok(file))
+                .unwrap_or_else(|e| panic!("{configured:?} must not fail: {e:#}"))
+                .expect("remote");
+            assert_eq!(remote.prefix, expected, "{configured:?}");
+        }
+    }
+
+    #[test]
+    fn legacy_empty_env_prefix_means_the_bucket_root() {
+        let _guard = config_path_lock();
+        let _bucket = set_env_var_for_test("KACHE_S3_BUCKET", "legacy-bucket");
+        let _prefix = set_env_var_for_test("KACHE_S3_PREFIX", "");
+
+        let remote = Config::load_remote_config(&Ok(FileConfig::default()))
+            .expect("empty prefix must be accepted")
+            .expect("remote");
+        assert_eq!(remote.prefix, "");
+    }
+
+    /// Regression: a present-but-empty override used to be filtered out, so the
+    /// job silently got the *file-configured* bucket instead of no remote.
+    #[test]
+    fn empty_env_bucket_disables_the_remote_instead_of_falling_back() {
+        let _guard = config_path_lock();
+        let _bucket = set_env_var_for_test("KACHE_S3_BUCKET", "");
+        let file = FileConfig {
+            cache: Some(CacheFileConfig {
+                remote: Some(RemoteFileConfig {
+                    bucket: Some("production-cache".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert!(
+            Config::load_remote_config(&Ok(file))
+                .expect("empty override is not an error without an explicit type")
+                .is_none(),
+            "an empty KACHE_S3_BUCKET must not select the file-configured bucket"
+        );
+    }
+
+    /// The load-bearing invariant: an unusable remote must cost cache hits, never
+    /// the build. `Config::load` is on the rustc-wrapper path.
+    #[test]
+    fn unusable_remote_config_degrades_to_local_only() {
+        let _lock = config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = dir.path().join("config.toml");
+        let _g = set_kache_config_for_test(&cfg);
+        for var in ["KACHE_S3_BUCKET", "KACHE_S3_PREFIX"] {
+            unsafe { std::env::remove_var(var) };
+        }
+
+        // `..` cannot be normalized, so this is a genuinely unusable remote.
+        std::fs::write(
+            &cfg,
+            "[cache.remote]\ntype = \"s3\"\nbucket = \"b\"\nprefix = \"a/../b\"\n",
+        )
+        .unwrap();
+
+        let loaded = Config::load().expect("a bad remote must not fail Config::load");
+        assert!(loaded.remote.is_none(), "remote must be dropped");
+        let reason = loaded
+            .remote_error
+            .as_deref()
+            .expect("reason must be recorded");
+        assert!(reason.contains("path segments"), "{reason}");
+        // ...but a command that exists to use the remote still fails loudly.
+        let error = loaded
+            .require_remote()
+            .expect_err("require_remote must fail");
+        assert!(error.to_string().contains("unusable"), "{error}");
+    }
+
+    #[test]
+    fn staging_dir_inside_the_object_prefix_is_rejected() {
+        let root = std::path::Path::new("/tmp/kache-remote");
+        let problem =
+            filesystem_staging_problem(root, &root.join("artifacts").join("staging"), "artifacts")
+                .expect("staging inside the prefix must be rejected");
+        assert!(problem.contains("inside the object prefix"), "{problem}");
+
+        // The default lives beside the prefix, not inside it.
+        assert!(filesystem_staging_problem(root, &root.join(".kache-tmp"), "artifacts").is_none());
     }
 
     #[test]

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -12,8 +12,8 @@ use std::time::Duration;
 
 use crate::config::{
     CacheFileConfig, CcFileConfig, Config, EnvOverrides, FileConfig, PathsFileConfig,
-    PlannerFileConfig, RemoteFileConfig, default_cache_dir, parse_size, resolve_config_path,
-    shellexpand, validate_remote_prefix,
+    PlannerFileConfig, RemoteFileConfig, default_cache_dir, normalize_remote_prefix, parse_size,
+    resolve_config_path, shellexpand,
 };
 
 // ── Field definitions ─────────────────────────────────────────────────────
@@ -509,12 +509,12 @@ fn validate_cross_field(fields: &[FormField]) -> Vec<(usize, String)> {
     .any(|key| is_configured(key));
 
     if let Some(prefix) = configured_value("remote_prefix")
-        && validate_remote_prefix(prefix).is_err()
+        && normalize_remote_prefix(prefix).is_err()
         && let Some(idx) = index("remote_prefix")
     {
         errors.push((
             idx,
-            "Prefix must be a canonical relative path without leading/trailing slashes".to_string(),
+            "Prefix must not contain backslashes or '.'/'..' path segments".to_string(),
         ));
     }
 
@@ -1763,9 +1763,9 @@ mod tests {
     }
 
     #[test]
-    fn test_remote_prefix_validation_rejects_noncanonical_paths() {
+    fn test_remote_prefix_validation_rejects_only_unnormalizable_paths() {
         let config = FileConfig::default();
-        for prefix in [" artifacts", "/artifacts", "artifacts/", "a//b", "a/../b"] {
+        let validate = |prefix: &str| {
             let mut fields = build_fields(&config, &empty_env());
             for (key, value) in [
                 ("remote_type", "s3"),
@@ -1778,12 +1778,19 @@ mod tests {
                     .unwrap()
                     .value = value.to_string();
             }
-            assert!(
-                validate_cross_field(&fields)
-                    .iter()
-                    .any(|(_, message)| message.contains("canonical relative path")),
-                "{prefix:?}"
-            );
+            validate_cross_field(&fields)
+                .iter()
+                .any(|(_, message)| message.contains("path segments"))
+        };
+
+        // Traversal shapes stay rejected.
+        for prefix in ["a/../b", r"a\b", ".."] {
+            assert!(validate(prefix), "{prefix:?} must be rejected");
+        }
+        // Shapes the loader normalizes must not block saving — the editor would
+        // otherwise refuse a config that kache itself accepts.
+        for prefix in [" artifacts", "/artifacts", "artifacts/", "a//b"] {
+            assert!(!validate(prefix), "{prefix:?} must be accepted");
         }
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5790,6 +5790,7 @@ mod tests {
             cache_dir: dir.to_path_buf(),
             max_size: 50 * 1024 * 1024, // 50 MiB
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: false,

--- a/src/fallback_planner.rs
+++ b/src/fallback_planner.rs
@@ -115,6 +115,7 @@ mod tests {
         remote: Option<crate::config::RemoteConfig>,
     ) -> Config {
         Config {
+            remote_error: None,
             fallback: None,
             key_salt: None,
             cc_extra_allowlist_flags: Vec::new(),

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -92,7 +92,8 @@ pub async fn download_manifest(
     prefix: &str,
     manifest_key: &str,
 ) -> Result<BuildManifest> {
-    let object_key = format!("{prefix}/{MANIFEST_PREFIX}/{manifest_key}.json");
+    let object_key =
+        crate::config::join_remote_key(prefix, &format!("{MANIFEST_PREFIX}/{manifest_key}.json"));
 
     let fetched = backend
         .get(&object_key, Some(MAX_METADATA_BYTES))
@@ -109,7 +110,8 @@ pub async fn upload_manifest(
     manifest_key: &str,
     manifest: &BuildManifest,
 ) -> Result<()> {
-    let object_key = format!("{prefix}/{MANIFEST_PREFIX}/{manifest_key}.json");
+    let object_key =
+        crate::config::join_remote_key(prefix, &format!("{MANIFEST_PREFIX}/{manifest_key}.json"));
     let body = serde_json::to_vec_pretty(manifest).context("serializing manifest")?;
 
     backend
@@ -122,7 +124,10 @@ pub async fn upload_manifest(
 
 /// Format: `{prefix}/_manifests/v3/{namespace}/shards/{shard_hash}.json`
 pub fn shard_object_key(prefix: &str, namespace: &str, shard_hash: &str) -> String {
-    format!("{prefix}/{MANIFEST_PREFIX}/{MANIFEST_VERSION}/{namespace}/shards/{shard_hash}.json")
+    crate::config::join_remote_key(
+        prefix,
+        &format!("{MANIFEST_PREFIX}/{MANIFEST_VERSION}/{namespace}/shards/{shard_hash}.json"),
+    )
 }
 
 pub async fn download_shard(

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -53,8 +53,13 @@ const READ_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(30);
 const LIST_TOTAL_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// Ceiling on entries returned by a single LIST, so a pathological or hostile
-/// listing cannot exhaust memory in a compiler process.
+/// listing cannot exhaust memory in a compiler process. A DoS backstop, not a
+/// tuning knob: set far above any plausible real cache.
 const LIST_MAX_ENTRIES: usize = 1_000_000;
+
+/// Companion byte ceiling on retained key text, because entry count alone does not
+/// bound memory when keys are long.
+const LIST_MAX_KEY_BYTES: usize = 256 * 1024 * 1024;
 
 /// A fetched object plus the timing split callers report as transfer telemetry.
 #[derive(Debug)]
@@ -135,9 +140,25 @@ impl OpenDalBackend {
             return Ok(());
         };
         let target = root.join(key);
-        // The leaf need not exist yet; the nearest existing ancestor is what a
-        // hostile symlink would have to live at or above.
-        let Some(existing) = target.ancestors().skip(1).find(|path| path.exists()) else {
+        // Start at the leaf, not its parent: the destination itself may already
+        // exist as a symlink. `symlink_metadata` so the check sees the link rather
+        // than its target.
+        let mut existing = None;
+        for candidate in target.ancestors() {
+            match candidate.symlink_metadata() {
+                Ok(_) => {
+                    existing = Some(candidate);
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("inspecting {} for containment check", candidate.display())
+                    });
+                }
+            }
+        }
+        let Some(existing) = existing else {
             return Ok(());
         };
         let resolved = existing
@@ -286,14 +307,7 @@ impl RemoteBackend for OpenDalBackend {
         // keeps the failure at the transport (where the key and byte counts are
         // known) instead of surfacing as a confusing hash mismatch, and it also
         // covers objects fetched outside that gate.
-        if let Some(advertised) = advertised_length
-            && length != advertised
-        {
-            anyhow::bail!(
-                "{} truncated: read {length} bytes, expected {advertised}",
-                self.describe(key)
-            );
-        }
+        verify_complete_body(advertised_length, length, &self.describe(key))?;
 
         let body_ms = body_start.elapsed().as_millis() as u64;
         let body = chunks.into_iter().collect::<opendal::Buffer>().to_bytes();
@@ -328,26 +342,38 @@ impl RemoteBackend for OpenDalBackend {
 
         let mut entries = Vec::new();
         let mut seen = HashSet::new();
+        let mut key_bytes = 0_usize;
         let list_start = Instant::now();
         loop {
-            // Two independent guards: no-progress (a stalled lister) and total
-            // elapsed (a lister that keeps trickling entries forever).
-            if list_start.elapsed() > LIST_TOTAL_TIMEOUT {
+            // Two guards: no-progress (a stalled lister) and total elapsed (one that
+            // keeps trickling entries forever). Wait for whichever comes first, so
+            // the total deadline cannot be overshot by a whole progress timeout.
+            let elapsed = list_start.elapsed();
+            let Some(remaining) = LIST_TOTAL_TIMEOUT.checked_sub(elapsed) else {
                 anyhow::bail!(
-                    "LIST {} exceeded {}s after {} entries",
+                    "LIST {} exceeded its {}s total deadline after {} entries",
                     self.describe(prefix),
                     LIST_TOTAL_TIMEOUT.as_secs(),
                     entries.len()
                 );
-            }
-            let next = tokio::time::timeout(LIST_PROGRESS_TIMEOUT, lister.try_next())
+            };
+            let wait = LIST_PROGRESS_TIMEOUT.min(remaining);
+            let next = tokio::time::timeout(wait, lister.try_next())
                 .await
                 .with_context(|| {
-                    format!(
-                        "LIST {} made no progress for {}s",
-                        self.describe(prefix),
-                        LIST_PROGRESS_TIMEOUT.as_secs()
-                    )
+                    if wait == remaining {
+                        format!(
+                            "LIST {} exceeded its {}s total deadline",
+                            self.describe(prefix),
+                            LIST_TOTAL_TIMEOUT.as_secs()
+                        )
+                    } else {
+                        format!(
+                            "LIST {} made no progress for {}s",
+                            self.describe(prefix),
+                            LIST_PROGRESS_TIMEOUT.as_secs()
+                        )
+                    }
                 })?;
             match next {
                 Ok(Some(entry)) => {
@@ -359,10 +385,16 @@ impl RemoteBackend for OpenDalBackend {
                             self.describe(prefix)
                         );
                     }
-                    if seen.len() > LIST_MAX_ENTRIES {
+                    // Bound entries AND bytes: each path is retained twice (once in
+                    // `seen`, once in `entries`), so a flood of long keys can exhaust
+                    // memory well before any plausible entry count.
+                    key_bytes = key_bytes.saturating_add(path.len() * 2);
+                    if seen.len() > LIST_MAX_ENTRIES || key_bytes > LIST_MAX_KEY_BYTES {
                         anyhow::bail!(
-                            "LIST {} exceeded the {LIST_MAX_ENTRIES}-entry cap",
-                            self.describe(prefix)
+                            "LIST {} exceeded its limits ({} entries, {key_bytes} key bytes; \
+                             caps are {LIST_MAX_ENTRIES} entries and {LIST_MAX_KEY_BYTES} bytes)",
+                            self.describe(prefix),
+                            seen.len()
                         );
                     }
                     if entry.metadata().is_file() {
@@ -384,6 +416,22 @@ impl RemoteBackend for OpenDalBackend {
             format!("{}/{}", self.root_description, key)
         }
     }
+}
+
+/// A stream that ends before its advertised length has not delivered the object.
+///
+/// Split out from `get` so the comparison itself is unit-testable: over HTTP the
+/// transport rejects an incomplete body first, so an integration test cannot prove
+/// this branch. It exists for the case the transport cannot see — a backend that
+/// ends the stream cleanly, such as the filesystem `stat`-then-read race where
+/// another process truncates the file in between.
+fn verify_complete_body(advertised: Option<u64>, read: u64, description: &str) -> Result<()> {
+    if let Some(advertised) = advertised
+        && read != advertised
+    {
+        anyhow::bail!("{description} truncated: read {read} bytes, expected {advertised}");
+    }
+    Ok(())
 }
 
 fn with_retries(operator: Operator) -> Operator {
@@ -544,7 +592,13 @@ fn shlex_split(input: &str) -> Option<Vec<String>> {
             }
             '\\' => {
                 has_token = true;
-                current.push(chars.next()?);
+                // POSIX shells escape with backslash; Windows uses it as a path
+                // separator, so `C:\tools\creds.exe` must survive intact.
+                if cfg!(windows) {
+                    current.push('\\');
+                } else {
+                    current.push(chars.next()?);
+                }
             }
             c => {
                 has_token = true;
@@ -660,8 +714,55 @@ fn create_s3_operator(config: &S3RemoteConfig, pool_idle_secs: u64) -> Result<Op
     Ok(with_retries(operator))
 }
 
+/// Same-filesystem check for the staging directory.
+///
+/// Publishing renames from the staging dir onto the final path, and `rename(2)`
+/// cannot cross a mount point, so a cross-device staging dir fails EVERY write
+/// with `EXDEV`. Deliberately here rather than in `Config::load`: it needs real
+/// syscalls, and `Config::load` runs on the rustc-wrapper hot path where stat-ing
+/// an unavailable network mount could stall the compiler. By the time a backend is
+/// built, the remote is actually being used and this I/O is inherent.
+///
+/// A heuristic, not a proof: device ids can match across boundaries that still
+/// reject a cross-boundary rename, and paths created later may be mounted
+/// elsewhere. Being wrong here just means the clearer error comes from the write.
+#[cfg(unix)]
+fn verify_same_filesystem(
+    root: &std::path::Path,
+    atomic_write_dir: &std::path::Path,
+) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+    let device_of = |path: &std::path::Path| -> Option<u64> {
+        let existing = path.ancestors().find(|candidate| candidate.exists())?;
+        std::fs::metadata(existing).ok().map(|meta| meta.dev())
+    };
+    let (Some(root_device), Some(staging_device)) = (device_of(root), device_of(atomic_write_dir))
+    else {
+        return Ok(());
+    };
+    if root_device != staging_device {
+        anyhow::bail!(
+            "atomic_write_dir {} is on a different filesystem than the remote root {}; \
+             publishing renames between them, which fails with EXDEV",
+            atomic_write_dir.display(),
+            root.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn verify_same_filesystem(
+    _root: &std::path::Path,
+    _atomic_write_dir: &std::path::Path,
+) -> Result<()> {
+    // No portable device id without extra syscalls; the write's own error stands.
+    Ok(())
+}
+
 fn create_filesystem_operator(config: &FilesystemRemoteConfig) -> Result<Operator> {
     ensure_rustls_provider();
+    verify_same_filesystem(&config.root, &config.atomic_write_dir)?;
     let root = config
         .root
         .to_str()
@@ -1055,6 +1156,83 @@ mod tests {
             assert_eq!(program, "helper");
             assert_eq!(args, vec![expected], "{raw:?}");
         }
+    }
+
+    #[test]
+    fn verify_complete_body_only_rejects_a_short_read() {
+        assert!(verify_complete_body(Some(5), 5, "obj").is_ok());
+        assert!(
+            verify_complete_body(None, 5, "obj").is_ok(),
+            "unknown length cannot be checked"
+        );
+        let error = verify_complete_body(Some(10), 5, "obj")
+            .expect_err("a short read must be rejected")
+            .to_string();
+        assert!(error.contains("truncated"), "{error}");
+        // A longer-than-advertised body is equally wrong.
+        assert!(verify_complete_body(Some(4), 5, "obj").is_err());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn credential_command_relexing_keeps_posix_backslash_escapes() {
+        // reqsign splits `helper --path /opt/a\ b` into these tokens.
+        let (program, args) =
+            relex_credential_command("helper", &["--path", "/opt/a\\", "b"]).unwrap();
+        assert_eq!(program, "helper");
+        assert_eq!(args, vec!["--path", "/opt/a b"]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn credential_command_relexing_keeps_windows_paths_intact() {
+        // A backslash is a path separator on Windows, not an escape.
+        let (program, args) =
+            relex_credential_command("C:\\tools\\aws-creds.exe", &["--profile", "ci"]).unwrap();
+        assert_eq!(program, "C:\\tools\\aws-creds.exe");
+        assert_eq!(args, vec!["--profile", "ci"]);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn filesystem_put_refuses_an_existing_symlinked_destination() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let victim = outside.path().join("victim");
+        std::fs::write(&victim, b"original").unwrap();
+
+        // The destination key itself already exists, as a symlink out of the cache.
+        std::fs::create_dir_all(root.path().join("artifacts/v3")).unwrap();
+        std::os::unix::fs::symlink(&victim, root.path().join("artifacts/v3/key")).unwrap();
+
+        let remote = RemoteConfig {
+            prefix: "artifacts".to_string(),
+            backend: RemoteBackendConfig::Filesystem(FilesystemRemoteConfig {
+                root: root.path().to_path_buf(),
+                atomic_write_dir: root.path().join(".kache-tmp"),
+            }),
+        };
+        let backend = create_backend(&remote, 30).await.unwrap();
+
+        backend
+            .put("artifacts/v3/key", b"attacker".to_vec(), None)
+            .await
+            .expect_err("an existing symlinked destination must be refused");
+        assert_eq!(
+            std::fs::read(&victim).unwrap(),
+            b"original",
+            "the file outside the root must be untouched"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cross_device_staging_dir_is_rejected_at_backend_build() {
+        // /dev/shm (Linux) or /Volumes (macOS) would be needed for a true
+        // cross-device pair; instead assert the same-device case passes, which is
+        // what every correct configuration hits.
+        let root = tempfile::tempdir().unwrap();
+        assert!(verify_same_filesystem(root.path(), &root.path().join(".kache-tmp")).is_ok());
     }
 
     #[test]

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -26,7 +26,6 @@ use reqsign_aws_v4::{
     ProcessCredentialProvider, ProfileCredentialProvider, SSOCredentialProvider,
     StaticCredentialProvider,
 };
-use reqsign_command_execute_tokio::TokioCommandExecute;
 use reqsign_core::{
     CommandExecute, Context as SigningContext, Env, OsEnv, ProvideCredential,
     ProvideCredentialChain,
@@ -612,8 +611,11 @@ fn shlex_split(input: &str) -> Option<Vec<String>> {
     Some(tokens)
 }
 
-#[derive(Debug, Clone, Copy)]
-struct KacheCommandExecute;
+#[derive(Debug, Clone, Default)]
+struct KacheCommandExecute {
+    /// Profile to hand the child, when Kache selected one explicitly.
+    profile: Option<String>,
+}
 
 impl CommandExecute for KacheCommandExecute {
     async fn command_execute(
@@ -623,8 +625,30 @@ impl CommandExecute for KacheCommandExecute {
     ) -> reqsign_core::Result<reqsign_core::CommandOutput> {
         let (program, args) = relex_credential_command(program, args)
             .map_err(|error| reqsign_core::Error::config_invalid(format!("{error:#}")))?;
-        let args: Vec<&str> = args.iter().map(String::as_str).collect();
-        TokioCommandExecute.command_execute(&program, &args).await
+
+        // `ProfileSelectingEnv` only redirects reqsign's own in-process reads. The
+        // credential helper is a separate process that inherits this one's
+        // environment, so without this it sees the ambient `AWS_PROFILE` and can
+        // return credentials for a different account than the one Kache asked for.
+        // Set it on the child only; the process environment is never mutated.
+        let mut command = tokio::process::Command::new(&program);
+        command
+            .args(&args)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        if let Some(profile) = &self.profile {
+            command.env("AWS_PROFILE", profile);
+        }
+        let output = command.output().await.map_err(|error| {
+            reqsign_core::Error::unexpected(format!("failed to execute command '{program}'"))
+                .with_source(error)
+        })?;
+
+        Ok(reqsign_core::CommandOutput {
+            status: output.status.code().unwrap_or(-1),
+            stdout: output.stdout,
+            stderr: output.stderr,
+        })
     }
 }
 
@@ -635,7 +659,9 @@ impl ProvideCredential for KacheCredentialProvider {
         &self,
         context: &SigningContext,
     ) -> reqsign_core::Result<Option<Self::Credential>> {
-        let context = context.clone().with_command_execute(KacheCommandExecute);
+        let context = context.clone().with_command_execute(KacheCommandExecute {
+            profile: self.profile.clone(),
+        });
         if let Some(profile) = &self.profile {
             let context = context.with_env(ProfileSelectingEnv {
                 inner: OsEnv,
@@ -1121,7 +1147,7 @@ mod tests {
     async fn credential_process_executor_preserves_quoted_arguments() {
         // reqsign splits on whitespace without stripping quotes, so the quote
         // characters arrive inside the tokens exactly like this.
-        let output = KacheCommandExecute
+        let output = KacheCommandExecute::default()
             .command_execute("printf", &["'%s'", "'hello", "world'"])
             .await
             .unwrap();
@@ -1155,6 +1181,42 @@ mod tests {
             let (program, args) = relex_credential_command("helper", &[raw]).unwrap();
             assert_eq!(program, "helper");
             assert_eq!(args, vec![expected], "{raw:?}");
+        }
+    }
+
+    /// The in-process `ProfileSelectingEnv` does not reach a `credential_process`
+    /// child, which is a separate process inheriting this one's environment. A
+    /// helper that shells out to AWS tooling would otherwise resolve the ambient
+    /// profile and return credentials for the wrong account.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn credential_process_child_sees_the_configured_profile() {
+        // SAFETY: single-threaded tokio test; the value is restored below.
+        let previous = std::env::var_os("AWS_PROFILE");
+        unsafe { std::env::set_var("AWS_PROFILE", "ambient") };
+
+        let selected = KacheCommandExecute {
+            profile: Some("selected".to_string()),
+        };
+        let output = selected
+            .command_execute("printenv", &["AWS_PROFILE"])
+            .await
+            .unwrap();
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "selected");
+
+        // With no profile configured, the ambient value must still be visible.
+        let inherited = KacheCommandExecute::default();
+        let output = inherited
+            .command_execute("printenv", &["AWS_PROFILE"])
+            .await
+            .unwrap();
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "ambient");
+
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("AWS_PROFILE", value),
+                None => std::env::remove_var("AWS_PROFILE"),
+            }
         }
     }
 

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -39,6 +39,23 @@ use crate::config::{FilesystemRemoteConfig, RemoteBackendConfig, RemoteConfig, S
 /// yielding the first page without ever stalling.
 const LIST_PROGRESS_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Matches the AWS SDK's former default (`SDK_DEFAULT_CONNECT_TIMEOUT`), so a
+/// black-holed endpoint fails fast instead of stalling a compile.
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(3100);
+
+/// Per-read inactivity deadline. Not a total-request timeout: a large pack on a
+/// slow link is legitimate, a stalled socket is not.
+const READ_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Ceiling on a single LIST. `LIST_PROGRESS_TIMEOUT` only catches a *stalled*
+/// lister; an endpoint that keeps emitting fresh entries just under that timeout
+/// would otherwise run unbounded while both `entries` and `seen` grow.
+const LIST_TOTAL_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Ceiling on entries returned by a single LIST, so a pathological or hostile
+/// listing cannot exhaust memory in a compiler process.
+const LIST_MAX_ENTRIES: usize = 1_000_000;
+
 /// A fetched object plus the timing split callers report as transfer telemetry.
 #[derive(Debug)]
 pub struct GetObject {
@@ -81,7 +98,10 @@ pub trait RemoteBackend: Send + Sync {
 pub struct OpenDalBackend {
     operator: Operator,
     root_description: String,
-    is_filesystem: bool,
+    /// Canonical filesystem root, for the filesystem backend only. Present means
+    /// "this backend writes real paths", which enables the extra key rules and the
+    /// write-containment check.
+    filesystem_root: Option<PathBuf>,
 }
 
 impl OpenDalBackend {
@@ -89,8 +109,50 @@ impl OpenDalBackend {
         Self {
             operator,
             root_description,
-            is_filesystem: false,
+            filesystem_root: None,
         }
+    }
+
+    fn is_filesystem(&self) -> bool {
+        self.filesystem_root.is_some()
+    }
+
+    /// Best-effort check that `key` resolves inside the configured root.
+    ///
+    /// [`Self::validate_key`] is purely lexical, and OpenDAL's fs service
+    /// canonicalizes only the root (once, at build time) before joining each key
+    /// onto it — so a symlink at an intermediate path *inside* the root is
+    /// followed. On a shared cache that another user can write, a symlink at
+    /// `<prefix>/v3/packs` would redirect kache's writes outside the cache
+    /// entirely, which is a real escalation over ordinary cache poisoning (that
+    /// is already bounded by the layout layer's blake3 gate).
+    ///
+    /// This is defense in depth, not a hermetic boundary: the resolved path can
+    /// still change between this check and the write. A hermetic version needs
+    /// `openat2(RESOLVE_BENEATH)`, which OpenDAL does not expose.
+    fn verify_write_containment(&self, key: &str) -> Result<()> {
+        let Some(root) = &self.filesystem_root else {
+            return Ok(());
+        };
+        let target = root.join(key);
+        // The leaf need not exist yet; the nearest existing ancestor is what a
+        // hostile symlink would have to live at or above.
+        let Some(existing) = target.ancestors().skip(1).find(|path| path.exists()) else {
+            return Ok(());
+        };
+        let resolved = existing
+            .canonicalize()
+            .with_context(|| format!("resolving {} for containment check", existing.display()))?;
+        if !resolved.starts_with(root) {
+            anyhow::bail!(
+                "refusing to write {}: {} resolves to {}, outside the configured remote root {}",
+                self.describe(key),
+                existing.display(),
+                resolved.display(),
+                root.display()
+            );
+        }
+        Ok(())
     }
 
     fn contextual_error(&self, operation: &str, key: &str, error: opendal::Error) -> anyhow::Error {
@@ -109,10 +171,21 @@ impl OpenDalBackend {
             || (!key.is_empty()
                 && !original.starts_with('/')
                 && !key.contains('\\')
+                // Control characters have no legitimate place in a cache key and
+                // enable log injection in the messages built from it.
+                && !key.chars().any(char::is_control)
                 // On Windows a colon can introduce a drive prefix or alternate
                 // data stream. Reject it for filesystem keys on every platform
                 // so a shared config stays portable and contained by its root.
-                && !(self.is_filesystem && key.contains(':'))
+                && !(self.is_filesystem() && key.contains(':'))
+                // Windows silently strips trailing dots and spaces from path
+                // components, so `a.` and `a` would collide on a filesystem
+                // remote written from Windows. Reject on every platform to keep
+                // one shared cache addressable from all of them.
+                && !(self.is_filesystem()
+                    && key
+                        .split('/')
+                        .any(|segment| segment.ends_with('.') || segment.ends_with(' ')))
                 && key
                     .split('/')
                     .all(|segment| !segment.is_empty() && segment != "." && segment != ".."));
@@ -208,6 +281,20 @@ impl RemoteBackend for OpenDalBackend {
             }
             chunks.extend(chunk);
         }
+        // A stream that ends early is not a valid object. The layout layer's
+        // blake3 gate would reject a truncated pack anyway, but catching it here
+        // keeps the failure at the transport (where the key and byte counts are
+        // known) instead of surfacing as a confusing hash mismatch, and it also
+        // covers objects fetched outside that gate.
+        if let Some(advertised) = advertised_length
+            && length != advertised
+        {
+            anyhow::bail!(
+                "{} truncated: read {length} bytes, expected {advertised}",
+                self.describe(key)
+            );
+        }
+
         let body_ms = body_start.elapsed().as_millis() as u64;
         let body = chunks.into_iter().collect::<opendal::Buffer>().to_bytes();
 
@@ -220,6 +307,7 @@ impl RemoteBackend for OpenDalBackend {
 
     async fn put(&self, key: &str, body: Vec<u8>, content_type: Option<&str>) -> Result<()> {
         self.validate_key("PUT", key, false)?;
+        self.verify_write_containment(key)?;
         let request = self.operator.write_with(key, body);
         let result = match content_type {
             Some(content_type) => request.content_type(content_type).await,
@@ -240,7 +328,18 @@ impl RemoteBackend for OpenDalBackend {
 
         let mut entries = Vec::new();
         let mut seen = HashSet::new();
+        let list_start = Instant::now();
         loop {
+            // Two independent guards: no-progress (a stalled lister) and total
+            // elapsed (a lister that keeps trickling entries forever).
+            if list_start.elapsed() > LIST_TOTAL_TIMEOUT {
+                anyhow::bail!(
+                    "LIST {} exceeded {}s after {} entries",
+                    self.describe(prefix),
+                    LIST_TOTAL_TIMEOUT.as_secs(),
+                    entries.len()
+                );
+            }
             let next = tokio::time::timeout(LIST_PROGRESS_TIMEOUT, lister.try_next())
                 .await
                 .with_context(|| {
@@ -257,6 +356,12 @@ impl RemoteBackend for OpenDalBackend {
                         anyhow::bail!(
                             "LIST {} returned duplicate entry {path:?}; \
                              the remote likely supplied an invalid continuation token",
+                            self.describe(prefix)
+                        );
+                    }
+                    if seen.len() > LIST_MAX_ENTRIES {
+                        anyhow::bail!(
+                            "LIST {} exceeded the {LIST_MAX_ENTRIES}-entry cap",
                             self.describe(prefix)
                         );
                     }
@@ -357,9 +462,102 @@ impl KacheCredentialProvider {
     }
 }
 
-/// Reassemble reqsign's tokenized `credential_process` and run it through the
-/// platform shell, matching the AWS SDK's support for quoted arguments and
-/// executable paths containing spaces.
+/// Re-lex reqsign's `credential_process` tokens and execute the result directly.
+///
+/// reqsign splits the configured command with `split_whitespace()` and no quote
+/// handling (see `reqsign-aws-v4`'s `execute_process`), so quote characters
+/// survive *inside* the tokens: `credential_process = "/opt/my helper" --role "a b"`
+/// arrives as `["\"/opt/my", "helper\"", "--role", "\"a", "b\""]`. Executing those
+/// tokens as-is would try to run a program literally named `"/opt/my`, so the
+/// quoting has to be reapplied.
+///
+/// Rejoining and handing the string to `sh -c` / `cmd.exe /C` does reapply it,
+/// but it also hands the user's config to a shell: globs expand, `$(...)` and
+/// backticks execute, `%VAR%` expands, and `&`/`|`/`^`/parens become operators.
+/// Under `cmd.exe` it is worse still — single quotes are not quoting characters
+/// there, so `'a b'` would not regroup. The AWS SDKs deliberately do shlex-style
+/// splitting and never invoke a shell; match that instead.
+fn relex_credential_command(program: &str, args: &[&str]) -> Result<(String, Vec<String>)> {
+    let mut command = program.to_string();
+    for arg in args {
+        command.push(' ');
+        command.push_str(arg);
+    }
+    let tokens = shlex_split(&command)
+        .with_context(|| "credential_process has unbalanced quotes".to_string())?;
+    let mut tokens = tokens.into_iter();
+    let program = tokens
+        .next()
+        .context("credential_process resolved to an empty command")?;
+    Ok((program, tokens.collect()))
+}
+
+/// Minimal POSIX-style lexer: single quotes are literal, double quotes group
+/// while honoring `\` escapes, and unquoted `\` escapes the next character.
+///
+/// Deliberately does NOT implement expansion of any kind — this exists to undo
+/// reqsign's whitespace split, not to emulate a shell. Returns `None` on
+/// unterminated quotes rather than guessing where the argument ended.
+fn shlex_split(input: &str) -> Option<Vec<String>> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut has_token = false;
+    let mut chars = input.chars();
+
+    while let Some(c) = chars.next() {
+        match c {
+            c if c.is_whitespace() => {
+                if has_token {
+                    tokens.push(std::mem::take(&mut current));
+                    has_token = false;
+                }
+            }
+            '\'' => {
+                has_token = true;
+                loop {
+                    match chars.next() {
+                        Some('\'') => break,
+                        Some(c) => current.push(c),
+                        None => return None,
+                    }
+                }
+            }
+            '"' => {
+                has_token = true;
+                loop {
+                    match chars.next() {
+                        Some('"') => break,
+                        Some('\\') => match chars.next() {
+                            // Only these are special inside double quotes; every
+                            // other backslash stays literal, as in POSIX sh.
+                            Some(escaped @ ('"' | '\\' | '$' | '`')) => current.push(escaped),
+                            Some(other) => {
+                                current.push('\\');
+                                current.push(other);
+                            }
+                            None => return None,
+                        },
+                        Some(c) => current.push(c),
+                        None => return None,
+                    }
+                }
+            }
+            '\\' => {
+                has_token = true;
+                current.push(chars.next()?);
+            }
+            c => {
+                has_token = true;
+                current.push(c);
+            }
+        }
+    }
+    if has_token {
+        tokens.push(current);
+    }
+    Some(tokens)
+}
+
 #[derive(Debug, Clone, Copy)]
 struct KacheCommandExecute;
 
@@ -369,18 +567,10 @@ impl CommandExecute for KacheCommandExecute {
         program: &str,
         args: &[&str],
     ) -> reqsign_core::Result<reqsign_core::CommandOutput> {
-        let mut command = program.to_string();
-        for arg in args {
-            command.push(' ');
-            command.push_str(arg);
-        }
-        #[cfg(windows)]
-        let (shell, shell_args) = ("cmd.exe", ["/C", command.as_str()]);
-        #[cfg(not(windows))]
-        let (shell, shell_args) = ("sh", ["-c", command.as_str()]);
-        TokioCommandExecute
-            .command_execute(shell, &shell_args)
-            .await
+        let (program, args) = relex_credential_command(program, args)
+            .map_err(|error| reqsign_core::Error::config_invalid(format!("{error:#}")))?;
+        let args: Vec<&str> = args.iter().map(String::as_str).collect();
+        TokioCommandExecute.command_execute(&program, &args).await
     }
 }
 
@@ -411,6 +601,16 @@ fn create_s3_operator(config: &S3RemoteConfig, pool_idle_secs: u64) -> Result<Op
     ensure_rustls_provider();
     let client = reqwest::Client::builder()
         .pool_idle_timeout(Duration::from_secs(pool_idle_secs))
+        // `pool_idle_timeout` only reaps idle pooled connections; without these an
+        // endpoint that accepts a connection and then goes silent hangs the
+        // operation forever, and `RetryLayer` never fires because no error is ever
+        // produced. On the rustc-wrapper path that is an apparently-hung build.
+        // The AWS SDK supplied a 3.1s connect timeout by default
+        // (aws-config's SDK_DEFAULT_CONNECT_TIMEOUT); keep parity and add a
+        // read-inactivity deadline. Deliberately NOT a total-request timeout,
+        // which would cap large artifact transfers on slow links.
+        .connect_timeout(CONNECT_TIMEOUT)
+        .read_timeout(READ_INACTIVITY_TIMEOUT)
         .build()
         .context("building S3 HTTP client")?;
     let context = OperationContext::new()
@@ -493,7 +693,13 @@ pub async fn create_backend(
                 create_filesystem_operator(config)?,
                 format!("file://{}", config.root.display()),
             );
-            backend.is_filesystem = true;
+            // Canonicalize once: the containment check compares against this, and
+            // OpenDAL's fs service has already canonicalized the same root, so a
+            // symlinked *root* is expected and fine — it is symlinks *below* it
+            // that the check is for.
+            backend.filesystem_root = Some(config.root.canonicalize().with_context(|| {
+                format!("resolving filesystem remote root {}", config.root.display())
+            })?);
             backend
         }
     };
@@ -812,12 +1018,128 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn credential_process_executor_preserves_quoted_arguments() {
+        // reqsign splits on whitespace without stripping quotes, so the quote
+        // characters arrive inside the tokens exactly like this.
         let output = KacheCommandExecute
-            .command_execute("printf", &["'%s'", "'hello world'"])
+            .command_execute("printf", &["'%s'", "'hello", "world'"])
             .await
             .unwrap();
         assert!(output.success());
         assert_eq!(output.stdout, b"hello world");
+    }
+
+    #[test]
+    fn credential_command_relexing_restores_quoted_grouping() {
+        // `credential_process = "/opt/my helper" --role "build cache"` as reqsign
+        // hands it over: whitespace-split, quotes intact.
+        let (program, args) =
+            relex_credential_command("\"/opt/my", &["helper\"", "--role", "\"build", "cache\""])
+                .unwrap();
+        assert_eq!(program, "/opt/my helper");
+        assert_eq!(args, vec!["--role", "build cache"]);
+    }
+
+    #[test]
+    fn credential_command_relexing_does_not_let_a_shell_interpret_the_command() {
+        // Each of these would be reinterpreted by `sh -c` / `cmd.exe /C`. They must
+        // survive as literal argument text instead.
+        for (raw, expected) in [
+            ("--token=a&b", "--token=a&b"),
+            ("$HOME", "$HOME"),
+            ("$(id)", "$(id)"),
+            ("*.json", "*.json"),
+            ("%USERPROFILE%", "%USERPROFILE%"),
+            ("a|b", "a|b"),
+        ] {
+            let (program, args) = relex_credential_command("helper", &[raw]).unwrap();
+            assert_eq!(program, "helper");
+            assert_eq!(args, vec![expected], "{raw:?}");
+        }
+    }
+
+    #[test]
+    fn credential_command_relexing_rejects_unbalanced_quotes() {
+        let error = relex_credential_command("\"/opt/helper", &[])
+            .expect_err("unbalanced quotes must not be guessed at")
+            .to_string();
+        assert!(error.contains("unbalanced quotes"), "{error}");
+    }
+
+    /// A body shorter than its advertised length must never surface as a hit.
+    ///
+    /// Over HTTP the transport itself rejects the incomplete body, so this pins
+    /// the invariant rather than the mechanism. The explicit length comparison in
+    /// `get` covers the case the transport cannot see: a backend that ends the
+    /// stream cleanly, such as the filesystem `stat`-then-read race where another
+    /// process truncates the file in between.
+    #[tokio::test]
+    async fn get_never_returns_a_body_shorter_than_content_length() {
+        // Content-Length promises 10 bytes; the server sends 5 and closes.
+        let truncated = "HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\
+                         Content-Type: application/octet-stream\r\n\
+                         Connection: close\r\n\r\nhello";
+        let (endpoint, _requests) = mock_http_server(vec![truncated.to_string()]).await;
+        let backend = anonymous_s3_backend(&endpoint);
+
+        let error = backend
+            .get("key", None)
+            .await
+            .expect_err("a truncated body must not be returned as a hit")
+            .to_string();
+        assert!(error.contains("s3://bucket/key"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn filesystem_put_refuses_to_follow_a_symlink_out_of_the_root() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        // A hostile peer on a shared cache plants a symlink inside the root.
+        std::os::unix::fs::symlink(outside.path(), root.path().join("artifacts")).unwrap();
+
+        let remote = RemoteConfig {
+            prefix: "artifacts".to_string(),
+            backend: RemoteBackendConfig::Filesystem(FilesystemRemoteConfig {
+                root: root.path().to_path_buf(),
+                atomic_write_dir: root.path().join(".kache-tmp"),
+            }),
+        };
+        let backend = create_backend(&remote, 30).await.unwrap();
+
+        let error = backend
+            .put("artifacts/v3/key", b"escaped".to_vec(), None)
+            .await
+            .expect_err("writing through a symlink out of the root must be refused")
+            .to_string();
+        assert!(
+            error.contains("outside the configured remote root"),
+            "{error}"
+        );
+        assert!(
+            !outside.path().join("v3/key").exists(),
+            "bytes must not land outside the root"
+        );
+    }
+
+    #[tokio::test]
+    async fn filesystem_keys_reject_windows_hostile_shapes() {
+        let root = tempfile::tempdir().unwrap();
+        let remote = RemoteConfig {
+            prefix: "artifacts".to_string(),
+            backend: RemoteBackendConfig::Filesystem(FilesystemRemoteConfig {
+                root: root.path().to_path_buf(),
+                atomic_write_dir: root.path().join(".kache-tmp"),
+            }),
+        };
+        let backend = create_backend(&remote, 30).await.unwrap();
+
+        for key in [
+            "artifacts/trailing.",   // Windows strips the trailing dot
+            "artifacts/trailing ",   // ...and the trailing space
+            "artifacts/ctrl\u{7f}x", // control characters
+        ] {
+            backend.put(key, b"nope".to_vec(), None).await.unwrap_err();
+        }
     }
 
     #[test]

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -1188,13 +1188,17 @@ mod tests {
     /// child, which is a separate process inheriting this one's environment. A
     /// helper that shells out to AWS tooling would otherwise resolve the ambient
     /// profile and return credentials for the wrong account.
+    /// The in-process `ProfileSelectingEnv` does not reach a `credential_process`
+    /// child, which is a separate process inheriting this one's environment. A
+    /// helper that shells out to AWS tooling would otherwise resolve the ambient
+    /// profile and return credentials for the wrong account.
+    ///
+    /// Reads the ambient value rather than setting one: mutating process env from a
+    /// test races every other test in the binary, and CI may already export
+    /// `AWS_PROFILE`.
     #[cfg(unix)]
     #[tokio::test]
     async fn credential_process_child_sees_the_configured_profile() {
-        // SAFETY: single-threaded tokio test; the value is restored below.
-        let previous = std::env::var_os("AWS_PROFILE");
-        unsafe { std::env::set_var("AWS_PROFILE", "ambient") };
-
         let selected = KacheCommandExecute {
             profile: Some("selected".to_string()),
         };
@@ -1202,22 +1206,23 @@ mod tests {
             .command_execute("printenv", &["AWS_PROFILE"])
             .await
             .unwrap();
-        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "selected");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "selected",
+            "the configured profile must reach the child"
+        );
 
-        // With no profile configured, the ambient value must still be visible.
+        // With no profile configured the child keeps whatever this process has.
         let inherited = KacheCommandExecute::default();
         let output = inherited
             .command_execute("printenv", &["AWS_PROFILE"])
             .await
             .unwrap();
-        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "ambient");
-
-        unsafe {
-            match previous {
-                Some(value) => std::env::set_var("AWS_PROFILE", value),
-                None => std::env::remove_var("AWS_PROFILE"),
-            }
-        }
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            std::env::var("AWS_PROFILE").unwrap_or_default(),
+            "without a configured profile the ambient value must pass through"
+        );
     }
 
     #[test]

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -181,7 +181,10 @@ impl<'a> RemoteLayout<'a> {
     }
 
     pub async fn list_keys(&self) -> Result<HashMap<String, String>> {
-        let manifest_prefix = format!("{}/{V3_ROOT}/{V3_MANIFESTS}/", self.remote.prefix);
+        let manifest_prefix = crate::config::join_remote_key(
+            &self.remote.prefix,
+            &format!("{V3_ROOT}/{V3_MANIFESTS}/"),
+        );
         let objects = self
             .backend
             .list(&manifest_prefix)
@@ -208,9 +211,9 @@ impl<'a> RemoteLayout<'a> {
         let mut keys = HashMap::new();
 
         for crate_name in crate_names {
-            let manifest_prefix = format!(
-                "{}/{V3_ROOT}/{V3_MANIFESTS}/{crate_name}/",
-                self.remote.prefix
+            let manifest_prefix = crate::config::join_remote_key(
+                &self.remote.prefix,
+                &format!("{V3_ROOT}/{V3_MANIFESTS}/{crate_name}/"),
             );
             let objects = self
                 .backend
@@ -230,11 +233,17 @@ impl<'a> RemoteLayout<'a> {
 }
 
 fn v3_manifest_key(prefix: &str, cache_key: &str, crate_name: &str) -> String {
-    format!("{prefix}/{V3_ROOT}/{V3_MANIFESTS}/{crate_name}/{cache_key}.json")
+    crate::config::join_remote_key(
+        prefix,
+        &format!("{V3_ROOT}/{V3_MANIFESTS}/{crate_name}/{cache_key}.json"),
+    )
 }
 
 fn v3_pack_key(prefix: &str, cache_key: &str, crate_name: &str) -> String {
-    format!("{prefix}/{V3_ROOT}/{V3_PACKS}/{crate_name}/{cache_key}.tar.zst")
+    crate::config::join_remote_key(
+        prefix,
+        &format!("{V3_ROOT}/{V3_PACKS}/{crate_name}/{cache_key}.tar.zst"),
+    )
 }
 
 /// Marker error: the requested entry does not exist in the remote (GET 404).
@@ -599,6 +608,7 @@ mod tests {
             cache_dir: tmp.path().join("cache"),
             max_size: 1024 * 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -669,6 +679,7 @@ mod tests {
             cache_dir: restore_cache_dir,
             max_size: 1024 * 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -719,6 +730,7 @@ mod tests {
             cache_dir: tmp.path().join("cache"),
             max_size: 1024 * 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -846,6 +858,7 @@ mod tests {
             cache_dir,
             max_size: 1024 * 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -1024,6 +1037,44 @@ mod tests {
         assert_eq!(keys.get("aaaa1111").map(String::as_str), Some("serde"));
         assert_eq!(keys.get("bbbb2222").map(String::as_str), Some("tokio"));
         assert_eq!(keys.len(), 2, "non-.json objects must be ignored: {keys:?}");
+    }
+
+    /// An empty prefix means "store at the bucket root". Naive `{prefix}/{rest}`
+    /// formatting would emit a leading `/`, which the transport rejects as a
+    /// non-canonical key — so this must round-trip through a real backend, not just
+    /// produce a plausible-looking string.
+    #[tokio::test]
+    async fn empty_prefix_addresses_the_root_and_round_trips() {
+        assert_eq!(
+            v3_manifest_key("", "key123", "foo"),
+            "v3/manifests/foo/key123.json"
+        );
+        assert_eq!(
+            v3_pack_key("", "key123", "foo"),
+            "v3/packs/foo/key123.tar.zst"
+        );
+
+        let remote = RemoteConfig {
+            prefix: String::new(),
+            backend: crate::config::RemoteBackendConfig::S3(crate::config::S3RemoteConfig {
+                bucket: "bucket".to_string(),
+                endpoint: None,
+                region: "us-east-1".to_string(),
+                profile: None,
+            }),
+        };
+        let backend = memory_backend();
+        let key = v3_manifest_key(&remote.prefix, "key123", "foo");
+        backend
+            .put(&key, b"{}".to_vec(), Some("application/json"))
+            .await
+            .expect("root-relative key must be accepted by the transport");
+        let layout = RemoteLayout::new(&backend, &remote);
+        let keys = layout
+            .list_keys()
+            .await
+            .expect("listing the root must work");
+        assert_eq!(keys.get("key123").map(String::as_str), Some("foo"));
     }
 
     #[tokio::test]

--- a/src/remote_plan.rs
+++ b/src/remote_plan.rs
@@ -95,6 +95,7 @@ mod tests {
             cache_dir: PathBuf::from("/tmp/kache-test"),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,

--- a/src/report.rs
+++ b/src/report.rs
@@ -208,15 +208,20 @@ pub struct NetworkAnalysis {
     pub max_download_ms: u64,
     /// Throughput based on total wall-clock time (includes local restore work).
     pub throughput_mbps: f64,
-    /// Which remote backend produced these numbers: `"s3"`, `"filesystem"`, or
-    /// `""` when unknown.
+    /// The remote backend CONFIGURED WHEN THIS REPORT WAS GENERATED: `"s3"`,
+    /// `"filesystem"`, or `""` when no remote is configured.
     ///
     /// The surrounding field NAMES are HTTP-shaped for backward compatibility
     /// (`network_throughput_mbps`, `total_get_requests`), but a filesystem remote
-    /// now populates them with local file reads. Without this discriminator a CI
-    /// consumer cannot tell a network regression from a fast local mount.
+    /// populates them with local file reads, so a CI consumer otherwise cannot
+    /// tell a network regression from a fast local mount.
+    ///
+    /// Not per-transfer: transfer events do not record which backend served them,
+    /// so a report whose window spans a backend switch carries a single label that
+    /// does not describe all of its transfers. Hence the explicit name — treat it
+    /// as "how the remote is configured now", not "what produced these bytes".
     #[serde(default)]
-    pub backend: String,
+    pub configured_backend: String,
     /// Throughput based on remote-read time only (GET + body collection).
     pub network_throughput_mbps: f64,
     /// Throughput based on response body time only.
@@ -568,7 +573,7 @@ pub fn generate_report_with_filter(
         None
     } else {
         let mut analysis = build_network_analysis(&transfers, top);
-        analysis.backend = config
+        analysis.configured_backend = config
             .remote
             .as_ref()
             .map(|remote| remote.backend_kind().to_string())
@@ -1301,7 +1306,7 @@ fn build_network_analysis(transfers: &[TransferEvent], top: usize) -> NetworkAna
     };
 
     NetworkAnalysis {
-        backend: String::new(),
+        configured_backend: String::new(),
         bytes_up,
         bytes_down,
         uploads_ok,
@@ -3728,7 +3733,7 @@ mod tests {
         let mut report = generate_report(&config, 24, 10).unwrap();
 
         report.network = Some(NetworkAnalysis {
-            backend: "s3".to_string(),
+            configured_backend: "s3".to_string(),
             bytes_up: 5 * 1024 * 1024,
             bytes_down: 20 * 1024 * 1024,
             uploads_ok: 4,

--- a/src/report.rs
+++ b/src/report.rs
@@ -208,6 +208,15 @@ pub struct NetworkAnalysis {
     pub max_download_ms: u64,
     /// Throughput based on total wall-clock time (includes local restore work).
     pub throughput_mbps: f64,
+    /// Which remote backend produced these numbers: `"s3"`, `"filesystem"`, or
+    /// `""` when unknown.
+    ///
+    /// The surrounding field NAMES are HTTP-shaped for backward compatibility
+    /// (`network_throughput_mbps`, `total_get_requests`), but a filesystem remote
+    /// now populates them with local file reads. Without this discriminator a CI
+    /// consumer cannot tell a network regression from a fast local mount.
+    #[serde(default)]
+    pub backend: String,
     /// Throughput based on remote-read time only (GET + body collection).
     pub network_throughput_mbps: f64,
     /// Throughput based on response body time only.
@@ -558,7 +567,13 @@ pub fn generate_report_with_filter(
     let network = if transfers.is_empty() {
         None
     } else {
-        Some(build_network_analysis(&transfers, top))
+        let mut analysis = build_network_analysis(&transfers, top);
+        analysis.backend = config
+            .remote
+            .as_ref()
+            .map(|remote| remote.backend_kind().to_string())
+            .unwrap_or_default();
+        Some(analysis)
     };
 
     // Prefetch
@@ -1286,6 +1301,7 @@ fn build_network_analysis(transfers: &[TransferEvent], top: usize) -> NetworkAna
     };
 
     NetworkAnalysis {
+        backend: String::new(),
         bytes_up,
         bytes_down,
         uploads_ok,
@@ -2902,6 +2918,7 @@ mod tests {
             cache_dir: dir.to_path_buf(),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -3317,6 +3334,7 @@ mod tests {
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -3363,6 +3381,7 @@ mod tests {
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -3419,6 +3438,7 @@ mod tests {
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -3476,6 +3496,7 @@ mod tests {
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -3538,6 +3559,7 @@ mod tests {
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -3706,6 +3728,7 @@ mod tests {
         let mut report = generate_report(&config, 24, 10).unwrap();
 
         report.network = Some(NetworkAnalysis {
+            backend: "s3".to_string(),
             bytes_up: 5 * 1024 * 1024,
             bytes_down: 20 * 1024 * 1024,
             uploads_ok: 4,
@@ -3822,6 +3845,7 @@ mod tests {
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,
@@ -4014,6 +4038,7 @@ mod tests {
             cache_dir: dir.path().to_path_buf(),
             max_size: 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,

--- a/src/store.rs
+++ b/src/store.rs
@@ -2833,6 +2833,7 @@ mod tests {
             cache_dir: dir.to_path_buf(),
             max_size: 1024 * 1024, // 1 MiB
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1926,6 +1926,7 @@ mod tests {
             cache_dir: std::env::temp_dir().join("kache-tui-test"),
             max_size: 1024 * 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3217,6 +3217,7 @@ mod tests {
             cache_dir,
             max_size: 1024 * 1024,
             remote: None,
+            remote_error: None,
             disabled: false,
             cache_executables: false,
             clean_incremental: true,


### PR DESCRIPTION
Follow-up hardening for the OpenDAL remote (#593), from a review of that change after it merged.

## Why this is worth landing soon

Three of these break setups that worked before #593, and the first one breaks builds rather than just cache hits.

### A misconfigured remote failed every compiler invocation

`load_remote_config` became fallible in #593, `Config::load` propagates it with `?`, and so does `run_wrapper_mode`. A remote config error therefore meant kache exited non-zero and rustc never ran.

Two configs that the pre-OpenDAL loader accepted started hard-failing on that path:

- `prefix = "team/"` (or any leading/trailing/duplicated slash)
- `KACHE_S3_PREFIX=""`, which used to mean "store at the bucket root"

The reason is now recorded in `Config::remote_error`, the build continues local-only, and commands that exist to talk to the remote surface it through `require_remote()`. `kache status` reports `MISCONFIGURED` with the reason instead of claiming no remote was configured.

### Legacy prefixes are normalized instead of rejected

Non-canonical prefixes normalize and log a warning. Only backslashes and `.` / `..` segments stay errors, because there is no safe normalization for those.

Normalization moves objects: `prefix = "team/"` previously wrote `team//v3/...` and now writes `team/v3/...`, so the remote repopulates once. That is a deliberate trade against the alternatives of failing the build or disabling the remote entirely. Cache keys are content hashes and the layout layer verifies blake3 per file, so sharing a namespace across two spellings of the same prefix cannot serve a wrong artifact.

An empty prefix addresses the bucket root, which needed `join_remote_key` so keys do not gain a leading `/`. Without that, the config parsed but every operation failed key validation.

### An empty `KACHE_S3_BUCKET` selected a different bucket

`.filter(|v| !v.is_empty())` made a present-but-empty override fall through to the file-configured bucket, so a job that neutralized its remote silently got the one from the config file. It now disables the remote.

### The S3 client had no connect or request timeout

Only `pool_idle_timeout` was set, which just reaps idle pooled connections. An endpoint that accepted a connection and then went silent hung `head`/`get`/`put` forever, and `RetryLayer` could not fire because no error was ever produced. On the wrapper path that looks like a hung build.

Restored a 3.1s connect timeout, matching `SDK_DEFAULT_CONNECT_TIMEOUT` from the `aws-config` this replaced, plus a 30s read-inactivity deadline. Not a total-request timeout, which would cap large transfers on slow links.

## Transport and filesystem

- `credential_process` is re-lexed with shlex-style rules and executed directly, replacing `sh -c` / `cmd.exe /C`. reqsign parses the configured command with `command.split_whitespace()` and does not strip quotes, so quote characters arrive inside the tokens and the quoting does have to be reapplied. Doing it with a shell also expands globs, `$(...)` and `%VAR%`, treats `&` `|` `^` as operators, and under `cmd.exe` does not regroup single quotes at all. Known limitation: reqsign's split has already collapsed runs of whitespace inside quoted arguments, and no amount of re-lexing here can recover that.
- A `credential_process` child now receives the selected `AWS_PROFILE`. `ProfileSelectingEnv` only redirects reqsign's own in-process reads, but the helper is a separate process inheriting kache's environment, so it saw the ambient profile. A helper that shells out to AWS tooling could return credentials for a different account than `profile` asked for, silently. The child is spawned directly with `AWS_PROFILE` set on it alone; the process environment is still never mutated. This removed the last use of `reqsign-command-execute-tokio`, so that direct dependency is gone.
- Filesystem writes verify the resolved target stays inside the configured root. OpenDAL's fs service canonicalizes only the root, once at build time, so a symlink planted below it redirected writes out of the cache. Best effort, with a TOCTOU window that a hermetic fix would need `openat2(RESOLVE_BENEATH)` to close.
- `get` rejects a body shorter than its advertised length. Over HTTP the transport catches this first; the check covers a backend that ends the stream cleanly, such as the filesystem stat-then-read race.
- LIST gained a total deadline and entry/byte caps. The existing per-entry timeout only caught a stalled lister, not one trickling fresh entries forever.
- Keys reject control characters, and trailing dots or spaces on filesystem remotes, which Windows strips and which would make two distinct keys collide.
- `atomic_write_dir` is rejected when inside the object tree (staging files would list as cached objects) or on another filesystem (rename fails with EXDEV on every write). The EXDEV check runs at backend creation, not in `Config::load`, so it never stats an unavailable mount on the wrapper path.

## Smaller items

- The JSON report carries `network.configured_backend`, so a consumer can tell whether the HTTP-named metrics describe a network or a local mount. It reflects the backend configured when the report is generated, not per transfer, and says so.
- `default-features = false` on the remaining OpenDAL crates. The resolved graph is unchanged; the manifest now matches the stated policy.
- `sync --workspace` validates the workspace before resolving credentials, so it no longer prompts for SSO and then reports there are no members.
- Docs updated for the new prefix rules, the staging containment rule, and the shared-directory trust boundary.

## Deliberately not done

`deny_unknown_fields` on `[cache.remote]` looked attractive but is a trap. Serde fails the whole `FileConfig` parse on an unknown key, so a single typo takes every other setting with it. Measured with `key_salt = "from-file"` in `[cache]` and a typo'd `bukcet` under `[cache.remote]`:

```
key_salt     = None      <- file value lost, so the cache key shifts
remote       = None
remote_error = None      <- not even a reason to report
```

Silently rebuilding the world because of one typo is a worse outcome than ignoring the typo, and the config does not even end up with something to show in `kache status`. Reporting unknown keys properly needs remote parsing isolated from the rest of the config.

## Validation

- `cargo test -q -p kache --locked` (1333 unit tests plus all integration suites)
- `cargo clippy -q -p kache --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo deny check bans licenses sources`

Every regression fix has a test that fails without it. The symlink containment test was checked red by disabling the guard, so it is not a vacuous gate.


