### PR TITLE
Disable daemon idle timeout by default

### DIFF
--- a/docs/daemon/lifecycle.mdx
+++ b/docs/daemon/lifecycle.mdx
@@ -71,14 +71,15 @@ Restarting the daemon adds no latency to in-progress rustc invocations: the remo
 
 ## Idle shutdown
 
-The daemon can auto-exit after a stretch with no connections, so zombie daemons don't accumulate when you aren't building. It is re-spawned on the next build.
+The daemon runs indefinitely by default. You can opt into automatic shutdown after a stretch with no connections; it is re-spawned on the next build.
 
 ```toml
 # config.toml
-daemon_idle_timeout_secs = 600   # exit after 10 min idle; 0 disables
+[cache]
+daemon_idle_timeout_secs = 600   # opt into exit after 10 min idle; 0 disables
 ```
 
-You can also set `KACHE_DAEMON_IDLE_TIMEOUT` (seconds). **The default is 600 seconds (10 minutes).** Set it to `0` to disable the watchdog so the daemon runs indefinitely until you stop it, the binary updates, or the OS signals it.
+You can also set `KACHE_DAEMON_IDLE_TIMEOUT` (seconds). **The default is `0`, which disables the watchdog.** Set it to a positive number to opt into idle shutdown; otherwise the daemon runs until you stop it, the binary updates, or the OS signals it.
 
 ## Lifecycle internals
 

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -92,7 +92,7 @@ for AWS SDK-specific cases that need attention.
 | `KACHE_PREFETCH_MAX_BYTES` | `cache.prefetch_max_bytes` | `2GiB` | Max compressed bytes one prefetch plan may download; `0` = unlimited. Soft cap: downloads already in flight still finish, so overshoot is bounded by the prefetch concurrency |
 | `KACHE_PREFETCH_DEADLINE_SECS` | `cache.prefetch_deadline_secs` | `300` | How long a prefetch plan may keep starting downloads; `0` = no deadline |
 | `KACHE_S3_POOL_IDLE_SECS` | `cache.s3_pool_idle_secs` | `300` | How long an idle S3 connection is kept in the HTTP pool. Higher values reuse warm TLS sessions across build phases; lower this if you sit behind a load balancer that drops idle connections aggressively |
-| `KACHE_DAEMON_IDLE_TIMEOUT` | `cache.daemon_idle_timeout_secs` | `600` | Idle daemon shutdown timeout in seconds (`0` disables auto-shutdown) |
+| `KACHE_DAEMON_IDLE_TIMEOUT` | `cache.daemon_idle_timeout_secs` | `0` | Idle daemon shutdown timeout in seconds (`0` disables auto-shutdown) |
 | `KACHE_KEY_SALT` | `cache.key_salt` | — | Opaque string folded into every cache key. Change it to force a cold cache on a toolchain change kache cannot otherwise see (see [Cache-key salt](#cache-key-salt)) |
 | `KACHE_CC_EXTRA_ALLOWLIST_FLAGS` | `cc.extra_allowlist_flags` | `[]` | C/C++ flags to opt into caching that kache's built-in allow-list doesn't yet model (see [Extra cc allowlist flags](#extra-cc-allowlist-flags)). Env value is whitespace-separated |
 | `KACHE_DISABLED` | — | `false` | Disable caching entirely (pass-through to rustc). Env-only, no config key: `1` or `true` (case-insensitive) disables; any other value — including `0`, `false`, or unset — leaves caching on |

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -125,7 +125,7 @@ in
               daemon_idle_timeout_secs = lib.mkOption {
                 type = lib.types.nullOr lib.types.ints.unsigned;
                 default = null;
-                description = "Daemon idle timeout in seconds. 0 = no timeout. Default: 600.";
+                description = "Daemon idle timeout in seconds. 0 = no timeout. Default: 0.";
               };
 
               remote = lib.mkOption {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use bytesize::ByteSize;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
-pub const DEFAULT_DAEMON_IDLE_TIMEOUT_SECS: u64 = 10 * 60;
+pub const DEFAULT_DAEMON_IDLE_TIMEOUT_SECS: u64 = 0;
 
 /// Default in-flight heartbeat cadence (kunobi-ninja/kache#131).
 pub const DEFAULT_HEARTBEAT_SECS: u64 = 30;
@@ -70,7 +70,7 @@ pub struct Config {
     /// already in flight are allowed to finish: cancelling one throws away
     /// bytes already paid for.
     pub prefetch_deadline_secs: u64,
-    /// Daemon idle timeout in seconds (default 600 = 10 minutes). 0 = no timeout.
+    /// Daemon idle timeout in seconds (default 0 = no timeout).
     pub daemon_idle_timeout_secs: u64,
     /// How long an idle TCP/TLS connection is kept in the S3 client's pool, in
     /// seconds (default 300). Tuned higher than hyper's 90s default so that
@@ -2043,6 +2043,17 @@ mod tests {
     fn test_default_cache_dir() {
         let dir = default_cache_dir();
         assert!(dir.to_string_lossy().contains("kache"));
+    }
+
+    #[test]
+    fn daemon_idle_timeout_defaults_to_disabled() {
+        let _lock = config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let _config = set_kache_config_for_test(&config_path);
+        let _timeout = NamedEnvGuard::remove("KACHE_DAEMON_IDLE_TIMEOUT");
+
+        assert_eq!(Config::load().unwrap().daemon_idle_timeout_secs, 0);
     }
 
     #[test]

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -21,14 +21,15 @@ use crate::config::{
 /// The two `Option<Vec<String>>` members are copied by name on purpose: their
 /// identical types make a positional swap compile while silently corrupting a
 /// user's path-only and key-environment declarations. Keep that explicit
-/// mapping alongside the differently typed prefetch fields so a save preserves
-/// every advanced value instead of silently reverting policy.
+/// mapping alongside the differently typed prefetch and daemon fields so a save
+/// preserves every advanced value instead of silently reverting policy.
 #[derive(Debug, Clone, Default)]
 struct PreservedAdvancedConfig {
     path_only_env_vars: Option<Vec<String>>,
     key_env_vars: Option<Vec<String>>,
     prefetch_enabled: Option<bool>,
     remote_key_cache_refresh_secs: Option<u64>,
+    daemon_idle_timeout_secs: Option<u64>,
 }
 
 impl PreservedAdvancedConfig {
@@ -39,6 +40,7 @@ impl PreservedAdvancedConfig {
             key_env_vars: cache.and_then(|c| c.key_env_vars.clone()),
             prefetch_enabled: cache.and_then(|c| c.prefetch_enabled),
             remote_key_cache_refresh_secs: cache.and_then(|c| c.remote_key_cache_refresh_secs),
+            daemon_idle_timeout_secs: cache.and_then(|c| c.daemon_idle_timeout_secs),
         }
     }
 }
@@ -119,8 +121,8 @@ struct EditorState {
     preserved_cc: Option<CcFileConfig>,
     /// `[paths]` is advanced/file-only; preserve it verbatim on TUI saves.
     preserved_paths: Option<PathsFileConfig>,
-    /// `[cache] path_only_env_vars` / `key_env_vars` as loaded — the editor has
-    /// no form field for either, so carry them through verbatim on save.
+    /// Advanced `[cache]` settings as loaded — the editor has no form fields for
+    /// them, so carry them through verbatim on save.
     preserved_advanced: PreservedAdvancedConfig,
     /// `[cache] local_only` as loaded — strict local-only mode (#221). The
     /// editor has no form field for it, so carry it through verbatim on save.
@@ -805,8 +807,7 @@ fn fields_to_file_config(
             event_log_keep_lines: get_usize("event_log_keep_lines"),
             compression_level: get("compression_level").and_then(|s| s.parse::<i32>().ok()),
             s3_concurrency: get("s3_concurrency").and_then(|s| s.parse::<u32>().ok()),
-            daemon_idle_timeout_secs: get("daemon_idle_timeout_secs")
-                .and_then(|s| s.parse::<u64>().ok()),
+            daemon_idle_timeout_secs: preserved_advanced.daemon_idle_timeout_secs,
             s3_pool_idle_secs: get("s3_pool_idle_secs").and_then(|s| s.parse::<u64>().ok()),
             fallback: get("fallback"),
             key_salt: get("key_salt"),
@@ -1911,7 +1912,7 @@ mod tests {
                 prefetch_max_keys: None,
                 prefetch_max_bytes: None,
                 prefetch_deadline_secs: None,
-                daemon_idle_timeout_secs: None,
+                daemon_idle_timeout_secs: Some(600),
                 s3_pool_idle_secs: None,
                 remote: Some(RemoteFileConfig {
                     _type: Some("s3".to_string()),
@@ -1969,6 +1970,7 @@ mod tests {
         assert_eq!(cache.local_store.as_deref(), Some("~/cache"));
         assert_eq!(cache.prefetch_enabled, Some(false));
         assert_eq!(cache.remote_key_cache_refresh_secs, Some(900));
+        assert_eq!(cache.daemon_idle_timeout_secs, Some(600));
         // The editor has no planner fields, but a save must preserve the
         // loaded `[cache.planner]` section verbatim (endpoint + token).
         let planner = cache.planner.as_ref().expect("planner preserved on save");
@@ -2022,6 +2024,7 @@ mod tests {
             cache: Some(CacheFileConfig {
                 key_env_vars: Some(vec!["BOLTFFI_*".to_string()]),
                 path_only_env_vars: Some(vec!["BUILDCONFIG_RS".to_string()]),
+                daemon_idle_timeout_secs: Some(600),
                 ..Default::default()
             }),
             ..Default::default()
@@ -2036,6 +2039,7 @@ mod tests {
             state.preserved_advanced.path_only_env_vars.as_deref(),
             Some(&["BUILDCONFIG_RS".to_string()][..])
         );
+        assert_eq!(state.preserved_advanced.daemon_idle_timeout_secs, Some(600));
 
         // ...and back out again through the save path.
         let saved = fields_to_file_config(
@@ -2067,6 +2071,7 @@ mod tests {
             cache.path_only_env_vars.as_deref(),
             Some(&["BUILDCONFIG_RS".to_string()][..])
         );
+        assert_eq!(cache.daemon_idle_timeout_secs, Some(600));
     }
 
     #[test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -173,12 +173,27 @@ pub(crate) fn warn_once_per_session(marker: &Path, session_secs: u64, message: &
     // would always read "stale" here and let a second wrapper warn again — on
     // the very platform this advisory targets. Same reason
     // `write_marker_timestamp` writes through the locked handle (#348).
-    if marker_file_is_fresh(&lock_file, session_secs) {
-        return false;
-    }
-    eprintln!("{message}");
-    write_marker_timestamp(&lock_file);
-    true
+    finish_warn_once_per_session(&lock_file, session_secs, message)
+}
+
+/// Re-check and update a warn-once marker while its lock is held, then release
+/// the lock explicitly. Relying on `File` drop is racy with concurrent process
+/// spawning: a fork can briefly inherit a duplicate descriptor that keeps the
+/// lock alive after this function returns.
+fn finish_warn_once_per_session(
+    lock_file: &std::fs::File,
+    session_secs: u64,
+    message: &str,
+) -> bool {
+    let emitted = if marker_file_is_fresh(lock_file, session_secs) {
+        false
+    } else {
+        eprintln!("{message}");
+        write_marker_timestamp(lock_file);
+        true
+    };
+    let _ = std::fs::File::unlock(lock_file);
+    emitted
 }
 
 /// Emit the `store_unavailable_message` to stderr **at most once per build
@@ -3174,6 +3189,27 @@ mod tests {
             warn_once_per_session(&marker, 0, "advisory"),
             "a stale marker must let the advisory through again"
         );
+    }
+
+    #[test]
+    fn warn_once_per_session_unlocks_even_with_a_duplicated_descriptor() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("cow-warn");
+        let lock_file = open_marker_for_lock(&marker).unwrap();
+        lock_file.try_lock().unwrap();
+        let inherited = lock_file.try_clone().unwrap();
+
+        assert!(finish_warn_once_per_session(&lock_file, 0, "advisory"));
+        drop(lock_file);
+
+        let contender = open_marker_for_lock(&marker).unwrap();
+        assert!(
+            contender.try_lock().is_ok(),
+            "the explicit unlock must release the lock even while a duplicated \
+             descriptor remains open"
+        );
+        let _ = contender.unlock();
+        drop(inherited);
     }
 
     #[test]

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -29,7 +29,7 @@ fn kache(home: &Path, cache_dir: &Path) -> Command {
         .env("HOME", home)
         .env("CARGO_HOME", home.join(".cargo"))
         // Daemons spawned during tests must self-exit quickly instead of
-        // lingering for the default 10min — otherwise, under `just coverage`,
+        // lingering indefinitely — otherwise, under `just coverage`,
         // they pile up and CPU-starve the rest of the suite.
         .env("KACHE_DAEMON_IDLE_TIMEOUT", "3")
         // Never let a real wrapper config leak into the spawned process.


### PR DESCRIPTION
## Summary

- change the daemon idle-timeout default from 600 seconds to disabled (`0`)
- preserve explicit positive timeouts when saving through `kache config`
- update lifecycle/configuration docs and the Nix option description
- explicitly release the warn-once marker lock and cover duplicated descriptors

## Why

`kache init` installs a daemon service, but the daemon currently exits successfully after ten idle minutes. Service managers configured to restart only on failure then leave it stopped. The runtime already treats `0` as no watchdog, so this makes the daemon stay resident by default while keeping positive values as an opt-in idle shutdown.

CI also exposed a pre-existing macOS race in the warn-once marker test. A concurrently spawned process can briefly retain a duplicated lock descriptor, so the acquired lock is now explicitly released instead of relying on `File` drop. The regression test verifies immediate re-locking while a duplicate remains open.

Fixes #661

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (signing disabled only for disposable test repositories)
- focused marker-lock regression tests
- `nix-instantiate --parse nix/module.nix`
- `git diff --check`
