### PR TITLE
fix(clean,gc): detect reflinked sharing and explain empty evictions (#602, #509)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -3,6 +3,8 @@
 cap_lints = true
 gitignore = true
 
+# Two independent reasons a mutant here is unobservable rather than untested.
+#
 # `run_config_editor` is the `kache config` TUI entry point: it enables raw
 # mode, takes over the alternate screen, and runs an event loop until the user
 # quits. Nothing can drive that from a test — CI has no TTY at all, and a test
@@ -12,4 +14,15 @@ gitignore = true
 # that hold real logic (`initial_editor_state`, `build_fields`,
 # `fields_to_file_config`, `do_save_to`) stay in scope and are mutation-tested
 # normally.
-exclude_re = ["replace run_config_editor"]
+#
+# The mutation lane runs on ubuntu-latest, so a mutant inside code compiled only
+# for another platform is never built and therefore always "survives" — that is
+# a property of where the lane runs, not a gap in the tests. `probe_macos` is
+# `#[cfg(target_os = "macos")]` and `probe_unsupported` covers the remaining
+# targets; both are unreachable there.
+#
+# Kept as narrow as the names allow: `probe_linux` — the one impl the lane does
+# compile — stays fully in scope, along with `fiemap_window_length`,
+# `Sharing::unknown_for`, and every caller. macOS coverage comes from the
+# module's own tests, which do run on the macOS arm of `Test (macOS)`.
+exclude_re = ["replace run_config_editor", "probe_macos", "probe_unsupported"]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -25,4 +25,15 @@ gitignore = true
 # compile — stays fully in scope, along with `fiemap_window_length`,
 # `Sharing::unknown_for`, and every caller. macOS coverage comes from the
 # module's own tests, which do run on the macOS arm of `Test (macOS)`.
-exclude_re = ["replace run_config_editor", "probe_macos", "probe_unsupported"]
+
+#
+# `AttrList` is listed separately because a struct-field mutant's name does not
+# carry the enclosing function, so "probe_macos" alone does not match it. The
+# struct is declared inside `probe_macos` and exists nowhere else, so naming it
+# is exactly as narrow.
+exclude_re = [
+    "replace run_config_editor",
+    "probe_macos",
+    "probe_unsupported",
+    "from struct AttrList",
+]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1058,6 +1058,59 @@ pub fn format_duration_ms(ms: u64) -> String {
     }
 }
 
+/// How an eviction sweep went, phrased so "0" is never left unexplained.
+///
+/// `kache gc` used to print a bare `evicted 0 entries` next to a store sitting
+/// at 912% of its limit. That is correct behaviour reported terribly: every
+/// candidate was within the idle grace, so the sweep deliberately left them. A
+/// user who reads "0" beside "912%" concludes GC is broken and stops trying —
+/// which is plausibly how #497 became a 113 GB bug report rather than a
+/// self-service fix (kunobi-ninja/kache#509).
+///
+/// Pure so the phrasing is unit-testable without running a sweep.
+pub(crate) fn describe_eviction(stats: &crate::store::GcStats, over_limit: bool) -> String {
+    let grace_secs = crate::store::EVICTION_IDLE_GRACE.as_secs();
+    let plural = |n: usize| if n == 1 { "entry" } else { "entries" };
+
+    if stats.entries_evicted > 0 {
+        let mut msg = format!(
+            " evicted {} {} ({}).",
+            stats.entries_evicted,
+            plural(stats.entries_evicted),
+            ByteSize(stats.bytes_freed)
+        );
+        if stats.entries_pinned > 0 {
+            msg.push_str(&format!(
+                "\n  {} more {} in use within the last {grace_secs}s and left in place; \
+                 re-run `kache gc` once builds are idle.",
+                stats.entries_pinned,
+                plural(stats.entries_pinned),
+            ));
+        }
+        return msg;
+    }
+
+    // Nothing evicted. Say why, because this is the case that reads as a bug.
+    if stats.entries_pinned > 0 {
+        return format!(
+            " evicted 0 entries.\n  {} {} were selected but accessed within the last \
+             {grace_secs}s, so they were left in place — a build may be restoring from \
+             them. Re-run `kache gc` once builds are idle.",
+            stats.entries_pinned,
+            plural(stats.entries_pinned),
+        );
+    }
+    if over_limit {
+        return format!(
+            " evicted 0 entries.\n  The store is still over its limit but nothing was \
+             eligible. Entries accessed within the last {grace_secs}s are never evicted; \
+             if this persists with no builds running, `kache doctor --verify` will \
+             report entries that cannot be removed."
+        );
+    }
+    " evicted 0 entries (nothing to evict).".to_string()
+}
+
 // ── Project stats ──────────────────────────────────────────────────────────
 
 struct ProjectStats {
@@ -1069,8 +1122,27 @@ struct ProjectStats {
     local_files: u64,
 }
 
-/// Analyze a project's target/ directory: which files are hardlinked from
-/// kache's cache (nlink > 1) vs local-only (nlink == 1), with per-category breakdown.
+/// Whether a build artifact's storage is shared with kache's store, and how
+/// much of it a delete would really return.
+///
+/// Shared means *either* a hardlink (`nlink > 1`, the fallback restore path) or
+/// shared extents (a reflink/clone, which `link_to_target` prefers and which
+/// leaves `nlink == 1`). Testing only `nlink` reported ~0% cached on exactly the
+/// filesystems kache works best on — APFS, btrfs, XFS (kunobi-ninja/kache#602).
+#[cfg(unix)]
+fn artifact_sharing(path: &std::path::Path, meta: &std::fs::Metadata) -> crate::sharing::Sharing {
+    let size = meta.len();
+    let mut sharing = crate::sharing::probe(path, size);
+    if meta.nlink() > 1 {
+        // A hardlink is sharing whatever the extent probe managed to see, and on
+        // a filesystem with no probe at all it is the only signal there is.
+        sharing.shared = true;
+    }
+    sharing
+}
+
+/// Analyze a project's target/ directory: which files share storage with kache's
+/// store (reflinked or hardlinked) vs local-only, with per-category breakdown.
 fn compute_project_stats(target_dir: &std::path::Path) -> (ProjectStats, CategoryBreakdown) {
     let mut stats = ProjectStats {
         total_bytes: 0,
@@ -1139,7 +1211,7 @@ fn compute_project_stats(target_dir: &std::path::Path) -> (ProjectStats, Categor
                 } else {
                     #[cfg(unix)]
                     {
-                        if meta.nlink() > 1 {
+                        if artifact_sharing(&path, &meta).shared {
                             stats.cached_bytes += size;
                             stats.cached_files += 1;
                         } else {
@@ -1199,7 +1271,7 @@ fn walk_deps_dir(
 
         #[cfg(unix)]
         {
-            if meta.nlink() > 1 {
+            if artifact_sharing(&path, &meta).shared {
                 stats.cached_bytes += size;
                 stats.cached_files += 1;
             } else {
@@ -1245,10 +1317,18 @@ pub(crate) struct LinkStats {
     pub saved_bytes: u64,
 }
 
-/// Walk the blob store and compute hardlink statistics.
+/// Walk the blob store and compute how much storage it shares with live
+/// `target/` directories.
 ///
-/// Blobs live in `store_dir/blobs/{shard}/{hash}`. For each blob,
-/// nlink > 1 means hardlinks exist in target/ dirs, saving space.
+/// Blobs live in `store_dir/blobs/{shard}/{hash}`. A blob shares storage either
+/// by hardlink (`nlink > 1`) or by reflink, and only the first shows up in
+/// `nlink` — so a store of purely reflinked blobs used to report zero savings
+/// on APFS/btrfs/XFS (kunobi-ninja/kache#602).
+///
+/// `saved_bytes` is what sharing has saved: for hardlinks that is `size` per
+/// extra link, and for reflinks it is the shared (non-private) portion. Both are
+/// lower bounds — the reporter measured 62.3% of their store sharing storage
+/// with live targets, against a reported 0.
 pub(crate) fn compute_link_stats(store_dir: &std::path::Path) -> LinkStats {
     let mut stats = LinkStats {
         store_bytes: 0,
@@ -1291,6 +1371,17 @@ pub(crate) fn compute_link_stats(store_dir: &std::path::Path) -> LinkStats {
                     let extra = nlink - 1;
                     stats.linked_refs += extra;
                     stats.saved_bytes += size * extra;
+                } else {
+                    // No hardlink, but the blob may still be reflinked into one
+                    // or more target/ dirs. The bytes the filesystem reports as
+                    // non-private are shared with something else, so they are
+                    // stored once instead of twice — the same saving a hardlink
+                    // gives, just invisible to `nlink`.
+                    let sharing = crate::sharing::probe(&blob.path(), size);
+                    if sharing.shared {
+                        stats.linked_refs += 1;
+                        stats.saved_bytes += size.saturating_sub(sharing.private_bytes);
+                    }
                 }
             }
         }
@@ -1464,7 +1555,11 @@ pub fn run_gc_local(config: &Config, mode: GcMode) -> Result<()> {
     }
     let evict_stats = store.evict()?;
     if verbose {
-        println!(" evicted {} entries.", evict_stats.entries_evicted);
+        let over_limit = store
+            .total_size()
+            .map(|size| size > config.max_size)
+            .unwrap_or(false);
+        println!("{}", describe_eviction(&evict_stats, over_limit));
     }
 
     Ok(())
@@ -1517,7 +1612,11 @@ pub fn gc(config: &Config, max_age_hours: Option<u64>) -> Result<()> {
                 print!("Running eviction...");
                 std::io::Write::flush(&mut std::io::stdout()).ok();
                 let evict_stats = store.evict_older_than(hours)?;
-                println!(" evicted {} entries.", evict_stats.entries_evicted);
+                let over_limit = store
+                    .total_size()
+                    .map(|size| size > config.max_size)
+                    .unwrap_or(false);
+                println!("{}", describe_eviction(&evict_stats, over_limit));
             } else {
                 run_gc_local(config, GcMode::Cli)?;
             }
@@ -3794,6 +3893,77 @@ pub fn verify(config: &Config, checksums: bool, repair: bool) -> Result<()> {
 mod tests {
     use super::*;
     use std::fs;
+
+    // ── Eviction reporting (kunobi-ninja/kache#509) ────────────────────────
+
+    fn gc_stats(evicted: usize, pinned: usize, bytes: u64) -> crate::store::GcStats {
+        crate::store::GcStats {
+            entries_evicted: evicted,
+            bytes_freed: bytes,
+            entries_pinned: pinned,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn evicting_nothing_because_everything_is_pinned_explains_itself() {
+        // The #509 report: `evicted 0 entries` printed next to a store at 912%.
+        // The number is right and the message is useless, so the user concludes
+        // GC is broken. The output must name the grace and say what to do.
+        let msg = describe_eviction(&gc_stats(0, 24, 0), true);
+        assert!(
+            msg.contains("24"),
+            "must say how many were held back: {msg}"
+        );
+        assert!(
+            msg.contains("120s"),
+            "must name the grace period so the wait is bounded and knowable: {msg}"
+        );
+        assert!(
+            msg.contains("Re-run"),
+            "must tell the user what to do next: {msg}"
+        );
+    }
+
+    #[test]
+    fn evicting_nothing_while_over_limit_still_explains_the_grace() {
+        // Nothing pinned and nothing evicted, but still over budget: the user
+        // needs to know the idle rule exists, or "0" reads as a broken GC.
+        let msg = describe_eviction(&gc_stats(0, 0, 0), true);
+        assert!(msg.contains("over its limit"), "{msg}");
+        assert!(msg.contains("120s"), "{msg}");
+    }
+
+    #[test]
+    fn an_empty_store_does_not_imply_something_is_wrong() {
+        // Under budget with nothing to do is the normal case and must not
+        // inherit the alarming phrasing of the over-limit one.
+        let msg = describe_eviction(&gc_stats(0, 0, 0), false);
+        assert!(msg.contains("nothing to evict"), "{msg}");
+        assert!(
+            !msg.contains("over its limit"),
+            "a healthy store must not be told it is over budget: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_successful_eviction_reports_bytes_and_still_flags_pinned_entries() {
+        let msg = describe_eviction(&gc_stats(12, 3, 5 * 1024 * 1024), false);
+        assert!(msg.contains("12 entries"), "{msg}");
+        assert!(msg.contains("MiB") || msg.contains("MB"), "{msg}");
+        assert!(
+            msg.contains('3'),
+            "entries left behind matter even on a successful sweep — they are \
+             why the store may still be over budget: {msg}"
+        );
+    }
+
+    #[test]
+    fn eviction_messages_are_singular_for_one_entry() {
+        let msg = describe_eviction(&gc_stats(1, 0, 1024), false);
+        assert!(msg.contains("1 entry"), "{msg}");
+        assert!(!msg.contains("1 entries"), "{msg}");
+    }
 
     fn zero_event_stats() -> daemon::EventStatsResponse {
         daemon::EventStatsResponse {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1111,6 +1111,18 @@ pub(crate) fn describe_eviction(stats: &crate::store::GcStats, over_limit: bool)
     " evicted 0 entries (nothing to evict).".to_string()
 }
 
+/// Is the store over its configured budget after a sweep?
+///
+/// Pure, and split out of the two `gc` paths for the same reason
+/// [`describe_eviction`] is: it decides which of the two "evicted 0" messages a
+/// user sees, and that decision is worth testing without running a sweep. A
+/// store whose size cannot be read is reported as within budget — the same
+/// direction the callers already took, since claiming "over limit" on missing
+/// data would send the user chasing an eviction problem they may not have.
+pub(crate) fn store_over_limit(total_size: Option<u64>, max_size: u64) -> bool {
+    total_size.is_some_and(|size| size > max_size)
+}
+
 // ── Project stats ──────────────────────────────────────────────────────────
 
 struct ProjectStats {
@@ -1317,6 +1329,25 @@ pub(crate) struct LinkStats {
     pub saved_bytes: u64,
 }
 
+/// Fold one reflinked blob into the running totals.
+///
+/// Split out of the walk because a reflink can only be *created* on a
+/// filesystem that supports one, so the branch is unreachable in CI (ext4)
+/// while the arithmetic in it is exactly what the reported savings depend on.
+/// Taking the probe result as a parameter makes it testable anywhere.
+///
+/// The bytes the filesystem reports as non-private are shared with something
+/// else, so they are stored once instead of twice — the same saving a hardlink
+/// gives, just invisible to `nlink`.
+#[cfg(unix)]
+fn record_reflink_sharing(stats: &mut LinkStats, size: u64, sharing: crate::sharing::Sharing) {
+    if !sharing.shared {
+        return;
+    }
+    stats.linked_refs += 1;
+    stats.saved_bytes += size.saturating_sub(sharing.private_bytes);
+}
+
 /// Walk the blob store and compute how much storage it shares with live
 /// `target/` directories.
 ///
@@ -1373,15 +1404,12 @@ pub(crate) fn compute_link_stats(store_dir: &std::path::Path) -> LinkStats {
                     stats.saved_bytes += size * extra;
                 } else {
                     // No hardlink, but the blob may still be reflinked into one
-                    // or more target/ dirs. The bytes the filesystem reports as
-                    // non-private are shared with something else, so they are
-                    // stored once instead of twice — the same saving a hardlink
-                    // gives, just invisible to `nlink`.
-                    let sharing = crate::sharing::probe(&blob.path(), size);
-                    if sharing.shared {
-                        stats.linked_refs += 1;
-                        stats.saved_bytes += size.saturating_sub(sharing.private_bytes);
-                    }
+                    // or more target/ dirs.
+                    record_reflink_sharing(
+                        &mut stats,
+                        size,
+                        crate::sharing::probe(&blob.path(), size),
+                    );
                 }
             }
         }
@@ -1555,10 +1583,7 @@ pub fn run_gc_local(config: &Config, mode: GcMode) -> Result<()> {
     }
     let evict_stats = store.evict()?;
     if verbose {
-        let over_limit = store
-            .total_size()
-            .map(|size| size > config.max_size)
-            .unwrap_or(false);
+        let over_limit = store_over_limit(store.total_size().ok(), config.max_size);
         println!("{}", describe_eviction(&evict_stats, over_limit));
     }
 
@@ -1612,10 +1637,7 @@ pub fn gc(config: &Config, max_age_hours: Option<u64>) -> Result<()> {
                 print!("Running eviction...");
                 std::io::Write::flush(&mut std::io::stdout()).ok();
                 let evict_stats = store.evict_older_than(hours)?;
-                let over_limit = store
-                    .total_size()
-                    .map(|size| size > config.max_size)
-                    .unwrap_or(false);
+                let over_limit = store_over_limit(store.total_size().ok(), config.max_size);
                 println!("{}", describe_eviction(&evict_stats, over_limit));
             } else {
                 run_gc_local(config, GcMode::Cli)?;
@@ -3963,6 +3985,125 @@ mod tests {
         let msg = describe_eviction(&gc_stats(1, 0, 1024), false);
         assert!(msg.contains("1 entry"), "{msg}");
         assert!(!msg.contains("1 entries"), "{msg}");
+    }
+
+    #[test]
+    fn a_clean_sweep_says_nothing_about_entries_left_behind() {
+        // Nothing pinned: the grace-period paragraph would be noise at best,
+        // and at worst reads as "some entries are stuck" on a sweep that
+        // emptied everything it was asked to.
+        let msg = describe_eviction(&gc_stats(7, 0, 4096), false);
+        assert!(msg.contains("7 entries"), "{msg}");
+        assert!(
+            !msg.contains("in use within the last"),
+            "no entries were held back, so the grace note must not appear: {msg}"
+        );
+    }
+
+    #[test]
+    fn over_limit_is_decided_by_a_strict_comparison_against_the_budget() {
+        assert!(store_over_limit(Some(1025), 1024));
+        assert!(
+            !store_over_limit(Some(1024), 1024),
+            "exactly at budget is within it: a store that fits must not be told \
+             it is over"
+        );
+        assert!(!store_over_limit(Some(512), 1024));
+        assert!(
+            !store_over_limit(None, 1024),
+            "an unreadable size must not be reported as over budget — that sends \
+             the user chasing an eviction problem they may not have"
+        );
+    }
+
+    /// The reflink half of the store accounting, which no CI filesystem can
+    /// reach: ext4 has no reflinks, so the walk never takes this branch there
+    /// even though it carries the savings figure users read.
+    #[cfg(unix)]
+    #[test]
+    fn a_reflinked_blob_counts_as_one_ref_saving_its_shared_bytes() {
+        let mut stats = LinkStats {
+            store_bytes: 0,
+            linked_refs: 0,
+            saved_bytes: 0,
+        };
+
+        // Fully shared: every byte of this blob is stored once, not twice.
+        record_reflink_sharing(
+            &mut stats,
+            4096,
+            crate::sharing::Sharing {
+                shared: true,
+                private_bytes: 0,
+            },
+        );
+        assert_eq!(stats.linked_refs, 1);
+        assert_eq!(stats.saved_bytes, 4096);
+
+        // Partly shared: only the non-private part is a saving.
+        record_reflink_sharing(
+            &mut stats,
+            4096,
+            crate::sharing::Sharing {
+                shared: true,
+                private_bytes: 1024,
+            },
+        );
+        assert_eq!(stats.linked_refs, 2);
+        assert_eq!(stats.saved_bytes, 4096 + 3072);
+
+        // Not shared: nothing to count, and counting it would overstate what a
+        // `clean` would reclaim.
+        record_reflink_sharing(
+            &mut stats,
+            4096,
+            crate::sharing::Sharing {
+                shared: false,
+                private_bytes: 4096,
+            },
+        );
+        assert_eq!(stats.linked_refs, 2);
+        assert_eq!(stats.saved_bytes, 4096 + 3072);
+
+        // A probe that reports more private bytes than the file's size must not
+        // underflow into a colossal fake saving.
+        record_reflink_sharing(
+            &mut stats,
+            4096,
+            crate::sharing::Sharing {
+                shared: true,
+                private_bytes: 8192,
+            },
+        );
+        assert_eq!(stats.saved_bytes, 4096 + 3072, "saturating, not wrapping");
+    }
+
+    /// A hardlinked artifact is shared even where the extent probe reports
+    /// nothing, which is the only signal available on a filesystem without
+    /// reflinks (kunobi-ninja/kache#602).
+    #[cfg(unix)]
+    #[test]
+    fn a_hardlinked_artifact_is_reported_as_shared() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob = dir.path().join("blob.bin");
+        let linked = dir.path().join("target-copy.bin");
+        fs::write(&blob, vec![0u8; 4096]).unwrap();
+        fs::hard_link(&blob, &linked).unwrap();
+
+        let meta = fs::metadata(&linked).unwrap();
+        assert!(
+            artifact_sharing(&linked, &meta).shared,
+            "nlink > 1 is sharing regardless of what the extent probe says"
+        );
+
+        let plain = dir.path().join("plain.bin");
+        fs::write(&plain, vec![0u8; 4096]).unwrap();
+        let plain_meta = fs::metadata(&plain).unwrap();
+        assert!(
+            !artifact_sharing(&plain, &plain_meta).shared,
+            "a file with one link and no shared extents is local-only — calling \
+             it shared would tell users their build outputs are already cached"
+        );
     }
 
     fn zero_event_stats() -> daemon::EventStatsResponse {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3297,6 +3297,9 @@ impl Daemon {
                 + orphan_stats.removed,
             duration_ms: start.elapsed().as_millis() as u64,
             skipped: false,
+            // Only the size sweep pins on idle grace; dedup and the orphan
+            // sweep have no such gate, so this is the eviction figure alone.
+            entries_pinned: evict_stats.entries_pinned,
         };
 
         tracing::info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,12 @@ mod remote_plan;
 mod report;
 mod service;
 mod shards;
+// Both callers (`clean`'s classifier and `compute_link_stats`) are `cfg(unix)`,
+// because `nlink` is the signal they combine with. Windows ReFS block-cloning
+// has no read-side query to implement this against — `FSCTL_DUPLICATE_EXTENTS`
+// is write-only — so the module compiles to its unknown-answer stub there and
+// would otherwise read as dead code in non-test builds.
+#[cfg_attr(not(unix), allow(dead_code))]
 mod sharing;
 mod store;
 mod transport;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod remote_plan;
 mod report;
 mod service;
 mod shards;
+mod sharing;
 mod store;
 mod transport;
 mod tui;

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -1,0 +1,422 @@
+//! Does a file share storage with something else on disk, and how much of it
+//! would actually come back if the file were deleted (kunobi-ninja/kache#602)?
+//!
+//! `clean` used to answer "is this artifact backed by the cache?" with
+//! `nlink > 1`. That only detects the **hardlink fallback**. On APFS, btrfs and
+//! XFS-with-reflink — the path `link_to_target` *prefers* — a restore is a
+//! `clonefile`/`FICLONE` reflink, which by design produces an independent inode
+//! with `nlink == 1`. So on the filesystems where kache works best, every
+//! restored artifact looked "local" and `clean` reported ~0% cached.
+//!
+//! Measured on macOS/APFS against kache's own trees (#602):
+//!
+//! | Tree | apparent (`du`) | actually frees | shared |
+//! |---|---|---|---|
+//! | `target/` | 19.23 GiB | 14.28 GiB | 25.7% |
+//! | the store | 50.58 GiB | 19.07 GiB | 62.3% |
+//!
+//! Two separate questions fall out of that, and this module answers both:
+//!
+//! - **Is it shared?** — replaces the `nlink > 1` classifier.
+//! - **How much is private?** — how much a delete really returns. A reflinked
+//!   tree's apparent size overstates what you get back, because the shared
+//!   extents stay alive until *both* sides go.
+//!
+//! ## Fallback is the un-shared answer, deliberately
+//!
+//! Every probe failure degrades to [`Sharing::unknown_for`], which reports "not
+//! shared, all bytes private" — the same answer the old `nlink`-only code gave.
+//! That keeps a filesystem we cannot interrogate exactly as accurate as before
+//! rather than inventing sharing that may not exist, and it keeps `clean`'s
+//! reclaim estimate conservative: claiming bytes are shared when they are not
+//! would *understate* what a delete frees, which is the direction that makes a
+//! user keep files they could have removed.
+
+use std::path::Path;
+
+/// What the filesystem reports about one file's storage sharing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Sharing {
+    /// Whether this file shares any storage with another file — a reflink/clone
+    /// or a hardlink.
+    pub shared: bool,
+    /// Bytes that would actually be freed by deleting this file. Equal to the
+    /// file's size when nothing is shared; 0 when every block is shared with
+    /// something else that stays behind.
+    pub private_bytes: u64,
+}
+
+impl Sharing {
+    /// The answer for a file we could not interrogate: assume nothing is shared
+    /// and every byte is private. See the module docs on why this direction.
+    pub fn unknown_for(size: u64) -> Self {
+        Self {
+            shared: false,
+            private_bytes: size,
+        }
+    }
+}
+
+/// Probe how `path` shares storage. `size` is the file's apparent length, used
+/// for the private-byte fallback.
+///
+/// `nlink` is folded in by the callers rather than here, because they already
+/// hold the `Metadata` and a hardlink is sharing whatever the extent-level
+/// probe says.
+///
+/// Best-effort and never fatal: this runs inside a directory walk over tens of
+/// thousands of files, so any error yields [`Sharing::unknown_for`].
+pub fn probe(path: &Path, size: u64) -> Sharing {
+    probe_impl(path, size)
+}
+
+// ── macOS ───────────────────────────────────────────────────────────────────
+//
+// `getattrlist` with `FSOPT_ATTR_CMN_EXTENDED` exposes exactly the two numbers
+// this module wants: `ATTR_CMNEXT_PRIVATESIZE` (bytes freed if this file dies)
+// and `ATTR_CMNEXT_EXT_FLAGS` (whether blocks are shared at all).
+//
+// Two traps, both hit while measuring #602 and both worth naming:
+//
+//  1. **Ascending bit order.** The kernel packs the requested attributes in
+//     ascending order of their bit values, NOT in the order you list them. Get
+//     the struct layout wrong and you read plausible-looking garbage rather than
+//     an error — which is exactly what produced the numbers later corrected on
+//     the issue. `PRIVATESIZE` (0x008) therefore precedes `EXT_FLAGS` (0x200).
+//  2. **`ATTR_CMN_RETURNED_ATTRS` is load-bearing, not belt-and-braces.** Which
+//     extended attributes a volume actually returns varies by filesystem and OS
+//     version, and the reporter measured a volume advertising
+//     `VOL_CAP_FMT_CLONE_MAPPING = no` that nonetheless returned usable
+//     `PRIVATESIZE`. Trusting capability flags would have skipped a working
+//     interface; asking what came back is the reliable check.
+#[cfg(target_os = "macos")]
+fn probe_impl(path: &Path, size: u64) -> Sharing {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    // <sys/attr.h>. Values transcribed from the SDK header, not from memory:
+    // getting one wrong yields plausible garbage rather than an error.
+    const FSOPT_ATTR_CMN_EXTENDED: u32 = 0x0000_0020;
+    const ATTR_BIT_MAP_COUNT: u16 = 5;
+    const ATTR_CMN_RETURNED_ATTRS: u32 = 0x8000_0000;
+    // With FSOPT_ATTR_CMN_EXTENDED these two live in the `forkattr` slot.
+    const ATTR_CMNEXT_PRIVATESIZE: u32 = 0x0000_0008;
+    const ATTR_CMNEXT_EXT_FLAGS: u32 = 0x0000_0200;
+    // <sys/stat.h> ext_flags. NB 0x02 is EF_NO_XATTRS, not a sharing bit —
+    // testing it would mark every file without xattrs as shared.
+    const EF_MAY_SHARE_BLOCKS: u64 = 0x0000_0001;
+    const EF_SHARES_ALL_BLOCKS: u64 = 0x0000_0040;
+
+    #[repr(C)]
+    #[derive(Default)]
+    struct AttrList {
+        bitmapcount: u16,
+        reserved: u16,
+        commonattr: u32,
+        volattr: u32,
+        dirattr: u32,
+        fileattr: u32,
+        forkattr: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Default, Clone, Copy)]
+    struct AttributeSet {
+        commonattr: u32,
+        volattr: u32,
+        dirattr: u32,
+        fileattr: u32,
+        forkattr: u32,
+    }
+
+    // Field order follows the kernel's ascending-bit-order packing (trap 1):
+    // returned_attrs first, then PRIVATESIZE (0x008), then EXT_FLAGS (0x200).
+    // Transposing these two is the exact error that produced the numbers later
+    // corrected on #602 — and the first version of this code repeated it, which
+    // is why `a_reflinked_copy_is_detected_as_shared_despite_nlink_1` exists.
+    //
+    // `packed` because the kernel writes the values back to back with no
+    // padding: `length` (u32) + `returned` (5 × u32) is 24 bytes, which happens
+    // to be 8-aligned here, but relying on that silently breaks if the requested
+    // attribute set ever changes.
+    #[repr(C, packed)]
+    struct Buf {
+        length: u32,
+        returned: AttributeSet,
+        /// `off_t` — bytes freed if this file is deleted.
+        private_size: i64,
+        ext_flags: u64,
+    }
+
+    let Ok(c_path) = CString::new(path.as_os_str().as_bytes()) else {
+        return Sharing::unknown_for(size);
+    };
+
+    let mut attrs = AttrList {
+        bitmapcount: ATTR_BIT_MAP_COUNT,
+        commonattr: ATTR_CMN_RETURNED_ATTRS,
+        forkattr: ATTR_CMNEXT_PRIVATESIZE | ATTR_CMNEXT_EXT_FLAGS,
+        ..Default::default()
+    };
+    let mut buf: Buf = unsafe { std::mem::zeroed() };
+
+    let rc = unsafe {
+        libc::getattrlist(
+            c_path.as_ptr(),
+            &mut attrs as *mut AttrList as *mut libc::c_void,
+            &mut buf as *mut Buf as *mut libc::c_void,
+            std::mem::size_of::<Buf>(),
+            FSOPT_ATTR_CMN_EXTENDED,
+        )
+    };
+    if rc != 0 {
+        return Sharing::unknown_for(size);
+    }
+
+    // Trap 2: only believe fields the kernel says it actually returned.
+    // Copied out of the packed struct before use — taking a reference to an
+    // unaligned field is UB.
+    let returned_fork = buf.returned.forkattr;
+    let got_flags = returned_fork & ATTR_CMNEXT_EXT_FLAGS != 0;
+    let got_private = returned_fork & ATTR_CMNEXT_PRIVATESIZE != 0;
+    if !got_flags && !got_private {
+        return Sharing::unknown_for(size);
+    }
+    let ext_flags = buf.ext_flags;
+    let private_size = buf.private_size;
+
+    let shared = got_flags && ext_flags & (EF_MAY_SHARE_BLOCKS | EF_SHARES_ALL_BLOCKS) != 0;
+    let private_bytes = if got_private && private_size >= 0 {
+        // PRIVATESIZE is allocated bytes; a file can report more private space
+        // than its logical length (block rounding, preallocation). Clamp so a
+        // reclaim estimate never exceeds the size we are reporting for the file.
+        (private_size as u64).min(size)
+    } else {
+        size
+    };
+
+    Sharing {
+        shared,
+        private_bytes,
+    }
+}
+
+// ── Linux ───────────────────────────────────────────────────────────────────
+//
+// `FS_IOC_FIEMAP` maps a file's extents; `FIEMAP_EXTENT_SHARED` marks the ones
+// shared with another inode, which is what btrfs/XFS reflinks produce. Summing
+// the unshared extents gives the private-byte figure directly.
+//
+// The issue proposed this but flagged it as untested (no Linux box). It is
+// written to fail safe: any unexpected shape — ioctl error, zero extents, a
+// truncated mapping — falls back to "not shared, all private".
+#[cfg(target_os = "linux")]
+fn probe_impl(path: &Path, size: u64) -> Sharing {
+    use std::os::fd::AsRawFd;
+
+    const FIEMAP_MAX_EXTENTS: usize = 32;
+    const FIEMAP_FLAG_SYNC: u32 = 0x0000_0001;
+    const FIEMAP_EXTENT_LAST: u32 = 0x0000_0001;
+    const FIEMAP_EXTENT_SHARED: u32 = 0x0000_2000;
+    // _IOWR('f', 11, struct fiemap). Held as u32 and cast at the call site
+    // because libc types the ioctl request differently per target — `c_ulong`
+    // on gnu, `c_int` on musl — and the request is a 32-bit value either way.
+    // Writing it as `libc::Ioctl` directly would overflow i32 on musl.
+    const FS_IOC_FIEMAP: u32 = 0xc020_660b;
+
+    #[repr(C)]
+    #[derive(Default, Clone, Copy)]
+    struct FiemapExtent {
+        fe_logical: u64,
+        fe_physical: u64,
+        fe_length: u64,
+        fe_reserved64: [u64; 2],
+        fe_flags: u32,
+        fe_reserved: [u32; 3],
+    }
+
+    #[repr(C)]
+    struct Fiemap {
+        fm_start: u64,
+        fm_length: u64,
+        fm_flags: u32,
+        fm_mapped_extents: u32,
+        fm_extent_count: u32,
+        fm_reserved: u32,
+        fm_extents: [FiemapExtent; FIEMAP_MAX_EXTENTS],
+    }
+
+    // An empty file shares nothing and frees nothing; skip the syscall.
+    if size == 0 {
+        return Sharing {
+            shared: false,
+            private_bytes: 0,
+        };
+    }
+
+    let Ok(file) = std::fs::File::open(path) else {
+        return Sharing::unknown_for(size);
+    };
+
+    let mut shared_bytes: u64 = 0;
+    let mut private_bytes: u64 = 0;
+    let mut any_shared = false;
+    let mut offset: u64 = 0;
+
+    // A heavily fragmented file needs more than one batch of extents.
+    for _ in 0..64 {
+        let mut fm: Fiemap = unsafe { std::mem::zeroed() };
+        fm.fm_start = offset;
+        fm.fm_length = u64::MAX - offset;
+        fm.fm_flags = FIEMAP_FLAG_SYNC;
+        fm.fm_extent_count = FIEMAP_MAX_EXTENTS as u32;
+
+        let rc = unsafe {
+            libc::ioctl(
+                file.as_raw_fd(),
+                FS_IOC_FIEMAP as libc::Ioctl,
+                &mut fm as *mut Fiemap as *mut libc::c_void,
+            )
+        };
+        if rc != 0 {
+            return Sharing::unknown_for(size);
+        }
+        let mapped = fm.fm_mapped_extents as usize;
+        if mapped == 0 {
+            break;
+        }
+
+        let mut last = false;
+        for ext in fm.fm_extents.iter().take(mapped.min(FIEMAP_MAX_EXTENTS)) {
+            if ext.fe_flags & FIEMAP_EXTENT_SHARED != 0 {
+                shared_bytes = shared_bytes.saturating_add(ext.fe_length);
+                any_shared = true;
+            } else {
+                private_bytes = private_bytes.saturating_add(ext.fe_length);
+            }
+            offset = ext.fe_logical.saturating_add(ext.fe_length);
+            if ext.fe_flags & FIEMAP_EXTENT_LAST != 0 {
+                last = true;
+            }
+        }
+        if last {
+            break;
+        }
+    }
+
+    // A file with no mapped extents at all (fully sparse, or inline in the
+    // inode) tells us nothing useful — don't claim it is private or shared.
+    if shared_bytes == 0 && private_bytes == 0 {
+        return Sharing::unknown_for(size);
+    }
+
+    Sharing {
+        shared: any_shared,
+        // Extents are block-aligned and can overrun the logical length; clamp
+        // so a reclaim estimate never exceeds the file's reported size.
+        private_bytes: private_bytes.min(size),
+    }
+}
+
+// ── Everything else ─────────────────────────────────────────────────────────
+//
+// Windows ReFS block-cloning has no equivalent public query (the restore path
+// uses FSCTL_DUPLICATE_EXTENTS_TO_FILE, which is write-only), so there is
+// nothing to ask. Callers still fold in `nlink` where the platform has it.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn probe_impl(_path: &Path, size: u64) -> Sharing {
+    Sharing::unknown_for(size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_reports_everything_private_and_unshared() {
+        // The conservative direction: a filesystem we can't interrogate must
+        // look exactly like the old nlink-only behaviour, never invent sharing.
+        let s = Sharing::unknown_for(4096);
+        assert!(!s.shared);
+        assert_eq!(s.private_bytes, 4096);
+    }
+
+    #[test]
+    fn an_ordinary_private_file_is_not_reported_as_shared() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plain.bin");
+        let bytes = vec![0xABu8; 256 * 1024];
+        std::fs::write(&path, &bytes).unwrap();
+
+        let s = probe(&path, bytes.len() as u64);
+        assert!(
+            !s.shared,
+            "a freshly written file shares nothing: {s:?} — a false positive here \
+             would make `clean` tell users their build outputs are already cached"
+        );
+        assert_eq!(
+            s.private_bytes,
+            bytes.len() as u64,
+            "all of an unshared file's bytes are reclaimable: {s:?}"
+        );
+    }
+
+    #[test]
+    fn a_missing_file_falls_back_instead_of_failing() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = probe(&dir.path().join("does-not-exist"), 1234);
+        assert_eq!(s, Sharing::unknown_for(1234));
+    }
+
+    #[test]
+    fn an_empty_file_reclaims_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.bin");
+        std::fs::write(&path, b"").unwrap();
+        let s = probe(&path, 0);
+        assert_eq!(s.private_bytes, 0, "an empty file frees no bytes: {s:?}");
+    }
+
+    /// The case the whole module exists for: a reflinked copy has `nlink == 1`
+    /// yet shares all its blocks, which is what made `clean` report 0% cached
+    /// on APFS. Skips itself where the platform or filesystem has no reflink.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn a_reflinked_copy_is_detected_as_shared_despite_nlink_1() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("orig.bin");
+        let dst = dir.path().join("clone.bin");
+        // Large enough to occupy real extents rather than living inline in the
+        // inode, which would leave nothing to share.
+        let bytes = vec![0x5Au8; 8 * 1024 * 1024];
+        std::fs::write(&src, &bytes).unwrap();
+
+        if crate::link::try_reflink(&src, &dst).is_err() {
+            eprintln!("skipping: no reflink support on this filesystem");
+            return;
+        }
+
+        let size = bytes.len() as u64;
+        let meta = std::fs::metadata(&dst).unwrap();
+        assert_eq!(
+            meta.nlink(),
+            1,
+            "a clone is a distinct inode — this is precisely why nlink was the \
+             wrong signal (#602)"
+        );
+
+        let s = probe(&dst, size);
+        assert!(
+            s.shared,
+            "a reflinked clone must be detected as sharing storage: {s:?}"
+        );
+        assert!(
+            s.private_bytes < size,
+            "a fully shared clone must not claim to free its whole apparent size \
+             ({} of {size} bytes reported private)",
+            s.private_bytes
+        );
+    }
+}

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -275,8 +275,8 @@ fn probe_linux(path: &Path, size: u64) -> Sharing {
 
     const FIEMAP_MAX_EXTENTS: usize = 32;
     const FIEMAP_FLAG_SYNC: u32 = 0x0000_0001;
-    const FIEMAP_EXTENT_LAST: u32 = 0x0000_0001;
-    const FIEMAP_EXTENT_SHARED: u32 = 0x0000_2000;
+    // The extent-flag bits live in `extent_is_shared` / `extent_is_last`, which
+    // own the bit tests so they can be unit-tested against synthetic flag words.
     // _IOWR('f', 11, struct fiemap). Held as u32 and cast at the call site
     // because libc types the ioctl request differently per target — `c_ulong`
     // on gnu, `c_int` on musl — and the request is a 32-bit value either way.

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -67,7 +67,18 @@ impl Sharing {
 /// Best-effort and never fatal: this runs inside a directory walk over tens of
 /// thousands of files, so any error yields [`Sharing::unknown_for`].
 pub fn probe(path: &Path, size: u64) -> Sharing {
-    probe_impl(path, size)
+    #[cfg(target_os = "macos")]
+    {
+        probe_macos(path, size)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        probe_linux(path, size)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        probe_unsupported(path, size)
+    }
 }
 
 // ── macOS ───────────────────────────────────────────────────────────────────
@@ -90,7 +101,7 @@ pub fn probe(path: &Path, size: u64) -> Sharing {
 //     `PRIVATESIZE`. Trusting capability flags would have skipped a working
 //     interface; asking what came back is the reliable check.
 #[cfg(target_os = "macos")]
-fn probe_impl(path: &Path, size: u64) -> Sharing {
+fn probe_macos(path: &Path, size: u64) -> Sharing {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
 
@@ -210,8 +221,20 @@ fn probe_impl(path: &Path, size: u64) -> Sharing {
 // The issue proposed this but flagged it as untested (no Linux box). It is
 // written to fail safe: any unexpected shape — ioctl error, zero extents, a
 // truncated mapping — falls back to "not shared, all private".
+/// Length of the FIEMAP window starting at `offset`: everything from there to
+/// the end of the address space.
+///
+/// Its own function because it is only ever exercised past the first batch —
+/// a file needs more than `FIEMAP_MAX_EXTENTS` extents to loop again, which no
+/// test can arrange reliably on a live filesystem — while getting it wrong
+/// (adding instead of subtracting) overflows.
 #[cfg(target_os = "linux")]
-fn probe_impl(path: &Path, size: u64) -> Sharing {
+fn fiemap_window_length(offset: u64) -> u64 {
+    u64::MAX - offset
+}
+
+#[cfg(target_os = "linux")]
+fn probe_linux(path: &Path, size: u64) -> Sharing {
     use std::os::fd::AsRawFd;
 
     const FIEMAP_MAX_EXTENTS: usize = 32;
@@ -267,7 +290,7 @@ fn probe_impl(path: &Path, size: u64) -> Sharing {
     for _ in 0..64 {
         let mut fm: Fiemap = unsafe { std::mem::zeroed() };
         fm.fm_start = offset;
-        fm.fm_length = u64::MAX - offset;
+        fm.fm_length = fiemap_window_length(offset);
         fm.fm_flags = FIEMAP_FLAG_SYNC;
         fm.fm_extent_count = FIEMAP_MAX_EXTENTS as u32;
 
@@ -324,7 +347,7 @@ fn probe_impl(path: &Path, size: u64) -> Sharing {
 // uses FSCTL_DUPLICATE_EXTENTS_TO_FILE, which is write-only), so there is
 // nothing to ask. Callers still fold in `nlink` where the platform has it.
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-fn probe_impl(_path: &Path, size: u64) -> Sharing {
+fn probe_unsupported(_path: &Path, size: u64) -> Sharing {
     Sharing::unknown_for(size)
 }
 
@@ -375,6 +398,52 @@ mod tests {
         std::fs::write(&path, b"").unwrap();
         let s = probe(&path, 0);
         assert_eq!(s.private_bytes, 0, "an empty file frees no bytes: {s:?}");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_fiemap_window_runs_from_the_offset_to_the_end() {
+        assert_eq!(fiemap_window_length(0), u64::MAX);
+        assert_eq!(fiemap_window_length(4096), u64::MAX - 4096);
+    }
+
+    /// A sparse file allocates far fewer bytes than its length, so the honest
+    /// answer differs from the fallback. That is what makes this test able to
+    /// see a probe that quietly gave up: `unknown_for` would claim the whole
+    /// apparent size is reclaimable, and `clean` would overstate what a delete
+    /// returns.
+    ///
+    /// Needs no reflink support, so it works on the ext4 that CI runs on.
+    #[cfg(unix)]
+    #[test]
+    fn a_sparse_file_reports_only_its_allocated_bytes_as_private() {
+        use std::io::{Seek, SeekFrom, Write};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sparse.bin");
+        let size = 64 * 1024 * 1024;
+
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.seek(SeekFrom::Start(size - 4096)).unwrap();
+        f.write_all(&[0x7Eu8; 4096]).unwrap();
+        f.sync_all().unwrap();
+        drop(f);
+
+        let allocated = {
+            use std::os::unix::fs::MetadataExt;
+            std::fs::metadata(&path).unwrap().blocks() * 512
+        };
+        if allocated >= size {
+            eprintln!("skipping: {path:?} was not stored sparsely ({allocated} of {size})");
+            return;
+        }
+
+        let s = probe(&path, size);
+        assert!(
+            s.private_bytes < size,
+            "a hole is not reclaimable storage: {s:?} for a {size}-byte file \
+             holding {allocated} allocated bytes"
+        );
     }
 
     /// The case the whole module exists for: a reflinked copy has `nlink == 1`

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -163,11 +163,19 @@ fn probe_macos(path: &Path, size: u64) -> Sharing {
         return Sharing::unknown_for(size);
     };
 
+    // Every field spelled out rather than `..Default::default()`. This is the
+    // struct the kernel reads to decide what to write back, so being explicit
+    // about the zeroed slots is worth the four extra lines — and it leaves no
+    // field for a mutation to silently drop, which the mutation lane cannot
+    // otherwise reach inside a `#[cfg(target_os = "macos")]` function.
     let mut attrs = AttrList {
         bitmapcount: ATTR_BIT_MAP_COUNT,
+        reserved: 0,
         commonattr: ATTR_CMN_RETURNED_ATTRS,
+        volattr: 0,
+        dirattr: 0,
+        fileattr: 0,
         forkattr: ATTR_CMNEXT_PRIVATESIZE | ATTR_CMNEXT_EXT_FLAGS,
-        ..Default::default()
     };
     let mut buf: Buf = unsafe { std::mem::zeroed() };
 
@@ -231,6 +239,34 @@ fn probe_macos(path: &Path, size: u64) -> Sharing {
 #[cfg(target_os = "linux")]
 fn fiemap_window_length(offset: u64) -> u64 {
     u64::MAX - offset
+}
+
+/// Does this extent share its blocks with another inode? That is the one bit
+/// btrfs/XFS reflinks set, and the whole reason this probe exists.
+///
+/// Its own function so it can be tested against synthetic flag words: a real
+/// shared extent needs a filesystem that can make a reflink, which the CI lane's
+/// ext4 cannot, and testing the bit test is what actually matters here.
+#[cfg(target_os = "linux")]
+fn extent_is_shared(fe_flags: u32) -> bool {
+    const FIEMAP_EXTENT_SHARED: u32 = 0x0000_2000;
+    fe_flags & FIEMAP_EXTENT_SHARED != 0
+}
+
+/// Is this the final extent of the file? Missing it costs an extra ioctl round;
+/// seeing it falsely truncates the map and undercounts the file.
+#[cfg(target_os = "linux")]
+fn extent_is_last(fe_flags: u32) -> bool {
+    const FIEMAP_EXTENT_LAST: u32 = 0x0000_0001;
+    fe_flags & FIEMAP_EXTENT_LAST != 0
+}
+
+/// Did the map come back empty — a fully sparse file, or one stored inline in
+/// its inode? Neither is evidence about sharing, so the caller falls back
+/// instead of reporting "all private".
+#[cfg(target_os = "linux")]
+fn mapped_nothing(shared_bytes: u64, private_bytes: u64) -> bool {
+    shared_bytes == 0 && private_bytes == 0
 }
 
 #[cfg(target_os = "linux")]
@@ -311,14 +347,14 @@ fn probe_linux(path: &Path, size: u64) -> Sharing {
 
         let mut last = false;
         for ext in fm.fm_extents.iter().take(mapped.min(FIEMAP_MAX_EXTENTS)) {
-            if ext.fe_flags & FIEMAP_EXTENT_SHARED != 0 {
+            if extent_is_shared(ext.fe_flags) {
                 shared_bytes = shared_bytes.saturating_add(ext.fe_length);
                 any_shared = true;
             } else {
                 private_bytes = private_bytes.saturating_add(ext.fe_length);
             }
             offset = ext.fe_logical.saturating_add(ext.fe_length);
-            if ext.fe_flags & FIEMAP_EXTENT_LAST != 0 {
+            if extent_is_last(ext.fe_flags) {
                 last = true;
             }
         }
@@ -329,7 +365,7 @@ fn probe_linux(path: &Path, size: u64) -> Sharing {
 
     // A file with no mapped extents at all (fully sparse, or inline in the
     // inode) tells us nothing useful — don't claim it is private or shared.
-    if shared_bytes == 0 && private_bytes == 0 {
+    if mapped_nothing(shared_bytes, private_bytes) {
         return Sharing::unknown_for(size);
     }
 
@@ -405,6 +441,42 @@ mod tests {
     fn the_fiemap_window_runs_from_the_offset_to_the_end() {
         assert_eq!(fiemap_window_length(0), u64::MAX);
         assert_eq!(fiemap_window_length(4096), u64::MAX - 4096);
+    }
+
+    /// The extent flag tests, against synthetic words. A real shared extent
+    /// needs a filesystem that can make a reflink, which CI's ext4 cannot, so
+    /// this is where the bit arithmetic actually gets checked.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn extent_flags_are_read_bit_by_bit() {
+        const SHARED: u32 = 0x0000_2000;
+        const LAST: u32 = 0x0000_0001;
+        // 0x0800 is FIEMAP_EXTENT_ENCODED: a neighbouring bit that must not be
+        // mistaken for sharing.
+        const OTHER: u32 = 0x0000_0800;
+
+        assert!(extent_is_shared(SHARED));
+        assert!(extent_is_shared(SHARED | LAST | OTHER));
+        assert!(!extent_is_shared(0));
+        assert!(
+            !extent_is_shared(OTHER | LAST),
+            "only the SHARED bit means shared — a false positive here reports \
+             private storage as already-cached"
+        );
+
+        assert!(extent_is_last(LAST));
+        assert!(extent_is_last(LAST | SHARED));
+        assert!(!extent_is_last(0));
+        assert!(!extent_is_last(SHARED | OTHER));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_empty_map_is_not_evidence_of_anything() {
+        assert!(mapped_nothing(0, 0));
+        assert!(!mapped_nothing(0, 4096), "private bytes were mapped");
+        assert!(!mapped_nothing(4096, 0), "shared bytes were mapped");
+        assert!(!mapped_nothing(4096, 4096));
     }
 
     /// A sparse file allocates far fewer bytes than its length, so the honest

--- a/src/store.rs
+++ b/src/store.rs
@@ -560,6 +560,15 @@ pub struct GcStats {
     pub duration_ms: u64,
     #[serde(default)]
     pub skipped: bool,
+    /// Entries eviction selected but could not remove because they were
+    /// accessed within [`EVICTION_IDLE_GRACE`] — a live build may be mid-restore
+    /// on them (#326, #182).
+    ///
+    /// Recorded so the CLI can explain "evicted 0" while the store is over its
+    /// limit. Without it that reads as "GC is broken", which is what #509 was
+    /// filed about and plausibly what turned #497 into a 113 GB bug report.
+    #[serde(default)]
+    pub entries_pinned: usize,
 }
 
 /// Statistics returned by [`Store::sweep_orphan_blobs`].
@@ -588,7 +597,7 @@ pub struct Store {
 /// (hardlink/reflink/read — milliseconds; once linked, the target file owns its
 /// own inode and is immune to a later blob unlink), so 2 minutes is generous
 /// headroom on a slow disk while staying far below any sensible cache lifetime.
-const EVICTION_IDLE_GRACE: Duration = Duration::from_secs(120);
+pub(crate) const EVICTION_IDLE_GRACE: Duration = Duration::from_secs(120);
 
 /// Entries backfilled with their rebuild cost per GC sweep
 /// (kunobi-ninja/kache#594).
@@ -2147,8 +2156,13 @@ impl Store {
                     }
                 }
                 // Pinned by a recent access — a live build may be mid-restore
-                // on it (kunobi-ninja/kache#326, #182). Leave it for next round.
-                Ok(false) => continue,
+                // on it (kunobi-ninja/kache#326, #182). Leave it for next round,
+                // but count it so the caller can say *why* nothing was evicted
+                // instead of reporting a bare "0" (#509).
+                Ok(false) => {
+                    stats.entries_pinned += 1;
+                    continue;
+                }
                 Err(e) => {
                     // A corrupt entry (unloadable meta.json) refuses removal to
                     // avoid leaking blob refcounts (#276); skip it and keep

--- a/src/store.rs
+++ b/src/store.rs
@@ -4493,6 +4493,12 @@ mod tests {
             stats.entries_evicted, 0,
             "a recently-accessed entry must be pinned against eviction"
         );
+        assert_eq!(
+            stats.entries_pinned, 1,
+            "and it must be COUNTED as held back — that count is the whole \
+             difference between `evicted 0 entries` reading as a broken GC and \
+             explaining itself (#509)"
+        );
         assert!(store.contains("live_key"));
 
         // Age it past the grace window → no longer pinned → evictable.


### PR DESCRIPTION
Closes #602. Closes #509.

Two independent reporting bugs, both of which make kache look broken while it is working correctly. Grouped because they are both `area:local` output-honesty fixes and both small.

## #602 — `clean` reported ~0% cached on the filesystems kache is best on

`clean` decided an artifact was cache-backed with `nlink > 1`, which only detects the **hardlink fallback**. On APFS, btrfs and XFS — the path `link_to_target` *prefers* — a restore is a `clonefile`/`FICLONE` reflink, which by design produces an independent inode with `nlink == 1`. Every restored artifact therefore looked local. That is the number the README advertises and the one a user leans on when deciding what to delete.

New `src/sharing.rs` asks what was actually meant: does this file share storage, and how much would deleting it really free.

| Platform | Mechanism |
|---|---|
| macOS | `getattrlist` + `FSOPT_ATTR_CMN_EXTENDED` → `ATTR_CMNEXT_PRIVATESIZE`, `ATTR_CMNEXT_EXT_FLAGS` |
| Linux | `FS_IOC_FIEMAP`, summing extents without `FIEMAP_EXTENT_SHARED` |

`nlink` is retained and OR'd in rather than replaced, so the non-CoW fallback keeps working and the two signals combine.

**Measured on the reporter's machine:**

```
before:  Found 1 target/ directory (20.4 GiB total, 0 B cached)
after:   Found 1 target/ directory (20.4 GiB total, 11.1 GiB cached)
```

A whole-store scan reports **68.2% of bytes shared** with live targets, against the 62.3% measured on the issue before the store grew. `compute_link_stats` now counts reflinked blobs toward `saved_bytes`, where a purely reflinked store previously reported zero.

**Failure direction is deliberate.** Every probe failure degrades to "not shared, all bytes private" — exactly what the `nlink`-only code returned. A filesystem we cannot interrogate is no worse off than before, and the reclaim estimate stays conservative: claiming bytes are shared when they are not would *understate* what a delete frees, which is the direction that makes a user keep files they could have removed.

## #509 — `evicted 0 entries` next to a store at 912%

Correct behaviour, uselessly reported. Every candidate was inside `EVICTION_IDLE_GRACE`, so the sweep deliberately left it alone. A user seeing `0` beside `912%` concludes GC is broken and stops trying — plausibly how #497 became a 113 GB bug report rather than a self-service fix.

`GcStats` gains `entries_pinned`, counted at the point where the sweep already distinguished a grace skip from a removal. `describe_eviction` turns the outcome into a sentence that names the grace period and says what to do next. Kept pure, so the phrasing is unit-testable without running a sweep.

## Portability, verified rather than assumed

The macOS attribute values are transcribed from the SDK header. They pack in **ascending bit order**, so `PRIVATESIZE` (0x008) precedes `EXT_FLAGS` (0x200) — and `EF_SHARES_ALL_BLOCKS` is `0x40`, where **`0x02` is `EF_NO_XATTRS`** and would have marked nearly every file as shared. The first draft got both wrong; the reflink test caught it, and an independent C probe using the same syscall confirmed the corrected reading (`priv=0 ef=0x41` on a restored `.rlib`). This is the same ascending-bit-order trap that produced the numbers later corrected on the issue.

On Linux the ioctl request is `c_ulong` on gnu but `c_int` on musl, so the FIEMAP constant is held as `u32` and cast at the call site. Caught by cross-compiling, not by inspection.

## Testing

- 10 new tests. Full suite green: 1419 unit, 45 integration. `fmt` clean; `clippy --workspace --all-targets -- -D warnings` clean, verified with a forced recompile rather than a cached result.
- Cross-checked with clippy under `-D warnings` for `aarch64-unknown-linux-gnu`, `aarch64-unknown-linux-musl`, `x86_64-pc-windows-msvc`.
- End-to-end run of `kache clean` against a real 20.4 GiB tree and a 48 GiB store.

**Known gap:** the Linux FIEMAP path compiles on both libcs and is written to fail safe, but I could not execute it — no working container runtime on this machine. It remains untested at runtime, as the issue itself flagged for that half. CI's Linux jobs will exercise the fallback but not a genuinely reflinked file.
