### PR TITLE
feat(rustc): support response files

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -175,10 +175,7 @@ fn expand_rustc_argfiles(args: &[String]) -> Result<Option<Vec<String>>> {
         return Ok(None);
     }
 
-    let mut expander = RustcArgfileExpander {
-        expanded: Vec::with_capacity(args.len()),
-        ..RustcArgfileExpander::default()
-    };
+    let mut expander = RustcArgfileExpander::default();
     for arg in args {
         expander.expand_arg(arg)?;
     }
@@ -1003,6 +1000,59 @@ mod tests {
             let parsed = RustcArgs::parse(&raw).unwrap();
             assert!(parsed.argfile_expansion_failed(), "option: {option}");
             assert_eq!(parsed.all_args, raw[1..], "option: {option}");
+        }
+    }
+
+    #[test]
+    fn shell_argfiles_option_recognition_is_precise() {
+        assert!(RustcArgfileExpander::is_shell_argfiles_option(
+            "shell-argfiles"
+        ));
+        assert!(RustcArgfileExpander::is_shell_argfiles_option(
+            "shell-argfiles=yes"
+        ));
+        assert!(!RustcArgfileExpander::is_shell_argfiles_option(
+            "other-option"
+        ));
+        assert!(!RustcArgfileExpander::is_shell_argfiles_option(
+            "shell-argfiles-extra"
+        ));
+    }
+
+    #[test]
+    fn regular_response_file_expands_with_shell_mode_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let response = dir.path().join("rustc.args");
+        std::fs::write(&response, "--crate-name\nfoo\nsrc/lib.rs\n").unwrap();
+        let raw = vec![
+            "rustc".to_string(),
+            "-Zshell-argfiles".to_string(),
+            format!("@{}", response.display()),
+        ];
+
+        let parsed = RustcArgs::parse(&raw).unwrap();
+        assert!(parsed.has_expanded_argfiles());
+        assert!(!parsed.argfile_expansion_failed());
+        assert_eq!(parsed.crate_name.as_deref(), Some("foo"));
+        assert_eq!(parsed.source_file.as_deref(), Some(Path::new("src/lib.rs")));
+    }
+
+    #[test]
+    fn response_file_with_unrepresentable_direct_arg_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let response = dir.path().join("rustc.args");
+        std::fs::write(&response, "--crate-name\nfoo\n").unwrap();
+
+        for argument in ["line\nbreak", "carriage\rreturn"] {
+            let raw = vec![
+                "rustc".to_string(),
+                argument.to_string(),
+                format!("@{}", response.display()),
+            ];
+
+            let parsed = RustcArgs::parse(&raw).unwrap();
+            assert!(parsed.argfile_expansion_failed(), "argument: {argument:?}");
+            assert_eq!(parsed.all_args, raw[1..], "argument: {argument:?}");
         }
     }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,5 @@
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use crate::compiler::rustc::RustcCompiler;
@@ -101,6 +102,101 @@ pub fn unit_id_from_artifact_path(path: &Path) -> Option<String> {
     hex.then(|| suffix.to_string())
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum RustcArgfileState {
+    #[default]
+    None,
+    Expanded,
+    Unsupported,
+}
+
+#[derive(Default)]
+struct RustcArgfileExpander {
+    shell_argfiles: bool,
+    next_is_unstable_option: bool,
+    expanded: Vec<String>,
+}
+
+impl RustcArgfileExpander {
+    fn is_shell_argfiles_option(option: &str) -> bool {
+        option == "shell-argfiles" || option.starts_with("shell-argfiles=")
+    }
+
+    fn expand_arg(&mut self, arg: &str) -> Result<()> {
+        let Some(path) = arg.strip_prefix('@') else {
+            self.push(arg.to_string());
+            return Ok(());
+        };
+
+        if self.shell_argfiles && path.starts_with("shell:") {
+            bail!("rustc shell-style response files are not yet supported");
+        }
+
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("reading rustc response file `{path}`"))?;
+        // Match rustc exactly: each line is one argument, whitespace and blank
+        // lines are preserved, and lines originating in a response file are
+        // pushed verbatim rather than recursively expanded.
+        for line in contents.lines() {
+            self.push(line.to_string());
+        }
+        Ok(())
+    }
+
+    fn push(&mut self, arg: String) {
+        // rustc inspects -Z options while expanding because
+        // `-Zshell-argfiles` changes the meaning of a later top-level
+        // `@shell:path`. We track that state only to fail closed on the
+        // unsupported shell-style subset; ordinary response files still work.
+        if self.next_is_unstable_option {
+            if Self::is_shell_argfiles_option(&arg) {
+                self.shell_argfiles = true;
+            }
+            self.next_is_unstable_option = false;
+        } else if let Some(option) = arg.strip_prefix("-Z") {
+            if option.is_empty() {
+                self.next_is_unstable_option = true;
+            } else if Self::is_shell_argfiles_option(option) {
+                self.shell_argfiles = true;
+            }
+        }
+        self.expanded.push(arg);
+    }
+}
+
+/// Expand rustc's standard UTF-8, one-argument-per-line response files.
+///
+/// Returns `None` without allocating when the invocation contains no response
+/// files. Expansion is atomic: any read/UTF-8/shell-style/lossless-transport
+/// failure makes the whole invocation unsupported so the wrapper can pass the
+/// original argv to rustc for its authoritative diagnostic.
+fn expand_rustc_argfiles(args: &[String]) -> Result<Option<Vec<String>>> {
+    if !args.iter().any(|arg| arg.starts_with('@')) {
+        return Ok(None);
+    }
+
+    let mut expander = RustcArgfileExpander {
+        expanded: Vec::with_capacity(args.len()),
+        ..RustcArgfileExpander::default()
+    };
+    for arg in args {
+        expander.expand_arg(arg)?;
+    }
+
+    // Kache snapshots the effective argv into its own standard response file
+    // before invoking rustc. Newlines and carriage returns cannot be encoded
+    // losslessly in that format, so leave these rare invocations uncached.
+    if expander
+        .expanded
+        .iter()
+        .any(|arg| arg.contains('\n') || arg.contains('\r'))
+    {
+        bail!("rustc response file expands to an argument containing a line break");
+    }
+
+    Ok(Some(expander.expanded))
+}
+
 /// Parsed rustc invocation arguments relevant to caching.
 #[derive(Debug, Clone, Default)]
 pub struct RustcArgs {
@@ -158,8 +254,13 @@ pub struct RustcArgs {
     /// When both wrappers are active, cargo passes: wrapper workspace_wrapper rustc <args>.
     /// This field holds the rustc path that the workspace wrapper expects as its first arg.
     pub inner_rustc: Option<PathBuf>,
-    /// All original arguments (everything after the rustc path)
+    /// Effective rustc arguments after standard response-file expansion.
+    /// Identical to the original arguments when no response file was used.
     pub all_args: Vec<String>,
+    /// Original compact argv for authoritative passthrough on response-file
+    /// expansion/transport failure. Populated only after successful expansion.
+    raw_args: Option<Vec<String>>,
+    argfile_state: RustcArgfileState,
     /// Argv tokens not matched by any modeled flag above, excluding the
     /// diagnostics / lint / query / already-keyed path flags that parsing
     /// explicitly drops. These can still affect codegen (e.g. `-O`, `-g`, or a
@@ -204,6 +305,26 @@ impl RustcArgs {
             (None, &args[1..])
         };
 
+        let (parse_args, raw_args, argfile_state) = match expand_rustc_argfiles(rustc_args) {
+            Ok(Some(expanded)) => (
+                Cow::Owned(expanded),
+                Some(rustc_args.to_vec()),
+                RustcArgfileState::Expanded,
+            ),
+            Ok(None) => (Cow::Borrowed(rustc_args), None, RustcArgfileState::None),
+            Err(error) => {
+                tracing::debug!(
+                    "rustc response-file expansion failed; passing through uncached: {error:#}"
+                );
+                (
+                    Cow::Borrowed(rustc_args),
+                    None,
+                    RustcArgfileState::Unsupported,
+                )
+            }
+        };
+        let rustc_args = parse_args.as_ref();
+
         let mut parsed = RustcArgs {
             rustc,
             crate_name: None,
@@ -227,6 +348,8 @@ impl RustcArgs {
             remap_path_prefixes: Vec::new(),
             inner_rustc,
             all_args: rustc_args.to_vec(),
+            raw_args,
+            argfile_state,
             residual_args: Vec::new(),
             is_test: false,
             is_primary: false,
@@ -430,6 +553,23 @@ impl RustcArgs {
         parsed.is_primary = parsed.crate_name.is_some() && parsed.source_file.is_some();
 
         Ok(parsed)
+    }
+
+    /// Original compact argv. This differs from [`Self::all_args`] only after
+    /// a response file was expanded successfully.
+    pub(crate) fn raw_args(&self) -> &[String] {
+        self.raw_args.as_deref().unwrap_or(&self.all_args)
+    }
+
+    /// Whether cached child processes should receive the effective snapshot
+    /// through a Kache-owned response file.
+    pub(crate) fn has_expanded_argfiles(&self) -> bool {
+        self.argfile_state == RustcArgfileState::Expanded
+    }
+
+    /// Whether expansion failed and the invocation must remain uncached.
+    pub(crate) fn argfile_expansion_failed(&self) -> bool {
+        self.argfile_state == RustcArgfileState::Unsupported
     }
 
     /// Whether this invocation produces an artifact the OS loads at runtime
@@ -767,6 +907,103 @@ mod tests {
         );
         assert!(!parsed.is_executable_output());
         assert!(parsed.is_primary);
+    }
+
+    #[test]
+    fn rustc_response_file_is_expanded_before_parsing() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, "pub fn answer() -> u32 { 42 }\n").unwrap();
+        let response = dir.path().join("rustc.args");
+        std::fs::write(
+            &response,
+            format!(
+                "--crate-name\nresponse_file\n{}\n--crate-type\nlib\n-C\nopt-level=2\n",
+                source.display()
+            ),
+        )
+        .unwrap();
+
+        let parsed =
+            RustcArgs::parse(&["rustc".to_string(), format!("@{}", response.display())]).unwrap();
+
+        assert!(parsed.is_primary);
+        assert_eq!(parsed.crate_name.as_deref(), Some("response_file"));
+        assert_eq!(parsed.source_file.as_deref(), Some(source.as_path()));
+        assert_eq!(parsed.get_codegen_opt("opt-level"), Some("2"));
+        assert!(parsed.has_expanded_argfiles());
+        assert_eq!(parsed.raw_args(), &[format!("@{}", response.display())]);
+        assert!(
+            !parsed
+                .all_args
+                .iter()
+                .any(|arg| arg == &format!("@{}", response.display()))
+        );
+    }
+
+    #[test]
+    fn rustc_response_file_line_semantics_match_rustc() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("nested.args");
+        std::fs::write(&nested, "must-not-be-expanded\n").unwrap();
+        let response = dir.path().join("rustc.args");
+        std::fs::write(
+            &response,
+            format!(
+                "--crate-name\r\nfoo\r\n\r\n  spaced  \r\n@{}\r\n",
+                nested.display()
+            ),
+        )
+        .unwrap();
+
+        let parsed =
+            RustcArgs::parse(&["rustc".to_string(), format!("@{}", response.display())]).unwrap();
+
+        assert_eq!(
+            parsed.all_args,
+            vec![
+                "--crate-name".to_string(),
+                "foo".to_string(),
+                String::new(),
+                "  spaced  ".to_string(),
+                format!("@{}", nested.display()),
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_response_file_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let response = dir.path().join("invalid.args");
+        std::fs::write(&response, [0xff, 0xfe]).unwrap();
+        let raw = vec![
+            "rustc".to_string(),
+            "--crate-name".to_string(),
+            "foo".to_string(),
+            "src/lib.rs".to_string(),
+            format!("@{}", response.display()),
+        ];
+
+        let parsed = RustcArgs::parse(&raw).unwrap();
+        assert!(parsed.argfile_expansion_failed());
+        assert!(!parsed.has_expanded_argfiles());
+        assert_eq!(parsed.all_args, raw[1..]);
+        assert_eq!(parsed.raw_args(), &raw[1..]);
+    }
+
+    #[test]
+    fn shell_style_response_file_fails_closed() {
+        for option in ["-Zshell-argfiles", "-Zshell-argfiles=yes"] {
+            let raw = vec![
+                "rustc".to_string(),
+                option.to_string(),
+                "@shell:rustc.args".to_string(),
+            ];
+
+            let parsed = RustcArgs::parse(&raw).unwrap();
+            assert!(parsed.argfile_expansion_failed(), "option: {option}");
+            assert_eq!(parsed.all_args, raw[1..], "option: {option}");
+        }
     }
 
     #[test]

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -163,6 +163,10 @@ use std::path::{Path, PathBuf};
 // cross-compilation. Stripping the target triple from target_dir() when cross-compiling
 // alters the path remapping prefix and dep-info rewriting anchor. Bumping the key version
 // invalidates v21 cross-compiled cache entries cleanly.
+//
+// #647 deliberately needs no bump: rustc response files were refused under
+// every existing version, while their expanded effective arguments key exactly
+// like the equivalent inline argv and leave ordinary invocation keys unchanged.
 pub(crate) const CACHE_KEY_VERSION: u32 = 22;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
@@ -905,7 +909,14 @@ pub fn compute_cache_key(
         .source_file
         .as_ref()
         .map(|source| {
-            run_dep_info_pass(&args.rustc, source, &args.all_args).with_context(|| {
+            run_dep_info_pass(
+                &args.rustc,
+                args.inner_rustc.as_deref(),
+                source,
+                &args.all_args,
+                args.has_expanded_argfiles(),
+            )
+            .with_context(|| {
                 format!(
                     "dep-info pre-pass failed for {} — refusing to cache from an \
                      incomplete input set",
@@ -2619,8 +2630,10 @@ fn system_time_ns(time: Option<std::time::SystemTime>) -> Option<i64> {
 /// never stores an entry keyed off an incomplete input set (kunobi-ninja/kache#323).
 pub fn run_dep_info_pass(
     rustc: &Path,
+    inner_rustc: Option<&Path>,
     source_file: &Path,
     rustc_args: &[String],
+    use_response_file: bool,
 ) -> Result<DepInfo> {
     let temp_dir = tempfile::Builder::new()
         .prefix("kache-depinfo")
@@ -2629,9 +2642,12 @@ pub fn run_dep_info_pass(
     let dep_file = temp_dir.path().join("deps.d");
 
     let mut cmd = std::process::Command::new(rustc);
-    cmd.arg(source_file);
+    if let Some(inner_rustc) = inner_rustc {
+        cmd.arg(inner_rustc);
+    }
 
     let source_str = source_file.to_string_lossy();
+    let mut dep_args = vec![source_str.to_string()];
 
     // Filter out --emit, --out-dir, -o, -C incremental, and the source file
     // (already added above) from original args.
@@ -2665,14 +2681,27 @@ pub fn run_dep_info_pass(
                 continue;
             }
             _ => {
-                cmd.arg(arg);
+                dep_args.push(arg.clone());
             }
         }
         i += 1;
     }
 
-    cmd.args(["--emit", "dep-info"]);
-    cmd.arg("-o").arg(&dep_file);
+    dep_args.push("--emit".to_string());
+    dep_args.push("dep-info".to_string());
+    dep_args.push("-o".to_string());
+    dep_args.push(dep_file.to_string_lossy().into_owned());
+
+    let response_file = if use_response_file {
+        let response = crate::compile::RustcResponseFile::new(
+            dep_args.iter().map(std::string::String::as_str),
+        )?;
+        cmd.arg(response.argument());
+        Some(response)
+    } else {
+        cmd.args(&dep_args);
+        None
+    };
 
     tracing::trace!("dep-info pre-pass: {:?}", cmd);
 
@@ -2681,6 +2710,7 @@ pub fn run_dep_info_pass(
         .stderr(std::process::Stdio::piped())
         .output()
         .context("running rustc --emit=dep-info")?;
+    drop(response_file);
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -4202,6 +4232,34 @@ mod tests {
         );
     }
 
+    #[test]
+    fn response_file_flags_share_inline_key_and_track_contents() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+        let response = dir.path().join("rustc.args");
+        let at_response = format!("@{}", response.display());
+
+        std::fs::write(&response, "--cfg\nresponse_v1\n-C\nopt-level=1\n").unwrap();
+        let inline = key_of_flags(&flag_base(
+            &source,
+            &["--cfg", "response_v1", "-C", "opt-level=1"],
+        ));
+        let response_v1 = key_of_flags(&flag_base(&source, &[&at_response]));
+        assert_eq!(
+            response_v1, inline,
+            "transporting identical flags through @file must not change the key"
+        );
+
+        std::fs::write(&response, "--cfg\nresponse_v2\n-C\nopt-level=2\n").unwrap();
+        let response_v2 = key_of_flags(&flag_base(&source, &[&at_response]));
+        assert_ne!(
+            response_v1, response_v2,
+            "rewriting the same response-file path must change the effective key"
+        );
+    }
+
     /// kunobi-ninja/kache#324: residual tokens are sorted before folding, so
     /// argv order does not perturb the key (the fold is a coarse safety net for
     /// unmodeled flags, not an order-sensitive channel).
@@ -5584,7 +5642,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             "2021".to_string(),
         ];
 
-        let dep_info = run_dep_info_pass(&rustc, &source, &args).unwrap();
+        let dep_info = run_dep_info_pass(&rustc, None, &source, &args, false).unwrap();
 
         assert!(
             dep_info.source_files.len() >= 2,
@@ -5624,7 +5682,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         ];
 
         assert!(
-            run_dep_info_pass(&rustc, &source, &args).is_err(),
+            run_dep_info_pass(&rustc, None, &source, &args, false).is_err(),
             "expected Err on a failing dep-info pass (source has a syntax error)"
         );
     }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,4 +1,5 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -11,6 +12,44 @@ pub struct CompileResult {
     pub stderr: String,
     /// Full artifact set produced by this compilation.
     pub artifacts: ArtifactSet,
+}
+
+/// A securely-created standard rustc response file that owns its lifetime.
+///
+/// Every argument is written verbatim followed by `\n`. This is the inverse
+/// of rustc's `str::lines()` expansion for the argument shapes Kache accepts,
+/// including interior and trailing empty arguments.
+pub(crate) struct RustcResponseFile {
+    file: tempfile::NamedTempFile,
+    argument: String,
+}
+
+impl RustcResponseFile {
+    pub(crate) fn new<'a>(args: impl IntoIterator<Item = &'a str>) -> Result<Self> {
+        let mut file = tempfile::Builder::new()
+            .prefix("kache-rustc-")
+            .suffix(".args")
+            .tempfile()
+            .context("creating rustc response file")?;
+        for arg in args {
+            if arg.contains('\n') || arg.contains('\r') {
+                bail!("rustc response-file argument contains a line break");
+            }
+            file.write_all(arg.as_bytes())?;
+            file.write_all(b"\n")?;
+        }
+        file.flush().context("flushing rustc response file")?;
+        let path = file
+            .path()
+            .to_str()
+            .context("rustc response-file path is not valid Unicode")?;
+        let argument = format!("@{path}");
+        Ok(Self { file, argument })
+    }
+
+    pub(crate) fn argument(&self) -> &str {
+        &self.argument
+    }
 }
 
 /// Run rustc with the given arguments, capturing all outputs.
@@ -26,6 +65,7 @@ pub fn run_rustc(
     rustc: &Path,
     inner_rustc: Option<&Path>,
     args: &[String],
+    use_response_file: bool,
     output_path: Option<&Path>,
     out_dir: Option<&Path>,
     crate_name: Option<&str>,
@@ -84,9 +124,25 @@ pub fn run_rustc(
             args.len() - filtered_args.len()
         );
     }
-    cmd.args(&filtered_args);
+    let response_file = if use_response_file {
+        let response = RustcResponseFile::new(filtered_args.iter().map(|arg| arg.as_str()))?;
+        cmd.arg(response.argument());
+        Some(response)
+    } else {
+        cmd.args(&filtered_args);
+        None
+    };
 
-    tracing::debug!("running: {} {}", rustc.display(), args.join(" "));
+    if let Some(response) = &response_file {
+        tracing::debug!(
+            "running: {} @{} ({} expanded args)",
+            rustc.display(),
+            response.file.path().display(),
+            filtered_args.len()
+        );
+    } else {
+        tracing::debug!("running: {} {}", rustc.display(), args.join(" "));
+    }
 
     // Spawn + `wait_with_output()` rather than `Command::output()` so the
     // child PID is known while the compile runs — the heartbeat monitor
@@ -105,6 +161,7 @@ pub fn run_rustc(
     let output = child
         .wait_with_output()
         .with_context(|| format!("executing {}", rustc.display()))?;
+    drop(response_file);
     if let Some(monitor) = monitor {
         monitor.finish();
     }
@@ -661,6 +718,20 @@ mod tests {
             fs::metadata(&blob).unwrap().permissions().readonly(),
             "removing the output must not make the shared blob writable"
         );
+    }
+
+    #[test]
+    fn rustc_response_file_round_trips_verbatim_arguments() {
+        let args = ["first", "", "  spaced  ", "@nested.args", ""];
+        let response = RustcResponseFile::new(args).unwrap();
+        let contents = fs::read_to_string(response.file.path()).unwrap();
+        assert_eq!(contents.lines().collect::<Vec<_>>(), args);
+    }
+
+    #[test]
+    fn rustc_response_file_rejects_unrepresentable_arguments() {
+        assert!(RustcResponseFile::new(["line\nbreak"]).is_err());
+        assert!(RustcResponseFile::new(["carriage\rreturn"]).is_err());
     }
 
     #[test]

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -157,6 +157,7 @@ impl Compiler for RustcCompiler {
             &parsed.rustc,
             parsed.inner_rustc.as_deref(),
             &parsed.all_args,
+            parsed.has_expanded_argfiles(),
             parsed.output.as_deref(),
             parsed.out_dir.as_deref(),
             parsed.crate_name.as_deref(),
@@ -205,15 +206,12 @@ fn rustc_refuse_reasons(
             "rustc build-script probe — not yet",
         ));
     }
-    // Response files: any arg starting with `@` (a path to a file containing
-    // additional flags). cargo emits these to dodge command-line length limits
-    // (large workspaces, Windows). The flags inside aren't visible to our parser
-    // without recursive expansion + path normalization, so codegen/cfg flags in
-    // an argfile would otherwise bypass the cache key and cause a false hit.
-    // Refuse to cache until expansion is supported. Mirrors the cc adapter guard.
-    if parsed.all_args.iter().any(|a| a.starts_with('@')) {
+    // Expansion is atomic. A missing/non-UTF-8 response file or the unstable
+    // shell-style subset keeps its original compact argv and passes through to
+    // rustc, which remains the authority for diagnostics and exit status.
+    if parsed.argfile_expansion_failed() {
         reasons.push(RefuseReason::Unsupported(
-            "rustc response file @file (expansion) — not yet",
+            "rustc response file could not be safely expanded — not yet supported",
         ));
     }
     // `--pretty`/`--unpretty` (and the `-Z unpretty=…` form) make rustc dump
@@ -336,17 +334,39 @@ mod tests {
     }
 
     #[test]
-    fn refuse_reasons_refuses_response_file_argfile() {
-        // A primary-looking compilation that also passes an `@argfile`. Codegen
-        // flags could live inside the unexpanded argfile and bypass the cache
-        // key, so we must refuse rather than risk a false hit.
+    fn refuse_reasons_accepts_expanded_response_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, "pub fn answer() -> u32 { 42 }\n").unwrap();
+        let response = dir.path().join("rustc.args");
+        std::fs::write(
+            &response,
+            format!(
+                "--crate-name\nfoo\n{}\n--crate-type\nlib\n",
+                source.display()
+            ),
+        )
+        .unwrap();
+
+        let parsed = RustcCompiler::new()
+            .parse(&["rustc".to_string(), format!("@{}", response.display())])
+            .unwrap();
+        assert!(parsed.is_primary);
+        let reasons = RustcCompiler::new().refuse_reasons(&parsed);
+        assert!(reasons.is_empty(), "unexpected refusal: {reasons:?}");
+    }
+
+    #[test]
+    fn refuse_reasons_refuses_unreadable_response_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.args");
         let parsed = RustcCompiler::new()
             .parse(&s(&[
                 "rustc",
                 "--crate-name",
                 "foo",
                 "src/lib.rs",
-                "@/tmp/cargo/argfile.txt",
+                &format!("@{}", missing.display()),
             ]))
             .unwrap();
         let reasons = RustcCompiler::new().refuse_reasons(&parsed);

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2172,6 +2172,26 @@ fn passthrough(args: &RustcArgs, fallback: Option<&str>) -> Result<PassthroughOu
         );
     }
 
+    // Keep successfully-expanded invocations compact and apply Kache's
+    // incremental filtering before re-serializing them. On any temp-file
+    // failure, use rustc's untouched original argv and remain uncached.
+    let response_file = if args.has_expanded_argfiles() {
+        match compile::RustcResponseFile::new(filtered.iter().map(|arg| arg.as_str())) {
+            Ok(response) => Some(response),
+            Err(error) => {
+                tracing::warn!(
+                    "failed to materialize expanded rustc response file; using original argv: {error:#}"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let direct_args = response_file
+        .is_none()
+        .then(|| compile::strip_incremental_flags(args.raw_args()));
+
     // A prior cache hit may have restored read-only (0444) hardlinks into the
     // target dir; rustc can't overwrite those and fails with EACCES. The cached
     // path pre-cleans them in `run_rustc`, and the disabled/re-entrant path does
@@ -2198,7 +2218,11 @@ fn passthrough(args: &RustcArgs, fallback: Option<&str>) -> Result<PassthroughOu
         if let Some(inner) = &args.inner_rustc {
             cmd.arg(inner);
         }
-        cmd.args(&filtered);
+        if let Some(response) = &response_file {
+            cmd.arg(response.argument());
+        } else if let Some(direct) = &direct_args {
+            cmd.args(direct);
+        }
         if let Some(output) = run_fallback(cmd, fb)? {
             return Ok(output);
         }
@@ -2210,7 +2234,11 @@ fn passthrough(args: &RustcArgs, fallback: Option<&str>) -> Result<PassthroughOu
     if let Some(inner) = &args.inner_rustc {
         cmd.arg(inner);
     }
-    cmd.args(&filtered);
+    if let Some(response) = &response_file {
+        cmd.arg(response.argument());
+    } else if let Some(direct) = &direct_args {
+        cmd.args(direct);
+    }
     let status = cmd
         .status()
         .with_context(|| format!("executing {}", args.rustc.display()))?;

--- a/tests/cache_key_underkeying_test.rs
+++ b/tests/cache_key_underkeying_test.rs
@@ -145,6 +145,38 @@ fn codegen_shorthand_override_order_changes_cache_key() {
     );
 }
 
+/// #647: response-file contents are effective rustc arguments, not merely a
+/// path token. An unchanged file must hit, while changing a cfg at the same
+/// path must miss rather than restore the artifact built under the old cfg.
+#[test]
+fn rustc_response_file_content_changes_cache_key() {
+    build_kache();
+    let cache_dir = TempDir::new().unwrap();
+    let out = TempDir::new().unwrap();
+    let src_dir = TempDir::new().unwrap();
+    let src = src_dir.path().join("lib.rs");
+    std::fs::write(
+        &src,
+        b"#[cfg(response_v1)]\npub fn f() -> u32 { 1 }\n\
+          #[cfg(response_v2)]\npub fn f() -> u32 { 2 }\n",
+    )
+    .unwrap();
+    let response = src_dir.path().join("rustc.args");
+    let at_response = format!("@{}", response.display());
+
+    std::fs::write(&response, b"--cfg\nresponse_v1\n").unwrap();
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &[&at_response]); // miss
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &[&at_response]); // hit
+    std::fs::write(&response, b"--cfg\nresponse_v2\n").unwrap();
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &[&at_response]); // miss
+
+    assert_eq!(
+        compiled_hit_counts(cache_dir.path()),
+        (2, 1),
+        "expected response v1 -> miss, unchanged v1 -> hit, rewritten v2 -> miss"
+    );
+}
+
 /// Direct remaps alter `file!()` and debug paths. Equivalent spelling and a
 /// relocated matching FROM must hit; a non-matching FROM or changed TO misses.
 #[test]


### PR DESCRIPTION
## Summary

- expand standard UTF-8, line-delimited rustc `@file` arguments before parsing and cache-key computation
- snapshot effective arguments into Kache-owned response files for dep-info, compiler, and passthrough execution
- safely bypass caching for unreadable, non-UTF-8, unrepresentable, or shell-style response files
- cover parser semantics, key equivalence/content changes, forwarding, and end-to-end hit/miss behavior

## Why

Cargo uses response files to avoid command-line length limits, especially in large Windows workspaces. Kache previously refused every rustc invocation containing `@file`, so those builds could not be cached. Expanding once and forwarding the captured effective argv preserves rustc semantics, avoids a time-of-check/time-of-use race, and keeps child command lines compact.

Closes #647

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
