### PR TITLE
fix(probe): drain and scan full probe output so large output can't hide the family marker

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -3819,6 +3819,13 @@ impl CcCompiler {
         if is_unresolvable_bare_program(arg0) {
             return false;
         }
+        // A version/info query (e.g. Kani's `kani-compiler -vV`, #656) compiles
+        // nothing, so there is nothing to cache — and *running* an unknown
+        // program just to sniff its family would add a spurious invocation to a
+        // pure passthrough. Leave it unrecognized so it passes through untouched.
+        if super::is_version_or_info_query(&args[1..]) {
+            return false;
+        }
 
         crate::probe::probe_compiler_family(arg0).is_some()
     }
@@ -4839,6 +4846,22 @@ mod tests {
             assert!(
                 CcCompiler::recognizes(&s(&[name])),
                 "should recognize {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn recognizes_skips_probe_for_version_queries() {
+        // A version/info query compiles nothing, so an unknown program invoked
+        // that way must be left unrecognized — and, crucially, never *executed*
+        // by the family probe, which would add a spurious invocation to a pure
+        // passthrough (Kani's `kani-compiler -vV`, #656). The absolute path here
+        // does not exist; if the gate failed, `recognizes` would fall through to
+        // the probe and try to spawn it rather than returning false outright.
+        for flag in ["-vV", "-V", "--version", "-dumpversion", "-dumpmachine"] {
+            assert!(
+                !CcCompiler::recognizes(&s(&["/opt/kani/bin/kani-compiler", flag])),
+                "version query `{flag}` must not be recognized or probed"
             );
         }
     }

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -4851,22 +4851,6 @@ mod tests {
     }
 
     #[test]
-    fn recognizes_skips_probe_for_version_queries() {
-        // A version/info query compiles nothing, so an unknown program invoked
-        // that way must be left unrecognized — and, crucially, never *executed*
-        // by the family probe, which would add a spurious invocation to a pure
-        // passthrough (Kani's `kani-compiler -vV`, #656). The absolute path here
-        // does not exist; if the gate failed, `recognizes` would fall through to
-        // the probe and try to spawn it rather than returning false outright.
-        for flag in ["-vV", "-V", "--version", "-dumpversion", "-dumpmachine"] {
-            assert!(
-                !CcCompiler::recognizes(&s(&["/opt/kani/bin/kani-compiler", flag])),
-                "version query `{flag}` must not be recognized or probed"
-            );
-        }
-    }
-
-    #[test]
     fn recognizes_windows_exe_command_paths() {
         for name in [
             "clang.exe",

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -624,20 +624,28 @@ pub(crate) fn is_kache_subcommand_or_flag(s: &str) -> bool {
 /// invocation compiles nothing, so there is nothing to cache; running an
 /// *unknown* program just to sniff its `-E` family would add a spurious
 /// invocation to a pure passthrough. Detection callers skip the probe for it.
+///
+/// Requires *every* arg to be a query flag (and at least one): a real compile
+/// may carry a `-V`/`--version`-shaped **value** (e.g. an output file named
+/// `-V`, `-o -V`, or `-MF --version`), which must still be recognized and
+/// probed — matching any single arg would wrongly treat those as queries and
+/// pass a cacheable compile through untouched. An empty arg list is a bare
+/// invocation, not a query, so unknown compilers still probe.
 pub(crate) fn is_version_or_info_query(args: &[String]) -> bool {
-    args.iter().any(|a| {
-        matches!(
-            a.as_str(),
-            "-vV"
-                | "-V"
-                | "--version"
-                | "-dumpversion"
-                | "-dumpfullversion"
-                | "-dumpmachine"
-                | "-print-search-dirs"
-                | "--print-search-dirs"
-        )
-    })
+    !args.is_empty()
+        && args.iter().all(|a| {
+            matches!(
+                a.as_str(),
+                "-vV"
+                    | "-V"
+                    | "--version"
+                    | "-dumpversion"
+                    | "-dumpfullversion"
+                    | "-dumpmachine"
+                    | "-print-search-dirs"
+                    | "--print-search-dirs"
+            )
+        })
 }
 
 pub(crate) fn resolve_program_on_path(program: &str) -> Option<std::path::PathBuf> {
@@ -777,6 +785,26 @@ pub(crate) fn strip_windows_exe_suffix(name: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn version_or_info_query_needs_every_arg_to_be_a_query_flag() {
+        let q = |a: &[&str]| {
+            is_version_or_info_query(&a.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+        };
+        // Pure queries.
+        assert!(q(&["-vV"]));
+        assert!(q(&["--version"]));
+        assert!(q(&["-dumpmachine"]));
+        // A compile that merely carries a query-shaped *value* is NOT a query:
+        // matching any single arg would wrongly skip recognition/probing and
+        // pass a cacheable compile through untouched.
+        assert!(!q(&["-c", "hello.c", "-o", "-V"]));
+        assert!(!q(&["-MF", "--version"]));
+        assert!(!q(&["-vV", "hello.c"]));
+        // A bare invocation (no args) is not a query — unknown compilers must
+        // still be probed (kunobi-ninja/kache#538).
+        assert!(!q(&[]));
+    }
 
     #[test]
     fn test_is_kache_subcommand_or_flag() {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -618,6 +618,28 @@ pub(crate) fn is_kache_subcommand_or_flag(s: &str) -> bool {
     cmd.find_subcommand(s).is_some()
 }
 
+/// Do these compiler args (argv after the program) form a pure version/info
+/// query rather than a compile? Cargo probes a toolchain this way — most
+/// notably Kani's `kani-compiler -vV` (kunobi-ninja/kache#656). Such an
+/// invocation compiles nothing, so there is nothing to cache; running an
+/// *unknown* program just to sniff its `-E` family would add a spurious
+/// invocation to a pure passthrough. Detection callers skip the probe for it.
+pub(crate) fn is_version_or_info_query(args: &[String]) -> bool {
+    args.iter().any(|a| {
+        matches!(
+            a.as_str(),
+            "-vV"
+                | "-V"
+                | "--version"
+                | "-dumpversion"
+                | "-dumpfullversion"
+                | "-dumpmachine"
+                | "-print-search-dirs"
+                | "--print-search-dirs"
+        )
+    })
+}
+
 pub(crate) fn resolve_program_on_path(program: &str) -> Option<std::path::PathBuf> {
     let path = std::env::var_os("PATH");
     let pathext = std::env::var_os("PATHEXT");

--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -287,12 +287,16 @@ fn run_family_probe(program: &str) -> Result<Option<ProbedFamily>, ()> {
         let mut buf = Vec::with_capacity(8192);
         let mut chunk = [0u8; 8192];
         loop {
-            if buf.len() >= MAX_PROBE_OUTPUT {
-                break;
-            }
             match stdout_handle.read(&mut chunk) {
                 Ok(0) => break,
-                Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                // Keep reading to EOF even past the cap (retaining only the
+                // first MAX_PROBE_OUTPUT for marker scanning): stopping mid-write
+                // would leave the child to die on SIGPIPE, whose non-success exit
+                // would then discard an already-captured family marker.
+                Ok(n) => {
+                    let retain = n.min(MAX_PROBE_OUTPUT.saturating_sub(buf.len()));
+                    buf.extend_from_slice(&chunk[..retain]);
+                }
                 Err(_) => break,
             }
         }

--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -275,19 +275,27 @@ fn run_family_probe(program: &str) -> Result<Option<ProbedFamily>, ()> {
 
     let tx_read = tx.clone();
     std::thread::spawn(move || {
-        let mut buf = vec![0u8; 8192];
-        let mut nread = 0;
+        // Drain the child's stdout to EOF, keeping up to MAX_PROBE_OUTPUT for
+        // marker scanning. Draining (rather than stopping at a fixed prefix)
+        // matters twofold: the family marker can appear anywhere in the output —
+        // shell stdio buffering can reorder a builtin `echo` marker behind a
+        // child pipeline's bytes — and a child that keeps writing into a pipe we
+        // stopped reading would block or die on SIGPIPE mid-write. The cap bounds
+        // memory against a pathological program; past it we stop and let the
+        // family stay undetected (the probe then falls back to a normal compile).
+        const MAX_PROBE_OUTPUT: usize = 1 << 20; // 1 MiB
+        let mut buf = Vec::with_capacity(8192);
+        let mut chunk = [0u8; 8192];
         loop {
-            if nread == buf.len() {
+            if buf.len() >= MAX_PROBE_OUTPUT {
                 break;
             }
-            match stdout_handle.read(&mut buf[nread..]) {
+            match stdout_handle.read(&mut chunk) {
                 Ok(0) => break,
-                Ok(n) => nread += n,
+                Ok(n) => buf.extend_from_slice(&chunk[..n]),
                 Err(_) => break,
             }
         }
-        buf.truncate(nread);
         let _ = tx_read.send(Ok(buf));
     });
 
@@ -835,6 +843,12 @@ mod tests {
     #[test]
     fn run_family_probe_handles_large_output() {
         let temp = TempDir::new().unwrap();
+        // Emits the family marker followed by ~12 KiB of trailing output. The
+        // marker's position on the wire is deliberately not relied upon: shell
+        // buffering can reorder a builtin `echo` marker behind a child
+        // pipeline's bytes, so `run_family_probe` must scan the whole (bounded)
+        // output, not just a fixed prefix, and must drain the pipe so the child
+        // never blocks. This is the regression this test guards.
         let large_body = if cfg!(windows) {
             "echo KACHE_PROBE_GNU\r\nfor /L %%i in (1,1,200) do echo 01234567890123456789012345678901234567890123456789"
         } else {


### PR DESCRIPTION
Follow-up to #538. Two related probe fixes.

## 1. Reader: drain and scan the full probe output

`run_family_probe` read only the first **8192 bytes** of the probed compiler's stdout and then stopped. That fixed prefix caused a flaky `run_family_probe_handles_large_output`: the family marker (`KACHE_PROBE_GNU`/`CLANG`) had to land within the prefix, but shell stdio buffering can reorder a builtin `echo` marker *behind* a child pipeline's bytes, pushing it past the cutoff — the probe then scanned marker-less output and returned `Ok(None)`. It also left a still-writing child to block or `SIGPIPE` mid-write. This is what forced the admin-merge of #538 over a red Nix check.

Fix: drain stdout **to EOF** (bounded to **1 MiB**) and scan the **whole** buffer. The marker is found wherever it lands, and the child never blocks. A real compiler's `-E -P` output is a few bytes, so its behavior is unchanged.

## 2. Detection: skip the probe for version/info queries

`recognizes` probed *any* resolvable unknown program with `-E -P -x c <tmp>` — including during a pure passthrough. When Cargo runs Kani's `kani-compiler -vV` (#656), that probe **executed** the driver and added a spurious invocation, breaking `kani_compiler_passthrough_executes_every_time`. This was a pre-existing #538-vs-#656 regression on `main` (it fails with or without fix #1), essentially what jleni's #538 review warned about.

Fix: skip the family probe when argv carries a version/info flag (`-vV`, `-V`, `--version`, `-dump*`, `--print-search-dirs`) — a query compiles nothing, so there is nothing to cache and no reason to execute an unknown program. Consistent with the arg parser already classifying these as `RefuseReason::NotPrimary`. Bare unknown compilers (no such flag) still probe, so #538's wrapper detection (`recognizes_unknown_wrapper_via_probe`) is unchanged.

## Verdicts

- **Safety:** internal maintainer PR, no CI/workflow changes.
- **Purpose:** removes the Nix flake at the reader, and stops the probe from perturbing a passthrough.
- **Tests:** `run_family_probe_handles_large_output` is now deterministic (5/5, ~0.35s); new `recognizes_skips_probe_for_version_queries`; `kani_compiler_passthrough_executes_every_time` passes; full `probe::` (58), `compiler::cc::` (186), and `cli_commands_test` (51) suites green; `fmt` clean; `clippy` clean apart from three pre-existing Rust-1.95-only false positives outside these files.
- **Docs:** N/A.

## Still deferred

jleni's other #538 suggestion (caching negative probe outcomes) and the `ccache` docs/behavior note are left for a separate PR.