### PR TITLE
feat(report): surface compiles that failed to store (#629)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -545,6 +545,27 @@ fn format_relative_time(sqlite_dt: &str) -> String {
 
 /// Diagnose cache misses for a specific crate by inspecting the event log
 /// and the local store.
+/// The store-failure banner for [`why_miss`], or `None` when the compile was
+/// stored normally (kunobi-ninja/kache#629).
+///
+/// A compile that ran and could not be stored answers the question outright, and
+/// it outranks the key analysis `why_miss` prints below it: the key never got
+/// the chance to matter, because nothing was written for a later build to match
+/// against. Deliberately not labelled `Diagnosis:` — that heading belongs to the
+/// stored-entry analysis, and two of them read as contradictory findings.
+fn store_failure_banner(miss: &crate::events::BuildEvent) -> Option<String> {
+    if miss.store_error.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "  NOT CACHED: this compile ran and its outputs failed to store,\n  \
+         so the crate misses on every build until the cause is fixed.\n    \
+         reason: {}\n  \
+         (the key analysis below is secondary: nothing was stored to match)",
+        miss.store_error
+    ))
+}
+
 pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
     let all_events = events::read_events(&config.event_log_path())?;
     let crate_events: Vec<_> = all_events
@@ -593,6 +614,15 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
         "  Last {}: {miss_time} (key: {miss_key_display})",
         miss.result
     );
+
+    // A compile that ran and could not be stored answers the question outright,
+    // and it outranks the key-diff analysis below: the key never got the chance
+    // to matter, because nothing was written for a later build to match against
+    // (kunobi-ninja/kache#629).
+    if let Some(banner) = store_failure_banner(miss) {
+        println!();
+        println!("{banner}");
+    }
 
     // Show miss metadata if it was subsequently stored
     if !miss.cache_key.is_empty() {
@@ -4744,6 +4774,32 @@ mod tests {
     }
 
     #[test]
+    fn why_miss_leads_with_a_store_failure_when_there_was_one() {
+        // The store-failure banner replaces guesswork about the key: nothing was
+        // stored, so no later build could have matched (kunobi-ninja/kache#629).
+        let mut miss = build_event(
+            "lint_crate",
+            crate::events::EventResult::Miss,
+            1000,
+            900,
+            4096,
+            "somekey",
+        );
+        assert!(
+            store_failure_banner(&miss).is_none(),
+            "a normal miss gets no banner"
+        );
+
+        miss.store_error = "creating blob shard directory: Permission denied (os error 13)".into();
+        let banner = store_failure_banner(&miss).expect("failed store should produce a banner");
+        assert!(banner.contains("NOT CACHED"));
+        assert!(banner.contains("Permission denied (os error 13)"));
+        // The stored-entry analysis owns the `Diagnosis:` label; a second one
+        // here would read as a competing conclusion.
+        assert!(!banner.contains("Diagnosis:"), "banner: {banner}");
+    }
+
+    #[test]
     fn why_miss_all_hits_reports_no_misses() {
         // Events exist but none are Miss/Dup -> the "all events are hits" path.
         let dir = tempfile::tempdir().unwrap();
@@ -5276,6 +5332,7 @@ mod tests {
             store_copied_bytes: 0,
             root: String::new(),
             passthrough_reason: String::new(),
+            store_error: String::new(),
             fallback: false,
             exit_code: None,
             key_fields: Default::default(),

--- a/src/events.rs
+++ b/src/events.rs
@@ -36,7 +36,8 @@ pub struct BuildEvent {
     /// 7 = restore-method bytes, 8 = dup outcome + store blob counters,
     /// 9 = event root, 10 = build session id (#583),
     /// 11 = key field hashes + miss key diff (#131),
-    /// 12 = per-extern artifact digests (#609).
+    /// 12 = per-extern artifact digests (#609),
+    /// 13 = store-failure reason (#629).
     #[serde(default)]
     pub schema: u32,
     /// Build session this event belongs to (kunobi-ninja/kache#583 P0.5).
@@ -123,6 +124,18 @@ pub struct BuildEvent {
     /// Why kache passed the invocation through instead of caching it.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub passthrough_reason: String,
+    /// Why `Store::put` failed, when the compiler ran and produced outputs that
+    /// were then not cached (kunobi-ninja/kache#629).
+    ///
+    /// The event stays a `Miss` — the compiler really did run, and demoting it
+    /// to `Skipped` would drop it out of the hit-rate denominator and out of the
+    /// miss table, which is exactly where a repeating miss is visible. This
+    /// field is the annotation that separates "cold miss, now cached" from "will
+    /// miss again on every build", which the result alone cannot express.
+    ///
+    /// Empty on every normal outcome, so it costs nothing on the wire.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub store_error: String,
     /// Whether a configured fallback wrapper handled the passthrough.
     #[serde(default, skip_serializing_if = "is_false")]
     pub fallback: bool,
@@ -904,6 +917,16 @@ pub struct EventStats {
     pub store_hardlinked_bytes: u64,
     /// Bytes ingested into the store by a full physical copy (a real second copy).
     pub store_copied_bytes: u64,
+    /// Compiles whose outputs were produced but not cached, because
+    /// `Store::put` failed (kunobi-ninja/kache#629). A subset of `misses` —
+    /// a failed put leaves the blob counters at zero, which resolves to `Miss`,
+    /// never `Dup` — counted separately because an ordinary miss becomes a hit
+    /// next build and one of these misses again every time.
+    ///
+    /// Covers the local store only. A local put that succeeded and a remote
+    /// upload that then failed is a different condition (cacheable here, likely
+    /// a miss on a fresh CI worker) and is not counted here.
+    pub store_failures: usize,
 }
 
 pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
@@ -934,6 +957,7 @@ pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
         store_reflinked_bytes: 0,
         store_hardlinked_bytes: 0,
         store_copied_bytes: 0,
+        store_failures: 0,
     };
 
     for event in events {
@@ -973,6 +997,15 @@ pub fn compute_stats(events: &[BuildEvent]) -> EventStats {
             }
             EventResult::Error => stats.errors += 1,
             EventResult::Passthrough | EventResult::Skipped => continue,
+        }
+        // Counted on top of the outcome above, not instead of it: the compile
+        // is a real miss, and this says it will be one again next build (#629).
+        // Gated on a compiled outcome so the counter cannot be inflated by a
+        // malformed or future event that carries the field on a hit or an error.
+        if matches!(event.result, EventResult::Miss | EventResult::Dup)
+            && !event.store_error.is_empty()
+        {
+            stats.store_failures += 1;
         }
         stats.total_size += event.size;
         stats.total_elapsed_ms += event.elapsed_ms;
@@ -1043,6 +1076,7 @@ impl BuildEvent {
             store_hardlinked_bytes: 0,
             store_copied_bytes: 0,
             passthrough_reason: String::new(),
+            store_error: String::new(),
             fallback: false,
             exit_code: None,
             key_fields: Default::default(),
@@ -1112,6 +1146,7 @@ mod tests {
             store_hardlinked_bytes: 0,
             store_copied_bytes: 0,
             passthrough_reason: String::new(),
+            store_error: String::new(),
             fallback: false,
             exit_code: None,
             key_fields: Default::default(),

--- a/src/report.rs
+++ b/src/report.rs
@@ -93,6 +93,12 @@ pub struct ReportSummary {
     pub probes: usize,
     #[serde(default)]
     pub skipped: usize,
+    /// Compiles that ran and produced outputs kache then failed to store
+    /// (kunobi-ninja/kache#629). Still counted in `misses` — the compiler did
+    /// run — but broken out because these are the misses that repeat on every
+    /// build instead of warming up.
+    #[serde(default)]
+    pub store_failures: usize,
     #[serde(default)]
     pub fallbacks: usize,
     pub total_duration_ms: u64,
@@ -413,6 +419,11 @@ pub struct CrateDetail {
     /// Memoized on disk — one per build per flag set, 0 once warm.
     #[serde(default)]
     pub probe_runs: u32,
+    /// Why this compile's outputs were not cached, when `Store::put` failed
+    /// (kunobi-ninja/kache#629). Empty on every normal outcome; when set, this
+    /// row is a miss that will recur on every build until the cause is fixed.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub store_error: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -654,6 +665,7 @@ pub fn generate_report_with_filter(
             passthroughs: bypass.passthroughs,
             probes: bypass.probes,
             skipped: bypass.skipped,
+            store_failures: stats.store_failures,
             fallbacks: bypass.fallbacks,
             total_duration_ms: stats.total_elapsed_ms,
             cache_efficiency_pct: {
@@ -939,6 +951,7 @@ fn to_crate_detail(e: &BuildEvent) -> CrateDetail {
         compiler_runs: e.compiler_runs,
         preprocessor_runs: e.preprocessor_runs,
         probe_runs: e.probe_runs,
+        store_error: e.store_error.clone(),
     }
 }
 
@@ -1356,6 +1369,42 @@ fn generate_suggestions(
 ) -> Vec<String> {
     let mut suggestions = Vec::new();
 
+    // Compiles kache could not store (kunobi-ninja/kache#629). First, because
+    // it outranks every tuning hint below: an ordinary miss becomes a hit on the
+    // next build, one of these misses forever. Named where possible — the
+    // reasons are per-crate causes (a corrupt output, a full disk, store
+    // permissions), not one global condition.
+    if stats.store_failures > 0 {
+        // `top_misses` is already truncated to the report's top-N, so it can
+        // hold fewer failures than actually occurred. Name the one example it
+        // gives, but take the count from `stats`, which sees every event.
+        let example = top_misses.iter().find(|c| !c.store_error.is_empty());
+        let detail = match example {
+            Some(first) => format!(
+                " — e.g. `{}`: {}{}",
+                first.crate_name,
+                first.store_error,
+                if stats.store_failures > 1 {
+                    format!(" ({} affected in total)", stats.store_failures)
+                } else {
+                    String::new()
+                }
+            ),
+            None => String::new(),
+        };
+        suggestions.push(format!(
+            "{} compile{} produced outputs kache failed to store, so {} miss on every build{}",
+            stats.store_failures,
+            if stats.store_failures == 1 { "" } else { "s" },
+            if stats.store_failures == 1 {
+                "it will"
+            } else {
+                "they will"
+            },
+            detail,
+        ));
+    }
+
     // High miss share
     let total_compiled = stats.dups + stats.misses;
     if total_cacheable > 0 && stats.miss_compile_time_ms > 0 {
@@ -1760,6 +1809,12 @@ pub fn format_markdown(report: &BuildReport) -> String {
         lines.push(format!("| Dups | {} |", s.dups));
     }
     lines.push(format!("| Misses | {} |", s.misses));
+    if s.store_failures > 0 {
+        lines.push(format!(
+            "| Compiled but not cached | {} (will miss again) |",
+            s.store_failures
+        ));
+    }
     if s.errors > 0 {
         lines.push(format!("| Errors | {} |", s.errors));
     }
@@ -2096,6 +2151,12 @@ pub fn format_github(report: &BuildReport) -> String {
         lines.push(format!(
             "| **Miss compile work** | {} aggregate |",
             format_duration_ms(t.miss_compile_time_ms)
+        ));
+    }
+    if s.store_failures > 0 {
+        lines.push(format!(
+            "| **Compiled but not cached** | {} (will miss again) |",
+            s.store_failures
         ));
     }
     if s.errors > 0 {
@@ -2523,6 +2584,12 @@ pub fn format_text(report: &BuildReport) -> String {
             format_duration_ms(t.miss_compile_time_ms)
         ));
     }
+    if s.store_failures > 0 {
+        lines.push(format!(
+            "  Compiled but not cached: {} (will miss again next build)",
+            s.store_failures
+        ));
+    }
     if s.errors > 0 {
         lines.push(format!("  Errors: {}", s.errors));
     }
@@ -2691,11 +2758,19 @@ pub fn format_text(report: &BuildReport) -> String {
     if !report.top_misses.is_empty() {
         lines.push("Top compiled cache-key misses:".to_string());
         for c in &report.top_misses {
+            // A row that failed to store is not a cold miss that warms up on the
+            // next build; say so where the user is already looking (#629).
+            let not_cached = if c.store_error.is_empty() {
+                String::new()
+            } else {
+                format!("  [not cached: {}]", c.store_error)
+            };
             lines.push(format!(
-                "  {} — {} ({})",
+                "  {} — {} ({}){}",
                 c.crate_name,
                 format_duration_ms(c.compile_time_ms),
                 format_bytes(c.size),
+                not_cached,
             ));
         }
         lines.push(String::new());
@@ -2845,6 +2920,7 @@ mod tests {
             store_hardlinked_bytes: 0,
             store_copied_bytes: 0,
             passthrough_reason: String::new(),
+            store_error: String::new(),
             fallback: false,
             exit_code: None,
             key_fields: Default::default(),
@@ -3052,6 +3128,69 @@ mod tests {
         }
 
         config
+    }
+
+    /// A compile kache failed to store stays a miss (so the hit rate keeps
+    /// counting it and the miss table keeps showing it) and is additionally
+    /// broken out as a store failure, named in the suggestions and flagged in
+    /// the miss row (kunobi-ninja/kache#629).
+    #[test]
+    fn store_failures_are_visible_without_leaving_the_miss_accounting() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = write_test_events(dir.path());
+
+        let mut failed = test_event(
+            "lint_crate",
+            EventResult::Miss,
+            60_000,
+            59_000,
+            4 * 1024 * 1024,
+            "fff999",
+        );
+        failed.store_error = "refusing to cache zero-byte artifact: liblint.rmeta".to_string();
+        events::log_event(&config.event_log_path(), &failed).unwrap();
+
+        let report = generate_report(&config, 24, 10).unwrap();
+
+        assert_eq!(report.summary.store_failures, 1);
+        // Still a miss: the compiler ran, and demoting it would drop it out of
+        // both the denominator and the miss table.
+        assert_eq!(report.summary.misses, 2);
+        assert_eq!(report.summary.total_crates, 6);
+
+        let row = report
+            .top_misses
+            .iter()
+            .find(|c| c.crate_name == "lint_crate")
+            .expect("a failed store is still listed as a compiled miss");
+        assert_eq!(
+            row.store_error,
+            "refusing to cache zero-byte artifact: liblint.rmeta"
+        );
+
+        assert!(
+            report
+                .suggestions
+                .iter()
+                .any(|s| s.contains("failed to store") && s.contains("lint_crate")),
+            "suggestions should name the crate: {:?}",
+            report.suggestions
+        );
+
+        // A hit that somehow carries the field must not inflate the counter:
+        // only a compiled outcome can be a compile that failed to store.
+        let mut bogus = test_event("serde", EventResult::LocalHit, 5, 300, 1024, "abc123def456");
+        bogus.store_error = "should not be counted".to_string();
+        events::log_event(&config.event_log_path(), &bogus).unwrap();
+        let report = generate_report(&config, 24, 10).unwrap();
+        assert_eq!(report.summary.store_failures, 1);
+
+        let text = format_text(&report);
+        assert!(text.contains("Compiled but not cached: 1"), "text: {text}");
+        assert!(
+            text.contains("[not cached: refusing to cache zero-byte artifact: liblint.rmeta]"),
+            "the miss row should carry the reason: {text}"
+        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2122,6 +2122,7 @@ mod tests {
             store_copied_bytes: 0,
             root: String::new(),
             passthrough_reason: "linker invocation".to_string(),
+            store_error: String::new(),
             fallback: false,
             exit_code: Some(0),
             key_fields: Default::default(),

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -655,6 +655,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // code and let cargo see the failure.
     let store_start = std::time::Instant::now();
     let mut store_put = StorePutResult::default();
+    let mut store_error = String::new();
     if result.exit_code == 0 && !result.artifacts.is_empty() {
         let depinfo_anchor = cc_depinfo_rewrite_root(&parsed);
         if let Some(anchor) = depinfo_anchor.as_deref() {
@@ -681,7 +682,14 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                 // budget (kunobi-ninja/kache#497). Never blocks the compile path.
                 maybe_spawn_auto_gc(config, &store);
             }
-            Err(e) => tracing::warn!("failed to store cc cache entry for {}: {}", crate_name, e),
+            Err(e) => {
+                store_error = store_error_for_event(&e);
+                tracing::warn!(
+                    "failed to store cc cache entry for {}: {}",
+                    crate_name,
+                    store_error
+                );
+            }
         }
 
         if let Some(anchor) = depinfo_anchor.as_deref() {
@@ -693,7 +701,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let elapsed = start.elapsed().as_millis() as u64;
     let size = result.artifacts.total_size();
     let event_result = event_result_for_store_put(store_put);
-    log_event_with_store_stats(
+    log_event_with_store_outcome(
         config,
         &event_root,
         &crate_name,
@@ -708,6 +716,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         0,
         store_ms,
         store_put,
+        store_error,
     );
     print_progress(&crate_name, event_result, elapsed, size);
     Ok(result.exit_code)
@@ -1556,6 +1565,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let store_start = std::time::Instant::now();
     let store_files = result.artifacts.store_files();
     let mut store_put = StorePutResult::default();
+    let mut store_error = String::new();
     match store.put_with_compile_time(
         &cache_key,
         crate_name,
@@ -1576,8 +1586,17 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         }
         // Name the crate, as the cc path already does: a failed store leaves that
         // unit re-compiling on every build while the aggregate hit rate barely
-        // moves, and the crate name is the only thread back to it (#624).
-        Err(e) => tracing::warn!("failed to store cache entry for {}: {}", crate_name, e),
+        // moves, and the crate name is the only thread back to it (#624). The
+        // reason also rides the event, so `report` / `why-miss` can say the miss
+        // is permanent rather than cold (#629).
+        Err(e) => {
+            store_error = store_error_for_event(&e);
+            tracing::warn!(
+                "failed to store cache entry for {}: {}",
+                crate_name,
+                store_error
+            );
+        }
     }
     let store_ms = store_start.elapsed().as_millis() as u64;
 
@@ -1602,7 +1621,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let elapsed = start.elapsed().as_millis() as u64;
     let size = result.artifacts.total_size();
     let event_result = event_result_for_store_put(store_put);
-    log_event_with_store_stats(
+    log_event_with_store_outcome(
         config,
         &event_root,
         crate_name,
@@ -1617,6 +1636,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         0,
         store_ms,
         store_put,
+        store_error,
     );
     print_progress(crate_name, event_result, elapsed, size);
 
@@ -2234,6 +2254,36 @@ fn log_event_with_hash_stats(
     );
 }
 
+/// Render a failed `Store::put` for the event log and the report.
+///
+/// `{:#}` keeps anyhow's whole context chain — the outer context alone
+/// ("creating blob shard directory") never names the cause. Two guards, because
+/// unlike the `WARN` this string is persisted and re-rendered inside JSON, a
+/// text table and a markdown table:
+/// - control characters (a newline from a nested compiler error) become spaces,
+///   so one failure cannot break the row it is printed in;
+/// - the result is capped, so a pathological error message cannot bloat every
+///   event line in the log.
+///
+/// Hardening for shape, not secrecy: it does not redact. The reason is derived
+/// from filesystem and SQLite errors, so it can carry absolute paths, and a
+/// report shared outside the machine carries them too.
+fn store_error_for_event(error: &anyhow::Error) -> String {
+    const MAX_CHARS: usize = 2048;
+
+    let rendered = format!("{error:#}");
+    let mut chars = rendered.chars();
+    let mut bounded: String = chars
+        .by_ref()
+        .take(MAX_CHARS)
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .collect();
+    if chars.next().is_some() {
+        bounded.push_str("… [truncated]");
+    }
+    bounded
+}
+
 #[allow(clippy::too_many_arguments)]
 fn log_event_with_store_stats(
     config: &Config,
@@ -2251,6 +2301,46 @@ fn log_event_with_store_stats(
     store_ms: u64,
     store_put: StorePutResult,
 ) {
+    log_event_with_store_outcome(
+        config,
+        root,
+        crate_name,
+        result,
+        elapsed_ms,
+        compile_time_ms,
+        size,
+        cache_key,
+        key_ms,
+        key_hash_stats,
+        lookup_ms,
+        restore_ms,
+        store_ms,
+        store_put,
+        String::new(),
+    );
+}
+
+/// Like [`log_event_with_store_stats`], but carries the reason `Store::put`
+/// failed so the compile is recorded as the *repeating* miss it is
+/// (kunobi-ninja/kache#629). `store_error` is empty on the normal path.
+#[allow(clippy::too_many_arguments)]
+fn log_event_with_store_outcome(
+    config: &Config,
+    root: &str,
+    crate_name: &str,
+    result: EventResult,
+    elapsed_ms: u64,
+    compile_time_ms: u64,
+    size: u64,
+    cache_key: &str,
+    key_ms: u64,
+    key_hash_stats: FileHashStats,
+    lookup_ms: u64,
+    restore_ms: u64,
+    store_ms: u64,
+    store_put: StorePutResult,
+    store_error: String,
+) {
     log_event_details(
         config,
         root,
@@ -2267,6 +2357,7 @@ fn log_event_with_store_stats(
         store_ms,
         store_put,
         String::new(),
+        store_error,
         false,
         None,
     );
@@ -2296,6 +2387,7 @@ fn log_passthrough_event(
         0,
         StorePutResult::default(),
         reason,
+        String::new(),
         output.fallback,
         Some(output.exit_code),
     );
@@ -2318,6 +2410,7 @@ fn log_event_details(
     store_ms: u64,
     store_put: StorePutResult,
     passthrough_reason: String,
+    store_error: String,
     fallback: bool,
     exit_code: Option<i32>,
 ) {
@@ -2357,7 +2450,7 @@ fn log_event_details(
         compile_time_ms,
         size,
         cache_key: cache_key.to_string(),
-        schema: 12,
+        schema: 13,
         session_id,
         key_ms,
         key_hash_hits: key_hash_stats.cache_hits,
@@ -2381,6 +2474,7 @@ fn log_event_details(
         store_hardlinked_bytes: crate::opcounts::store_hardlinked_bytes(),
         store_copied_bytes: crate::opcounts::store_copied_bytes(),
         passthrough_reason,
+        store_error,
         fallback,
         exit_code,
         key_fields,
@@ -3957,7 +4051,7 @@ mod tests {
         assert_eq!(event.compile_time_ms, 20);
         assert_eq!(event.size, 30);
         assert_eq!(event.cache_key, "cache-key");
-        assert_eq!(event.schema, 12);
+        assert_eq!(event.schema, 13);
         assert_eq!(event.key_ms, 40);
         assert_eq!(event.key_hash_hits, 4);
         assert_eq!(event.key_hash_misses, 5);
@@ -3968,6 +4062,77 @@ mod tests {
         assert_eq!(event.store_output_blobs, 3);
         assert_eq!(event.store_duplicate_blobs, 1);
         assert_eq!(event.store_new_blobs, 2);
+        assert!(
+            event.store_error.is_empty(),
+            "a successful store records no failure reason"
+        );
+    }
+
+    #[test]
+    fn store_error_for_event_keeps_the_chain_but_bounds_the_shape() {
+        // The whole anyhow chain, not just the outermost context — that is the
+        // half that names the cause.
+        let err = anyhow::anyhow!("Permission denied (os error 13)")
+            .context("creating blob shard directory");
+        assert_eq!(
+            store_error_for_event(&err),
+            "creating blob shard directory: Permission denied (os error 13)"
+        );
+
+        // A newline would break the report row this string is printed inside.
+        let multiline = anyhow::anyhow!("line one\nline two\r\tline three");
+        let flattened = store_error_for_event(&multiline);
+        assert!(!flattened.contains('\n') && !flattened.contains('\r'));
+        assert_eq!(flattened, "line one line two  line three");
+
+        // And it cannot grow without bound: this reason is persisted on every
+        // failing compile.
+        let huge = anyhow::anyhow!("x".repeat(5000));
+        let capped = store_error_for_event(&huge);
+        assert!(capped.ends_with("… [truncated]"));
+        assert_eq!(
+            capped.chars().count(),
+            2048 + "… [truncated]".chars().count()
+        );
+    }
+
+    /// A failed `Store::put` stays a `Miss` (the compiler ran) but carries the
+    /// reason, so the report can tell a cold miss from one that repeats forever
+    /// (kunobi-ninja/kache#629).
+    #[test]
+    fn log_event_with_store_outcome_persists_the_store_failure_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+
+        log_event_with_store_outcome(
+            &config,
+            "/repo",
+            "foo",
+            EventResult::Miss,
+            10,
+            20,
+            30,
+            "cache-key",
+            0,
+            FileHashStats::default(),
+            0,
+            0,
+            0,
+            StorePutResult::default(),
+            "refusing to cache zero-byte artifact: libfoo.rlib".to_string(),
+        );
+
+        let events = crate::events::read_events(&config.event_log_path()).unwrap();
+        let event = &events[0];
+        assert_eq!(
+            event.result,
+            EventResult::Miss,
+            "the compiler ran, so it stays a miss and stays in the hit-rate denominator"
+        );
+        assert_eq!(
+            event.store_error,
+            "refusing to cache zero-byte artifact: libfoo.rlib"
+        );
     }
 
     /// Passthrough events intentionally omit cache timings but preserve the


### PR DESCRIPTION
Fixes #629.

## What was wrong

When `Store::put` failed, the wrapper logged a `WARN` and the event was still recorded as a plain `Miss`. Accurate as far as it goes, since the compiler did run, but it loses the part that matters: nothing was stored, so the unit misses again next build, and the one after that. In a report it is indistinguishable from an ordinary cold miss.

#624 showed the effect. A workspace crate sat at the top of the miss table at roughly 60s on every CI run while the aggregate hit rate stayed at 86%, and nothing said those misses could never become hits.

## Why not `Skipped`

The obvious fix is to log these as `EventResult::Skipped` with a reason, reusing the missing-emit path. That is worse. `compute_stats` does `Passthrough | Skipped => continue`, so a `Skipped` event leaves the hit-rate denominator entirely, and `report.rs` builds the miss table by filtering on `Dup | Miss`. The row would disappear from the exact table where the problem was noticed, while the report claimed to be reporting it.

So the result stays `Miss` and the reason rides alongside it.

## What is added

- `BuildEvent.store_error`, schema 13. Additive, `#[serde(default)]`, skipped when empty, so old logs read fine and normal events are unchanged on the wire.
- `EventStats.store_failures`, counted only on a compiled outcome (`Miss` / `Dup`) so a malformed or future event carrying the field on a hit cannot inflate it.
- `kache report`: a summary line, the reason appended to the affected miss row, and a suggestion naming an example crate. The count comes from the stats rather than the truncated top-N list, which would understate it.
- `kache why-miss`: leads with the store failure. The key analysis below it is secondary when nothing was stored for a later build to match against. Deliberately not labelled `Diagnosis:`, since that heading belongs to the stored-entry analysis and two of them read as competing conclusions.
- `--format json`: `summary.store_failures`, and `top_misses[].store_error` on affected rows.

Both wrapper store paths are covered, rustc and cc. Those are the only production `Store::put` call sites; everything else that greps as `put` is either in `mod tests` or the unrelated file-hash cache.

## The reason string

It keeps anyhow's full context chain (`{:#}`), because the outer context alone does not name the cause:

```
creating blob shard directory
creating blob shard directory: Permission denied (os error 13)
```

Unlike the `WARN`, this string is persisted and re-rendered inside JSON and two table formats, so `store_error_for_event` flattens control characters (a newline would break the row it prints inside) and caps the length. That hardens shape, not secrecy: these reasons come from filesystem and SQLite errors and can carry absolute paths, so a report shared off the machine carries them too. The doc comment says so.

## Scope

Local store put only, which is what a wrapper can observe synchronously. A local put that succeeded followed by a failed remote upload is a different condition (cacheable here, likely a miss on a fresh CI worker) and is not counted. Noted in the doc comment rather than folded in.

## Verification

Forced a real failure rather than relying on unit tests alone: cold build, then `chmod -R a-w` on the store's blob directory, then edit and rebuild.

```
  Compiled but not cached: 1 (will miss again next build)
  zbfail — ~14ms (7.6 KB)  [not cached: creating blob shard directory: Permission denied (os error 13)]
  - 1 compile produced outputs kache failed to store, so it will miss on every build — e.g. `zbfail`: ...
```

`why-miss` leads with the same reason, and `--format json` carries `summary.store_failures = 1` plus the per-row reason.

Checks: 1390 unit tests, clippy clean, `cargo fmt` applied, and the full e2e gate suite green (40 fixtures, 2 skipped as platform-specific). The e2e run matters here because the harness parses `report --format json`; its structs do not deny unknown fields, so the added fields are compatible.

## Known gap

No automated test forces a real `Store::put` failure through `run` / `run_cc`. The permission trick is awkward to make portable (it is a no-op as root, which the Docker e2e runs as). That link is covered by the manual run above, with tests on either side of it: the sanitizer, the logging helper, the stats gating, and the report rendering.

## Review note

A blind 2-leg cross-model review (2/2 usable) caught three things, all fixed here: the reason string was unhardened for persisted output, the "and N more" count read from the truncated list, and the counter accepted the field on any non-skipped event. Two further concerns it raised, uncovered put call sites and possible `schema` version gating, I checked and neither exists in the tree.
