### PR TITLE
chore: bump kache to v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more, with S3 and shared-filesystem remotes."
 license = "Apache-2.0"
@@ -36,7 +36,7 @@ reqsign-aws-v4 = { version = "=3.0.2", default-features = false }
 reqsign-core = { version = "=3.1.0", default-features = false }
 # Direct dep so OpenDAL/reqwest can use ring without reintroducing aws-lc.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.11.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.12.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps the workspace version from 0.11.0 to 0.12.0.

Touches the four workspace manifests plus the lockfile, matching the shape of the previous bump (2aa704e, 0.10.0 -> 0.11.0):

- `Cargo.toml` (workspace version + the `kache-core` path dependency)
- `crates/kache-core/Cargo.toml`
- `crates/kache-e2e/Cargo.toml`
- `crates/kache-service/Cargo.toml`
- `Cargo.lock` (regenerated with `cargo update --workspace --offline`, workspace members only)

Nothing else pins the version:

- `aur/kache-bin/PKGBUILD` has `pkgver=0.11.0`, but `package-publish.yml` rewrites it from the release tag, so the in-repo value is a placeholder.
- `charts/kache-service/Chart.yaml` stays at `0.0.0` and is stamped at publish time.
- No version literals in code or tests; everything reads `env!("CARGO_PKG_VERSION")`.

`cargo check --workspace --all-targets` passes.