### PR TITLE
feat(why-miss): walk the extern chain to the crate that actually changed (#609)

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -484,6 +484,15 @@ pub fn compute_cache_key(
     let mut hasher = GroupedHasher::new("compiler");
     let crate_name = args.crate_name.as_deref().unwrap_or("unknown");
 
+    // Clear the extern stash up front (#609). It is written near the end of
+    // this function, so a computation that bails before the externs group —
+    // or one that never reaches the event writer — would otherwise leave a
+    // previous invocation's dependency digests to be picked up as if they
+    // belonged to this compile.
+    if let Ok(mut stash) = LAST_KEY_EXTERNS.lock() {
+        *stash = None;
+    }
+
     // key version — bump CACHE_KEY_VERSION to invalidate all prior entries
     hasher.update(b"key_version:");
     hasher.update(CACHE_KEY_VERSION.to_string().as_bytes());

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -432,6 +432,35 @@ pub fn take_last_key_fields() -> Option<std::collections::BTreeMap<String, Strin
     LAST_KEY_FIELDS.lock().ok().and_then(|mut g| g.take())
 }
 
+/// Per-EXTERN artifact digests of the most recent [`compute_cache_key`] run
+/// (kunobi-ninja/kache#609), stashed like [`LAST_KEY_FIELDS`].
+///
+/// The `externs` group digest says only THAT some dependency's artifact
+/// changed. In an `extern:` cascade — one native `-sys` crate's `.a` diverging
+/// and re-keying everything above it — every downstream crate reports the same
+/// undifferentiated "externs changed", which is exactly the case that has to
+/// be diagnosed by hand today. Keeping the per-dependency hashes lets
+/// `why-miss` name WHICH dependency moved, then follow that dependency's own
+/// events to the root of the chain.
+///
+/// The value is the dependency artifact's own content hash (the same bytes
+/// folded into the key), truncated to [`KEY_FIELD_HEX`] — not a digest of the
+/// folded segment. Same discriminating power, and it can be compared against
+/// hashes recorded elsewhere.
+static LAST_KEY_EXTERNS: std::sync::Mutex<Option<std::collections::BTreeMap<String, String>>> =
+    std::sync::Mutex::new(None);
+
+/// Marker recorded for an extern whose artifact could not be hashed — a
+/// sysroot crate (`std`, `core`), whose identity rides on rustc version + name
+/// instead. Distinct from any real hash, so it never reads as a content match.
+pub const EXTERN_UNREADABLE: &str = "(sysroot)";
+
+/// Take (consume) the per-extern artifact digests of the last computed rustc
+/// key. `None` for cc compiles and passthroughs, which compute no rustc key.
+pub fn take_last_key_externs() -> Option<std::collections::BTreeMap<String, String>> {
+    LAST_KEY_EXTERNS.lock().ok().and_then(|mut g| g.take())
+}
+
 /// Compute the blake3 cache key for a rustc invocation.
 ///
 /// The key captures everything that affects compilation output:
@@ -727,6 +756,12 @@ pub fn compute_cache_key(
 
     // ── Group B: extern crate artifacts ──
     hasher.set_group("externs");
+    // Per-dependency digests teed off the same hashes folded below, for
+    // `why-miss`'s extern-chain walk (#609). Recording happens unconditionally
+    // — it is one map insert per extern, no extra I/O, since the hash is
+    // already in hand — while the decision to PERSIST it stays with the
+    // wrapper's `explain_miss` gate.
+    let mut extern_digests = std::collections::BTreeMap::new();
     for ext in &externs {
         if let Some(path) = &ext.path {
             match file_hasher.hash(path) {
@@ -736,6 +771,13 @@ pub fn compute_cache_key(
                     hasher.update(b"=");
                     hasher.update(dep_hash.as_bytes());
                     hasher.update(b"\n");
+                    extern_digests.insert(
+                        ext.name.clone(),
+                        dep_hash
+                            .get(..KEY_FIELD_HEX)
+                            .unwrap_or(dep_hash.as_str())
+                            .to_string(),
+                    );
                     tracing::trace!(
                         "[key:{}] extern:{}={}",
                         crate_name,
@@ -750,10 +792,14 @@ pub fn compute_cache_key(
                     hasher.update(b"extern_unreadable:");
                     hasher.update(ext.name.as_bytes());
                     hasher.update(b"\n");
+                    extern_digests.insert(ext.name.clone(), EXTERN_UNREADABLE.to_string());
                     tracing::trace!("[key:{}] extern_unreadable:{}", crate_name, ext.name);
                 }
             }
         }
+    }
+    if let Ok(mut stash) = LAST_KEY_EXTERNS.lock() {
+        *stash = Some(extern_digests);
     }
 
     // RUSTFLAGS — normalize via PathNormalizer (canonical-prefix

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -794,7 +794,13 @@ fn print_extern_chain(
     miss: &events::BuildEvent,
     explain_miss: bool,
 ) {
-    let Some(chain) = crate::miss_chain::analyze(all_events, miss) else {
+    // The walk is driven by position in the oldest-first slice, so the exact
+    // event has to be located rather than re-found by name and timestamp
+    // (which can collide).
+    let Some(miss_index) = all_events.iter().position(|e| std::ptr::eq(e, miss)) else {
+        return;
+    };
+    let Some(chain) = crate::miss_chain::analyze(all_events, miss_index) else {
         if !explain_miss && miss.key_externs.is_empty() {
             println!(
                 "\n  Dependency cascade: not analyzed (no per-dependency digests recorded).\n    \
@@ -804,59 +810,80 @@ fn print_extern_chain(
         return;
     };
 
-    println!("\n  Dependency cascade: this miss is downstream of a dependency change");
-    for hop in &chain.hops {
-        let from = hop.via.from.as_deref().unwrap_or("(absent)");
-        let to = hop.via.to.as_deref().unwrap_or("(removed)");
-        println!(
-            "    {} <- {} changed ({from} -> {to})",
-            hop.crate_name, hop.via.name
-        );
-        if !hop.siblings.is_empty() {
-            println!("      (also changed here: {})", hop.siblings.join(", "));
-        }
-    }
+    let direct: Vec<&str> = chain.direct.iter().map(|d| d.name.as_str()).collect();
+    println!(
+        "\n  Dependency cascade: this miss is downstream of {} that changed ({})",
+        if direct.len() == 1 {
+            "a dependency".to_string()
+        } else {
+            format!("{} dependencies", direct.len())
+        },
+        direct.join(", ")
+    );
 
-    let root = &chain.root;
-    match &root.kind {
-        crate::miss_chain::RootKind::Groups(groups) => {
-            println!(
-                "    root: {} -- own inputs changed: {}",
+    for root in &chain.roots {
+        let via = if root.branches > 1 {
+            format!(" (reached by {} branches)", root.branches)
+        } else {
+            String::new()
+        };
+        match &root.kind {
+            crate::miss_chain::RootKind::Groups(groups) => println!(
+                "    root: {}{via} -- own inputs changed: {}",
                 root.crate_name,
                 groups.join(", ")
-            );
-        }
-        crate::miss_chain::RootKind::NoMissRecorded => {
-            println!(
-                "    root: {} -- artifact differs, but no miss recorded for it in this event window",
+            ),
+            crate::miss_chain::RootKind::NothingRecorded => println!(
+                "    root: {}{via} -- dependencies stable and no traced input group changed \
+                 (key salt or extra inputs?)",
                 root.crate_name
-            );
-        }
-        crate::miss_chain::RootKind::NoBaseline => {
-            println!(
-                "    root: {} -- no earlier hit to compare against",
+            ),
+            // Everything below is an unresolved endpoint, not a cause. Worded
+            // so it can't be read as "this crate is why you missed".
+            crate::miss_chain::RootKind::NoMissRecorded => println!(
+                "    unresolved: {}{via} -- artifact differs, but it has no compile recorded in \
+                 this event window",
                 root.crate_name
-            );
-        }
-        crate::miss_chain::RootKind::NothingRecorded => {
-            println!(
-                "    root: {} -- no traced input group changed (key salt or extra inputs?)",
+            ),
+            crate::miss_chain::RootKind::NoBaseline => println!(
+                "    unresolved: {}{via} -- nothing earlier to compare it against",
                 root.crate_name
-            );
+            ),
+            crate::miss_chain::RootKind::NoDiffableHistory => println!(
+                "    unresolved: {}{via} -- its own dependency history is not comparable, so the \
+                 cascade may continue below it",
+                root.crate_name
+            ),
+            crate::miss_chain::RootKind::LimitReached => println!(
+                "    unresolved: {}{via} -- still descending when the walk limit was reached",
+                root.crate_name
+            ),
         }
-    }
-
-    if !root.passthroughs.is_empty() {
-        println!(
-            "    {} also has uncached (passthrough) compiles, which make its artifact vary per checkout:",
-            root.crate_name
-        );
+        if root.path.len() > 1 {
+            let mut path: Vec<&str> = root.path.iter().map(|h| h.crate_name.as_str()).collect();
+            path.push(root.crate_name.as_str());
+            println!("      via: {}", path.join(" <- "));
+        }
         for group in &root.passthroughs {
-            println!("      {}x {}", group.count, group.reason);
+            println!(
+                "      {}x uncached compile in {}: {}",
+                group.count, root.crate_name, group.reason
+            );
         }
-        println!("      (attributed by package directory -- see `kache report` for the full list)");
+        if !root.passthroughs.is_empty() {
+            println!(
+                "      (uncached compiles make the artifact vary per checkout; attributed by \
+                 package directory)"
+            );
+        }
     }
 
+    if !chain.has_resolved_root() {
+        println!(
+            "    note: no endpoint could be resolved -- the recorded history does not explain \
+             this miss"
+        );
+    }
     if let Some(reason) = chain.truncated {
         println!("    note: walk stopped early -- {reason}");
     }
@@ -5220,6 +5247,7 @@ mod tests {
             key_fields: Default::default(),
             key_diff: Vec::new(),
             key_externs: Default::default(),
+            key_externs_recorded: false,
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -714,6 +714,13 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
         }
     }
 
+    // ── Dependency cascade ────────────────────────────────────────────
+    // The diagnosis above compares this crate's stored entries against each
+    // other, which in a cascade says the same undifferentiated thing for every
+    // crate downstream of the one that actually moved. Walk the recorded
+    // dependency digests instead and name the crate at the bottom (#609).
+    print_extern_chain(&all_events, miss, config.explain_miss);
+
     // ── Recent event history ──────────────────────────────────────────
     println!("\n  Recent events:");
     let recent: Vec<_> = crate_events.iter().rev().take(5).collect();
@@ -774,6 +781,85 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Render the `extern:` cascade for a miss, when one is recorded (#609).
+///
+/// Prints nothing when the miss is not downstream of a dependency change, so
+/// the ordinary single-crate case reads exactly as before. When the digests
+/// were never recorded, says how to turn them on rather than staying silent
+/// about a diagnosis it could have given.
+fn print_extern_chain(
+    all_events: &[events::BuildEvent],
+    miss: &events::BuildEvent,
+    explain_miss: bool,
+) {
+    let Some(chain) = crate::miss_chain::analyze(all_events, miss) else {
+        if !explain_miss && miss.key_externs.is_empty() {
+            println!(
+                "\n  Dependency cascade: not analyzed (no per-dependency digests recorded).\n    \
+                 Enable [cache] explain_miss to record them, then rebuild."
+            );
+        }
+        return;
+    };
+
+    println!("\n  Dependency cascade: this miss is downstream of a dependency change");
+    for hop in &chain.hops {
+        let from = hop.via.from.as_deref().unwrap_or("(absent)");
+        let to = hop.via.to.as_deref().unwrap_or("(removed)");
+        println!(
+            "    {} <- {} changed ({from} -> {to})",
+            hop.crate_name, hop.via.name
+        );
+        if !hop.siblings.is_empty() {
+            println!("      (also changed here: {})", hop.siblings.join(", "));
+        }
+    }
+
+    let root = &chain.root;
+    match &root.kind {
+        crate::miss_chain::RootKind::Groups(groups) => {
+            println!(
+                "    root: {} -- own inputs changed: {}",
+                root.crate_name,
+                groups.join(", ")
+            );
+        }
+        crate::miss_chain::RootKind::NoMissRecorded => {
+            println!(
+                "    root: {} -- artifact differs, but no miss recorded for it in this event window",
+                root.crate_name
+            );
+        }
+        crate::miss_chain::RootKind::NoBaseline => {
+            println!(
+                "    root: {} -- no earlier hit to compare against",
+                root.crate_name
+            );
+        }
+        crate::miss_chain::RootKind::NothingRecorded => {
+            println!(
+                "    root: {} -- no traced input group changed (key salt or extra inputs?)",
+                root.crate_name
+            );
+        }
+    }
+
+    if !root.passthroughs.is_empty() {
+        println!(
+            "    {} also has uncached (passthrough) compiles, which make its artifact vary per checkout:",
+            root.crate_name
+        );
+        for group in &root.passthroughs {
+            println!("      {}x {}", group.count, group.reason);
+        }
+        println!("      (attributed by package directory -- see `kache report` for the full list)");
+    }
+
+    if let Some(reason) = chain.truncated {
+        println!("    note: walk stopped early -- {reason}");
+    }
 }
 
 /// Compare the miss event's stored metadata against other stored entries
@@ -5133,6 +5219,7 @@ mod tests {
             exit_code: None,
             key_fields: Default::default(),
             key_diff: Vec::new(),
+            key_externs: Default::default(),
         }
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -35,7 +35,8 @@ pub struct BuildEvent {
     /// 5 = passthrough details, 6 = file-hash cache metrics,
     /// 7 = restore-method bytes, 8 = dup outcome + store blob counters,
     /// 9 = event root, 10 = build session id (#583),
-    /// 11 = key field hashes + miss key diff (#131).
+    /// 11 = key field hashes + miss key diff (#131),
+    /// 12 = per-extern artifact digests (#609).
     #[serde(default)]
     pub schema: u32,
     /// Build session this event belongs to (kunobi-ninja/kache#583 P0.5).
@@ -140,6 +141,22 @@ pub struct BuildEvent {
     /// changed vs this crate's last hit in the same build tree.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub key_diff: Vec<String>,
+    /// Per-dependency artifact digests folded into the `externs` group
+    /// (kunobi-ninja/kache#609), as `crate name -> 16-hex of the dependency's
+    /// artifact content hash`, or `(sysroot)` for a dependency whose artifact
+    /// isn't readable.
+    ///
+    /// The group digest in `key_fields` says only that SOME dependency moved.
+    /// This map says which one, which is what lets `why-miss` walk an
+    /// `extern:` cascade to the crate that actually changed instead of
+    /// reporting the same undifferentiated diagnosis for every crate above it.
+    ///
+    /// Written on both hits and misses (the diff needs a baseline) but only
+    /// when `[cache] explain_miss` is on: a crate with 150 dependencies would
+    /// otherwise add 150 entries to every event on the hot path. Empty for cc
+    /// compiles, passthroughs, and pre-#609 wrappers.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub key_externs: std::collections::BTreeMap<String, String>,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -966,9 +983,14 @@ pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+impl BuildEvent {
+    /// Minimal event for tests in this crate: identity fields set, everything
+    /// else zeroed. Callers set the few fields their case is about.
+    pub(crate) fn new_for_test(crate_name: &str, result: EventResult) -> BuildEvent {
+        BuildEvent::test_event(crate_name, result, 0, 0, 0, "")
+    }
 
+    #[cfg(test)]
     fn test_event(
         crate_name: &str,
         result: EventResult,
@@ -1013,7 +1035,31 @@ mod tests {
             exit_code: None,
             key_fields: Default::default(),
             key_diff: Vec::new(),
+            key_externs: Default::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_event(
+        crate_name: &str,
+        result: EventResult,
+        elapsed_ms: u64,
+        compile_time_ms: u64,
+        size: u64,
+        cache_key: &str,
+    ) -> BuildEvent {
+        BuildEvent::test_event(
+            crate_name,
+            result,
+            elapsed_ms,
+            compile_time_ms,
+            size,
+            cache_key,
+        )
     }
 
     #[test]
@@ -1057,6 +1103,7 @@ mod tests {
             exit_code: None,
             key_fields: Default::default(),
             key_diff: Vec::new(),
+            key_externs: Default::default(),
         };
 
         log_event(&log_path, &event).unwrap();
@@ -1120,6 +1167,35 @@ mod tests {
         assert!(
             serde_json::from_str::<HeartbeatEvent>(&build_line).is_err(),
             "BuildEvent must not deserialize as heartbeat"
+        );
+    }
+
+    /// #609: `key_externs` is additive. A schema-11 line written before it
+    /// existed must still read, with an empty map rather than a parse error
+    /// that would drop the whole event from `report` / `why-miss`.
+    #[test]
+    fn pre_609_events_deserialize_without_extern_digests() {
+        let line = r#"{"ts":"2026-07-01T00:00:00Z","crate_name":"serde",
+            "result":"miss","elapsed_ms":1,"size":2,"cache_key":"k","schema":11,
+            "key_fields":{"externs":"aaaa"}}"#;
+        let event: BuildEvent = serde_json::from_str(line).expect("schema 11 must still parse");
+        assert_eq!(event.schema, 11);
+        assert!(event.key_externs.is_empty());
+        assert_eq!(
+            event.key_fields.get("externs").map(String::as_str),
+            Some("aaaa")
+        );
+    }
+
+    /// The map is skipped when empty, so events from builds without
+    /// `explain_miss` do not grow by an empty object.
+    #[test]
+    fn empty_extern_digests_are_not_serialized() {
+        let event = test_event("serde", EventResult::Miss, 1, 1, 1, "k");
+        let line = serde_json::to_string(&event).unwrap();
+        assert!(
+            !line.contains("key_externs"),
+            "empty key_externs must not be written: {line}"
         );
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -157,6 +157,18 @@ pub struct BuildEvent {
     /// compiles, passthroughs, and pre-#609 wrappers.
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
     pub key_externs: std::collections::BTreeMap<String, String>,
+    /// Whether `key_externs` was recorded for this compile, as opposed to being
+    /// absent (kunobi-ninja/kache#609).
+    ///
+    /// An empty map is skipped on the wire, so without this flag a crate with
+    /// NO dependencies is indistinguishable from one built before the digests
+    /// existed. That difference decides whether the cascade walk can conclude
+    /// "its dependencies are stable, so this is the root" or has to stop with
+    /// an unresolved endpoint — and a dependency-free leaf is a very common
+    /// root. Written only alongside `key_externs`, so it costs nothing on the
+    /// default (non-`explain_miss`) path.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub key_externs_recorded: bool,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -1036,6 +1048,7 @@ impl BuildEvent {
             key_fields: Default::default(),
             key_diff: Vec::new(),
             key_externs: Default::default(),
+            key_externs_recorded: false,
         }
     }
 }
@@ -1104,6 +1117,7 @@ mod tests {
             key_fields: Default::default(),
             key_diff: Vec::new(),
             key_externs: Default::default(),
+            key_externs_recorded: false,
         };
 
         log_event(&log_path, &event).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod extra_inputs;
 mod fallback_planner;
 mod heartbeat;
 mod link;
+mod miss_chain;
 mod native_archive;
 mod opcounts;
 mod path_normalizer;

--- a/src/miss_chain.rs
+++ b/src/miss_chain.rs
@@ -9,65 +9,104 @@
 //! by hand to find that `aws_lc_sys` was the root.
 //!
 //! The per-dependency digests recorded on each event (`key_externs`) make the
-//! walk mechanical: diff a crate's miss against its own last hit to see WHICH
-//! dependency moved, then repeat for that dependency until reaching one whose
-//! divergence is not itself dependency-driven. That crate is the root.
+//! walk mechanical: diff a crate's compile against the previous recorded state
+//! of the same crate to see WHICH dependencies moved, then repeat for each of
+//! them until reaching crates whose divergence is not itself dependency-driven.
+//!
+//! # Why every branch is walked
+//!
+//! In a real cascade the crate being asked about usually has SEVERAL changed
+//! dependencies — in #580, `rig_core` sits above `aws_lc_rs`, `aws_sdk_*`,
+//! `async_nats` and more, all re-keyed by the same leaf. Following one of them
+//! and calling it "the root" would be an arbitrary choice dressed up as a
+//! diagnosis. Bailing out whenever more than one moved would instead give up
+//! exactly in the case this exists to explain. So every branch is walked, and
+//! the roots are ranked by how many branches converge on them: the crate that
+//! shows up under most of the changed dependencies is the one to look at.
+//!
+//! # Event selection
+//!
+//! The walk is driven by POSITION in the oldest-first event slice, never by
+//! timestamp. Each hop searches strictly before the parent's event, so the
+//! selected events are causally ordered and the walk cannot pick a later,
+//! unrelated compile of a dependency. Timestamps are unfit for this: two events
+//! can share one, and a dependency can be recompiled between the moment a
+//! parent hashes its artifact and the moment the parent's own event is logged.
+//!
+//! # What this cannot know
+//!
+//! `crate_name` is not a stable compilation-unit identity. Two versions of a
+//! package, a host and a target build of the same crate, or a dependency
+//! renamed through Cargo's `package = "..."` key all collapse onto one name, so
+//! a walk can pair events that belong to different units. Nothing here can
+//! repair that; it needs a producer identity (package id + unit disambiguator)
+//! recorded per extern. Until then the walk reports an unresolved endpoint
+//! rather than a confident wrong one wherever the recorded history does not
+//! support a conclusion.
 //!
 //! Everything here is a pure function over already-read events: no store, no
 //! filesystem, no clock. `cli` renders the result.
 
 use crate::events::{BuildEvent, EventResult};
-use chrono::{DateTime, Utc};
 use std::collections::{BTreeMap, HashSet};
 
-/// Hops to follow before giving up. A cascade deeper than this is possible in
-/// principle; the walk stops so a pathological graph can't spin, and says so.
+/// Hops to follow down one branch before giving up.
 const MAX_DEPTH: usize = 12;
 
-/// Changed dependencies listed per hop before eliding the rest.
-const MAX_LISTED: usize = 4;
+/// Total crates examined across all branches, so a wide graph cannot turn a
+/// diagnostic into a long walk.
+const MAX_NODES: usize = 64;
 
-/// A dependency whose artifact digest differs between a crate's last hit and
-/// its subsequent miss.
+/// A dependency whose artifact digest differs between a crate's compile and the
+/// previous recorded state of that crate.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChangedDep {
     pub name: String,
-    /// Digest at the last hit. `None` when the dependency is new since then.
+    /// Digest in the baseline event. `None` when the dependency is new.
     pub from: Option<String>,
-    /// Digest at the miss. `None` when the dependency went away.
+    /// Digest at the compile being explained. `None` when it went away.
     pub to: Option<String>,
 }
 
-/// One step down the cascade: `crate_name` missed because `via` moved.
+/// One step down a branch: `crate_name` diverged because `via` moved.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Hop {
     pub crate_name: String,
     pub via: ChangedDep,
-    /// Other dependencies that also moved at this hop. The walk follows one;
-    /// this keeps the rest from being silently dropped.
-    pub siblings: Vec<String>,
 }
 
-/// Why the crate at the end of the chain diverged.
+/// Why the crate at the end of a branch diverged.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RootKind {
-    /// Key input groups that moved, `externs` excluded — this is the crate
-    /// whose own inputs changed.
+    /// Key input groups that moved, `externs` excluded. The only variant that
+    /// asserts a cause; everything else is an explicit dead end.
     Groups(Vec<String>),
-    /// Its dependencies are unchanged and so are its recorded groups. Usually
-    /// means the divergence sits in a post-hoc fold (key salt, extra inputs).
+    /// Dependencies compared clean and no traced group moved: the difference
+    /// sits in a post-hoc fold (key salt, extra inputs).
     NothingRecorded,
-    /// The dependency moved but has no miss recorded in the event window, so
-    /// the walk cannot go further. Not a dead end worth hiding: it still names
-    /// the crate to look at.
+    /// The dependency moved but has no compile recorded in this event window.
     NoMissRecorded,
-    /// No prior hit to diff this crate against.
+    /// Nothing earlier to diff this crate against.
     NoBaseline,
+    /// Reached, but its own dependency history is not comparable, so it cannot
+    /// be shown to be the end of the cascade. Distinct from "dependencies were
+    /// compared and were stable" — conflating the two invents a root.
+    NoDiffableHistory,
+    /// The branch was still descending when a limit was hit.
+    LimitReached,
 }
 
-/// Passthrough (uncached) compiles attributed to the root crate, grouped by
-/// reason. This is what turns "aws_lc_sys's sources changed" into "aws_lc_sys
-/// contains uncached cc TUs, and here is the flag that blocked them".
+impl RootKind {
+    /// Whether this endpoint actually explains anything. Renderers must not
+    /// present an unresolved endpoint as the cause.
+    pub fn is_resolved(&self) -> bool {
+        matches!(self, RootKind::Groups(_) | RootKind::NothingRecorded)
+    }
+}
+
+/// Passthrough (uncached) compiles attributed to a root crate, grouped by
+/// reason. This is the actionable half: a passthrough there means the crate's
+/// artifact varies per checkout, and the reason names the flag to model.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PassthroughGroup {
     pub reason: String,
@@ -79,117 +118,179 @@ pub struct Root {
     pub crate_name: String,
     pub kind: RootKind,
     pub passthroughs: Vec<PassthroughGroup>,
+    /// Distinct branches from the starting crate that ended here. A root many
+    /// branches converge on is the likely cause of the whole cascade.
+    pub branches: usize,
+    /// Shortest path of hops that reached this root.
+    pub path: Vec<Hop>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Chain {
-    pub hops: Vec<Hop>,
-    pub root: Root,
-    /// Set when the walk stopped early rather than reaching a root.
+    /// Endpoints, most-converged first, then shallowest.
+    pub roots: Vec<Root>,
+    /// Dependencies that moved directly under the crate being explained.
+    pub direct: Vec<ChangedDep>,
+    /// Set when exploration stopped early rather than exhausting the graph.
     pub truncated: Option<&'static str>,
 }
 
-/// Walk the cascade starting from `crate_name`'s miss.
+impl Chain {
+    /// Whether any endpoint actually explains the cascade.
+    pub fn has_resolved_root(&self) -> bool {
+        self.roots.iter().any(|r| r.kind.is_resolved())
+    }
+}
+
+/// Walk the cascade below the compile at `miss_index`.
 ///
-/// `None` means there is nothing to report: no per-dependency digests were
-/// recorded (the wrapper writes them only under `[cache] explain_miss`, or the
-/// events predate #609), or this crate's dependencies did not move — in which
-/// case the existing diagnosis already says everything known.
-pub fn analyze(events: &[BuildEvent], miss: &BuildEvent) -> Option<Chain> {
-    if miss.key_externs.is_empty() {
+/// `miss_index` indexes `events` — an oldest-first slice. `None` means there is
+/// nothing to report: no per-dependency digests were recorded (the wrapper
+/// writes them only under `[cache] explain_miss`, or the events predate #609),
+/// or this crate's dependencies did not move, in which case the existing
+/// diagnosis already says everything known.
+pub fn analyze(events: &[BuildEvent], miss_index: usize) -> Option<Chain> {
+    let miss = events.get(miss_index)?;
+    if !miss.key_externs_recorded || miss.root.is_empty() {
         return None;
     }
-    let changed = changed_deps(events, &miss.crate_name, &miss.root, miss.ts)?;
-    if changed.is_empty() {
+    let direct = changed_deps_at(events, miss_index)?;
+    if direct.is_empty() {
         return None;
     }
 
-    let mut hops = Vec::new();
-    let mut visited: HashSet<String> = HashSet::new();
-    visited.insert(miss.crate_name.clone());
-
-    let mut current = miss.crate_name.clone();
-    let mut current_changed = changed;
+    // Breadth-first over (crate, event position), so the first path reaching a
+    // crate is the shortest one. `seen` is keyed by crate name: revisiting a
+    // crate on another branch adds no information beyond the convergence count,
+    // which is tracked separately.
+    let mut queue: Vec<(usize, Vec<Hop>)> = vec![(miss_index, Vec::new())];
+    let mut seen: HashSet<String> = HashSet::from([miss.crate_name.clone()]);
+    // Branches that reached each crate, counted independently of `roots`: a
+    // crate can be reached again while it is still queued, long before it
+    // becomes an endpoint.
+    let mut reached: BTreeMap<String, usize> = BTreeMap::new();
+    let mut roots: Vec<Root> = Vec::new();
+    let mut nodes = 0usize;
     let mut truncated = None;
 
-    let root = loop {
-        // Follow a dependency that actually has a compiled event to inspect;
-        // a dependency that only ever hit cannot be the thing that moved.
-        let followed = current_changed
-            .iter()
-            .find(|dep| {
-                !visited.contains(&dep.name)
-                    && last_compiled(events, &dep.name, &miss.root, miss.ts).is_some()
-            })
-            .or_else(|| current_changed.iter().find(|d| !visited.contains(&d.name)))
-            .cloned();
-
-        let Some(dep) = followed else {
-            // Every changed dependency is already on the path: a cycle in the
-            // recorded data, not a real dependency cycle. Stop and report the
-            // crate we are on.
-            truncated = Some("cycle in recorded dependency digests");
-            break classify(events, &current, &miss.root, miss.ts);
+    while let Some((index, path)) = queue.pop() {
+        let changed = match changed_deps_at(events, index) {
+            Some(changed) => changed,
+            // Guarded by the caller for the first node; deeper nodes are
+            // checked before being enqueued.
+            None => continue,
         };
 
-        let siblings = current_changed
-            .iter()
-            .filter(|d| d.name != dep.name)
-            .map(|d| d.name.clone())
-            .take(MAX_LISTED)
-            .collect();
-        hops.push(Hop {
-            crate_name: current.clone(),
-            via: dep.clone(),
-            siblings,
-        });
-
-        if hops.len() >= MAX_DEPTH {
-            truncated = Some("chain longer than the walk limit");
-            break classify(events, &dep.name, &miss.root, miss.ts);
-        }
-
-        visited.insert(dep.name.clone());
-
-        // Does this dependency's own miss point further down?
-        match changed_deps(events, &dep.name, &miss.root, miss.ts) {
-            Some(next) if !next.is_empty() => {
-                current = dep.name;
-                current_changed = next;
+        for dep in changed {
+            if nodes >= MAX_NODES {
+                truncated = Some("too many changed dependencies to follow");
+                break;
             }
-            // Its dependencies are stable (or undiffable): it is the root.
-            _ => break classify(events, &dep.name, &miss.root, miss.ts),
+            nodes += 1;
+            *reached.entry(dep.name.clone()).or_default() += 1;
+
+            let mut next_path = path.clone();
+            next_path.push(Hop {
+                crate_name: events[index].crate_name.clone(),
+                via: dep.clone(),
+            });
+
+            if path.iter().any(|hop| hop.crate_name == dep.name) || dep.name == miss.crate_name {
+                // The recorded digests loop back onto this path. Not a real
+                // dependency cycle — cargo forbids those — so it means the
+                // events being paired belong to different compilation units
+                // that share a crate name. Stop this branch and say so.
+                truncated = Some("cycle in recorded dependency digests");
+                continue;
+            }
+
+            if !seen.insert(dep.name.clone()) {
+                // Reached by another branch already; the convergence is
+                // recorded above and there is nothing new to explore.
+                continue;
+            }
+
+            // Strictly before the parent's event: positions decrease as the
+            // walk descends, which is what keeps selection causal.
+            let Some(dep_index) =
+                last_compiled_index(events, &dep.name, &events[index].root, index)
+            else {
+                roots.push(unresolved(dep.name, RootKind::NoMissRecorded, next_path));
+                continue;
+            };
+
+            match changed_deps_at(events, dep_index) {
+                // Its own dependencies moved: keep descending, unless this
+                // branch has run out of depth.
+                Some(next) if !next.is_empty() => {
+                    if next_path.len() >= MAX_DEPTH {
+                        truncated = Some("chain longer than the walk limit");
+                        roots.push(unresolved(dep.name, RootKind::LimitReached, next_path));
+                        continue;
+                    }
+                    queue.push((dep_index, next_path));
+                }
+                // Compared cleanly and stable: this is a genuine endpoint.
+                Some(_) => roots.push(classify_at(events, dep_index, next_path)),
+                // Not comparable. NOT the same as stable — saying so would
+                // invent a root out of missing data.
+                None => {
+                    let mut root = unresolved(dep.name, RootKind::NoDiffableHistory, next_path);
+                    root.passthroughs = passthroughs_for(events, &root.crate_name, dep_index);
+                    roots.push(root);
+                }
+            }
         }
-    };
+        if truncated == Some("too many changed dependencies to follow") {
+            break;
+        }
+    }
+
+    for root in &mut roots {
+        root.branches = reached.get(&root.crate_name).copied().unwrap_or(1);
+    }
+    // Most-converged first, then shallowest, then by name so output is stable.
+    roots.sort_by(|a, b| {
+        b.branches
+            .cmp(&a.branches)
+            .then_with(|| a.path.len().cmp(&b.path.len()))
+            .then_with(|| a.crate_name.cmp(&b.crate_name))
+    });
 
     Some(Chain {
-        hops,
-        root,
+        roots,
+        direct,
         truncated,
     })
 }
 
-/// Dependencies whose digests differ between `crate_name`'s last compile at or
-/// before `at` and the last hit preceding it.
+fn unresolved(crate_name: String, kind: RootKind, path: Vec<Hop>) -> Root {
+    Root {
+        crate_name,
+        kind,
+        passthroughs: Vec::new(),
+        branches: 1,
+        path,
+    }
+}
+
+/// Dependencies whose digests differ between the compile at `index` and the
+/// previous recorded state of the same crate in the same build tree.
 ///
-/// `None` when there is no diffable pair (no compile, no prior hit, or either
-/// side recorded no digests) — distinct from `Some(vec![])`, which means the
-/// pair exists and the dependencies are identical.
-fn changed_deps(
-    events: &[BuildEvent],
-    crate_name: &str,
-    root: &str,
-    at: DateTime<Utc>,
-) -> Option<Vec<ChangedDep>> {
-    let compiled = last_compiled(events, crate_name, root, at)?;
-    if compiled.key_externs.is_empty() {
+/// `None` means the history is not diffable (no baseline, or either side
+/// recorded no digests). That is deliberately distinct from `Some(vec![])`,
+/// which means the comparison succeeded and the dependencies are identical —
+/// only the latter supports concluding that a crate ends the cascade.
+fn changed_deps_at(events: &[BuildEvent], index: usize) -> Option<Vec<ChangedDep>> {
+    let compiled = events.get(index)?;
+    if !compiled.key_externs_recorded {
         return None;
     }
-    let hit = last_hit_before(events, crate_name, root, compiled.ts)?;
-    if hit.key_externs.is_empty() {
-        return None;
-    }
-    Some(diff_externs(&hit.key_externs, &compiled.key_externs))
+    let baseline = last_baseline_index(events, &compiled.crate_name, &compiled.root, index)?;
+    Some(diff_externs(
+        &events[baseline].key_externs,
+        &compiled.key_externs,
+    ))
 }
 
 /// Symmetric diff of two dependency-digest maps, sorted by name.
@@ -223,30 +324,30 @@ fn diff_externs(
 }
 
 /// Explain a crate's own divergence, dependencies aside.
-fn classify(events: &[BuildEvent], crate_name: &str, root: &str, at: DateTime<Utc>) -> Root {
-    let passthroughs = passthroughs_for(events, crate_name, root, at);
-    let Some(compiled) = last_compiled(events, crate_name, root, at) else {
+fn classify_at(events: &[BuildEvent], index: usize, path: Vec<Hop>) -> Root {
+    let compiled = &events[index];
+    let passthroughs = passthroughs_for(events, &compiled.crate_name, index);
+    let Some(baseline) = last_baseline_index(events, &compiled.crate_name, &compiled.root, index)
+    else {
         return Root {
-            crate_name: crate_name.to_string(),
-            kind: RootKind::NoMissRecorded,
-            passthroughs,
-        };
-    };
-    let Some(hit) = last_hit_before(events, crate_name, root, compiled.ts) else {
-        return Root {
-            crate_name: crate_name.to_string(),
+            crate_name: compiled.crate_name.clone(),
             kind: RootKind::NoBaseline,
             passthroughs,
+            branches: 1,
+            path,
         };
     };
 
-    // Prefer the diff the wrapper already computed; fall back to diffing the
-    // group digests here when `explain_miss` was off at the time.
-    let mut groups: Vec<String> = if compiled.key_diff.is_empty() {
-        changed_groups(&hit.key_fields, &compiled.key_fields)
-    } else {
-        compiled.key_diff.clone()
-    };
+    // Diff against the SAME baseline the dependency comparison used. The
+    // wrapper's own `key_diff` is computed against that crate's last hit, which
+    // can be an older event than this baseline, so preferring it here would mix
+    // two different comparisons.
+    let mut groups = changed_groups(&events[baseline].key_fields, &compiled.key_fields);
+    if groups.is_empty() && !compiled.key_diff.is_empty() {
+        // No group digests recorded to diff (pre-#131 events): fall back to
+        // whatever the wrapper concluded at the time.
+        groups = compiled.key_diff.clone();
+    }
     groups.retain(|g| g != "externs");
     groups.sort();
     groups.dedup();
@@ -257,9 +358,11 @@ fn classify(events: &[BuildEvent], crate_name: &str, root: &str, at: DateTime<Ut
         RootKind::Groups(groups)
     };
     Root {
-        crate_name: crate_name.to_string(),
+        crate_name: compiled.crate_name.clone(),
         kind,
         passthroughs,
+        branches: 1,
+        path,
     }
 }
 
@@ -282,26 +385,22 @@ fn changed_groups(
 /// driven by a build script logs the source file as its `crate_name`
 /// (`bcm.c`), so it cannot be joined to the Rust crate by name; what it does
 /// carry is a `root` derived from the build-script cwd, which for a registry
-/// dependency contains the package directory (`.../aws-lc-sys-0.43.0/...`).
+/// dependency contains the package directory (`.../aws-lc-sys-0.43.0`).
 /// Matching on that names the right crate for the case this exists to
 /// diagnose, and when it is wrong it over-reports rather than pointing
 /// somewhere else. `cli` labels the line as inferred.
+///
+/// Bounded to events before the compile being explained, so an unrelated later
+/// build cannot be folded in.
 fn passthroughs_for(
     events: &[BuildEvent],
     crate_name: &str,
-    root: &str,
-    at: DateTime<Utc>,
+    before: usize,
 ) -> Vec<PassthroughGroup> {
     let needle = crate_name.replace('_', "-");
     let mut counts: BTreeMap<String, usize> = BTreeMap::new();
-    for event in events {
-        if event.result != EventResult::Passthrough || event.ts > at {
-            continue;
-        }
-        // Skip the build tree's own root: every event shares it, so matching
-        // on it would attribute the whole build to whichever crate is asked
-        // about.
-        if event.root == root || event.root.is_empty() {
+    for event in &events[..before.min(events.len())] {
+        if event.result != EventResult::Passthrough || event.root.is_empty() {
             continue;
         }
         if !package_dir_matches(&event.root, &needle) {
@@ -319,70 +418,94 @@ fn passthroughs_for(
         .map(|(reason, count)| PassthroughGroup { reason, count })
         .collect();
     out.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.reason.cmp(&b.reason)));
-    out.truncate(MAX_LISTED);
+    out.truncate(4);
     out
 }
 
-/// Whether any path component of `root` is the package directory for
-/// `needle` — exactly `needle`, or `needle-<version>`.
+/// Whether any path component of `root` is the package directory for `needle` —
+/// exactly `needle`, or `needle-<semver>`.
 ///
-/// Component-wise and version-aware on purpose: a plain `contains` would let
-/// `aws-lc` match `aws-lc-sys-0.43.0` and attribute one crate's passthroughs
-/// to another.
+/// Split on both separators rather than using `Path::components`, so a Windows
+/// path analyzed on Unix (or the reverse) still resolves. Component-wise and
+/// version-shaped on purpose: a plain `contains` would let `aws-lc` match
+/// `aws-lc-sys-0.43.0`, and a bare "starts with a digit" test would let
+/// `foo-2-helper-0.1.0` match `foo`.
 fn package_dir_matches(root: &str, needle: &str) -> bool {
-    std::path::Path::new(root)
-        .components()
-        .filter_map(|c| c.as_os_str().to_str())
-        .any(|component| {
-            component == needle
-                || component
-                    .strip_prefix(needle)
-                    .and_then(|rest| rest.strip_prefix('-'))
-                    .is_some_and(|version| version.starts_with(|c: char| c.is_ascii_digit()))
-        })
+    root.split(['/', '\\']).any(|component| {
+        component == needle
+            || component
+                .strip_prefix(needle)
+                .and_then(|rest| rest.strip_prefix('-'))
+                .is_some_and(looks_like_semver)
+    })
 }
 
-fn last_compiled<'a>(
-    events: &'a [BuildEvent],
+/// `MAJOR.MINOR.PATCH`, with an optional `-pre` / `+build` tail — the shape
+/// Cargo puts in a registry package directory.
+fn looks_like_semver(value: &str) -> bool {
+    let core = value.split(['-', '+']).next().unwrap_or_default();
+    let parts: Vec<&str> = core.split('.').collect();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|part| !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit()))
+}
+
+/// Last compile (`Miss`/`Dup`) of `crate_name` strictly before `before`.
+fn last_compiled_index(
+    events: &[BuildEvent],
     crate_name: &str,
     root: &str,
-    at: DateTime<Utc>,
-) -> Option<&'a BuildEvent> {
-    events.iter().rev().find(|e| {
+    before: usize,
+) -> Option<usize> {
+    events[..before.min(events.len())].iter().rposition(|e| {
         e.crate_name == crate_name
             && same_root(e, root)
-            && e.ts <= at
             && matches!(e.result, EventResult::Miss | EventResult::Dup)
     })
 }
 
-fn last_hit_before<'a>(
-    events: &'a [BuildEvent],
+/// The previous event that recorded dependency digests for this crate.
+///
+/// Any keyed outcome counts, not just a hit: after two consecutive misses,
+/// diffing the second against the last HIT reports everything that changed
+/// across both, which over-reports the dependencies responsible for the second
+/// one. A dependency can equally reach its new artifact through a remote or
+/// prefetch hit, so those count too.
+fn last_baseline_index(
+    events: &[BuildEvent],
     crate_name: &str,
     root: &str,
-    before: DateTime<Utc>,
-) -> Option<&'a BuildEvent> {
-    events.iter().rev().find(|e| {
+    before: usize,
+) -> Option<usize> {
+    events[..before.min(events.len())].iter().rposition(|e| {
         e.crate_name == crate_name
             && same_root(e, root)
-            && e.ts < before
+            && e.key_externs_recorded
             && matches!(
                 e.result,
-                EventResult::LocalHit | EventResult::PrefetchHit | EventResult::RemoteHit
+                EventResult::LocalHit
+                    | EventResult::PrefetchHit
+                    | EventResult::RemoteHit
+                    | EventResult::Miss
+                    | EventResult::Dup
             )
     })
 }
 
-/// Scope to one build tree, tolerating legacy events that recorded no root
-/// (matching those would be better than dropping the whole diagnosis).
+/// Exact build-tree match.
+///
+/// A missing root is NOT a wildcard. Treating it as one lets a legacy or
+/// foreign event stand in as the baseline for a crate of the same name in a
+/// different workspace, which produces a confident and wrong cascade.
 fn same_root(event: &BuildEvent, root: &str) -> bool {
-    root.is_empty() || event.root.is_empty() || event.root == root
+    !root.is_empty() && event.root == root
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
+    use chrono::{DateTime, TimeZone, Utc};
 
     fn ts(secs: i64) -> DateTime<Utc> {
         Utc.timestamp_opt(1_700_000_000 + secs, 0).unwrap()
@@ -401,6 +524,15 @@ mod tests {
             .iter()
             .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
             .collect();
+        e.key_externs_recorded = true;
+        e
+    }
+
+    /// An event from a build where the digests were not recorded at all —
+    /// `explain_miss` off, or a pre-#609 wrapper.
+    fn unrecorded(crate_name: &str, result: EventResult, at: i64) -> BuildEvent {
+        let mut e = event(crate_name, result, at, &[]);
+        e.key_externs_recorded = false;
         e
     }
 
@@ -412,12 +544,15 @@ mod tests {
         e
     }
 
+    fn analyze_last(events: &[BuildEvent]) -> Option<Chain> {
+        analyze(events, events.len() - 1)
+    }
+
     /// The #580 shape: a leaf `-sys` crate's artifact moves and re-keys two
     /// crates above it. The walk must name the leaf, not the crate asked about.
     #[test]
     fn walks_a_cascade_to_the_leaf_that_changed() {
         let events = vec![
-            // Baseline hits.
             event(
                 "rig_core",
                 EventResult::LocalHit,
@@ -434,7 +569,6 @@ mod tests {
                 event("aws_lc_sys", EventResult::LocalHit, 2, &[("libc", "cccc")]),
                 &[("sources", "1111")],
             ),
-            // The leaf recompiles with different sources; the cascade follows.
             with_fields(
                 event("aws_lc_sys", EventResult::Miss, 10, &[("libc", "cccc")]),
                 &[("sources", "2222")],
@@ -447,34 +581,156 @@ mod tests {
             ),
             event("rig_core", EventResult::Miss, 12, &[("aws_lc_rs", "eeee")]),
         ];
-        let miss = events.last().unwrap();
 
-        let chain = analyze(&events, miss).expect("cascade should be reported");
+        let chain = analyze_last(&events).expect("cascade should be reported");
+        assert_eq!(chain.roots.len(), 1);
+        let root = &chain.roots[0];
+        assert_eq!(root.crate_name, "aws_lc_sys");
+        assert_eq!(root.kind, RootKind::Groups(vec!["sources".to_string()]));
         assert_eq!(
-            chain
-                .hops
+            root.path
                 .iter()
                 .map(|h| (h.crate_name.as_str(), h.via.name.as_str()))
                 .collect::<Vec<_>>(),
             vec![("rig_core", "aws_lc_rs"), ("aws_lc_rs", "aws_lc_sys")]
         );
-        assert_eq!(chain.root.crate_name, "aws_lc_sys");
-        assert_eq!(
-            chain.root.kind,
-            RootKind::Groups(vec!["sources".to_string()])
-        );
         assert!(chain.truncated.is_none());
+        assert!(chain.has_resolved_root());
     }
 
-    /// A crate whose own dependencies are unchanged is not part of a cascade,
-    /// and must not be dressed up as one.
+    /// Several dependencies moving is the NORMAL case in a cascade (#580's
+    /// `rig_core` sits above a whole re-keyed subtree). Every branch must be
+    /// walked, and the root they converge on ranked first — following one
+    /// branch and calling it "the root" would be an arbitrary choice.
+    #[test]
+    fn ranks_the_root_that_most_branches_converge_on() {
+        let events = vec![
+            event(
+                "top",
+                EventResult::LocalHit,
+                0,
+                &[("a", "1111"), ("b", "2222")],
+            ),
+            event("a", EventResult::LocalHit, 1, &[("leaf", "5555")]),
+            event("b", EventResult::LocalHit, 2, &[("leaf", "5555")]),
+            with_fields(
+                event("leaf", EventResult::LocalHit, 3, &[("libc", "9999")]),
+                &[("sources", "1111")],
+            ),
+            with_fields(
+                event("leaf", EventResult::Miss, 10, &[("libc", "9999")]),
+                &[("sources", "2222")],
+            ),
+            event("a", EventResult::Miss, 11, &[("leaf", "6666")]),
+            event("b", EventResult::Miss, 12, &[("leaf", "6666")]),
+            event(
+                "top",
+                EventResult::Miss,
+                13,
+                &[("a", "3333"), ("b", "4444")],
+            ),
+        ];
+
+        let chain = analyze_last(&events).unwrap();
+        assert_eq!(chain.direct.len(), 2, "both direct dependencies moved");
+        let leaf = &chain.roots[0];
+        assert_eq!(leaf.crate_name, "leaf");
+        assert_eq!(leaf.branches, 2, "reached via both a and b");
+        assert_eq!(leaf.kind, RootKind::Groups(vec!["sources".to_string()]));
+    }
+
+    /// A dependency whose own history is not comparable must NOT be reported as
+    /// a root: missing data is not evidence that its dependencies were stable.
+    #[test]
+    fn undiffable_history_is_not_reported_as_a_root() {
+        let events = vec![
+            // b's baseline recorded no digests (explain_miss was off then).
+            unrecorded("b", EventResult::LocalHit, 0),
+            with_fields(
+                event("b", EventResult::Miss, 1, &[("c", "1111")]),
+                &[("sources", "2222")],
+            ),
+            event("a", EventResult::LocalHit, 2, &[("b", "aaaa")]),
+            event("a", EventResult::Miss, 3, &[("b", "bbbb")]),
+        ];
+        let chain = analyze_last(&events).unwrap();
+        assert_eq!(chain.roots.len(), 1);
+        assert_eq!(chain.roots[0].crate_name, "b");
+        assert_eq!(chain.roots[0].kind, RootKind::NoDiffableHistory);
+        assert!(
+            !chain.has_resolved_root(),
+            "an undiffable endpoint must not read as an explanation"
+        );
+    }
+
+    /// After two consecutive misses the baseline is the previous MISS, not the
+    /// older hit — otherwise the diff reports everything that moved across
+    /// both compiles and can follow the wrong branch.
+    #[test]
+    fn baseline_is_the_previous_recorded_state_not_the_last_hit() {
+        let events = vec![
+            event(
+                "b",
+                EventResult::LocalHit,
+                0,
+                &[("c", "1111"), ("d", "2222")],
+            ),
+            // c moved here.
+            event("b", EventResult::Miss, 1, &[("c", "9999"), ("d", "2222")]),
+            // only d moved here; c is unchanged since the previous miss.
+            event("b", EventResult::Miss, 2, &[("c", "9999"), ("d", "8888")]),
+        ];
+        let chain = analyze_last(&events).unwrap();
+        assert_eq!(
+            chain
+                .direct
+                .iter()
+                .map(|d| d.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["d"],
+            "diffing against the last hit would wrongly also report c"
+        );
+    }
+
+    /// Walking must descend strictly backwards through the log, so a later,
+    /// causally unrelated compile of a dependency is never selected.
+    #[test]
+    fn dependency_lookup_cannot_select_a_later_compile() {
+        let events = vec![
+            with_fields(
+                event("c", EventResult::LocalHit, 0, &[("d", "1111")]),
+                &[("sources", "aaaa")],
+            ),
+            event("b", EventResult::LocalHit, 1, &[("c", "5555")]),
+            event("a", EventResult::LocalHit, 2, &[("b", "7777")]),
+            // The compile of c that b actually consumed: driven by d.
+            with_fields(
+                event("c", EventResult::Miss, 10, &[("d", "2222")]),
+                &[("sources", "aaaa")],
+            ),
+            event("b", EventResult::Miss, 11, &[("c", "6666")]),
+            // A LATER, independent change to c, after b was already built.
+            with_fields(
+                event("c", EventResult::Miss, 12, &[("d", "2222")]),
+                &[("sources", "bbbb")],
+            ),
+            event("a", EventResult::Miss, 13, &[("b", "8888")]),
+        ];
+        let chain = analyze_last(&events).unwrap();
+        // c's dependencies moved at the event b consumed, so the walk descends
+        // past c to d rather than stopping at c's later source change.
+        assert_eq!(chain.roots[0].crate_name, "d");
+        assert_eq!(chain.roots[0].kind, RootKind::NoMissRecorded);
+    }
+
+    /// A crate with no dependency movement is not part of a cascade.
     #[test]
     fn reports_nothing_when_dependencies_are_stable() {
         let events = vec![
             event("foo", EventResult::LocalHit, 0, &[("bar", "aaaa")]),
             event("foo", EventResult::Miss, 1, &[("bar", "aaaa")]),
         ];
-        assert!(analyze(&events, events.last().unwrap()).is_none());
+        assert!(analyze_last(&events).is_none());
     }
 
     /// Without recorded digests there is nothing to walk, and the caller must
@@ -482,26 +738,32 @@ mod tests {
     #[test]
     fn reports_nothing_without_recorded_digests() {
         let events = vec![
-            event("foo", EventResult::LocalHit, 0, &[]),
-            event("foo", EventResult::Miss, 1, &[]),
+            unrecorded("foo", EventResult::LocalHit, 0),
+            unrecorded("foo", EventResult::Miss, 1),
         ];
-        assert!(analyze(&events, events.last().unwrap()).is_none());
+        assert!(analyze_last(&events).is_none());
     }
 
-    /// A dependency that moved but never missed in the window is still worth
-    /// naming; the walk just cannot go past it.
+    /// A rootless legacy event must not stand in as a baseline for a crate of
+    /// the same name in a real build tree.
     #[test]
-    fn stops_at_a_dependency_with_no_recorded_miss() {
+    fn rootless_events_are_not_wildcards() {
+        let mut legacy = event("app", EventResult::LocalHit, 0, &[("dep", "1111")]);
+        legacy.root = String::new();
         let events = vec![
-            event("foo", EventResult::LocalHit, 0, &[("bar", "aaaa")]),
-            event("foo", EventResult::Miss, 1, &[("bar", "bbbb")]),
+            legacy,
+            event("app", EventResult::Miss, 1, &[("dep", "2222")]),
         ];
-        let chain = analyze(&events, events.last().unwrap()).unwrap();
-        assert_eq!(chain.root.crate_name, "bar");
-        assert_eq!(chain.root.kind, RootKind::NoMissRecorded);
+        assert!(
+            analyze_last(&events).is_none(),
+            "an unrelated rootless event must not seed a cascade"
+        );
     }
 
-    /// Digests that point in a loop must terminate the walk, not spin it.
+    /// Digests that point in a loop must terminate the walk and be reported as
+    /// unexplained. Cargo forbids real dependency cycles, so a loop here means
+    /// two compilation units were paired by a shared crate name — which is
+    /// exactly when a confident answer would be wrong.
     #[test]
     fn terminates_on_a_cycle_in_recorded_digests() {
         let events = vec![
@@ -510,34 +772,71 @@ mod tests {
             event("b", EventResult::Miss, 10, &[("a", "4444")]),
             event("a", EventResult::Miss, 11, &[("b", "2222")]),
         ];
-        let chain = analyze(&events, events.last().unwrap()).unwrap();
+        let chain = analyze_last(&events).unwrap();
         assert_eq!(
             chain.truncated,
             Some("cycle in recorded dependency digests")
         );
-        assert!(chain.hops.len() <= MAX_DEPTH);
+        assert!(
+            !chain.has_resolved_root(),
+            "a cycle must not yield a confident root: {:?}",
+            chain.roots
+        );
+        assert!(chain.roots.iter().all(|r| r.path.len() <= MAX_DEPTH));
     }
 
-    /// Several dependencies moving at once must not silently drop all but one.
+    /// A chain exactly MAX_DEPTH long ends in a real root, not a truncation.
     #[test]
-    fn records_siblings_when_several_dependencies_moved() {
-        let events = vec![
-            event(
-                "foo",
-                EventResult::LocalHit,
-                0,
-                &[("bar", "aaaa"), ("baz", "cccc")],
-            ),
-            event(
-                "foo",
-                EventResult::Miss,
-                1,
-                &[("bar", "bbbb"), ("baz", "dddd")],
-            ),
-        ];
-        let chain = analyze(&events, events.last().unwrap()).unwrap();
-        assert_eq!(chain.hops.len(), 1);
-        assert_eq!(chain.hops[0].siblings, vec!["baz".to_string()]);
+    fn a_chain_at_the_depth_limit_still_resolves() {
+        let mut events = Vec::new();
+        let names: Vec<String> = (0..=MAX_DEPTH).map(|i| format!("c{i}")).collect();
+        let last = names.len() - 1;
+        // Every crate keeps one dependency, including the deepest: an empty
+        // digest map cannot be told apart from an unrecorded one, so a
+        // dependency-free crate would end the branch unresolved for reasons
+        // unrelated to the depth limit under test.
+        let deps_of = |i: usize, digest: &'static str| -> Vec<(String, &'static str)> {
+            match names.get(i + 1) {
+                Some(next) => vec![(next.clone(), digest)],
+                None => vec![("libc".to_string(), "stable")],
+            }
+        };
+        // Baselines, shallowest first.
+        for (i, name) in names.iter().enumerate() {
+            let deps = deps_of(i, "old");
+            let deps: Vec<(&str, &str)> = deps.iter().map(|(n, d)| (n.as_str(), *d)).collect();
+            events.push(with_fields(
+                event(name, EventResult::LocalHit, i as i64, &deps),
+                &[("sources", "1111")],
+            ));
+        }
+        // Misses, deepest first, so each parent's dependency compile precedes it.
+        for (i, name) in names.iter().enumerate().rev() {
+            let deps = deps_of(i, "new");
+            let deps: Vec<(&str, &str)> = deps.iter().map(|(n, d)| (n.as_str(), *d)).collect();
+            events.push(with_fields(
+                event(
+                    name,
+                    EventResult::Miss,
+                    100 + (names.len() - i) as i64,
+                    &deps,
+                ),
+                &[("sources", if i == last { "2222" } else { "1111" })],
+            ));
+        }
+        let start = events
+            .iter()
+            .rposition(|e| e.crate_name == "c0" && e.result == EventResult::Miss)
+            .unwrap();
+
+        let chain = analyze(&events, start).unwrap();
+        assert_eq!(chain.roots[0].crate_name, format!("c{MAX_DEPTH}"));
+        assert!(
+            chain.roots[0].kind.is_resolved(),
+            "a root exactly at the limit must still resolve: {:?}",
+            chain.roots[0].kind
+        );
+        assert!(chain.truncated.is_none());
     }
 
     #[test]
@@ -554,9 +853,8 @@ mod tests {
         ]
         .into_iter()
         .collect();
-        let diff = diff_externs(&before, &after);
         assert_eq!(
-            diff,
+            diff_externs(&before, &after),
             vec![
                 ChangedDep {
                     name: "gone".to_string(),
@@ -573,7 +871,8 @@ mod tests {
     }
 
     /// The passthrough join is by package directory, so a shorter crate name
-    /// must not absorb a longer one's uncached compiles.
+    /// must not absorb a longer one's uncached compiles, and a directory that
+    /// merely starts with the name must not read as a version.
     #[test]
     fn package_dir_match_is_component_and_version_aware() {
         assert!(package_dir_matches(
@@ -581,6 +880,10 @@ mod tests {
             "aws-lc-sys"
         ));
         assert!(package_dir_matches("/src/aws-lc-sys", "aws-lc-sys"));
+        assert!(package_dir_matches(
+            "/registry/src/idx/serde-1.0.0-alpha.1",
+            "serde"
+        ));
         // `aws-lc` must not swallow `aws-lc-sys`.
         assert!(!package_dir_matches(
             "/home/u/.cargo/registry/src/idx/aws-lc-sys-0.43.0",
@@ -591,6 +894,13 @@ mod tests {
             "/src/my-aws-lc-sys-fork",
             "aws-lc-sys"
         ));
+        // "starts with a digit" is not enough to be a version.
+        assert!(!package_dir_matches("/src/foo-2-helper-0.1.0", "foo"));
+        // Windows separators resolve even when parsed on Unix.
+        assert!(package_dir_matches(
+            r"C:\Users\u\.cargo\registry\src\idx\aws-lc-sys-0.43.0",
+            "aws-lc-sys"
+        ));
     }
 
     /// The root crate's uncached cc TUs are the actionable half of the answer.
@@ -599,21 +909,41 @@ mod tests {
         let mut pt = BuildEvent::new_for_test("bcm.c", EventResult::Passthrough);
         pt.ts = ts(5);
         pt.root = "/home/u/.cargo/registry/src/idx/aws-lc-sys-0.43.0".to_string();
-        pt.passthrough_reason = "cc unsupported flag(s): --include=... — not yet".to_string();
+        pt.passthrough_reason = "cc unsupported flag(s): --include=... not yet".to_string();
 
         let mut unrelated = pt.clone();
         unrelated.root = "/home/u/.cargo/registry/src/idx/ring-0.17.8".to_string();
 
         let events = vec![
-            event("aws_lc_sys", EventResult::LocalHit, 0, &[("libc", "cccc")]),
+            with_fields(
+                event("aws_lc_sys", EventResult::LocalHit, 0, &[("libc", "cccc")]),
+                &[("sources", "1111")],
+            ),
             pt.clone(),
             pt,
             unrelated,
-            event("aws_lc_sys", EventResult::Miss, 10, &[("libc", "cccc")]),
+            with_fields(
+                event("aws_lc_sys", EventResult::Miss, 10, &[("libc", "cccc")]),
+                &[("sources", "2222")],
+            ),
         ];
-        let root = classify(&events, "aws_lc_sys", "/w", ts(10));
+        let root = classify_at(&events, events.len() - 1, Vec::new());
         assert_eq!(root.passthroughs.len(), 1);
         assert_eq!(root.passthroughs[0].count, 2);
         assert!(root.passthroughs[0].reason.contains("--include="));
+    }
+
+    /// Passthroughs logged after the compile being explained belong to a later
+    /// build and must not be folded in.
+    #[test]
+    fn passthrough_attribution_is_bounded_to_earlier_events() {
+        let mut pt = BuildEvent::new_for_test("bcm.c", EventResult::Passthrough);
+        pt.root = "/registry/src/idx/aws-lc-sys-0.43.0".to_string();
+        pt.passthrough_reason = "later build".to_string();
+        let events = vec![
+            event("aws_lc_sys", EventResult::Miss, 0, &[("libc", "cccc")]),
+            pt,
+        ];
+        assert!(passthroughs_for(&events, "aws_lc_sys", 1).is_empty());
     }
 }

--- a/src/miss_chain.rs
+++ b/src/miss_chain.rs
@@ -1,0 +1,619 @@
+//! Walking an `extern:` cascade back to the crate that actually changed
+//! (kunobi-ninja/kache#609).
+//!
+//! When one crate's artifact content moves, `extern:<name>=<hash>` re-keys
+//! every crate above it. `why-miss` then reports the same thing for all of
+//! them: "same config -- likely source code, dependency, or rustc version
+//! change". True for the crate that changed, useless for the forty that are
+//! only downstream of it, and the reporter in #580 had to work down the chain
+//! by hand to find that `aws_lc_sys` was the root.
+//!
+//! The per-dependency digests recorded on each event (`key_externs`) make the
+//! walk mechanical: diff a crate's miss against its own last hit to see WHICH
+//! dependency moved, then repeat for that dependency until reaching one whose
+//! divergence is not itself dependency-driven. That crate is the root.
+//!
+//! Everything here is a pure function over already-read events: no store, no
+//! filesystem, no clock. `cli` renders the result.
+
+use crate::events::{BuildEvent, EventResult};
+use chrono::{DateTime, Utc};
+use std::collections::{BTreeMap, HashSet};
+
+/// Hops to follow before giving up. A cascade deeper than this is possible in
+/// principle; the walk stops so a pathological graph can't spin, and says so.
+const MAX_DEPTH: usize = 12;
+
+/// Changed dependencies listed per hop before eliding the rest.
+const MAX_LISTED: usize = 4;
+
+/// A dependency whose artifact digest differs between a crate's last hit and
+/// its subsequent miss.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChangedDep {
+    pub name: String,
+    /// Digest at the last hit. `None` when the dependency is new since then.
+    pub from: Option<String>,
+    /// Digest at the miss. `None` when the dependency went away.
+    pub to: Option<String>,
+}
+
+/// One step down the cascade: `crate_name` missed because `via` moved.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Hop {
+    pub crate_name: String,
+    pub via: ChangedDep,
+    /// Other dependencies that also moved at this hop. The walk follows one;
+    /// this keeps the rest from being silently dropped.
+    pub siblings: Vec<String>,
+}
+
+/// Why the crate at the end of the chain diverged.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RootKind {
+    /// Key input groups that moved, `externs` excluded — this is the crate
+    /// whose own inputs changed.
+    Groups(Vec<String>),
+    /// Its dependencies are unchanged and so are its recorded groups. Usually
+    /// means the divergence sits in a post-hoc fold (key salt, extra inputs).
+    NothingRecorded,
+    /// The dependency moved but has no miss recorded in the event window, so
+    /// the walk cannot go further. Not a dead end worth hiding: it still names
+    /// the crate to look at.
+    NoMissRecorded,
+    /// No prior hit to diff this crate against.
+    NoBaseline,
+}
+
+/// Passthrough (uncached) compiles attributed to the root crate, grouped by
+/// reason. This is what turns "aws_lc_sys's sources changed" into "aws_lc_sys
+/// contains uncached cc TUs, and here is the flag that blocked them".
+#[derive(Debug, Clone, PartialEq)]
+pub struct PassthroughGroup {
+    pub reason: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Root {
+    pub crate_name: String,
+    pub kind: RootKind,
+    pub passthroughs: Vec<PassthroughGroup>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Chain {
+    pub hops: Vec<Hop>,
+    pub root: Root,
+    /// Set when the walk stopped early rather than reaching a root.
+    pub truncated: Option<&'static str>,
+}
+
+/// Walk the cascade starting from `crate_name`'s miss.
+///
+/// `None` means there is nothing to report: no per-dependency digests were
+/// recorded (the wrapper writes them only under `[cache] explain_miss`, or the
+/// events predate #609), or this crate's dependencies did not move — in which
+/// case the existing diagnosis already says everything known.
+pub fn analyze(events: &[BuildEvent], miss: &BuildEvent) -> Option<Chain> {
+    if miss.key_externs.is_empty() {
+        return None;
+    }
+    let changed = changed_deps(events, &miss.crate_name, &miss.root, miss.ts)?;
+    if changed.is_empty() {
+        return None;
+    }
+
+    let mut hops = Vec::new();
+    let mut visited: HashSet<String> = HashSet::new();
+    visited.insert(miss.crate_name.clone());
+
+    let mut current = miss.crate_name.clone();
+    let mut current_changed = changed;
+    let mut truncated = None;
+
+    let root = loop {
+        // Follow a dependency that actually has a compiled event to inspect;
+        // a dependency that only ever hit cannot be the thing that moved.
+        let followed = current_changed
+            .iter()
+            .find(|dep| {
+                !visited.contains(&dep.name)
+                    && last_compiled(events, &dep.name, &miss.root, miss.ts).is_some()
+            })
+            .or_else(|| current_changed.iter().find(|d| !visited.contains(&d.name)))
+            .cloned();
+
+        let Some(dep) = followed else {
+            // Every changed dependency is already on the path: a cycle in the
+            // recorded data, not a real dependency cycle. Stop and report the
+            // crate we are on.
+            truncated = Some("cycle in recorded dependency digests");
+            break classify(events, &current, &miss.root, miss.ts);
+        };
+
+        let siblings = current_changed
+            .iter()
+            .filter(|d| d.name != dep.name)
+            .map(|d| d.name.clone())
+            .take(MAX_LISTED)
+            .collect();
+        hops.push(Hop {
+            crate_name: current.clone(),
+            via: dep.clone(),
+            siblings,
+        });
+
+        if hops.len() >= MAX_DEPTH {
+            truncated = Some("chain longer than the walk limit");
+            break classify(events, &dep.name, &miss.root, miss.ts);
+        }
+
+        visited.insert(dep.name.clone());
+
+        // Does this dependency's own miss point further down?
+        match changed_deps(events, &dep.name, &miss.root, miss.ts) {
+            Some(next) if !next.is_empty() => {
+                current = dep.name;
+                current_changed = next;
+            }
+            // Its dependencies are stable (or undiffable): it is the root.
+            _ => break classify(events, &dep.name, &miss.root, miss.ts),
+        }
+    };
+
+    Some(Chain {
+        hops,
+        root,
+        truncated,
+    })
+}
+
+/// Dependencies whose digests differ between `crate_name`'s last compile at or
+/// before `at` and the last hit preceding it.
+///
+/// `None` when there is no diffable pair (no compile, no prior hit, or either
+/// side recorded no digests) — distinct from `Some(vec![])`, which means the
+/// pair exists and the dependencies are identical.
+fn changed_deps(
+    events: &[BuildEvent],
+    crate_name: &str,
+    root: &str,
+    at: DateTime<Utc>,
+) -> Option<Vec<ChangedDep>> {
+    let compiled = last_compiled(events, crate_name, root, at)?;
+    if compiled.key_externs.is_empty() {
+        return None;
+    }
+    let hit = last_hit_before(events, crate_name, root, compiled.ts)?;
+    if hit.key_externs.is_empty() {
+        return None;
+    }
+    Some(diff_externs(&hit.key_externs, &compiled.key_externs))
+}
+
+/// Symmetric diff of two dependency-digest maps, sorted by name.
+fn diff_externs(
+    before: &BTreeMap<String, String>,
+    after: &BTreeMap<String, String>,
+) -> Vec<ChangedDep> {
+    let mut out = Vec::new();
+    for (name, to) in after {
+        match before.get(name) {
+            Some(from) if from == to => {}
+            from => out.push(ChangedDep {
+                name: name.clone(),
+                from: from.cloned(),
+                to: Some(to.clone()),
+            }),
+        }
+    }
+    // Dependencies that disappeared also moved the key.
+    for (name, from) in before {
+        if !after.contains_key(name) {
+            out.push(ChangedDep {
+                name: name.clone(),
+                from: Some(from.clone()),
+                to: None,
+            });
+        }
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+/// Explain a crate's own divergence, dependencies aside.
+fn classify(events: &[BuildEvent], crate_name: &str, root: &str, at: DateTime<Utc>) -> Root {
+    let passthroughs = passthroughs_for(events, crate_name, root, at);
+    let Some(compiled) = last_compiled(events, crate_name, root, at) else {
+        return Root {
+            crate_name: crate_name.to_string(),
+            kind: RootKind::NoMissRecorded,
+            passthroughs,
+        };
+    };
+    let Some(hit) = last_hit_before(events, crate_name, root, compiled.ts) else {
+        return Root {
+            crate_name: crate_name.to_string(),
+            kind: RootKind::NoBaseline,
+            passthroughs,
+        };
+    };
+
+    // Prefer the diff the wrapper already computed; fall back to diffing the
+    // group digests here when `explain_miss` was off at the time.
+    let mut groups: Vec<String> = if compiled.key_diff.is_empty() {
+        changed_groups(&hit.key_fields, &compiled.key_fields)
+    } else {
+        compiled.key_diff.clone()
+    };
+    groups.retain(|g| g != "externs");
+    groups.sort();
+    groups.dedup();
+
+    let kind = if groups.is_empty() {
+        RootKind::NothingRecorded
+    } else {
+        RootKind::Groups(groups)
+    };
+    Root {
+        crate_name: crate_name.to_string(),
+        kind,
+        passthroughs,
+    }
+}
+
+fn changed_groups(
+    before: &BTreeMap<String, String>,
+    after: &BTreeMap<String, String>,
+) -> Vec<String> {
+    let mut out: Vec<String> = after
+        .iter()
+        .filter(|(group, digest)| before.get(*group) != Some(digest))
+        .map(|(group, _)| group.clone())
+        .collect();
+    out.extend(before.keys().filter(|g| !after.contains_key(*g)).cloned());
+    out
+}
+
+/// Passthrough compiles plausibly belonging to `crate_name`, grouped by reason.
+///
+/// Attribution is a heuristic and deliberately a loose one. A cc invocation
+/// driven by a build script logs the source file as its `crate_name`
+/// (`bcm.c`), so it cannot be joined to the Rust crate by name; what it does
+/// carry is a `root` derived from the build-script cwd, which for a registry
+/// dependency contains the package directory (`.../aws-lc-sys-0.43.0/...`).
+/// Matching on that names the right crate for the case this exists to
+/// diagnose, and when it is wrong it over-reports rather than pointing
+/// somewhere else. `cli` labels the line as inferred.
+fn passthroughs_for(
+    events: &[BuildEvent],
+    crate_name: &str,
+    root: &str,
+    at: DateTime<Utc>,
+) -> Vec<PassthroughGroup> {
+    let needle = crate_name.replace('_', "-");
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for event in events {
+        if event.result != EventResult::Passthrough || event.ts > at {
+            continue;
+        }
+        // Skip the build tree's own root: every event shares it, so matching
+        // on it would attribute the whole build to whichever crate is asked
+        // about.
+        if event.root == root || event.root.is_empty() {
+            continue;
+        }
+        if !package_dir_matches(&event.root, &needle) {
+            continue;
+        }
+        let reason = if event.passthrough_reason.is_empty() {
+            "(no reason recorded)".to_string()
+        } else {
+            event.passthrough_reason.clone()
+        };
+        *counts.entry(reason).or_default() += 1;
+    }
+    let mut out: Vec<PassthroughGroup> = counts
+        .into_iter()
+        .map(|(reason, count)| PassthroughGroup { reason, count })
+        .collect();
+    out.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.reason.cmp(&b.reason)));
+    out.truncate(MAX_LISTED);
+    out
+}
+
+/// Whether any path component of `root` is the package directory for
+/// `needle` — exactly `needle`, or `needle-<version>`.
+///
+/// Component-wise and version-aware on purpose: a plain `contains` would let
+/// `aws-lc` match `aws-lc-sys-0.43.0` and attribute one crate's passthroughs
+/// to another.
+fn package_dir_matches(root: &str, needle: &str) -> bool {
+    std::path::Path::new(root)
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .any(|component| {
+            component == needle
+                || component
+                    .strip_prefix(needle)
+                    .and_then(|rest| rest.strip_prefix('-'))
+                    .is_some_and(|version| version.starts_with(|c: char| c.is_ascii_digit()))
+        })
+}
+
+fn last_compiled<'a>(
+    events: &'a [BuildEvent],
+    crate_name: &str,
+    root: &str,
+    at: DateTime<Utc>,
+) -> Option<&'a BuildEvent> {
+    events.iter().rev().find(|e| {
+        e.crate_name == crate_name
+            && same_root(e, root)
+            && e.ts <= at
+            && matches!(e.result, EventResult::Miss | EventResult::Dup)
+    })
+}
+
+fn last_hit_before<'a>(
+    events: &'a [BuildEvent],
+    crate_name: &str,
+    root: &str,
+    before: DateTime<Utc>,
+) -> Option<&'a BuildEvent> {
+    events.iter().rev().find(|e| {
+        e.crate_name == crate_name
+            && same_root(e, root)
+            && e.ts < before
+            && matches!(
+                e.result,
+                EventResult::LocalHit | EventResult::PrefetchHit | EventResult::RemoteHit
+            )
+    })
+}
+
+/// Scope to one build tree, tolerating legacy events that recorded no root
+/// (matching those would be better than dropping the whole diagnosis).
+fn same_root(event: &BuildEvent, root: &str) -> bool {
+    root.is_empty() || event.root.is_empty() || event.root == root
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(1_700_000_000 + secs, 0).unwrap()
+    }
+
+    fn event(
+        crate_name: &str,
+        result: EventResult,
+        at: i64,
+        externs: &[(&str, &str)],
+    ) -> BuildEvent {
+        let mut e = BuildEvent::new_for_test(crate_name, result);
+        e.ts = ts(at);
+        e.root = "/w".to_string();
+        e.key_externs = externs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        e
+    }
+
+    fn with_fields(mut e: BuildEvent, fields: &[(&str, &str)]) -> BuildEvent {
+        e.key_fields = fields
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        e
+    }
+
+    /// The #580 shape: a leaf `-sys` crate's artifact moves and re-keys two
+    /// crates above it. The walk must name the leaf, not the crate asked about.
+    #[test]
+    fn walks_a_cascade_to_the_leaf_that_changed() {
+        let events = vec![
+            // Baseline hits.
+            event(
+                "rig_core",
+                EventResult::LocalHit,
+                0,
+                &[("aws_lc_rs", "aaaa")],
+            ),
+            event(
+                "aws_lc_rs",
+                EventResult::LocalHit,
+                1,
+                &[("aws_lc_sys", "bbbb")],
+            ),
+            with_fields(
+                event("aws_lc_sys", EventResult::LocalHit, 2, &[("libc", "cccc")]),
+                &[("sources", "1111")],
+            ),
+            // The leaf recompiles with different sources; the cascade follows.
+            with_fields(
+                event("aws_lc_sys", EventResult::Miss, 10, &[("libc", "cccc")]),
+                &[("sources", "2222")],
+            ),
+            event(
+                "aws_lc_rs",
+                EventResult::Miss,
+                11,
+                &[("aws_lc_sys", "dddd")],
+            ),
+            event("rig_core", EventResult::Miss, 12, &[("aws_lc_rs", "eeee")]),
+        ];
+        let miss = events.last().unwrap();
+
+        let chain = analyze(&events, miss).expect("cascade should be reported");
+        assert_eq!(
+            chain
+                .hops
+                .iter()
+                .map(|h| (h.crate_name.as_str(), h.via.name.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("rig_core", "aws_lc_rs"), ("aws_lc_rs", "aws_lc_sys")]
+        );
+        assert_eq!(chain.root.crate_name, "aws_lc_sys");
+        assert_eq!(
+            chain.root.kind,
+            RootKind::Groups(vec!["sources".to_string()])
+        );
+        assert!(chain.truncated.is_none());
+    }
+
+    /// A crate whose own dependencies are unchanged is not part of a cascade,
+    /// and must not be dressed up as one.
+    #[test]
+    fn reports_nothing_when_dependencies_are_stable() {
+        let events = vec![
+            event("foo", EventResult::LocalHit, 0, &[("bar", "aaaa")]),
+            event("foo", EventResult::Miss, 1, &[("bar", "aaaa")]),
+        ];
+        assert!(analyze(&events, events.last().unwrap()).is_none());
+    }
+
+    /// Without recorded digests there is nothing to walk, and the caller must
+    /// fall back to the existing diagnosis rather than print an empty chain.
+    #[test]
+    fn reports_nothing_without_recorded_digests() {
+        let events = vec![
+            event("foo", EventResult::LocalHit, 0, &[]),
+            event("foo", EventResult::Miss, 1, &[]),
+        ];
+        assert!(analyze(&events, events.last().unwrap()).is_none());
+    }
+
+    /// A dependency that moved but never missed in the window is still worth
+    /// naming; the walk just cannot go past it.
+    #[test]
+    fn stops_at_a_dependency_with_no_recorded_miss() {
+        let events = vec![
+            event("foo", EventResult::LocalHit, 0, &[("bar", "aaaa")]),
+            event("foo", EventResult::Miss, 1, &[("bar", "bbbb")]),
+        ];
+        let chain = analyze(&events, events.last().unwrap()).unwrap();
+        assert_eq!(chain.root.crate_name, "bar");
+        assert_eq!(chain.root.kind, RootKind::NoMissRecorded);
+    }
+
+    /// Digests that point in a loop must terminate the walk, not spin it.
+    #[test]
+    fn terminates_on_a_cycle_in_recorded_digests() {
+        let events = vec![
+            event("a", EventResult::LocalHit, 0, &[("b", "1111")]),
+            event("b", EventResult::LocalHit, 1, &[("a", "3333")]),
+            event("b", EventResult::Miss, 10, &[("a", "4444")]),
+            event("a", EventResult::Miss, 11, &[("b", "2222")]),
+        ];
+        let chain = analyze(&events, events.last().unwrap()).unwrap();
+        assert_eq!(
+            chain.truncated,
+            Some("cycle in recorded dependency digests")
+        );
+        assert!(chain.hops.len() <= MAX_DEPTH);
+    }
+
+    /// Several dependencies moving at once must not silently drop all but one.
+    #[test]
+    fn records_siblings_when_several_dependencies_moved() {
+        let events = vec![
+            event(
+                "foo",
+                EventResult::LocalHit,
+                0,
+                &[("bar", "aaaa"), ("baz", "cccc")],
+            ),
+            event(
+                "foo",
+                EventResult::Miss,
+                1,
+                &[("bar", "bbbb"), ("baz", "dddd")],
+            ),
+        ];
+        let chain = analyze(&events, events.last().unwrap()).unwrap();
+        assert_eq!(chain.hops.len(), 1);
+        assert_eq!(chain.hops[0].siblings, vec!["baz".to_string()]);
+    }
+
+    #[test]
+    fn diff_externs_reports_added_and_removed() {
+        let before: BTreeMap<String, String> = [
+            ("keep".to_string(), "1".to_string()),
+            ("gone".to_string(), "2".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let after: BTreeMap<String, String> = [
+            ("keep".to_string(), "1".to_string()),
+            ("new".to_string(), "3".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let diff = diff_externs(&before, &after);
+        assert_eq!(
+            diff,
+            vec![
+                ChangedDep {
+                    name: "gone".to_string(),
+                    from: Some("2".to_string()),
+                    to: None
+                },
+                ChangedDep {
+                    name: "new".to_string(),
+                    from: None,
+                    to: Some("3".to_string())
+                },
+            ]
+        );
+    }
+
+    /// The passthrough join is by package directory, so a shorter crate name
+    /// must not absorb a longer one's uncached compiles.
+    #[test]
+    fn package_dir_match_is_component_and_version_aware() {
+        assert!(package_dir_matches(
+            "/home/u/.cargo/registry/src/idx/aws-lc-sys-0.43.0",
+            "aws-lc-sys"
+        ));
+        assert!(package_dir_matches("/src/aws-lc-sys", "aws-lc-sys"));
+        // `aws-lc` must not swallow `aws-lc-sys`.
+        assert!(!package_dir_matches(
+            "/home/u/.cargo/registry/src/idx/aws-lc-sys-0.43.0",
+            "aws-lc"
+        ));
+        // A substring that isn't a whole component doesn't count.
+        assert!(!package_dir_matches(
+            "/src/my-aws-lc-sys-fork",
+            "aws-lc-sys"
+        ));
+    }
+
+    /// The root crate's uncached cc TUs are the actionable half of the answer.
+    #[test]
+    fn attributes_passthroughs_to_the_root_package_dir() {
+        let mut pt = BuildEvent::new_for_test("bcm.c", EventResult::Passthrough);
+        pt.ts = ts(5);
+        pt.root = "/home/u/.cargo/registry/src/idx/aws-lc-sys-0.43.0".to_string();
+        pt.passthrough_reason = "cc unsupported flag(s): --include=... — not yet".to_string();
+
+        let mut unrelated = pt.clone();
+        unrelated.root = "/home/u/.cargo/registry/src/idx/ring-0.17.8".to_string();
+
+        let events = vec![
+            event("aws_lc_sys", EventResult::LocalHit, 0, &[("libc", "cccc")]),
+            pt.clone(),
+            pt,
+            unrelated,
+            event("aws_lc_sys", EventResult::Miss, 10, &[("libc", "cccc")]),
+        ];
+        let root = classify(&events, "aws_lc_sys", "/w", ts(10));
+        assert_eq!(root.passthroughs.len(), 1);
+        assert_eq!(root.passthroughs[0].count, 2);
+        assert!(root.passthroughs[0].reason.contains("--include="));
+    }
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -2850,6 +2850,7 @@ mod tests {
             key_fields: Default::default(),
             key_diff: Vec::new(),
             key_externs: Default::default(),
+            key_externs_recorded: false,
         }
     }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -2849,6 +2849,7 @@ mod tests {
             exit_code: None,
             key_fields: Default::default(),
             key_diff: Vec::new(),
+            key_externs: Default::default(),
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2127,6 +2127,7 @@ mod tests {
             key_fields: Default::default(),
             key_diff: Vec::new(),
             key_externs: Default::default(),
+            key_externs_recorded: false,
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2126,6 +2126,7 @@ mod tests {
             exit_code: Some(0),
             key_fields: Default::default(),
             key_diff: Vec::new(),
+            key_externs: Default::default(),
         }
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2301,9 +2301,14 @@ fn log_event_details(
     // process; persisted only under `explain_miss` (#609). Unlike `key_diff`,
     // this rides HITS too — the chain walk diffs a miss against the last hit,
     // so a hit with no recorded externs leaves nothing to diff against.
-    let key_externs = crate::cache_key::take_last_key_externs().unwrap_or_default();
-    let key_externs = if config.explain_miss {
-        key_externs
+    // `Some(map)` means a rustc key was computed for this compile, even when
+    // the map is empty (a crate with no dependencies) — which the cascade walk
+    // must be able to tell apart from "not recorded". Persisted only under
+    // `explain_miss`.
+    let recorded_externs = crate::cache_key::take_last_key_externs();
+    let key_externs_recorded = config.explain_miss && recorded_externs.is_some();
+    let key_externs = if key_externs_recorded {
+        recorded_externs.unwrap_or_default()
     } else {
         Default::default()
     };
@@ -2347,6 +2352,7 @@ fn log_event_details(
         key_fields,
         key_diff,
         key_externs,
+        key_externs_recorded,
     };
     let _ = events::log_event(&config.event_log_path(), &event);
     let _ = events::rotate_if_needed(

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2297,6 +2297,16 @@ fn log_event_details(
     // passthrough). Consumed here, at the single write site, so no signature
     // threading (kunobi-ninja/kache#131).
     let key_fields = crate::cache_key::take_last_key_fields().unwrap_or_default();
+    // Always consumed, so the stash never leaks into a later compile in this
+    // process; persisted only under `explain_miss` (#609). Unlike `key_diff`,
+    // this rides HITS too — the chain walk diffs a miss against the last hit,
+    // so a hit with no recorded externs leaves nothing to diff against.
+    let key_externs = crate::cache_key::take_last_key_externs().unwrap_or_default();
+    let key_externs = if config.explain_miss {
+        key_externs
+    } else {
+        Default::default()
+    };
     let key_diff = explain_miss_diff(config, root, crate_name, result, cache_key, &key_fields);
     let event = BuildEvent {
         ts: Utc::now(),
@@ -2308,7 +2318,7 @@ fn log_event_details(
         compile_time_ms,
         size,
         cache_key: cache_key.to_string(),
-        schema: 11,
+        schema: 12,
         session_id,
         key_ms,
         key_hash_hits: key_hash_stats.cache_hits,
@@ -2336,6 +2346,7 @@ fn log_event_details(
         exit_code,
         key_fields,
         key_diff,
+        key_externs,
     };
     let _ = events::log_event(&config.event_log_path(), &event);
     let _ = events::rotate_if_needed(
@@ -3906,7 +3917,7 @@ mod tests {
         assert_eq!(event.compile_time_ms, 20);
         assert_eq!(event.size, 30);
         assert_eq!(event.cache_key, "cache-key");
-        assert_eq!(event.schema, 11);
+        assert_eq!(event.schema, 12);
         assert_eq!(event.key_ms, 40);
         assert_eq!(event.key_hash_hits, 4);
         assert_eq!(event.key_hash_misses, 5);


### PR DESCRIPTION
Closes #609. Follows #607, which fixed the specific flags behind the #580 cascade; this is about not needing a manual investigation the next time an equivalent one shows up.

## The problem

When one crate's artifact content moves, `extern:<name>=<hash>` re-keys every crate above it. `why-miss` then reports the same thing for all of them:

```
Differences detected:
  - same config as 37d5a93469ec -- likely source code, dependency, or rustc version change
```

True for the crate that changed, useless for the forty that are only downstream of it. The reporter in #580 had to work down the chain by hand to find that `aws_lc_sys` was the root and that its C TUs were passing through uncached.

#131 already records a digest per key input **group**, so kache could say "the externs group changed" but not which extern.

## What this does

Records the digests per **dependency** as well (`key_externs`, event schema 12), teed off the hashes the externs loop already computes, so no extra I/O. The walk is then mechanical: diff a crate's compile against the previous recorded state of that crate to see which dependencies moved, then repeat for each until reaching crates whose divergence is not itself dependency-driven.

```
Dependency cascade: this miss is downstream of a dependency that changed (mid)
  root: leaf -- own inputs changed: sources
    via: top <- mid <- leaf
```

The root's uncached compiles are reported too, which is the actionable half: a passthrough there means its artifact varies per checkout, and the reason names the flag to add to `CC_FLAGS`.

## Design notes worth reviewing

**Every branch is walked, and roots are ranked by convergence.** In a real cascade the crate being asked about usually has several changed dependencies (#580's `rig_core` sits above `aws_lc_rs`, `aws_sdk_*`, `async_nats`, all re-keyed by the same leaf). Following one and calling it "the root" would be an arbitrary choice dressed up as a diagnosis; bailing out whenever more than one moved would give up exactly where this is needed. So the walk explores all branches under a node budget and ranks endpoints by how many branches reach them. The crate most branches converge on is the one to look at.

**Selection is by position, never timestamp.** Each hop searches strictly before its parent's event, so a dependency recompiled after the parent consumed its artifact cannot be selected as the cause. Two events can also share a timestamp.

**Unresolved endpoints are labeled as unresolved, not as roots.** "Compared and stable" is the only state that supports concluding a crate ends the cascade. "History not comparable", cycles, and limit stops each get their own wording, and the renderer says plainly when nothing was explained.

**Gated behind `[cache] explain_miss`,** so off by default. A crate with 150 dependencies would otherwise add 150 entries to every event on the hot path. The cost is that you must have opted in before the build you want to diagnose; `why-miss` says so when the digests are absent rather than staying silent. Flipping the default is a separate call.

**Passthrough attribution is heuristic.** A cc invocation logs its source file as `crate_name` (`bcm.c`), so it cannot be joined to the Rust crate by name. The join is on the package directory in the event root, matched component-wise, split on both path separators, and requiring a semver-shaped version so neither `aws-lc` nor `foo-2-helper-0.1.0` absorbs another crate's passthroughs. Bounded to events before the compile being explained. Output labels it as inferred.

## Known limitation

`crate_name` is not a stable compilation-unit identity. Two versions of a package, host-vs-target units, and Cargo `package = "..."` renames all collapse onto one name, so a walk can pair events belonging to different units. Nothing here can repair that; it needs a producer identity (package id plus unit disambiguator) recorded per extern. Where the recorded history does not support a conclusion, the walk reports an unresolved endpoint rather than a confident wrong one. Documented in the module header.

## Structure

The walk is a pure function over already-read events (no store, no filesystem, no clock) in its own module, with a depth cap, a node budget, and cycle detection. `key_externs` is additive and `#[serde(default)]`, so schema-11 lines still parse; a test pins that.

## Verification

Full workspace suite green (1353 + others), `cargo fmt --check` and `clippy --all-targets --all-features -D warnings` clean.

Verified live on a three-crate cascade: changing only the leaf names the leaf, `why-miss` on the leaf itself claims no cascade, and a build with `explain_miss` off prints the hint.

The second commit is a round of fixes from a cross-model review of the first. Each item has a test that fails on the old behavior:

- event selection was by timestamp and could pick a later, causally unrelated compile of a dependency
- the baseline was the last **hit**, so after two consecutive misses the diff reported everything that moved across both and could follow the wrong branch
- "history not comparable" was collapsed into "compared and stable", which invented roots out of missing data
- an empty digest map was indistinguishable from an unrecorded one, so a dependency-free crate (a very common cascade root) ended the branch unresolved; a `key_externs_recorded` flag now separates the two
- a missing event root acted as a wildcard and could pair crates from unrelated workspaces
- a chain of exactly `MAX_DEPTH` was marked truncated without checking whether its endpoint was already a root
- the extern stash is now cleared on entry to `compute_cache_key`, so a computation that never reaches the event writer cannot donate its digests to the next one
