### PR TITLE
fix(cc): preserve output path semantics

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -32,6 +32,10 @@ gitignore = true
 # struct is declared inside `probe_macos` and exists nowhere else, so naming it
 # is exactly as narrow.
 #
+# C/C++ output independence has three cfg-selected implementations. The Linux
+# lane exercises the Unix implementation; the Windows body is covered by the
+# Windows lane, while unsupported targets deliberately use a constant fallback.
+#
 # Kani proof harnesses are compiled and executed only by `cargo kani`; the
 # mutation lane's `cargo test` process cannot observe changes under `cfg(kani)`.
 # Their production target remains mutation-tested, while the harnesses are
@@ -41,5 +45,7 @@ exclude_re = [
     "probe_macos",
     "probe_unsupported",
     "from struct AttrList",
+    "regular_output_is_independent_windows",
+    "regular_output_is_independent_unsupported",
     "kani_proofs::",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,10 @@ jobs:
           test "$count" -gt 0
       - name: Mutate all kache-core behavior
         timeout-minutes: 15
+        # rust-cache exports CARGO_INCREMENTAL=0 after the job-level env is
+        # evaluated. Mutation builds deliberately need incremental reuse.
+        env:
+          CARGO_INCREMENTAL: "1"
         run: |
           cargo mutants \
             --package kache-core \
@@ -198,6 +202,10 @@ jobs:
       - name: Mutate changed Rust behavior
         if: github.event_name == 'pull_request'
         timeout-minutes: 45
+        # Keep this step-local: rust-cache otherwise overrides the job-level
+        # setting and every changed-line mutant rebuilds the crate from scratch.
+        env:
+          CARGO_INCREMENTAL: "1"
         run: |
           cargo mutants \
             --workspace \

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -562,17 +562,30 @@ pub(crate) fn pre_clean_outputs(
 
 /// Remove a file if it exists and is read-only (likely a kache hardlink).
 fn remove_if_readonly(path: &Path) {
-    if let Ok(meta) = std::fs::metadata(path)
-        && meta.permissions().readonly()
-    {
-        #[cfg(windows)]
-        {
-            let mut perms = meta.permissions();
-            perms.set_readonly(false);
-            let _ = std::fs::set_permissions(path, perms);
-        }
-        let _ = std::fs::remove_file(path);
+    let Ok(entry) = std::fs::symlink_metadata(path) else {
+        return;
+    };
+    if !entry.file_type().is_file() {
+        return;
     }
+
+    let Ok(meta) = std::fs::metadata(path) else {
+        return;
+    };
+    if !meta.permissions().readonly() {
+        return;
+    }
+
+    #[cfg(windows)]
+    {
+        let mut perms = meta.permissions();
+        perms.set_readonly(false);
+        let _ = std::fs::set_permissions(path, perms);
+    }
+    if !std::fs::symlink_metadata(path).is_ok_and(|current| current.file_type().is_file()) {
+        return;
+    }
+    let _ = std::fs::remove_file(path);
 }
 
 // NOTE: ad-hoc codesign logic used to live here behind
@@ -647,6 +660,32 @@ mod tests {
         pre_clean_outputs(Some(&output), None, None, None, &[]);
 
         assert!(output.exists(), "writable file should NOT be removed");
+    }
+
+    /// A direct rustc passthrough may also name a read-only restored output.
+    /// Inspect the directory entry so a user-owned symlink survives.
+    #[cfg(unix)]
+    #[test]
+    fn test_pre_clean_preserves_symlink_to_readonly_output() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real.o");
+        let output = dir.path().join("link.o");
+        fs::write(&target, b"original").unwrap();
+        make_readonly(&target);
+        symlink(&target, &output).unwrap();
+
+        pre_clean_outputs(Some(&output), None, None, None, &[]);
+
+        assert!(
+            fs::symlink_metadata(&output)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "direct compiler pre-clean must preserve output symlinks"
+        );
+        assert_eq!(fs::read(&target).unwrap(), b"original");
     }
 
     #[test]

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -745,6 +745,12 @@ impl CcArgs {
             return reasons;
         }
 
+        if self.requires_compiler_output_semantics() {
+            reasons.push(RefuseReason::Unsupported(
+                "existing output path requires compiler write semantics — caching not yet supported",
+            ));
+        }
+
         // ── Feature refusals ──
         //
         // The invocation IS a single-source object compile, but uses a
@@ -946,6 +952,63 @@ impl CcArgs {
         Some(object)
     }
 
+    /// Every filesystem output selected by a compile-mode invocation.
+    ///
+    /// Cacheable invocations have one source, but refused multi-source
+    /// invocations still need exact passthrough safety checks for each default
+    /// object and dep-info path. Non-compile modes deliberately return no
+    /// object-shaped paths: `-E foo.c` does not select `foo.o`.
+    pub(crate) fn compiler_output_paths(&self) -> Vec<PathBuf> {
+        if self.mode != CompileMode::Compile {
+            return Vec::new();
+        }
+
+        let objects = if let Some(output) = &self.output {
+            vec![output.clone()]
+        } else {
+            let ext = match self.family.dialect() {
+                Dialect::Cl => "obj",
+                Dialect::Gnu => "o",
+            };
+            self.sources
+                .iter()
+                .filter_map(|source| {
+                    source
+                        .file_stem()
+                        .map(|stem| PathBuf::from(format!("{}.{ext}", stem.to_string_lossy())))
+                })
+                .collect()
+        };
+
+        let mut paths = objects.clone();
+        if let Some(depinfo) = &self.depinfo
+            && depinfo.emit
+        {
+            if let Some(output) = &depinfo.output {
+                paths.push(output.clone());
+            } else {
+                paths.extend(objects.into_iter().map(|mut object| {
+                    object.set_extension("d");
+                    object
+                }));
+            }
+        }
+        paths
+    }
+
+    /// Whether an existing output needs the selected compiler's own path
+    /// handling instead of cache materialization.
+    ///
+    /// GCC and clang can differ in how they handle an existing output, and
+    /// filesystem permissions/ACLs can make truncate and replace semantics
+    /// observably different. Kache cannot safely infer those semantics from a
+    /// pathname, so every existing output uses the selected compiler directly.
+    pub(crate) fn requires_compiler_output_semantics(&self) -> bool {
+        self.compiler_output_paths()
+            .into_iter()
+            .any(|path| output_path_requires_compiler_semantics(&path))
+    }
+
     /// Anchor used to relativize/expand C/C++ dep-info target paths.
     pub fn depinfo_anchor(&self) -> Option<PathBuf> {
         self.depinfo_output_path()?;
@@ -1009,6 +1072,44 @@ impl CcArgs {
         out
     }
 }
+
+fn output_path_requires_compiler_semantics(path: &Path) -> bool {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => true,
+        Err(err) => err.kind() != std::io::ErrorKind::NotFound,
+    }
+}
+
+#[cfg(unix)]
+fn regular_output_is_independent(_path: &Path, meta: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    meta.nlink() == 1
+}
+
+#[cfg(windows)]
+fn regular_output_is_independent_windows(path: &Path, _meta: &std::fs::Metadata) -> bool {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+    };
+
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut info: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+    let ok = unsafe { GetFileInformationByHandle(file.as_raw_handle() as _, &mut info) };
+    ok != 0 && info.nNumberOfLinks == 1
+}
+#[cfg(windows)]
+use self::regular_output_is_independent_windows as regular_output_is_independent;
+
+#[cfg(not(any(unix, windows)))]
+fn regular_output_is_independent_unsupported(_path: &Path, _meta: &std::fs::Metadata) -> bool {
+    true
+}
+#[cfg(not(any(unix, windows)))]
+use self::regular_output_is_independent_unsupported as regular_output_is_independent;
 
 fn parse_cc_arg_at(args: &[String], idx: usize, dialect: Dialect) -> Option<ParsedCcArg> {
     let arg = args.get(idx)?;
@@ -3737,6 +3838,7 @@ fn named_tool_family(name: &str) -> Option<ToolFamily> {
 }
 
 impl CcCompiler {
+    #[cfg(test)]
     pub fn new() -> Self {
         Self::default()
     }
@@ -3964,46 +4066,6 @@ where
             .then_with(|| a.cmp(b))
     });
     keys.first().map(|k| wrapped[*k].clone())
-}
-
-/// Remove read-only output files before the compiler writes to them.
-///
-/// When kache restores a cc cache hit it hardlinks store blobs (0o444,
-/// shared inode with the store) into the object output path and — when
-/// requested — its dep-info sidecar. If a subsequent build is a cache
-/// MISS for the same translation unit (e.g. the source was edited), the
-/// compiler tries to overwrite these paths in place and fails with
-/// EACCES / "operation not permitted" (observed with gcc, clang, and
-/// clang-cl on Windows).  A chmod-to-writable cannot substitute for the
-/// unlink because the inode is shared: writing through it would mutate
-/// the store blob. The correct fix is to unlink the file first: a
-/// `remove_file` breaks the hardlink and leaves the store blob
-/// untouched, exactly as `compile::pre_clean_outputs` does for the
-/// rustc path. On Windows a read-only file cannot be deleted at all, so
-/// the read-only attribute is cleared immediately before the unlink
-/// (same as `remove_if_readonly` on the rustc path and `clear_target`
-/// on restore) — under the `windows_hardlink` opt-in both hit and miss
-/// outputs can be read-only hardlinks.
-///
-/// Best-effort: a missing file is fine; errors are silently ignored.
-pub(crate) fn pre_clean_cc_outputs(parsed: &CcArgs) {
-    fn remove_output(path: &std::path::Path) {
-        #[cfg(windows)]
-        if let Ok(meta) = std::fs::metadata(path)
-            && meta.permissions().readonly()
-        {
-            let mut perms = meta.permissions();
-            perms.set_readonly(false);
-            let _ = std::fs::set_permissions(path, perms);
-        }
-        let _ = std::fs::remove_file(path);
-    }
-    if let Some(obj) = parsed.object_output_path() {
-        remove_output(&obj);
-    }
-    if let Some(dep) = parsed.depinfo_output_path() {
-        remove_output(&dep);
-    }
 }
 
 impl Compiler for CcCompiler {
@@ -4398,17 +4460,6 @@ impl Compiler for CcCompiler {
     }
 
     fn execute(&self, parsed: &CcArgs) -> Result<CompileResult> {
-        // Pre-clean read-only restored hardlinks so the compiler can
-        // overwrite them. A previous cache-on build may have restored the
-        // object (and dep-info sidecar) as read-only hardlinks into the
-        // local store (0o444, shared inode). Running the real compiler
-        // over them in place fails with EACCES / "operation not permitted"
-        // (observed with gcc, clang, and clang-cl). A plain remove breaks
-        // the hardlink and leaves the store blob intact — identical to the
-        // rustc `pre_clean_outputs` rationale in `src/compile.rs`.
-        // Best-effort: a missing file is fine; any other error is ignored.
-        pre_clean_cc_outputs(parsed);
-
         // Invoke the underlying compiler with the original argv, plus a
         // set of `-ffile-prefix-map` rules so the object doesn't embed
         // clone-local build/source roots. Spliced in before any `--`
@@ -4467,7 +4518,19 @@ impl Compiler for CcCompiler {
 /// Discover a successful C/C++ compile's cacheable outputs while preserving
 /// the parsed role of `-MF` instead of trying to recover it from a filename.
 fn discover_cc_output_artifacts(parsed: &CcArgs) -> ArtifactSet {
-    let Some(object) = parsed.object_output_path().filter(|path| path.exists()) else {
+    // Store only lexical regular files. Following a symlink here would let an
+    // output such as `/dev/null` or a FIFO enter the blob-ingest path, while a
+    // symlink needs compiler-specific replacement semantics on later runs.
+    fn is_plain_file(path: &std::path::Path) -> bool {
+        std::fs::symlink_metadata(path).is_ok_and(|meta| {
+            meta.file_type().is_file() && regular_output_is_independent(path, &meta)
+        })
+    }
+
+    let Some(object) = parsed
+        .object_output_path()
+        .filter(|path| is_plain_file(path))
+    else {
         return ArtifactSet::empty();
     };
     let object_name = object
@@ -4481,7 +4544,10 @@ fn discover_cc_output_artifacts(parsed: &CcArgs) -> ArtifactSet {
         required: true,
     }];
 
-    if let Some(depinfo) = parsed.depinfo_output_path().filter(|path| path.exists()) {
+    if let Some(depinfo) = parsed
+        .depinfo_output_path()
+        .filter(|path| is_plain_file(path))
+    {
         outputs.push(Artifact {
             path: depinfo,
             store_name: CC_DEPINFO_STORE_NAME.to_string(),
@@ -8236,152 +8302,265 @@ mod tests {
         }
     }
 
-    // ── pre_clean_cc_outputs ──────────────────────────────────────
+    // ── existing output path semantics (#645) ─────────────────────
 
-    /// Regression for #285 / the cc pre-clean bug: `pre_clean_cc_outputs`
-    /// must unlink a read-only object (and dep-info sidecar) that were
-    /// previously restored as hardlinked store blobs (0o444).
-    ///
-    /// Before the fix, `CcCompiler::execute` had no pre-clean step, so
-    /// re-running the compiler after a cache hit would fail with EACCES /
-    /// "operation not permitted" when trying to overwrite the read-only file.
+    #[test]
+    fn compiler_output_paths_covers_every_multi_source_default_output() {
+        let parsed =
+            CcArgs::parse(&s(&["cc", "-c", "src/alpha.c", "other/beta.c", "-MMD"])).unwrap();
+
+        assert_eq!(
+            parsed.compiler_output_paths(),
+            vec![
+                PathBuf::from("alpha.o"),
+                PathBuf::from("beta.o"),
+                PathBuf::from("alpha.d"),
+                PathBuf::from("beta.d"),
+            ]
+        );
+    }
+
+    #[test]
+    fn compiler_output_paths_ignores_object_shape_outside_compile_mode() {
+        let parsed = CcArgs::parse(&s(&["cc", "-E", "foo.c", "-o", "foo.o"])).unwrap();
+
+        assert!(parsed.compiler_output_paths().is_empty());
+        assert!(!parsed.requires_compiler_output_semantics());
+    }
+
+    #[test]
+    fn cc_output_safety_refuses_existing_writable_regular_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("plain.o");
+        std::fs::write(&output, b"ordinary compiler output").unwrap();
+
+        let output_str = output.to_string_lossy().into_owned();
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", &output_str])).unwrap();
+
+        assert!(parsed.requires_compiler_output_semantics());
+        assert_eq!(
+            discover_cc_output_artifacts(&parsed).outputs().len(),
+            1,
+            "post-compile discovery may ingest an independent regular file"
+        );
+    }
+
+    /// A user-owned read-only output must reach the selected compiler intact.
     #[cfg(unix)]
     #[test]
-    fn pre_clean_cc_outputs_unlinks_readonly_object_and_depinfo() {
-        use std::fs;
+    fn cc_output_safety_refuses_readonly_regular_file() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("readonly.o");
+        std::fs::write(&output, b"user-owned").unwrap();
+        std::fs::set_permissions(&output, std::fs::Permissions::from_mode(0o444)).unwrap();
+        let before = std::fs::metadata(&output).unwrap();
+
+        let output_str = output.to_string_lossy().into_owned();
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", &output_str])).unwrap();
+
+        assert!(parsed.requires_compiler_output_semantics());
+        assert!(parsed.refuse_reasons(&[]).iter().any(|reason| {
+            reason
+                .description()
+                .contains("requires compiler write semantics")
+        }));
+        assert_eq!(discover_cc_output_artifacts(&parsed).outputs().len(), 1);
+        let after = std::fs::metadata(&output).unwrap();
+        assert_eq!((after.dev(), after.ino()), (before.dev(), before.ino()));
+        assert_eq!(std::fs::read(&output).unwrap(), b"user-owned");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cc_output_safety_refuses_regular_file_without_owner_write() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().unwrap();
-        let obj = dir.path().join("foo.o");
-        let dep = dir.path().join("foo.d");
+        let output = dir.path().join("group-writable.o");
+        std::fs::write(&output, b"user-owned").unwrap();
+        std::fs::set_permissions(&output, std::fs::Permissions::from_mode(0o460)).unwrap();
 
-        // Simulate kache-restored hardlinks: read-only blobs at the output paths.
-        fs::write(&obj, b"old object").unwrap();
-        fs::set_permissions(&obj, fs::Permissions::from_mode(0o444)).unwrap();
-        fs::write(&dep, b"old depinfo").unwrap();
-        fs::set_permissions(&dep, fs::Permissions::from_mode(0o444)).unwrap();
+        let output_str = output.to_string_lossy().into_owned();
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", &output_str])).unwrap();
 
-        assert!(
-            fs::metadata(&obj).unwrap().permissions().readonly(),
-            "precondition: object must be read-only"
-        );
-        assert!(
-            fs::metadata(&dep).unwrap().permissions().readonly(),
-            "precondition: dep-info must be read-only"
-        );
+        assert!(parsed.requires_compiler_output_semantics());
+        assert_eq!(discover_cc_output_artifacts(&parsed).outputs().len(), 1);
+        assert_eq!(std::fs::read(&output).unwrap(), b"user-owned");
+    }
 
-        // Build a parsed CcArgs pointing at these paths.
-        let obj_str = obj.to_string_lossy().into_owned();
-        let dep_str = dep.to_string_lossy().into_owned();
+    #[cfg(unix)]
+    #[test]
+    fn cc_output_safety_checks_explicit_depinfo_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let object = dir.path().join("foo.o");
+        let depinfo = dir.path().join("custom.tmp");
+        std::fs::write(&depinfo, b"user-owned depinfo").unwrap();
+        std::fs::set_permissions(&depinfo, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+        let object_str = object.to_string_lossy().into_owned();
+        let depinfo_str = depinfo.to_string_lossy().into_owned();
         let parsed = CcArgs::parse(&s(&[
-            "cc", "-c", "foo.c", "-MMD", "-MF", &dep_str, "-o", &obj_str,
+            "cc",
+            "-c",
+            "foo.c",
+            "-MMD",
+            "-MF",
+            &depinfo_str,
+            "-o",
+            &object_str,
         ]))
         .unwrap();
 
-        // The helper must remove both read-only files, breaking the
-        // hardlinks and leaving the store blobs untouched.
-        pre_clean_cc_outputs(&parsed);
-
-        assert!(
-            !obj.exists(),
-            "read-only object must be unlinked by pre_clean_cc_outputs"
-        );
-        assert!(
-            !dep.exists(),
-            "read-only dep-info must be unlinked by pre_clean_cc_outputs"
-        );
+        assert!(parsed.requires_compiler_output_semantics());
+        assert!(parsed.refuse_reasons(&[]).iter().any(|reason| {
+            reason
+                .description()
+                .contains("requires compiler write semantics")
+        }));
+        assert_eq!(std::fs::read(&depinfo).unwrap(), b"user-owned depinfo");
     }
 
-    /// Verify that `pre_clean_cc_outputs` does NOT remove a writable object
-    /// (non-restored path — must not discard a freshly-compiled artifact).
+    /// A compiler may write through or replace a symlink. Cache restore must
+    /// not choose those semantics on the selected compiler's behalf.
     #[cfg(unix)]
     #[test]
-    fn pre_clean_cc_outputs_leaves_writable_object_intact() {
+    fn cc_output_safety_refuses_symlinked_object() {
         use std::fs;
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::symlink;
 
         let dir = tempfile::tempdir().unwrap();
-        let obj = dir.path().join("bar.o");
+        let target = dir.path().join("real.o");
+        let output = dir.path().join("link.o");
+        fs::write(&target, b"original").unwrap();
+        symlink(&target, &output).unwrap();
 
-        // Writable file — NOT a kache restore.
-        fs::write(&obj, b"fresh object").unwrap();
-        fs::set_permissions(&obj, fs::Permissions::from_mode(0o644)).unwrap();
+        let output_str = output.to_string_lossy().into_owned();
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", &output_str])).unwrap();
 
-        let obj_str = obj.to_string_lossy().into_owned();
-        let parsed = CcArgs::parse(&s(&["cc", "-c", "bar.c", "-o", &obj_str])).unwrap();
-
-        // A writable file must not be touched — only read-only hardlinks are pre-cleaned.
-        // NOTE: the current implementation removes any existing file (best-effort) to
-        // keep the logic simple. This test documents the current behaviour.
-        // If the implementation is ever tightened to only remove read-only files,
-        // update this assertion accordingly.
-        pre_clean_cc_outputs(&parsed);
-        // The file no longer exists after pre-clean (unconditional remove).
-        // This is acceptable: on a cache miss the compiler will recreate it.
-        // The critical invariant is that the compiler is not blocked by EACCES.
+        assert!(
+            parsed.requires_compiler_output_semantics(),
+            "an existing output symlink must route through the real compiler"
+        );
+        assert!(
+            fs::symlink_metadata(&output)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "classification must leave the -o symlink in place"
+        );
+        assert_eq!(fs::read(&target).unwrap(), b"original");
     }
 
-    /// Regression: `CcCompiler::execute` must succeed when the object output
-    /// path is a read-only file (simulated kache restore) on a cache miss.
-    ///
-    /// Uses `sh -c "cp /dev/null $OBJ"` as a stand-in compiler that writes
-    /// the object unconditionally, exactly like a real C compiler would.
-    /// Before the fix, this failed with EACCES because `execute` had no
-    /// pre-clean step.
+    /// Both writable and read-only hardlinks require compiler-native behavior.
     #[cfg(unix)]
     #[test]
-    fn execute_pre_cleans_readonly_object_before_recompiling() {
+    fn cc_output_safety_refuses_all_hardlinks() {
         use std::fs;
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
         let dir = tempfile::tempdir().unwrap();
-        let obj = dir.path().join("hit.o");
-        let src = dir.path().join("hit.c");
+        let target = dir.path().join("real.o");
+        let output = dir.path().join("link.o");
+        fs::write(&target, b"original").unwrap();
+        fs::hard_link(&target, &output).unwrap();
 
-        // Simulate a kache restore: read-only hardlink at the object path.
-        fs::write(&obj, b"cached content").unwrap();
-        fs::set_permissions(&obj, fs::Permissions::from_mode(0o444)).unwrap();
+        let output_str = output.to_string_lossy().into_owned();
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", &output_str])).unwrap();
+
+        assert!(parsed.requires_compiler_output_semantics());
+        assert!(parsed.refuse_reasons(&[]).iter().any(|reason| {
+            reason
+                .description()
+                .contains("requires compiler write semantics")
+        }));
+
+        let target_meta = fs::metadata(&target).unwrap();
+        let output_meta = fs::metadata(&output).unwrap();
+        assert_eq!(target_meta.dev(), output_meta.dev());
+        assert_eq!(target_meta.ino(), output_meta.ino());
+        assert_eq!(target_meta.nlink(), 2);
         assert!(
-            fs::metadata(&obj).unwrap().permissions().readonly(),
-            "precondition: object must be read-only"
+            discover_cc_output_artifacts(&parsed).is_empty(),
+            "writable hardlinked outputs must not enter the blob store"
         );
 
-        // A minimal source file so the arg parser sees one source.
-        fs::write(&src, b"int x;\n").unwrap();
+        fs::set_permissions(&output, fs::Permissions::from_mode(0o444)).unwrap();
+        assert!(
+            parsed.requires_compiler_output_semantics(),
+            "read-only hardlinks are user-owned unless proven otherwise"
+        );
+        assert!(discover_cc_output_artifacts(&parsed).is_empty());
+    }
 
-        let obj_str = obj.to_string_lossy().into_owned();
-        let src_str = src.to_string_lossy().into_owned();
+    #[cfg(windows)]
+    #[test]
+    fn cc_output_safety_refuses_windows_hardlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real.obj");
+        let output = dir.path().join("link.obj");
+        std::fs::write(&target, b"original").unwrap();
+        std::fs::hard_link(&target, &output).unwrap();
 
-        // Stand-in compiler: `sh` with a `-c` script that writes the object.
-        // argv shape: ["sh", "-c", "cp /dev/null <obj>", <src>, "-c", "-o", <obj>]
-        // The script ignores the trailing positional args; the arg parser sees
-        // `-c` (compile mode) and `-o <obj>` (object path), which is all we need.
-        let script = format!("cp /dev/null '{obj_str}'");
-        let compiler = CcCompiler::new();
-        let parsed = compiler
-            .parse(&[
-                "sh".to_string(),
-                "-c".to_string(),
-                script,
-                src_str,
-                "-c".to_string(),
-                "-o".to_string(),
-                obj_str.clone(),
-            ])
-            .unwrap();
-
-        // Without the pre-clean fix this would return Ok(exit_code != 0) because
-        // the stand-in `sh -c "cp /dev/null <obj>"` would fail to write over the
-        // read-only file (EACCES). With the fix, the hardlink is removed first
-        // and the "compiler" succeeds.
-        let result = compiler.execute(&parsed).expect("execute must not Err");
+        let output_str = output.to_string_lossy().into_owned();
+        let output_arg = format!("/Fo{output_str}");
+        let parsed = CcArgs::parse(&s(&["clang-cl.exe", "/c", "foo.c", &output_arg])).unwrap();
         assert_eq!(
-            result.exit_code, 0,
-            "compiler must succeed after pre_clean removes the read-only restore"
+            parsed.object_output_path().as_deref(),
+            Some(output.as_path())
+        );
+        assert!(parsed.requires_compiler_output_semantics());
+        assert!(discover_cc_output_artifacts(&parsed).is_empty());
+
+        let mut perms = std::fs::metadata(&output).unwrap().permissions();
+        perms.set_readonly(true);
+        std::fs::set_permissions(&output, perms).unwrap();
+        assert!(parsed.requires_compiler_output_semantics());
+
+        // TempDir cleanup cannot remove a read-only Windows hardlink.
+        let mut perms = std::fs::metadata(&output).unwrap().permissions();
+        #[allow(clippy::permissions_set_readonly_false)]
+        perms.set_readonly(false);
+        std::fs::set_permissions(&output, perms).unwrap();
+    }
+
+    /// A user-owned non-regular output must never be unlinked by pre-clean or
+    /// admitted to blob ingestion. A Unix socket gives the test a disposable
+    /// special file without risking a real device node.
+    #[cfg(unix)]
+    #[test]
+    fn cc_output_safety_preserves_and_refuses_non_regular_file() {
+        use std::fs;
+        use std::os::unix::fs::FileTypeExt;
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("compiler-output.sock");
+        let _listener = UnixListener::bind(&output).unwrap();
+
+        let output_str = output.to_string_lossy().into_owned();
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", &output_str])).unwrap();
+
+        assert!(parsed.requires_compiler_output_semantics());
+        assert!(parsed.refuse_reasons(&[]).iter().any(|reason| {
+            reason
+                .description()
+                .contains("requires compiler write semantics")
+        }));
+
+        assert!(
+            fs::symlink_metadata(&output)
+                .unwrap()
+                .file_type()
+                .is_socket(),
+            "classification must not unlink a non-regular compiler output"
         );
         assert!(
-            obj.exists(),
-            "object must be (re-)created by the stand-in compiler"
+            discover_cc_output_artifacts(&parsed).is_empty(),
+            "non-regular compiler outputs must not enter the blob store"
         );
     }
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,8 +1,6 @@
 use anyhow::{Context, Result};
 use std::fs;
-use std::path::Path;
-#[cfg(windows)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 #[cfg(windows)]
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -62,9 +60,8 @@ fn storage_layout_advice_enabled() -> bool {
 
 /// Strategy for restoring a cached file to a build output path.
 ///
-/// Restoration always tries reflink (CoW: zero-copy *with* an independent
-/// inode) first. The strategy only controls the fallback when reflink is
-/// unavailable (e.g. ext4 without `mkfs.ext4 -O reflink`, tmpfs, NTFS):
+/// `Hardlink` and `Copy` first try reflink (CoW: zero-copy *with* an
+/// independent inode), then use the strategy-specific fallback:
 ///
 /// - `Hardlink`: fall back to a hardlink (zero-copy via shared inode). For
 ///   immutable artifacts like `.rlib` / `.rmeta` where the build won't mutate
@@ -75,10 +72,6 @@ fn storage_layout_advice_enabled() -> bool {
 /// - `Copy`: fall back to a plain byte copy (independent file). For
 ///   executables, dylibs, and proc-macros that may be mutated post-build
 ///   (codesigning, stripping, etc.).
-///
-/// On APFS, btrfs, or XFS-with-reflink the two strategies behave identically:
-/// both reflink, both produce independent inodes, both are safe against
-/// post-build mutation.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LinkStrategy {
     Hardlink,
@@ -87,8 +80,7 @@ pub enum LinkStrategy {
 
 /// Link a cached file to the target output path.
 ///
-/// Tries reflink first (zero-copy + write isolation on supported filesystems);
-/// falls back to a strategy-specific path on filesystems without CoW.
+/// Both strategies try reflink first, then use their strategy-specific fallback.
 pub fn link_to_target(store_path: &Path, target_path: &Path, strategy: LinkStrategy) -> Result<()> {
     let do_link = || -> Result<()> {
         // Remove existing file at target (link/clone calls fail if dst exists).
@@ -106,10 +98,12 @@ pub fn link_to_target(store_path: &Path, target_path: &Path, strategy: LinkStrat
         // block-clone" from "this one file couldn't be cloned" (#508).
         let reflink_err = match try_reflink(store_path, target_path) {
             Ok(()) => {
-                if matches!(strategy, LinkStrategy::Copy) {
-                    // Reflink preserves source mode (0o444 for stored blobs);
-                    // executables/dylibs need 0o755 so cargo can run/load them.
-                    set_executable_perms(target_path)?;
+                match strategy {
+                    LinkStrategy::Hardlink => {}
+                    // Reflink preserves source mode (read-only for stored
+                    // blobs). Independent restores need consumer-facing
+                    // permissions without discarding umask-shaped read bits.
+                    LinkStrategy::Copy => set_executable_permissions(target_path)?,
                 }
                 tracing::debug!(
                     "reflinked {} -> {}",
@@ -551,14 +545,14 @@ fn windows_volume_root(path: &Path) -> Option<String> {
     Some(String::from_utf16_lossy(&root[..len]))
 }
 
-/// Set 0o755 on a file. Applied after a successful reflink for the Copy
-/// strategy because the reflink preserves the source's 0o444 mode.
-fn set_executable_perms(path: &Path) -> Result<()> {
+/// Set 0o755 after an executable/dylib reflink. Reflink preserves the store
+/// blob's read-only mode, but runtime-loaded artifacts must be executable.
+fn set_executable_permissions(path: &Path) -> Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         fs::set_permissions(path, fs::Permissions::from_mode(0o755))
-            .with_context(|| format!("setting executable perms on {}", path.display()))?;
+            .with_context(|| format!("setting executable permissions on {}", path.display()))?;
     }
     #[cfg(not(unix))]
     {
@@ -783,6 +777,96 @@ fn copy_file(src: &Path, dst: &Path, executable: bool) -> Result<()> {
 
     tracing::debug!("copied {} -> {}", src.display(), dst.display());
     Ok(())
+}
+
+/// A fully-written C/C++ cache artifact awaiting no-clobber publication.
+///
+/// The staging file is created in the target directory with the same requested
+/// mode as a compiler output (`0666`). The kernel therefore applies the current
+/// umask and any inherited default ACL exactly where the final file will live.
+/// No metadata operation is performed through the final pathname.
+pub(crate) struct PreparedWritableTarget {
+    staged: tempfile::NamedTempFile,
+    target: PathBuf,
+    bytes: u64,
+}
+
+impl PreparedWritableTarget {
+    pub(crate) fn target(&self) -> &Path {
+        &self.target
+    }
+
+    pub(crate) fn publish(self) -> Result<()> {
+        let target = self.target;
+        self.staged
+            .persist_noclobber(&target)
+            .map_err(|error| error.error)
+            .with_context(|| {
+                format!(
+                    "publishing cc output without replacing {}",
+                    target.display()
+                )
+            })?;
+        crate::opcounts::record_copied(self.bytes);
+        Ok(())
+    }
+}
+
+fn new_writable_staging_file(target: &Path) -> Result<tempfile::NamedTempFile> {
+    let parent = target
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(".kache-cc-restore-");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(fs::Permissions::from_mode(0o666));
+    }
+    builder
+        .tempfile_in(parent)
+        .with_context(|| format!("creating cc restore staging file in {}", parent.display()))
+}
+
+/// Prepare cached file bytes without touching an existing target entry.
+pub(crate) fn prepare_writable_target_from_file(
+    src: &Path,
+    target: &Path,
+) -> Result<PreparedWritableTarget> {
+    let mut source = fs::File::open(src)
+        .with_context(|| format!("opening cached cc artifact {}", src.display()))?;
+    let mut staged = new_writable_staging_file(target)?;
+    let bytes = std::io::copy(&mut source, &mut staged).with_context(|| {
+        format!(
+            "copying cached cc artifact {} for {}",
+            src.display(),
+            target.display()
+        )
+    })?;
+    Ok(PreparedWritableTarget {
+        staged,
+        target: target.to_path_buf(),
+        bytes,
+    })
+}
+
+/// Prepare transformed C/C++ bytes with the same absent-only guarantee.
+pub(crate) fn prepare_writable_target_from_bytes(
+    target: &Path,
+    content: &[u8],
+) -> Result<PreparedWritableTarget> {
+    use std::io::Write;
+
+    let mut staged = new_writable_staging_file(target)?;
+    staged
+        .write_all(content)
+        .with_context(|| format!("writing staged cc output for {}", target.display()))?;
+    Ok(PreparedWritableTarget {
+        staged,
+        target: target.to_path_buf(),
+        bytes: content.len() as u64,
+    })
 }
 
 /// Remove any file already at `target_path` so a fresh clone / hardlink /
@@ -1150,6 +1234,105 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn writable_copy_is_private_and_compiler_writable() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let blob = dir.path().join("blob.o");
+        fs::write(&blob, b"cached object").unwrap();
+        fs::set_permissions(&blob, fs::Permissions::from_mode(0o400)).unwrap();
+
+        let output = dir.path().join("output.o");
+        prepare_writable_target_from_file(&blob, &output)
+            .unwrap()
+            .publish()
+            .unwrap();
+
+        assert_ne!(
+            fs::metadata(&output).unwrap().permissions().mode() & 0o200,
+            0,
+            "restore must be owner-writable regardless of blob permissions"
+        );
+        assert_ne!(
+            fs::metadata(&blob).unwrap().ino(),
+            fs::metadata(&output).unwrap().ino(),
+            "writable output must never share the blob inode"
+        );
+        fs::write(&output, b"changed").unwrap();
+        assert_eq!(fs::read(&blob).unwrap(), b"cached object");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn writable_copy_is_private_and_writable_on_windows() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob = dir.path().join("blob.obj");
+        fs::write(&blob, b"cached object").unwrap();
+        let mut perms = fs::metadata(&blob).unwrap().permissions();
+        perms.set_readonly(true);
+        fs::set_permissions(&blob, perms).unwrap();
+
+        let output = dir.path().join("output.obj");
+        prepare_writable_target_from_file(&blob, &output)
+            .unwrap()
+            .publish()
+            .unwrap();
+
+        assert!(!fs::metadata(&output).unwrap().permissions().readonly());
+        fs::write(&output, b"changed").unwrap();
+        assert_eq!(fs::read(&blob).unwrap(), b"cached object");
+        assert!(fs::metadata(&blob).unwrap().permissions().readonly());
+
+        let mut perms = fs::metadata(&blob).unwrap().permissions();
+        #[allow(clippy::permissions_set_readonly_false)]
+        perms.set_readonly(false);
+        fs::set_permissions(&blob, perms).unwrap();
+    }
+
+    #[test]
+    fn writable_materializers_never_replace_existing_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob = dir.path().join("blob.o");
+        let linked = dir.path().join("linked.o");
+        let written = dir.path().join("written.d");
+        fs::write(&blob, b"cached").unwrap();
+        fs::write(&linked, b"race winner").unwrap();
+        fs::write(&written, b"race winner").unwrap();
+
+        #[cfg(windows)]
+        for target in [&linked, &written] {
+            let mut permissions = fs::metadata(target).unwrap().permissions();
+            permissions.set_readonly(true);
+            fs::set_permissions(target, permissions).unwrap();
+        }
+
+        assert!(
+            prepare_writable_target_from_file(&blob, &linked)
+                .unwrap()
+                .publish()
+                .is_err()
+        );
+        assert!(
+            prepare_writable_target_from_bytes(&written, b"cached depinfo")
+                .unwrap()
+                .publish()
+                .is_err()
+        );
+        assert_eq!(fs::read(&linked).unwrap(), b"race winner");
+        assert_eq!(fs::read(&written).unwrap(), b"race winner");
+
+        #[cfg(windows)]
+        for target in [&linked, &written] {
+            let mut permissions = fs::metadata(target).unwrap().permissions();
+            assert!(permissions.readonly(), "refusal must not chmod the target");
+            #[allow(clippy::permissions_set_readonly_false)]
+            permissions.set_readonly(false);
+            fs::set_permissions(target, permissions).unwrap();
+        }
+    }
+
     #[test]
     fn test_copy_strategy() {
         let dir = tempfile::tempdir().unwrap();
@@ -1352,6 +1535,50 @@ Unified_mm_ettings-WrongChannel0.o: Unified_mm_ettings-WrongChannel0.mm \\
             0o200,
             "executable should be writable: {mode:#o}"
         );
+    }
+
+    #[test]
+    fn executable_permission_helper_restores_consumer_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("restored-executable");
+        fs::write(&path, b"executable").unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o400)).unwrap();
+        }
+        #[cfg(not(unix))]
+        {
+            let mut permissions = fs::metadata(&path).unwrap().permissions();
+            permissions.set_readonly(true);
+            fs::set_permissions(&path, permissions).unwrap();
+        }
+
+        set_executable_permissions(&path).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o755
+            );
+        }
+        #[cfg(not(unix))]
+        assert!(!fs::metadata(&path).unwrap().permissions().readonly());
+    }
+
+    #[test]
+    fn writable_staging_file_is_created_beside_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("outputs");
+        fs::create_dir(&parent).unwrap();
+        let target = parent.join("output.o");
+
+        let staged = new_writable_staging_file(&target).unwrap();
+
+        assert_eq!(staged.path().parent(), Some(parent.as_path()));
     }
 
     #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -582,8 +582,21 @@ const KACHE_ACTIVE_ENV: &str = "KACHE_ACTIVE";
 /// Incremental flags are stripped (rustc-only — a no-op on cc args) to
 /// prevent APFS-related corruption in git worktrees on macOS. Returns
 /// the child's exit code.
-fn run_compiler_directly(args: &[String]) -> Result<i32> {
-    // A previous cache-on build may have restored this crate's outputs
+fn run_compiler_directly(config: &config::Config, args: &[String]) -> Result<i32> {
+    if is_cc_compiler_invocation(args) {
+        let parsed = compiler::cc::CcArgs::parse(args)?;
+        wrapper::refuse_legacy_cc_blob_outputs(config, &parsed)?;
+    }
+
+    run_compiler_process_directly(args)
+}
+
+fn is_cc_compiler_invocation(args: &[String]) -> bool {
+    compiler::detect_compiler(args).is_some_and(|adapter| adapter.id() == compiler::cc::CC_ID)
+}
+
+fn run_compiler_process_directly(args: &[String]) -> Result<i32> {
+    // A previous rustc cache-on build may have restored this crate's outputs
     // as read-only hardlinks into the store (0o444, shared inode).
     // Running the real compiler over them in place would fail with
     // EACCES — and a chmod could not help, since the inode is shared
@@ -593,10 +606,13 @@ fn run_compiler_directly(args: &[String]) -> Result<i32> {
     // before recompiling. Without this, `KACHE_DISABLED=1` (or a nested
     // re-entrant compile) over a warm target dir breaks the build.
     //
-    // Best-effort and rustc-shaped: the arg parser is lenient, so a cc
-    // argv yields just its `-o` target (also a read-only restore) and an
-    // unparseable argv cleans nothing.
-    if let Ok(parsed) = args::RustcArgs::parse(args) {
+    // This is deliberately rustc-only. C/C++ output paths have compiler-
+    // specific symlink, hardlink, device, and read-only behavior (#645), and
+    // their cache restores are now writable independent files that need no
+    // pre-clean.
+    if let Some(rustc_args) = rustc_args_for_direct_preclean(args)
+        && let Ok(parsed) = args::RustcArgs::parse(rustc_args)
+    {
         compile::pre_clean_outputs(
             parsed.output.as_deref(),
             parsed.out_dir.as_deref(),
@@ -615,6 +631,15 @@ fn run_compiler_directly(args: &[String]) -> Result<i32> {
     Ok(status.code().unwrap_or(1))
 }
 
+fn rustc_args_for_direct_preclean(args: &[String]) -> Option<&[String]> {
+    match compiler::detect_compiler(args) {
+        Some(adapter) if adapter.id() == compiler::rustc::RUSTC_ID => Some(args),
+        Some(_) => None,
+        None if compiler::is_workspace_wrapper_chain(args) => Some(&args[1..]),
+        None => None,
+    }
+}
+
 fn run_wrapper_mode(args: &[String]) -> Result<()> {
     // Re-entrancy guard. If a child compiler kache spawns is itself a
     // kache wrapper — e.g. `cc` on PATH shadowed by `kache cc` — the
@@ -624,7 +649,8 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
     // it is nested. This runs before the `disabled` check below, so
     // the loop is broken even when caching is turned off.
     if std::env::var_os(KACHE_ACTIVE_ENV).is_some() {
-        std::process::exit(run_compiler_directly(args)?);
+        let config = config::Config::load()?;
+        std::process::exit(run_compiler_directly(&config, args)?);
     }
     // SAFETY: wrapper startup is single-threaded — no threads are
     // spawned before this point — so mutating the process environment
@@ -638,7 +664,7 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
 
     if config.disabled {
         // Caching off — pass straight through to the real compiler.
-        std::process::exit(run_compiler_directly(args)?);
+        std::process::exit(run_compiler_directly(&config, args)?);
     }
 
     // Compiler-family probe (`kache -E <file>` from the `cc` Rust
@@ -658,7 +684,7 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
                 program = ?args.first(),
                 "compiler has no cache adapter; passing through uncached"
             );
-            std::process::exit(run_compiler_directly(args)?);
+            std::process::exit(run_compiler_directly(&config, args)?);
         }
         anyhow::bail!(
             "wrapper-mode dispatched but no compiler adapter matched argv[0] = {:?}",
@@ -695,6 +721,15 @@ fn parse_duration_hours(s: &str) -> Option<u64> {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn write_success_program(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let shell = compiler::resolve_program_on_path("sh").expect("sh must be available on PATH");
+        std::fs::write(path, format!("#!{}\nexit 0\n", shell.display())).unwrap();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
     #[test]
     fn test_parse_duration_hours() {
         assert_eq!(parse_duration_hours("7d"), Some(168));
@@ -710,8 +745,50 @@ mod tests {
         // `args[0]` is the program, `args[1..]` its args. The unix
         // `true` / `false` utilities are the simplest stand-ins for a
         // compiler: they exit 0 / 1 and ignore their arguments.
-        assert_eq!(run_compiler_directly(&["true".to_string()]).unwrap(), 0);
-        assert_eq!(run_compiler_directly(&["false".to_string()]).unwrap(), 1);
+        assert_eq!(
+            run_compiler_process_directly(&["true".to_string()]).unwrap(),
+            0
+        );
+        assert_eq!(
+            run_compiler_process_directly(&["false".to_string()]).unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn rustc_args_for_direct_preclean_truth_table() {
+        let rustc = vec!["rustc".to_string()];
+        assert_eq!(
+            rustc_args_for_direct_preclean(&rustc),
+            Some(rustc.as_slice())
+        );
+
+        let cc = vec!["cc".to_string()];
+        assert_eq!(rustc_args_for_direct_preclean(&cc), None);
+
+        let chained = vec![
+            "/tmp/outer-wrapper".to_string(),
+            "rustc".to_string(),
+            "--crate-name".to_string(),
+        ];
+        assert_eq!(
+            rustc_args_for_direct_preclean(&chained),
+            Some(&chained[1..])
+        );
+
+        let unknown = vec![
+            "/tmp/outer-wrapper".to_string(),
+            "other-tool".to_string(),
+            "--crate-name".to_string(),
+        ];
+        assert_eq!(rustc_args_for_direct_preclean(&unknown), None);
+    }
+
+    #[test]
+    fn direct_cc_safety_check_applies_only_to_cc_invocations() {
+        assert!(is_cc_compiler_invocation(&["cc".to_string()]));
+        assert!(!is_cc_compiler_invocation(&["rustc".to_string()]));
+        assert!(!is_cc_compiler_invocation(&["other-tool".to_string()]));
     }
 
     #[cfg(unix)]
@@ -724,6 +801,8 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().unwrap();
+        let fake_rustc = dir.path().join("rustc");
+        write_success_program(&fake_rustc);
         let restored = dir.path().join("libfoo.rlib");
         std::fs::write(&restored, b"cached").unwrap();
         std::fs::set_permissions(&restored, std::fs::Permissions::from_mode(0o444)).unwrap();
@@ -734,10 +813,10 @@ mod tests {
                 .readonly()
         );
 
-        // `true` stands in for the compiler (ignores args, exits 0); the
+        // A `rustc`-named symlink to `true` stands in for the compiler; the
         // rustc-shaped flags drive the pre-clean's out-dir branch.
-        let code = run_compiler_directly(&[
-            "true".to_string(),
+        let code = run_compiler_process_directly(&[
+            fake_rustc.to_string_lossy().into_owned(),
             "--crate-name".to_string(),
             "foo".to_string(),
             "--out-dir".to_string(),
@@ -750,6 +829,65 @@ mod tests {
             !restored.exists(),
             "read-only restore should have been unlinked before exec"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_compiler_directly_pre_cleans_workspace_wrapper_chain_restores() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let outer_wrapper = dir.path().join("outer-wrapper");
+        write_success_program(&outer_wrapper);
+        let fake_rustc = dir.path().join("rustc");
+        write_success_program(&fake_rustc);
+        let restored = dir.path().join("libfoo.rlib");
+        std::fs::write(&restored, b"cached").unwrap();
+        std::fs::set_permissions(&restored, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+        let code = run_compiler_process_directly(&[
+            outer_wrapper.to_string_lossy().into_owned(),
+            fake_rustc.to_string_lossy().into_owned(),
+            "--crate-name".to_string(),
+            "foo".to_string(),
+            "--out-dir".to_string(),
+            dir.path().to_string_lossy().into_owned(),
+        ])
+        .unwrap();
+
+        assert_eq!(code, 0);
+        assert!(
+            !restored.exists(),
+            "workspace-wrapper chains must pre-clean the inner rustc outputs"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_compiler_directly_preserves_cc_readonly_output() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let fake_cc = dir.path().join("cc");
+        write_success_program(&fake_cc);
+        let output = dir.path().join("user-owned.o");
+        std::fs::write(&output, b"original").unwrap();
+        std::fs::set_permissions(&output, std::fs::Permissions::from_mode(0o444)).unwrap();
+        let before = std::fs::metadata(&output).unwrap();
+
+        let code = run_compiler_process_directly(&[
+            fake_cc.to_string_lossy().into_owned(),
+            "-c".to_string(),
+            "foo.c".to_string(),
+            "-o".to_string(),
+            output.to_string_lossy().into_owned(),
+        ])
+        .unwrap();
+
+        assert_eq!(code, 0);
+        let after = std::fs::metadata(&output).unwrap();
+        assert_eq!((after.dev(), after.ino()), (before.dev(), before.ino()));
+        assert_eq!(std::fs::read(&output).unwrap(), b"original");
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -104,6 +104,14 @@ fn hardlink_eligible(store_name: &str, executable: bool) -> bool {
     }
 }
 
+fn source_hardlink_allowed(
+    allow_source_hardlinks: bool,
+    store_name: &str,
+    executable: bool,
+) -> bool {
+    allow_source_hardlinks && hardlink_eligible(store_name, executable)
+}
+
 /// How a new blob was staged into the store before publish. Counters are
 /// recorded only when this call actually publishes (`atomic_write_and_replace`
 /// returns `true`); a concurrent winner already accounted for their ingest,
@@ -273,6 +281,10 @@ fn paths_share_inode(a: &Path, b: &Path) -> bool {
         let _ = (a, b);
         false
     }
+}
+
+fn metadata_is_readonly_regular(metadata: &fs::Metadata) -> bool {
+    metadata.file_type().is_file() && metadata.permissions().readonly()
 }
 
 /// After a hardlink ingest that did not publish, clear read-only on `source`
@@ -1520,6 +1532,67 @@ impl Store {
         stderr: &str,
         compile_time_ms: u64,
     ) -> Result<StorePutResult> {
+        self.put_with_compile_time_policy(
+            cache_key,
+            crate_name,
+            crate_types,
+            features,
+            target,
+            profile,
+            output_files,
+            stdout,
+            stderr,
+            compile_time_ms,
+            true,
+        )
+    }
+
+    /// Store outputs without ever sharing the compiler output inode with the
+    /// read-only blob. Reflinks remain eligible because they provide CoW
+    /// isolation; the fallback is a byte copy rather than a hardlink.
+    pub(crate) fn put_with_compile_time_independent(
+        &self,
+        cache_key: &str,
+        crate_name: &str,
+        crate_types: &[String],
+        features: &[String],
+        target: &str,
+        profile: &str,
+        output_files: &[(PathBuf, String)],
+        stdout: &str,
+        stderr: &str,
+        compile_time_ms: u64,
+    ) -> Result<StorePutResult> {
+        self.put_with_compile_time_policy(
+            cache_key,
+            crate_name,
+            crate_types,
+            features,
+            target,
+            profile,
+            output_files,
+            stdout,
+            stderr,
+            compile_time_ms,
+            false,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn put_with_compile_time_policy(
+        &self,
+        cache_key: &str,
+        crate_name: &str,
+        crate_types: &[String],
+        features: &[String],
+        target: &str,
+        profile: &str,
+        output_files: &[(PathBuf, String)],
+        stdout: &str,
+        stderr: &str,
+        compile_time_ms: u64,
+        allow_source_hardlinks: bool,
+    ) -> Result<StorePutResult> {
         let entry_dir = self.entry_dir(cache_key);
         fs::create_dir_all(&entry_dir).context("creating entry directory")?;
 
@@ -1530,7 +1603,7 @@ impl Store {
         // half-registered entry. `sources` is kept so Phase 2 can
         // re-materialize a blob if a concurrent remove unlinks it.
         let mut cached_files = Vec::new();
-        let mut sources: Vec<PathBuf> = Vec::new();
+        let mut sources: Vec<(PathBuf, bool)> = Vec::new();
         let mut seen_output_blobs = std::collections::HashSet::new();
         let mut put_result = StorePutResult::default();
         let mut total_size = 0u64;
@@ -1553,11 +1626,9 @@ impl Store {
                 }
             }
 
-            materialize_blob(
-                source_path,
-                &self.blob_path(&hash),
-                hardlink_eligible(store_name, executable),
-            )?;
+            let use_source_hardlink =
+                source_hardlink_allowed(allow_source_hardlinks, store_name, executable);
+            materialize_blob(source_path, &self.blob_path(&hash), use_source_hardlink)?;
 
             cached_files.push(CachedFile {
                 name: store_name.clone(),
@@ -1565,7 +1636,7 @@ impl Store {
                 hash,
                 executable,
             });
-            sources.push(source_path.clone());
+            sources.push((source_path.clone(), use_source_hardlink));
         }
 
         let content_hash = compute_content_hash(&cached_files);
@@ -1608,7 +1679,7 @@ impl Store {
         let crate_type_str = crate_types.join(",");
         let num_features = features.len() as i64;
         let tx = self.db.unchecked_transaction()?;
-        for (file, source) in meta.files.iter().zip(sources.iter()) {
+        for (file, (source, use_source_hardlink)) in meta.files.iter().zip(sources.iter()) {
             let inserted = tx.execute(
                 "INSERT OR IGNORE INTO blobs (hash, size, refcount) VALUES (?1, ?2, 1)",
                 params![file.hash, file.size as i64],
@@ -1624,11 +1695,7 @@ impl Store {
             // so a concurrent reclaim cannot interleave here. If a remove
             // unlinked this blob between Phase 1 and now, re-materialize it from
             // the source before we commit a reference to it.
-            materialize_blob(
-                source,
-                &self.blob_path(&file.hash),
-                hardlink_eligible(&file.name, file.executable),
-            )?;
+            materialize_blob(source, &self.blob_path(&file.hash), *use_source_hardlink)?;
         }
         tx.execute(
             "INSERT OR REPLACE INTO entries (cache_key, crate_name, crate_type, profile, num_features, size, content_hash, compile_time_ms, committed) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1)",
@@ -2010,6 +2077,42 @@ impl Store {
     /// Layout: store/blobs/{first 2 hex chars}/{full hash}
     pub fn blob_path(&self, hash: &str) -> PathBuf {
         blob_path_in_store_dir(&self.config.store_dir(), hash)
+    }
+
+    /// Return the content-addressed blob whose inode a read-only output still
+    /// shares, if any.
+    ///
+    /// Older C/C++ restores could hardlink a build output to a read-only store
+    /// blob. Passing that pathname to a compiler as root can truncate the blob
+    /// and corrupt every cache entry that references it. This check is strictly
+    /// read-only; callers fail closed instead of trying a racy path-based unlink.
+    pub(crate) fn matching_readonly_blob_inode(
+        store_dir: &Path,
+        output: &Path,
+    ) -> Result<Option<PathBuf>> {
+        let Ok(initial) = fs::metadata(output) else {
+            return Ok(None);
+        };
+        if !metadata_is_readonly_regular(&initial) {
+            return Ok(None);
+        }
+
+        let hash = crate::cache_key::hash_file(output)
+            .with_context(|| format!("hashing possible legacy output {}", output.display()))?;
+        let blob = blob_path_in_store_dir(store_dir, &hash);
+        if !blob.is_file() {
+            return Ok(None);
+        }
+
+        // Recheck after hashing. A concurrent path swap can only make this
+        // check fail closed; no pathname is ever mutated here.
+        let Ok(current) = fs::metadata(output) else {
+            return Ok(None);
+        };
+        if !metadata_is_readonly_regular(&current) {
+            return Ok(None);
+        }
+        Ok(paths_share_inode(output, &blob).then_some(blob))
     }
 
     /// Directory containing all blobs.
@@ -3001,6 +3104,32 @@ mod tests {
     use super::*;
     use crate::eviction::EvictionPolicy as _;
 
+    #[test]
+    fn readonly_regular_metadata_requires_both_properties() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("artifact");
+        fs::write(&file, b"artifact").unwrap();
+
+        assert!(!metadata_is_readonly_regular(&fs::metadata(&file).unwrap()));
+
+        let mut permissions = fs::metadata(&file).unwrap().permissions();
+        permissions.set_readonly(true);
+        fs::set_permissions(&file, permissions).unwrap();
+        assert!(metadata_is_readonly_regular(&fs::metadata(&file).unwrap()));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let readonly_dir = dir.path().join("readonly-dir");
+            fs::create_dir(&readonly_dir).unwrap();
+            fs::set_permissions(&readonly_dir, fs::Permissions::from_mode(0o555)).unwrap();
+            assert!(!metadata_is_readonly_regular(
+                &fs::metadata(&readonly_dir).unwrap()
+            ));
+        }
+    }
+
     // Regression guard for #324: the local content-dedup hash must distinguish
     // entries that the old (bare-hash, 16-hex-truncated) fold could collide —
     // otherwise `evict_duplicate_entries` keeps the wrong survivor.
@@ -3076,6 +3205,56 @@ mod tests {
         assert!(!hardlink_eligible("serde-abc123.d", false));
         assert!(!hardlink_eligible("my-binary", false));
         assert!(!hardlink_eligible("libserde-abc123.rlib", true));
+    }
+
+    #[test]
+    fn source_hardlink_policy_honors_independent_storage() {
+        assert!(!source_hardlink_allowed(false, "foo.o", false));
+        assert_eq!(
+            source_hardlink_allowed(true, "foo.o", false),
+            hardlink_eligible("foo.o", false)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn independent_put_never_hardlinks_or_marks_source_readonly() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let output = dir.path().join("compiler-output.o");
+        fs::write(&output, b"independent cc artifact").unwrap();
+        fs::set_permissions(&output, fs::Permissions::from_mode(0o660)).unwrap();
+
+        store
+            .put_with_compile_time_independent(
+                "cc-independent",
+                "foo.c",
+                &[],
+                &[],
+                "x86_64-unknown-linux-gnu",
+                "",
+                &[(output.clone(), "foo.o".to_string())],
+                "",
+                "",
+                1,
+            )
+            .unwrap();
+
+        let meta = store.get("cc-independent").unwrap().unwrap();
+        let blob = store.blob_path(&meta.files[0].hash);
+        let output_meta = fs::metadata(&output).unwrap();
+        let blob_meta = fs::metadata(&blob).unwrap();
+        assert_eq!(output_meta.permissions().mode() & 0o777, 0o660);
+        assert!(!output_meta.permissions().readonly());
+        assert_ne!(
+            (output_meta.dev(), output_meta.ino()),
+            (blob_meta.dev(), blob_meta.ino()),
+            "independent ingest must never share the compiler output inode"
+        );
+        assert!(blob_meta.permissions().readonly());
     }
 
     /// A mutable-kind blob must never share an inode with the build's output:

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -378,6 +378,17 @@ fn event_result_for_store_put(put: StorePutResult) -> EventResult {
     }
 }
 
+fn should_store_cc_result(exit_code: i32, has_artifacts: bool) -> bool {
+    exit_code == 0 && has_artifacts
+}
+
+fn cc_output_path_requires_passthrough(path: &Path) -> bool {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => true,
+        Err(error) => error.kind() != std::io::ErrorKind::NotFound,
+    }
+}
+
 /// Forward a `cc`-crate compiler-family probe (`kache -E <file>`) to
 /// the real underlying compiler.
 ///
@@ -484,14 +495,19 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             compiler.id().as_str(),
             reasons.join("; ")
         );
-        return cc_passthrough_with_event(
-            config,
-            &parsed,
-            &crate_name,
-            &event_root,
-            start,
-            refuse_reason_string(&refuse),
-        );
+        let reason = refuse_reason_string(&refuse);
+        return if parsed.requires_compiler_output_semantics() {
+            cc_direct_passthrough_with_event(
+                config,
+                &parsed,
+                &crate_name,
+                &event_root,
+                start,
+                reason,
+            )
+        } else {
+            cc_passthrough_with_event(config, &parsed, &crate_name, &event_root, start, reason)
+        };
     }
 
     let current_dir = std::env::current_dir().ok();
@@ -598,6 +614,9 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         } else {
             let restore_start = std::time::Instant::now();
             if let Err(e) = restore_cc_from_cache(&store, &parsed, &meta) {
+                if e.downcast_ref::<PartialCcRestore>().is_some() {
+                    return Err(e);
+                }
                 tracing::warn!(
                     "restoring cc cache hit for {} failed: {} — recompiling",
                     crate_name,
@@ -649,6 +668,19 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     }
 
     // ── Cache miss — compile, then store ─────────────────────────
+    // Key generation and lookup can take long enough for another process to
+    // create an output. Recheck at the last possible wrapper boundary and run
+    // the selected compiler directly if its pathname semantics are now needed.
+    if parsed.requires_compiler_output_semantics() {
+        return cc_direct_passthrough_with_event(
+            config,
+            &parsed,
+            &crate_name,
+            &event_root,
+            start,
+            "output appeared before compiler execution",
+        );
+    }
     let compile_start = std::time::Instant::now();
     let result = match compiler.execute(&parsed) {
         Ok(r) => r,
@@ -683,44 +715,45 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let store_start = std::time::Instant::now();
     let mut store_put = StorePutResult::default();
     let mut store_error = String::new();
-    if result.exit_code == 0 && !result.artifacts.is_empty() {
+    if should_store_cc_result(result.exit_code, !result.artifacts.is_empty()) {
         let depinfo_anchor = cc_depinfo_rewrite_root(&parsed);
-        if let Some(anchor) = depinfo_anchor.as_deref() {
-            rewrite_depinfo_outputs(&result.artifacts, anchor, link::DepInfoMode::Relativize);
-        }
-
         let target = parsed.cache_target_arch();
-        let store_files = result.artifacts.store_files();
-        match store.put_with_compile_time(
-            &cache_key,
-            &crate_name,
-            &[], // crate_types: n/a for cc objects
-            &[], // features: n/a
-            &target,
-            "", // profile: n/a (opt level is in the key)
-            &store_files,
-            &result.stdout,
-            &result.stderr,
-            compile_time_ms,
-        ) {
-            Ok(result) => {
-                store_put = result;
-                // Store grew — throttled size check + detached background GC if over
-                // budget (kunobi-ninja/kache#497). Never blocks the compile path.
-                maybe_spawn_auto_gc(config, &store);
-            }
+        match prepare_cc_store_files(&result.artifacts, depinfo_anchor.as_deref()) {
+            Ok(prepared) => match store.put_with_compile_time_independent(
+                &cache_key,
+                &crate_name,
+                &[], // crate_types: n/a for cc objects
+                &[], // features: n/a
+                &target,
+                "", // profile: n/a (opt level is in the key)
+                &prepared.files,
+                &result.stdout,
+                &result.stderr,
+                compile_time_ms,
+            ) {
+                Ok(result) => {
+                    store_put = result;
+                    // Store grew — throttled size check + detached background GC if over
+                    // budget (kunobi-ninja/kache#497). Never blocks the compile path.
+                    maybe_spawn_auto_gc(config, &store);
+                }
+                Err(e) => {
+                    store_error = store_error_for_event(&e);
+                    tracing::warn!(
+                        "failed to store cc cache entry for {}: {}",
+                        crate_name,
+                        store_error
+                    );
+                }
+            },
             Err(e) => {
                 store_error = store_error_for_event(&e);
                 tracing::warn!(
-                    "failed to store cc cache entry for {}: {}",
+                    "failed to prepare cc cache entry for {}: {}",
                     crate_name,
                     store_error
                 );
             }
-        }
-
-        if let Some(anchor) = depinfo_anchor.as_deref() {
-            rewrite_depinfo_outputs(&result.artifacts, anchor, link::DepInfoMode::Expand);
         }
     }
     let store_ms = store_start.elapsed().as_millis() as u64;
@@ -769,14 +802,32 @@ fn refuse_reason_string(refuse: &[crate::compiler::RefuseReason]) -> String {
 /// Run a cc-family invocation without caching — invoke the compiler
 /// with the original argv, propagate stdout / stderr / exit.
 fn cc_passthrough(
+    config: &Config,
     parsed: &crate::compiler::cc::CcArgs,
-    fallback: Option<&str>,
+) -> Result<PassthroughOutput> {
+    cc_passthrough_impl(config, parsed, false)
+}
+
+fn cc_direct_passthrough(
+    config: &Config,
+    parsed: &crate::compiler::cc::CcArgs,
+) -> Result<PassthroughOutput> {
+    cc_passthrough_impl(config, parsed, true)
+}
+
+fn cc_passthrough_impl(
+    config: &Config,
+    parsed: &crate::compiler::cc::CcArgs,
+    force_direct: bool,
 ) -> Result<PassthroughOutput> {
     // Configured fallback wrapper: `<fallback> <cc> <args>`.
     // kache's C/C++ coverage is narrower than its rustc support, so
     // the fallback is most valuable on this path. Falls through to a
     // plain passthrough if the fallback is not on PATH.
-    if let Some(fb) = fallback {
+    if let Some(fb) = config.fallback.as_deref()
+        && !force_direct
+        && !parsed.requires_compiler_output_semantics()
+    {
         let mut cmd = std::process::Command::new(fb);
         cmd.arg(&parsed.program);
         cmd.args(&parsed.rest);
@@ -785,18 +836,39 @@ fn cc_passthrough(
         }
     }
 
-    let compiler = CcCompiler::new();
-    let result = compiler.execute(parsed)?;
-    if !result.stdout.is_empty() {
-        print!("{}", result.stdout);
-    }
-    if !result.stderr.is_empty() {
-        eprint!("{}", result.stderr);
-    }
+    // A refusal means Kache has promised to preserve the selected compiler's
+    // behavior exactly. The cache-miss execution path injects prefix-map flags
+    // and SOURCE_DATE_EPOCH for reproducible cache entries, so it cannot be
+    // reused here: even an added flag can change how a compiler replaces an
+    // existing output path (#645).
+    refuse_legacy_cc_blob_outputs(config, parsed)?;
+    crate::opcounts::record_compiler_run();
+    let status = std::process::Command::new(&parsed.program)
+        .args(&parsed.rest)
+        .status()
+        .with_context(|| format!("executing {}", parsed.program))?;
     Ok(PassthroughOutput {
-        exit_code: result.exit_code,
+        exit_code: status.code().unwrap_or(1),
         fallback: false,
     })
+}
+
+pub(crate) fn refuse_legacy_cc_blob_outputs(
+    config: &Config,
+    parsed: &crate::compiler::cc::CcArgs,
+) -> Result<()> {
+    let store_dir = config.store_dir();
+    for output in parsed.compiler_output_paths() {
+        if let Some(blob) = Store::matching_readonly_blob_inode(&store_dir, &output)? {
+            anyhow::bail!(
+                "refusing to invoke the compiler because {} still shares the \
+                 read-only cache blob {}; remove the build output and retry",
+                output.display(),
+                blob.display()
+            );
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -936,18 +1008,113 @@ fn common_path_prefix(left: &Path, right: &Path) -> Option<std::path::PathBuf> {
     matched.then_some(prefix)
 }
 
+#[derive(Debug)]
+struct PartialCcRestore;
+
+impl std::fmt::Display for PartialCcRestore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("cc cache restore published only part of the output set")
+    }
+}
+
+impl std::error::Error for PartialCcRestore {}
+
+fn prepare_cc_cached_artifact(
+    store: &Store,
+    cached: &crate::store::CachedFile,
+    target: &Path,
+    kind: ArtifactKind,
+    depinfo_anchor: &Path,
+) -> Result<link::PreparedWritableTarget> {
+    let plan = plan_post_restore(kind);
+    anyhow::ensure!(
+        plan.iter().all(|action| action.is_content_transform()),
+        "cc restore: artifact requires a post-publish path mutation"
+    );
+
+    let blob = store.blob_path(&cached.hash);
+    if !blob.exists() {
+        anyhow::bail!(
+            "cc restore: blob for {} (hash {}) was evicted before restore: {}",
+            cached.name,
+            &cached.hash[..16.min(cached.hash.len())],
+            blob.display()
+        );
+    }
+
+    if plan.is_empty() {
+        return link::prepare_writable_target_from_file(&blob, target).with_context(|| {
+            format!(
+                "cc restore: staging {} -> {}",
+                blob.display(),
+                target.display()
+            )
+        });
+    }
+
+    let mut content = std::fs::read(&blob)
+        .with_context(|| format!("cc restore: reading blob {}", blob.display()))?;
+    for action in plan {
+        content = action.transform(content, depinfo_anchor);
+    }
+    link::prepare_writable_target_from_bytes(target, &content)
+        .with_context(|| format!("cc restore: staging transformed {}", target.display()))
+}
+
+fn publish_prepared_cc_artifacts(prepared: Vec<link::PreparedWritableTarget>) -> Result<()> {
+    publish_prepared_cc_artifacts_with(prepared, |_, _| Ok(()))
+}
+
+fn publish_prepared_cc_artifacts_with(
+    prepared: Vec<link::PreparedWritableTarget>,
+    mut before_publish: impl FnMut(usize, &Path) -> Result<()>,
+) -> Result<()> {
+    // Validate the whole set before making any final pathname visible.
+    for artifact in &prepared {
+        if cc_output_path_requires_passthrough(artifact.target()) {
+            anyhow::bail!(
+                "cc restore: output path changed and now requires compiler passthrough semantics"
+            );
+        }
+    }
+
+    for (index, artifact) in prepared.into_iter().enumerate() {
+        if let Err(error) = before_publish(index, artifact.target()) {
+            return if index == 0 {
+                Err(error)
+            } else {
+                Err(error.context(PartialCcRestore))
+            };
+        }
+        if let Err(error) = artifact.publish() {
+            return if index == 0 {
+                Err(error)
+            } else {
+                Err(error.context(PartialCcRestore))
+            };
+        }
+    }
+    Ok(())
+}
+
 /// Restore cached cc artifacts to this invocation's output paths.
 ///
-/// Object files go to the current `-o` target. Dep-info sidecars go to the
-/// current `-MF` target, or the compiler's default `.d` next to the object.
+/// Every artifact is staged first, then the set is published absent-only. If a
+/// race wins after publication starts, the caller receives `PartialCcRestore`
+/// and must not run the compiler over the partially restored output set.
 fn restore_cc_from_cache(
     store: &Store,
     parsed: &crate::compiler::cc::CcArgs,
     meta: &crate::store::EntryMeta,
 ) -> Result<()> {
+    if parsed.requires_compiler_output_semantics() {
+        anyhow::bail!("cc restore: existing output requires compiler passthrough semantics");
+    }
+
     let depinfo_anchor =
         cc_depinfo_rewrite_root(parsed).unwrap_or_else(|| Path::new(".").to_path_buf());
-    let platform = platform::current();
+    let mut prepared = Vec::new();
+    let mut targets = std::collections::HashSet::new();
 
     for cached in &meta.files {
         let kind = classify_by_filename(&cached.name);
@@ -975,17 +1142,28 @@ fn restore_cc_from_cache(
             }
         };
 
-        materialize_cached_artifact(
-            &BlobSource::Store(store),
+        // Recheck immediately before the path-based restore. The initial
+        // refusal happens before lookup; this catches ordinary path changes
+        // during key computation and narrows the window before restore.
+        if cc_output_path_requires_passthrough(&target) {
+            anyhow::bail!(
+                "cc restore: output path changed and now requires compiler passthrough semantics"
+            );
+        }
+        anyhow::ensure!(
+            targets.insert(target.clone()),
+            "cc restore: cache entry maps multiple artifacts to {}",
+            target.display()
+        );
+        prepared.push(prepare_cc_cached_artifact(
+            store,
             cached,
             &target,
             kind,
             &depinfo_anchor,
-            &*platform,
-            "cc restore",
-        )?;
+        )?);
     }
-    Ok(())
+    publish_prepared_cc_artifacts(prepared)
 }
 
 /// Run kache in RUSTC_WRAPPER mode.
@@ -1682,6 +1860,68 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     Ok(result.exit_code)
 }
 
+struct PreparedCcStoreFiles {
+    files: Vec<(PathBuf, String)>,
+    _temporary_files: Vec<tempfile::TempPath>,
+}
+
+/// Freeze store inputs without rewriting or later reopening compiler-owned
+/// output paths.
+///
+/// Every artifact is copied into a private temporary file before Store::put
+/// hashes it. This keeps a concurrent replacement of a compiler output from
+/// publishing different bytes under the hash chosen for the original path.
+/// Dep-info normalization happens while creating that private snapshot.
+fn prepare_cc_store_files(
+    artifacts: &ArtifactSet,
+    depinfo_anchor: Option<&Path>,
+) -> Result<PreparedCcStoreFiles> {
+    use std::io::{Read, Write};
+
+    let mut files = Vec::with_capacity(artifacts.outputs().len());
+    let mut temporary_files = Vec::with_capacity(artifacts.outputs().len());
+    for artifact in artifacts.outputs() {
+        let mut staged = tempfile::Builder::new()
+            .prefix("kache-cc-artifact-")
+            .tempfile()
+            .context("cc store: creating private artifact staging file")?;
+
+        if artifact.kind == ArtifactKind::DepInfo {
+            let anchor = depinfo_anchor.context("cc store: missing dep-info rewrite anchor")?;
+            let mut content = String::new();
+            std::fs::File::open(&artifact.path)
+                .with_context(|| format!("cc store: opening dep-info {}", artifact.path.display()))?
+                .read_to_string(&mut content)
+                .with_context(|| {
+                    format!("cc store: reading dep-info {}", artifact.path.display())
+                })?;
+            let normalized =
+                link::rewrite_depinfo_content(&content, anchor, link::DepInfoMode::Relativize);
+            staged
+                .write_all(normalized.as_bytes())
+                .context("cc store: writing normalized dep-info staging file")?;
+        } else {
+            let mut source = std::fs::File::open(&artifact.path).with_context(|| {
+                format!("cc store: opening artifact {}", artifact.path.display())
+            })?;
+            std::io::copy(&mut source, &mut staged).with_context(|| {
+                format!("cc store: copying artifact {}", artifact.path.display())
+            })?;
+        }
+        staged
+            .flush()
+            .context("cc store: flushing private artifact staging file")?;
+        let staged = staged.into_temp_path();
+        files.push((staged.to_path_buf(), artifact.store_name.clone()));
+        temporary_files.push(staged);
+    }
+
+    Ok(PreparedCcStoreFiles {
+        files,
+        _temporary_files: temporary_files,
+    })
+}
+
 /// Rewrite every dep-info (`.d`) file in a compiler artifact set, in place,
 /// against `anchor`.
 ///
@@ -1797,7 +2037,6 @@ fn materialize_cached_artifact(
     };
 
     let strategy = restore_link_strategy(kind, cached_file.executable);
-
     match transformed {
         Some(content) => {
             link::write_restored(target_path, &content, strategy)
@@ -2291,7 +2530,27 @@ fn cc_passthrough_with_event<R: Into<String>>(
     start: std::time::Instant,
     reason: R,
 ) -> Result<i32> {
-    let output = cc_passthrough(parsed, config.fallback.as_deref())?;
+    let output = cc_passthrough(config, parsed)?;
+    log_passthrough_event(
+        config,
+        root,
+        crate_name,
+        start.elapsed().as_millis() as u64,
+        reason.into(),
+        &output,
+    );
+    Ok(output.exit_code)
+}
+
+fn cc_direct_passthrough_with_event<R: Into<String>>(
+    config: &Config,
+    parsed: &crate::compiler::cc::CcArgs,
+    crate_name: &str,
+    root: &str,
+    start: std::time::Instant,
+    reason: R,
+) -> Result<i32> {
+    let output = cc_direct_passthrough(config, parsed)?;
     log_passthrough_event(
         config,
         root,
@@ -3699,6 +3958,60 @@ mod tests {
         );
     }
 
+    #[test]
+    fn cc_store_freezes_private_artifacts_without_mutating_compiler_outputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let object = dir.path().join("foo.o");
+        let depinfo = dir.path().join("foo.d");
+        let original = format!(
+            "{}/foo.o: {}/src/foo.c\n",
+            dir.path().display(),
+            dir.path().display()
+        );
+        std::fs::write(&object, b"object").unwrap();
+        std::fs::write(&depinfo, &original).unwrap();
+        let artifacts = ArtifactSet::new(vec![
+            crate::compiler::Artifact {
+                path: object.clone(),
+                store_name: "foo.o".to_string(),
+                kind: ArtifactKind::Object,
+                required: true,
+            },
+            crate::compiler::Artifact {
+                path: depinfo.clone(),
+                store_name: "foo.d".to_string(),
+                kind: ArtifactKind::DepInfo,
+                required: true,
+            },
+        ]);
+
+        let prepared = prepare_cc_store_files(&artifacts, Some(dir.path())).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&depinfo).unwrap(), original);
+        assert_ne!(prepared.files[0].0, object);
+        assert_ne!(prepared.files[1].0, depinfo);
+        assert_eq!(std::fs::read(&prepared.files[0].0).unwrap(), b"object");
+        assert!(
+            std::fs::read_to_string(&prepared.files[1].0)
+                .unwrap()
+                .contains("__kache_root__/")
+        );
+
+        std::fs::write(&object, b"concurrent replacement").unwrap();
+        std::fs::write(&depinfo, b"concurrent replacement").unwrap();
+        assert_eq!(
+            std::fs::read(&prepared.files[0].0).unwrap(),
+            b"object",
+            "Store::put must read the frozen object snapshot"
+        );
+        assert!(
+            std::fs::read_to_string(&prepared.files[1].0)
+                .unwrap()
+                .contains("__kache_root__/"),
+            "Store::put must read the frozen normalized dep-info snapshot"
+        );
+    }
+
     /// `rewrite_depinfo_outputs` rewrites dep-info files in place and the
     /// relativize→expand round trip re-roots the cached blob's paths at
     /// the restoring build's target dir — the property that lets dep-info
@@ -4007,6 +4320,154 @@ mod tests {
         assert!(
             err.contains("cannot determine object output path"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restore_cc_object_is_writable_private_and_keeps_blob_immutable() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+        let store = Store::open(&config).unwrap();
+        let hash = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        create_blob(&store, hash, b"cached object");
+        std::fs::set_permissions(
+            store.blob_path(hash),
+            std::fs::Permissions::from_mode(0o400),
+        )
+        .unwrap();
+
+        let output = dir.path().join("output.o");
+        let output_str = output.to_string_lossy().into_owned();
+        let parsed = CcCompiler::new()
+            .parse(&s(&["cc", "-c", "foo.c", "-o", &output_str]))
+            .unwrap();
+        let meta = entry_meta("cc-private-key", vec![cached_file("foo.o", hash)], &[]);
+
+        restore_cc_from_cache(&store, &parsed, &meta).unwrap();
+
+        let output_meta = std::fs::metadata(&output).unwrap();
+        let blob_meta = std::fs::metadata(store.blob_path(hash)).unwrap();
+        assert_ne!(output_meta.permissions().mode() & 0o200, 0);
+        assert_eq!(output_meta.permissions().mode() & 0o111, 0);
+        assert_ne!(output_meta.ino(), blob_meta.ino());
+        std::fs::write(&output, b"changed").unwrap();
+        assert_eq!(
+            std::fs::read(store.blob_path(hash)).unwrap(),
+            b"cached object"
+        );
+        assert!(blob_meta.permissions().readonly());
+    }
+
+    #[test]
+    fn cc_restore_marks_partial_publication_and_preserves_race_winner() {
+        let dir = tempfile::tempdir().unwrap();
+        let object = dir.path().join("foo.o");
+        let depinfo = dir.path().join("foo.d");
+        let prepared = vec![
+            link::prepare_writable_target_from_bytes(&object, b"cached object").unwrap(),
+            link::prepare_writable_target_from_bytes(&depinfo, b"cached depinfo").unwrap(),
+        ];
+
+        let error = publish_prepared_cc_artifacts_with(prepared, |index, target| {
+            if index == 1 {
+                std::fs::write(target, b"race winner")?;
+            }
+            Ok(())
+        })
+        .unwrap_err();
+
+        assert!(
+            error.downcast_ref::<PartialCcRestore>().is_some(),
+            "{error:#}"
+        );
+        assert_eq!(
+            error.to_string(),
+            "cc cache restore published only part of the output set"
+        );
+        assert_eq!(std::fs::read(&object).unwrap(), b"cached object");
+        assert_eq!(std::fs::read(&depinfo).unwrap(), b"race winner");
+    }
+
+    #[test]
+    fn cc_restore_classifies_hook_failures_by_publication_progress() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_target = dir.path().join("first.o");
+        let first =
+            vec![link::prepare_writable_target_from_bytes(&first_target, b"first").unwrap()];
+        let first_error = publish_prepared_cc_artifacts_with(first, |_, _| {
+            anyhow::bail!("fail before first publication")
+        })
+        .unwrap_err();
+
+        assert!(first_error.downcast_ref::<PartialCcRestore>().is_none());
+        assert!(!first_target.exists());
+
+        let object = dir.path().join("object.o");
+        let depinfo = dir.path().join("object.d");
+        let prepared = vec![
+            link::prepare_writable_target_from_bytes(&object, b"cached object").unwrap(),
+            link::prepare_writable_target_from_bytes(&depinfo, b"cached depinfo").unwrap(),
+        ];
+        let later_error = publish_prepared_cc_artifacts_with(prepared, |index, _| {
+            if index == 1 {
+                anyhow::bail!("fail after first publication");
+            }
+            Ok(())
+        })
+        .unwrap_err();
+
+        assert!(
+            later_error.downcast_ref::<PartialCcRestore>().is_some(),
+            "{later_error:#}"
+        );
+        assert_eq!(std::fs::read(&object).unwrap(), b"cached object");
+        assert!(!depinfo.exists());
+    }
+
+    /// Regression for #645: cache restore must not choose symlink semantics on
+    /// the compiler's behalf. GCC writes through this path while some clang
+    /// versions replace it, so the wrapper must refuse the hit and passthrough.
+    #[cfg(unix)]
+    #[test]
+    fn restore_cc_from_cache_refuses_symlinked_object_output() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+        let store = Store::open(&config).unwrap();
+        let hash = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        create_blob(&store, hash, b"cached object");
+
+        let target = dir.path().join("real.o");
+        let output = dir.path().join("link.o");
+        std::fs::write(&target, b"original").unwrap();
+        symlink(&target, &output).unwrap();
+
+        let output_str = output.to_string_lossy().into_owned();
+        let args = s(&["cc", "-c", "foo.c", "-o", &output_str]);
+        let parsed = CcCompiler::new().parse(&args).unwrap();
+        let meta = entry_meta("cc-symlink-key", vec![cached_file("foo.o", hash)], &[]);
+
+        let err = restore_cc_from_cache(&store, &parsed, &meta)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("requires compiler passthrough"), "{err}");
+        assert!(
+            std::fs::symlink_metadata(&output)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "refused cache restore must leave the -o symlink in place"
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), b"original");
+        assert_eq!(
+            std::fs::read(store.blob_path(hash)).unwrap(),
+            b"cached object",
+            "refusing the hit must not mutate the cache blob"
         );
     }
 
@@ -4351,6 +4812,222 @@ mod tests {
             event_result_for_store_put(empty),
             EventResult::Miss
         ));
+    }
+
+    #[test]
+    fn cc_store_gate_requires_success_and_artifacts() {
+        let cases = [
+            (0, true, true),
+            (1, true, false),
+            (0, false, false),
+            (1, false, false),
+        ];
+
+        for (exit_code, has_artifacts, expected) in cases {
+            assert_eq!(
+                should_store_cc_result(exit_code, has_artifacts),
+                expected,
+                "exit={exit_code}, artifacts={has_artifacts}"
+            );
+        }
+    }
+
+    #[test]
+    fn cc_output_path_passthrough_distinguishes_absent_and_existing_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("output.o");
+
+        assert!(!cc_output_path_requires_passthrough(&output));
+        std::fs::write(&output, b"existing").unwrap();
+        assert!(cc_output_path_requires_passthrough(&output));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+
+            let dangling = dir.path().join("dangling.o");
+            symlink(dir.path().join("missing-target"), &dangling).unwrap();
+            assert!(cc_output_path_requires_passthrough(&dangling));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cc_passthrough_forwards_the_original_arguments_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let fake_cc = dir.path().join("cc");
+        let capture = dir.path().join("capture.c");
+        let output = dir.path().join("output.o");
+        let fallback = dir.path().join("fallback");
+        let shell =
+            crate::compiler::resolve_program_on_path("sh").expect("sh must be available on PATH");
+        std::fs::write(
+            &fake_cc,
+            format!(
+                "#!{}\ncapture=\"$1\"\nshift\nprintf '%s\\n' \"$@\" > \"$capture\"\n",
+                shell.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_cc, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::write(
+            &fallback,
+            format!("#!{}\nprintf 'fallback\\n' > \"$2\"\n", shell.display()),
+        )
+        .unwrap();
+        std::fs::set_permissions(&fallback, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::write(&output, b"existing output").unwrap();
+
+        let capture_arg = capture.to_string_lossy().into_owned();
+        let output_arg = output.to_string_lossy().into_owned();
+        let parsed = CcCompiler::new()
+            .parse(&s(&[
+                &fake_cc.to_string_lossy(),
+                &capture_arg,
+                "-c",
+                "-o",
+                &output_arg,
+            ]))
+            .unwrap();
+
+        let mut config = test_config(dir.path().join("cache"));
+        config.fallback = fallback.to_str().map(ToOwned::to_owned);
+        let result = cc_passthrough(&config, &parsed).unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(
+            std::fs::read_to_string(&capture).unwrap(),
+            format!("-c\n-o\n{output_arg}\n"),
+            "unsafe output passthrough must bypass fallback and cache-only flags"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cc_direct_passthrough_bypasses_configured_fallback() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let fake_cc = dir.path().join("cc");
+        let fallback = dir.path().join("fallback");
+        let compiler_marker = dir.path().join("compiler-ran");
+        let fallback_marker = dir.path().join("fallback-ran");
+        let output = dir.path().join("output.o");
+        let shell =
+            crate::compiler::resolve_program_on_path("sh").expect("sh must be available on PATH");
+
+        std::fs::write(
+            &fake_cc,
+            format!(
+                "#!{}\nprintf direct > '{}'\n",
+                shell.display(),
+                compiler_marker.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_cc, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::write(
+            &fallback,
+            format!(
+                "#!{}\nprintf fallback > '{}'\n",
+                shell.display(),
+                fallback_marker.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&fallback, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let parsed = CcCompiler::new()
+            .parse(&s(&[
+                &fake_cc.to_string_lossy(),
+                "-c",
+                "foo.c",
+                "-o",
+                &output.to_string_lossy(),
+            ]))
+            .unwrap();
+        assert!(
+            !parsed.requires_compiler_output_semantics(),
+            "the fallback branch must be eligible except for force_direct"
+        );
+
+        let mut config = test_config(dir.path().join("cache"));
+        config.fallback = fallback.to_str().map(ToOwned::to_owned);
+        let result = cc_direct_passthrough(&config, &parsed).unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert!(!result.fallback);
+        assert!(compiler_marker.exists());
+        assert!(!fallback_marker.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cc_direct_passthrough_refuses_legacy_cache_blob_hardlink() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+        let store = Store::open(&config).unwrap();
+        let content = b"cached object";
+        let hash = blake3::hash(content).to_hex().to_string();
+        create_blob(&store, &hash, content);
+        let blob = store.blob_path(&hash);
+        std::fs::set_permissions(&blob, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+        let output = dir.path().join("output.o");
+        std::fs::hard_link(&blob, &output).unwrap();
+        drop(store);
+        let index_path = config.index_db_path();
+        std::fs::remove_file(&index_path).unwrap();
+        std::fs::create_dir(&index_path).unwrap();
+
+        let marker = dir.path().join("compiler-ran");
+        let fake_cc = dir.path().join("cc");
+        let shell =
+            crate::compiler::resolve_program_on_path("sh").expect("sh must be available on PATH");
+        std::fs::write(
+            &fake_cc,
+            format!(
+                "#!{}\nprintf ran > '{}'\n",
+                shell.display(),
+                marker.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_cc, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let parsed = CcCompiler::new()
+            .parse(&s(&[
+                &fake_cc.to_string_lossy(),
+                "-c",
+                "foo.c",
+                "-o",
+                &output.to_string_lossy(),
+            ]))
+            .unwrap();
+        let error = cc_direct_passthrough(&config, &parsed).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("shares the read-only cache blob")
+        );
+        assert!(
+            !marker.exists(),
+            "compiler must not run over a shared blob inode"
+        );
+        assert!(
+            index_path.is_dir(),
+            "the direct-mode safety check must not open or repair the cache index"
+        );
+        assert_eq!(std::fs::read(&blob).unwrap(), content);
+        assert_eq!(
+            std::fs::metadata(&blob).unwrap().ino(),
+            std::fs::metadata(&output).unwrap().ino()
+        );
     }
 
     /// Store stats and hash stats should be carried into the event JSONL entry

--- a/tests/cc_passthrough_args_test.rs
+++ b/tests/cc_passthrough_args_test.rs
@@ -1,25 +1,8 @@
-//! End-to-end regression test for issue #300 ("Firefox fails to build
-//! whatsys on Windows").
+//! End-to-end regression test for exact C/C++ passthrough arguments.
 //!
-//! cc-rs emits a `--` end-of-options separator before the source file on
-//! clang-cl invocations, and the clang/clang-cl driver treats every token
-//! *after* `--` as an input file. kache injects `-ffile-prefix-map=…`
-//! path-portability rules when it runs the real compiler; the old code
-//! appended them to the very end of the argv, so they landed after `--`
-//! and the driver parsed them as extra source files:
-//!
-//! ```text
-//! clang-cl: error: cannot specify '-Fo…' when compiling multiple source files
-//! clang-cl: warning: -ffile-prefix-map=…: 'linker' input unused
-//! ```
-//!
-//! This drives the real `kache` binary as a `cc` wrapper around a fake
-//! compiler that records the argv it actually receives, then asserts the
-//! injected `-ffile-prefix-map` flag arrives *before* the `--` separator
-//! — i.e. classified as an option, not an input. It exercises the full
-//! path (wrapper → passthrough → `execute` → `compose_cc_args` → spawned
-//! command), so a regression in the `execute` wiring — not just the
-//! `compose_cc_args` helper — fails the test.
+//! A refused invocation must reach the selected compiler byte-for-byte at the
+//! argument boundary: no cache-only prefix-map flags may be injected. The
+//! `compose_cc_args` unit tests separately cover ordering on cacheable misses.
 //!
 //! Unix-only: it relies on a shell-script stand-in for the compiler. The
 //! splice logic itself is also covered by the `compose_cc_args` unit
@@ -36,7 +19,7 @@ fn kache_binary() -> &'static str {
 }
 
 #[test]
-fn injected_prefix_map_lands_before_the_double_dash_separator() {
+fn refused_double_dash_invocation_is_exact_passthrough() {
     let dir = tempfile::tempdir().unwrap();
 
     // Fake compiler: dump every argument it receives, one per line, then
@@ -59,9 +42,7 @@ fn injected_prefix_map_lands_before_the_double_dash_separator() {
     .unwrap();
     fs::set_permissions(&fake, fs::Permissions::from_mode(0o755)).unwrap();
 
-    // A real source so the prefix-map derivation has something to anchor
-    // on; `KACHE_BASE_DIR` guarantees at least one map is injected
-    // regardless of the test process's cwd.
+    // A real source keeps the invocation representative of cc-rs.
     let source = dir.path().join("windows.c");
     fs::write(&source, b"int main(void){return 0;}\n").unwrap();
 
@@ -99,22 +80,9 @@ fn injected_prefix_map_lands_before_the_double_dash_separator() {
     let recorded = fs::read_to_string(&argv_dump).expect("fake compiler did not record argv");
     let args: Vec<&str> = recorded.lines().collect();
 
-    let sep = args.iter().position(|a| *a == "--");
-    let map = args
-        .iter()
-        .position(|a| a.starts_with("-ffile-prefix-map="));
-
-    assert!(
-        map.is_some(),
-        "kache should have injected a -ffile-prefix-map flag; recorded argv: {args:?}"
-    );
-    assert!(
-        sep.is_some(),
-        "the `--` separator should be preserved in the spawned argv: {args:?}"
-    );
-    assert!(
-        map < sep,
-        "injected -ffile-prefix-map (idx {map:?}) must precede `--` (idx {sep:?}), \
-         else the driver treats it as an input file (#300); recorded argv: {args:?}"
+    assert_eq!(
+        args,
+        ["-c", "-o", "windows.o", "--", source.to_str().unwrap()],
+        "refused passthrough must preserve the original argv without cache-only flags"
     );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -601,6 +601,686 @@ fn cc_accepts_gnu_forced_include(dir: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Regression for #645. Existing output symlink semantics differ by compiler:
+/// GCC writes through the link, while some clang versions replace it. Kache
+/// must passthrough and match the selected compiler instead of unlinking first.
+#[cfg(unix)]
+#[test]
+fn test_cc_existing_symlink_output_matches_selected_compiler() {
+    use std::os::unix::fs::symlink;
+
+    build_kache();
+    let project = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    let control = project.path().join("control");
+    let seed = project.path().join("seed");
+    let wrapped = project.path().join("wrapped");
+    std::fs::create_dir_all(&control).unwrap();
+    std::fs::create_dir_all(&seed).unwrap();
+    std::fs::create_dir_all(&wrapped).unwrap();
+
+    let source = project.path().join("foo.c");
+    std::fs::write(&source, "int f(void) { return 42; }\n").unwrap();
+    let control_target = control.join("real.o");
+    let control_output = control.join("link.o");
+    let wrapped_target = wrapped.join("real.o");
+    let wrapped_output = wrapped.join("link.o");
+    for target in [&control_target, &wrapped_target] {
+        std::fs::write(target, b"original").unwrap();
+    }
+    symlink("real.o", &control_output).unwrap();
+    symlink("real.o", &wrapped_output).unwrap();
+
+    let plain = std::process::Command::new("cc")
+        .arg("-c")
+        .arg(&source)
+        .arg("-o")
+        .arg(&control_output)
+        .args(["-O0", "-g0"])
+        .output()
+        .expect("failed to run control cc");
+    assert!(
+        plain.status.success(),
+        "control cc failed: {}",
+        String::from_utf8_lossy(&plain.stderr)
+    );
+
+    let source_str = source.to_string_lossy().into_owned();
+    let seed_output = seed.join("link.o");
+    let seed_output_str = seed_output.to_string_lossy().into_owned();
+    run_kache_cc(
+        project.path(),
+        cache_dir.path(),
+        &[
+            "cc",
+            "-c",
+            &source_str,
+            "-o",
+            &seed_output_str,
+            "-O0",
+            "-g0",
+        ],
+    );
+    assert!(seed_output.is_file(), "seed compile must produce an object");
+
+    // The seed has the same source, flags, and output basename, so it creates
+    // the entry this invocation would hit if the symlink-specific refusal were
+    // accidentally bypassed. The wrapper must still run the selected compiler.
+    let wrapped_output_str = wrapped_output.to_string_lossy().into_owned();
+    run_kache_cc(
+        project.path(),
+        cache_dir.path(),
+        &[
+            "cc",
+            "-c",
+            &source_str,
+            "-o",
+            &wrapped_output_str,
+            "-O0",
+            "-g0",
+        ],
+    );
+
+    let control_is_symlink = std::fs::symlink_metadata(&control_output)
+        .unwrap()
+        .file_type()
+        .is_symlink();
+    let wrapped_is_symlink = std::fs::symlink_metadata(&wrapped_output)
+        .unwrap()
+        .file_type()
+        .is_symlink();
+    assert_eq!(
+        wrapped_is_symlink, control_is_symlink,
+        "kache must preserve the selected compiler's symlink semantics"
+    );
+    assert_eq!(
+        std::fs::read(&wrapped_target).unwrap() != b"original",
+        std::fs::read(&control_target).unwrap() != b"original",
+        "kache and the control compiler must update the same referent"
+    );
+
+    let report = kache_report(cache_dir.path());
+    assert_eq!(report["summary"]["passthroughs"].as_u64(), Some(1));
+    assert_cc_report_counts(&report, 1, 0);
+}
+
+/// Read-only regular files are user-owned, not evidence of a Kache restore.
+/// Normal and disabled wrapper paths must produce the selected compiler's
+/// status and leave/replace the directory entry exactly as that compiler does.
+#[cfg(unix)]
+#[test]
+fn test_cc_existing_readonly_output_matches_selected_compiler() {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    fn prepare(path: &Path) -> std::fs::File {
+        std::fs::write(path, b"user-owned").unwrap();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o444)).unwrap();
+        // Keep the original inode alive so a remove-and-recreate compiler
+        // cannot immediately receive the same inode number and look like an
+        // in-place write (observed on ext4 in Linux CI).
+        std::fs::File::open(path).unwrap()
+    }
+
+    fn state(path: &Path, before: &std::fs::File) -> (bool, bool, bool, u32) {
+        let Ok(meta) = std::fs::metadata(path) else {
+            return (false, false, true, 0);
+        };
+        let before = before.metadata().unwrap();
+        (
+            true,
+            (meta.dev(), meta.ino()) == (before.dev(), before.ino()),
+            std::fs::read(path).unwrap() != b"user-owned",
+            meta.permissions().mode() & 0o777,
+        )
+    }
+
+    build_kache();
+    let project = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    let control_dir = project.path().join("control");
+    let seed_dir = project.path().join("seed");
+    let wrapped_dir = project.path().join("wrapped");
+    let disabled_dir = project.path().join("disabled");
+    for dir in [&control_dir, &seed_dir, &wrapped_dir, &disabled_dir] {
+        std::fs::create_dir_all(dir).unwrap();
+    }
+    let source = project.path().join("foo.c");
+    std::fs::write(&source, "int f(void) { return 42; }\n").unwrap();
+    let source_str = source.to_string_lossy().into_owned();
+
+    let seed_output = seed_dir.join("output.o");
+    let seed_str = seed_output.to_string_lossy().into_owned();
+    run_kache_cc(
+        project.path(),
+        cache_dir.path(),
+        &["cc", "-c", &source_str, "-o", &seed_str, "-O0", "-g0"],
+    );
+
+    let control_output = control_dir.join("output.o");
+    let control_before = prepare(&control_output);
+    let plain = std::process::Command::new("cc")
+        .arg("-c")
+        .arg(&source)
+        .arg("-o")
+        .arg(&control_output)
+        .args(["-O0", "-g0"])
+        .output()
+        .expect("failed to run control cc");
+    let plain_state = state(&control_output, &control_before);
+
+    let wrapped_output = wrapped_dir.join("output.o");
+    let wrapped_before = prepare(&wrapped_output);
+    let wrapped = std::process::Command::new(kache_binary())
+        .args(["cc", "-c"])
+        .arg(&source)
+        .arg("-o")
+        .arg(&wrapped_output)
+        .args(["-O0", "-g0"])
+        .current_dir(project.path())
+        .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
+        .output()
+        .expect("failed to run wrapped cc");
+
+    assert_eq!(wrapped.status.code(), plain.status.code());
+    assert_eq!(state(&wrapped_output, &wrapped_before), plain_state);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(report["summary"]["passthroughs"].as_u64(), Some(1));
+    assert_cc_report_counts(&report, 1, 0);
+
+    let disabled_output = disabled_dir.join("output.o");
+    let disabled_before = prepare(&disabled_output);
+    let disabled = std::process::Command::new(kache_binary())
+        .args(["cc", "-c"])
+        .arg(&source)
+        .arg("-o")
+        .arg(&disabled_output)
+        .args(["-O0", "-g0"])
+        .current_dir(project.path())
+        .env("KACHE_DISABLED", "1")
+        .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
+        .output()
+        .expect("failed to run disabled wrapped cc");
+    assert_eq!(disabled.status.code(), plain.status.code());
+    assert_eq!(state(&disabled_output, &disabled_before), plain_state);
+}
+
+/// Refused C/C++ invocations are a true process passthrough: byte streams and
+/// exit status must not be buffered through UTF-8 conversion.
+#[cfg(unix)]
+#[test]
+fn test_cc_passthrough_preserves_non_utf8_streams_and_exit_status() {
+    use std::os::unix::fs::PermissionsExt;
+
+    build_kache();
+    let project = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    let shell = std::process::Command::new("sh")
+        .args(["-c", "command -v sh"])
+        .output()
+        .expect("sh must be available on PATH");
+    assert!(shell.status.success());
+    let shell = String::from_utf8(shell.stdout).unwrap();
+    let fake_cc = project.path().join("cc");
+    std::fs::write(
+        &fake_cc,
+        format!(
+            "#!{}\nprintf '\\377'\nprintf '\\376' >&2\nexit 7\n",
+            shell.trim()
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&fake_cc, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let output_path = project.path().join("existing.o");
+    std::fs::write(&output_path, b"existing").unwrap();
+
+    let output = std::process::Command::new(kache_binary())
+        .arg(&fake_cc)
+        .args(["-c", "foo.c", "-o"])
+        .arg(&output_path)
+        .current_dir(project.path())
+        .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
+        .env_remove("KACHE_LOG")
+        .env_remove("KACHE_PROGRESS")
+        .output()
+        .expect("failed to run kache cc passthrough");
+
+    assert_eq!(output.status.code(), Some(7));
+    assert_eq!(output.stdout, [0xff]);
+    assert_eq!(output.stderr, [0xfe]);
+    assert_eq!(std::fs::read(&output_path).unwrap(), b"existing");
+}
+
+/// A writable hardlinked `-o` needs the selected compiler's overwrite
+/// semantics just like a symlink. Even with a matching cache entry present,
+/// kache must passthrough instead of unlinking one name of the hardlink pair.
+#[cfg(unix)]
+#[test]
+fn test_cc_existing_writable_hardlink_output_matches_selected_compiler() {
+    use std::os::unix::fs::MetadataExt;
+
+    fn reset_pair(referent: &Path, output: &Path) {
+        if output.exists() {
+            std::fs::remove_file(output).unwrap();
+        }
+        if referent.exists() {
+            std::fs::remove_file(referent).unwrap();
+        }
+        std::fs::write(referent, b"original").unwrap();
+        std::fs::hard_link(referent, output).unwrap();
+        let meta = std::fs::metadata(output).unwrap();
+        assert!(!meta.permissions().readonly());
+        assert_eq!(meta.nlink(), 2);
+    }
+
+    fn link_state(referent: &Path, output: &Path) -> (bool, u64, u64) {
+        let referent_meta = std::fs::metadata(referent).unwrap();
+        let output_meta = std::fs::metadata(output).unwrap();
+        (
+            (referent_meta.dev(), referent_meta.ino()) == (output_meta.dev(), output_meta.ino()),
+            referent_meta.nlink(),
+            output_meta.nlink(),
+        )
+    }
+
+    build_kache();
+    let project = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    let seed_dir = project.path().join("seed");
+    let hardlink_dir = project.path().join("hardlink");
+    std::fs::create_dir_all(&seed_dir).unwrap();
+    std::fs::create_dir_all(&hardlink_dir).unwrap();
+    let source = project.path().join("foo.c");
+    std::fs::write(&source, "int f(void) { return 42; }\n").unwrap();
+
+    let source_str = source.to_string_lossy().into_owned();
+    let seed_output = seed_dir.join("output.o");
+    let seed_output_str = seed_output.to_string_lossy().into_owned();
+    run_kache_cc(
+        project.path(),
+        cache_dir.path(),
+        &[
+            "cc",
+            "-c",
+            &source_str,
+            "-o",
+            &seed_output_str,
+            "-O0",
+            "-g0",
+        ],
+    );
+
+    let referent = hardlink_dir.join("real.o");
+    let output = hardlink_dir.join("output.o");
+    let output_str = output.to_string_lossy().into_owned();
+    reset_pair(&referent, &output);
+    let plain = std::process::Command::new("cc")
+        .arg("-c")
+        .arg(&source)
+        .arg("-o")
+        .arg(&output)
+        .args(["-O0", "-g0"])
+        .output()
+        .expect("failed to run control cc");
+    assert!(
+        plain.status.success(),
+        "control cc failed: {}",
+        String::from_utf8_lossy(&plain.stderr)
+    );
+    let plain_state = link_state(&referent, &output);
+    let plain_referent = std::fs::read(&referent).unwrap();
+
+    reset_pair(&referent, &output);
+    run_kache_cc(
+        project.path(),
+        cache_dir.path(),
+        &["cc", "-c", &source_str, "-o", &output_str, "-O0", "-g0"],
+    );
+
+    assert_eq!(
+        link_state(&referent, &output),
+        plain_state,
+        "kache must preserve the selected compiler's hardlink semantics"
+    );
+    assert_eq!(
+        std::fs::read(&referent).unwrap(),
+        plain_referent,
+        "kache and the control compiler must leave identical referent bytes"
+    );
+
+    let report = kache_report(cache_dir.path());
+    assert_eq!(report["summary"]["passthroughs"].as_u64(), Some(1));
+    assert_cc_report_counts(&report, 1, 0);
+}
+
+/// Read-only hardlinks are no more Kache-owned than writable hardlinks. The
+/// wrapper must not unlink one name before the selected compiler sees it.
+#[cfg(unix)]
+#[test]
+fn test_cc_existing_readonly_hardlink_output_matches_selected_compiler() {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    fn prepare(dir: &Path) -> (PathBuf, PathBuf, (u64, u64)) {
+        let referent = dir.join("real.o");
+        let output = dir.join("output.o");
+        std::fs::write(&referent, b"user-owned").unwrap();
+        std::fs::hard_link(&referent, &output).unwrap();
+        std::fs::set_permissions(&output, std::fs::Permissions::from_mode(0o444)).unwrap();
+        let meta = std::fs::metadata(&output).unwrap();
+        (referent, output, (meta.dev(), meta.ino()))
+    }
+
+    fn state(referent: &Path, output: &Path, before: (u64, u64)) -> (bool, bool, u64, bool, u32) {
+        let referent_meta = std::fs::metadata(referent).unwrap();
+        let output_meta = std::fs::metadata(output).unwrap();
+        (
+            (referent_meta.dev(), referent_meta.ino()) == (output_meta.dev(), output_meta.ino()),
+            (output_meta.dev(), output_meta.ino()) == before,
+            output_meta.nlink(),
+            std::fs::read(referent).unwrap() != b"user-owned",
+            output_meta.permissions().mode() & 0o777,
+        )
+    }
+
+    build_kache();
+    let project = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    let control_dir = project.path().join("control");
+    let seed_dir = project.path().join("seed");
+    let wrapped_dir = project.path().join("wrapped");
+    for dir in [&control_dir, &seed_dir, &wrapped_dir] {
+        std::fs::create_dir_all(dir).unwrap();
+    }
+    let source = project.path().join("foo.c");
+    std::fs::write(&source, "int f(void) { return 42; }\n").unwrap();
+    let source_str = source.to_string_lossy().into_owned();
+    let seed_output = seed_dir.join("output.o");
+    let seed_str = seed_output.to_string_lossy().into_owned();
+    run_kache_cc(
+        project.path(),
+        cache_dir.path(),
+        &["cc", "-c", &source_str, "-o", &seed_str, "-O0", "-g0"],
+    );
+
+    let (control_referent, control_output, control_before) = prepare(&control_dir);
+    let plain = std::process::Command::new("cc")
+        .arg("-c")
+        .arg(&source)
+        .arg("-o")
+        .arg(&control_output)
+        .args(["-O0", "-g0"])
+        .output()
+        .expect("failed to run control cc");
+    let plain_state = state(&control_referent, &control_output, control_before);
+
+    let (wrapped_referent, wrapped_output, wrapped_before) = prepare(&wrapped_dir);
+    let wrapped = std::process::Command::new(kache_binary())
+        .args(["cc", "-c"])
+        .arg(&source)
+        .arg("-o")
+        .arg(&wrapped_output)
+        .args(["-O0", "-g0"])
+        .current_dir(project.path())
+        .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
+        .output()
+        .expect("failed to run wrapped cc");
+
+    assert_eq!(wrapped.status.code(), plain.status.code());
+    assert_eq!(
+        state(&wrapped_referent, &wrapped_output, wrapped_before),
+        plain_state
+    );
+    let report = kache_report(cache_dir.path());
+    assert_eq!(report["summary"]["passthroughs"].as_u64(), Some(1));
+    assert_cc_report_counts(&report, 1, 0);
+}
+
+/// Exact device-node regression for #645. Run only as the current non-root
+/// process: the broken implementation attempted to unlink `/dev/null`, so a
+/// root test of the pre-fix code would damage its own test environment.
+#[cfg(unix)]
+#[test]
+fn test_cc_dev_null_output_is_passthrough_and_preserved() {
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping /dev/null regression as root");
+        return;
+    }
+
+    let dev_null = Path::new("/dev/null");
+    let before = std::fs::symlink_metadata(dev_null).expect("stat /dev/null before compile");
+    assert!(
+        before.file_type().is_char_device(),
+        "precondition: /dev/null must be a character device"
+    );
+    let before_identity = (before.dev(), before.ino(), before.rdev(), before.mode());
+
+    build_kache();
+    let project = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    std::fs::write(project.path().join("foo.c"), "int f(void) { return 42; }\n").unwrap();
+
+    run_kache_cc(
+        project.path(),
+        cache_dir.path(),
+        &["cc", "-c", "foo.c", "-o", "/dev/null", "-O0", "-g0"],
+    );
+
+    let after = std::fs::symlink_metadata(dev_null).expect("stat /dev/null after compile");
+    assert!(
+        after.file_type().is_char_device(),
+        "kache must not replace /dev/null with a regular file"
+    );
+    assert_eq!(
+        (after.dev(), after.ino(), after.rdev(), after.mode()),
+        before_identity,
+        "kache must not unlink, replace, or chmod /dev/null"
+    );
+
+    let report = kache_report(cache_dir.path());
+    assert_eq!(report["summary"]["passthroughs"].as_u64(), Some(1));
+    assert_cc_report_counts(&report, 0, 0);
+    let refusal_reasons = report["bypass"]["reasons"]
+        .as_array()
+        .expect("report should include passthrough reasons");
+    assert!(
+        refusal_reasons.iter().any(|entry| {
+            entry["reason"]
+                .as_str()
+                .is_some_and(|reason| reason.contains("requires compiler write semantics"))
+        }),
+        "report must attribute /dev/null passthrough to output-path safety: {report}"
+    );
+}
+
+/// C/C++ cache materialization must never recreate the read-only/shared shape
+/// that forced unsafe pre-cleaning. An existing warm output is passed to the
+/// selected compiler unchanged rather than replaced by Kache.
+#[cfg(unix)]
+#[test]
+fn test_cc_cache_output_stays_writable_across_miss_hit_and_recompile() {
+    use std::os::unix::fs::PermissionsExt;
+
+    build_kache();
+    let project = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    let source = project.path().join("foo.c");
+    let output = project.path().join("foo.o");
+    std::fs::write(&source, "int f(void) { return 1; }\n").unwrap();
+
+    let source_str = source.to_string_lossy().into_owned();
+    let output_str = output.to_string_lossy().into_owned();
+    let args = ["cc", "-c", &source_str, "-o", &output_str, "-O0", "-g0"];
+
+    run_kache_cc(project.path(), cache_dir.path(), &args);
+    let miss_mode = std::fs::metadata(&output).unwrap().permissions().mode() & 0o777;
+    assert_ne!(miss_mode & 0o200, 0, "miss output must stay owner-writable");
+
+    std::fs::remove_file(&output).unwrap();
+    run_kache_cc(project.path(), cache_dir.path(), &args);
+    let hit_mode = std::fs::metadata(&output).unwrap().permissions().mode() & 0o777;
+    assert_eq!(hit_mode, miss_mode, "hit must restore the compiler's mode");
+    assert_ne!(hit_mode & 0o200, 0, "hit output must be owner-writable");
+
+    std::fs::write(&source, "int f(void) { return 2002; }\n").unwrap();
+    run_kache_cc(project.path(), cache_dir.path(), &args);
+    assert_ne!(
+        std::fs::metadata(&output).unwrap().permissions().mode() & 0o200,
+        0,
+        "passthrough compiler must overwrite the warm output without pre-clean"
+    );
+
+    let report = kache_report(cache_dir.path());
+    assert_cc_report_counts(&report, 1, 1);
+    assert_eq!(report["summary"]["passthroughs"].as_u64(), Some(1));
+}
+
+/// A cache hit must not create an output directory that the selected compiler
+/// would reject as missing.
+#[cfg(unix)]
+#[test]
+fn test_cc_hit_preserves_missing_parent_failure() {
+    build_kache();
+    let project = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    let source = project.path().join("foo.c");
+    let seed_dir = project.path().join("seed");
+    std::fs::create_dir(&seed_dir).unwrap();
+    std::fs::write(&source, "int f(void) { return 42; }\n").unwrap();
+    let source_str = source.to_string_lossy().into_owned();
+    let seed_output = seed_dir.join("foo.o");
+    let seed_str = seed_output.to_string_lossy().into_owned();
+    run_kache_cc(
+        project.path(),
+        cache_dir.path(),
+        &["cc", "-c", &source_str, "-o", &seed_str, "-O0", "-g0"],
+    );
+
+    let control_parent = project.path().join("missing-control");
+    let control_output = control_parent.join("foo.o");
+    let plain = std::process::Command::new("cc")
+        .arg("-c")
+        .arg(&source)
+        .arg("-o")
+        .arg(&control_output)
+        .args(["-O0", "-g0"])
+        .output()
+        .expect("failed to run control cc");
+
+    let wrapped_parent = project.path().join("missing-wrapped");
+    let wrapped_output = wrapped_parent.join("foo.o");
+    let wrapped = std::process::Command::new(kache_binary())
+        .args(["cc", "-c"])
+        .arg(&source)
+        .arg("-o")
+        .arg(&wrapped_output)
+        .args(["-O0", "-g0"])
+        .current_dir(project.path())
+        .env("KACHE_CACHE_DIR", cache_dir.path())
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
+        .output()
+        .expect("failed to run wrapped cc");
+
+    assert_eq!(wrapped.status.code(), plain.status.code());
+    assert!(!control_parent.exists());
+    assert!(!wrapped_parent.exists());
+    let report = kache_report(cache_dir.path());
+    assert_cc_report_counts(&report, 1, 0);
+    assert_eq!(report["summary"]["passthroughs"].as_u64(), Some(1));
+}
+
+/// Relative dep-info can require no content transform, so the raw blob restore
+/// path must still produce independent outputs with the current invocation's
+/// umask, not the producer's cached mode.
+#[cfg(unix)]
+#[test]
+fn test_cc_relative_depinfo_stays_writable_across_repeated_hits() {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    use std::os::unix::process::CommandExt;
+
+    fn run_with_umask(project: &Path, cache_dir: &Path, args: &[&str], mask: u32) {
+        let mut command = std::process::Command::new(kache_binary());
+        command
+            .args(args)
+            .current_dir(project)
+            .env("KACHE_CACHE_DIR", cache_dir)
+            .env("KACHE_CONFIG", isolated_config_path(cache_dir))
+            .env("KACHE_LOG", "kache=debug");
+        // SAFETY: pre_exec runs after fork in the child, and umask is an
+        // async-signal-safe syscall that changes only that child process.
+        unsafe {
+            command.pre_exec(move || {
+                libc::umask(mask as libc::mode_t);
+                Ok(())
+            });
+        }
+        let output = command.output().expect("failed to run kache cc");
+        assert!(
+            output.status.success(),
+            "kache cc failed.\nargs: {args:?}\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    build_kache();
+    let project = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    std::fs::create_dir(project.path().join("build")).unwrap();
+    std::fs::write(project.path().join("foo.c"), "int f(void) { return 42; }\n").unwrap();
+    let args = [
+        "cc",
+        "-c",
+        "foo.c",
+        "-MMD",
+        "-MF",
+        "build/foo.d",
+        "-o",
+        "build/foo.o",
+        "-O0",
+        "-g0",
+    ];
+    let object = project.path().join("build/foo.o");
+    let depinfo = project.path().join("build/foo.d");
+
+    run_with_umask(project.path(), cache_dir.path(), &args, 0o000);
+    let miss_modes = (
+        std::fs::metadata(&object).unwrap().permissions().mode() & 0o777,
+        std::fs::metadata(&depinfo).unwrap().permissions().mode() & 0o777,
+    );
+    assert_eq!(miss_modes, (0o666, 0o666));
+
+    std::fs::remove_file(&object).unwrap();
+    std::fs::remove_file(&depinfo).unwrap();
+    run_with_umask(project.path(), cache_dir.path(), &args, 0o077);
+    for path in [&object, &depinfo] {
+        let meta = std::fs::metadata(path).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+        assert_eq!(
+            meta.nlink(),
+            1,
+            "{} must not share a blob inode",
+            path.display()
+        );
+    }
+
+    std::fs::remove_file(&object).unwrap();
+    std::fs::remove_file(&depinfo).unwrap();
+    run_with_umask(project.path(), cache_dir.path(), &args, 0o022);
+    for path in [&object, &depinfo] {
+        let meta = std::fs::metadata(path).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o644);
+        assert_eq!(meta.nlink(), 1);
+    }
+
+    let report = kache_report(cache_dir.path());
+    assert_cc_report_counts(&report, 1, 2);
+}
+
 /// aws-lc-sys drives BoringSSL symbol prefixing with
 /// `--include=<generated-include>/boringssl_prefix_symbols*.h` and compiles
 /// jitterentropy with `-fwrapv --param ssp-buffer-size=4`. Unclassified,
@@ -715,6 +1395,7 @@ fn test_cc_forced_include_and_param_converge_across_clones_issue_580() {
         "-O0",
         "-g0",
     ];
+    std::fs::remove_file(clone_a.path().join("bcm.o")).unwrap();
     run_kache_cc(clone_a.path(), cache_dir.path(), &no_wrapv);
     let report = kache_report(cache_dir.path());
     let summary = &report["summary"];
@@ -774,6 +1455,7 @@ fn test_cc_depinfo_sidecar_restores_on_hit_and_new_mf_path() {
     assert_last_cc_event(&report, "miss", 1);
 
     std::fs::remove_dir_all(project.path().join("build")).unwrap();
+    std::fs::create_dir_all(project.path().join("build")).unwrap();
     run_kache_cc(project.path(), cache_dir.path(), &base_args);
     let warm_depinfo = std::fs::read_to_string(project.path().join("build/foo.d")).unwrap();
     assert!(project.path().join("build/foo.o").exists());
@@ -783,6 +1465,8 @@ fn test_cc_depinfo_sidecar_restores_on_hit_and_new_mf_path() {
     assert_last_cc_event(&report, "local_hit", 0);
 
     std::fs::remove_dir_all(project.path().join("build")).unwrap();
+    std::fs::create_dir_all(project.path().join("build")).unwrap();
+    std::fs::create_dir_all(project.path().join("deps")).unwrap();
     let mf_args = [
         "cc",
         "-O0",
@@ -837,6 +1521,8 @@ fn test_cc_depinfo_sidecar_restores_on_hit_and_new_mf_path() {
 
     std::fs::remove_dir_all(project.path().join("build")).unwrap();
     std::fs::remove_dir_all(project.path().join("deps")).unwrap();
+    std::fs::create_dir_all(project.path().join("build")).unwrap();
+    std::fs::create_dir_all(project.path().join("deps")).unwrap();
     run_kache_cc(project.path(), pp_cache_dir.path(), &pp_args);
     let warm_pp_depinfo = std::fs::read_to_string(project.path().join("deps/custom.pp")).unwrap();
     assert!(project.path().join("build/foo.o").exists());


### PR DESCRIPTION
## Summary

- preserve the selected compiler's exact behavior whenever a C/C++ object or dep-info output already exists
- restore cache hits as writable, private files without clobbering concurrent outputs
- close multi-artifact restore and cache-ingest races
- protect legacy read-only blob hardlinks without mutating user paths or requiring the cache index

## Details

Refused or unsafe C/C++ invocations now run the selected compiler directly with the original arguments, inherited byte-exact streams, and original exit status. Kache does not inject cache-only flags or environment variables, and it bypasses configured fallback wrappers when exact output-path semantics are required.

Cache hits stage every requested artifact in the output directory, using the current umask and default ACL, then publish absent-only. All artifacts are staged and preflighted before publication; a race after partial publication is a hard error and never falls back to compiling over a mixed output set.

Successful compiler outputs are privately snapshotted before `Store::put`, including normalized dep-info, so a concurrent path replacement cannot publish bytes under the wrong content hash. Legacy read-only hardlinks are detected from the content-addressed blob layout and inode identity before direct execution, including disabled and re-entrant modes, without opening SQLite or rewriting the output.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `nix flake check --keep-going --print-build-logs`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #645
