### PR TITLE
fix(cc): preserve temporary dep-info artifacts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -575,6 +575,50 @@ fn store_failure_banner(miss: &crate::events::BuildEvent) -> Option<String> {
     ))
 }
 
+/// The exact-key lookup-rejection diagnosis for [`why_miss`].
+///
+/// Without this persisted pre-compile reason, a replacement entry written
+/// under the same key makes the current store look like a successful cold
+/// population. With other entries present, the old fallback was worse: it
+/// claimed a key mismatch even though lookup found the exact key (#655).
+fn lookup_rejection_banner(
+    miss: &crate::events::BuildEvent,
+    same_key_present: bool,
+) -> Option<String> {
+    if miss.lookup_rejection.is_empty() {
+        return None;
+    }
+    let replacement = if same_key_present {
+        "currently present under the same key"
+    } else {
+        "not currently present in the local store"
+    };
+    Some(format!(
+        "  Diagnosis: matching key was found but rejected before restore\n    \
+         reason: {}\n    \
+         replacement: {replacement}",
+        miss.lookup_rejection
+    ))
+}
+
+/// Conservative fallback for events written before lookup rejections were
+/// persisted. Seeing the same non-empty key earlier proves that the miss was
+/// not caused by different inputs, but old logs cannot distinguish cleanup,
+/// eviction, corruption, or rejection.
+fn legacy_repeated_same_key_banner(
+    miss: &crate::events::BuildEvent,
+    prior_same_key_event: bool,
+) -> Option<&'static str> {
+    if miss.schema >= 15 || !miss.lookup_rejection.is_empty() || !prior_same_key_event {
+        return None;
+    }
+    Some(
+        "  Diagnosis: repeated miss for the same cache key\n    \
+         this older event did not record whether the entry was absent, evicted, invalid, or rejected\n    \
+         the miss was not caused by a cache-key change",
+    )
+}
+
 pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
     let all_events = events::read_events(&config.event_log_path())?;
     let crate_events: Vec<_> = all_events
@@ -590,14 +634,14 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
     }
 
     // ── Find last entry miss ───────────────────────────────────────────
-    let last_miss = crate_events.iter().rev().find(|e| {
+    let last_miss_index = crate_events.iter().rposition(|e| {
         matches!(
             e.result,
             events::EventResult::Dup | events::EventResult::Miss
         )
     });
 
-    if last_miss.is_none() {
+    let Some(last_miss_index) = last_miss_index else {
         println!("No misses or dups found for `{crate_name}` -- all events are hits!");
         println!("\nRecent events:");
         for event in crate_events.iter().rev().take(5).rev() {
@@ -610,9 +654,21 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
             );
         }
         return Ok(());
-    }
+    };
 
-    let miss = last_miss.unwrap();
+    let miss = crate_events[last_miss_index];
+    let prior_same_key_event = !miss.cache_key.is_empty()
+        && crate_events[..last_miss_index].iter().any(|event| {
+            event.cache_key == miss.cache_key
+                && matches!(
+                    event.result,
+                    events::EventResult::LocalHit
+                        | events::EventResult::PrefetchHit
+                        | events::EventResult::RemoteHit
+                        | events::EventResult::Dup
+                        | events::EventResult::Miss
+                )
+        });
 
     // ── Header ─────────────────────────────────────────────────────────
     println!("Why `{crate_name}` missed:\n");
@@ -664,7 +720,13 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
     if stored.is_empty() {
         println!("  Stored entries for `{crate_name}`: (none)");
         println!();
-        println!("  Diagnosis: never cached -- first build of this crate");
+        if let Some(banner) = lookup_rejection_banner(miss, false) {
+            println!("{banner}");
+        } else if let Some(banner) = legacy_repeated_same_key_banner(miss, prior_same_key_event) {
+            println!("{banner}");
+        } else {
+            println!("  Diagnosis: never cached -- first build of this crate");
+        }
     } else {
         // Show stored entries (cap at 10 most recent)
         println!(
@@ -726,7 +788,11 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
             .filter(|e| e.cache_key != miss.cache_key)
             .collect();
 
-        if miss_key_stored && !other_entries.is_empty() {
+        if let Some(banner) = lookup_rejection_banner(miss, miss_key_stored) {
+            println!("{banner}");
+        } else if let Some(banner) = legacy_repeated_same_key_banner(miss, prior_same_key_event) {
+            println!("{banner}");
+        } else if miss_key_stored && !other_entries.is_empty() {
             println!(
                 "  Diagnosis: key mismatch -- {} other entr{} exist but {} matched the current build inputs",
                 other_entries.len(),
@@ -788,15 +854,15 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
         )
     });
 
-    if let (Some(hit), Some(miss_ev)) = (last_hit, last_miss)
-        && hit.cache_key != miss_ev.cache_key
-        && miss_ev.ts > hit.ts
+    if let Some(hit) = last_hit
+        && hit.cache_key != miss.cache_key
+        && miss.ts > hit.ts
     {
         println!(
             "\n  Key changed: {} (last hit) -> {} ({})",
             key_short(&hit.cache_key),
-            key_short(&miss_ev.cache_key),
-            miss_ev.result,
+            key_short(&miss.cache_key),
+            miss.result,
         );
     }
 
@@ -5153,6 +5219,53 @@ mod tests {
     }
 
     #[test]
+    fn why_miss_prioritizes_same_key_lookup_rejection() {
+        let mut miss = build_event(
+            "foo.c",
+            crate::events::EventResult::Miss,
+            10,
+            20,
+            30,
+            "same-key",
+        );
+        assert!(lookup_rejection_banner(&miss, true).is_none());
+
+        miss.lookup_rejection =
+            "matching entry lacks dep-info required by this invocation".to_string();
+        let banner = lookup_rejection_banner(&miss, true).unwrap();
+        assert!(banner.contains("matching key was found but rejected"));
+        assert!(banner.contains("lacks dep-info required"));
+        assert!(banner.contains("currently present under the same key"));
+        assert!(!banner.contains("key mismatch"), "banner: {banner}");
+    }
+
+    #[test]
+    fn why_miss_legacy_same_key_repeat_does_not_claim_key_mismatch() {
+        let mut miss = build_event(
+            "foo.c",
+            crate::events::EventResult::Miss,
+            10,
+            20,
+            30,
+            "same-key",
+        );
+        miss.schema = 14;
+
+        assert!(legacy_repeated_same_key_banner(&miss, false).is_none());
+        let banner = legacy_repeated_same_key_banner(&miss, true).unwrap();
+        assert!(banner.contains("repeated miss for the same cache key"));
+        assert!(banner.contains("older event did not record"));
+        assert!(banner.contains("not caused by a cache-key change"));
+        assert!(
+            !banner.contains("Diagnosis: key mismatch"),
+            "banner: {banner}"
+        );
+
+        miss.schema = 15;
+        assert!(legacy_repeated_same_key_banner(&miss, true).is_none());
+    }
+
+    #[test]
     fn why_miss_all_hits_reports_no_misses() {
         // Events exist but none are Miss/Dup -> the "all events are hits" path.
         let dir = tempfile::tempdir().unwrap();
@@ -5703,6 +5816,7 @@ mod tests {
             root: String::new(),
             passthrough_reason: String::new(),
             store_error: String::new(),
+            lookup_rejection: String::new(),
             fallback: false,
             exit_code: None,
             key_fields: Default::default(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -634,14 +634,14 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
     }
 
     // ── Find last entry miss ───────────────────────────────────────────
-    let last_miss_index = crate_events.iter().rposition(|e| {
+    let last_miss = crate_events.iter().rev().find(|e| {
         matches!(
             e.result,
             events::EventResult::Dup | events::EventResult::Miss
         )
     });
 
-    let Some(last_miss_index) = last_miss_index else {
+    if last_miss.is_none() {
         println!("No misses or dups found for `{crate_name}` -- all events are hits!");
         println!("\nRecent events:");
         for event in crate_events.iter().rev().take(5).rev() {
@@ -654,21 +654,17 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
             );
         }
         return Ok(());
-    };
+    }
 
-    let miss = crate_events[last_miss_index];
+    let miss = last_miss.unwrap();
+    let last_miss_index = crate_events
+        .iter()
+        .position(|event| std::ptr::eq(*event, *miss))
+        .expect("last miss came from crate_events");
     let prior_same_key_event = !miss.cache_key.is_empty()
-        && crate_events[..last_miss_index].iter().any(|event| {
-            event.cache_key == miss.cache_key
-                && matches!(
-                    event.result,
-                    events::EventResult::LocalHit
-                        | events::EventResult::PrefetchHit
-                        | events::EventResult::RemoteHit
-                        | events::EventResult::Dup
-                        | events::EventResult::Miss
-                )
-        });
+        && crate_events[..last_miss_index]
+            .iter()
+            .any(|event| event.cache_key == miss.cache_key);
 
     // ── Header ─────────────────────────────────────────────────────────
     println!("Why `{crate_name}` missed:\n");
@@ -854,15 +850,15 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
         )
     });
 
-    if let Some(hit) = last_hit
-        && hit.cache_key != miss.cache_key
-        && miss.ts > hit.ts
+    if let (Some(hit), Some(miss_ev)) = (last_hit, last_miss)
+        && hit.cache_key != miss_ev.cache_key
+        && miss_ev.ts > hit.ts
     {
         println!(
             "\n  Key changed: {} (last hit) -> {} ({})",
             key_short(&hit.cache_key),
-            key_short(&miss.cache_key),
-            miss.result,
+            key_short(&miss_ev.cache_key),
+            miss_ev.result,
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -607,9 +607,9 @@ fn lookup_rejection_banner(
 /// eviction, corruption, or rejection.
 fn legacy_repeated_same_key_banner(
     miss: &crate::events::BuildEvent,
-    prior_same_key_event: bool,
+    prior_same_key_miss: bool,
 ) -> Option<&'static str> {
-    if miss.schema >= 15 || !miss.lookup_rejection.is_empty() || !prior_same_key_event {
+    if miss.schema >= 15 || !miss.lookup_rejection.is_empty() || !prior_same_key_miss {
         return None;
     }
     Some(
@@ -661,10 +661,14 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
         .iter()
         .position(|event| std::ptr::eq(*event, *miss))
         .expect("last miss came from crate_events");
-    let prior_same_key_event = !miss.cache_key.is_empty()
-        && crate_events[..last_miss_index]
-            .iter()
-            .any(|event| event.cache_key == miss.cache_key);
+    let prior_same_key_miss = last_miss_index > 0 && !miss.cache_key.is_empty() && {
+        let previous = crate_events[last_miss_index - 1];
+        previous.cache_key == miss.cache_key
+            && matches!(
+                previous.result,
+                events::EventResult::Dup | events::EventResult::Miss
+            )
+    };
 
     // ── Header ─────────────────────────────────────────────────────────
     println!("Why `{crate_name}` missed:\n");
@@ -718,7 +722,7 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
         println!();
         if let Some(banner) = lookup_rejection_banner(miss, false) {
             println!("{banner}");
-        } else if let Some(banner) = legacy_repeated_same_key_banner(miss, prior_same_key_event) {
+        } else if let Some(banner) = legacy_repeated_same_key_banner(miss, prior_same_key_miss) {
             println!("{banner}");
         } else {
             println!("  Diagnosis: never cached -- first build of this crate");
@@ -786,7 +790,7 @@ pub fn why_miss(config: &Config, crate_name: &str) -> Result<()> {
 
         if let Some(banner) = lookup_rejection_banner(miss, miss_key_stored) {
             println!("{banner}");
-        } else if let Some(banner) = legacy_repeated_same_key_banner(miss, prior_same_key_event) {
+        } else if let Some(banner) = legacy_repeated_same_key_banner(miss, prior_same_key_miss) {
             println!("{banner}");
         } else if miss_key_stored && !other_entries.is_empty() {
             println!(

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -7857,6 +7857,80 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn successful_non_compile_execute_never_discovers_cache_artifacts() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("linker.sh");
+        let source = dir.path().join("foo.c");
+        let output = dir.path().join("foo.o");
+        std::fs::write(&source, "int main(void) { return 0; }\n").unwrap();
+        std::fs::write(&script, "#!/bin/sh\nprintf object > \"$3\"\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let compiler = CcCompiler::new();
+        let parsed = compiler
+            .parse(&[
+                script.to_string_lossy().into_owned(),
+                source.to_string_lossy().into_owned(),
+                "-o".to_string(),
+                output.to_string_lossy().into_owned(),
+            ])
+            .unwrap();
+        assert_eq!(parsed.mode, CompileMode::Link);
+
+        let result = compiler
+            .execute(&parsed)
+            .expect("stand-in linker should run");
+        assert_eq!(result.exit_code, 0);
+        assert!(output.exists(), "stand-in linker should create its output");
+        assert!(
+            result.artifacts.is_empty(),
+            "a successful link must remain passthrough-only even when its output resembles an object"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_compile_execute_never_discovers_leftover_artifacts() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("compiler.sh");
+        let source = dir.path().join("foo.c");
+        let object = dir.path().join("foo.o");
+        std::fs::write(&source, "int answer(void) { return 42; }\n").unwrap();
+        std::fs::write(&script, "#!/bin/sh\nprintf object > \"$4\"\nexit 1\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let compiler = CcCompiler::new();
+        let parsed = compiler
+            .parse(&[
+                script.to_string_lossy().into_owned(),
+                source.to_string_lossy().into_owned(),
+                "-c".to_string(),
+                "-o".to_string(),
+                object.to_string_lossy().into_owned(),
+            ])
+            .unwrap();
+        assert_eq!(parsed.mode, CompileMode::Compile);
+
+        let result = compiler
+            .execute(&parsed)
+            .expect("failed-but-spawned compiler should return a result");
+        assert_ne!(result.exit_code, 0);
+        assert!(
+            object.exists(),
+            "stand-in compiler should leave an object behind before failing"
+        );
+        assert!(
+            result.artifacts.is_empty(),
+            "failed compiles must never publish artifacts even when the compiler left outputs"
+        );
+    }
+
     #[test]
     fn classify_output_delegates_to_shared_classifier() {
         let compiler = CcCompiler::new();

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -46,8 +46,8 @@ use std::sync::OnceLock;
 
 use super::flags::{Dialect, FlagClass, FlagSpec, Matcher};
 use super::{
-    ArtifactKind, ArtifactSet, CompileResult, Compiler, CompilerAdapter, CompilerId, KeyCtx,
-    RefuseReason, classify_by_filename,
+    Artifact, ArtifactKind, ArtifactSet, CompileResult, Compiler, CompilerAdapter, CompilerId,
+    KeyCtx, RefuseReason, classify_by_filename,
 };
 
 /// Compiler driver family of a cc-wrapper invocation.
@@ -1177,6 +1177,17 @@ const CC_BUILD_SENTINEL: &str = "/proc/self/cwd";
 #[cfg(not(target_os = "linux"))]
 const CC_BUILD_SENTINEL: &str = "/kache/cc-build";
 const CC_SOURCE_SENTINEL: &str = "/kache/cc-source";
+/// Stable store-side name for a C/C++ dependency artifact.
+///
+/// `-MF` accepts arbitrary filenames. Inferring the artifact kind from that
+/// filename loses the parser's knowledge for compound or extensionless names
+/// such as OpenSSL's `a_bitstr.d.tmp` (kunobi-ninja/kache#655). The restore
+/// target always comes from the current parsed invocation, so the cache entry
+/// can use one semantic name ending in `.d`. Besides making every future `-MF`
+/// spelling restoreable, this keeps pre-fix `.d.tmp` entries untrusted: their
+/// old raw name still fails the coverage gate once, is evicted, and is replaced
+/// with a normalized entry without a store-wide cache-version bump.
+pub(crate) const CC_DEPINFO_STORE_NAME: &str = "__kache_cc_depinfo.d";
 /// Target for a user-declared `KACHE_BASE_DIR` (ccache `CCACHE_BASEDIR`
 /// analog). Shares the spelling with the rustc `<BASE_DIR>` target (same
 /// concept, compiler-independent) and stays distinct from the derived roots so
@@ -4350,30 +4361,12 @@ impl Compiler for CcCompiler {
 
         // Output discovery: on a successful `-c` compile, the object
         // file is the cacheable artifact. Skip on failure (nothing to
-        // cache) or non-Compile mode (refused upstream anyway). The
-        // store name is the bare filename so restore can place it at
-        // whatever `-o` path the warm invocation requests.
+        // cache) or non-Compile mode (refused upstream anyway). Objects
+        // retain their basename; dep-info gets a semantic store name because
+        // `-MF` permits arbitrary suffixes and restore already takes its real
+        // destination from the current invocation (kunobi-ninja/kache#655).
         let artifacts = if exit_code == 0 && parsed.mode == CompileMode::Compile {
-            match parsed.object_output_path() {
-                Some(obj) if obj.exists() => {
-                    let name = obj
-                        .file_name()
-                        .map(|n| n.to_string_lossy().into_owned())
-                        .unwrap_or_default();
-                    let mut outputs = vec![(obj, name)];
-                    if let Some(depinfo) = parsed.depinfo_output_path()
-                        && depinfo.exists()
-                    {
-                        let name = depinfo
-                            .file_name()
-                            .map(|n| n.to_string_lossy().into_owned())
-                            .unwrap_or_default();
-                        outputs.push((depinfo, name));
-                    }
-                    ArtifactSet::from_output_files(outputs, classify_by_filename)
-                }
-                _ => ArtifactSet::empty(),
-            }
+            discover_cc_output_artifacts(parsed)
         } else {
             ArtifactSet::empty()
         };
@@ -4394,6 +4387,35 @@ impl Compiler for CcCompiler {
         // .dylib, etc.).
         classify_by_filename(name)
     }
+}
+
+/// Discover a successful C/C++ compile's cacheable outputs while preserving
+/// the parsed role of `-MF` instead of trying to recover it from a filename.
+fn discover_cc_output_artifacts(parsed: &CcArgs) -> ArtifactSet {
+    let Some(object) = parsed.object_output_path().filter(|path| path.exists()) else {
+        return ArtifactSet::empty();
+    };
+    let object_name = object
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let mut outputs = vec![Artifact {
+        path: object,
+        kind: classify_by_filename(&object_name),
+        store_name: object_name,
+        required: true,
+    }];
+
+    if let Some(depinfo) = parsed.depinfo_output_path().filter(|path| path.exists()) {
+        outputs.push(Artifact {
+            path: depinfo,
+            store_name: CC_DEPINFO_STORE_NAME.to_string(),
+            kind: ArtifactKind::DepInfo,
+            required: true,
+        });
+    }
+
+    ArtifactSet::new(outputs)
 }
 
 #[cfg(test)]
@@ -7855,6 +7877,44 @@ mod tests {
             compiler.classify_output(&parsed, "foo.o.pp"),
             ArtifactKind::DepInfo
         );
+    }
+
+    #[test]
+    fn output_discovery_keeps_arbitrary_mf_paths_semantically_depinfo() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("foo.c");
+        let object = dir.path().join("foo.o");
+        std::fs::write(&source, "int answer(void) { return 42; }\n").unwrap();
+        std::fs::write(&object, b"object").unwrap();
+
+        for dep_name in ["foo.d.tmp", "extensionless", "foo.unrelated"] {
+            let depinfo = dir.path().join(dep_name);
+            std::fs::write(&depinfo, b"foo.o: foo.c\n").unwrap();
+            let parsed = CcCompiler::new()
+                .parse(&[
+                    "cc".to_string(),
+                    "-c".to_string(),
+                    source.to_string_lossy().into_owned(),
+                    "-o".to_string(),
+                    object.to_string_lossy().into_owned(),
+                    "-MMD".to_string(),
+                    "-MF".to_string(),
+                    depinfo.to_string_lossy().into_owned(),
+                ])
+                .unwrap();
+
+            let artifacts = discover_cc_output_artifacts(&parsed);
+            assert_eq!(artifacts.outputs().len(), 2);
+            assert_eq!(artifacts.outputs()[0].kind, ArtifactKind::Object);
+            assert_eq!(artifacts.outputs()[1].path, depinfo);
+            assert_eq!(artifacts.outputs()[1].kind, ArtifactKind::DepInfo);
+            assert_eq!(artifacts.outputs()[1].store_name, CC_DEPINFO_STORE_NAME);
+            assert_eq!(
+                classify_by_filename(&artifacts.outputs()[1].store_name),
+                ArtifactKind::DepInfo,
+                "the semantic store name must survive metadata-only classification"
+            );
+        }
     }
 
     // ── pre_clean_cc_outputs ──────────────────────────────────────

--- a/src/events.rs
+++ b/src/events.rs
@@ -38,7 +38,8 @@ pub struct BuildEvent {
     /// 11 = key field hashes + miss key diff (#131),
     /// 12 = per-extern artifact digests (#609),
     /// 13 = store-failure reason (#629),
-    /// 14 = compilation-unit identity, own and per-extern (#627).
+    /// 14 = compilation-unit identity, own and per-extern (#627),
+    /// 15 = same-key lookup rejection reason (#655).
     #[serde(default)]
     pub schema: u32,
     /// Build session this event belongs to (kunobi-ninja/kache#583 P0.5).
@@ -137,6 +138,15 @@ pub struct BuildEvent {
     /// Empty on every normal outcome, so it costs nothing on the wire.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub store_error: String,
+    /// Why an existing entry for this exact key was rejected before the
+    /// compiler ran (kunobi-ninja/kache#655).
+    ///
+    /// This is distinct from `store_error`: the lookup found an entry, but its
+    /// artifact set could not satisfy the current invocation. The subsequent
+    /// compile and replacement store may succeed, otherwise leaving
+    /// `why-miss` to misdiagnose the event as a cold miss or key mismatch.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub lookup_rejection: String,
     /// Whether a configured fallback wrapper handled the passthrough.
     #[serde(default, skip_serializing_if = "is_false")]
     pub fallback: bool,
@@ -1108,6 +1118,7 @@ impl BuildEvent {
             store_copied_bytes: 0,
             passthrough_reason: String::new(),
             store_error: String::new(),
+            lookup_rejection: String::new(),
             fallback: false,
             exit_code: None,
             key_fields: Default::default(),
@@ -1180,6 +1191,7 @@ mod tests {
             store_copied_bytes: 0,
             passthrough_reason: String::new(),
             store_error: String::new(),
+            lookup_rejection: String::new(),
             fallback: false,
             exit_code: None,
             key_fields: Default::default(),
@@ -1197,6 +1209,25 @@ mod tests {
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].crate_name, "serde");
         assert_eq!(events[0].result, EventResult::LocalHit);
+    }
+
+    #[test]
+    fn lookup_rejection_round_trips_and_defaults_for_older_events() {
+        let mut event = BuildEvent::new_for_test("foo.c", EventResult::Miss);
+        event.lookup_rejection =
+            "matching entry lacks dep-info required by this invocation".to_string();
+
+        let mut value = serde_json::to_value(&event).unwrap();
+        assert_eq!(
+            value["lookup_rejection"],
+            "matching entry lacks dep-info required by this invocation"
+        );
+        let round_trip: BuildEvent = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(round_trip.lookup_rejection, event.lookup_rejection);
+
+        value.as_object_mut().unwrap().remove("lookup_rejection");
+        let legacy: BuildEvent = serde_json::from_value(value).unwrap();
+        assert!(legacy.lookup_rejection.is_empty());
     }
 
     fn test_heartbeat(crate_name: &str, elapsed_s: u64) -> HeartbeatEvent {

--- a/src/report.rs
+++ b/src/report.rs
@@ -2921,6 +2921,7 @@ mod tests {
             store_copied_bytes: 0,
             passthrough_reason: String::new(),
             store_error: String::new(),
+            lookup_rejection: String::new(),
             fallback: false,
             exit_code: None,
             key_fields: Default::default(),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2286,6 +2286,7 @@ mod tests {
             root: String::new(),
             passthrough_reason: "linker invocation".to_string(),
             store_error: String::new(),
+            lookup_rejection: String::new(),
             fallback: false,
             exit_code: Some(0),
             key_fields: Default::default(),

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -4449,6 +4449,7 @@ mod tests {
         let event = &events[0];
         assert_eq!(event.result, EventResult::Miss);
         assert_eq!(event.cache_key, "same-key");
+        assert_eq!(event.schema, 15);
         assert_eq!(
             event.lookup_rejection,
             "matching entry lacks dep-info required by this invocation"

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -566,16 +566,19 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         }
     };
     let lookup_ms = lookup_start.elapsed().as_millis() as u64;
+    let mut lookup_rejection = String::new();
     if let Some(meta) = lookup {
         if meta.files.is_empty() {
             // Poisoned entry (earlier bug) — evict and recompile.
             tracing::warn!("cc cache entry for {} has no files, evicting", crate_name);
+            lookup_rejection = "matching entry has no cached artifacts".to_string();
             let _ = store.remove_entry(&cache_key);
-        } else if !cc_cache_entry_satisfies_invocation(&parsed, &meta) {
+        } else if let Some(reason) = cc_cache_entry_rejection_reason(&parsed, &meta) {
             tracing::warn!(
-                "cc cache entry for {} lacks artifacts required by this invocation, evicting",
-                crate_name
+                "cc cache entry for {} lacks artifacts required by this invocation ({reason}), evicting",
+                crate_name,
             );
+            lookup_rejection = reason.to_string();
             let _ = store.remove_entry(&cache_key);
         } else {
             let restore_start = std::time::Instant::now();
@@ -710,7 +713,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let elapsed = start.elapsed().as_millis() as u64;
     let size = result.artifacts.total_size();
     let event_result = event_result_for_store_put(store_put);
-    log_event_with_store_outcome(
+    log_event_with_store_and_lookup_outcome(
         config,
         &event_root,
         &crate_name,
@@ -726,6 +729,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         store_ms,
         store_put,
         store_error,
+        lookup_rejection,
     );
     print_progress(&crate_name, event_result, elapsed, size);
     Ok(result.exit_code)
@@ -780,10 +784,18 @@ fn cc_passthrough(
     })
 }
 
+#[cfg(test)]
 fn cc_cache_entry_satisfies_invocation(
     parsed: &crate::compiler::cc::CcArgs,
     meta: &crate::store::EntryMeta,
 ) -> bool {
+    cc_cache_entry_rejection_reason(parsed, meta).is_none()
+}
+
+fn cc_cache_entry_rejection_reason(
+    parsed: &crate::compiler::cc::CcArgs,
+    meta: &crate::store::EntryMeta,
+) -> Option<&'static str> {
     let has_object = meta
         .files
         .iter()
@@ -793,7 +805,13 @@ fn cc_cache_entry_satisfies_invocation(
         .iter()
         .any(|file| classify_by_filename(&file.name) == ArtifactKind::DepInfo);
 
-    has_object && (parsed.depinfo_output_path().is_none() || has_depinfo)
+    if !has_object {
+        Some("matching entry lacks the object artifact required by this invocation")
+    } else if parsed.depinfo_output_path().is_some() && !has_depinfo {
+        Some("matching entry lacks dep-info required by this invocation")
+    } else {
+        None
+    }
 }
 
 fn cc_depinfo_rewrite_root(parsed: &crate::compiler::cc::CcArgs) -> Option<std::path::PathBuf> {
@@ -2395,6 +2413,47 @@ fn log_event_with_store_outcome(
     store_put: StorePutResult,
     store_error: String,
 ) {
+    log_event_with_store_and_lookup_outcome(
+        config,
+        root,
+        crate_name,
+        result,
+        elapsed_ms,
+        compile_time_ms,
+        size,
+        cache_key,
+        key_ms,
+        key_hash_stats,
+        lookup_ms,
+        restore_ms,
+        store_ms,
+        store_put,
+        store_error,
+        String::new(),
+    );
+}
+
+/// Like [`log_event_with_store_outcome`], but records why an exact-key cache
+/// entry was rejected before the replacement compile (kunobi-ninja/kache#655).
+#[allow(clippy::too_many_arguments)]
+fn log_event_with_store_and_lookup_outcome(
+    config: &Config,
+    root: &str,
+    crate_name: &str,
+    result: EventResult,
+    elapsed_ms: u64,
+    compile_time_ms: u64,
+    size: u64,
+    cache_key: &str,
+    key_ms: u64,
+    key_hash_stats: FileHashStats,
+    lookup_ms: u64,
+    restore_ms: u64,
+    store_ms: u64,
+    store_put: StorePutResult,
+    store_error: String,
+    lookup_rejection: String,
+) {
     log_event_details(
         config,
         root,
@@ -2412,6 +2471,7 @@ fn log_event_with_store_outcome(
         store_put,
         String::new(),
         store_error,
+        lookup_rejection,
         false,
         None,
     );
@@ -2442,6 +2502,7 @@ fn log_passthrough_event(
         StorePutResult::default(),
         reason,
         String::new(),
+        String::new(),
         output.fallback,
         Some(output.exit_code),
     );
@@ -2465,6 +2526,7 @@ fn log_event_details(
     store_put: StorePutResult,
     passthrough_reason: String,
     store_error: String,
+    lookup_rejection: String,
     fallback: bool,
     exit_code: Option<i32>,
 ) {
@@ -2519,7 +2581,7 @@ fn log_event_details(
         compile_time_ms,
         size,
         cache_key: cache_key.to_string(),
-        schema: 14,
+        schema: 15,
         session_id,
         key_ms,
         key_hash_hits: key_hash_stats.cache_hits,
@@ -2544,6 +2606,7 @@ fn log_event_details(
         store_copied_bytes: crate::opcounts::store_copied_bytes(),
         passthrough_reason,
         store_error,
+        lookup_rejection,
         fallback,
         exit_code,
         key_fields,
@@ -3734,6 +3797,18 @@ mod tests {
             &with_depinfo,
             &meta(&["foo.o", "foo.o.pp"])
         ));
+        assert!(
+            !cc_cache_entry_satisfies_invocation(&with_depinfo, &meta(&["foo.o", "foo.d.tmp"])),
+            "a pre-fix raw compound dep-info entry must self-heal, not become trusted"
+        );
+        assert_eq!(
+            cc_cache_entry_rejection_reason(&with_depinfo, &meta(&["foo.o", "foo.d.tmp"])),
+            Some("matching entry lacks dep-info required by this invocation")
+        );
+        assert!(cc_cache_entry_satisfies_invocation(
+            &with_depinfo,
+            &meta(&["foo.o", crate::compiler::cc::CC_DEPINFO_STORE_NAME])
+        ));
 
         let object_only_args: Vec<String> = ["cc", "-c", "foo.c", "-o", "foo.o"]
             .into_iter()
@@ -4258,7 +4333,7 @@ mod tests {
         assert_eq!(event.compile_time_ms, 20);
         assert_eq!(event.size, 30);
         assert_eq!(event.cache_key, "cache-key");
-        assert_eq!(event.schema, 14);
+        assert_eq!(event.schema, 15);
         assert_eq!(event.key_ms, 40);
         assert_eq!(event.key_hash_hits, 4);
         assert_eq!(event.key_hash_misses, 5);
@@ -4340,6 +4415,45 @@ mod tests {
             event.store_error,
             "refusing to cache zero-byte artifact: libfoo.rlib"
         );
+    }
+
+    #[test]
+    fn log_event_persists_same_key_lookup_rejection() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+
+        log_event_with_store_and_lookup_outcome(
+            &config,
+            "/repo",
+            "foo.c",
+            EventResult::Miss,
+            10,
+            20,
+            30,
+            "same-key",
+            0,
+            FileHashStats::default(),
+            1,
+            0,
+            2,
+            StorePutResult {
+                output_blobs: 2,
+                duplicate_blobs: 0,
+                new_blobs: 2,
+            },
+            String::new(),
+            "matching entry lacks dep-info required by this invocation".to_string(),
+        );
+
+        let events = crate::events::read_events(&config.event_log_path()).unwrap();
+        let event = &events[0];
+        assert_eq!(event.result, EventResult::Miss);
+        assert_eq!(event.cache_key, "same-key");
+        assert_eq!(
+            event.lookup_rejection,
+            "matching entry lacks dep-info required by this invocation"
+        );
+        assert!(event.store_error.is_empty());
     }
 
     /// Passthrough events intentionally omit cache timings but preserve the

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -81,6 +81,30 @@ impl Env {
     }
 }
 
+/// Write the minimal event shape understood by old schemas. This deliberately
+/// omits `lookup_rejection`, which did not exist before schema 15.
+fn write_legacy_miss_events(e: &Env, crate_name: &str, keys: &[&str]) {
+    let mut lines = keys
+        .iter()
+        .enumerate()
+        .map(|(index, key)| {
+            serde_json::to_string(&serde_json::json!({
+                "ts": format!("2026-01-01T00:00:{index:02}Z"),
+                "crate_name": crate_name,
+                "result": "miss",
+                "elapsed_ms": 1,
+                "size": 1,
+                "cache_key": key,
+                "schema": 14
+            }))
+            .unwrap()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    lines.push('\n');
+    std::fs::write(e.cache.join("events.jsonl"), lines).unwrap();
+}
+
 /// Scaffold a minimal standalone library crate (its own empty `[workspace]`,
 /// so cargo treats it as a leaf) with the given name and source body.
 fn scaffold_lib(name: &str, body: &str) -> TempDir {
@@ -689,7 +713,10 @@ fn commands_operate_on_a_populated_cache() {
         .args(["why-miss", "kachetestlib"])
         .assert()
         .success()
-        .stdout(predicates::str::contains("kachetestlib"));
+        .stdout(predicates::str::contains("kachetestlib"))
+        .stdout(predicates::str::contains(
+            "Diagnosis: first build with these inputs -- entry is now cached",
+        ));
 
     // Listing the specific crate shows its entry detail.
     e.cmd().args(["list", "kachetestlib"]).assert().success();
@@ -739,7 +766,7 @@ fn why_miss_reports_key_mismatch_after_source_edit() {
         .assert()
         .success()
         .stdout(predicates::str::contains("Why `kachediff` missed"))
-        .stdout(predicates::str::contains("Diagnosis"));
+        .stdout(predicates::str::contains("Diagnosis: key mismatch"));
 
     // Two distinct stored entries are listed for the crate.
     e.cmd()
@@ -747,6 +774,54 @@ fn why_miss_reports_key_mismatch_after_source_edit() {
         .assert()
         .success()
         .stdout(predicates::str::contains("kachediff"));
+}
+
+#[test]
+fn why_miss_legacy_repeated_same_key_does_not_claim_key_mismatch() {
+    let e = env();
+    write_legacy_miss_events(&e, "legacy-cc", &["same-key", "same-key"]);
+
+    let output = e
+        .cmd()
+        .args(["why-miss", "legacy-cc"])
+        .output()
+        .expect("run why-miss");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Diagnosis: repeated miss for the same cache key"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("the miss was not caused by a cache-key change"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Diagnosis: key mismatch"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn why_miss_legacy_different_keys_remain_a_cold_miss() {
+    let e = env();
+    write_legacy_miss_events(&e, "legacy-cc", &["old-key", "new-key"]);
+
+    let output = e
+        .cmd()
+        .args(["why-miss", "legacy-cc"])
+        .output()
+        .expect("run why-miss");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Diagnosis: never cached -- first build of this crate"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("repeated miss for the same cache key"),
+        "stdout: {stdout}"
+    );
 }
 
 #[test]

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -9,6 +9,7 @@
 //! the daemon-unavailable fallback to direct store reads.
 
 use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
 use std::path::Path;
 use tempfile::TempDir;
 
@@ -83,15 +84,15 @@ impl Env {
 
 /// Write the minimal event shape understood by old schemas. This deliberately
 /// omits `lookup_rejection`, which did not exist before schema 15.
-fn write_legacy_miss_events(e: &Env, crate_name: &str, keys: &[&str]) {
-    let mut lines = keys
+fn write_legacy_events(e: &Env, crate_name: &str, events: &[(&str, &str)]) {
+    let mut lines = events
         .iter()
         .enumerate()
-        .map(|(index, key)| {
+        .map(|(index, (result, key))| {
             serde_json::to_string(&serde_json::json!({
                 "ts": format!("2026-01-01T00:00:{index:02}Z"),
                 "crate_name": crate_name,
-                "result": "miss",
+                "result": result,
                 "elapsed_ms": 1,
                 "size": 1,
                 "cache_key": key,
@@ -103,6 +104,11 @@ fn write_legacy_miss_events(e: &Env, crate_name: &str, keys: &[&str]) {
         .join("\n");
     lines.push('\n');
     std::fs::write(e.cache.join("events.jsonl"), lines).unwrap();
+}
+
+fn write_legacy_miss_events(e: &Env, crate_name: &str, keys: &[&str]) {
+    let events = keys.iter().map(|key| ("miss", *key)).collect::<Vec<_>>();
+    write_legacy_events(e, crate_name, &events);
 }
 
 /// Scaffold a minimal standalone library crate (its own empty `[workspace]`,
@@ -822,6 +828,34 @@ fn why_miss_legacy_different_keys_remain_a_cold_miss() {
         !stdout.contains("repeated miss for the same cache key"),
         "stdout: {stdout}"
     );
+}
+
+#[test]
+fn why_miss_legacy_nonconsecutive_same_key_does_not_claim_a_repeat() {
+    let e = env();
+    write_legacy_miss_events(&e, "legacy-cc", &["key-x", "key-y", "key-x"]);
+
+    e.cmd()
+        .args(["why-miss", "legacy-cc"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("repeated miss for the same cache key").not());
+}
+
+#[test]
+fn why_miss_legacy_prior_hit_does_not_claim_a_repeated_miss() {
+    let e = env();
+    write_legacy_events(
+        &e,
+        "legacy-cc",
+        &[("local_hit", "same-key"), ("miss", "same-key")],
+    );
+
+    e.cmd()
+        .args(["why-miss", "legacy-cc"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("repeated miss for the same cache key").not());
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -846,6 +846,165 @@ fn test_cc_depinfo_sidecar_restores_on_hit_and_new_mf_path() {
     assert_last_cc_event(&report, "local_hit", 0);
 }
 
+#[cfg(unix)]
+#[test]
+fn test_cc_compound_depinfo_suffix_restores_across_relocated_build_root() {
+    build_kache();
+
+    let root = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    let clone_a = root.path().join("clone-a");
+    let clone_b = root.path().join("clone-b");
+
+    for clone in [&clone_a, &clone_b] {
+        std::fs::create_dir_all(clone.join("src")).unwrap();
+        std::fs::create_dir_all(clone.join("build")).unwrap();
+        std::fs::write(clone.join("src/bar.h"), "#define ANSWER 42\n").unwrap();
+        std::fs::write(
+            clone.join("src/foo.c"),
+            "#include \"bar.h\"\nint answer(void) { return ANSWER; }\n",
+        )
+        .unwrap();
+    }
+
+    // OpenSSL writes dependency data through a temporary compound suffix and
+    // then renames it. Absolute paths make the warm compile prove both cache
+    // portability and dep-info re-rooting to a recreated build tree.
+    let compile_args = |clone: &Path| {
+        vec![
+            "cc".to_string(),
+            "-O0".to_string(),
+            "-g0".to_string(),
+            "-MMD".to_string(),
+            "-MP".to_string(),
+            "-MF".to_string(),
+            clone.join("build/foo.d.tmp").to_string_lossy().into_owned(),
+            "-MT".to_string(),
+            "build/foo.o".to_string(),
+            format!("-I{}", clone.join("src").display()),
+            "-c".to_string(),
+            clone.join("src/foo.c").to_string_lossy().into_owned(),
+            "-o".to_string(),
+            clone.join("build/foo.o").to_string_lossy().into_owned(),
+        ]
+    };
+
+    let cold_args = compile_args(&clone_a);
+    let cold_args_ref: Vec<&str> = cold_args.iter().map(String::as_str).collect();
+    run_kache_cc(&clone_a, cache_dir.path(), &cold_args_ref);
+
+    let cold_depinfo = std::fs::read_to_string(clone_a.join("build/foo.d.tmp")).unwrap();
+    assert!(clone_a.join("build/foo.o").exists());
+    assert!(cold_depinfo.contains("build/foo.o"));
+    assert!(cold_depinfo.contains(&clone_a.join("src/foo.c").to_string_lossy().to_string()));
+    assert!(cold_depinfo.contains(&clone_a.join("src/bar.h").to_string_lossy().to_string()));
+    assert_cc_report_counts(&kache_report(cache_dir.path()), 1, 0);
+
+    let warm_args = compile_args(&clone_b);
+    let warm_args_ref: Vec<&str> = warm_args.iter().map(String::as_str).collect();
+    run_kache_cc(&clone_b, cache_dir.path(), &warm_args_ref);
+
+    let warm_depinfo = std::fs::read_to_string(clone_b.join("build/foo.d.tmp")).unwrap();
+    let expected_warm_depinfo = cold_depinfo.replace(
+        &format!("{}/", clone_a.display()),
+        &format!("{}/", clone_b.display()),
+    );
+    assert!(clone_b.join("build/foo.o").exists());
+    assert_eq!(
+        warm_depinfo, expected_warm_depinfo,
+        "restored compound-suffix dep-info must be re-rooted to the warm build"
+    );
+    assert!(
+        !warm_depinfo.contains(&clone_a.to_string_lossy().to_string()),
+        "restored dep-info must not retain the cold build root: {warm_depinfo}"
+    );
+
+    let report = kache_report(cache_dir.path());
+    assert_cc_report_counts(&report, 1, 1);
+    assert_last_cc_event(&report, "local_hit", 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cc_legacy_compound_depinfo_entry_self_heals_and_why_miss_explains_it() {
+    build_kache();
+
+    let project = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(project.path().join("src")).unwrap();
+    std::fs::create_dir_all(project.path().join("build")).unwrap();
+    std::fs::write(
+        project.path().join("src/foo.c"),
+        "int answer(void) { return 42; }\n",
+    )
+    .unwrap();
+    let args = [
+        "cc",
+        "-O0",
+        "-g0",
+        "-MMD",
+        "-MF",
+        "build/foo.d.tmp",
+        "-c",
+        "src/foo.c",
+        "-o",
+        "build/foo.o",
+    ];
+
+    run_kache_cc(project.path(), cache_dir.path(), &args);
+    let report = kache_report(cache_dir.path());
+    let key = report["all_events"][0]["cache_key"]
+        .as_str()
+        .expect("cold event should carry its key");
+
+    // Simulate the metadata written by v0.12/v0.13 before #655: the parsed
+    // dep-info role was discarded and only OpenSSL's raw `.d.tmp` name
+    // survived. Its blob contents remain valid; the old name must nevertheless
+    // be rejected once because old versions skipped dep-info normalization.
+    let meta_path = cache_dir.path().join("store").join(key).join("meta.json");
+    let mut meta: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&meta_path).unwrap()).unwrap();
+    let files = meta["files"].as_array_mut().unwrap();
+    let depinfo = files
+        .iter_mut()
+        .find(|file| file["name"] == "__kache_cc_depinfo.d")
+        .expect("fixed cold entry should use the semantic dep-info name");
+    depinfo["name"] = serde_json::Value::String("foo.d.tmp".to_string());
+    std::fs::write(&meta_path, serde_json::to_vec_pretty(&meta).unwrap()).unwrap();
+
+    std::fs::remove_dir_all(project.path().join("build")).unwrap();
+    std::fs::create_dir_all(project.path().join("build")).unwrap();
+    run_kache_cc(project.path(), cache_dir.path(), &args);
+
+    let why = std::process::Command::new(kache_binary())
+        .args(["why-miss", "foo.c"])
+        .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
+        .output()
+        .expect("failed to run why-miss");
+    assert!(why.status.success());
+    let stdout = String::from_utf8_lossy(&why.stdout);
+    assert!(
+        stdout.contains("matching key was found but rejected before restore"),
+        "why-miss should report the exact-key rejection: {stdout}"
+    );
+    assert!(
+        stdout.contains("matching entry lacks dep-info required by this invocation"),
+        "why-miss should name the missing artifact role: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Diagnosis: key mismatch"),
+        "why-miss must not mislabel an exact-key rejection: {stdout}"
+    );
+
+    // The rejected legacy entry was replaced in the new format, so the next
+    // recreation is a normal warm hit rather than another self-eviction.
+    std::fs::remove_dir_all(project.path().join("build")).unwrap();
+    std::fs::create_dir_all(project.path().join("build")).unwrap();
+    run_kache_cc(project.path(), cache_dir.path(), &args);
+    assert_cc_report_counts(&kache_report(cache_dir.path()), 2, 1);
+}
+
 #[test]
 fn test_cc_depinfo_restore_preserves_parent_relative_deps() {
     build_kache();


### PR DESCRIPTION
## Summary

- preserve the parsed `-MF` output as semantic C/C++ dep-info even when its filename ends in `.d.tmp`, has no extension, or uses another suffix
- store dep-info under a stable `.d` name so lookup validation, safe ingest, normalization, and restore agree
- reject and replace pre-fix compound-suffix entries once instead of trusting their unnormalized blobs
- persist exact-key lookup rejection reasons and make `why-miss` report them instead of claiming a key mismatch
- conservatively identify repeated same-key misses in pre-schema-15 event logs without guessing their cause

## Root cause

OpenSSL compiles with arguments such as:

```text
-MMD -MF a_bitstr.d.tmp
```

Kache parsed and stored that file, but later recovered its artifact kind only from the final extension. `.tmp` was classified as `Other`, so the next same-key lookup rejected and evicted the entry for lacking dep-info, recompiled, and stored two new blobs again.

## Reproduction and regression coverage

- exact OpenSSL-style `-MMD -MF build/foo.d.tmp -MT build/foo.o` cold/warm reproduction
- relocated source and build roots, including restored dep-info path re-rooting
- arbitrary and extensionless `-MF` unit cases
- simulated v0.12/v0.13 metadata, one-time self-heal, and subsequent warm hit
- real `kache why-miss foo.c` assertion for the exact rejection reason
- legacy event-log fallback that never labels repeated identical keys as a key mismatch

The primary regression test fails on the pre-fix `main` commit with two misses and passes here with one miss and one local hit.

## Verification

```text
just check
```

This runs formatting, Clippy for all workspace targets with warnings denied, and the full workspace test suite.

Fixes #655
