### PR TITLE
fix(e2e): enforce gate integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,7 @@ jobs:
       # the cargo build or a fixture's `make`. Mirrors the verification step in
       # ans-runners/tasks/windows/setup_packages.yml — keep the two tool lists in sync.
       #   cc/c++/make  -> C/C++ fixtures (harness sets CC="$KACHE cc")
+      #   clang/clang-cl -> fixtures that exercise clang-specific classification
       #   nasm         -> ring's x86_64 `.asm` (the rustls crypto provider).
       #                   perl/cmake are no longer needed: they were aws-lc-sys
       #                   build deps, and aws-lc-sys was dropped in favour of ring.
@@ -294,8 +295,18 @@ jobs:
               missing=1
             fi
           done
+          for t in clang clang-cl; do
+            if [ ! -f "$CLANG_CL_BIN/$t.exe" ]; then
+              echo "MISSING: $t at $CLANG_CL_BIN — provision it (see ans-runners/tasks/windows/setup_packages.yml)"
+              missing=1
+            fi
+          done
           [ -z "$missing" ] || exit 1
+          cygpath -w "$CLANG_CL_BIN" >> "$GITHUB_PATH"
           echo "all build/fixture tools present"
+        env:
+          # VS-integrated LLVM is provisioned but not on the runner's default PATH.
+          CLANG_CL_BIN: "/c/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/x64/bin"
       # Point tool state at the per-run temp dir before installing. All the
       # self-hosted runners (macOS AND Windows) are persistent: shared rustup /
       # mise state goes stale and makes `mise --force rust` try to remove a
@@ -403,26 +414,47 @@ jobs:
         # against `kache report --format json`, and writes a single
         # results.json. Replaces the previous per-language bash scripts.
         run: |
+          rm -rf tmp/e2e
           mkdir -p tmp/e2e
           # Bounded retry to absorb transient self-hosted-runner / Windows
           # file-system flakes (e.g. a relocate-phase build hiccup). Each
           # attempt is a full clean re-run, so cache assertions stay sound.
           # A real failure fails all attempts; retries are logged as warnings
           # so a genuinely-intermittent issue stays visible, not hidden.
-          n=0
-          until ./target/release/kache-scenario${{ matrix.exe_suffix }} \
-            --kache ./target/release/kache${{ matrix.exe_suffix }} \
-            --scenarios ./scenarios \
-            --select suite:e2e \
-            --select tier:gate \
-            --out tmp/e2e/results.json
-          do
-            n=$((n + 1))
-            if [ "$n" -ge 3 ]; then
-              echo "::error::e2e harness failed after $n attempts"
-              exit 1
+          attempt=1
+          while true; do
+            attempt_out="tmp/e2e/results-attempt-${attempt}.json"
+            rm -f "$attempt_out"
+            if ./target/release/kache-scenario${{ matrix.exe_suffix }} \
+              --kache ./target/release/kache${{ matrix.exe_suffix }} \
+              --scenarios ./scenarios \
+              --select suite:e2e \
+              --select tier:gate \
+              --deny-missing-tools \
+              --out "$attempt_out"
+            then
+              mv "$attempt_out" tmp/e2e/results.json
+              break
+            else
+              rc=$?
             fi
-            echo "::warning::e2e harness attempt $n failed; retrying (transient-flake mitigation)"
+            if [ -f "$attempt_out" ]; then
+              mv "$attempt_out" "tmp/e2e/results-attempt-${attempt}-failed.json"
+            fi
+            if [ "$rc" -eq 2 ]; then
+              echo "::error::e2e harness found missing tools on supported fixtures; not retrying"
+              exit 2
+            fi
+            if [ "$rc" -ne 1 ]; then
+              echo "::error::e2e harness exited unexpectedly with status $rc; not retrying"
+              exit "$rc"
+            fi
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::e2e harness failed after $attempt attempts"
+              exit "$rc"
+            fi
+            echo "::warning::e2e harness attempt $attempt failed; retrying (transient-flake mitigation)"
+            attempt=$((attempt + 1))
             sleep 15
           done
       - name: Run e2e negative-control (falsifiability check)
@@ -440,6 +472,7 @@ jobs:
             --scenarios ./scenarios \
             --select suite:e2e \
             --select tier:gate \
+            --deny-missing-tools \
             --negative-control \
             --out tmp/e2e/negative-control.json
       - name: Check the sccache fallback caches an rlib

--- a/crates/kache-e2e/src/bench_profile.rs
+++ b/crates/kache-e2e/src/bench_profile.rs
@@ -19,6 +19,7 @@ use crate::scenario::{ScenarioChecks, Selectors, SourceKind, discover_metadata};
 /// A project the clone benchmark engine can benchmark, parsed from
 /// `scenarios/bench-*/scenario.toml`.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BenchProfile {
     /// Scenario id; must match the scenario directory (`bench-firefox`).
     pub name: String,
@@ -102,6 +103,7 @@ pub struct BenchProfile {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct BenchSourceConfig {
     kind: SourceKind,
     repo: String,
@@ -115,6 +117,7 @@ struct BenchSourceConfig {
 /// One file injection. The `mode` selects how `content` is applied; it
 /// defaults to [`FileMode::Write`].
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct FileInject {
     /// Path relative to the checkout root.
     pub path: String,
@@ -463,22 +466,43 @@ fn expected_name_for_path(path: &Path) -> String {
 
 /// Minimal `which`: first `PATH` entry containing an executable named
 /// `tool`. Enough for the `requires` skip check.
-fn which_on_path(tool: &str) -> Option<PathBuf> {
+pub(crate) fn which_on_path(tool: &str) -> Option<PathBuf> {
     let path = std::env::var_os("PATH")?;
     std::env::split_paths(&path).find_map(|dir| executable_in_dir(&dir, tool))
+}
+
+/// Find a program that can be launched directly with `std::process::Command`.
+/// Unlike [`which_on_path`], this does not accept Windows shell scripts.
+pub(crate) fn native_executable_on_path(tool: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path).find_map(|dir| native_executable_in_dir(&dir, tool))
 }
 
 /// Find an executable named `tool` in `dir`: the exact name, plus — on
 /// Windows — the usual executable extensions, so a bare `cargo` matches
 /// `cargo.exe` (PATH entries on Windows hold `*.exe`, not extensionless files).
 fn executable_in_dir(dir: &Path, tool: &str) -> Option<PathBuf> {
+    if let Some(candidate) = native_executable_in_dir(dir, tool) {
+        return Some(candidate);
+    }
+    #[cfg(windows)]
+    for ext in ["cmd", "bat"] {
+        let candidate = dir.join(format!("{tool}.{ext}"));
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn native_executable_in_dir(dir: &Path, tool: &str) -> Option<PathBuf> {
     let exact = dir.join(tool);
     if exact.is_file() {
         return Some(exact);
     }
     #[cfg(windows)]
-    for ext in ["exe", "cmd", "bat"] {
-        let candidate = dir.join(format!("{tool}.{ext}"));
+    {
+        let candidate = dir.join(format!("{tool}.exe"));
         if candidate.is_file() {
             return Some(candidate);
         }
@@ -491,7 +515,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn executable_in_dir_finds_exact_and_windows_exe() {
+    fn executable_in_dir_distinguishes_shell_and_native_programs() {
         let dir = std::env::temp_dir().join(format!("kb-which-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         // Exact name is found on every platform.
@@ -505,6 +529,21 @@ mod tests {
         assert_eq!(got, Some(dir.join("foo.exe")));
         #[cfg(not(windows))]
         assert_eq!(got, None);
+        // Shell scripts are valid for shell-driven bench requirements, but
+        // not for fixture delegates launched directly by Command.
+        std::fs::write(dir.join("baz.cmd"), b"@exit /b 0\r\n").unwrap();
+        let shell = executable_in_dir(&dir, "baz");
+        let native = native_executable_in_dir(&dir, "baz");
+        #[cfg(windows)]
+        {
+            assert_eq!(shell, Some(dir.join("baz.cmd")));
+            assert_eq!(native, None);
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(shell, None);
+            assert_eq!(native, None);
+        }
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -534,6 +573,54 @@ build = "cargo build"
         assert!(p.requires.is_empty());
         assert!(p.files.is_empty());
         assert_eq!(p.dir, dir.path());
+    }
+
+    #[test]
+    fn rejects_misspelled_bench_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let root_typo = write_profile(
+            dir.path(),
+            "root-typo",
+            r#"
+name = "root-typo"
+repo = "https://example.com/demo.git"
+ref = "v1"
+objdir = "target"
+build = "cargo build"
+setup_maker = "~/.ready"
+"#,
+        );
+        let err = BenchProfile::load(&root_typo).unwrap_err();
+        let message = format!("{err:#}");
+        assert!(message.contains("unknown field"), "{message}");
+
+        let file_typo = write_profile(
+            dir.path(),
+            "file-typo",
+            r#"
+name = "file-typo"
+repo = "https://example.com/demo.git"
+ref = "v1"
+objdir = "target"
+build = "cargo build"
+
+[[file]]
+path = "config"
+mod = "append"
+content = "value"
+"#,
+        );
+        let err = BenchProfile::load(&file_typo).unwrap_err();
+        let message = format!("{err:#}");
+        assert!(message.contains("unknown field"), "{message}");
+    }
+
+    #[test]
+    fn all_shipped_bench_schemas_load() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scenarios");
+        let selectors = Selectors::parse_many(&["suite:bench".to_string()]).unwrap();
+        let profiles = BenchProfile::discover(&root, &selectors).unwrap();
+        assert!(!profiles.is_empty());
     }
 
     #[test]

--- a/crates/kache-e2e/src/fixture.rs
+++ b/crates/kache-e2e/src/fixture.rs
@@ -30,6 +30,7 @@ pub struct FixtureSourceConfig {
 
 /// A single example project the harness will drive.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Fixture {
     /// Human-readable identifier; used in result JSON and CLI output.
     /// Must match the scenario directory name (the harness checks this).
@@ -145,6 +146,7 @@ pub struct Fixture {
 /// one the real compiler produced on the cold build. Catches
 /// store/restore corruption and wrong-key miscaches.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DiffSpec {
     /// Artifact paths relative to the project root (e.g.
     /// `build/foo.o`). Compared after cold (the baseline) and after
@@ -160,6 +162,7 @@ pub struct DiffSpec {
 /// across a relocation. Guards the stale-restore bug class (a content
 /// change wrongly served from cache).
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ModifySpec {
     /// Source file to edit, relative to the project root.
     pub file: String,
@@ -187,6 +190,7 @@ pub struct Commands {
 /// (MinGW C objects can't link into an MSVC Rust binary), which changes the
 /// build command and the artifact output paths.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OsOverride {
     /// Replaces `commands.build`.
     #[serde(default)]
@@ -225,6 +229,7 @@ pub struct OsOverride {
 /// embeds machine-local paths in DWARF / panic strings / track_caller)
 /// surfaces structurally.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Verify {
     /// Shell command (relative paths resolve against fixture dir).
     pub run: String,
@@ -263,6 +268,7 @@ fn default_verify_timeout() -> u64 {
 /// Per-phase assertion bundle. Absent phases skip assertion checks
 /// entirely (the phase still runs and is measured).
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PhaseAssertions {
     pub cold: Option<MetricAssertions>,
     pub warm: Option<MetricAssertions>,
@@ -305,6 +311,7 @@ pub struct PhaseAssertions {
 /// opt-in (`Option<...>`) — declaring only the constraints that matter
 /// for this fixture keeps the toml signal-to-noise high.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MetricAssertions {
     /// Lower bound on `summary.total_crates` (events seen this phase).
     /// Useful as a coarse "did anything land in the cache" check.
@@ -358,6 +365,7 @@ pub struct MetricAssertions {
 /// by grepping the build's stdout for [`NoopAssertions::recompile_marker`]
 /// (e.g. cargo's `"Compiling"`).
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NoopAssertions {
     /// If `true` and the marker appears in stdout, the assertion fails.
     /// If `false`, the assertion passes regardless (used by skeleton
@@ -448,6 +456,14 @@ impl Fixture {
                 scenario_name
             ));
         }
+        for os in &fixture.os {
+            if !matches!(os.as_str(), "linux" | "macos" | "windows") {
+                return Err(anyhow!(
+                    "fixture `{}` declares unsupported operating system `{os}`",
+                    fixture.name
+                ));
+            }
+        }
         let source_dir = match &fixture.source {
             Some(source) => {
                 if source.kind != SourceKind::Fixture {
@@ -524,6 +540,78 @@ pub fn discover(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rejects_unknown_fixture_and_assertion_fields() {
+        for raw in [
+            r#"
+name = "e2e-typo"
+requiers = ["cargo"]
+
+[commands]
+build = "cargo build"
+clean = "rm -rf target"
+"#,
+            r#"
+name = "e2e-typo"
+
+[commands]
+build = "cargo build"
+clean = "rm -rf target"
+
+[assertions.warm]
+min_hitz = 1
+"#,
+        ] {
+            let err = toml::from_str::<Fixture>(raw).unwrap_err();
+            assert!(err.to_string().contains("unknown field"), "{err}");
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_operating_systems() {
+        let temp = tempfile::tempdir().unwrap();
+        let scenario = temp.path().join("e2e-invalid-os");
+        std::fs::create_dir_all(scenario.join("source")).unwrap();
+        std::fs::write(
+            scenario.join("scenario.toml"),
+            r#"
+name = "e2e-invalid-os"
+os = ["windwos"]
+
+[source]
+kind = "fixture"
+path = "source"
+
+[commands]
+build = "unused"
+clean = "unused"
+"#,
+        )
+        .unwrap();
+
+        let err =
+            Fixture::load(&scenario, Path::new("/kache"), Path::new("/fallback")).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported operating system `windwos`"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn all_shipped_fixture_schemas_load() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scenarios");
+        let selectors = Selectors::parse_many(&["suite:e2e".to_string()]).unwrap();
+        let fixtures = discover(
+            &root,
+            &selectors,
+            Path::new("/kache"),
+            Path::new("/fallback"),
+        )
+        .unwrap();
+        assert!(!fixtures.is_empty());
+    }
 
     #[test]
     fn expand_tokens_substitutes_paths() {

--- a/crates/kache-e2e/src/fixture_runner.rs
+++ b/crates/kache-e2e/src/fixture_runner.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 use crate::fixture;
 use crate::portable_path;
-use crate::result::{FixtureResult, RunResults};
+use crate::result::{FixtureResult, RunResults, SkipReason};
 use crate::runner;
 use crate::scenario::Selectors;
 
@@ -18,6 +18,7 @@ pub struct FixtureRunConfig {
     pub only: Option<String>,
     pub select: Vec<String>,
     pub negative_control: bool,
+    pub deny_missing_tools: bool,
 }
 
 pub fn run(config: FixtureRunConfig) -> Result<()> {
@@ -92,6 +93,7 @@ pub fn run(config: FixtureRunConfig) -> Result<()> {
 
     let mut fixture_results = Vec::new();
     let mut any_failed = false;
+    let mut denied_missing_tools = false;
     for fixture in fixtures.values() {
         if !fixture.os.is_empty() && !fixture.os.iter().any(|o| o == std::env::consts::OS) {
             eprintln!(
@@ -104,6 +106,10 @@ pub fn run(config: FixtureRunConfig) -> Result<()> {
             fixture_results.push(FixtureResult {
                 name: fixture.name.clone(),
                 status: "skip".to_string(),
+                skip_reason: Some(SkipReason::UnsupportedOs {
+                    current_os: std::env::consts::OS.to_string(),
+                    supported_os: fixture.os.clone(),
+                }),
                 phases: Vec::new(),
             });
             continue;
@@ -119,8 +125,14 @@ pub fn run(config: FixtureRunConfig) -> Result<()> {
             fixture_results.push(FixtureResult {
                 name: fixture.name.clone(),
                 status: "skip".to_string(),
+                skip_reason: Some(SkipReason::MissingTools {
+                    tools: missing.clone(),
+                }),
                 phases: Vec::new(),
             });
+            if config.deny_missing_tools {
+                denied_missing_tools = true;
+            }
             continue;
         }
         let result = runner::run_fixture(fixture, &kache_path)?;
@@ -174,6 +186,10 @@ pub fn run(config: FixtureRunConfig) -> Result<()> {
         .with_context(|| format!("writing {}", config.out.display()))?;
     eprintln!("Results written to {}", config.out.display());
 
+    if denied_missing_tools {
+        eprintln!("FAIL: one or more supported fixtures are missing required tools");
+        std::process::exit(2);
+    }
     if any_failed {
         eprintln!(
             "{}",
@@ -185,22 +201,25 @@ pub fn run(config: FixtureRunConfig) -> Result<()> {
         );
         std::process::exit(1);
     }
-    eprintln!(
-        "{}",
-        if config.negative_control {
-            "PASS: negative-control — every non-exempt fixture is falsifiable"
-        } else {
-            "PASS: all fixtures green"
-        }
-    );
+    let skipped = results
+        .fixtures
+        .iter()
+        .filter(|result| result.status == "skip")
+        .count();
+    if config.negative_control {
+        eprintln!(
+            "PASS: negative-control — every executed non-exempt fixture is falsifiable ({skipped} skipped)"
+        );
+    } else {
+        eprintln!("PASS: all executed fixtures green ({skipped} skipped)");
+    }
     Ok(())
 }
 
 fn missing_tools(tools: &[String]) -> Vec<String> {
-    let path = std::env::var_os("PATH").unwrap_or_default();
     tools
         .iter()
-        .filter(|tool| !std::env::split_paths(&path).any(|dir| dir.join(tool).is_file()))
+        .filter(|tool| crate::bench_profile::native_executable_on_path(tool).is_none())
         .cloned()
         .collect()
 }

--- a/crates/kache-e2e/src/result.rs
+++ b/crates/kache-e2e/src/result.rs
@@ -30,7 +30,22 @@ pub struct FixtureResult {
     /// string (not bool) so future states (`"skip"`, `"flaky"`) can land
     /// without breaking consumers.
     pub status: String,
+    /// Why a fixture did not execute. Absent for pass/fail results.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip_reason: Option<SkipReason>,
     pub phases: Vec<PhaseResult>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SkipReason {
+    UnsupportedOs {
+        current_os: String,
+        supported_os: Vec<String>,
+    },
+    MissingTools {
+        tools: Vec<String>,
+    },
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -264,6 +264,7 @@ pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult
     Ok(FixtureResult {
         name: fixture.name.clone(),
         status,
+        skip_reason: None,
         phases: phase_results,
     })
 }

--- a/crates/kache-e2e/src/scenario.rs
+++ b/crates/kache-e2e/src/scenario.rs
@@ -200,6 +200,7 @@ pub fn discover_metadata(root: &Path) -> Result<Vec<ScenarioMetadata>> {
 /// gives clone-style scenarios a shared blocking verdict surface, while
 /// `checks.measure` is advisory only.
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ScenarioChecks {
     #[serde(default, rename = "assert")]
     pub assertions: PhaseAssertSpecs,
@@ -239,6 +240,7 @@ impl PhaseAssertSpecs {
 
 /// Blocking thresholds currently used by clone-scale scenarios.
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ScenarioAssertSpec {
     pub min_key_stability_pct: Option<f64>,
     pub max_passthrough_pct: Option<f64>,
@@ -278,6 +280,7 @@ impl PhaseMeasureSpecs {
 /// Advisory thresholds. Violations are recorded as warnings in results JSON
 /// and never change phase/scenario status.
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MeasureSpec {
     pub max_wall_s: Option<u64>,
     pub min_hit_rate_pct: Option<f64>,
@@ -694,6 +697,17 @@ min_hit_rate_pct = 50.0
             .for_phase("pull")
             .expect("pull measure gate must bind");
         assert_eq!(measure.min_hit_rate_pct, Some(50.0));
+    }
+
+    #[test]
+    fn scenario_checks_reject_misspelled_fields() {
+        for raw in [
+            "[assert.warm]\nmax_erors = 0\n",
+            "[measure.warm]\nmin_hit_rate_pxt = 90.0\n",
+        ] {
+            let err = toml::from_str::<ScenarioChecks>(raw).unwrap_err();
+            assert!(err.to_string().contains("unknown field"), "{err}");
+        }
     }
 
     #[test]

--- a/crates/kache-e2e/src/scenario_runner.rs
+++ b/crates/kache-e2e/src/scenario_runner.rs
@@ -55,6 +55,10 @@ struct Args {
     #[arg(long)]
     negative_control: bool,
 
+    /// Fail after writing results if a supported fixture is missing a required tool.
+    #[arg(long)]
+    deny_missing_tools: bool,
+
     /// Override a selected clone scenario's pinned `source.ref`.
     #[arg(long = "ref")]
     git_ref: Option<String>,
@@ -120,6 +124,9 @@ pub fn main() -> Result<()> {
     if args.negative_control && clone_selected {
         bail!("--negative-control is only valid for fixture scenarios");
     }
+    if args.deny_missing_tools && clone_selected {
+        bail!("--deny-missing-tools is only valid for fixture scenarios");
+    }
     let bench_flags = args.git_ref.is_some()
         || args.work_dir.is_some()
         || args.skip_clone
@@ -139,6 +146,7 @@ pub fn main() -> Result<()> {
             only: args.only.clone(),
             select: select.clone(),
             negative_control: args.negative_control,
+            deny_missing_tools: args.deny_missing_tools,
         })?;
     }
 

--- a/crates/kache-e2e/tests/strict_gate.rs
+++ b/crates/kache-e2e/tests/strict_gate.rs
@@ -1,0 +1,122 @@
+use std::process::Command;
+
+fn write_scenario(root: &std::path::Path, name: &str, constraints: &str) {
+    let scenario_dir = root.join(name);
+    std::fs::create_dir_all(scenario_dir.join("source")).unwrap();
+    std::fs::write(
+        scenario_dir.join("scenario.toml"),
+        format!(
+            r#"
+name = "{name}"
+tags = ["suite:e2e"]
+{constraints}
+
+[source]
+kind = "fixture"
+path = "source"
+
+[commands]
+build = "unused"
+clean = "unused"
+"#
+        ),
+    )
+    .unwrap();
+}
+
+fn run_strict(root: &std::path::Path, results: &std::path::Path) -> std::process::ExitStatus {
+    run(root, results, true)
+}
+
+fn run(
+    root: &std::path::Path,
+    results: &std::path::Path,
+    deny_missing_tools: bool,
+) -> std::process::ExitStatus {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kache-scenario"));
+    command
+        .arg("--kache")
+        .arg(env!("CARGO_BIN_EXE_kache-scenario"))
+        .arg("--scenarios")
+        .arg(root)
+        .arg("--select")
+        .arg("suite:e2e");
+    if deny_missing_tools {
+        command.arg("--deny-missing-tools");
+    }
+    command.arg("--out").arg(results).status().unwrap()
+}
+
+fn read_results(path: &std::path::Path) -> serde_json::Value {
+    serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap()
+}
+
+#[test]
+fn deny_missing_tools_fails_after_writing_skip_results() {
+    let temp = tempfile::tempdir().unwrap();
+    write_scenario(
+        temp.path(),
+        "e2e-missing-tool",
+        r#"requires = ["kache-e2e-tool-that-does-not-exist"]"#,
+    );
+    let results = temp.path().join("results.json");
+
+    let status = run_strict(temp.path(), &results);
+
+    assert_eq!(status.code(), Some(2));
+    let json = read_results(&results);
+    assert_eq!(json["fixtures"][0]["status"], "skip");
+    assert_eq!(json["fixtures"][0]["skip_reason"]["kind"], "missing_tools");
+    assert_eq!(
+        json["fixtures"][0]["skip_reason"]["tools"][0],
+        "kache-e2e-tool-that-does-not-exist"
+    );
+}
+
+#[test]
+fn missing_tools_remain_lenient_by_default() {
+    let temp = tempfile::tempdir().unwrap();
+    write_scenario(
+        temp.path(),
+        "e2e-missing-tool",
+        r#"requires = ["kache-e2e-tool-that-does-not-exist"]"#,
+    );
+    let results = temp.path().join("results.json");
+
+    let status = run(temp.path(), &results, false);
+
+    assert!(status.success());
+    let json = read_results(&results);
+    assert_eq!(json["fixtures"][0]["status"], "skip");
+    assert_eq!(json["fixtures"][0]["skip_reason"]["kind"], "missing_tools");
+}
+
+#[test]
+fn deny_missing_tools_allows_declared_os_skips() {
+    let temp = tempfile::tempdir().unwrap();
+    let other_os = if std::env::consts::OS == "linux" {
+        "windows"
+    } else {
+        "linux"
+    };
+    write_scenario(
+        temp.path(),
+        "e2e-other-os",
+        &format!(
+            r#"requires = ["kache-e2e-tool-that-does-not-exist"]
+os = ["{other_os}"]"#
+        ),
+    );
+    let results = temp.path().join("results.json");
+
+    let status = run_strict(temp.path(), &results);
+
+    assert!(status.success());
+    let json = read_results(&results);
+    assert_eq!(json["fixtures"][0]["status"], "skip");
+    assert_eq!(json["fixtures"][0]["skip_reason"]["kind"], "unsupported_os");
+    assert_eq!(
+        json["fixtures"][0]["skip_reason"]["current_os"],
+        std::env::consts::OS
+    );
+}

--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -60,6 +60,10 @@ Existing fixture `[assertions.<phase>]` tables remain the blocking e2e
 correctness contract. `[checks.measure.<phase>]` is advisory only and never
 fails the run.
 
+Fixtures may declare `requires = ["tool"]` and `os = ["linux", "macos",
+"windows"]`. Missing tools skip by default for local portability; CI passes
+`--deny-missing-tools`, so a supported fixture cannot silently disappear.
+
 ## Clone Benchmark Scenario
 
 Clone scenarios describe an external repository and optional file injections.

--- a/scenarios/e2e-cc-cl-debug/scenario.toml
+++ b/scenarios/e2e-cc-cl-debug/scenario.toml
@@ -9,6 +9,7 @@
 name = "e2e-cc-cl-debug"
 tags = ["suite:e2e", "lang:cc", "os:windows"]
 requires = ["clang-cl"]
+os = ["windows"]
 
 [source]
 kind = "fixture"

--- a/src/store.rs
+++ b/src/store.rs
@@ -3902,10 +3902,11 @@ mod tests {
         let mut policy_old = crate::eviction::OlderThanPolicy { hours: 24 }.select(&candidates);
         policy_old.sort();
 
-        // Away from the cutoff the two agree exactly. `boundary` sits *on* the
-        // cutoff and is the one documented divergence: SQLite's `datetime()`
-        // compares whole seconds, so the old query kept it, while `julianday()`
-        // resolves sub-second and the policy evicts it. See `OlderThanPolicy`.
+        // Away from the cutoff the two agree exactly. Do not assert boundary
+        // membership here: insertion and selection evaluate separate
+        // `datetime('now')` calls, so a second rollover can move `boundary`
+        // across the old SQL cutoff. Strict cutoff behavior is covered
+        // deterministically by `OlderThanPolicy`'s pure unit test.
         let unambiguous = |v: &[String]| -> Vec<String> {
             let mut v: Vec<String> = v.iter().filter(|k| *k != "boundary").cloned().collect();
             v.sort();
@@ -3915,14 +3916,6 @@ mod tests {
             unambiguous(&policy_old),
             unambiguous(&sql_old),
             "older-than selection diverged away from the cutoff boundary"
-        );
-        assert!(
-            !sql_old.contains(&"boundary".to_string()),
-            "sanity: whole-second SQL should keep the on-cutoff entry"
-        );
-        assert!(
-            policy_old.contains(&"boundary".to_string()),
-            "sub-second comparison should evict the on-cutoff entry (documented difference)"
         );
 
         let sql_dup: Vec<String> = {


### PR DESCRIPTION
## Summary

- add `--deny-missing-tools`: eligible fixtures with missing prerequisites write structured skip evidence, then exit 2; declared OS skips remain valid
- reject unknown fixture/bench/check TOML fields and invalid OS names
- make fixture executable discovery Windows `.exe`-aware without accepting shell-only `.cmd`/`.bat` delegates
- mark the real `clang-cl` fixture Windows-only and make CI retries preserve fresh per-attempt evidence
- verify and expose VS LLVM on the Windows E2E runner
- remove a timing-dependent exact-boundary assertion from the store parity test; strict cutoff behavior remains covered by a deterministic unit test

## Why

Missing prerequisites previously produced an indistinguishable `status: "skip"` and exit 0. CI therefore stayed green while coverage silently disappeared. TOML typos were also ignored by Serde, allowing intended assertions or requirements to vanish.

Local runs remain lenient by default. CI opts into the strict contract.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p kache`
- `cargo test -p kache-e2e` — 87 unit tests and 3 strict-gate integration tests passed
- strict release E2E — 38 executed, 2 declared OS skips, 0 missing-tool skips
- strict negative-control — every executed non-exempt fixture falsifiable, 2 declared OS skips
- workflow YAML parse and `git diff --check`

## Windows provisioning dependency

VS LLVM is now present on the live Windows runner, and the strict preflight passed in https://github.com/kunobi-ninja/kache/actions/runs/30200356316.

Zondax/ans-runners#9 still needs merging so that runner state is reproducible from the provisioning configuration: https://github.com/Zondax/ans-runners/pull/9
