### PR TITLE
fix(why-miss): join the cascade walk by compilation unit, not crate name (#627)

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -59,6 +59,48 @@ pub fn format_crate_output_stem(crate_name: &str, extra_filename: &str) -> Strin
     format!("{crate_name}{extra_filename}")
 }
 
+/// Compilation-unit identity for diagnostics: cargo's `-C extra-filename` hash,
+/// without its leading dash (kunobi-ninja/kache#627).
+///
+/// `crate_name` is not a unit identity — two versions of a package, a host and
+/// a target build of the same crate, and different feature sets all collapse
+/// onto one name. Cargo's `extra-filename` is exactly the disambiguator that
+/// keeps those units' artifacts from colliding in one `deps/` directory, so
+/// within a build tree it identifies the unit precisely.
+///
+/// Deliberately NOT `-C metadata`: cargo sets the two to different hashes
+/// (`-C metadata=04bad873faff484a -C extra-filename=-843f02d6a46ebef1` in one
+/// observed invocation), and it is `extra-filename` that appears in the
+/// artifact filename a consumer sees on its `--extern` path. Matching the two
+/// sides needs the one that is visible from both.
+///
+/// This is recorded on events, never folded into a cache key: keying on it
+/// would tie the key to cargo's unit hashing and break cross-machine sharing.
+pub fn unit_id_from_extra_filename(extra_filename: &str) -> Option<String> {
+    let id = extra_filename.strip_prefix('-').unwrap_or(extra_filename);
+    (!id.is_empty()).then(|| id.to_string())
+}
+
+/// The producing unit's identity, recovered from an `--extern` artifact path.
+///
+/// Cargo names dependency artifacts `lib{crate_name}-{hash}.rlib` (`.rmeta`,
+/// `.dylib`, `.so`, `.dll`), where `-{hash}` is the producer's
+/// `-C extra-filename`. Taking the tail after the LAST dash is safe because a
+/// rustc crate name cannot contain one.
+///
+/// Returns `None` for anything not carrying that suffix — a sysroot crate, a
+/// hand-rolled rustc invocation, an artifact built without `extra-filename` —
+/// so callers fall back to name matching rather than inventing an identity.
+pub fn unit_id_from_artifact_path(path: &Path) -> Option<String> {
+    let stem = path.file_stem()?.to_str()?;
+    let (_, suffix) = stem.rsplit_once('-')?;
+    // Cargo's hash is lowercase hex. Requiring that shape keeps a crate whose
+    // *file* name happens to carry a dash (`libfoo-bar.rlib`, built outside
+    // cargo) from being read as a unit id.
+    let hex = suffix.len() >= 8 && suffix.bytes().all(|b| b.is_ascii_hexdigit());
+    hex.then(|| suffix.to_string())
+}
+
 /// Parsed rustc invocation arguments relevant to caching.
 #[derive(Debug, Clone, Default)]
 pub struct RustcArgs {
@@ -537,6 +579,15 @@ impl RustcArgs {
         ))
     }
 
+    /// This compile's own unit identity, for diagnostics only
+    /// (kunobi-ninja/kache#627). `None` when cargo passed no `-C extra-filename`,
+    /// which is the same case [`unit_id_from_artifact_path`] cannot resolve from
+    /// the consumer side — so the two sides go unidentified together, and
+    /// `why-miss` falls back to matching by crate name.
+    pub fn unit_id(&self) -> Option<String> {
+        unit_id_from_extra_filename(self.extra_filename.as_deref()?)
+    }
+
     /// Whether this compilation has coverage instrumentation enabled (-C instrument-coverage).
     /// When active, path remapping must be skipped so coverage tools (tarpaulin, llvm-cov)
     /// can map profraw data back to source files.
@@ -618,6 +669,59 @@ fn record_codegen_opt(parsed: &mut RustcArgs, value: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two sides of the #627 join have to agree: what a producer records
+    /// for itself (`-C extra-filename`) must equal what a consumer recovers
+    /// from the artifact filename cargo built with that flag.
+    #[test]
+    fn unit_id_round_trips_between_the_producer_and_its_artifact() {
+        let producer = unit_id_from_extra_filename("-843f02d6a46ebef1").unwrap();
+        for artifact in [
+            "/w/target/debug/deps/librust_check-843f02d6a46ebef1.rmeta",
+            "/w/target/debug/deps/librust_check-843f02d6a46ebef1.rlib",
+            "/w/target/debug/deps/librust_check-843f02d6a46ebef1.dylib",
+            r"C:\w\target\debug\deps\librust_check-843f02d6a46ebef1.rlib",
+        ] {
+            assert_eq!(
+                unit_id_from_artifact_path(Path::new(artifact)).as_deref(),
+                Some(producer.as_str()),
+                "{artifact}"
+            );
+        }
+    }
+
+    #[test]
+    fn unit_id_declines_paths_without_a_cargo_hash_suffix() {
+        // A sysroot crate, and a crate whose file name merely contains a dash:
+        // inventing an identity for either would be worse than falling back to
+        // matching by name.
+        for artifact in [
+            "/toolchain/lib/rustlib/x86_64/lib/libstd.rlib",
+            "/w/target/debug/deps/libfoo-bar.rlib",
+            "/w/target/debug/deps/libfoo-123.rlib",
+        ] {
+            assert_eq!(
+                unit_id_from_artifact_path(Path::new(artifact)),
+                None,
+                "{artifact}"
+            );
+        }
+        assert_eq!(unit_id_from_extra_filename(""), None);
+        assert_eq!(unit_id_from_extra_filename("-"), None);
+    }
+
+    #[test]
+    fn unit_id_reads_the_parsed_extra_filename() {
+        let args: Vec<String> = ["rustc", "rustc", "--crate-name", "foo", "src/lib.rs"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let mut parsed = RustcArgs::parse(&args).unwrap();
+        assert_eq!(parsed.unit_id(), None, "no -C extra-filename, no identity");
+
+        parsed.extra_filename = Some("-d44c553abc12".to_string());
+        assert_eq!(parsed.unit_id().as_deref(), Some("d44c553abc12"));
+    }
 
     #[test]
     fn test_parse_basic_lib() {

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -5269,6 +5269,51 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
     }
 
+    /// Key computation stashes this compile's unit identity and its per-extern
+    /// producer ids, and each is TAKEN — a second read yields `None`, so a
+    /// compile that computes no rustc key cannot inherit the previous one's
+    /// identities from the same process (kunobi-ninja/kache#627).
+    #[test]
+    fn key_computation_stashes_unit_identity_and_yields_it_once() {
+        let _lock = key_test_lock();
+        let args: Vec<String> = [
+            "rustc",
+            "--crate-name",
+            "app",
+            "src/lib.rs",
+            "-C",
+            "extra-filename=-843f02d6a46ebef1",
+            "--extern",
+            "foo_old=/w/target/debug/deps/libfoo-0532daf0ee3516f0.rlib",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let mut parsed = RustcArgs::parse(&args).unwrap();
+        // Skip the dep-info pre-pass: this is about what the externs loop
+        // records, not source discovery.
+        parsed.source_file = None;
+
+        compute_cache_key(&parsed, &FileHasher::new(), &PathNormalizer::empty()).unwrap();
+
+        assert_eq!(
+            take_last_key_unit_id().as_deref(),
+            Some("843f02d6a46ebef1"),
+            "the compile's own `-C extra-filename`"
+        );
+        assert_eq!(take_last_key_unit_id(), None, "taken, not copied");
+
+        let units = take_last_key_extern_units().expect("recorded with the digests");
+        assert_eq!(
+            units.get("foo_old").map(String::as_str),
+            // Keyed by the alias the consumer used; the value is the producer's
+            // identity, recovered from the artifact filename even though that
+            // file does not exist here.
+            Some("0532daf0ee3516f0")
+        );
+        assert_eq!(take_last_key_extern_units(), None, "taken, not copied");
+    }
+
     /// True if a bare `rustc` is invocable. `compute_cache_key` forks
     /// rustc for the version probe and dep-info pre-pass; without it
     /// the key still computes (the pre-pass falls back) but the

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -461,6 +461,39 @@ pub fn take_last_key_externs() -> Option<std::collections::BTreeMap<String, Stri
     LAST_KEY_EXTERNS.lock().ok().and_then(|mut g| g.take())
 }
 
+/// Producing-unit identity per extern, teed off the same loop that computes
+/// [`LAST_KEY_EXTERNS`] (kunobi-ninja/kache#627).
+///
+/// Keyed by the name the CONSUMER used, which under Cargo's `package = "..."`
+/// renaming is an alias (`foo_old` for a crate whose own events say `foo`). The
+/// value is the producer's `-C extra-filename`, recovered from the artifact path
+/// — the one identity visible from both sides, so `why-miss` can join a changed
+/// dependency to the exact unit that produced it instead of guessing by name.
+///
+/// Absent for an extern whose path carries no such suffix (sysroot crates,
+/// non-cargo invocations); the walk then falls back to matching by name.
+static LAST_KEY_EXTERN_UNITS: std::sync::Mutex<Option<std::collections::BTreeMap<String, String>>> =
+    std::sync::Mutex::new(None);
+
+/// Take (consume) the per-extern producing-unit ids of the last computed rustc
+/// key. Always taken alongside [`take_last_key_externs`] so a stale map cannot
+/// outlive its digests.
+pub fn take_last_key_extern_units() -> Option<std::collections::BTreeMap<String, String>> {
+    LAST_KEY_EXTERN_UNITS.lock().ok().and_then(|mut g| g.take())
+}
+
+/// The compiling unit's own identity, stashed at key computation so the event
+/// writer needs no extra plumbing — the same pattern the per-group digests use
+/// (kunobi-ninja/kache#131). Set unconditionally at the top of
+/// [`compute_cache_key`], including to `None` when cargo passed no
+/// `-C extra-filename`, so it can never carry over from a previous compile.
+static LAST_KEY_UNIT_ID: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+
+/// Take (consume) the unit id of the last computed rustc key.
+pub fn take_last_key_unit_id() -> Option<String> {
+    LAST_KEY_UNIT_ID.lock().ok().and_then(|mut g| g.take())
+}
+
 /// Compute the blake3 cache key for a rustc invocation.
 ///
 /// The key captures everything that affects compilation output:
@@ -491,6 +524,15 @@ pub fn compute_cache_key(
     // belonged to this compile.
     if let Ok(mut stash) = LAST_KEY_EXTERNS.lock() {
         *stash = None;
+    }
+    // Same reasoning for the unit ids (#627); both are cleared and written
+    // together so the walk can never pair one compile's digests with another's
+    // identities.
+    if let Ok(mut stash) = LAST_KEY_EXTERN_UNITS.lock() {
+        *stash = None;
+    }
+    if let Ok(mut stash) = LAST_KEY_UNIT_ID.lock() {
+        *stash = args.unit_id();
     }
 
     // key version — bump CACHE_KEY_VERSION to invalidate all prior entries
@@ -771,8 +813,15 @@ pub fn compute_cache_key(
     // already in hand — while the decision to PERSIST it stays with the
     // wrapper's `explain_miss` gate.
     let mut extern_digests = std::collections::BTreeMap::new();
+    // Producing-unit ids, from the artifact filename rather than the extern
+    // name, so a renamed or duplicated dependency still joins to its producer
+    // (kunobi-ninja/kache#627).
+    let mut extern_units = std::collections::BTreeMap::new();
     for ext in &externs {
         if let Some(path) = &ext.path {
+            if let Some(unit) = crate::args::unit_id_from_artifact_path(path) {
+                extern_units.insert(ext.name.clone(), unit);
+            }
             match file_hasher.hash(path) {
                 Ok(dep_hash) => {
                     hasher.update(b"extern:");
@@ -809,6 +858,9 @@ pub fn compute_cache_key(
     }
     if let Ok(mut stash) = LAST_KEY_EXTERNS.lock() {
         *stash = Some(extern_digests);
+    }
+    if let Ok(mut stash) = LAST_KEY_EXTERN_UNITS.lock() {
+        *stash = Some(extern_units);
     }
 
     // RUSTFLAGS — normalize via PathNormalizer (canonical-prefix

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5365,6 +5365,8 @@ mod tests {
             key_diff: Vec::new(),
             key_externs: Default::default(),
             key_externs_recorded: false,
+            unit_id: String::new(),
+            extern_units: Default::default(),
         }
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -37,7 +37,8 @@ pub struct BuildEvent {
     /// 9 = event root, 10 = build session id (#583),
     /// 11 = key field hashes + miss key diff (#131),
     /// 12 = per-extern artifact digests (#609),
-    /// 13 = store-failure reason (#629).
+    /// 13 = store-failure reason (#629),
+    /// 14 = compilation-unit identity, own and per-extern (#627).
     #[serde(default)]
     pub schema: u32,
     /// Build session this event belongs to (kunobi-ninja/kache#583 P0.5).
@@ -182,6 +183,35 @@ pub struct BuildEvent {
     /// default (non-`explain_miss`) path.
     #[serde(default, skip_serializing_if = "is_false")]
     pub key_externs_recorded: bool,
+    /// This compile's own compilation-unit identity — cargo's
+    /// `-C extra-filename` hash (kunobi-ninja/kache#627).
+    ///
+    /// `crate_name` cannot carry this: two versions of a package, a host and a
+    /// target build of the same crate, and two feature sets of it all share one
+    /// name, so pairing a compile with "the previous event of the same crate"
+    /// can pair two unrelated units. This is the disambiguator cargo itself uses
+    /// to keep those units' artifacts apart in one `deps/` directory.
+    ///
+    /// Diagnostic only — never folded into a cache key, which would tie the key
+    /// to cargo's unit hashing and break cross-machine sharing. Written under
+    /// the same `[cache] explain_miss` gate as `key_externs`; empty for cc
+    /// compiles, passthroughs, non-cargo rustc invocations, and pre-#627
+    /// wrappers.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub unit_id: String,
+    /// Producing unit per extern, as `name the consumer used -> the producer's
+    /// unit id` (kunobi-ninja/kache#627).
+    ///
+    /// The companion to `key_externs`: that map says which dependency's artifact
+    /// moved, this one says which compilation unit produced it. It is what lets
+    /// the cascade walk follow a renamed dependency (`foo_old = { package =
+    /// "foo" }` records the alias in the consumer's key but `foo` in the
+    /// producer's events) and pick the right one of several same-named units.
+    ///
+    /// Recovered from the `--extern` artifact filename, so an extern without
+    /// that suffix simply has no entry and the walk falls back to name matching.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub extern_units: std::collections::BTreeMap<String, String>,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -1083,6 +1113,8 @@ impl BuildEvent {
             key_diff: Vec::new(),
             key_externs: Default::default(),
             key_externs_recorded: false,
+            unit_id: String::new(),
+            extern_units: Default::default(),
         }
     }
 }
@@ -1153,6 +1185,8 @@ mod tests {
             key_diff: Vec::new(),
             key_externs: Default::default(),
             key_externs_recorded: false,
+            unit_id: String::new(),
+            extern_units: Default::default(),
         };
 
         log_event(&log_path, &event).unwrap();

--- a/src/miss_chain.rs
+++ b/src/miss_chain.rs
@@ -33,16 +33,27 @@
 //! can share one, and a dependency can be recompiled between the moment a
 //! parent hashes its artifact and the moment the parent's own event is logged.
 //!
-//! # What this cannot know
+//! # Unit identity
 //!
-//! `crate_name` is not a stable compilation-unit identity. Two versions of a
-//! package, a host and a target build of the same crate, or a dependency
-//! renamed through Cargo's `package = "..."` key all collapse onto one name, so
-//! a walk can pair events that belong to different units. Nothing here can
-//! repair that; it needs a producer identity (package id + unit disambiguator)
-//! recorded per extern. Until then the walk reports an unresolved endpoint
-//! rather than a confident wrong one wherever the recorded history does not
-//! support a conclusion.
+//! `crate_name` is not a compilation-unit identity: two versions of a package,
+//! a host and a target build of the same crate, and two feature sets of it all
+//! collapse onto one name, and Cargo's `package = "..."` renaming makes the
+//! consumer's name for a dependency differ from the producer's own
+//! (kunobi-ninja/kache#627). Pairing by name therefore risks comparing
+//! unrelated units, or dead-ending on an alias no event carries.
+//!
+//! So the walk pairs by unit id wherever the events have one: cargo's
+//! `-C extra-filename` hash, recorded on the producing event (`unit_id`) and
+//! recovered by the consumer from its `--extern` artifact filename
+//! (`extern_units`). That is the disambiguator cargo itself uses to keep those
+//! units' artifacts apart in one `deps/` directory, and it is visible from both
+//! sides, so the join holds regardless of the name the consumer used.
+//!
+//! Name matching stays as the fallback for events carrying no unit id — a
+//! non-cargo rustc invocation, a sysroot crate, a pre-#627 wrapper. There the
+//! old ambiguity remains, and the walk still prefers an unresolved endpoint
+//! over a confident wrong one wherever the history does not support a
+//! conclusion.
 //!
 //! Everything here is a pure function over already-read events: no store, no
 //! filesystem, no clock. `cli` renders the result.
@@ -61,18 +72,39 @@ const MAX_NODES: usize = 64;
 /// previous recorded state of that crate.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChangedDep {
+    /// The name the CONSUMER used, which Cargo's `package = "..."` renaming can
+    /// make different from the producing crate's own name.
     pub name: String,
     /// Digest in the baseline event. `None` when the dependency is new.
     pub from: Option<String>,
     /// Digest at the compile being explained. `None` when it went away.
     pub to: Option<String>,
+    /// The producing unit's id, when the consumer's event recorded one
+    /// (kunobi-ninja/kache#627). This, not `name`, is what selects the
+    /// dependency's own events.
+    pub unit: Option<String>,
 }
 
 /// One step down a branch: `crate_name` diverged because `via` moved.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Hop {
     pub crate_name: String,
+    /// Unit id of the crate at this hop, when its event recorded one. Carried
+    /// so cycle detection can compare units rather than names; renderers use
+    /// `crate_name`.
+    pub unit: Option<String>,
     pub via: ChangedDep,
+}
+
+/// Identity a branch is tracked by: the unit id when known, else the name.
+///
+/// Prefixed so a unit id can never collide with a crate that happens to be
+/// named the same as some hash.
+fn node_key(name: &str, unit: Option<&str>) -> String {
+    match unit {
+        Some(unit) => format!("unit:{unit}"),
+        None => format!("name:{name}"),
+    }
 }
 
 /// Why the crate at the end of a branch diverged.
@@ -116,6 +148,14 @@ pub struct PassthroughGroup {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Root {
     pub crate_name: String,
+    /// Unit id of the event this endpoint resolved to, when that event recorded
+    /// one.
+    ///
+    /// Taken from the SELECTED producer rather than from what the consumer
+    /// asked for, so `crate_name` and `unit` always describe the same event and
+    /// convergence counting keys on the node actually analyzed. Renderers show
+    /// `crate_name`.
+    pub unit: Option<String>,
     pub kind: RootKind,
     pub passthroughs: Vec<PassthroughGroup>,
     /// Distinct branches from the starting crate that ended here. A root many
@@ -160,14 +200,16 @@ pub fn analyze(events: &[BuildEvent], miss_index: usize) -> Option<Chain> {
     }
 
     // Breadth-first over (crate, event position), so the first path reaching a
-    // crate is the shortest one. `seen` is keyed by crate name: revisiting a
-    // crate on another branch adds no information beyond the convergence count,
-    // which is tracked separately.
+    // crate is the shortest one. `seen` and `reached` are keyed by unit where
+    // the events carry one, so two same-named units count as two nodes rather
+    // than silently folding into one (#627); revisiting a node on another
+    // branch adds no information beyond the convergence count, tracked
+    // separately.
     let mut queue: Vec<(usize, Vec<Hop>)> = vec![(miss_index, Vec::new())];
-    let mut seen: HashSet<String> = HashSet::from([miss.crate_name.clone()]);
-    // Branches that reached each crate, counted independently of `roots`: a
-    // crate can be reached again while it is still queued, long before it
-    // becomes an endpoint.
+    let mut seen: HashSet<String> = HashSet::from([node_key(&miss.crate_name, unit_of(miss))]);
+    // Branches that reached each node, counted independently of `roots`: a node
+    // can be reached again while it is still queued, long before it becomes an
+    // endpoint.
     let mut reached: BTreeMap<String, usize> = BTreeMap::new();
     let mut roots: Vec<Root> = Vec::new();
     let mut nodes = 0usize;
@@ -187,37 +229,68 @@ pub fn analyze(events: &[BuildEvent], miss_index: usize) -> Option<Chain> {
                 break;
             }
             nodes += 1;
-            *reached.entry(dep.name.clone()).or_default() += 1;
 
             let mut next_path = path.clone();
             next_path.push(Hop {
                 crate_name: events[index].crate_name.clone(),
+                unit: unit_of(&events[index]).map(str::to_string),
                 via: dep.clone(),
             });
 
-            if path.iter().any(|hop| hop.crate_name == dep.name) || dep.name == miss.crate_name {
-                // The recorded digests loop back onto this path. Not a real
-                // dependency cycle — cargo forbids those — so it means the
-                // events being paired belong to different compilation units
-                // that share a crate name. Stop this branch and say so.
+            // A dependency that points back at a crate already on this path is
+            // a loop, whether or not it has an event of its own to resolve to.
+            // Checking the REQUESTED identity here catches the case where it
+            // has none — the walk would otherwise report the crate being
+            // explained as an unresolved endpoint of its own cascade.
+            if loops_back(&path, miss, &node_key(&dep.name, dep.unit.as_deref())) {
                 truncated = Some("cycle in recorded dependency digests");
                 continue;
             }
 
-            if !seen.insert(dep.name.clone()) {
+            // Resolve the producer, then track the branch by the identity of the
+            // event actually selected — not by the identity the consumer asked
+            // for. The two differ whenever a dep carrying a unit id resolves to
+            // a legacy event that has none, and every downstream structure
+            // (`reached`, `seen`, the cycle check, each root) has to agree on
+            // one key, or the walk reports a converged root as reached by a
+            // single branch, explores one event twice, and misses loops. Hops
+            // carry their own event's identity, so comparing against the
+            // selected producer's keeps that check apples-to-apples.
+            let Some(dep_index) = producer_index(events, &dep, &events[index].root, index) else {
+                // Nothing was selected, so the requested identity is all there
+                // is to count this dead end under.
+                *reached
+                    .entry(node_key(&dep.name, dep.unit.as_deref()))
+                    .or_default() += 1;
+                roots.push(unresolved(
+                    dep.name,
+                    dep.unit,
+                    RootKind::NoMissRecorded,
+                    next_path,
+                ));
+                continue;
+            };
+            let producer = &events[dep_index];
+            // Report the producing crate's OWN name from here down. Under
+            // Cargo's `package = "..."` renaming the consumer's alias names no
+            // crate the user can go look at (#627).
+            let dep_name = producer.crate_name.clone();
+            let dep_unit = unit_of(producer).map(str::to_string);
+            let dep_key = node_key(&dep_name, dep_unit.as_deref());
+            *reached.entry(dep_key.clone()).or_default() += 1;
+
+            // And again on the resolved identity: name matching in a mixed
+            // window can land on an event already visited under a unit id.
+            if loops_back(&path, miss, &dep_key) {
+                truncated = Some("cycle in recorded dependency digests");
+                continue;
+            }
+
+            if !seen.insert(dep_key) {
                 // Reached by another branch already; the convergence is
                 // recorded above and there is nothing new to explore.
                 continue;
             }
-
-            // Strictly before the parent's event: positions decrease as the
-            // walk descends, which is what keeps selection causal.
-            let Some(dep_index) =
-                last_compiled_index(events, &dep.name, &events[index].root, index)
-            else {
-                roots.push(unresolved(dep.name, RootKind::NoMissRecorded, next_path));
-                continue;
-            };
 
             match changed_deps_at(events, dep_index) {
                 // Its own dependencies moved: keep descending, unless this
@@ -225,17 +298,24 @@ pub fn analyze(events: &[BuildEvent], miss_index: usize) -> Option<Chain> {
                 Some(next) if !next.is_empty() => {
                     if next_path.len() >= MAX_DEPTH {
                         truncated = Some("chain longer than the walk limit");
-                        roots.push(unresolved(dep.name, RootKind::LimitReached, next_path));
+                        roots.push(unresolved(
+                            dep_name,
+                            dep_unit,
+                            RootKind::LimitReached,
+                            next_path,
+                        ));
                         continue;
                     }
                     queue.push((dep_index, next_path));
                 }
                 // Compared cleanly and stable: this is a genuine endpoint.
+                // `classify_at` derives the same identity from the same event.
                 Some(_) => roots.push(classify_at(events, dep_index, next_path)),
                 // Not comparable. NOT the same as stable — saying so would
                 // invent a root out of missing data.
                 None => {
-                    let mut root = unresolved(dep.name, RootKind::NoDiffableHistory, next_path);
+                    let mut root =
+                        unresolved(dep_name, dep_unit, RootKind::NoDiffableHistory, next_path);
                     root.passthroughs = passthroughs_for(events, &root.crate_name, dep_index);
                     roots.push(root);
                 }
@@ -247,7 +327,10 @@ pub fn analyze(events: &[BuildEvent], miss_index: usize) -> Option<Chain> {
     }
 
     for root in &mut roots {
-        root.branches = reached.get(&root.crate_name).copied().unwrap_or(1);
+        root.branches = reached
+            .get(&node_key(&root.crate_name, root.unit.as_deref()))
+            .copied()
+            .unwrap_or(1);
     }
     // Most-converged first, then shallowest, then by name so output is stable.
     roots.sort_by(|a, b| {
@@ -264,9 +347,23 @@ pub fn analyze(events: &[BuildEvent], miss_index: usize) -> Option<Chain> {
     })
 }
 
-fn unresolved(crate_name: String, kind: RootKind, path: Vec<Hop>) -> Root {
+/// Whether `key` names a node already on this path, or the crate being
+/// explained.
+///
+/// Cargo forbids real dependency cycles, so a loop here means the recorded
+/// digests are inconsistent: with unit ids present, two compiles disagreeing
+/// about what produced what; without them, the older failure of two units
+/// sharing a crate name being paired as one. Either way the branch stops.
+fn loops_back(path: &[Hop], miss: &BuildEvent, key: &str) -> bool {
+    path.iter()
+        .any(|hop| node_key(&hop.crate_name, hop.unit.as_deref()) == key)
+        || key == node_key(&miss.crate_name, unit_of(miss))
+}
+
+fn unresolved(crate_name: String, unit: Option<String>, kind: RootKind, path: Vec<Hop>) -> Root {
     Root {
         crate_name,
+        unit,
         kind,
         passthroughs: Vec::new(),
         branches: 1,
@@ -286,17 +383,24 @@ fn changed_deps_at(events: &[BuildEvent], index: usize) -> Option<Vec<ChangedDep
     if !compiled.key_externs_recorded {
         return None;
     }
-    let baseline = last_baseline_index(events, &compiled.crate_name, &compiled.root, index)?;
+    let baseline = last_baseline_index(events, compiled, &compiled.root, index)?;
     Some(diff_externs(
         &events[baseline].key_externs,
         &compiled.key_externs,
+        &compiled.extern_units,
     ))
 }
 
 /// Symmetric diff of two dependency-digest maps, sorted by name.
+///
+/// `units` comes from the LATER of the two events: it describes the dependency
+/// set as of the compile being explained, which is the one the walk descends
+/// into. A dependency that only exists in the baseline has no unit recorded and
+/// falls back to name matching, which is all that state supports anyway.
 fn diff_externs(
     before: &BTreeMap<String, String>,
     after: &BTreeMap<String, String>,
+    units: &BTreeMap<String, String>,
 ) -> Vec<ChangedDep> {
     let mut out = Vec::new();
     for (name, to) in after {
@@ -306,6 +410,7 @@ fn diff_externs(
                 name: name.clone(),
                 from: from.cloned(),
                 to: Some(to.clone()),
+                unit: units.get(name).cloned(),
             }),
         }
     }
@@ -316,6 +421,7 @@ fn diff_externs(
                 name: name.clone(),
                 from: Some(from.clone()),
                 to: None,
+                unit: units.get(name).cloned(),
             });
         }
     }
@@ -327,10 +433,10 @@ fn diff_externs(
 fn classify_at(events: &[BuildEvent], index: usize, path: Vec<Hop>) -> Root {
     let compiled = &events[index];
     let passthroughs = passthroughs_for(events, &compiled.crate_name, index);
-    let Some(baseline) = last_baseline_index(events, &compiled.crate_name, &compiled.root, index)
-    else {
+    let Some(baseline) = last_baseline_index(events, compiled, &compiled.root, index) else {
         return Root {
             crate_name: compiled.crate_name.clone(),
+            unit: unit_of(compiled).map(str::to_string),
             kind: RootKind::NoBaseline,
             passthroughs,
             branches: 1,
@@ -359,6 +465,7 @@ fn classify_at(events: &[BuildEvent], index: usize, path: Vec<Hop>) -> Root {
     };
     Root {
         crate_name: compiled.crate_name.clone(),
+        unit: unit_of(compiled).map(str::to_string),
         kind,
         passthroughs,
         branches: 1,
@@ -451,18 +558,52 @@ fn looks_like_semver(value: &str) -> bool {
             .all(|part| !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit()))
 }
 
-/// Last compile (`Miss`/`Dup`) of `crate_name` strictly before `before`.
-fn last_compiled_index(
+/// This compile's unit id, or `None` when it recorded none.
+fn unit_of(event: &BuildEvent) -> Option<&str> {
+    (!event.unit_id.is_empty()).then_some(event.unit_id.as_str())
+}
+
+/// Whether `event` is the unit `dep` names.
+///
+/// Exact when both sides carry a unit id. When the dependency has one and the
+/// candidate does not, the candidate predates #627, so fall back to the name —
+/// otherwise the walk would go blind across the upgrade. An event with a
+/// DIFFERENT unit id is never accepted on the name: that is precisely the
+/// wrong-pairing this exists to stop.
+fn is_producer(event: &BuildEvent, dep: &ChangedDep) -> bool {
+    match (dep.unit.as_deref(), unit_of(event)) {
+        (Some(want), Some(have)) => want == have,
+        (Some(_), None) => event.crate_name == dep.name,
+        (None, _) => event.crate_name == dep.name,
+    }
+}
+
+/// Last compile (`Miss`/`Dup`) of the unit `dep` names, strictly before
+/// `before`.
+///
+/// Selection prefers an exact unit match anywhere in the window over a
+/// name-only match, so one legacy event cannot shadow the right unit's own
+/// history just by being closer.
+fn producer_index(
     events: &[BuildEvent],
-    crate_name: &str,
+    dep: &ChangedDep,
     root: &str,
     before: usize,
 ) -> Option<usize> {
-    events[..before.min(events.len())].iter().rposition(|e| {
-        e.crate_name == crate_name
-            && same_root(e, root)
-            && matches!(e.result, EventResult::Miss | EventResult::Dup)
-    })
+    let window = &events[..before.min(events.len())];
+    let compiled = |e: &BuildEvent| matches!(e.result, EventResult::Miss | EventResult::Dup);
+
+    if let Some(want) = dep.unit.as_deref() {
+        let exact = window
+            .iter()
+            .rposition(|e| unit_of(e) == Some(want) && same_root(e, root) && compiled(e));
+        if exact.is_some() {
+            return exact;
+        }
+    }
+    window
+        .iter()
+        .rposition(|e| is_producer(e, dep) && same_root(e, root) && compiled(e))
 }
 
 /// The previous event that recorded dependency digests for this crate.
@@ -472,15 +613,19 @@ fn last_compiled_index(
 /// across both, which over-reports the dependencies responsible for the second
 /// one. A dependency can equally reach its new artifact through a remote or
 /// prefetch hit, so those count too.
+/// Matched by unit id when the compile has one, so the previous state of THIS
+/// unit is compared rather than that of a same-named sibling — a duplicate
+/// package version, or the host build of a crate also built for the target
+/// (#627). Events with no unit id (pre-#627, non-cargo) still match by name, so
+/// a mixed window keeps working.
 fn last_baseline_index(
     events: &[BuildEvent],
-    crate_name: &str,
+    compiled: &BuildEvent,
     root: &str,
     before: usize,
 ) -> Option<usize> {
-    events[..before.min(events.len())].iter().rposition(|e| {
-        e.crate_name == crate_name
-            && same_root(e, root)
+    let keyed = |e: &BuildEvent| {
+        same_root(e, root)
             && e.key_externs_recorded
             && matches!(
                 e.result,
@@ -490,7 +635,25 @@ fn last_baseline_index(
                     | EventResult::Miss
                     | EventResult::Dup
             )
-    })
+    };
+    let window = &events[..before.min(events.len())];
+
+    if let Some(unit) = unit_of(compiled) {
+        if let Some(exact) = window
+            .iter()
+            .rposition(|e| unit_of(e) == Some(unit) && keyed(e))
+        {
+            return Some(exact);
+        }
+        // No event for this unit carries an id: only legacy events are left to
+        // compare against, and those can only be matched by name.
+        return window.iter().rposition(|e| {
+            e.unit_id.is_empty() && e.crate_name == compiled.crate_name && keyed(e)
+        });
+    }
+    window
+        .iter()
+        .rposition(|e| e.crate_name == compiled.crate_name && keyed(e))
 }
 
 /// Exact build-tree match.
@@ -546,6 +709,346 @@ mod tests {
 
     fn analyze_last(events: &[BuildEvent]) -> Option<Chain> {
         analyze(events, events.len() - 1)
+    }
+
+    /// This event's own compilation unit (cargo's `-C extra-filename`).
+    fn with_unit(mut e: BuildEvent, unit: &str) -> BuildEvent {
+        e.unit_id = unit.to_string();
+        e
+    }
+
+    /// The producing unit behind each of this event's externs, as the consumer
+    /// recovered it from the `--extern` artifact path.
+    fn with_extern_units(mut e: BuildEvent, units: &[(&str, &str)]) -> BuildEvent {
+        e.extern_units = units
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        e
+    }
+
+    /// Cargo's `package = "..."` renaming: the consumer's key records the alias
+    /// (`foo_old`), the producer's events record its real name (`foo`). Matching
+    /// by name dead-ends on the alias; matching by unit reaches the producer and
+    /// reports the name the user can actually go look at (#627).
+    #[test]
+    fn follows_a_renamed_dependency_to_the_crate_that_produced_it() {
+        let events = vec![
+            with_extern_units(
+                event("app", EventResult::LocalHit, 0, &[("foo_old", "aaaa")]),
+                &[("foo_old", "ufoo")],
+            ),
+            with_unit(
+                with_fields(
+                    event("foo", EventResult::LocalHit, 1, &[]),
+                    &[("sources", "1111")],
+                ),
+                "ufoo",
+            ),
+            with_unit(
+                with_fields(
+                    event("foo", EventResult::Miss, 10, &[]),
+                    &[("sources", "2222")],
+                ),
+                "ufoo",
+            ),
+            with_extern_units(
+                event("app", EventResult::Miss, 11, &[("foo_old", "bbbb")]),
+                &[("foo_old", "ufoo")],
+            ),
+        ];
+
+        let chain = analyze_last(&events).expect("cascade should be reported");
+        assert_eq!(chain.roots.len(), 1);
+        let root = &chain.roots[0];
+        assert_eq!(
+            root.crate_name, "foo",
+            "the producing crate's own name, not the consumer's alias"
+        );
+        assert_eq!(root.kind, RootKind::Groups(vec!["sources".to_string()]));
+        // The alias still names the edge, since that is what the consumer's
+        // manifest says.
+        assert_eq!(chain.direct[0].name, "foo_old");
+
+        // Strip the unit ids and the same events reproduce the pre-#627
+        // behaviour: no crate is named `foo_old`, so the walk dead-ends on the
+        // alias. This is what the fix buys.
+        let by_name: Vec<BuildEvent> = events
+            .iter()
+            .cloned()
+            .map(|mut e| {
+                e.unit_id.clear();
+                e.extern_units.clear();
+                e
+            })
+            .collect();
+        let chain = analyze_last(&by_name).expect("cascade should still be reported");
+        assert_eq!(chain.roots[0].crate_name, "foo_old");
+        assert_eq!(chain.roots[0].kind, RootKind::NoMissRecorded);
+    }
+
+    /// Two versions of one package in the same graph. The consumer depends on
+    /// the second, so the walk must diff THAT unit's history — matching by name
+    /// would pick whichever `foo` event came last and report a change that
+    /// belongs to the other version (#627).
+    #[test]
+    fn picks_the_right_unit_when_two_versions_share_a_crate_name() {
+        let events = vec![
+            with_extern_units(
+                event("app", EventResult::LocalHit, 0, &[("foo", "aaaa")]),
+                &[("foo", "foo_v2")],
+            ),
+            // v2: stable dependencies, its own sources moved.
+            with_unit(
+                with_fields(
+                    event("foo", EventResult::LocalHit, 1, &[("libc", "cccc")]),
+                    &[("sources", "1111")],
+                ),
+                "foo_v2",
+            ),
+            with_unit(
+                with_fields(
+                    event("foo", EventResult::Miss, 10, &[("libc", "cccc")]),
+                    &[("sources", "2222")],
+                ),
+                "foo_v2",
+            ),
+            // v1 compiles later and is the nearest `foo` event by name, with a
+            // completely different dependency set. A name-keyed walk would diff
+            // against this one.
+            with_unit(
+                with_fields(
+                    event("foo", EventResult::Miss, 11, &[("bitflags", "zzzz")]),
+                    &[("args", "9999")],
+                ),
+                "foo_v1",
+            ),
+            with_extern_units(
+                event("app", EventResult::Miss, 12, &[("foo", "bbbb")]),
+                &[("foo", "foo_v2")],
+            ),
+        ];
+
+        let chain = analyze_last(&events).expect("cascade should be reported");
+        assert_eq!(chain.roots.len(), 1);
+        let root = &chain.roots[0];
+        assert_eq!(root.crate_name, "foo");
+        assert_eq!(root.unit.as_deref(), Some("foo_v2"));
+        assert_eq!(
+            root.kind,
+            RootKind::Groups(vec!["sources".to_string()]),
+            "v2's own inputs moved; v1's `args` change belongs to a different unit"
+        );
+
+        // Without unit ids the walk picks v1 — the nearest `foo` by name — then
+        // diffs it against v2's event, so v1's unrelated dependency set reads as
+        // "everything changed" and the walk descends into crates the miss has
+        // nothing to do with. The pre-#627 failure, pinned.
+        let by_name: Vec<BuildEvent> = events
+            .iter()
+            .cloned()
+            .map(|mut e| {
+                e.unit_id.clear();
+                e.extern_units.clear();
+                e
+            })
+            .collect();
+        let chain = analyze_last(&by_name).expect("cascade should still be reported");
+        let mut names: Vec<&str> = chain.roots.iter().map(|r| r.crate_name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec!["bitflags", "libc"],
+            "name matching walks into v1's dependencies: {:?}",
+            chain.roots
+        );
+        assert!(
+            !chain.has_resolved_root(),
+            "and explains nothing, having compared two different units"
+        );
+    }
+
+    /// A host build and a target build of one crate, interleaved. Each unit's
+    /// baseline must be its own previous compile: pairing across the two makes
+    /// stable dependencies look like they were added and removed.
+    #[test]
+    fn baselines_a_unit_against_itself_not_a_same_named_sibling() {
+        let events = vec![
+            with_unit(
+                event("shared", EventResult::LocalHit, 0, &[("libc", "aaaa")]),
+                "host",
+            ),
+            with_unit(
+                event("shared", EventResult::LocalHit, 1, &[("libc", "aaaa")]),
+                "target",
+            ),
+            // The host unit recompiles with everything unchanged. Diffed against
+            // the target unit's event it would look identical here, so give the
+            // target unit a different dependency set to make a wrong pairing
+            // visible.
+            with_unit(
+                event("shared", EventResult::Miss, 2, &[("libc", "aaaa")]),
+                "host",
+            ),
+        ];
+
+        // Same unit, same digests: comparison succeeded and nothing moved.
+        assert_eq!(changed_deps_at(&events, 2), Some(vec![]));
+
+        let mut cross = events.clone();
+        cross[1].key_externs = [("winapi".to_string(), "bbbb".to_string())]
+            .into_iter()
+            .collect();
+        assert_eq!(
+            changed_deps_at(&cross, 2),
+            Some(vec![]),
+            "the target unit's different dependency set must not leak into the host unit's diff"
+        );
+    }
+
+    /// Convergence counting has to use the identity the BRANCH was tracked by.
+    /// Here two branches reach one dependency that the consumers identify by
+    /// unit, but whose own events are legacy and carry no id: keying the root
+    /// off the producing event instead would report 1 branch for a root that 2
+    /// converge on, which is the ranking signal `why-miss` sorts by (#627).
+    #[test]
+    fn counts_converging_branches_when_the_producer_is_a_legacy_event() {
+        let via_foo = |name: &str, unit: &str, at: i64, digest: &str, result| {
+            with_extern_units(
+                with_unit(event(name, result, at, &[("foo", digest)]), unit),
+                &[("foo", "ufoo")],
+            )
+        };
+        let events = vec![
+            with_extern_units(
+                event(
+                    "app",
+                    EventResult::LocalHit,
+                    0,
+                    &[("b1", "aa"), ("b2", "aa")],
+                ),
+                &[("b1", "ub1"), ("b2", "ub2")],
+            ),
+            via_foo("b1", "ub1", 1, "x1", EventResult::LocalHit),
+            via_foo("b2", "ub2", 2, "x1", EventResult::LocalHit),
+            // The shared dependency predates #627: no unit id of its own.
+            with_fields(
+                event("foo", EventResult::LocalHit, 3, &[]),
+                &[("sources", "1111")],
+            ),
+            with_fields(
+                event("foo", EventResult::Miss, 4, &[]),
+                &[("sources", "2222")],
+            ),
+            via_foo("b1", "ub1", 5, "x2", EventResult::Miss),
+            via_foo("b2", "ub2", 6, "x2", EventResult::Miss),
+            with_extern_units(
+                event("app", EventResult::Miss, 7, &[("b1", "bb"), ("b2", "bb")]),
+                &[("b1", "ub1"), ("b2", "ub2")],
+            ),
+        ];
+
+        let chain = analyze_last(&events).expect("cascade should be reported");
+        let foo = chain
+            .roots
+            .iter()
+            .find(|r| r.crate_name == "foo")
+            .expect("the shared dependency should be a root");
+        assert_eq!(foo.kind, RootKind::Groups(vec!["sources".to_string()]));
+        assert_eq!(
+            foo.branches, 2,
+            "both b1 and b2 converge on it: {:?}",
+            chain.roots
+        );
+    }
+
+    /// Two consumers ask for two DIFFERENT units that both fall back, by name,
+    /// to the same legacy producer. Tracking the branch by what was asked for
+    /// would explore that one event twice and report two roots for it; tracking
+    /// it by the event actually selected collapses them into one node, which is
+    /// what the walk analyzed (#627).
+    #[test]
+    fn two_requested_units_resolving_to_one_legacy_event_are_one_node() {
+        let events = vec![
+            with_extern_units(
+                event(
+                    "app",
+                    EventResult::LocalHit,
+                    0,
+                    &[("b1", "aa"), ("b2", "aa")],
+                ),
+                &[("b1", "ub1"), ("b2", "ub2")],
+            ),
+            with_extern_units(
+                with_unit(
+                    event("b1", EventResult::LocalHit, 1, &[("foo", "x1")]),
+                    "ub1",
+                ),
+                // b1 and b2 disagree about which unit of `foo` they used, and
+                // neither id exists in the window.
+                &[("foo", "ufoo_a")],
+            ),
+            with_extern_units(
+                with_unit(
+                    event("b2", EventResult::LocalHit, 2, &[("foo", "x1")]),
+                    "ub2",
+                ),
+                &[("foo", "ufoo_b")],
+            ),
+            with_fields(
+                event("foo", EventResult::LocalHit, 3, &[]),
+                &[("sources", "1111")],
+            ),
+            with_fields(
+                event("foo", EventResult::Miss, 4, &[]),
+                &[("sources", "2222")],
+            ),
+            with_extern_units(
+                with_unit(event("b1", EventResult::Miss, 5, &[("foo", "x2")]), "ub1"),
+                &[("foo", "ufoo_a")],
+            ),
+            with_extern_units(
+                with_unit(event("b2", EventResult::Miss, 6, &[("foo", "x2")]), "ub2"),
+                &[("foo", "ufoo_b")],
+            ),
+            with_extern_units(
+                event("app", EventResult::Miss, 7, &[("b1", "bb"), ("b2", "bb")]),
+                &[("b1", "ub1"), ("b2", "ub2")],
+            ),
+        ];
+
+        let chain = analyze_last(&events).expect("cascade should be reported");
+        let foo: Vec<&Root> = chain
+            .roots
+            .iter()
+            .filter(|r| r.crate_name == "foo")
+            .collect();
+        assert_eq!(foo.len(), 1, "one event, one node: {:?}", chain.roots);
+        assert_eq!(foo[0].branches, 2, "both consumers converge on it");
+    }
+
+    /// Mixed windows happen across an upgrade: the compile carries a unit id,
+    /// the only earlier event for it does not. Falling back to the name keeps
+    /// the walk working rather than going blind.
+    #[test]
+    fn falls_back_to_the_name_when_only_legacy_events_are_available() {
+        let events = vec![
+            event("foo", EventResult::LocalHit, 0, &[("libc", "aaaa")]),
+            with_unit(
+                event("foo", EventResult::Miss, 10, &[("libc", "bbbb")]),
+                "ufoo",
+            ),
+        ];
+
+        assert_eq!(
+            changed_deps_at(&events, 1),
+            Some(vec![ChangedDep {
+                name: "libc".to_string(),
+                from: Some("aaaa".to_string()),
+                to: Some("bbbb".to_string()),
+                unit: None,
+            }])
+        );
     }
 
     /// The #580 shape: a leaf `-sys` crate's artifact moves and re-keys two
@@ -853,18 +1356,25 @@ mod tests {
         ]
         .into_iter()
         .collect();
+        // The unit map covers only the current dependency set, so the removed
+        // one carries no unit and the added one does.
+        let units: BTreeMap<String, String> = [("new".to_string(), "unit3".to_string())]
+            .into_iter()
+            .collect();
         assert_eq!(
-            diff_externs(&before, &after),
+            diff_externs(&before, &after, &units),
             vec![
                 ChangedDep {
                     name: "gone".to_string(),
                     from: Some("2".to_string()),
-                    to: None
+                    to: None,
+                    unit: None,
                 },
                 ChangedDep {
                     name: "new".to_string(),
                     from: None,
-                    to: Some("3".to_string())
+                    to: Some("3".to_string()),
+                    unit: Some("unit3".to_string()),
                 },
             ]
         );

--- a/src/miss_chain.rs
+++ b/src/miss_chain.rs
@@ -1027,6 +1027,110 @@ mod tests {
         assert_eq!(foo[0].branches, 2, "both consumers converge on it");
     }
 
+    /// A loop back onto a crate that is NOT the one being explained. Only the
+    /// path half of the cycle test fires here, so it pins that the two halves
+    /// are alternatives rather than joint conditions.
+    #[test]
+    fn terminates_on_a_cycle_that_does_not_include_the_starting_crate() {
+        let events = vec![
+            event("b", EventResult::LocalHit, 0, &[("c", "1111")]),
+            event("c", EventResult::LocalHit, 1, &[("b", "3333")]),
+            event("a", EventResult::LocalHit, 2, &[("b", "5555")]),
+            // c's digests point back at b, which is already on the path.
+            event("c", EventResult::Miss, 10, &[("b", "4444")]),
+            event("b", EventResult::Miss, 11, &[("c", "2222")]),
+            event("a", EventResult::Miss, 12, &[("b", "6666")]),
+        ];
+        let chain = analyze_last(&events).unwrap();
+        assert_eq!(
+            chain.truncated,
+            Some("cycle in recorded dependency digests")
+        );
+    }
+
+    /// The node cap stops a pathologically wide graph from turning a diagnostic
+    /// into a long walk.
+    #[test]
+    fn stops_after_too_many_changed_dependencies() {
+        let deps: Vec<(String, &str)> = (0..MAX_NODES + 8)
+            .map(|i| (format!("d{i}"), "2222"))
+            .collect();
+        let before: Vec<(&str, &str)> = deps.iter().map(|(n, _)| (n.as_str(), "1111")).collect();
+        let after: Vec<(&str, &str)> = deps.iter().map(|(n, _)| (n.as_str(), "2222")).collect();
+        let events = vec![
+            event("app", EventResult::LocalHit, 0, &before),
+            event("app", EventResult::Miss, 10, &after),
+        ];
+
+        let chain = analyze_last(&events).unwrap();
+        assert_eq!(
+            chain.truncated,
+            Some("too many changed dependencies to follow")
+        );
+        assert!(
+            chain.roots.len() <= MAX_NODES,
+            "the cap must bound the work actually done: {}",
+            chain.roots.len()
+        );
+    }
+
+    /// Convergence is counted for unresolved endpoints too: "three branches all
+    /// end at a dependency with no compile recorded" is exactly the signal that
+    /// says where to look next.
+    #[test]
+    fn counts_converging_branches_on_an_unresolved_endpoint() {
+        let events = vec![
+            event(
+                "app",
+                EventResult::LocalHit,
+                0,
+                &[("b1", "aa"), ("b2", "aa")],
+            ),
+            event("b1", EventResult::LocalHit, 1, &[("ghost", "x1")]),
+            event("b2", EventResult::LocalHit, 2, &[("ghost", "x1")]),
+            event("b1", EventResult::Miss, 3, &[("ghost", "x2")]),
+            event("b2", EventResult::Miss, 4, &[("ghost", "x2")]),
+            event("app", EventResult::Miss, 5, &[("b1", "bb"), ("b2", "bb")]),
+        ];
+
+        let chain = analyze_last(&events).expect("cascade should be reported");
+        let ghost = chain
+            .roots
+            .iter()
+            .find(|r| r.crate_name == "ghost")
+            .expect("the never-compiled dependency should be an endpoint");
+        assert_eq!(ghost.kind, RootKind::NoMissRecorded);
+        assert_eq!(ghost.branches, 2, "both b1 and b2 end here");
+    }
+
+    /// The legacy fallback in `last_baseline_index` has to satisfy all three of
+    /// its conditions at once. Here a nearer legacy event of a DIFFERENT crate
+    /// would be accepted if any one of them were optional, and the diff it
+    /// produces is visibly wrong.
+    #[test]
+    fn the_legacy_baseline_fallback_requires_name_and_keying_together() {
+        let events = vec![
+            event("foo", EventResult::LocalHit, 0, &[("libc", "aaaa")]),
+            // Same build tree, keyed, no unit id — but a different crate.
+            event("bar", EventResult::LocalHit, 1, &[("other", "zzzz")]),
+            with_unit(
+                event("foo", EventResult::Miss, 2, &[("libc", "bbbb")]),
+                "ufoo",
+            ),
+        ];
+
+        assert_eq!(
+            changed_deps_at(&events, 2),
+            Some(vec![ChangedDep {
+                name: "libc".to_string(),
+                from: Some("aaaa".to_string()),
+                to: Some("bbbb".to_string()),
+                unit: None,
+            }]),
+            "must diff against foo's own legacy event, not bar's"
+        );
+    }
+
     /// Mixed windows happen across an upgrade: the compile carries a unit id,
     /// the only earlier event for it does not. Falling back to the name keeps
     /// the walk working rather than going blind.

--- a/src/report.rs
+++ b/src/report.rs
@@ -2927,6 +2927,8 @@ mod tests {
             key_diff: Vec::new(),
             key_externs: Default::default(),
             key_externs_recorded: false,
+            unit_id: String::new(),
+            extern_units: Default::default(),
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2289,6 +2289,8 @@ mod tests {
             key_diff: Vec::new(),
             key_externs: Default::default(),
             key_externs_recorded: false,
+            unit_id: String::new(),
+            extern_units: Default::default(),
         }
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2445,6 +2445,21 @@ fn log_event_details(
     } else {
         Default::default()
     };
+    // Unit identities ride the same stash-and-gate as the digests they explain
+    // (kunobi-ninja/kache#627): taken unconditionally so nothing leaks into the
+    // next compile in this process, persisted only under `explain_miss`, and
+    // only together with `key_externs` — a unit id with no digests to join is
+    // dead weight on the wire.
+    let recorded_extern_units = crate::cache_key::take_last_key_extern_units();
+    let recorded_unit_id = crate::cache_key::take_last_key_unit_id();
+    let (unit_id, extern_units) = if key_externs_recorded {
+        (
+            recorded_unit_id.unwrap_or_default(),
+            recorded_extern_units.unwrap_or_default(),
+        )
+    } else {
+        (String::new(), Default::default())
+    };
     let key_diff = explain_miss_diff(config, root, crate_name, result, cache_key, &key_fields);
     let event = BuildEvent {
         ts: Utc::now(),
@@ -2456,7 +2471,7 @@ fn log_event_details(
         compile_time_ms,
         size,
         cache_key: cache_key.to_string(),
-        schema: 13,
+        schema: 14,
         session_id,
         key_ms,
         key_hash_hits: key_hash_stats.cache_hits,
@@ -2487,6 +2502,8 @@ fn log_event_details(
         key_diff,
         key_externs,
         key_externs_recorded,
+        unit_id,
+        extern_units,
     };
     let _ = events::log_event(&config.event_log_path(), &event);
     let _ = events::rotate_if_needed(
@@ -4060,7 +4077,7 @@ mod tests {
         assert_eq!(event.compile_time_ms, 20);
         assert_eq!(event.size, 30);
         assert_eq!(event.cache_key, "cache-key");
-        assert_eq!(event.schema, 13);
+        assert_eq!(event.schema, 14);
         assert_eq!(event.key_ms, 40);
         assert_eq!(event.key_hash_hits, 4);
         assert_eq!(event.key_hash_misses, 5);


### PR DESCRIPTION
Fixes #627.

## What was wrong

The `extern:` cascade walk paired events by `crate_name`, which is not a compilation-unit identity. One build tree routinely holds several units sharing a name:

- two versions of a package (`foo v1` and `foo v2`)
- a host and a target build of the same crate (build scripts, proc macros)
- the same crate under different feature sets or crate types

Pairing by name lets the walk diff a compile against an unrelated unit's history and descend into a branch that has nothing to do with the miss. Cargo's dependency renaming breaks it from the other side: with `foo_old = { package = "foo" }` the consumer's key records `foo_old` while the producing crate's own events say `foo`, so the walk finds no event and dead-ends on the alias.

## The join

Cargo's `-C extra-filename` hash. The producing compile records it as `unit_id`; the consumer recovers the same value per extern from the `--extern` artifact filename (`lib<name>-<hash>.rlib`) into `extern_units`.

That hash is exactly what cargo uses to keep same-named units' artifacts from colliding in one `deps/` directory, so within a build tree it identifies the unit precisely, and it is visible from both sides, so the join holds whatever name the consumer used.

Not `-C metadata`: cargo sets the two to different hashes (observed `-C metadata=04bad873faff484a -C extra-filename=-843f02d6a46ebef1`), and only extra-filename appears in the filename a consumer sees on its `--extern` path.

## Why not the approach the issue proposed

The issue recommended recording the dependency artifact's content hash on the producing event (option 2). This is cheaper and fixes more:

- No hashing at all. Both values are already parsed from the command line, where a content hash needs the producing wrapper to hash its own outputs.
- A content hash changes on every compile, so it cannot pair a compile with its own previous compile. Baseline selection needs exactly that, and it is half the bug: a crate's history has to be diffed against its own past, not a same-named sibling's.
- Option 3 in the issue handled duplicate versions and host/target but explicitly not renames. This handles all three, because it never looks at the name.

## Diagnostic only

Neither field is folded into a cache key. Keying on cargo's unit hashing would tie kache's keys to it and break cross-machine sharing. Both ride the existing `[cache] explain_miss` gate, so the default path is unchanged, and both are `#[serde(default)]` and skipped when empty.

Events without them (pre-#627 wrappers, non-cargo rustc invocations, sysroot crates) still match by name. An event carrying a DIFFERENT unit id is never accepted on a name match, so the fallback cannot mispair two known units, and an exact unit match anywhere in the window is preferred over a nearer name-only one.

## Also

Endpoints now report the producing crate's own name rather than the consumer's alias, since the alias names nothing the user can go look at. The walk tracks each branch by the identity of the event it actually selected, so `reached`, `seen`, the cycle check and every root agree on what counts as one node.

## Verification

A real build with a renamed path dependency: `app` records `extern_units={foo_old: 0532daf0ee3516f0}` and `foo` records `unit_id=0532daf0ee3516f0`. `why-miss app` resolves to

```
Dependency cascade: this miss is downstream of a dependency that changed (foo_old)
  root: foo -- own inputs changed: sources
```

where it previously dead-ended at `unresolved: foo_old -- artifact differs, but it has no compile recorded in this event window`, the exact output quoted in the issue.

The rename and duplicate-version tests re-run their events with the unit ids stripped and assert the OLD, wrong result, so what the fix buys is pinned rather than assumed. One of those assertions corrected me: I expected name matching to blame the wrong version's `args` group, but it actually descends into that version's unrelated dependencies.

1418 unit tests pass (20 in `miss_chain`), clippy clean. The e2e gate suite passed locally before the final restructure; CI covers it here on all three platforms.

## Review note

A blind 2-leg cross-model review changed this patch. Both legs independently found the same identity inconsistency I had hit while they ran, but argued for the opposite normalization: track a branch by the identity of the event actually selected, not by what the consumer asked for. That is better, and the reason is concrete: when two different requested units both fall back by name to one legacy producer, my direction explores that event twice and emits two roots for it, while theirs collapses them into one node with the right branch count. It also makes cycle detection compare like with like, since hops carry their own event's identity. Adopted, with a test for that case.

Adopting it broke an existing cycle test, which was worth knowing: moving the check after producer resolution meant a dependency pointing back at the crate being explained, with no event of its own, stopped registering as a loop. The check now runs on both identities, requested before resolution and resolved after.

## Not addressed

`passthroughs_for` still attributes uncached compiles by package directory rather than by unit. Both review legs flagged it. It is pre-existing, already documented as a deliberately loose heuristic that over-reports rather than misdirects, and orthogonal to the join fixed here.
