### PR TITLE
ci(aur): use the real AUR account name (kunobi) as commit author

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -468,7 +468,7 @@ jobs:
         with:
           pkgname: ${{ matrix.pkg }}
           pkgbuild: aur/${{ matrix.pkg }}/PKGBUILD
-          commit_username: kunobi-ninja
+          commit_username: kunobi
           commit_email: feedback@kunobi.ninja
           ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
           commit_message: "${{ matrix.pkg }}: update to ${{ needs.resolve.outputs.version }}"


### PR DESCRIPTION
The AUR account is `kunobi` (not `kunobi-ninja`). Update `commit_username` in the `aur` job so the git author on the pushed AUR commits matches the maintainer. Cosmetic only — authentication is the SSH key.