### PR TITLE
test: add staged mutation testing

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,4 @@
+# Keep mutation runs focused on semantic failures rather than lint or copied
+# scratch-data noise. Scope, baseline, and time limits stay explicit per lane.
+cap_lints = true
+gitignore = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,90 @@ jobs:
           path: tmp/llvm-cov/html
           retention-days: 14
 
+  # Complete mutation coverage for the small, hermetic planner crate on every
+  # code PR/main push. PRs additionally mutate changed Rust lines across the
+  # workspace, so the gate grows with the patch without inheriting thousands
+  # of pre-existing mutants.
+  mutation:
+    name: Mutation testing
+    runs-on: ubuntu-latest
+    needs: [changes, check]
+    if: github.ref_type != 'tag' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true')
+    timeout-minutes: 65
+    env:
+      RUSTC_WRAPPER: ""
+      CARGO_INCREMENTAL: "1"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # PR checkout is a synthetic merge commit. Its first parent is the
+          # exact base used by this run, avoiding stale event SHAs.
+          fetch-depth: 0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          version: 2026.6.9
+          install_args: rust
+          cache: false
+      - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        with:
+          tool: cargo-mutants@27.1.0
+          fallback: none
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: mutants
+          cache-bin: false
+          cache-on-failure: false
+      - name: Verify complete mutation scope is non-empty
+        run: |
+          mkdir -p tmp/mutants
+          count="$(
+            cargo mutants --package kache-core --all-features --list --json |
+              python3 -c 'import json, sys; print(len(json.load(sys.stdin)))'
+          )"
+          echo "kache-core mutants: $count"
+          test "$count" -gt 0
+      - name: Mutate all kache-core behavior
+        timeout-minutes: 15
+        run: |
+          cargo mutants \
+            --package kache-core \
+            --all-features \
+            --in-place \
+            --baseline run \
+            --timeout 300 \
+            --build-timeout 600 \
+            --annotations github \
+            --output tmp/mutants/core
+      - name: Build PR Rust diff
+        if: github.event_name == 'pull_request'
+        run: |
+          git rev-parse --verify 'HEAD^1^{commit}'
+          git diff --no-ext-diff --unified=1 HEAD^1 HEAD -- '*.rs' \
+            > tmp/mutants/pr.diff
+          cat tmp/mutants/pr.diff
+      - name: Mutate changed Rust behavior
+        if: github.event_name == 'pull_request'
+        timeout-minutes: 45
+        run: |
+          cargo mutants \
+            --workspace \
+            --all-features \
+            --in-diff tmp/mutants/pr.diff \
+            --exclude 'crates/kache-core/**' \
+            --in-place \
+            --baseline run \
+            --timeout 300 \
+            --build-timeout 600 \
+            --annotations github \
+            --output tmp/mutants/diff
+      - name: Upload mutation reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutation-reports
+          path: tmp/mutants/
+          retention-days: 14
+
   # Fast, hermetic version gate (no nix / no cargo / no network). Runs on every
   # push & PR in internal mode (the shipping manifests must agree), and on a v*
   # tag additionally asserts the tag matches the manifest BEFORE the release job

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 #   tmp/llvm-cov/ — cargo-llvm-cov reports (HTML directory + JSON);
 #                    raw coverage data stays under target/llvm-cov-target/
 #                    (already covered by /target above).
+#   tmp/mutants/  — cargo-mutants logs, outcomes, and tested diffs.
 #
 # To recover disk: `rm -rf tmp/` — tools regenerate what they need.
 /tmp/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,9 @@ just test           # run all tests
 just lint           # clippy with -D warnings
 just fmt            # auto-format code
 just fix            # auto-fix formatting + clippy warnings
-just coverage       # tests with tarpaulin coverage (JSON)
+just coverage       # tests with cargo-llvm-cov coverage
 just coverage-open  # coverage with HTML report
+just mutants-core   # mutation-test all kache-core behavior
 just clean          # remove build artifacts
 ```
 
@@ -73,7 +74,16 @@ in `.pinact.yaml`; bump its SHA manually when you want a newer release.
 - **Unit tests**: Place `#[cfg(test)]` modules at the bottom of source files
 - **Integration tests**: Add to `tests/` — these run real binaries against temp directories
 - **Scenarios**: E2E fixture scenarios live under `scenarios/e2e-*`; benchmark scenarios live under `scenarios/bench-*`
-- **Coverage threshold**: CI enforces a minimum of 25% via `cargo-tarpaulin`
+- **Coverage threshold**: CI enforces a minimum of 88% via `cargo-llvm-cov`
+- **Mutation testing**: CI mutates all `kache-core` behavior plus changed Rust
+  lines in each PR. Reports are uploaded from `tmp/mutants/`.
+
+For local mutation runs, install the same version as CI:
+
+```sh
+cargo install --locked cargo-mutants --version 27.1.0
+just mutants-core
+```
 
 Run the full check suite before submitting a PR:
 

--- a/Justfile
+++ b/Justfile
@@ -61,6 +61,18 @@ image-service-release:
 test:
   cargo test --workspace
 
+# Mutation-test the complete hermetic planner crate. Install the pinned local
+# tool with: cargo install --locked cargo-mutants --version 27.1.0
+[group('dev')]
+mutants-core *ARGS:
+  cargo mutants --package kache-core --all-features --baseline run --timeout 300 --build-timeout 600 --output tmp/mutants/core {{ARGS}}
+
+# Mutation-test changed Rust lines outside kache-core (which mutants-core
+# already covers completely). DIFF must describe the current working tree.
+[group('dev')]
+mutants-diff DIFF *ARGS:
+  cargo mutants --workspace --all-features --in-diff "{{DIFF}}" --exclude 'crates/kache-core/**' --baseline run --timeout 300 --build-timeout 600 --output tmp/mutants/diff {{ARGS}}
+
 # Audit dependencies with cargo-deny (advisories + licenses + bans +
 # sources; config and documented exceptions in `deny.toml`). Runs once
 # per workspace MEMBER on purpose: cargo-deny graphs from the current

--- a/crates/kache-e2e/src/fixture_runner.rs
+++ b/crates/kache-e2e/src/fixture_runner.rs
@@ -223,3 +223,18 @@ fn missing_tools(tools: &[String]) -> Vec<String> {
         .cloned()
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::missing_tools;
+
+    #[test]
+    fn cargo_requirement_is_detected_on_path() {
+        let missing = missing_tools(&["cargo".to_string()]);
+
+        assert!(
+            missing.is_empty(),
+            "cargo must be available during cargo test"
+        );
+    }
+}

--- a/crates/kache-e2e/tests/skip_summary.rs
+++ b/crates/kache-e2e/tests/skip_summary.rs
@@ -1,0 +1,43 @@
+use std::process::Command;
+
+#[test]
+fn lenient_skip_summary_reports_the_fixture_count() {
+    let temp = tempfile::tempdir().unwrap();
+    let scenario = temp.path().join("e2e-missing-tool");
+    std::fs::create_dir_all(scenario.join("source")).unwrap();
+    std::fs::write(
+        scenario.join("scenario.toml"),
+        r#"
+name = "e2e-missing-tool"
+tags = ["suite:e2e"]
+requires = ["kache-e2e-tool-that-does-not-exist"]
+
+[source]
+kind = "fixture"
+path = "source"
+
+[commands]
+build = "unused"
+clean = "unused"
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kache-scenario"))
+        .arg("--kache")
+        .arg(env!("CARGO_BIN_EXE_kache-scenario"))
+        .arg("--scenarios")
+        .arg(temp.path())
+        .arg("--select")
+        .arg("suite:e2e")
+        .arg("--out")
+        .arg(temp.path().join("results.json"))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("PASS: all executed fixtures green (1 skipped)")
+    );
+}


### PR DESCRIPTION
## What changed

- add a pinned `cargo-mutants` CI job
- mutate all `kache-core` behavior on code PRs and `main` pushes
- mutate changed Rust lines across the workspace on PRs
- add positive PATH-requirement and skipped-summary regression tests
- add local recipes, configuration, reports, and current coverage docs

## Why

Line coverage alone did not show whether assertions detect semantic regressions.
Replaying the merged #628 Rust diff with cargo-mutants 27.1.0 found two
surviving mutants: the positive PATH-requirement path and the reported
skipped-fixture count were both untested.

The workspace has 7,000+ mutants, so a complete sweep on every PR is not
practical. This stages adoption with a complete hermetic crate plus
patch-bounded workspace coverage, baseline runs, non-vacuity validation, hard
timeouts, and uploaded reports.

## Impact

Code PRs get a focused mutation check without inheriting the full workspace
backlog. A surviving changed-line mutant now fails the job and names the
affected source line.

After this workflow lands, `Mutation testing` should be added to the required
`main` status checks so branch protection enforces it.

## Validation

- `just check`
- cargo-mutants 27.1.0 full `kache-core`: 11 tested, 7 caught, 4 unviable, 0 missed
- cargo-mutants 27.1.0 replay of #628 Rust diff: 16 tested, 14 caught, 2 unviable, 0 missed
- scoped `pinact run --check --verify .github/workflows/ci.yml`
- YAML parse and `git diff --check`
