### PR TITLE
feat(prefetch): bound a plan by keys, bytes, and time (#616 stage 1)

### DIFF
--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -86,6 +86,9 @@ for AWS SDK-specific cases that need attention.
 | — | `cache.exclude` | `[]` | Source-path glob patterns that bypass kache and compile normally without lookup, store, or upload |
 | `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd compression level (1–22) |
 | `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `16` | Max concurrent remote operations; the legacy S3 name applies to both remote types |
+| `KACHE_PREFETCH_MAX_KEYS` | `cache.prefetch_max_keys` | `2000` | Max cache entries one prefetch plan may download; `0` = unlimited |
+| `KACHE_PREFETCH_MAX_BYTES` | `cache.prefetch_max_bytes` | `2GiB` | Max compressed bytes one prefetch plan may download; `0` = unlimited. Soft cap: downloads already in flight still finish, so overshoot is bounded by the prefetch concurrency |
+| `KACHE_PREFETCH_DEADLINE_SECS` | `cache.prefetch_deadline_secs` | `300` | How long a prefetch plan may keep starting downloads; `0` = no deadline |
 | `KACHE_S3_POOL_IDLE_SECS` | `cache.s3_pool_idle_secs` | `300` | How long an idle S3 connection is kept in the HTTP pool. Higher values reuse warm TLS sessions across build phases; lower this if you sit behind a load balancer that drops idle connections aggressively |
 | `KACHE_DAEMON_IDLE_TIMEOUT` | `cache.daemon_idle_timeout_secs` | `600` | Idle daemon shutdown timeout in seconds (`0` disables auto-shutdown) |
 | `KACHE_KEY_SALT` | `cache.key_salt` | — | Opaque string folded into every cache key. Change it to force a cold cache on a toolchain change kache cannot otherwise see (see [Cache-key salt](#cache-key-salt)) |

--- a/notes/design/prefetch-budgets-and-ranking.md
+++ b/notes/design/prefetch-budgets-and-ranking.md
@@ -1,0 +1,142 @@
+# Prefetch budgets and cost-aware ranking (#616, #617)
+
+Design note for the work that closes #616 (plans have no budget) and #617 (the plan path
+dropped cost weighting). Cross-model reviewed; where the two reviews disagreed with each
+other or with the first draft, the disagreement is recorded rather than averaged away.
+
+## Why this is staged
+
+The two issues share a `PrefetchCandidate` wire change, which is why they were scoped
+together. Working the design through showed the combined change spans the planner, the
+`PlannerDataSource` trait, the shard object format, the store schema query, the daemon's
+enforcement path, the remote backend's read path, config, and telemetry. Landing that as one
+change would be hard to review and hard to revert.
+
+It splits cleanly because **enforcement does not need the metadata**, and that is also the
+half that carries the safety risk:
+
+1. **Daemon hard budgets** (this stage). Keys, bytes, deadline, enforced daemon-side on the
+   existing request shape. Bounds the pathology today. No wire change.
+2. **Bound the low-confidence source.** Per-crate and plan-wide caps on key-cache expansion,
+   plus a per-crate cap on local history.
+3. **Candidate metadata on the wire.** `compile_time_ms`, size, source, demand index, all
+   `Option`, plus shard writers persisting what `ManifestEntry` already carries.
+4. **Cost-aware ranking** using that metadata, behind a versioned policy.
+
+## Decisions that hold across the stages
+
+### Unknown must neither win nor lose
+
+Every metadata field is `Option`. Zero is not unknown: the store's `size` and
+`compile_time_ms` columns default to 0 for rows predating their migrations, so a raw 0 has to
+map to `None` or an un-backfilled entry reads as "free to fetch and worthless to have".
+
+Unknown-cost candidates are not scored against known-cost ones and are not assigned a
+fabricated average. They get a bounded lane of their own so they are neither dominant nor
+invisible. Unknown-size candidates are charged a configured nominal estimate against the byte
+budget, so they cannot be free.
+
+### The daemon is the only trust boundary
+
+The planner may be a remote HTTP service and is an untrusted boundary distinct from S3. So:
+
+- The planner MAY apply its own limits. That is an efficiency measure (smaller responses,
+  smaller DB result sets, less cloning), **not** a security boundary.
+- The daemon applies its own configured limits unconditionally, and a request may only
+  *lower* them, never raise them.
+- Candidate metadata coming from a planner is advisory. Byte accounting uses bytes actually
+  read from the remote, never a claimed `artifact_size`.
+- `warm_all` is subject to the same budgets. It is a request field, so it cannot be an escape
+  hatch from them.
+
+### Estimates rank; measurements enforce
+
+`artifact_size` (and the store's `size`) are admission and ranking inputs. They are not a
+promise about compressed transfer bytes. Anything enforced has to be counted on the wire.
+
+A **hard** byte cap needs a counted, cancellable read path, and concurrent tasks must reserve
+against the budget atomically or N workers each observe the same remaining balance. Until
+that exists, this is a **soft** cap: the coordinator stops launching new downloads once the
+budget is exhausted, and overshoot is bounded by what was already in flight. That bound must
+be stated wherever the limit is documented, rather than described as a hard cap.
+
+### Ranking: three signals that disagree
+
+Confidence (which source), value (avoided compile time per byte), and urgency (roughly when
+the build will ask). Prefetch is a race against the build, so a high-value artifact needed at
+minute eight is less urgent than a medium-value one needed at second five.
+
+Admission and dispatch are separate concerns and should not share one comparator:
+
+- **Admission** decides what is worth spending a finite budget on: confidence-weighted value
+  density.
+- **Dispatch** decides what starts first: coarse urgency windows, value descending inside a
+  window. Coarse because guppy position is a weak proxy for demand time, so treating position
+  40 versus 45 as meaningful is false precision while 40 versus 400 is real.
+
+The weights are guardrail constants, not measured probabilities, and they should be versioned
+as one policy rather than exposed as a dozen environment variables.
+
+**What would settle them:** cold-CI traces carrying candidate source, demand time, actual
+compressed bytes, and whether the candidate was demanded at all. #618 has to land first,
+because today's telemetry cannot say whether a candidate arrived before it was needed. Until
+then, offline instrumented benchmarks beat pretending the weights are learned.
+
+### The key cache needs dimensioning, not just capping
+
+It maps a crate name to every cache key in the bucket, with no target, toolchain, profile, or
+feature filtering, and it is built from object names so it has neither size, cost, nor
+timestamps. A crate name is not a build identity.
+
+Capping it is the available move; it is not a fix. Selection among variants uses a
+deterministic hash over the intent fingerprint plus crate name plus cache key rather than
+lexicographic first-N, because cache keys carry no recency or compatibility ordering and
+lexicographic choice would bake in a persistent arbitrary bias. Sampling does not make a
+variant likelier to match; it only avoids that bias.
+
+Not done here, and deliberately: per-key HEAD or GET to rank variants (that reinstates the
+per-object latency prefetch exists to remove), and extending `RemoteBackend::list` to return
+sizes (touches every backend for the benefit of the source being capped).
+
+Recording variant population per crate is cheap and useful: choosing 2 of 3 variants is a
+very different bet from choosing 2 of 100.
+
+### Truncated must not look like exhausted
+
+The failure this has to avoid is a plan cut short by a budget being indistinguishable from a
+plan that had nothing more to offer.
+
+Plan statistics are optional on the wire, and **absent means "completeness unknown", not
+"complete"** — an old planner makes no claim either way. Truncation is a list of reasons, not
+a boolean, so "hit the key cap" and "hit the byte cap" stay distinguishable.
+
+Planner-reported counts and daemon-observed counts are recorded separately and labelled as
+such: the former is advice, the latter is fact.
+
+Nothing here may be labelled a prefetch hit rate or an on-time arrival. That is exactly what
+current telemetry cannot measure (#618). These numbers show whether the budgets behaved, not
+whether prefetch helped.
+
+## Recorded disagreements
+
+- **The cheap-crate filter.** The older manifest path drops candidates below
+  `KACHE_MIN_COMPILE_MS` (default 1000ms). The first draft argued for removing it, on the
+  grounds that with a real budget cheap crates simply lose, and a hard filter throws away
+  value when budget is spare. Both independent reviews argued for keeping it for known-cost
+  candidates while exempting unknown-cost ones into their own lane. Keeping it: it preserves
+  existing configurable behavior, and the exemption is what stops it becoming an
+  unknown-swallows-everything rule.
+- **Scoring arithmetic.** Integer cross-multiplication versus float scores. Integer, for
+  determinism across platforms; a plan should not depend on floating-point rounding.
+- **Budget defaults.** The two reviews proposed 60s and 90s deadlines and 4 MiB versus 16 MiB
+  unknown-size charges. These are guardrails against pathology rather than tuned optima, and
+  the note should say so wherever they are documented.
+
+## Not in scope for any stage here
+
+- Encoding target, toolchain, profile, or features into the remote key layout. That is the
+  real key-cache fix and needs its own index version and migration.
+- Feedback-driven or learned weighting (needs #618).
+- Changing adaptive cancellation (#620-adjacent).
+- Replacing the older monolithic manifest path, though it should inherit daemon enforcement.
+- Bundling or multi-object GETs.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4670,6 +4670,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         }
@@ -4966,6 +4969,7 @@ mod tests {
             bytes_downloaded: 2048,
             keys_used: 2,
             keys_cancelled: 3,
+            keys_over_budget: 0,
             cancelled: true,
             plans_advisory: 1,
             plans_fallback: 2,

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,13 @@ pub const DEFAULT_HEARTBEAT_SECS: u64 = 30;
 pub const DEFAULT_PLANNER_TIMEOUT_MS: u64 = 750;
 pub const DEFAULT_S3_POOL_IDLE_SECS: u64 = 300;
 
+/// Prefetch plan budgets (kunobi-ninja/kache#616). These bound a pathological
+/// plan; they are not tuned optima, and settling them needs the cold-CI
+/// attribution that #618 is about. 0 disables a dimension.
+pub const DEFAULT_PREFETCH_MAX_KEYS: u64 = 2000;
+pub const DEFAULT_PREFETCH_MAX_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+pub const DEFAULT_PREFETCH_DEADLINE_SECS: u64 = 300;
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub cache_dir: PathBuf,
@@ -30,6 +37,25 @@ pub struct Config {
     pub compression_level: i32,
     /// Max concurrent S3 operations (default 16).
     pub s3_concurrency: u32,
+    /// Max cache entries one prefetch plan may download (default 2000, 0 =
+    /// unlimited). A guardrail against a pathological plan, not a tuned
+    /// optimum (kunobi-ninja/kache#616). Set via `KACHE_PREFETCH_MAX_KEYS` or
+    /// `[cache] prefetch_max_keys`.
+    pub prefetch_max_keys: u64,
+    /// Max compressed bytes one prefetch plan may download (default 2 GiB,
+    /// 0 = unlimited).
+    ///
+    /// SOFT cap: the coordinator stops LAUNCHING downloads once the budget is
+    /// spent, so the overshoot is bounded by whatever was already in flight
+    /// (at most `prefetch_concurrency_cap` objects). A hard cap would need a
+    /// counted, cancellable read path in the remote backend. Set via
+    /// `KACHE_PREFETCH_MAX_BYTES` or `[cache] prefetch_max_bytes`.
+    pub prefetch_max_bytes: u64,
+    /// How long one prefetch plan may keep starting downloads, in seconds
+    /// (default 300, 0 = no deadline). Measured from plan dispatch. Downloads
+    /// already in flight are allowed to finish: cancelling one throws away
+    /// bytes already paid for.
+    pub prefetch_deadline_secs: u64,
     /// Daemon idle timeout in seconds (default 600 = 10 minutes). 0 = no timeout.
     pub daemon_idle_timeout_secs: u64,
     /// How long an idle TCP/TLS connection is kept in the S3 client's pool, in
@@ -425,6 +451,9 @@ pub(crate) struct CacheFileConfig {
     pub(crate) event_log_keep_lines: Option<usize>,
     pub(crate) compression_level: Option<i32>,
     pub(crate) s3_concurrency: Option<u32>,
+    pub(crate) prefetch_max_keys: Option<u64>,
+    pub(crate) prefetch_max_bytes: Option<String>,
+    pub(crate) prefetch_deadline_secs: Option<u64>,
     pub(crate) daemon_idle_timeout_secs: Option<u64>,
     pub(crate) s3_pool_idle_secs: Option<u64>,
     /// Secondary compiler-wrapper for passed-through compiles.
@@ -778,6 +807,45 @@ impl Config {
             .unwrap_or(3)
             .clamp(1, 22);
 
+        // Prefetch plan budgets (kunobi-ninja/kache#616). Guardrails against a
+        // pathological plan, not tuned optima; 0 disables a dimension.
+        let prefetch_max_keys = env_or_ignored("KACHE_PREFETCH_MAX_KEYS", ignore_env)
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .or_else(|| {
+                file_config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.cache.as_ref())
+                    .and_then(|c| c.prefetch_max_keys)
+            })
+            .unwrap_or(DEFAULT_PREFETCH_MAX_KEYS);
+
+        let prefetch_max_bytes = env_or_ignored("KACHE_PREFETCH_MAX_BYTES", ignore_env)
+            .ok()
+            .and_then(|s| parse_size_checked(&s, "KACHE_PREFETCH_MAX_BYTES"))
+            .or_else(|| {
+                file_config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.cache.as_ref())
+                    .and_then(|c| c.prefetch_max_bytes.as_ref())
+                    .and_then(|s| parse_size_checked(s, "[cache] prefetch_max_bytes"))
+            })
+            .unwrap_or(DEFAULT_PREFETCH_MAX_BYTES);
+
+        let prefetch_deadline_secs = env_or_ignored("KACHE_PREFETCH_DEADLINE_SECS", ignore_env)
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .or_else(|| {
+                file_config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.cache.as_ref())
+                    .and_then(|c| c.prefetch_deadline_secs)
+            })
+            .unwrap_or(DEFAULT_PREFETCH_DEADLINE_SECS);
+
         let s3_concurrency = env_or_ignored("KACHE_S3_CONCURRENCY", ignore_env)
             .ok()
             .and_then(|s| s.parse::<u32>().ok())
@@ -960,6 +1028,9 @@ impl Config {
             event_log_keep_lines,
             compression_level,
             s3_concurrency,
+            prefetch_max_keys,
+            prefetch_max_bytes,
+            prefetch_deadline_secs,
             daemon_idle_timeout_secs,
             s3_pool_idle_secs,
             fallback,
@@ -2013,6 +2084,9 @@ mod tests {
                 event_log_keep_lines: Some(500),
                 compression_level: Some(3),
                 s3_concurrency: Some(8),
+                prefetch_max_keys: None,
+                prefetch_max_bytes: None,
+                prefetch_deadline_secs: None,
                 daemon_idle_timeout_secs: None,
                 s3_pool_idle_secs: None,
                 remote: Some(RemoteFileConfig {
@@ -2198,6 +2272,9 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -2232,6 +2309,9 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -2266,6 +2346,9 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -2303,6 +2386,9 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -2585,6 +2671,9 @@ exclude = ["src/generated/**", "vendor/problem/**"]
                 event_log_keep_lines: None,
                 compression_level: Some(5),
                 s3_concurrency: None,
+                prefetch_max_keys: None,
+                prefetch_max_bytes: None,
+                prefetch_deadline_secs: None,
                 daemon_idle_timeout_secs: None,
                 s3_pool_idle_secs: None,
                 remote: None,

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -123,6 +123,12 @@ struct EditorState {
     /// carry it through verbatim on save (dropping it would silently disable the
     /// env lockdown).
     preserved_ignore_env: Option<bool>,
+    /// `[cache] prefetch_*` budgets as loaded — the editor has no form fields
+    /// for them, so carry them through verbatim on save; dropping them would
+    /// silently restore unbounded prefetch plans (kunobi-ninja/kache#616).
+    preserved_prefetch_max_keys: Option<u64>,
+    preserved_prefetch_max_bytes: Option<String>,
+    preserved_prefetch_deadline_secs: Option<u64>,
 }
 
 // ── Build form fields from FileConfig ─────────────────────────────────────
@@ -661,6 +667,9 @@ fn fields_to_file_config(
     preserved_heartbeat_secs: Option<u64>,
     preserved_explain_miss: Option<bool>,
     preserved_ignore_env: Option<bool>,
+    preserved_prefetch_max_keys: Option<u64>,
+    preserved_prefetch_max_bytes: Option<String>,
+    preserved_prefetch_deadline_secs: Option<u64>,
 ) -> FileConfig {
     let get = |key: &str| -> Option<String> {
         fields.iter().find(|f| f.key == key).and_then(|f| {
@@ -757,6 +766,9 @@ fn fields_to_file_config(
             heartbeat_secs: preserved_heartbeat_secs,
             explain_miss: preserved_explain_miss,
             ignore_env: preserved_ignore_env,
+            prefetch_max_keys: preserved_prefetch_max_keys,
+            prefetch_max_bytes: preserved_prefetch_max_bytes,
+            prefetch_deadline_secs: preserved_prefetch_deadline_secs,
             cache_executables: get_bool("cache_executables"),
             clean_incremental: get_bool("clean_incremental"),
             exclude: get_list("exclude"),
@@ -822,6 +834,15 @@ pub fn run_config_editor() -> Result<()> {
         preserved_heartbeat_secs: file_config.cache.as_ref().and_then(|c| c.heartbeat_secs),
         preserved_explain_miss: file_config.cache.as_ref().and_then(|c| c.explain_miss),
         preserved_ignore_env: file_config.cache.as_ref().and_then(|c| c.ignore_env),
+        preserved_prefetch_max_keys: file_config.cache.as_ref().and_then(|c| c.prefetch_max_keys),
+        preserved_prefetch_max_bytes: file_config
+            .cache
+            .as_ref()
+            .and_then(|c| c.prefetch_max_bytes.clone()),
+        preserved_prefetch_deadline_secs: file_config
+            .cache
+            .as_ref()
+            .and_then(|c| c.prefetch_deadline_secs),
     };
 
     // Run initial validation
@@ -1017,6 +1038,9 @@ fn do_save_to(state: &mut EditorState, path: &std::path::Path) {
         state.preserved_heartbeat_secs,
         state.preserved_explain_miss,
         state.preserved_ignore_env,
+        state.preserved_prefetch_max_keys,
+        state.preserved_prefetch_max_bytes.clone(),
+        state.preserved_prefetch_deadline_secs,
     );
     match Config::save_file_config_to(&config, path) {
         Ok(()) => {
@@ -1839,6 +1863,9 @@ mod tests {
                 event_log_keep_lines: Some(500),
                 compression_level: Some(3),
                 s3_concurrency: Some(8),
+                prefetch_max_keys: None,
+                prefetch_max_bytes: None,
+                prefetch_deadline_secs: None,
                 daemon_idle_timeout_secs: None,
                 s3_pool_idle_secs: None,
                 remote: Some(RemoteFileConfig {
@@ -1878,6 +1905,15 @@ mod tests {
             original.cache.as_ref().and_then(|c| c.heartbeat_secs),
             original.cache.as_ref().and_then(|c| c.explain_miss),
             original.cache.as_ref().and_then(|c| c.ignore_env),
+            original.cache.as_ref().and_then(|c| c.prefetch_max_keys),
+            original
+                .cache
+                .as_ref()
+                .and_then(|c| c.prefetch_max_bytes.clone()),
+            original
+                .cache
+                .as_ref()
+                .and_then(|c| c.prefetch_deadline_secs),
         );
 
         let cache = reconstructed.cache.as_ref().unwrap();
@@ -1938,7 +1974,7 @@ mod tests {
         let fields = build_fields(&original, &empty_env());
         let reconstructed = fields_to_file_config(
             &fields, None, None, None, None, None, None, None, None, None, None, None, None, None,
-            None,
+            None, None, None, None,
         );
         let remote = reconstructed
             .cache
@@ -1965,7 +2001,7 @@ mod tests {
         let fields = build_fields(&config, &empty_env());
         let result = fields_to_file_config(
             &fields, None, None, None, None, None, None, None, None, None, None, None, None, None,
-            None,
+            None, None, None, None,
         );
         assert!(result.cache.as_ref().unwrap().remote.is_none());
     }
@@ -2042,6 +2078,9 @@ mod tests {
             preserved_heartbeat_secs: None,
             preserved_explain_miss: None,
             preserved_ignore_env: None,
+            preserved_prefetch_max_keys: None,
+            preserved_prefetch_max_bytes: None,
+            preserved_prefetch_deadline_secs: None,
         }
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -628,6 +628,12 @@ pub struct PrefetchStatsSnapshot {
     pub keys_used: u64,
     #[serde(default)]
     pub keys_cancelled: u64,
+    /// Candidates dropped un-downloaded because a plan budget was exhausted
+    /// (kunobi-ninja/kache#616). Distinct from `keys_cancelled`, which is the
+    /// adaptive hit-rate cancel: this is "the plan was too big / too slow",
+    /// that one is "the plan looked wrong".
+    #[serde(default)]
+    pub keys_over_budget: u64,
     /// Whether the daemon-lifetime adaptive cancel latch has fired.
     #[serde(default)]
     pub cancelled: bool,
@@ -1004,6 +1010,8 @@ pub(crate) struct PrefetchStats {
     pub keys_used: std::sync::atomic::AtomicU64,
     /// Keys dropped un-downloaded by an adaptive cancellation.
     pub keys_cancelled: std::sync::atomic::AtomicU64,
+    /// Keys dropped un-downloaded because a plan budget was exhausted (#616).
+    pub keys_over_budget: std::sync::atomic::AtomicU64,
     /// BuildStarted sessions planned by the advisory service vs locally.
     pub plans_advisory: std::sync::atomic::AtomicU64,
     pub plans_fallback: std::sync::atomic::AtomicU64,
@@ -1033,6 +1041,7 @@ impl PrefetchStats {
             bytes_downloaded: 0.into(),
             keys_used: 0.into(),
             keys_cancelled: 0.into(),
+            keys_over_budget: 0.into(),
             plans_advisory: 0.into(),
             plans_fallback: 0.into(),
             last_plan_candidates: 0.into(),
@@ -1175,6 +1184,24 @@ impl ActivePlan {
 /// review). Cancel only when even the upper-bound hit rate is below 30%
 /// after 10+ distinct demands: wasting a plan is cheaper than cancelling a
 /// good one on biased evidence.
+/// How many of `offered` candidates a key budget of `max_keys` drops
+/// (kunobi-ninja/kache#616). `0` disables the budget.
+pub(crate) fn prefetch_key_budget_overflow(offered: usize, max_keys: u64) -> usize {
+    if max_keys == 0 {
+        return 0;
+    }
+    offered.saturating_sub(max_keys as usize)
+}
+
+/// Has this plan spent its byte budget? `0` disables the budget.
+///
+/// Compared with `>=` so a budget already met stops the next download rather
+/// than allowing one more. The budget is soft either way: it gates what may
+/// still START, and whatever is in flight is left to finish.
+pub(crate) fn prefetch_byte_budget_exhausted(max_bytes: u64, spent: u64) -> bool {
+    max_bytes > 0 && spent >= max_bytes
+}
+
 pub(crate) fn should_cancel_prefetch(
     demanded: u64,
     demanded_candidates: u64,
@@ -1657,6 +1684,7 @@ impl Daemon {
                 bytes_downloaded: ps.bytes_downloaded.load(Ordering::Relaxed),
                 keys_used: ps.keys_used.load(Ordering::Relaxed),
                 keys_cancelled: ps.keys_cancelled.load(Ordering::Relaxed),
+                keys_over_budget: ps.keys_over_budget.load(Ordering::Relaxed),
                 cancelled: *self.prefetch_cancel.borrow(),
                 plans_advisory: ps.plans_advisory.load(Ordering::Relaxed),
                 plans_fallback: ps.plans_fallback.load(Ordering::Relaxed),
@@ -2587,10 +2615,35 @@ impl Daemon {
             }
         }
 
+        // Key budget (kunobi-ninja/kache#616). Applied AFTER the filters above,
+        // so the budget bounds work actually to be done rather than being spent
+        // on candidates that are already local or already in flight.
+        let offered = keys_to_fetch.len();
+        let dropped_over_key_budget =
+            prefetch_key_budget_overflow(offered, self.config.prefetch_max_keys);
+        if dropped_over_key_budget > 0 {
+            keys_to_fetch.truncate(offered - dropped_over_key_budget);
+        }
+
         let count = keys_to_fetch.len();
         if count == 0 {
             tracing::info!("prefetch: nothing to fetch");
             return Response::ok();
+        }
+
+        // Never silently truncate: a plan cut short by a budget must not look
+        // like a plan that had nothing more to offer (#616).
+        if dropped_over_key_budget > 0 {
+            self.prefetch_stats
+                .keys_over_budget
+                .fetch_add(dropped_over_key_budget as u64, Ordering::Relaxed);
+            tracing::warn!(
+                offered,
+                admitted = count,
+                dropped = dropped_over_key_budget,
+                max_keys = self.config.prefetch_max_keys,
+                "prefetch: plan truncated by the key budget"
+            );
         }
 
         // Candidates are deliberately NOT claimed here (kunobi-ninja/kache#613).
@@ -2619,8 +2672,65 @@ impl Daemon {
             // on-demand traffic; a 1-permit pool degrades to no reservation.
             let max_concurrent = prefetch_concurrency_cap(daemon.config.s3_concurrency);
 
+            // Byte and time budgets (#616). Both bound what this plan may still
+            // START; work already in flight is left to finish, because
+            // cancelling a live download throws away bytes already paid for.
+            //
+            // The byte budget is therefore SOFT: overshoot is bounded by what
+            // was in flight when it tripped, at most `max_concurrent` objects.
+            // A hard cap needs counted, cancellable reads in the backend.
+            let byte_budget = daemon.config.prefetch_max_bytes;
+            let bytes_at_start = daemon
+                .prefetch_stats
+                .bytes_downloaded
+                .load(Ordering::Relaxed);
+            let deadline = match daemon.config.prefetch_deadline_secs {
+                0 => None,
+                secs => Some(Instant::now() + Duration::from_secs(secs)),
+            };
+
             let mut keys_iter = keys_to_fetch.into_iter().peekable();
             while let Some((key, crate_name, entry_dir)) = keys_iter.next() {
+                if let Some(deadline) = deadline
+                    && Instant::now() >= deadline
+                {
+                    let dropped = 1 + keys_iter.count() as u64;
+                    daemon
+                        .prefetch_stats
+                        .keys_over_budget
+                        .fetch_add(dropped, Ordering::Relaxed);
+                    tracing::warn!(
+                        dropped,
+                        deadline_secs = daemon.config.prefetch_deadline_secs,
+                        "prefetch: plan truncated by the time budget"
+                    );
+                    break;
+                }
+
+                {
+                    let spent = daemon
+                        .prefetch_stats
+                        .bytes_downloaded
+                        .load(Ordering::Relaxed)
+                        .saturating_sub(bytes_at_start);
+                    if prefetch_byte_budget_exhausted(byte_budget, spent) {
+                        let dropped = 1 + keys_iter.count() as u64;
+                        daemon
+                            .prefetch_stats
+                            .keys_over_budget
+                            .fetch_add(dropped, Ordering::Relaxed);
+                        tracing::warn!(
+                            dropped,
+                            spent_bytes = spent,
+                            max_bytes = byte_budget,
+                            in_flight = in_flight.len(),
+                            "prefetch: plan truncated by the byte budget (soft: in-flight \
+                             downloads still finish)"
+                        );
+                        break;
+                    }
+                }
+
                 // Check for adaptive cancellation
                 if *cancel_rx.borrow() {
                     tracing::info!("prefetch: cancelled by adaptive hit-rate check");
@@ -5873,6 +5983,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         }
@@ -6289,6 +6402,7 @@ mod tests {
             bytes_downloaded: 1024,
             keys_used: 2,
             keys_cancelled: 1,
+            keys_over_budget: 5,
             cancelled: true,
             plans_advisory: 1,
             plans_fallback: 4,
@@ -8896,6 +9010,152 @@ mod tests {
                 .as_deref()
                 .unwrap()
                 .contains("no remote configured")
+        );
+    }
+
+    /// The key budget bounds a plan, and the truncation is reported rather than
+    /// silent (kunobi-ninja/kache#616).
+    ///
+    /// The budget applies AFTER the already-local / already-in-flight filters,
+    /// so it bounds work actually to be done. Three remote keys, budget of one:
+    /// one is admitted and two are counted as dropped over budget.
+    #[tokio::test]
+    async fn test_prefetch_key_budget_truncates_and_reports() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        config.prefetch_max_keys = 1;
+        // Keep the coordinator from racing the assertions: no download can
+        // start, so nothing is removed from the plan for any other reason.
+        config.s3_concurrency = 2;
+
+        let keys = [
+            "1111111111111111".repeat(4),
+            "2222222222222222".repeat(4),
+            "3333333333333333".repeat(4),
+        ];
+        let client = test_remote_backend();
+        for key in &keys {
+            put_test_object(&client, &test_manifest_object_key(key, "serde"), b"{}").await;
+            put_test_object(
+                &client,
+                &test_pack_object_key(key, "serde"),
+                &build_entry_pack(key, "serde"),
+            )
+            .await;
+        }
+
+        let daemon = Arc::new(Daemon::new(config.clone()));
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
+        let _gate = daemon
+            .prefetch_gate
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("gate permit");
+
+        let resp = daemon
+            .handle_prefetch(&PrefetchRequest {
+                keys: keys
+                    .iter()
+                    .map(|k| (k.clone(), "serde".to_string()))
+                    .collect(),
+                warm_all: false,
+            })
+            .await;
+        assert!(resp.ok, "prefetch dispatch should be ok: {resp:?}");
+
+        assert_eq!(
+            daemon
+                .prefetch_stats
+                .keys_over_budget
+                .load(Ordering::Relaxed),
+            2,
+            "two of three candidates should be reported as dropped over budget"
+        );
+    }
+
+    /// The key budget arithmetic, including the `0 = unlimited` sentinel (#616).
+    #[test]
+    fn test_prefetch_key_budget_overflow() {
+        assert_eq!(prefetch_key_budget_overflow(10, 4), 6);
+        assert_eq!(prefetch_key_budget_overflow(4, 4), 0, "exactly at budget");
+        assert_eq!(prefetch_key_budget_overflow(3, 4), 0, "under budget");
+        assert_eq!(prefetch_key_budget_overflow(0, 4), 0, "empty plan");
+        assert_eq!(
+            prefetch_key_budget_overflow(10_000, 0),
+            0,
+            "0 disables the key budget"
+        );
+    }
+
+    /// The byte budget predicate, including the `0 = unlimited` sentinel (#616).
+    #[test]
+    fn test_prefetch_byte_budget_exhausted() {
+        assert!(!prefetch_byte_budget_exhausted(1024, 0));
+        assert!(!prefetch_byte_budget_exhausted(1024, 1023));
+        assert!(
+            prefetch_byte_budget_exhausted(1024, 1024),
+            "a budget exactly met stops the next download"
+        );
+        assert!(prefetch_byte_budget_exhausted(1024, 4096), "overshot");
+        assert!(
+            !prefetch_byte_budget_exhausted(0, u64::MAX),
+            "0 disables the byte budget"
+        );
+    }
+
+    /// `prefetch_deadline_secs = 0` disables the deadline rather than dropping
+    /// the plan immediately (#616).
+    #[tokio::test]
+    async fn test_prefetch_deadline_stops_the_plan() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        // The coordinator checks the deadline before starting each candidate,
+        // so a zero-length budget drops the whole plan on the first iteration.
+        config.prefetch_deadline_secs = 0;
+
+        let key = "4444444444444444".repeat(4);
+        let client = test_remote_backend();
+        put_test_object(&client, &test_manifest_object_key(&key, "serde"), b"{}").await;
+        put_test_object(
+            &client,
+            &test_pack_object_key(&key, "serde"),
+            &build_entry_pack(&key, "serde"),
+        )
+        .await;
+
+        let daemon = Arc::new(Daemon::new(config.clone()));
+        assert!(
+            daemon.remote_backend.set(client).is_ok(),
+            "inject mock backend"
+        );
+
+        let resp = daemon
+            .handle_prefetch(&PrefetchRequest {
+                keys: vec![(key.clone(), "serde".to_string())],
+                warm_all: false,
+            })
+            .await;
+        assert!(resp.ok, "prefetch dispatch should be ok: {resp:?}");
+
+        // `0` means "no deadline", so the plan must still run.
+        let entry_meta = config.store_dir().join(&key).join("meta.json");
+        let mut imported = false;
+        for _ in 0..100 {
+            if entry_meta.exists() {
+                imported = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(
+            imported,
+            "prefetch_deadline_secs = 0 disables the deadline rather than dropping the plan"
         );
     }
 

--- a/src/fallback_planner.rs
+++ b/src/fallback_planner.rs
@@ -140,6 +140,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         }

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -616,6 +616,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -687,6 +690,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -738,6 +744,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -866,6 +875,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         }

--- a/src/remote_plan.rs
+++ b/src/remote_plan.rs
@@ -103,6 +103,9 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         }

--- a/src/report.rs
+++ b/src/report.rs
@@ -2933,6 +2933,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -3349,6 +3352,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -3396,6 +3402,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -3453,6 +3462,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -3511,6 +3523,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -3574,6 +3589,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -3860,6 +3878,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         };
@@ -4053,6 +4074,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         };

--- a/src/store.rs
+++ b/src/store.rs
@@ -3077,6 +3077,9 @@ mod tests {
             event_log_keep_lines: 100,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1934,6 +1934,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: DEFAULT_S3_POOL_IDLE_SECS,
         }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3276,6 +3276,9 @@ mod tests {
             event_log_keep_lines: 1000,
             compression_level: 3,
             s3_concurrency: 16,
+            prefetch_max_keys: crate::config::DEFAULT_PREFETCH_MAX_KEYS,
+            prefetch_max_bytes: crate::config::DEFAULT_PREFETCH_MAX_BYTES,
+            prefetch_deadline_secs: crate::config::DEFAULT_PREFETCH_DEADLINE_SECS,
             daemon_idle_timeout_secs: crate::config::DEFAULT_DAEMON_IDLE_TIMEOUT_SECS,
             s3_pool_idle_secs: crate::config::DEFAULT_S3_POOL_IDLE_SECS,
         }


### PR DESCRIPTION
Stage 1 of #616. Does **not** close it, and does not touch #617 yet: see "Why this is staged".

## The problem

A prefetch plan had no cap on candidate count, no cap on bytes, and no deadline. The only
backstop was adaptive hit-rate cancellation, which answers a different question ("does this
plan look wrong?") rather than "is this plan too big or too slow?".

## The change

Three daemon-side budgets, all configurable, `0` disabling a dimension:

| setting | default | bounds |
|---|---|---|
| `prefetch_max_keys` | 2000 | candidates one plan may download |
| `prefetch_max_bytes` | 2 GiB | compressed bytes one plan may download |
| `prefetch_deadline_secs` | 300 | how long a plan may keep starting downloads |

The key budget is applied **after** the already-local and already-in-flight filters, so it
bounds work actually to be done rather than being spent on candidates that were going to be
skipped.

The byte budget and the deadline gate what may still **start**. Work in flight is left to
finish, because cancelling a live download throws away bytes already paid for.

**The byte cap is therefore soft**, and I would rather say so than imply otherwise: overshoot
is bounded by whatever was in flight when it tripped, at most `prefetch_concurrency_cap`
objects. A hard cap needs a counted, cancellable read path in the remote backend, plus atomic
reservation so N workers do not each observe the same remaining balance. That is noted in the
design note and in the config docs.

Enforcement is daemon-side because the planner may be an untrusted remote HTTP service, so its
self-restraint cannot be load-bearing. `warm_all` is subject to the same budgets: it is a
request field, so it must not become an escape hatch from them.

**Truncation is reported, never silent.** A new `keys_over_budget` counter, separate from
`keys_cancelled`, plus a warn log naming the offered count, the admitted count, and which
budget tripped. A plan cut short by a budget must not look like a plan that had nothing more
to offer.

The defaults are guardrails against pathology, not tuned optima. Settling them needs the
cold-CI attribution #618 is about, and the note says so.

## Why this is staged

#616 and #617 were scoped together because they share a `PrefetchCandidate` wire change.
Working the design through showed the combined change spans the planner, the
`PlannerDataSource` trait, the shard object format, the store query, the daemon's enforcement
path, the backend read path, config, and telemetry. That is not reviewable as one diff.

It splits cleanly because **enforcement does not need the metadata**, and enforcement is the
half carrying the safety risk. `notes/design/prefetch-budgets-and-ranking.md` records the full
design and the remaining stages:

2. bound the low-confidence key-cache source (per-crate and plan-wide caps), plus a per-crate
   cap on local history
3. candidate metadata on the wire (`compile_time_ms`, size, source, demand index, all
   `Option`), and shard writers persisting what `ManifestEntry` already carries
4. cost-aware ranking (#617) behind a versioned policy

The note also records where a cross-model design review disagreed with my first draft, rather
than averaging it away. Notably I wanted to drop the `KACHE_MIN_COMPILE_MS` cheap-crate filter
on the grounds that a real budget makes it redundant; both independent reviews argued for
keeping it for known-cost candidates while exempting unknown-cost ones into their own lane,
and I came round to that.

## Config plumbing note

The three fields are carried through the config TUI's preserved-field path. The editor has no
form fields for them, and dropping them on save would silently restore unbounded plans, which
is the exact failure that path exists to prevent.

## Tests

- `test_prefetch_key_budget_overflow` and `test_prefetch_byte_budget_exhausted`: the budget
  arithmetic including the `0 = unlimited` sentinel and the boundary (a budget exactly met
  stops the next download). Pure helpers, following the existing `should_cancel_prefetch`
  precedent.
- `test_prefetch_key_budget_truncates_and_reports`: end-to-end, three remote keys with a
  budget of one. **Verified red before the fix** (`left: 0, right: 2`) by neutralising only
  the enforcement and keeping the test.
- `test_prefetch_deadline_stops_the_plan`: asserts the `0 = disabled` sentinel. Being explicit
  that this is a guard, not a reproduction: a stalled-gate test cannot reach a second
  coordinator iteration, so the deadline branch is not reachable end-to-end without either
  time control or a slow backend. That is why the arithmetic is covered by the pure helpers.

1390 bin tests and 11 kache-core tests pass. `cargo clippy --workspace --all-targets -D warnings`
(the actual `just lint` gate) and `cargo fmt --all --check` both clean.
