### PR TITLE
fix(wrapper): support Kani custom rustc drivers

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -31,9 +31,15 @@ gitignore = true
 # carry the enclosing function, so "probe_macos" alone does not match it. The
 # struct is declared inside `probe_macos` and exists nowhere else, so naming it
 # is exactly as narrow.
+#
+# Kani proof harnesses are compiled and executed only by `cargo kani`; the
+# mutation lane's `cargo test` process cannot observe changes under `cfg(kani)`.
+# Their production target remains mutation-tested, while the harnesses are
+# independently gated by the Kani proofs job.
 exclude_re = [
     "replace run_config_editor",
     "probe_macos",
     "probe_unsupported",
     "from struct AttrList",
+    "kani_proofs::",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,54 @@ jobs:
           path: tmp/mutants/
           retention-days: 14
 
+  # Bounded model checking for the small, hermetic planner crate. The proof
+  # command deliberately runs through the locally-built kache wrapper: Kani
+  # replaces rustc with `kani-compiler`, so this is also the end-to-end
+  # regression for #656. Unsupported compiler drivers must pass through
+  # uncached; Kache does not model Kani's verification artifacts.
+  kani:
+    name: Kani proofs
+    runs-on: ubuntu-24.04
+    needs: [changes, check]
+    if: github.ref_type != 'tag' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true')
+    timeout-minutes: 30
+    env:
+      RUSTC_WRAPPER: ""
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          version: 2026.6.9
+          install_args: rust
+          cache: false
+      - name: Verify kache-core's stable 1.93 MSRV
+        run: |
+          rustup toolchain install 1.93.0 --profile minimal
+          cargo +1.93.0 test --package kache-core --all-features --locked
+          cargo +1.93.0 check --package kache-core --no-default-features --locked
+      - name: Install Kani 0.67.0
+        run: |
+          cargo install --locked kani-verifier --version 0.67.0
+          cargo kani setup
+      - name: Build the local Kache wrapper
+        run: cargo build --bin kache
+      - name: Discover and verify Kani harnesses through Kache
+        env:
+          RUSTC_WRAPPER: ${{ github.workspace }}/target/debug/kache
+          KACHE_CACHE_DIR: ${{ runner.temp }}/kache-kani
+          KACHE_CONFIG: ${{ runner.temp }}/kache-kani-config.toml
+        run: |
+          cd crates/kache-core
+          cargo kani list --format json
+          count="$(python3 -c 'import json; print(json.load(open("kani-list.json"))["totals"]["standard-harnesses"])')"
+          echo "Kani harnesses: $count"
+          test "$count" -ge 6
+          output="$RUNNER_TEMP/kani-output.txt"
+          cargo kani --all-features --output-format terse 2>&1 | tee "$output"
+          covers="$(grep -c '1 of 1 cover properties satisfied' "$output" || true)"
+          echo "Satisfied reachability covers: $covers"
+          test "$covers" -eq "$count"
+
   # Fast, hermetic version gate (no nix / no cargo / no network). Runs on every
   # push & PR in internal mode (the shipping manifests must agree), and on a v*
   # tag additionally asserts the tag matches the manifest BEFORE the release job

--- a/Justfile
+++ b/Justfile
@@ -61,6 +61,12 @@ image-service-release:
 test:
   cargo test --workspace
 
+# Model-check the bounded planner invariants. Install the pinned verifier with:
+# cargo install --locked kani-verifier --version 0.67.0 && cargo kani setup
+[group('dev')]
+kani *ARGS:
+  cd crates/kache-core && cargo kani --all-features --output-format terse {{ARGS}}
+
 # Mutation-test the complete hermetic planner crate. Install the pinned local
 # tool with: cargo install --locked cargo-mutants --version 27.1.0
 [group('dev')]

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -5,7 +5,9 @@ edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"
-rust-version = "1.95"
+# Kani 0.67 bundles Rust 1.93; this crate's stable-1.93 test and proofs keep
+# the narrower package MSRV honest while the rest of Kache remains on 1.95.
+rust-version = "1.93"
 keywords = ["build-cache", "planner", "cache"]
 categories = ["development-tools::build-utils", "caching"]
 
@@ -17,6 +19,9 @@ planning = ["dep:anyhow", "dep:async-trait"]
 anyhow = { version = "1", optional = true }
 async-trait = { version = "0.1", optional = true }
 serde = { version = "1", features = ["derive"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 
 [dev-dependencies]
 proptest = { version = "1.11.0", default-features = false, features = ["std", "handle-panics"] }

--- a/crates/kache-core/src/lib.rs
+++ b/crates/kache-core/src/lib.rs
@@ -24,6 +24,7 @@ pub struct BuildIntent {
 /// this build has never heard of degrades to "untrusted" instead of failing
 /// the whole plan.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[cfg_attr(kani, derive(kani::Arbitrary))]
 #[serde(rename_all = "snake_case")]
 pub enum CandidateSource {
     /// Exact lockfile-shard match: this build's dependency set produced it.
@@ -184,6 +185,11 @@ pub fn dispatch_sort_key(candidate: &PrefetchCandidate) -> (u32, u8, std::cmp::R
         // candidate is worthless.
         std::cmp::Reverse(candidate.compile_time_ms.unwrap_or(0)),
     )
+}
+
+#[cfg(feature = "planning")]
+fn sort_candidates_for_dispatch(candidates: &mut [PrefetchCandidate]) {
+    candidates.sort_by_key(dispatch_sort_key);
 }
 
 /// Truncate `items` to `limit`, returning how many were dropped. `0` disables.
@@ -384,7 +390,7 @@ where
 
     // Dispatch order (#617). Stable, so equal keys keep the confidence-merge
     // order the sources were appended in.
-    candidates.sort_by_key(dispatch_sort_key);
+    sort_candidates_for_dispatch(&mut candidates);
 
     Ok((execute_plan(planner_name, candidates), composition))
 }
@@ -453,6 +459,116 @@ fn order_candidates_by_crate_order(
         .into_iter()
         .map(|(_, candidate)| candidate)
         .collect()
+}
+
+/// Bounded model-checking harnesses for the planner's dispatch contract.
+///
+/// These mirror the three lexicographic priorities documented by
+/// [`dispatch_sort_key`] and cover every primitive input value, rather than a
+/// sampled set. Kani injects its support crate when `cargo kani` sets
+/// `cfg(kani)`, so normal builds carry no additional dependency.
+#[cfg(all(kani, feature = "planning"))]
+mod kani_proofs {
+    use super::*;
+
+    fn candidate(
+        source: CandidateSource,
+        compile_time_ms: Option<u64>,
+        demand_index: Option<u32>,
+    ) -> PrefetchCandidate {
+        PrefetchCandidate {
+            cache_key: String::new(),
+            crate_name: String::new(),
+            compile_time_ms,
+            size_bytes: None,
+            source,
+            demand_index,
+        }
+    }
+
+    #[kani::proof]
+    fn known_demand_always_precedes_unknown_demand() {
+        let demand_index: u32 = kani::any();
+        let known = candidate(kani::any(), kani::any(), Some(demand_index));
+        let unknown = candidate(kani::any(), kani::any(), None);
+        kani::cover!();
+
+        assert!(dispatch_sort_key(&known) < dispatch_sort_key(&unknown));
+    }
+
+    #[kani::proof]
+    fn earlier_urgency_bucket_always_wins() {
+        let earlier: u32 = kani::any();
+        let later: u32 = kani::any();
+        kani::assume(earlier / URGENCY_BUCKET < later / URGENCY_BUCKET);
+        let earlier_candidate = candidate(kani::any(), kani::any(), Some(earlier));
+        let later_candidate = candidate(kani::any(), kani::any(), Some(later));
+        kani::cover!();
+
+        assert!(dispatch_sort_key(&earlier_candidate) < dispatch_sort_key(&later_candidate));
+    }
+
+    #[kani::proof]
+    fn confidence_always_wins_within_a_bucket() {
+        let better_source: CandidateSource = kani::any();
+        let worse_source: CandidateSource = kani::any();
+        kani::assume(better_source.confidence_rank() < worse_source.confidence_rank());
+        let better_demand: u32 = kani::any();
+        let worse_demand: u32 = kani::any();
+        kani::assume(better_demand / URGENCY_BUCKET == worse_demand / URGENCY_BUCKET);
+        let better = candidate(better_source, kani::any(), Some(better_demand));
+        let worse = candidate(worse_source, kani::any(), Some(worse_demand));
+        kani::cover!();
+
+        assert!(dispatch_sort_key(&better) < dispatch_sort_key(&worse));
+    }
+
+    #[kani::proof]
+    fn higher_compile_cost_wins_after_urgency_and_confidence() {
+        let cheaper: u64 = kani::any();
+        let costlier: u64 = kani::any();
+        kani::assume(cheaper < costlier);
+        let cheaper_demand: u32 = kani::any();
+        let costlier_demand: u32 = kani::any();
+        kani::assume(cheaper_demand / URGENCY_BUCKET == costlier_demand / URGENCY_BUCKET);
+        let source: CandidateSource = kani::any();
+        let cheaper_candidate = candidate(source, Some(cheaper), Some(cheaper_demand));
+        let costlier_candidate = candidate(source, Some(costlier), Some(costlier_demand));
+        kani::cover!();
+
+        assert!(dispatch_sort_key(&costlier_candidate) < dispatch_sort_key(&cheaper_candidate));
+    }
+
+    #[kani::proof]
+    fn known_positive_compile_cost_precedes_unknown_cost() {
+        let known_cost: u64 = kani::any();
+        kani::assume(known_cost > 0);
+        let demand_index: u32 = kani::any();
+        let source: CandidateSource = kani::any();
+        let known = candidate(source, Some(known_cost), Some(demand_index));
+        let unknown = candidate(source, None, Some(demand_index));
+        kani::cover!();
+
+        assert!(dispatch_sort_key(&known) < dispatch_sort_key(&unknown));
+    }
+
+    #[kani::proof]
+    fn dispatch_sort_preserves_equal_key_order() {
+        let source: CandidateSource = kani::any();
+        let compile_time_ms: Option<u64> = kani::any();
+        let demand_index: Option<u32> = kani::any();
+        let mut first = candidate(source, compile_time_ms, demand_index);
+        first.size_bytes = Some(1);
+        let mut second = candidate(source, compile_time_ms, demand_index);
+        second.size_bytes = Some(2);
+        let mut candidates = [first, second];
+
+        sort_candidates_for_dispatch(&mut candidates);
+        kani::cover!();
+
+        assert_eq!(candidates[0].size_bytes, Some(1));
+        assert_eq!(candidates[1].size_bytes, Some(2));
+    }
 }
 
 #[cfg(test)]

--- a/crates/kache-core/src/lib.rs
+++ b/crates/kache-core/src/lib.rs
@@ -1088,6 +1088,30 @@ mod tests {
         assert!(dispatch_sort_key(&known) < dispatch_sort_key(&no_demand));
     }
 
+    /// The production dispatch path applies the key with a stable sort.
+    #[cfg(feature = "planning")]
+    #[test]
+    fn test_dispatch_sort_orders_candidates_and_preserves_ties() {
+        let late = candidate("late", "late", CandidateSource::Shard, Some(1), Some(32));
+        let first_tie = candidate("first", "first", CandidateSource::Shard, Some(10), Some(0));
+        let second_tie = candidate(
+            "second",
+            "second",
+            CandidateSource::Shard,
+            Some(10),
+            Some(0),
+        );
+        let mut candidates = vec![late, first_tie, second_tie];
+
+        sort_candidates_for_dispatch(&mut candidates);
+
+        let keys = candidates
+            .iter()
+            .map(|candidate| candidate.cache_key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec!["first", "second", "late"]);
+    }
+
     /// The per-crate key-cache cap keeps the first N and reports the rest.
     #[cfg(feature = "planning")]
     #[tokio::test]

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -974,6 +974,9 @@ mod tests {
 
     #[test]
     fn passthrough_compiler_rejects_unrelated_programs() {
+        // Exercise the environment-reading facade too. A Kache command must
+        // never become a compiler invocation, even if RUSTC has the same name.
+        assert!(!is_passthrough_compiler_invocation(&s(&["gc"])));
         assert!(!is_passthrough_compiler_invocation_with(&[], None));
         assert!(!is_passthrough_compiler_invocation_with(
             &s(&["stat"]),

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -675,6 +675,35 @@ fn is_program_on_path(program: &str) -> bool {
     resolve_program_on_path(program).is_some()
 }
 
+/// Detect a real compiler invocation that must run uncached.
+///
+/// Cargo preserves `RUSTC` when it invokes `RUSTC_WRAPPER`, which identifies
+/// custom drivers such as Kani's `kani-compiler` without maintaining a list of
+/// tool names. `nvcc` remains an explicit passthrough because Kache supports it
+/// as a compiler launcher but cannot safely cache its multi-phase outputs.
+pub(crate) fn is_passthrough_compiler_invocation(args: &[String]) -> bool {
+    let rustc = std::env::var_os("RUSTC");
+    is_passthrough_compiler_invocation_with(args, rustc.as_deref())
+}
+
+pub(crate) fn is_passthrough_compiler_invocation_with(
+    args: &[String],
+    configured_rustc: Option<&std::ffi::OsStr>,
+) -> bool {
+    let Some(program) = args.first() else {
+        return false;
+    };
+    if is_kache_subcommand_or_flag(program) {
+        return false;
+    }
+    let is_configured_rustc =
+        configured_rustc.is_some_and(|rustc| rustc == std::ffi::OsStr::new(program.as_str()));
+    let is_nvcc = command_basename(program)
+        .map(strip_windows_exe_suffix)
+        .is_some_and(|name| name.eq_ignore_ascii_case("nvcc"));
+    is_configured_rustc || is_nvcc
+}
+
 pub fn is_workspace_wrapper_chain(args: &[String]) -> bool {
     let workspace_wrapper = std::env::var_os("RUSTC_WORKSPACE_WRAPPER");
     is_workspace_wrapper_chain_with(args, workspace_wrapper.as_deref(), is_program_on_path)
@@ -919,6 +948,45 @@ mod tests {
 
         // Too few args.
         assert!(!is_workspace_wrapper_chain(&s(&["/usr/bin/rustc"])));
+    }
+
+    #[test]
+    fn passthrough_compiler_accepts_configured_rustc_and_nvcc() {
+        assert!(is_passthrough_compiler_invocation_with(
+            &s(&["/home/user/.kani/kani-0.67.0/bin/kani-compiler", "-vV"]),
+            Some(std::ffi::OsStr::new(
+                "/home/user/.kani/kani-0.67.0/bin/kani-compiler",
+            )),
+        ));
+        assert!(is_passthrough_compiler_invocation_with(
+            &s(&["custom-rustc-driver", "--crate-name", "demo"]),
+            Some(std::ffi::OsStr::new("custom-rustc-driver")),
+        ));
+        assert!(is_passthrough_compiler_invocation_with(
+            &s(&[r"C:\CUDA\bin\nvcc.exe", "-c", "kernel.cu"]),
+            None,
+        ));
+        assert!(is_passthrough_compiler_invocation_with(
+            &s(&["nvcc", "-c", "kernel.cu"]),
+            None,
+        ));
+    }
+
+    #[test]
+    fn passthrough_compiler_rejects_unrelated_programs() {
+        assert!(!is_passthrough_compiler_invocation_with(&[], None));
+        assert!(!is_passthrough_compiler_invocation_with(
+            &s(&["stat"]),
+            None,
+        ));
+        assert!(!is_passthrough_compiler_invocation_with(
+            &s(&["/usr/bin/stat"]),
+            Some(std::ffi::OsStr::new("/usr/bin/other-driver")),
+        ));
+        assert!(!is_passthrough_compiler_invocation_with(
+            &s(&["gc"]),
+            Some(std::ffi::OsStr::new("gc")),
+        ));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,6 +303,14 @@ enum LogMode {
 }
 
 fn detect_log_mode(env_args: &[String]) -> LogMode {
+    let rustc = std::env::var_os("RUSTC");
+    detect_log_mode_with_rustc(env_args, rustc.as_deref())
+}
+
+fn detect_log_mode_with_rustc(
+    env_args: &[String],
+    configured_rustc: Option<&std::ffi::OsStr>,
+) -> LogMode {
     if env_args.len() >= 2 {
         let after = &env_args[1..];
         // Real compiler invocation (rustc / cc-family) OR a cc-crate
@@ -312,6 +320,7 @@ fn detect_log_mode(env_args: &[String]) -> LogMode {
         if compiler::detect_compiler(after).is_some()
             || compiler::cc::CcCompiler::recognizes_family_probe(after)
             || compiler::is_workspace_wrapper_chain(after)
+            || compiler::is_passthrough_compiler_invocation_with(after, configured_rustc)
         {
             return LogMode::Wrapper;
         }
@@ -642,21 +651,13 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
     }
 
     let Some(adapter) = compiler::detect_compiler(args) else {
-        if compiler::is_workspace_wrapper_chain(args) {
-            std::process::exit(run_compiler_directly(args)?);
-        }
-        // nvcc is recognized but never cached: sound nvcc caching
-        // requires decomposing its internal phase pipeline (see
-        // sccache's `--dryrun` handling), which kache does not do.
-        // Pass through so `CMAKE_CUDA_COMPILER_LAUNCHER=kache` and
-        // similar setups build correctly instead of erroring.
-        if args
-            .first()
-            .and_then(|arg0| compiler::command_basename(arg0))
-            .map(compiler::strip_windows_exe_suffix)
-            == Some("nvcc")
+        if compiler::is_workspace_wrapper_chain(args)
+            || compiler::is_passthrough_compiler_invocation(args)
         {
-            tracing::debug!("nvcc caching not supported; passing through uncached");
+            tracing::debug!(
+                program = ?args.first(),
+                "compiler has no cache adapter; passing through uncached"
+            );
             std::process::exit(run_compiler_directly(args)?);
         }
         anyhow::bail!(
@@ -820,6 +821,37 @@ mod tests {
                 r"C:\Program Files\Rust\bin\rustc.exe".into(),
                 "--crate-name".into(),
             ]),
+            LogMode::Wrapper
+        );
+        // Issue #656: Kani replaces Cargo's rustc with `kani-compiler` while
+        // preserving RUSTC_WRAPPER, so the compiler path must enter wrapper
+        // mode and be passed through instead of being parsed as a CLI command.
+        assert_eq!(
+            detect_log_mode_with_rustc(
+                &[
+                    "kache".into(),
+                    "/home/user/.kani/kani-0.67.0/bin/kani-compiler".into(),
+                    "-vV".into(),
+                ],
+                Some(std::ffi::OsStr::new(
+                    "/home/user/.kani/kani-0.67.0/bin/kani-compiler",
+                )),
+            ),
+            LogMode::Wrapper
+        );
+        // The same generic passthrough revives the existing nvcc compatibility
+        // path, which was previously unreachable because log-mode detection
+        // rejected nvcc before `run_wrapper_mode` could pass it through.
+        assert_eq!(
+            detect_log_mode_with_rustc(
+                &[
+                    "kache".into(),
+                    "/usr/local/cuda/bin/nvcc".into(),
+                    "-c".into(),
+                    "kernel.cu".into(),
+                ],
+                None,
+            ),
             LogMode::Wrapper
         );
         // Issue #505: unrecognized RUSTC_WORKSPACE_WRAPPER tools like

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -142,6 +142,46 @@ fn unknown_subcommand_is_a_usage_error() {
         .code(2);
 }
 
+#[cfg(unix)]
+#[test]
+fn path_resolvable_unknown_subcommand_is_still_a_usage_error() {
+    let e = env();
+    e.cmd().arg("true").assert().failure().code(2);
+}
+
+/// Issue #656: Cargo keeps RUSTC_WRAPPER while Kani replaces rustc with its
+/// own driver. Unknown-but-real compiler programs must execute uncached rather
+/// than being parsed as kache subcommands.
+#[cfg(unix)]
+#[test]
+fn kani_compiler_passthrough_executes_every_time() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let e = env();
+    let driver_dir = TempDir::new().unwrap();
+    let driver = driver_dir.path().join("kani-compiler");
+    let invocations = driver_dir.path().join("invocations.txt");
+    std::fs::write(
+        &driver,
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$KANI_INVOCATIONS\"\nprintf 'kani:%s\\n' \"$*\"\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&driver, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    for _ in 0..2 {
+        e.cmd()
+            .arg(&driver)
+            .arg("-vV")
+            .env("RUSTC", &driver)
+            .env("KANI_INVOCATIONS", &invocations)
+            .assert()
+            .success()
+            .stdout(predicates::str::diff("kani:-vV\n"));
+    }
+
+    assert_eq!(std::fs::read_to_string(invocations).unwrap(), "-vV\n-vV\n");
+}
+
 #[test]
 fn subcommand_help_is_available() {
     for sub in [


### PR DESCRIPTION
## Summary

- pass Cargo custom `RUSTC` drivers through uncached instead of parsing them as Kache subcommands
- add six native Kani proofs for planner dispatch invariants
- add pinned Kani and stable Rust 1.93 checks in CI

## Root cause

Kani replaces Cargo's `RUSTC` with `kani-compiler` while preserving `RUSTC_WRAPPER`. Kache only entered wrapper mode for known compiler adapters, so it sent the compiler path to Clap.

Kache does not model Kani artifacts, so the configured Rust driver now passes through uncached. Detection uses Cargo's inherited `RUSTC`, avoiding a growing executable allowlist. Existing `nvcc` passthrough also becomes reachable, while known Kache subcommands still win.

## Validation

- `cargo test --workspace --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo +1.93.0 test --package kache-core --all-features --locked`
- `cargo +1.93.0 check --package kache-core --no-default-features --locked`
- `just kani` - 6/6 harnesses, all reachability covers satisfied
- actual Kani invocation through the locally built Kache wrapper
- `cargo fmt --all -- --check`

Fixes #656.
