### PR TITLE
feat(cache): cache executables by default on Linux

### DIFF
--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -80,7 +80,7 @@ for AWS SDK-specific cases that need attention.
 | `KACHE_S3_PROFILE` | `cache.remote.profile` | — | AWS credentials profile |
 | `KACHE_S3_ACCESS_KEY` | — | — | Explicit S3 access key |
 | `KACHE_S3_SECRET_KEY` | — | — | Explicit S3 secret key |
-| `KACHE_CACHE_EXECUTABLES` | `cache.cache_executables` | `false` | Also cache user-facing executables (`bin` crates and `--test` binaries). dylib/cdylib/proc-macro are always cached and are unaffected by this flag |
+| `KACHE_CACHE_EXECUTABLES` | `cache.cache_executables` | `true` on Linux, `false` on macOS/Windows | Also cache user-facing executables (`bin` crates and `--test` binaries). dylib/cdylib/proc-macro are always cached and are unaffected by this flag. Defaults on for Linux only, where DWARF is embedded in the binary so a restored executable debugs like a fresh one; macOS (`N_OSO` records) and Windows (`.pdb` path) reference debug info outside the binary, so they stay off pending [#319](https://github.com/kunobi-ninja/kache/issues/319) |
 | `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly. Env is on unless the value is exactly `0` or `false` (case-insensitive) |
 | `KACHE_VERIFY_RESTORES` | — | `off` | Re-hash restored blobs before serving hits: `off`, `sampled` (~1/16 hits), or `always`. `1`/`true` map to `always` |
 | — | `cache.exclude` | `[]` | Source-path glob patterns that bypass kache and compile normally without lookup, store, or upload |

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: How to install kache — mise, cargo-binstall, source, or an OS package manager (Homebrew, APT, winget, Scoop, Chocolatey, AUR).
+description: How to install kache — mise, cargo-binstall, source, Nix, or an OS package manager (Homebrew, APT, winget, Scoop, Chocolatey, AUR).
 ---
 
 # Installation
@@ -145,6 +145,63 @@ kache is also published to Homebrew, APT, winget, Scoop, Chocolatey, and the AUR
     ```
   </Tab>
 </Tabs>
+
+## Nix
+
+The repo is a flake. Unlike the methods above it builds kache from source, with the Rust toolchain pinned in `rust-toolchain.toml` rather than whatever rustc your nixpkgs happens to ship.
+
+```sh
+# Run it once without installing
+nix run github:kunobi-ninja/kache -- --version
+
+# Install into your profile
+nix profile install github:kunobi-ninja/kache
+```
+
+To consume it from your own flake, add the input and apply the overlay. The overlay provides `pkgs.kache` and `pkgs.kache-rust-toolchain`:
+
+```nix
+{
+  inputs.kache.url = "github:kunobi-ninja/kache";
+
+  outputs = { nixpkgs, kache, ... }: {
+    # ...
+    nixpkgs.overlays = [ kache.overlays.default ];
+    environment.systemPackages = [ pkgs.kache ];
+  };
+}
+```
+
+There is also a NixOS and nix-darwin module that installs kache, writes `config.toml`, optionally sets `RUSTC_WRAPPER` system-wide, and runs the daemon as a systemd user service (Linux) or launchd agent (macOS):
+
+```nix
+{
+  imports = [ kache.nixosModules.default ];  # or kache.darwinModules.default
+
+  services.kache = {
+    enable = true;
+    daemon.enable = true;
+    settings.cache = {
+      local_max_size = "50GB";
+      remote = {
+        type = "s3";
+        bucket = "my-kache-bucket";
+      };
+    };
+  };
+}
+```
+
+Apply `kache.overlays.default` alongside the module. `services.kache.package` defaults to `pkgs.kache` from the overlay; without it the module falls back to building against nixpkgs' rustc, which can be older than the crate's `rust-version`.
+
+<Callout type="info">
+  The flake builds for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.
+  Intel macOS (`x86_64-darwin`) is absent because nixpkgs 26.11 dropped the
+  platform, not because kache dropped it: the pre-built `x86_64-apple-darwin`
+  binary and `cargo install` both still work there.
+</Callout>
+
+Contributors can get the pinned toolchain plus `just` and `cargo-deny` with `nix develop`. `mise` remains the primary tool manager for the repo.
 
 ## Supported platforms
 

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -108,7 +108,7 @@ kache stats              # one-shot summary (no UI)
 
 ## What kache does not cache
 
-By default, kache skips user-facing executables — `bin` crates and `--test` harnesses — because these linked outputs are more expensive to restore correctly. Dynamic libraries (`dylib`, `cdylib`) and proc-macros stay cached regardless. Set `KACHE_CACHE_EXECUTABLES=1` or `cache_executables = true` in the config file to cache executables too.
+On Linux, kache caches user-facing executables (`bin` crates and `--test` harnesses) by default: DWARF lives inside the binary, so a restored executable debugs exactly like a freshly linked one. On macOS and Windows it skips them by default, because their debug info is referenced from *outside* the binary (macOS `N_OSO` records point at per-build object files; a Windows `.exe` records its `.pdb` path), so a restored binary would lose source-level debugging — see [#319](https://github.com/kunobi-ninja/kache/issues/319). Dynamic libraries (`dylib`, `cdylib`) and proc-macros stay cached everywhere regardless. Override either way with `KACHE_CACHE_EXECUTABLES=1`/`=0` or `cache_executables` in the config file.
 
 Incremental compilation is automatically disabled when kache is active — kache strips the `-C incremental=...` flag from each rustc invocation (setting `CARGO_INCREMENTAL=0` would be too late, since cargo injects the flag before the wrapper runs). kache's artifact caching makes incremental redundant, and on macOS, APFS-related corruption can occur when both are active simultaneously.
 

--- a/docs/how-it-works/architecture.mdx
+++ b/docs/how-it-works/architecture.mdx
@@ -75,7 +75,7 @@ The daemon runs as a separate binary invocation (`kache daemon run`) and can be 
 
 As a `RUSTC_WRAPPER`, kache intercepts only `rustc` and `clippy-driver` invocations — not `cargo`, `ld`, or any other tool; linking, proc-macro expansion, and build scripts run unmodified. Separately, kache can be set as `CC` / `CXX` to wrap a C/C++ compiler — `gcc`/`clang`, or `clang` in MSVC driver mode (`clang-cl` / `--driver-mode=cl`, as used by mozconfigs and the `cc` crate on Windows) — for local object-compile caching. That path is independent of the rustc wrapper. See [C/C++ caching](/docs/getting-started/c-cpp).
 
-By default, kache skips only user-facing executables — `bin` crates and `--test` harness binaries — because their outputs depend on the linker and may be mutated post-build (code signing on macOS, stripping). dylib, cdylib, and proc-macro crates stay cached. Enabling `cache_executables` opts the executables in, but most of the compile-time savings come from caching rlibs anyway.
+Executables — `bin` crates and `--test` harness binaries — are cached by default on Linux and skipped by default on macOS and Windows, where debug info is referenced from outside the binary (see [#319](https://github.com/kunobi-ninja/kache/issues/319) and `cache_executables`). dylib, cdylib, and proc-macro crates stay cached everywhere. Restored executables are independent copies rather than hardlinks, so a post-build `strip` or code-signing step cannot write back into a store blob. The final binary is often the single most expensive unit on a warm build's critical path, so caching it is worth materially more than its one-unit share suggests.
 
 ## The remote planner
 

--- a/scenarios/e2e-rust-fallback/scenario.toml
+++ b/scenarios/e2e-rust-fallback/scenario.toml
@@ -5,9 +5,9 @@
 # `<fallback> <compiler> <args>` instead of the compiler directly
 # (#109). This fixture is the cell for that wiring.
 #
-# The project is a dependency-free `bin`. kache never caches a
-# user-facing executable, so building it ALWAYS takes the passthrough
-# path — which, with `KACHE_FALLBACK` set, hands the compile to the
+# The project is a dependency-free `bin`, and this fixture pins
+# `KACHE_CACHE_EXECUTABLES=0` (see `[env]`), so building it ALWAYS takes
+# the passthrough path — which, with `KACHE_FALLBACK` set, hands the compile to the
 # `e2e-fallback` wrapper. Driven by `E2E_FALLBACK_CFG`, it appends
 # `--cfg fallback_was_used` to the compile, which `src/main.rs` reads
 # via `cfg!`, so the binary's own output proves the fallback ran.
@@ -35,6 +35,13 @@ KACHE_FALLBACK = "$FALLBACK"
 # Drive the wrapper: append `--cfg fallback_was_used` to the fixture
 # crate's own compile (matched by `--crate-name rust_fallback`).
 E2E_FALLBACK_CRATE = "rust_fallback"
+# Pin the executable-caching default OFF for this fixture. It reaches the
+# fallback via the passthrough path, and a `bin` crate only lands there when
+# kache declines to cache executables — which is now the default on some
+# platforms but not others (kunobi-ninja/kache#319). The fixture is about the
+# fallback wiring, not about that default, so state it explicitly rather than
+# inheriting whatever the host platform decides.
+KACHE_CACHE_EXECUTABLES = "0"
 E2E_FALLBACK_CFG = "fallback_was_used"
 
 [commands]

--- a/scenarios/e2e-rust-sccache/scenario.toml
+++ b/scenarios/e2e-rust-sccache/scenario.toml
@@ -11,9 +11,9 @@
 # sccache is not on PATH — so a dev box or fork PR without sccache
 # stays green. CI installs sccache, so it runs there.
 #
-# The project is a dependency-free `bin`. kache never caches a
-# user-facing executable, so building it ALWAYS takes the passthrough
-# path — which, with `KACHE_FALLBACK` set, hands the compile to the
+# The project is a dependency-free `bin`, and this fixture pins
+# `KACHE_CACHE_EXECUTABLES=0` (see `[env]`), so building it ALWAYS takes
+# the passthrough path — which, with `KACHE_FALLBACK` set, hands the compile to the
 # `e2e-fallback` wrapper in `sccache` delegate mode: it `exec`s the real
 # `sccache` and appends `--cfg via_sccache`, which `src/main.rs` reads
 # via `cfg!`, so the binary's own output proves the compile travelled
@@ -40,6 +40,13 @@ RUSTC_WRAPPER = "$KACHE"
 # byte-identical to `RUSTC_WRAPPER=sccache`.
 KACHE_FALLBACK = "$FALLBACK"
 E2E_FALLBACK_DELEGATE = "sccache"
+# Pin the executable-caching default OFF for this fixture. It reaches the
+# fallback via the passthrough path, and a `bin` crate only lands there when
+# kache declines to cache executables — which is now the default on some
+# platforms but not others (kunobi-ninja/kache#319). The fixture is about the
+# fallback wiring, not about that default, so state it explicitly rather than
+# inheriting whatever the host platform decides.
+KACHE_CACHE_EXECUTABLES = "0"
 # This fixture only proves kache delegates to the sccache wrapper; the
 # separate `scripts/sccache-fallback-check.sh` step proves a real sccache
 # cache hit. On persistent Windows CI, sccache's daemon can occasionally reset

--- a/src/config.rs
+++ b/src/config.rs
@@ -610,7 +610,7 @@ impl Config {
                     .ok()
                     .and_then(|c| c.cache.as_ref())
                     .and_then(|c| c.cache_executables)
-                    .unwrap_or(false)
+                    .unwrap_or(default_cache_executables())
             });
 
         let clean_incremental = env_or_ignored("KACHE_CLEAN_INCREMENTAL", ignore_env)
@@ -1282,6 +1282,42 @@ fn source_excluded_by_patterns(patterns: &[String], source_path: &Path, roots: &
         .any(|pattern| exclude_pattern_matches(pattern, &candidates))
 }
 
+/// Whether user-facing executables (`bin` crates, `--test` harnesses) are
+/// cached when nothing is configured. Platform-dependent, because the reason
+/// this was ever off is platform-specific.
+///
+/// Measured on a 330-crate warm rebuild: caching executables took a `-j1` warm
+/// build from 42.3 s to 35.1 s (**17%**), and collapsed the passthrough
+/// population from 55 units to 18. The single final binary was 5.7 s on the
+/// critical path of every warm build — more than all cache-key computation on
+/// that path combined. Restored executables are byte-identical copies
+/// (`LinkStrategy::Copy`, so a post-build `strip`/codesign cannot corrupt a
+/// store blob) and are re-signed on restore where the platform needs it.
+///
+/// The cost is debuggability, and only where debug info lives *outside* the
+/// binary:
+///
+/// - **macOS**: a `-g` Mach-O carries `N_OSO` records pointing at per-build
+///   `.o` files. Restored elsewhere those are gone, so `lldb` cannot resolve
+///   source-level symbols (kunobi-ninja/kache#319). Off until that issue ships
+///   a store-time `.dSYM`.
+/// - **Windows**: the `.exe` references its `.pdb` by recorded path, the same
+///   class of problem. Off pending the equivalent investigation.
+/// - **Linux**: DWARF is embedded in the binary itself under the default
+///   `-Cdebuginfo` settings, so a restored executable is self-contained and
+///   debugs exactly like a freshly linked one. On by default.
+///
+/// A split-debuginfo configuration (`-Csplit-debuginfo=unpacked`) moves Linux
+/// into the same external-reference shape, but the sidecars are themselves
+/// cached artifacts (`ArtifactKind::DebugSidecar`) and this already applies to
+/// rlibs, which have always been cached — executables are not special there.
+///
+/// Override either way with `KACHE_CACHE_EXECUTABLES` or
+/// `[cache] cache_executables`.
+pub(crate) fn default_cache_executables() -> bool {
+    cfg!(target_os = "linux")
+}
+
 pub(crate) fn default_cache_dir() -> PathBuf {
     dirs::cache_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
@@ -1551,6 +1587,20 @@ mod tests {
     use super::*;
     use std::ffi::OsString;
     use std::sync::{Mutex, OnceLock};
+
+    /// kunobi-ninja/kache#319: executables are cached by default only where
+    /// debug info lives *inside* the binary. Linux embeds DWARF; macOS `N_OSO`
+    /// records and Windows `.pdb` paths both point outside it, so a restored
+    /// binary would lose source-level debugging. Pinned as a test because this
+    /// is a deliberate platform split, not an accident of the code.
+    #[test]
+    fn cache_executables_defaults_on_for_linux_only() {
+        assert_eq!(
+            default_cache_executables(),
+            cfg!(target_os = "linux"),
+            "executables default on for Linux only (see #319)"
+        );
+    }
 
     fn config_path_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -211,7 +211,14 @@ fn build_fields(file_config: &FileConfig, env: &EnvOverrides) -> Vec<FormField> 
                 .unwrap_or_default(),
             env_var: "KACHE_CACHE_EXECUTABLES",
             env_value: env_val("KACHE_CACHE_EXECUTABLES"),
-            default_hint: "false",
+            // Platform-dependent (on for Linux only) — see
+            // `config::default_cache_executables`. The editor shows the
+            // default that actually applies on this machine, not a constant.
+            default_hint: if crate::config::default_cache_executables() {
+                "true"
+            } else {
+                "false"
+            },
             validation_error: None,
             env_locked: env.cache_executables,
         },


### PR DESCRIPTION
Addresses the default-value half of #319.

## The measurement

Warm rebuild of a 330-crate graph (kache's own), `-j1`, same populated cache:

| | wall | passthrough units | passthrough cost |
|---|---|---|---|
| `cache_executables=false` (old default) | **42.3 s** | 55 | 9.0 s |
| `cache_executables=true` | **35.1 s** | 18 | 0.4 s |

**17% faster.** The single final `kache` binary was **5.7 s on the critical path of every warm build** — more than all cache-key computation on that path combined, and larger than the daemon local-hit path (#565), the dep-info memo (#334), and the thin wrapper split (#559) put together. Details in [#319](https://github.com/kunobi-ninja/kache/issues/319#issuecomment-5073605997).

## Why the old default was wrong *as a global*

The documented reason is macOS-specific: a `-g` Mach-O carries `N_OSO` records pointing at per-build `.o` files, so a restored binary can't resolve source-level symbols in `lldb`. #319's own implementation sketch scopes the fix as "macOS-only; no-op on Linux/Windows".

Linux embeds DWARF in the binary under default `-Cdebuginfo` settings, so a restored executable is self-contained and debugs exactly like a freshly linked one. It was paying a macOS debuggability tax for no benefit.

This change makes the default platform-conditional rather than flipping it globally:

| platform | default | why |
|---|---|---|
| **Linux** | **on** | DWARF is inside the binary |
| macOS | off | `N_OSO` → per-build `.o` files (#319) |
| Windows | off | `.exe` records its `.pdb` path — same class of problem |

I left Windows off deliberately. It has the same external-debug-info shape as macOS and I have not investigated it; flipping it would be a guess.

## Correctness

- Restored executables are `LinkStrategy::Copy`, not hardlinks, so a post-build `strip` or code-signing step cannot write back into a store blob. That disposes of the second documented concern ("may be mutated post-build").
- The verify-then-sign restore path (`PostRestoreAction::Sign`) already handles macOS when the flag is turned on explicitly.
- Verified on macOS that a cache-restored binary runs (`kache --version` → `0.11.0`) and passes `codesign -v`.

## What I could not verify locally

**Linux debuggability is argued, not tested end-to-end.** Docker was unavailable on this machine, so I could not step through a restored binary under `gdb`. The argument is that DWARF is in-binary by default, so a byte-identical copy debugs identically — but CI's Linux e2e is the check that actually matters here, and a reviewer with a Linux box may want to confirm `gdb` on a restored executable before merging.

Split-debuginfo (`-Csplit-debuginfo=unpacked`) moves Linux into the same external-reference shape. The sidecars are themselves cached artifacts (`ArtifactKind::DebugSidecar`), and this already applies to rlibs — which have always been cached — so executables aren't special there.

## Also

- The config TUI's default hint now reflects the platform default instead of a hardcoded `false`.
- Docs updated in three places (configuration reference, quick-start, architecture), including the now-false claim that "most of the compile-time savings come from caching rlibs anyway" — the measurement contradicts it.
- Test pins the platform split so it can't drift silently.

Full suite green (1320 unit + all integration).
