### PR TITLE
fix(sharing): never report a partial or unvalidated probe as authoritative

### DIFF
--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -269,6 +269,27 @@ fn extent_is_last(fe_flags: u32) -> bool {
     fe_flags & FIEMAP_EXTENT_LAST != 0
 }
 
+/// Did the kernel report more extents than it was given room for?
+///
+/// Extracted for the same reason as its siblings: a real kernel cannot produce
+/// this, so a synthetic count is the only way to cover it. Clamping with `min`
+/// instead — the original shape — silently accepts a reply we do not
+/// understand and reports it as authoritative.
+#[cfg(target_os = "linux")]
+fn batch_count_is_valid(mapped: usize, capacity: usize) -> bool {
+    mapped <= capacity
+}
+
+/// Did this batch advance the walk past where it started?
+///
+/// A batch that ends where it began means the next window re-reads the same
+/// region and counts it twice. The boundary is the whole point: equal offsets
+/// are NOT progress.
+#[cfg(target_os = "linux")]
+fn batch_made_progress(offset: u64, batch_start: u64) -> bool {
+    offset > batch_start
+}
+
 /// Is this extent a usable, forward-progressing piece of the map?
 ///
 /// Its own function for the same reason as the flag tests: the failure shapes
@@ -372,7 +393,7 @@ fn probe_linux(path: &Path, size: u64) -> Sharing {
         }
         // The kernel must never report more extents than it was given room for.
         // Clamping would silently accept a reply we do not understand.
-        if mapped > FIEMAP_MAX_EXTENTS {
+        if !batch_count_is_valid(mapped, FIEMAP_MAX_EXTENTS) {
             return Sharing::unknown_for(size);
         }
 
@@ -410,7 +431,7 @@ fn probe_linux(path: &Path, size: u64) -> Sharing {
             complete = true;
             break;
         }
-        if offset <= batch_start {
+        if !batch_made_progress(offset, batch_start) {
             return Sharing::unknown_for(size);
         }
     }
@@ -643,6 +664,41 @@ mod tests {
         assert!(
             !extent_is_usable(u64::MAX, 1, 0),
             "logical + length must not wrap"
+        );
+    }
+
+    /// A batch may fill the buffer exactly, but never overrun it
+    /// (kunobi-ninja/kache#602 review). The boundary is what matters: `==` and
+    /// `>=` in place of `>` both misclassify a full, legitimate batch.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_batch_may_fill_the_buffer_but_not_overrun_it() {
+        assert!(batch_count_is_valid(0, 32), "an empty batch is valid");
+        assert!(batch_count_is_valid(31, 32), "under capacity");
+        assert!(
+            batch_count_is_valid(32, 32),
+            "exactly full is the buffer being used, not an overrun"
+        );
+        assert!(
+            !batch_count_is_valid(33, 32),
+            "more extents than room is a reply we do not understand"
+        );
+    }
+
+    /// Equal offsets are not progress: the next window would re-read the same
+    /// region and double-count it.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_batch_that_ends_where_it_began_is_not_progress() {
+        assert!(batch_made_progress(4096, 0), "advanced");
+        assert!(batch_made_progress(1, 0), "advanced by one byte");
+        assert!(
+            !batch_made_progress(4096, 4096),
+            "ending where it started would re-read the region"
+        );
+        assert!(
+            !batch_made_progress(0, 4096),
+            "going backwards is not progress"
         );
     }
 }

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -311,6 +311,42 @@ fn mapped_nothing(shared_bytes: u64, private_bytes: u64) -> bool {
     shared_bytes == 0 && private_bytes == 0
 }
 
+/// Turn a finished FIEMAP walk into an answer.
+///
+/// The last decision in the walk, and the one most worth pinning: it is where
+/// "we did not finish reading the map" and "the map was empty" both have to
+/// collapse back to the conservative answer rather than to a tally that merely
+/// looks plausible. Pure, because `probe_linux` itself cannot be driven without
+/// a real FIEMAP filesystem, and an untestable comparison here is exactly how a
+/// partial map would come to be reported as authoritative.
+#[cfg(target_os = "linux")]
+fn fiemap_verdict(
+    complete: bool,
+    any_shared: bool,
+    shared_bytes: u64,
+    private_bytes: u64,
+    size: u64,
+) -> Sharing {
+    // Ran out of batches without the map ever ending: the tally covers a prefix
+    // of the file, which would understate the private bytes a delete frees.
+    if !complete {
+        return Sharing::unknown_for(size);
+    }
+
+    // A file with no mapped extents at all (fully sparse, or inline in the
+    // inode) tells us nothing useful — don't claim it is private or shared.
+    if mapped_nothing(shared_bytes, private_bytes) {
+        return Sharing::unknown_for(size);
+    }
+
+    Sharing {
+        shared: any_shared,
+        // Extents are block-aligned and can overrun the logical length; clamp
+        // so a reclaim estimate never exceeds the file's reported size.
+        private_bytes: private_bytes.min(size),
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn probe_linux(path: &Path, size: u64) -> Sharing {
     use std::os::fd::AsRawFd;
@@ -436,24 +472,7 @@ fn probe_linux(path: &Path, size: u64) -> Sharing {
         }
     }
 
-    // Ran out of batches without the map ever ending: the tally covers a prefix
-    // of the file, which would understate the private bytes a delete frees.
-    if !complete {
-        return Sharing::unknown_for(size);
-    }
-
-    // A file with no mapped extents at all (fully sparse, or inline in the
-    // inode) tells us nothing useful — don't claim it is private or shared.
-    if mapped_nothing(shared_bytes, private_bytes) {
-        return Sharing::unknown_for(size);
-    }
-
-    Sharing {
-        shared: any_shared,
-        // Extents are block-aligned and can overrun the logical length; clamp
-        // so a reclaim estimate never exceeds the file's reported size.
-        private_bytes: private_bytes.min(size),
-    }
+    fiemap_verdict(complete, any_shared, shared_bytes, private_bytes, size)
 }
 
 // ── Everything else ─────────────────────────────────────────────────────────
@@ -699,6 +718,44 @@ mod tests {
         assert!(
             !batch_made_progress(0, 4096),
             "going backwards is not progress"
+        );
+    }
+
+    /// The walk's final decision (kunobi-ninja/kache#602 review). An incomplete
+    /// map and an empty one must both collapse to the conservative answer,
+    /// never to a tally that merely looks plausible.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_unfinished_or_empty_map_is_not_an_answer() {
+        // Ran out of batches: the tally covers a prefix, so it must be discarded
+        // even though it holds real numbers.
+        assert_eq!(
+            fiemap_verdict(false, true, 4096, 4096, 8192),
+            Sharing::unknown_for(8192),
+            "an unfinished map must not be reported as authoritative"
+        );
+
+        // Finished, but nothing was mapped at all.
+        assert_eq!(
+            fiemap_verdict(true, false, 0, 0, 8192),
+            Sharing::unknown_for(8192),
+            "an empty map is not evidence of anything"
+        );
+
+        // Finished with real extents: the tally stands.
+        assert_eq!(
+            fiemap_verdict(true, true, 4096, 4096, 8192),
+            Sharing {
+                shared: true,
+                private_bytes: 4096,
+            }
+        );
+
+        // Block-aligned extents can overrun the logical length.
+        assert_eq!(
+            fiemap_verdict(true, false, 0, 8192, 5000).private_bytes,
+            5000,
+            "a reclaim estimate never exceeds the file's own size"
         );
     }
 }

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -311,6 +311,92 @@ fn mapped_nothing(shared_bytes: u64, private_bytes: u64) -> bool {
     shared_bytes == 0 && private_bytes == 0
 }
 
+/// One extent, reduced to what the walk actually reads.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Extent {
+    logical: u64,
+    length: u64,
+    flags: u32,
+}
+
+/// Walk a file's extent map and decide what it says about sharing.
+///
+/// `next_batch` supplies the extents starting at a byte offset, or `None` if the
+/// kernel could not be asked. Everything the walk decides — how far it got,
+/// whether a batch made progress, whether the map ended — is pure given that,
+/// so the whole thing can be driven from a test with synthetic replies.
+///
+/// That seam is the point. `probe_linux` cannot be run without a real FIEMAP
+/// filesystem, and the CI lane is ext4, so any branch left inside it is
+/// unobservable: a guard could be inverted and nothing would fail. Only the
+/// ioctl itself stays on the other side of this boundary.
+#[cfg(target_os = "linux")]
+fn walk_extent_map<F>(size: u64, mut next_batch: F) -> Sharing
+where
+    F: FnMut(u64) -> Option<Vec<Extent>>,
+{
+    let mut shared_bytes: u64 = 0;
+    let mut private_bytes: u64 = 0;
+    let mut any_shared = false;
+    let mut offset: u64 = 0;
+    // The batch cap below is a runaway guard, not permission to answer from a
+    // prefix of the map. Only a reply that actually ended — LAST seen, or an
+    // empty batch — may be reported (kunobi-ninja/kache#602 review).
+    let mut complete = false;
+
+    // A heavily fragmented file needs more than one batch of extents.
+    for _ in 0..64 {
+        let Some(batch) = next_batch(offset) else {
+            return Sharing::unknown_for(size);
+        };
+        if batch.is_empty() {
+            complete = true;
+            break;
+        }
+
+        let batch_start = offset;
+        let mut last = false;
+        for ext in &batch {
+            // A zero-length or backwards extent makes no forward progress, so
+            // the next window would re-read this region and double-count it.
+            // Saturating arithmetic would hide that as a plausible total.
+            if !extent_is_usable(ext.logical, ext.length, offset) {
+                return Sharing::unknown_for(size);
+            }
+            let Some(next_offset) = ext.logical.checked_add(ext.length) else {
+                return Sharing::unknown_for(size);
+            };
+
+            if extent_is_shared(ext.flags) {
+                let Some(total) = shared_bytes.checked_add(ext.length) else {
+                    return Sharing::unknown_for(size);
+                };
+                shared_bytes = total;
+                any_shared = true;
+            } else {
+                let Some(total) = private_bytes.checked_add(ext.length) else {
+                    return Sharing::unknown_for(size);
+                };
+                private_bytes = total;
+            }
+            offset = next_offset;
+            if extent_is_last(ext.flags) {
+                last = true;
+            }
+        }
+        if last {
+            complete = true;
+            break;
+        }
+        if !batch_made_progress(offset, batch_start) {
+            return Sharing::unknown_for(size);
+        }
+    }
+
+    fiemap_verdict(complete, any_shared, shared_bytes, private_bytes, size)
+}
+
 /// Turn a finished FIEMAP walk into an answer.
 ///
 /// The last decision in the walk, and the one most worth pinning: it is where
@@ -395,17 +481,7 @@ fn probe_linux(path: &Path, size: u64) -> Sharing {
         return Sharing::unknown_for(size);
     };
 
-    let mut shared_bytes: u64 = 0;
-    let mut private_bytes: u64 = 0;
-    let mut any_shared = false;
-    let mut offset: u64 = 0;
-    // The batch cap below is a runaway guard, not permission to answer from a
-    // prefix of the map. Only a reply that actually ended — LAST seen, or an
-    // empty batch — may be reported (kunobi-ninja/kache#602 review).
-    let mut complete = false;
-
-    // A heavily fragmented file needs more than one batch of extents.
-    for _ in 0..64 {
+    walk_extent_map(size, |offset| {
         let mut fm: Fiemap = unsafe { std::mem::zeroed() };
         fm.fm_start = offset;
         fm.fm_length = fiemap_window_length(offset);
@@ -420,59 +496,21 @@ fn probe_linux(path: &Path, size: u64) -> Sharing {
             )
         };
         if rc != 0 {
-            return Sharing::unknown_for(size);
+            return None;
         }
-        let mapped = fm.fm_mapped_extents as usize;
-        if mapped == 0 {
-            complete = true;
-            break;
-        }
-        // The kernel must never report more extents than it was given room for.
-        // Clamping would silently accept a reply we do not understand.
-        if !batch_count_is_valid(mapped, FIEMAP_MAX_EXTENTS) {
-            return Sharing::unknown_for(size);
-        }
-
-        let batch_start = offset;
-        let mut last = false;
-        for ext in fm.fm_extents.iter().take(mapped) {
-            // A zero-length or backwards extent makes no forward progress, so
-            // the next window would re-read this region and double-count it.
-            // Saturating arithmetic would hide that as a plausible total.
-            if !extent_is_usable(ext.fe_logical, ext.fe_length, offset) {
-                return Sharing::unknown_for(size);
-            }
-            let Some(next_offset) = ext.fe_logical.checked_add(ext.fe_length) else {
-                return Sharing::unknown_for(size);
-            };
-
-            if extent_is_shared(ext.fe_flags) {
-                let Some(total) = shared_bytes.checked_add(ext.fe_length) else {
-                    return Sharing::unknown_for(size);
-                };
-                shared_bytes = total;
-                any_shared = true;
-            } else {
-                let Some(total) = private_bytes.checked_add(ext.fe_length) else {
-                    return Sharing::unknown_for(size);
-                };
-                private_bytes = total;
-            }
-            offset = next_offset;
-            if extent_is_last(ext.fe_flags) {
-                last = true;
-            }
-        }
-        if last {
-            complete = true;
-            break;
-        }
-        if !batch_made_progress(offset, batch_start) {
-            return Sharing::unknown_for(size);
-        }
-    }
-
-    fiemap_verdict(complete, any_shared, shared_bytes, private_bytes, size)
+        Some(
+            fm.fm_extents
+                .iter()
+                .take((fm.fm_mapped_extents as usize).min(FIEMAP_MAX_EXTENTS))
+                .map(|ext| Extent {
+                    logical: ext.fe_logical,
+                    length: ext.fe_length,
+                    flags: ext.fe_flags,
+                })
+                .collect(),
+        )
+        .filter(|_| batch_count_is_valid(fm.fm_mapped_extents as usize, FIEMAP_MAX_EXTENTS))
+    })
 }
 
 // ── Everything else ─────────────────────────────────────────────────────────
@@ -756,6 +794,132 @@ mod tests {
             fiemap_verdict(true, false, 0, 8192, 5000).private_bytes,
             5000,
             "a reclaim estimate never exceeds the file's own size"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    fn extent(logical: u64, length: u64, flags: u32) -> Extent {
+        Extent {
+            logical,
+            length,
+            flags,
+        }
+    }
+
+    /// The whole walk, driven with synthetic kernel replies. Every branch below
+    /// is one that `probe_linux` itself cannot reach on the CI lane's ext4, so
+    /// this is the only place they are observable at all.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_walk_reads_a_finished_map() {
+        // One batch, ending with LAST: a plain private file.
+        let got = walk_extent_map(8192, |_| Some(vec![extent(0, 8192, 0x0001)]));
+        assert_eq!(
+            got,
+            Sharing {
+                shared: false,
+                private_bytes: 8192,
+            }
+        );
+
+        // A shared extent flips `shared` and stops counting those bytes as
+        // reclaimable.
+        let got = walk_extent_map(8192, |_| {
+            Some(vec![extent(0, 4096, 0x2000), extent(4096, 4096, 0x0001)])
+        });
+        assert_eq!(
+            got,
+            Sharing {
+                shared: true,
+                private_bytes: 4096,
+            }
+        );
+    }
+
+    /// The walk spans batches, and only stops when the map says it ended.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_walk_continues_across_batches() {
+        let mut calls = 0;
+        let got = walk_extent_map(8192, |offset| {
+            calls += 1;
+            match offset {
+                0 => Some(vec![extent(0, 4096, 0)]),
+                _ => Some(vec![extent(4096, 4096, 0x0001)]),
+            }
+        });
+        assert_eq!(
+            calls, 2,
+            "the first batch carried no LAST, so it asked again"
+        );
+        assert_eq!(
+            got,
+            Sharing {
+                shared: false,
+                private_bytes: 8192,
+            }
+        );
+    }
+
+    /// Every way a reply can be unusable collapses to the conservative answer.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_unusable_reply_is_never_reported_as_an_answer() {
+        let unknown = Sharing::unknown_for(8192);
+
+        assert_eq!(
+            walk_extent_map(8192, |_| None),
+            unknown,
+            "the kernel could not be asked"
+        );
+        assert_eq!(
+            walk_extent_map(8192, |_| Some(vec![extent(0, 0, 0)])),
+            unknown,
+            "a zero-length extent makes no progress"
+        );
+        assert_eq!(
+            walk_extent_map(8192, |_| Some(vec![extent(u64::MAX, 1, 0)])),
+            unknown,
+            "logical + length wraps"
+        );
+
+        // Never sets LAST and never advances: the batch repeats forever, so the
+        // walk must bail rather than spin to the cap and answer from a prefix.
+        assert_eq!(
+            walk_extent_map(8192, |_| Some(vec![extent(0, 4096, 0)])),
+            unknown,
+            "a batch that does not advance is refused"
+        );
+    }
+
+    /// Exhausting the batch cap is a failure, not a result. The supplier keeps
+    /// advancing so each batch is individually well-formed; the map simply never
+    /// ends, which is exactly the fragmented-file case that must not be answered
+    /// from a prefix.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn running_out_of_batches_is_not_an_answer() {
+        let mut calls = 0;
+        let got = walk_extent_map(1 << 30, |offset| {
+            calls += 1;
+            Some(vec![extent(offset, 4096, 0)])
+        });
+        assert_eq!(calls, 64, "the cap bounds the walk");
+        assert_eq!(
+            got,
+            Sharing::unknown_for(1 << 30),
+            "a map that never ended must not be reported as authoritative"
+        );
+    }
+
+    /// An empty first batch means nothing was mapped at all.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_empty_batch_ends_the_walk() {
+        assert_eq!(
+            walk_extent_map(8192, |_| Some(Vec::new())),
+            Sharing::unknown_for(8192),
+            "nothing mapped is not evidence of anything"
         );
     }
 }

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -498,10 +498,16 @@ fn probe_linux(path: &Path, size: u64) -> Sharing {
         if rc != 0 {
             return None;
         }
+        // The kernel must never report more extents than it was given room for.
+        // Truncating would silently accept a reply we do not understand.
+        let mapped = fm.fm_mapped_extents as usize;
+        if !batch_count_is_valid(mapped, FIEMAP_MAX_EXTENTS) {
+            return None;
+        }
         Some(
             fm.fm_extents
                 .iter()
-                .take((fm.fm_mapped_extents as usize).min(FIEMAP_MAX_EXTENTS))
+                .take(mapped)
                 .map(|ext| Extent {
                     logical: ext.fe_logical,
                     length: ext.fe_length,
@@ -509,7 +515,6 @@ fn probe_linux(path: &Path, size: u64) -> Sharing {
                 })
                 .collect(),
         )
-        .filter(|_| batch_count_is_valid(fm.fm_mapped_extents as usize, FIEMAP_MAX_EXTENTS))
     })
 }
 

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -192,6 +192,14 @@ fn probe_macos(path: &Path, size: u64) -> Sharing {
         return Sharing::unknown_for(size);
     }
 
+    // `length` is the kernel's own account of how much it wrote. A short reply
+    // would otherwise let the zeroed tail read as real values — and a zeroed
+    // `private_size` means "deleting this frees nothing", the one direction
+    // that loses a user's bytes (kunobi-ninja/kache#602 review).
+    if (buf.length as usize) < std::mem::size_of::<Buf>() {
+        return Sharing::unknown_for(size);
+    }
+
     // Trap 2: only believe fields the kernel says it actually returned.
     // Copied out of the packed struct before use — taking a reference to an
     // unaligned field is UB.
@@ -261,6 +269,19 @@ fn extent_is_last(fe_flags: u32) -> bool {
     fe_flags & FIEMAP_EXTENT_LAST != 0
 }
 
+/// Is this extent a usable, forward-progressing piece of the map?
+///
+/// Its own function for the same reason as the flag tests: the failure shapes
+/// matter and a real kernel will not produce them, so synthetic values are the
+/// only way to cover this. A zero-length extent, or one starting behind where
+/// the walk already is, leaves the window offset unmoved — the next batch would
+/// re-read the same region and count it twice, which saturating arithmetic
+/// would then hide behind a plausible-looking total.
+#[cfg(target_os = "linux")]
+fn extent_is_usable(fe_logical: u64, fe_length: u64, offset: u64) -> bool {
+    fe_length != 0 && fe_logical >= offset && fe_logical.checked_add(fe_length).is_some()
+}
+
 /// Did the map come back empty — a fully sparse file, or one stored inline in
 /// its inode? Neither is evidence about sharing, so the caller falls back
 /// instead of reporting "all private".
@@ -321,6 +342,10 @@ fn probe_linux(path: &Path, size: u64) -> Sharing {
     let mut private_bytes: u64 = 0;
     let mut any_shared = false;
     let mut offset: u64 = 0;
+    // The batch cap below is a runaway guard, not permission to answer from a
+    // prefix of the map. Only a reply that actually ended — LAST seen, or an
+    // empty batch — may be reported (kunobi-ninja/kache#602 review).
+    let mut complete = false;
 
     // A heavily fragmented file needs more than one batch of extents.
     for _ in 0..64 {
@@ -342,25 +367,58 @@ fn probe_linux(path: &Path, size: u64) -> Sharing {
         }
         let mapped = fm.fm_mapped_extents as usize;
         if mapped == 0 {
+            complete = true;
             break;
         }
+        // The kernel must never report more extents than it was given room for.
+        // Clamping would silently accept a reply we do not understand.
+        if mapped > FIEMAP_MAX_EXTENTS {
+            return Sharing::unknown_for(size);
+        }
 
+        let batch_start = offset;
         let mut last = false;
-        for ext in fm.fm_extents.iter().take(mapped.min(FIEMAP_MAX_EXTENTS)) {
+        for ext in fm.fm_extents.iter().take(mapped) {
+            // A zero-length or backwards extent makes no forward progress, so
+            // the next window would re-read this region and double-count it.
+            // Saturating arithmetic would hide that as a plausible total.
+            if !extent_is_usable(ext.fe_logical, ext.fe_length, offset) {
+                return Sharing::unknown_for(size);
+            }
+            let Some(next_offset) = ext.fe_logical.checked_add(ext.fe_length) else {
+                return Sharing::unknown_for(size);
+            };
+
             if extent_is_shared(ext.fe_flags) {
-                shared_bytes = shared_bytes.saturating_add(ext.fe_length);
+                let Some(total) = shared_bytes.checked_add(ext.fe_length) else {
+                    return Sharing::unknown_for(size);
+                };
+                shared_bytes = total;
                 any_shared = true;
             } else {
-                private_bytes = private_bytes.saturating_add(ext.fe_length);
+                let Some(total) = private_bytes.checked_add(ext.fe_length) else {
+                    return Sharing::unknown_for(size);
+                };
+                private_bytes = total;
             }
-            offset = ext.fe_logical.saturating_add(ext.fe_length);
+            offset = next_offset;
             if extent_is_last(ext.fe_flags) {
                 last = true;
             }
         }
         if last {
+            complete = true;
             break;
         }
+        if offset <= batch_start {
+            return Sharing::unknown_for(size);
+        }
+    }
+
+    // Ran out of batches without the map ever ending: the tally covers a prefix
+    // of the file, which would understate the private bytes a delete frees.
+    if !complete {
+        return Sharing::unknown_for(size);
     }
 
     // A file with no mapped extents at all (fully sparse, or inline in the
@@ -558,6 +616,33 @@ mod tests {
             "a fully shared clone must not claim to free its whole apparent size \
              ({} of {size} bytes reported private)",
             s.private_bytes
+        );
+    }
+
+    /// Only a forward-progressing, non-empty extent may be counted
+    /// (kunobi-ninja/kache#602 review). Each rejected shape would otherwise
+    /// leave the window offset unmoved and double-count the region.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn only_forward_progressing_extents_are_usable() {
+        assert!(extent_is_usable(0, 4096, 0), "a plain first extent");
+        assert!(extent_is_usable(8192, 4096, 4096), "a later extent");
+        assert!(
+            extent_is_usable(4096, 4096, 4096),
+            "starting exactly where the walk is, is progress"
+        );
+
+        assert!(
+            !extent_is_usable(4096, 0, 4096),
+            "a zero-length extent moves the offset nowhere"
+        );
+        assert!(
+            !extent_is_usable(0, 4096, 8192),
+            "an extent behind the walk would be re-counted"
+        );
+        assert!(
+            !extent_is_usable(u64::MAX, 1, 0),
+            "logical + length must not wrap"
         );
     }
 }


### PR DESCRIPTION
Follow-up to #641, which merged before this review landed. These are three violations of the
one safety property `src/sharing.rs` documents for itself:

> Every probe failure degrades to "not shared, all bytes private" — exactly what the
> `nlink`-only code returned.

All three occur on a **successful** syscall whose reply the code then over-trusts, which is
why none of them show up as an error path.

## 1. FIEMAP batch-cap exhaustion reported a prefix as the whole map

The loop runs at most 64 batches of 32 extents. If a file has more than ~2048 extents and no
processed extent carries `FIEMAP_EXTENT_LAST`, the loop simply expired and returned the
accumulated prefix as authoritative.

- `private_bytes` is understated, so `clean` promises less reclaimable space than a delete
  actually frees.
- A genuinely reflinked file whose shared extents sit past the cap is reported unshared.

The cap is a sensible runaway guard; exhausting it is just not permission to answer from a
prefix. It now returns `unknown_for(size)`.

## 2. Nothing validated the shape of a batch

- A zero-length extent, or one starting behind the walk, leaves the window offset unmoved, so
  the next batch re-reads the same region and counts it twice. `saturating_add` then hid the
  double-count behind a plausible total.
- `fm_mapped_extents > fm_extent_count` was clamped with `.min()`, silently accepting a reply
  the code does not understand.
- Accumulators could saturate.

Now: forward progress is required per extent, an over-large batch count is rejected, and both
accumulators use `checked_add`.

## 3. `getattrlist`'s reply length was never read

`Buf::length` was declared and never checked. A short-but-successful reply left the zeroed
tail to be parsed as real values — and a zeroed `private_size` reads as "deleting this frees
nothing", which is the one direction that costs a user bytes they could have reclaimed.

## Testing

`extent_is_usable` is extracted next to the existing `extent_is_shared` / `extent_is_last`
predicates, for the reason the file already gives for those: a real kernel will not produce
these shapes, so synthetic values are the only way to cover them. The new test pins each
rejected shape (zero length, backwards, wrapping) and the boundary where an extent starts
exactly where the walk is.

**Linux verified this time, not reasoned about.** `cargo zigbuild --target
aarch64-unknown-linux-gnu` under `RUSTFLAGS="-D warnings"` builds clean — the same gate that
caught the dead-code errors on #641, now reproducible locally rather than only in CI. macOS:
`fmt --check`, `clippy --workspace --all-targets -- -D warnings`, 1458 tests.

## Deliberately not fixed here

A cross-model review also argued the macOS parser should be rewritten to walk the payload by
cursor, on the theory that `getattrlist` packs a partial attribute set contiguously — so a
reply carrying `EXT_FLAGS` but not `PRIVATESIZE` would be read at the wrong offset.

That rests on a claim about Apple's ABI I could not confirm, and rewriting the parser against
an unverified layout would trade a possible bug for a certain one. The length check in (3)
blocks the short-reply case; settling the subset case needs a real partial response from a
filesystem that returns one. Worth its own issue.

Same review flagged a hardlink concern — `nlink > 1` sets `shared` but leaves `private_bytes`
at full size. I checked: `artifact_sharing`'s two call sites both read only `.shared`, and the
sole `private_bytes` consumer sits in the `nlink == 1` branch, so it does not bite today. It is
a latent trap if anyone starts consuming `private_bytes` from that path.
