### PR TITLE
fix(prefetch): merge planner sources; stop inferring whole-bucket warms (#614, #615)

### DIFF
--- a/crates/kache-core/src/lib.rs
+++ b/crates/kache-core/src/lib.rs
@@ -80,19 +80,17 @@ where
     if let Some(namespace) = intent.namespace.as_deref()
         && !intent.cargo_lock_deps.is_empty()
     {
-        match source
+        // A failed shard lookup is not fatal: the sources below still run.
+        if let Ok(shard_candidates) = source
             .shard_candidates(namespace, &intent.cargo_lock_deps)
             .await
         {
-            Ok(shard_candidates) => {
-                for candidate in order_candidates_by_crate_order(shard_candidates, intent) {
-                    resolved_crates.insert(candidate.crate_name.clone());
-                    if seen.insert(candidate.cache_key.clone()) {
-                        candidates.push(candidate);
-                    }
+            for candidate in order_candidates_by_crate_order(shard_candidates, intent) {
+                resolved_crates.insert(candidate.crate_name.clone());
+                if seen.insert(candidate.cache_key.clone()) {
+                    candidates.push(candidate);
                 }
             }
-            Err(_) => {}
         }
     }
 

--- a/crates/kache-core/src/lib.rs
+++ b/crates/kache-core/src/lib.rs
@@ -65,6 +65,18 @@ pub async fn build_prefetch_plan<T>(
 where
     T: PlannerDataSource + Sync + ?Sized,
 {
+    let crate_order = crate_query_order(intent);
+    let mut seen = HashSet::new();
+    let mut resolved_crates = HashSet::new();
+    let mut candidates = Vec::new();
+
+    // Sources are merged in descending order of confidence, each one filling
+    // only the crates the ones before it left unresolved. Shard lookups used
+    // to RETURN as soon as they produced anything (kunobi-ninja/kache#614),
+    // but a shard hit is exact per bucket: one dependency bump invalidates one
+    // of `NUM_SHARDS` buckets while the rest still match, so a single matching
+    // shard was enough to short-circuit history and key-cache recovery for
+    // every crate in every bucket that missed.
     if let Some(namespace) = intent.namespace.as_deref()
         && !intent.cargo_lock_deps.is_empty()
     {
@@ -72,35 +84,41 @@ where
             .shard_candidates(namespace, &intent.cargo_lock_deps)
             .await
         {
-            Ok(candidates) if !candidates.is_empty() => {
-                return Ok(execute_plan(
-                    planner_name,
-                    order_candidates_by_crate_order(candidates, intent),
-                ));
+            Ok(shard_candidates) => {
+                for candidate in order_candidates_by_crate_order(shard_candidates, intent) {
+                    resolved_crates.insert(candidate.crate_name.clone());
+                    if seen.insert(candidate.cache_key.clone()) {
+                        candidates.push(candidate);
+                    }
+                }
             }
-            Ok(_) | Err(_) => {}
+            Err(_) => {}
         }
     }
 
-    let crate_order = crate_query_order(intent);
-    let mut seen = HashSet::new();
-    let mut resolved_crates = HashSet::new();
-    let mut candidates = Vec::new();
+    let unresolved = |resolved: &HashSet<String>| -> Vec<String> {
+        crate_order
+            .iter()
+            .filter(|name| !resolved.contains(*name))
+            .cloned()
+            .collect()
+    };
 
-    for candidate in
-        order_candidates_by_crate_order(source.history_candidates(&crate_order).await?, intent)
-    {
-        resolved_crates.insert(candidate.crate_name.clone());
-        if seen.insert(candidate.cache_key.clone()) {
-            candidates.push(candidate);
+    let history_query = unresolved(&resolved_crates);
+    if !history_query.is_empty() {
+        for candidate in order_candidates_by_crate_order(
+            source.history_candidates(&history_query).await?,
+            intent,
+        ) {
+            resolved_crates.insert(candidate.crate_name.clone());
+            if seen.insert(candidate.cache_key.clone()) {
+                candidates.push(candidate);
+            }
         }
     }
 
-    for crate_name in crate_order
-        .iter()
-        .filter(|name| !resolved_crates.contains(*name))
-    {
-        for cache_key in source.key_cache_keys_for_crate(crate_name).await? {
+    for crate_name in unresolved(&resolved_crates) {
+        for cache_key in source.key_cache_keys_for_crate(&crate_name).await? {
             if seen.insert(cache_key.clone()) {
                 candidates.push(PrefetchCandidate {
                     cache_key,
@@ -385,6 +403,88 @@ mod tests {
             .map(|candidate| candidate.cache_key.as_str())
             .collect::<Vec<_>>();
         assert_eq!(keys, vec!["dep-key", "middle-key", "app-key"]);
+    }
+
+    /// A PARTIAL shard hit must not suppress the lower-confidence sources
+    /// (kunobi-ninja/kache#614).
+    ///
+    /// Shard matching is exact per bucket, so a dependency bump invalidates
+    /// one bucket while the rest still match. The planner used to return as
+    /// soon as shards produced anything, so the crates in the missed buckets
+    /// were dropped from the plan even though history and the key cache could
+    /// resolve them.
+    #[cfg(feature = "planning")]
+    #[tokio::test]
+    async fn test_build_prefetch_plan_fills_crates_a_partial_shard_hit_missed() {
+        let mut source = FakePlannerDataSource {
+            // Only `dep` is in a bucket that still matches.
+            shard_candidates: vec![PrefetchCandidate {
+                cache_key: "dep-shard-key".into(),
+                crate_name: "dep".into(),
+            }],
+            history_by_crate: HashMap::from([("middle".into(), "middle-history-key".into())]),
+            ..Default::default()
+        };
+        source
+            .key_cache
+            .insert("app".into(), vec!["app-key-cache-key".into()]);
+
+        let intent = BuildIntent {
+            crate_names: vec!["dep".into(), "middle".into(), "app".into()],
+            namespace: Some("linux/hash/debug".into()),
+            cargo_lock_deps: vec![("dep".into(), "1.0.0".into())],
+        };
+
+        let plan = build_prefetch_plan(&source, &intent, "fallback")
+            .await
+            .unwrap();
+
+        let keys = plan
+            .candidates
+            .iter()
+            .map(|candidate| candidate.cache_key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            keys,
+            vec!["dep-shard-key", "middle-history-key", "app-key-cache-key"],
+            "each source should fill the crates the higher-confidence ones left unresolved"
+        );
+    }
+
+    /// A crate the shards already resolved is not re-queried from the
+    /// lower-confidence sources (#614): shard keys are exact, history and the
+    /// key cache are not, so they only fill gaps.
+    #[cfg(feature = "planning")]
+    #[tokio::test]
+    async fn test_build_prefetch_plan_does_not_requery_shard_resolved_crates() {
+        let mut source = FakePlannerDataSource {
+            shard_candidates: vec![PrefetchCandidate {
+                cache_key: "serde-shard-key".into(),
+                crate_name: "serde".into(),
+            }],
+            history_by_crate: HashMap::from([("serde".into(), "serde-stale-history-key".into())]),
+            ..Default::default()
+        };
+        source
+            .key_cache
+            .insert("serde".into(), vec!["serde-stale-key-cache-key".into()]);
+
+        let intent = BuildIntent {
+            crate_names: vec!["serde".into()],
+            namespace: Some("linux/hash/debug".into()),
+            cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+        };
+
+        let plan = build_prefetch_plan(&source, &intent, "fallback")
+            .await
+            .unwrap();
+
+        let keys = plan
+            .candidates
+            .iter()
+            .map(|candidate| candidate.cache_key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec!["serde-shard-key"]);
     }
 
     #[cfg(feature = "planning")]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -446,11 +446,23 @@ pub struct HashFileResult {
 pub struct PrefetchRequest {
     /// (cache_key, crate_name) pairs
     pub keys: Vec<(String, String)>,
+    /// Warm the whole remote: LIST every key in the bucket and download the
+    /// ones missing locally, in addition to `keys`.
+    ///
+    /// This has to be asked for explicitly (kunobi-ninja/kache#615). It used
+    /// to be what an EMPTY `keys` meant, so any caller that encoded "no
+    /// candidates" the obvious way started a download proportional to the
+    /// entire bucket. An empty `keys` now means what it says: nothing to do.
+    ///
+    /// Still unbounded by key count, bytes, or time — see #616.
+    #[serde(default)]
+    pub warm_all: bool,
 }
 
 impl PrefetchRequest {
     pub fn from_plan(plan: PrefetchPlan) -> Self {
         Self {
+            warm_all: false,
             keys: plan
                 .candidates
                 .into_iter()
@@ -2547,8 +2559,10 @@ impl Daemon {
         }
         drop(downloading_guard);
 
-        // If empty keys were sent, fetch all remote keys missing locally.
-        if req.keys.is_empty()
+        // Explicitly requested whole-remote warm (#615). Never inferred from an
+        // empty candidate list: that made "nothing to prefetch" mean "download
+        // the bucket".
+        if req.warm_all
             && let Ok(backend) = self.get_remote_backend().await
             && let Ok(s3_keys) = crate::remote_plan::RemotePlanner::new(&self.config)
                 .plan(crate::remote_plan::RemoteWorkload::KeyDiscovery)
@@ -3937,6 +3951,7 @@ async fn shard_prefetch_for_deps(
     let count = prefetch_keys.len();
     let req = PrefetchRequest {
         keys: prefetch_keys,
+        warm_all: false,
     };
     let resp = daemon.handle_prefetch(&req).await;
     if !resp.ok {
@@ -4002,6 +4017,7 @@ async fn monolithic_manifest_prefetch(
 
     let req = PrefetchRequest {
         keys: prefetch_keys,
+        warm_all: false,
     };
     let resp = daemon.handle_prefetch(&req).await;
     if !resp.ok {
@@ -4485,6 +4501,7 @@ pub fn send_prefetch(config: &Config, keys: &[(String, String)]) -> Result<()> {
 
     let req = Request::Prefetch(PrefetchRequest {
         keys: keys.to_vec(),
+        warm_all: false,
     });
 
     let try_send = |path: &Path| -> Result<()> { send_request_fire_and_forget(path, &req) };
@@ -7947,7 +7964,10 @@ mod tests {
         let resp = one_shot_request(
             &daemon,
             &socket_path,
-            &Request::Prefetch(PrefetchRequest { keys: Vec::new() }),
+            &Request::Prefetch(PrefetchRequest {
+                keys: Vec::new(),
+                warm_all: false,
+            }),
         )
         .await;
 
@@ -8349,6 +8369,7 @@ mod tests {
         let resp = daemon
             .handle_prefetch(&PrefetchRequest {
                 keys: vec![(key.to_string(), "serde".to_string())],
+                warm_all: false,
             })
             .await;
         assert!(resp.ok, "prefetch dispatch should be ok: {resp:?}");
@@ -8397,6 +8418,7 @@ mod tests {
         let resp = daemon
             .handle_prefetch(&PrefetchRequest {
                 keys: vec![(key.to_string(), "serde".to_string())],
+                warm_all: false,
             })
             .await;
         assert!(
@@ -8593,6 +8615,7 @@ mod tests {
                 ("key_a".into(), "serde".into()),
                 ("key_b".into(), "tokio".into()),
             ],
+            warm_all: false,
         });
         let json = serde_json::to_string(&req).unwrap();
         let parsed: Request = serde_json::from_str(&json).unwrap();
@@ -8621,7 +8644,10 @@ mod tests {
 
     #[test]
     fn test_prefetch_request_empty_keys_serde() {
-        let req = Request::Prefetch(PrefetchRequest { keys: vec![] }); // empty vec of (String, String)
+        let req = Request::Prefetch(PrefetchRequest {
+            keys: vec![],
+            warm_all: false,
+        });
         let json = serde_json::to_string(&req).unwrap();
         let parsed: Request = serde_json::from_str(&json).unwrap();
         assert_eq!(req, parsed);
@@ -8840,6 +8866,7 @@ mod tests {
 
         let req = PrefetchRequest {
             keys: vec![("k".into(), "mycrate".into())],
+            warm_all: false,
         };
         let resp = daemon.handle_prefetch(&req).await;
         assert!(!resp.ok);
@@ -8848,6 +8875,112 @@ mod tests {
                 .as_deref()
                 .unwrap()
                 .contains("no remote configured")
+        );
+    }
+
+    /// An empty candidate list must mean "nothing to prefetch", never
+    /// "download the whole bucket" (kunobi-ninja/kache#615).
+    ///
+    /// The remote here holds an entry that is missing locally, so the old
+    /// empty-list sentinel would have LISTed the bucket and queued it.
+    #[tokio::test]
+    async fn test_empty_prefetch_request_does_not_warm_the_bucket() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+
+        let key = "cccccccccccccccc".repeat(4);
+        let client = test_remote_backend();
+        // Both objects, so the key IS discoverable by listing — otherwise this
+        // test would pass even with the old empty-list-means-everything path.
+        put_test_object(&client, &test_manifest_object_key(&key, "serde"), b"{}").await;
+        put_test_object(
+            &client,
+            &test_pack_object_key(&key, "serde"),
+            &build_entry_pack(&key, "serde"),
+        )
+        .await;
+
+        let daemon = Arc::new(Daemon::new(config.clone()));
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
+
+        let resp = daemon
+            .handle_prefetch(&PrefetchRequest {
+                keys: Vec::new(),
+                warm_all: false,
+            })
+            .await;
+        assert!(
+            resp.ok,
+            "an empty request is a no-op, not an error: {resp:?}"
+        );
+
+        // Nothing may be claimed, queued, or imported.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            daemon.downloading.read().await.is_empty(),
+            "an empty prefetch request must not claim any key"
+        );
+        assert!(
+            !config.store_dir().join(&key).join("meta.json").exists(),
+            "an empty prefetch request must not download anything"
+        );
+        assert_eq!(
+            daemon
+                .transfer_counters
+                .downloads_completed
+                .load(Ordering::Relaxed),
+            0
+        );
+    }
+
+    /// Whole-remote warming still works, but only when asked for (#615).
+    #[tokio::test]
+    async fn test_warm_all_prefetch_request_downloads_missing_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+
+        let key = "dddddddddddddddd".repeat(4);
+        let client = test_remote_backend();
+        // `list_keys` discovers keys from the manifest objects, not the packs.
+        put_test_object(&client, &test_manifest_object_key(&key, "serde"), b"{}").await;
+        put_test_object(
+            &client,
+            &test_pack_object_key(&key, "serde"),
+            &build_entry_pack(&key, "serde"),
+        )
+        .await;
+
+        let daemon = Arc::new(Daemon::new(config.clone()));
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
+
+        let resp = daemon
+            .handle_prefetch(&PrefetchRequest {
+                keys: Vec::new(),
+                warm_all: true,
+            })
+            .await;
+        assert!(resp.ok, "warm_all dispatch should be ok: {resp:?}");
+
+        let entry_meta = config.store_dir().join(&key).join("meta.json");
+        let mut imported = false;
+        for _ in 0..100 {
+            if entry_meta.exists() {
+                imported = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(
+            imported,
+            "warm_all should discover the key by listing and import it"
         );
     }
 
@@ -8912,6 +9045,7 @@ mod tests {
                     (stalled_key.clone(), "serde".to_string()),
                     (demanded_key.clone(), "serde".to_string()),
                 ],
+                warm_all: false,
             })
             .await;
         assert!(resp.ok, "prefetch dispatch should be ok: {resp:?}");
@@ -9108,6 +9242,7 @@ mod tests {
             &socket_path,
             &Request::Prefetch(PrefetchRequest {
                 keys: vec![("key1".into(), "mycrate".into())],
+                warm_all: false,
             }),
         )
         .await;


### PR DESCRIPTION
Fixes #614. Fixes #615.

Two independent defects in how a prefetch plan is built and dispatched. Both are small and in
the planning path, so they travel together.

## #614: a partial shard hit suppressed every fallback

`build_prefetch_plan` returned as soon as the shard lookup produced any candidates. Shard
matching is exact per bucket: `blake3(crate_name) % NUM_SHARDS` picks the bucket and the shard
hash covers that bucket's sorted `name@version` list, so one dependency bump invalidates one
bucket while the other 63 still match.

A single matching shard was therefore enough to short-circuit history and key-cache recovery
for every crate in every bucket that missed. The result was indistinguishable from a full hit:
an `Execute` plan with candidates, silently missing the crates most likely to need downloading,
since the missed buckets are exactly the ones a recent dependency change touched.

Sources are now merged in descending order of confidence, each filling only the crates the ones
before it left unresolved: shards, then local history, then the remote key cache. Crates already
resolved by shards are no longer re-queried from the lower-confidence sources, which also drops
a store lookup per resolved crate.

Candidates stay grouped by source rather than globally re-sorted by crate order. Ranking is
#617's problem, and the pre-existing history/key-cache path already concatenated this way.

## #615: an empty request meant "download the whole bucket"

An empty `PrefetchRequest.keys` did not mean "nothing to prefetch". It meant "LIST the whole
bucket and download everything missing locally", with no budget on the result. Any caller that
encoded no-candidates the obvious way started a download proportional to the entire remote.

The `BuildStarted` path happened to guard against it by checking `candidates.is_empty()` before
building the request, but that was a property of one call site rather than of the API.

Whole-remote warming now has to be asked for: a `warm_all` field, `#[serde(default)]` so an old
client's `{"keys": []}` becomes a no-op rather than a bucket-sized download. Making it a required
field in Rust also made the compiler enumerate every construction site. It is still unbounded by
keys, bytes, or time, which is #616.

Nothing in-tree relied on the old sentinel: the only caller that could reach it, `send_prefetch`,
is `#[allow(dead_code)]`.

## Tests

Four added. Two were confirmed red before the fix and green after:

- `test_build_prefetch_plan_fills_crates_a_partial_shard_hit_missed` — with the old logic the
  plan is `["dep-shard-key"]` instead of all three crates
- `test_empty_prefetch_request_does_not_warm_the_bucket` — with the old condition restored it
  fails on "an empty prefetch request must not download anything". The fixture deliberately
  seeds both the manifest and pack objects so the key IS discoverable by listing; otherwise the
  test would pass vacuously

The other two are regression guards rather than reproductions:
`test_build_prefetch_plan_does_not_requery_shard_resolved_crates` (passes on old code too, since
the early return produced the same result) and `test_warm_all_prefetch_request_downloads_missing_keys`.

Verified on the commit in an isolated worktree, so unrelated work in my tree could not affect it:
1360 bin tests and 11 kache-core tests pass, `cargo clippy --all-targets --all-features` clean,
`cargo fmt --check` clean.
