### PR TITLE
feat(nix): flake checks, devShell, formatter, and a standalone module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,15 +212,12 @@ jobs:
       # seconds and needs no emulation.
       - name: Check flake evaluation
         run: nix flake check --all-systems --no-build
-      - name: Build flake package
-        run: nix build .#kache --no-link --print-build-logs
-      # Cheap checks that `--no-build` skipped. The module check reuses the
-      # kache build from the step above.
-      - name: Run flake checks
-        run: |
-          nix build --no-link --print-build-logs \
-            .#checks.x86_64-linux.nixfmt \
-            .#checks.x86_64-linux.nixos-module
+      # Builds every check for THIS system, including `checks.package`, which
+      # is `pkgs.kache` — so this covers the package build too. Deliberately
+      # not an explicit list of check attrnames: that silently stops covering
+      # any check added later.
+      - name: Build flake checks
+        run: nix flake check --keep-going --print-build-logs
 
   # --- E2E smoke test ---
   # Builds kache, configures as RUSTC_WRAPPER, cold-builds a fixture project,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,10 +206,21 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      # `--all-systems` is the point: without it the check only evaluates the
+      # runner's own system, which is how the x86_64-darwin breakage in #597
+      # stayed invisible here. Evaluation is cross-system, so this costs
+      # seconds and needs no emulation.
       - name: Check flake evaluation
-        run: nix flake check --no-build
+        run: nix flake check --all-systems --no-build
       - name: Build flake package
         run: nix build .#kache --no-link --print-build-logs
+      # Cheap checks that `--no-build` skipped. The module check reuses the
+      # kache build from the step above.
+      - name: Run flake checks
+        run: |
+          nix build --no-link --print-build-logs \
+            .#checks.x86_64-linux.nixfmt \
+            .#checks.x86_64-linux.nixos-module
 
   # --- E2E smoke test ---
   # Builds kache, configures as RUSTC_WRAPPER, cold-builds a fixture project,

--- a/Justfile
+++ b/Justfile
@@ -235,6 +235,18 @@ fmt:
 fmt-check:
   cargo fmt --all -- --check
 
+# Format flake.nix and nix/ with nixfmt. Deliberately not part of `check`
+# or `ci`: nix isn't in mise.toml, so requiring it would break contributors
+# who only have the mise toolchain. CI gates it in the `nix-package` job.
+[group('dev')]
+fmt-nix:
+  nix fmt
+
+# Check Nix formatting without changing files.
+[group('dev')]
+fmt-nix-check:
+  nix fmt -- --fail-on-change
+
 # Lint the deployable Helm chart.
 [group('deploy')]
 helm-lint:

--- a/Justfile
+++ b/Justfile
@@ -248,7 +248,7 @@ fmt-nix:
 # flake check runs nixfmt --check in the sandbox and touches nothing.
 [group('dev')]
 fmt-nix-check:
-  nix build --no-link ".#checks.$(nix eval --impure --raw --expr builtins.currentSystem).nixfmt"
+  nix build --no-link ".#checks.$(nix eval --impure --raw --expr builtins.currentSystem).formatting"
 
 # Lint the deployable Helm chart.
 [group('deploy')]

--- a/Justfile
+++ b/Justfile
@@ -242,10 +242,13 @@ fmt-check:
 fmt-nix:
   nix fmt
 
-# Check Nix formatting without changing files.
+# Check Nix formatting without changing files. Deliberately NOT
+# `nix fmt -- --fail-on-change`: treefmt formats in place and only then
+# reports a nonzero exit, so it rewrites the working tree. Building the
+# flake check runs nixfmt --check in the sandbox and touches nothing.
 [group('dev')]
 fmt-nix-check:
-  nix fmt -- --fail-on-change
+  nix build --no-link ".#checks.$(nix eval --impure --raw --expr builtins.currentSystem).nixfmt"
 
 # Lint the deployable Helm chart.
 [group('deploy')]

--- a/flake.lock
+++ b/flake.lock
@@ -19,7 +19,8 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "rust-overlay": {
@@ -39,6 +40,26 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,10 @@
       };
 
       overlays = {
+        # NOTE: this one is NOT self-sufficient. It reads `final.rust-bin`, so
+        # it only works when rust-overlay is applied first; on its own it fails
+        # with "attribute 'rust-bin' missing" as soon as the derivation is
+        # forced. Use `overlays.default` unless you already apply rust-overlay.
         kache = kacheOverlay;
         default = lib.composeManyExtensions [
           rust-overlay.overlays.default

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,10 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -14,6 +18,7 @@
       self,
       nixpkgs,
       rust-overlay,
+      treefmt-nix,
     }:
     let
       inherit (nixpkgs) lib;
@@ -69,16 +74,45 @@
           ./nix
         ];
       };
+
+      # One config drives both `nix fmt` and the formatting check, so the two
+      # cannot drift apart.
+      treefmtFor =
+        pkgs:
+        treefmt-nix.lib.evalModule pkgs {
+          projectRootFile = "flake.nix";
+          programs.nixfmt.enable = true;
+        };
+
+      # Wraps ./nix/module.nix so the exported module works on its own. Without
+      # this, the option default falls back to nixpkgs' rustPlatform, whose
+      # rustc is below the crate's rust-version, and cargo refuses to build it.
+      # `pkgs.kache` comes first so a consumer who applied the overlay keeps
+      # their own nixpkgs; mkDefault so an explicit `services.kache.package`
+      # still wins.
+      moduleFor =
+        module:
+        {
+          pkgs,
+          lib,
+          ...
+        }:
+        {
+          imports = [ module ];
+          services.kache.package = lib.mkDefault (
+            pkgs.kache or self.packages.${pkgs.stdenv.hostPlatform.system}.kache
+          );
+        };
     in
     {
       nixosModules = {
-        kache = import ./nix/module.nix;
+        kache = moduleFor ./nix/module.nix;
         default = self.nixosModules.kache;
       };
 
       # The same module works for nix-darwin (launchd vs systemd is handled internally).
       darwinModules = {
-        kache = import ./nix/module.nix;
+        kache = moduleFor ./nix/module.nix;
         default = self.darwinModules.kache;
       };
 
@@ -109,34 +143,21 @@
             pkgs.kache-rust-toolchain
             pkgs.just
             pkgs.cargo-deny
-            pkgs.nixfmt
+            (treefmtFor pkgs).config.build.wrapper
           ];
         };
       });
 
-      # `nix fmt`. nixfmt-tree wraps nixfmt in treefmt so it can walk the tree;
-      # bare nixfmt only accepts explicit files.
-      formatter = forAllSystems (pkgs: pkgs.nixfmt-tree);
+      formatter = forAllSystems (pkgs: (treefmtFor pkgs).config.build.wrapper);
 
       checks = forAllSystems (
         pkgs:
         {
           package = pkgs.kache;
 
-          nixfmt =
-            pkgs.runCommand "kache-check-nixfmt"
-              {
-                nativeBuildInputs = [ pkgs.nixfmt ];
-              }
-              ''
-                find ${nixSources} -name '*.nix' -print0 > files
-                # Guard the empty case: bare `xargs nixfmt --check` with no
-                # input would read stdin instead of failing, so an empty
-                # fileset would look like a pass.
-                test -s files
-                xargs -0 nixfmt --check < files
-                touch "$out"
-              '';
+          # Same treefmt config as `nix fmt`, scoped to nixSources so a Rust
+          # edit doesn't invalidate it.
+          formatting = (treefmtFor pkgs).config.build.check nixSources;
         }
         // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
           # Evaluates the NixOS module end to end, which is what catches option

--- a/flake.nix
+++ b/flake.nix
@@ -16,14 +16,21 @@
       rust-overlay,
     }:
     let
+      inherit (nixpkgs) lib;
+
+      # x86_64-darwin is deliberately absent: nixpkgs 26.11 dropped the
+      # platform, so `import nixpkgs { system = "x86_64-darwin"; }` throws
+      # (#597). Intel macOS is still a supported *release* target — install the
+      # tarball or `cargo install` there.
       systems = [
         "x86_64-linux"
         "aarch64-linux"
         "aarch64-darwin"
       ];
+
       forAllSystems =
         f:
-        nixpkgs.lib.genAttrs systems (
+        lib.genAttrs systems (
           system:
           f (
             import nixpkgs {
@@ -32,6 +39,7 @@
             }
           )
         );
+
       kacheOverlay =
         final: _prev:
         let
@@ -45,7 +53,22 @@
           kache = final.callPackage ./nix/package.nix {
             inherit rustPlatform;
           };
+
+          # Exposed so devShells (and downstream consumers) get the toolchain
+          # pinned in rust-toolchain.toml instead of nixpkgs' rustc, which can
+          # lag the crate's rust-version.
+          kache-rust-toolchain = rustToolchain;
         };
+
+      # Only the Nix sources, so editing Rust code doesn't invalidate the
+      # formatting check.
+      nixSources = lib.fileset.toSource {
+        root = ./.;
+        fileset = lib.fileset.unions [
+          ./flake.nix
+          ./nix
+        ];
+      };
     in
     {
       nixosModules = {
@@ -61,7 +84,7 @@
 
       overlays = {
         kache = kacheOverlay;
-        default = nixpkgs.lib.composeManyExtensions [
+        default = lib.composeManyExtensions [
           rust-overlay.overlays.default
           kacheOverlay
         ];
@@ -71,5 +94,95 @@
         kache = pkgs.kache;
         default = pkgs.kache;
       });
+
+      # mise stays the primary tool manager for this repo (see mise.toml); this
+      # shell covers the Nix path with the pinned toolchain plus the tools
+      # `just check` and `just audit` shell out to. RUSTC_WRAPPER is left alone
+      # so dogfooding kache on kache keeps working inside the shell.
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = [
+            pkgs.kache-rust-toolchain
+            pkgs.just
+            pkgs.cargo-deny
+            pkgs.nixfmt
+          ];
+        };
+      });
+
+      # `nix fmt`. nixfmt-tree wraps nixfmt in treefmt so it can walk the tree;
+      # bare nixfmt only accepts explicit files.
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-tree);
+
+      checks = forAllSystems (
+        pkgs:
+        {
+          package = pkgs.kache;
+
+          nixfmt =
+            pkgs.runCommand "kache-check-nixfmt"
+              {
+                nativeBuildInputs = [ pkgs.nixfmt ];
+              }
+              ''
+                find ${nixSources} -name '*.nix' -print0 > files
+                # Guard the empty case: bare `xargs nixfmt --check` with no
+                # input would read stdin instead of failing, so an empty
+                # fileset would look like a pass.
+                test -s files
+                xargs -0 nixfmt --check < files
+                touch "$out"
+              '';
+        }
+        // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+          # Evaluates the NixOS module end to end, which is what catches option
+          # type and rename regressions. `nix flake check --no-build` stops at
+          # evaluation, so the interesting part runs even without building.
+          nixos-module =
+            let
+              machine = lib.nixosSystem {
+                modules = [
+                  self.nixosModules.kache
+                  {
+                    nixpkgs.pkgs = pkgs;
+                    boot.loader.grub.enable = false;
+                    fileSystems."/" = {
+                      device = "/dev/null";
+                      fsType = "ext4";
+                    };
+                    system.stateVersion = lib.trivial.release;
+
+                    services.kache = {
+                      enable = true;
+                      daemon.enable = true;
+                      settings.cache = {
+                        local_max_size = "10GB";
+                        remote = {
+                          type = "s3";
+                          bucket = "kache-check";
+                        };
+                      };
+                    };
+                  }
+                ];
+              };
+              inherit (machine.config.systemd.user.services.kache) serviceConfig;
+            in
+            pkgs.runCommand "kache-check-nixos-module" { } ''
+              mkdir -p "$out"
+
+              cp ${machine.config.environment.etc."kache/config.toml".source} "$out/config.toml"
+              grep -q 'local_max_size = "10GB"' "$out/config.toml"
+              grep -q 'bucket = "kache-check"' "$out/config.toml"
+
+              printf '%s\n' ${lib.escapeShellArg serviceConfig.ExecStart} > "$out/exec-start"
+              grep -q 'daemon run' "$out/exec-start"
+
+              # The module must resolve to the overlay's package, which is built
+              # with the rust-toolchain.toml toolchain rather than nixpkgs' rustc.
+              grep -qF '${pkgs.kache}' "$out/exec-start"
+            '';
+        }
+      );
     };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -6,9 +6,10 @@
   options,
   pkgs,
   ...
-}: let
+}:
+let
   cfg = config.services.kache;
-  tomlFormat = pkgs.formats.toml {};
+  tomlFormat = pkgs.formats.toml { };
 
   # Settings maps directly to config.toml. Freeform type allows arbitrary
   # keys so the module doesn't break when kache adds new config options.
@@ -23,13 +24,14 @@
   # which would create a circular dependency with lib.optionals.
   hasLaunchd = options ? launchd;
   hasSystemd = options ? systemd;
-in {
+in
+{
   options.services.kache = {
     enable = lib.mkEnableOption "kache, a build cache for Rust, C/C++ and more";
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = pkgs.callPackage ./package.nix {};
+      default = pkgs.callPackage ./package.nix { };
       defaultText = lib.literalExpression "pkgs.callPackage ./package.nix {}";
       description = "kache package to install and run.";
     };
@@ -63,13 +65,13 @@ in {
         See <https://github.com/kunobi-ninja/kache#configuration> for
         the full reference.
       '';
-      default = {};
+      default = { };
       type = lib.types.submodule {
         freeformType = tomlFormat.type;
 
         options.cache = lib.mkOption {
           description = "Cache settings.";
-          default = {};
+          default = { };
           type = lib.types.submodule {
             freeformType = tomlFormat.type;
 
@@ -120,7 +122,7 @@ in {
 
               remote = lib.mkOption {
                 description = "S3 remote cache settings.";
-                default = {};
+                default = { };
                 type = lib.types.submodule {
                   freeformType = tomlFormat.type;
 
@@ -170,57 +172,65 @@ in {
     };
   };
 
-  config = lib.mkIf cfg.enable (lib.mkMerge ([
-    # Install the package and config
-    {
-      environment.systemPackages = [cfg.package];
-      environment.etc."kache/config.toml".source = configFile;
-      environment.variables.KACHE_CONFIG = "${configFile}";
-    }
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge (
+      [
+        # Install the package and config
+        {
+          environment.systemPackages = [ cfg.package ];
+          environment.etc."kache/config.toml".source = configFile;
+          environment.variables.KACHE_CONFIG = "${configFile}";
+        }
 
-    # Set RUSTC_WRAPPER system-wide
-    (lib.mkIf cfg.rustcWrapper {
-      environment.variables.RUSTC_WRAPPER = kacheExe;
-    })
-  ]
-  # macOS: launchd user agent
-  ++ lib.optionals hasLaunchd [
-    (lib.mkIf cfg.daemon.enable {
-      launchd.user.agents.kache = {
-        serviceConfig = {
-          Label = "ninja.kunobi.kache";
-          ProgramArguments = [kacheExe "daemon" "run"];
-          RunAtLoad = true;
-          KeepAlive = {
-            SuccessfulExit = false;
+        # Set RUSTC_WRAPPER system-wide
+        (lib.mkIf cfg.rustcWrapper {
+          environment.variables.RUSTC_WRAPPER = kacheExe;
+        })
+      ]
+      # macOS: launchd user agent
+      ++ lib.optionals hasLaunchd [
+        (lib.mkIf cfg.daemon.enable {
+          launchd.user.agents.kache = {
+            serviceConfig = {
+              Label = "ninja.kunobi.kache";
+              ProgramArguments = [
+                kacheExe
+                "daemon"
+                "run"
+              ];
+              RunAtLoad = true;
+              KeepAlive = {
+                SuccessfulExit = false;
+              };
+              EnvironmentVariables = {
+                KACHE_LOG = cfg.daemon.logLevel;
+                KACHE_CONFIG = "${configFile}";
+              };
+              ThrottleInterval = 5;
+            };
           };
-          EnvironmentVariables = {
-            KACHE_LOG = cfg.daemon.logLevel;
-            KACHE_CONFIG = "${configFile}";
+        })
+      ]
+      # Linux: systemd user service
+      ++ lib.optionals hasSystemd [
+        (lib.mkIf cfg.daemon.enable {
+          systemd.user.services.kache = {
+            description = "kache build cache daemon";
+            after = [ "default.target" ];
+            wantedBy = [ "default.target" ];
+            serviceConfig = {
+              Type = "simple";
+              ExecStart = "${kacheExe} daemon run";
+              Restart = "on-failure";
+              RestartSec = "5s";
+            };
+            environment = {
+              KACHE_LOG = cfg.daemon.logLevel;
+              KACHE_CONFIG = "${configFile}";
+            };
           };
-          ThrottleInterval = 5;
-        };
-      };
-    })
-  ]
-  # Linux: systemd user service
-  ++ lib.optionals hasSystemd [
-    (lib.mkIf cfg.daemon.enable {
-      systemd.user.services.kache = {
-        description = "kache build cache daemon";
-        after = ["default.target"];
-        wantedBy = ["default.target"];
-        serviceConfig = {
-          Type = "simple";
-          ExecStart = "${kacheExe} daemon run";
-          Restart = "on-failure";
-          RestartSec = "5s";
-        };
-        environment = {
-          KACHE_LOG = cfg.daemon.logLevel;
-          KACHE_CONFIG = "${configFile}";
-        };
-      };
-    })
-  ]));
+        })
+      ]
+    )
+  );
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -31,9 +31,17 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = pkgs.callPackage ./package.nix { };
-      defaultText = lib.literalExpression "pkgs.callPackage ./package.nix {}";
-      description = "kache package to install and run.";
+      default = pkgs.kache or (pkgs.callPackage ./package.nix { });
+      defaultText = lib.literalExpression "pkgs.kache or (pkgs.callPackage ./package.nix {})";
+      description = ''
+        kache package to install and run.
+
+        Prefer applying this flake's `overlays.default`, which provides
+        `pkgs.kache` built with the toolchain pinned in `rust-toolchain.toml`.
+        Without the overlay this falls back to nixpkgs' `rustPlatform`, whose
+        rustc can be older than the crate's `rust-version` — cargo then refuses
+        to build it.
+      '';
     };
 
     rustcWrapper = lib.mkOption {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -9,11 +9,17 @@
 let
   cargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);
 
-  fetchurlWithCratesUserAgent = args:
-    fetchurl (args
+  fetchurlWithCratesUserAgent =
+    args:
+    fetchurl (
+      args
       // {
-        curlOptsList = (args.curlOptsList or []) ++ ["-A" "kache-nix"];
-      });
+        curlOptsList = (args.curlOptsList or [ ]) ++ [
+          "-A"
+          "kache-nix"
+        ];
+      }
+    );
 
   buildRustPackage = rustPlatform.buildRustPackage.override {
     importCargoLock = rustPlatform.importCargoLock.override {
@@ -43,8 +49,14 @@ buildRustPackage {
     };
   };
 
-  cargoBuildFlags = ["-p" "kache"];
-  cargoTestFlags = ["-p" "kache"];
+  cargoBuildFlags = [
+    "-p"
+    "kache"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "kache"
+  ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     apple-sdk_15


### PR DESCRIPTION
## Summary

Follow-up to #597. That PR fixed the `x86_64-darwin` breakage; this one closes the gaps that let it go unnoticed and fills in the flake outputs that were missing.

**CI evaluated one system.** `nix flake check` ran without `--all-systems`, so it only ever evaluated the runner's own system. That is exactly why the `x86_64-darwin` failure was invisible here. Now checked across all three declared systems. Evaluation is cross-system, so it costs seconds and needs no emulation.

**No devShell existed**, even though `docs/getting-started/configuration.mdx` documents `nix eval --raw .#devShells.default.outPath` as a `key_salt` source. That example could not have worked. There is now a shell with the pinned toolchain (rustc 1.95, with clippy and rustfmt), `just`, `cargo-deny`, and the treefmt wrapper. mise stays the primary tool manager; this covers the Nix path.

**The exported module could not build on its own.** `services.kache.package` fell back to nixpkgs' `rustPlatform`, whose rustc is 1.93.0, below the crate's `rust-version = 1.95`. Cargo refuses that. `nixosModules`/`darwinModules` now wrap `nix/module.nix` and bind the package, preferring `pkgs.kache` when the overlay is applied so consumers keep their own nixpkgs.

**Formatting had two definitions that could drift.** `pkgs.nixfmt-tree` as the formatter, plus a separate hand-written check. treefmt-nix now generates both from one config.

Also adds `checks` (package, formatting, NixOS module evaluation), a `formatter` output, `fmt-nix`/`fmt-nix-check` just recipes, and `pkgs.kache-rust-toolchain` on the overlay so the devShell reuses the pin.

`nix/module.nix` and `nix/package.nix` were still in the older alejandra style while `flake.nix` was nixfmt. The reformat is a separate commit so it does not drown the 14-line behaviour change.

## Test plan

`nix flake check --all-systems --no-build`: 26 outputs, 0 failures, against both the locked nixpkgs and current `nixpkgs-unstable`.

Checks that are not vacuous, verified by deliberately breaking each one:

- Formatting: unformatted `nix/package.nix` fails the check and names the file; restoring it passes. `just fmt-nix-check` leaves the working tree untouched (checksum unchanged).
- Module: evaluating `nixosModules.default` against plain nixpkgs with **no overlay** resolves `services.kache.package` to the same `drvPath` as `packages.x86_64-linux.kache`. Before this commit it silently selected the unbuildable nixpkgs-rustc build.
- NixOS module check asserts the generated `config.toml`, the systemd unit `ExecStart`, and that the module resolves to the overlay's package.

Also confirmed:

- `nix fmt` is a no-op on a clean tree and does not touch Rust files.
- The devShell toolchain ships `clippy-driver` and `rustfmt`, so `just check` works inside `nix develop`.
- `cargo fmt --all -- --check` is clean.

Three fixes here came from a cross-model review and were each settled by experiment rather than argument:

- `nix fmt -- --fail-on-change` formats in place and only then exits nonzero, so the original "check" recipe rewrote the working tree. It now builds the flake check instead, which runs in the sandbox.
- CI enumerated check attrnames, which silently stops covering any check added later. Plain `nix flake check` builds every check for the host system, and `checks.package` is `pkgs.kache`, so the separate package build step was redundant.
- `overlays.kache` reads `final.rust-bin`, so it is not self-sufficient. Forcing the derivation with only that overlay applied fails with `attribute 'rust-bin' missing`. Documented rather than changed, so it stays a distinct composable layer.

## Not in scope

A Nix binary cache is the biggest remaining CI gap and needs an account plus a secret, so it is filed separately. A NixOS VM test, a nix-darwin evaluation check, and a real Darwin build in CI were considered and judged more machinery than the payoff justifies right now.
