### PR TITLE
feat(aur): add kache-git + config-driven multi-package aur publishing

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -415,40 +415,62 @@ jobs:
             }
 
   # ---------------------------------------------------------------------------
-  # aur — publish the official `kache-bin` package to the Arch User Repository.
-  # An AUR package is a tiny git repo hosted by the AUR itself
-  # (ssh://aur@aur.archlinux.org/kache-bin.git) — NOT a GitHub repo; it holds
-  # just PKGBUILD + .SRCINFO. The recipe lives in-repo at aur/kache-bin/PKGBUILD;
-  # this job refreshes pkgver + checksums and pushes. STABLE only — AUR pkgver
-  # can't carry a pre-release '-' and AUR tracks the latest stable.
-  # Requires the AUR_SSH_KEY secret (private key of the key registered on the
-  # kunobi-ninja AUR account).
+  # aur — publish official Arch User Repository packages. Each aur/<name>/ folder
+  # is one AUR package (a tiny git repo hosted by the AUR itself,
+  # ssh://aur@aur.archlinux.org/<name>.git — NOT a GitHub repo, just
+  # PKGBUILD + .SRCINFO). Enable/disable a flavor per project by adding/removing
+  # its aur/<name>/ folder. Versioned packages (-bin, source) get pkgver
+  # refreshed to the release; VCS packages (-git) keep their git-derived pkgver
+  # (so a stable release is a no-op for them — allow_empty_commits:false). STABLE
+  # only — AUR pkgver can't carry a pre-release '-'. Requires the AUR_SSH_KEY secret.
   # ---------------------------------------------------------------------------
-  aur:
-    needs: [resolve, gate]
+  aur-list:
+    needs: resolve
     if: ${{ (github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'aur') && needs.resolve.outputs.channel == 'stable' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
+    outputs:
+      pkgs: ${{ steps.list.outputs.pkgs }}
     steps:
-      - name: Checkout (for the PKGBUILD)
-        uses: actions/checkout@v4
-
-      - name: Set pkgver in the PKGBUILD
-        env:
-          VERSION: ${{ needs.resolve.outputs.version }}
+      - uses: actions/checkout@v4
+      - id: list
         run: |
           set -euo pipefail
-          sed -i -e "s/^pkgver=.*/pkgver=${VERSION}/" -e "s/^pkgrel=.*/pkgrel=1/" aur/kache-bin/PKGBUILD
-          echo "--- PKGBUILD (checksums refreshed by updpkgsums in the deploy step) ---"
-          cat aur/kache-bin/PKGBUILD
+          PKGS=$(ls -d aur/*/ 2>/dev/null | xargs -rn1 basename | jq -R . | jq -sc . || echo '[]')
+          echo "pkgs=${PKGS:-[]}" >> "$GITHUB_OUTPUT"
+          echo "AUR packages: ${PKGS:-[]}"
 
-      - name: Publish kache-bin to the AUR
+  aur:
+    needs: [resolve, gate, aur-list]
+    if: ${{ needs.aur-list.outputs.pkgs != '' && needs.aur-list.outputs.pkgs != '[]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg: ${{ fromJson(needs.aur-list.outputs.pkgs) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Refresh pkgver for versioned packages (skip -git)
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          PKG: ${{ matrix.pkg }}
+        run: |
+          set -euo pipefail
+          if [[ "$PKG" != *-git ]]; then
+            sed -i -e "s/^pkgver=.*/pkgver=${VERSION}/" -e "s/^pkgrel=.*/pkgrel=1/" "aur/${PKG}/PKGBUILD"
+          fi
+          echo "--- aur/${PKG}/PKGBUILD ---"; cat "aur/${PKG}/PKGBUILD"
+
+      - name: Publish ${{ matrix.pkg }} to the AUR
         uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
         with:
-          pkgname: kache-bin
-          pkgbuild: aur/kache-bin/PKGBUILD
+          pkgname: ${{ matrix.pkg }}
+          pkgbuild: aur/${{ matrix.pkg }}/PKGBUILD
           commit_username: kunobi-ninja
           commit_email: feedback@kunobi.ninja
           ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
-          commit_message: "kache-bin: update to ${{ needs.resolve.outputs.version }}"
+          commit_message: "${{ matrix.pkg }}: update to ${{ needs.resolve.outputs.version }}"
           updpkgsums: true
+          allow_empty_commits: false

--- a/README.md
+++ b/README.md
@@ -112,14 +112,12 @@ choco install kache --pre
 
 **AUR (Arch Linux):**
 
-The official prebuilt-binary package is [`kache-bin`](https://aur.archlinux.org/packages/kache-bin):
+Pick one (all provide the `kache` command):
 
 ```sh
-# paru
-paru -S kache-bin
-
-# yay
-yay -S kache-bin
+paru -S kache-bin   # official prebuilt binary — recommended, no compile
+paru -S kache-git   # official, builds the latest main from source
+paru -S kache       # community-maintained, builds the latest release from source
 ```
 
 ## Quick start

--- a/aur/kache-git/PKGBUILD
+++ b/aur/kache-git/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Kunobi Ninja <feedback@kunobi.ninja>
+# Builds kache from the latest `main`. pkgver() derives the version from git,
+# so this tracks unreleased/dev code — rebuild to update.
+pkgname=kache-git
+pkgver=0.0.0.r0.g0000000
+pkgrel=1
+pkgdesc='Content-addressed zero-copy build cache for Rust, C/C++ and more (latest git main)'
+arch=('x86_64' 'aarch64')
+url='https://github.com/kunobi-ninja/kache'
+license=('Apache-2.0')
+depends=('gcc-libs')
+makedepends=('git' 'cargo')
+provides=('kache')
+conflicts=('kache')
+options=('!lto')
+source=("kache::git+https://github.com/kunobi-ninja/kache.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/kache"
+  printf '%s.r%s.g%s' \
+    "$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 0.0.0)" \
+    "$(git rev-list --count HEAD)" \
+    "$(git rev-parse --short=7 HEAD)"
+}
+
+prepare() {
+  cd "$srcdir/kache"
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "$srcdir/kache"
+  CARGO_TARGET_DIR=target cargo build --frozen --release -p kache
+}
+
+package() {
+  cd "$srcdir/kache"
+  install -Dm0755 target/release/kache "$pkgdir/usr/bin/kache"
+
+  local shell
+  for shell in bash zsh fish elvish; do
+    ./target/release/kache completions "$shell" > "kache.$shell"
+  done
+  install -Dm0644 kache.bash   "$pkgdir/usr/share/bash-completion/completions/kache"
+  install -Dm0644 kache.zsh    "$pkgdir/usr/share/zsh/site-functions/_kache"
+  install -Dm0644 kache.fish   "$pkgdir/usr/share/fish/vendor_completions.d/kache.fish"
+  install -Dm0644 kache.elvish "$pkgdir/usr/share/elvish/lib/kache.elv"
+
+  install -Dm0644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -134,15 +134,22 @@ kache is also published to Homebrew, APT, winget, Scoop, Chocolatey, and the AUR
     ```
   </Tab>
   <Tab value="AUR (Arch Linux)">
-    The official prebuilt-binary package is [`kache-bin`](https://aur.archlinux.org/packages/kache-bin) (statically linked, x86_64 + aarch64). Install it with your preferred AUR helper:
+    Three packages are available (all provide the `kache` command — install one):
 
     ```sh
-    # paru
+    # Official prebuilt binary — recommended (statically linked, x86_64 + aarch64, no compile)
     paru -S kache-bin
 
-    # yay
-    yay -S kache-bin
+    # Official, builds the latest main from source
+    paru -S kache-git
+
+    # Community-maintained, builds the latest release from source
+    paru -S kache
     ```
+
+    <Callout type="info">
+      `kache-bin` and `kache-git` are the official Kunobi packages; `kache` is a community-maintained source build.
+    </Callout>
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
Adds a **`kache-git`** AUR package (builds the latest `main` from source; `provides`/`conflicts` `kache`) and reworks the `aur` job so it publishes **every `aur/<name>/` folder** via a matrix.

- **Enable/disable per project** by adding/removing a folder under `aur/`.
- Versioned packages (`kache-bin`) get `pkgver` refreshed to the release; VCS packages (`kache-git`) keep their git-derived `pkgver` — `allow_empty_commits: false` makes a stable release a no-op for them (they only re-push when the recipe changes).
- Stable-only (AUR `pkgver` can't carry a pre-release `-`).

We intentionally do **not** ship a source `kache` — that stays KokaKiwi's community package until they hand it over. So kache = `kache-bin` (official binary) + `kache-git` (official git).

Once merged, the next stable release (or `only: aur` dispatch) publishes `kache-git` alongside `kache-bin`.