### PR TITLE
fix(tests): stop leaking ~2 GB target dirs per test run (#599)

### DIFF
--- a/tests/cache_key_underkeying_test.rs
+++ b/tests/cache_key_underkeying_test.rs
@@ -28,56 +28,10 @@
 //! faithful e2e needs a nightly toolchain / `-Zbuild-std`.
 
 use std::path::{Path, PathBuf};
-use std::sync::{Once, OnceLock};
 use tempfile::TempDir;
 
-fn kache_binary() -> PathBuf {
-    if let Some(path) = KACHE_BIN.get() {
-        return path.clone();
-    }
-    let mut path = std::env::current_exe().unwrap();
-    path.pop(); // test binary name
-    path.pop(); // deps/
-    path.push("kache");
-    path
-}
-
-static KACHE_BIN: OnceLock<PathBuf> = OnceLock::new();
-
-fn build_kache() {
-    static BUILD: Once = Once::new();
-    BUILD.call_once(|| {
-        // Bootstrap the binary under test with no configured wrapper; the
-        // wrapper behavior is exercised by invoking it directly below.
-        let target_dir =
-            std::env::temp_dir().join(format!("kache-underkeying-target-{}", std::process::id()));
-        let status = std::process::Command::new("cargo")
-            .args([
-                "build",
-                "--bin",
-                "kache",
-                "--target-dir",
-                target_dir.to_str().unwrap(),
-                "--config",
-                "build.rustc-wrapper=\"\"",
-            ])
-            .env_remove("RUSTC_WRAPPER")
-            .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
-            .status()
-            .expect("failed to build kache");
-        assert!(status.success(), "kache build failed");
-
-        let mut bin = target_dir.join("debug").join("kache");
-        if cfg!(windows) {
-            bin.set_extension("exe");
-        }
-        KACHE_BIN.set(bin).ok();
-    });
-}
-
-fn isolated_config_path(cache_dir: &Path) -> PathBuf {
-    cache_dir.join("config.toml")
-}
+mod common;
+use common::{build_kache, isolated_config_path, kache_binary};
 
 fn rustc_path() -> String {
     // cargo sets RUSTC to the absolute path when running tests; fall back

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,99 @@
+//! Shared bootstrap for the integration tests that drive the real `kache`
+//! binary as a compiler wrapper.
+//!
+//! These tests can't use `CARGO_BIN_EXE_kache`: the binary under test has to be
+//! built with no configured `rustc-wrapper`, so a developer dogfooding kache
+//! (or a broken wrapper being debugged) can't influence it. That means a second
+//! cargo build into its own target dir.
+//!
+//! That target dir is ~2 GB, so it is **one stable directory shared by every
+//! test binary**, not one per process (#599). Keying it on the PID meant every
+//! `cargo test` run left another 2 GB behind per suite, which filled a 926 GB
+//! disk twice; the resulting ENOSPC then surfaced as `kache build failed` and
+//! `Once instance has previously been poisoned`, reading like a cache-key
+//! regression rather than an infrastructure problem.
+//!
+//! It lives under the workspace target dir so `cargo clean` reclaims it, it is
+//! already gitignored, and concurrent suites reuse the same build instead of
+//! each doing their own (cargo's build-dir lock serializes them).
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// `<target>/kache-test-bootstrap`, derived from the running test binary at
+/// `<target>/<profile>/deps/<test-bin>` so it follows `CARGO_TARGET_DIR`
+/// (including `cargo llvm-cov`'s).
+fn bootstrap_target_dir() -> PathBuf {
+    let mut dir = std::env::current_exe().expect("test binary path");
+    dir.pop(); // test binary
+    dir.pop(); // deps/
+    dir.pop(); // <profile>/
+    dir.join("kache-test-bootstrap")
+}
+
+/// The bootstrap result, shared by every test in this binary.
+///
+/// Holds `Err(message)` rather than panicking inside the initializer: a panic
+/// there leaves the lock poisoned, so every later test reports "previously
+/// poisoned" instead of the real cause. Here each test gets the actual cargo
+/// failure — including its stderr, which is where `No space left on device`
+/// shows up.
+static KACHE_BIN: OnceLock<Result<PathBuf, String>> = OnceLock::new();
+
+/// Builds the `kache` binary under test if it isn't built yet.
+pub fn build_kache() {
+    let _ = kache_binary();
+}
+
+/// Path to the `kache` binary under test, building it on first call.
+pub fn kache_binary() -> PathBuf {
+    match KACHE_BIN.get_or_init(bootstrap_kache) {
+        Ok(path) => path.clone(),
+        Err(message) => panic!("{message}"),
+    }
+}
+
+fn bootstrap_kache() -> Result<PathBuf, String> {
+    let target_dir = bootstrap_target_dir();
+    let output = std::process::Command::new("cargo")
+        .args([
+            "build",
+            "--bin",
+            "kache",
+            "--target-dir",
+            target_dir.to_str().expect("bootstrap target dir is utf-8"),
+            "--config",
+            "build.rustc-wrapper=\"\"",
+        ])
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+        .output()
+        .map_err(|e| format!("failed to spawn cargo to build kache: {e}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "kache build failed ({}) in {}\nstdout: {}\nstderr: {}",
+            output.status,
+            target_dir.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        ));
+    }
+
+    let mut bin = target_dir.join("debug").join("kache");
+    if cfg!(windows) {
+        bin.set_extension("exe");
+    }
+    if !bin.is_file() {
+        return Err(format!(
+            "kache build reported success but {} is missing",
+            bin.display()
+        ));
+    }
+    Ok(bin)
+}
+
+/// Keeps tests off the developer's real `~/.config/kache/config.toml`.
+pub fn isolated_config_path(cache_dir: &Path) -> PathBuf {
+    cache_dir.join("config.toml")
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,56 +1,9 @@
 use assert_cmd::Command;
 use std::path::{Path, PathBuf};
-use std::sync::{Once, OnceLock};
 use tempfile::TempDir;
 
-fn kache_binary() -> PathBuf {
-    if let Some(path) = KACHE_BIN.get() {
-        return path.clone();
-    }
-    let mut path = std::env::current_exe().unwrap();
-    path.pop(); // remove test binary name
-    path.pop(); // remove deps/
-    path.push("kache");
-    path
-}
-
-static KACHE_BIN: OnceLock<PathBuf> = OnceLock::new();
-
-fn build_kache() {
-    static BUILD: Once = Once::new();
-    BUILD.call_once(|| {
-        // Bootstrap the binary under test without any configured wrapper. The wrapper
-        // behavior is exercised below by setting RUSTC_WRAPPER to this fresh binary.
-        let target_dir =
-            std::env::temp_dir().join(format!("kache-integration-target-{}", std::process::id()));
-        let status = std::process::Command::new("cargo")
-            .args([
-                "build",
-                "--bin",
-                "kache",
-                "--target-dir",
-                target_dir.to_str().unwrap(),
-                "--config",
-                "build.rustc-wrapper=\"\"",
-            ])
-            .env_remove("RUSTC_WRAPPER")
-            .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
-            .status()
-            .expect("failed to build kache");
-        assert!(status.success(), "kache build failed");
-
-        let mut bin = target_dir.join("debug").join("kache");
-        if cfg!(windows) {
-            bin.set_extension("exe");
-        }
-        KACHE_BIN.set(bin).ok();
-    });
-}
-
-fn isolated_config_path(cache_dir: &Path) -> PathBuf {
-    // Prevent tests from inheriting the developer's real ~/.config/kache/config.toml.
-    cache_dir.join("config.toml")
-}
+mod common;
+use common::{build_kache, isolated_config_path, kache_binary};
 
 fn run_kache_cc(project: &Path, cache_dir: &Path, args: &[&str]) {
     run_kache_cc_from(project, cache_dir, args);

--- a/tests/stale_artifact_test.rs
+++ b/tests/stale_artifact_test.rs
@@ -1,55 +1,8 @@
-use std::path::{Path, PathBuf};
-use std::sync::{Once, OnceLock};
+use std::path::Path;
 use tempfile::TempDir;
 
-/// Finds the kache binary in the test output directory.
-fn kache_binary() -> PathBuf {
-    if let Some(path) = KACHE_BIN.get() {
-        return path.clone();
-    }
-    let mut path = std::env::current_exe().unwrap();
-    path.pop(); // remove test binary name
-    path.pop(); // remove deps/
-    path.push("kache");
-    path
-}
-
-static KACHE_BIN: OnceLock<PathBuf> = OnceLock::new();
-
-/// Runs `cargo build` to ensure kache is built.
-fn build_kache() {
-    static BUILD: Once = Once::new();
-    BUILD.call_once(|| {
-        let target_dir =
-            std::env::temp_dir().join(format!("kache-stale-target-{}", std::process::id()));
-        let status = std::process::Command::new("cargo")
-            .args([
-                "build",
-                "--bin",
-                "kache",
-                "--target-dir",
-                target_dir.to_str().unwrap(),
-                "--config",
-                "build.rustc-wrapper=\"\"",
-            ])
-            .env_remove("RUSTC_WRAPPER")
-            .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
-            .status()
-            .expect("failed to build kache");
-        assert!(status.success(), "kache build failed");
-
-        let mut bin = target_dir.join("debug").join("kache");
-        if cfg!(windows) {
-            bin.set_extension("exe");
-        }
-        KACHE_BIN.set(bin).ok();
-    });
-}
-
-fn isolated_config_path(cache_dir: &Path) -> PathBuf {
-    // Prevent tests from inheriting the developer's real ~/.config/kache/config.toml.
-    cache_dir.join("config.toml")
-}
+mod common;
+use common::{build_kache, isolated_config_path, kache_binary};
 
 /// Recursively copies a directory.
 fn copy_dir(src: &Path, dst: &Path) {


### PR DESCRIPTION
Fixes #599.

## What was wrong

Three integration suites bootstrapped the `kache` binary into `$TMPDIR/kache-<name>-target-<pid>`:

| file | prefix |
|---|---|
| `tests/cache_key_underkeying_test.rs` | `kache-underkeying-target-<pid>` |
| `tests/stale_artifact_test.rs` | `kache-stale-target-<pid>` |
| `tests/integration_test.rs` | `kache-integration-target-<pid>` |

Nothing removed them, and the PID in the name meant every run made a new one: about 5.7 GB per full `cargo test`, accumulating until the disk filled. At ENOSPC the suites reported `kache build failed` and `Once instance has previously been poisoned`, which reads as a cache-key regression rather than a disk problem, because the assert discarded cargo's stderr.

## What changed

The three copies of the bootstrap now live in `tests/common/mod.rs` and share one stable directory, `<target>/kache-test-bootstrap`:

- reused across runs instead of re-created, so repeat runs skip the rebuild (about 20s to under 2s locally)
- one copy for all three suites instead of three; cargo's build-directory lock serializes the concurrent bootstraps, verified by running two suites at once
- under the workspace target dir, so `cargo clean` reclaims it and it is already gitignored; it is derived from the test binary's own path, so it follows `CARGO_TARGET_DIR` (including the one `cargo llvm-cov` sets)

The bootstrap keeps building with `build.rustc-wrapper=""` and no inherited `RUSTC_WRAPPER`, so a developer dogfooding kache still can't influence the binary under test.

On failure it now reports cargo's stdout and stderr, and it stores the failure in the `OnceLock` instead of panicking inside the initializer, so every later test sees the real cause instead of "previously poisoned".

## Verification

- `cargo test --test cache_key_underkeying_test --test stale_artifact_test --test integration_test` passes
- two suites run concurrently: second bootstrap blocks on the build-directory lock, then reuses the result
- after a full run: one 1.4 GB `target/kache-test-bootstrap`, zero `$TMPDIR/kache-*-target-*`
- `cargo fmt --check` and `cargo clippy --tests` clean

Anyone with leaked dirs from before can reclaim them with:

```
rm -rf "$TMPDIR"/kache-{underkeying,stale,integration}-target-*
```