### PR TITLE
test(core): add planner ordering properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
     env:
       RUSTC_WRAPPER: ""
       CARGO_INCREMENTAL: "1"
+      # Mutants fail properties intentionally; do not persist their shrunk cases.
+      PROPTEST_DISABLE_FAILURE_PERSISTENCE: "1"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,6 +2968,7 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "proptest",
  "serde",
  "serde_json",
  "tokio",
@@ -4333,6 +4334,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags 2.13.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4562,6 +4578,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -6864,6 +6889,12 @@ dependencies = [
  "serde",
  "web-time",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -19,5 +19,6 @@ async-trait = { version = "0.1", optional = true }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
+proptest = { version = "1.11.0", default-features = false, features = ["std", "handle-panics"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/kache-core/src/lib.rs
+++ b/crates/kache-core/src/lib.rs
@@ -196,6 +196,9 @@ mod tests {
     use anyhow::anyhow;
 
     #[cfg(feature = "planning")]
+    use proptest::prelude::*;
+
+    #[cfg(feature = "planning")]
     #[derive(Default)]
     struct FakePlannerDataSource {
         shard_candidates: Vec<PrefetchCandidate>,
@@ -512,5 +515,82 @@ mod tests {
             .map(|candidate| candidate.cache_key.as_str())
             .collect::<Vec<_>>();
         assert_eq!(keys, vec!["dep-key", "middle-key", "app-key"]);
+    }
+
+    #[cfg(feature = "planning")]
+    proptest! {
+        #[test]
+        fn property_crate_query_order_preserves_first_occurrence(
+            crate_ids in proptest::collection::vec(any::<u8>(), 1..64),
+        ) {
+            let mut crate_names = crate_ids
+                .into_iter()
+                .map(|id| format!("crate-{id}"))
+                .collect::<Vec<_>>();
+            crate_names.push(crate_names[0].clone());
+            let intent = BuildIntent {
+                crate_names: crate_names.clone(),
+                ..Default::default()
+            };
+
+            let mut expected = Vec::new();
+            for crate_name in crate_names {
+                if !expected.contains(&crate_name) {
+                    expected.push(crate_name);
+                }
+            }
+
+            prop_assert_eq!(crate_query_order(&intent), expected);
+        }
+
+        #[test]
+        fn property_candidate_ordering_is_a_stable_priority_permutation(
+            requested_ids in proptest::collection::vec(0u8..8, 1..24),
+            candidate_ids in proptest::collection::vec(0u8..16, 0..48),
+        ) {
+            let requested_names = requested_ids
+                .into_iter()
+                .map(|id| format!("crate-{id}"))
+                .collect::<Vec<_>>();
+            let intent = BuildIntent {
+                crate_names: requested_names.clone(),
+                ..Default::default()
+            };
+
+            // Interleave two unknown and two known candidates so even minimal
+            // shrunk inputs exercise both priority and stable tie ordering.
+            let mut candidate_names = Vec::with_capacity(candidate_ids.len() + 4);
+            candidate_names.push("not-requested".to_string());
+            candidate_names.push(requested_names[0].clone());
+            candidate_names.extend(
+                candidate_ids
+                    .into_iter()
+                    .map(|id| format!("crate-{id}")),
+            );
+            candidate_names.push("not-requested".to_string());
+            candidate_names.push(requested_names[0].clone());
+
+            let candidates = candidate_names
+                .into_iter()
+                .enumerate()
+                .map(|(index, crate_name)| PrefetchCandidate {
+                    cache_key: format!("key-{index}"),
+                    crate_name,
+                })
+                .collect::<Vec<_>>();
+
+            let mut expected = candidates.clone();
+            expected.sort_by_key(|candidate| {
+                requested_names
+                    .iter()
+                    .position(|name| name == &candidate.crate_name)
+                    .unwrap_or(usize::MAX)
+            });
+
+            prop_assert_eq!(
+                order_candidates_by_crate_order(candidates, &intent),
+                expected
+            );
+        }
     }
 }


### PR DESCRIPTION
## What changed

- Add bounded `proptest` coverage for planner crate de-duplication and candidate priority ordering.
- Guarantee every generated case exercises duplicate removal, requested-vs-unknown priority, and stable tie ordering.
- Disable proptest failure persistence only inside the mutation job so intentionally failing mutants cannot write regression seeds in-place.

## Why

These ordering helpers are pure and safety-relevant, making them a good first property-testing target. The tests broaden input coverage while staying fast enough for the existing cross-platform and complete `kache-core` mutation lanes.

## Impact

No production behavior changes. Normal property-test failures still persist shrunk regressions; mutation runs do not.

## Validation

- `PROPTEST_CASES=4096 cargo test -p kache-core --all-features property_`
- `cargo test -p kache-core --no-default-features`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (temporary fixture commit signing disabled only for the disposable Git repository)
- `cargo package -p kache-core --locked --allow-dirty`
- Complete `kache-core` mutation run: 11 mutants, 7 caught, 4 unviable
