### PR TITLE
test(probe): verify cc -### resolves on a live compiler (#626)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2323,7 +2323,19 @@ pub fn doctor(
         "Stale locks",
         "Service exe",
     ];
-    let check_is_optional = |label: &str| daemon_optional && DAEMON_CHECK_LABELS.contains(&label);
+
+    // Live compiler probe (#626): a toolchain whose `cc -###` resolves no
+    // compile line makes every probe-keyed C/C++ flag refuse to cache —
+    // builds stay correct but silently lose caching, with zero signal. Run
+    // here so the check below reports the live compiler, and so a host with
+    // no `cc` at all downgrades to informational instead of failing doctor.
+    let probe_diag = crate::probe::live_probe_diagnostic();
+    let probe_no_compiler = matches!(probe_diag, crate::probe::LiveProbeDiagnostic::NoCompiler);
+
+    let check_is_optional = |label: &str| {
+        (daemon_optional && DAEMON_CHECK_LABELS.contains(&label))
+            || (label == "Compiler probe" && probe_no_compiler)
+    };
 
     let mut checks: Vec<Check> = Vec::new();
 
@@ -2791,6 +2803,41 @@ pub fn doctor(
         }
     }
 
+    // Compiler probe (#626): reported from the live toolchain, bypassing the
+    // probe cache, so a stale stored "unresolved" record can't mask a fixed
+    // toolchain — or a fresh breakage.
+    checks.push(match probe_diag {
+        crate::probe::LiveProbeDiagnostic::Resolved { version_line } => Check {
+            label: "Compiler probe",
+            pass: true,
+            detail: format!("cc -### resolves ({version_line})"),
+            fix: None,
+        },
+        crate::probe::LiveProbeDiagnostic::NoCompiler => Check {
+            label: "Compiler probe",
+            pass: false,
+            detail: "no usable `cc` on PATH (C/C++ caching not in play)".into(),
+            fix: None,
+        },
+        crate::probe::LiveProbeDiagnostic::Unresolved {
+            version_line,
+            stderr_head,
+        } => Check {
+            label: "Compiler probe",
+            pass: false,
+            detail: format!("`cc -###` resolved no compile line ({version_line})"),
+            fix: Some(format!(
+                "probe-keyed C/C++ flags will refuse to cache on this toolchain; \
+                 report the `-###` output below\n{}",
+                if stderr_head.is_empty() {
+                    "(no -### stderr)"
+                } else {
+                    &stderr_head
+                }
+            )),
+        },
+    });
+
     // Print
     let version = crate::VERSION;
     let rustc_version = std::process::Command::new("rustc")
@@ -2806,7 +2853,7 @@ pub fn doctor(
 
     let label_width = checks.iter().map(|c| c.label.len()).max().unwrap_or(0);
 
-    let mut downgraded_any = false;
+    let mut downgraded_daemon = false;
     for check in &checks {
         let optional = check_is_optional(check.label);
         // A failing optional check is informational, not a problem: render it
@@ -2814,7 +2861,9 @@ pub fn doctor(
         let icon = if check.pass {
             "\x1b[32m✓\x1b[0m"
         } else if optional {
-            downgraded_any = true;
+            // The footnote below explains only the daemon downgrades; the
+            // compiler-probe downgrade's detail line is self-explanatory.
+            downgraded_daemon |= DAEMON_CHECK_LABELS.contains(&check.label);
             "\x1b[2m•\x1b[0m"
         } else {
             "\x1b[31m✗\x1b[0m"
@@ -2844,7 +2893,7 @@ pub fn doctor(
     } else {
         println!("  \x1b[31m{issues} issue(s) found.\x1b[0m");
     }
-    if downgraded_any {
+    if downgraded_daemon {
         println!(
             "  \x1b[2mDaemon checks are informational: no remote cache or planner \
              configured (the daemon is optional for local-only use).\x1b[0m"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2287,6 +2287,35 @@ fn is_doctor_issue(pass: bool, optional: bool) -> bool {
     !pass && !optional
 }
 
+/// Labels of the daemon-related checks that become informational when the
+/// daemon is optional. Kept in sync with the check constructions in
+/// [`doctor`]; module-level so the disposition logic below is unit-testable.
+const DAEMON_CHECK_LABELS: [&str; 5] = [
+    "Daemon version",
+    "Daemon service",
+    "Daemon processes",
+    "Stale locks",
+    "Service exe",
+];
+
+/// Whether a failing doctor check is informational rather than an issue:
+/// daemon checks when no remote/planner needs a daemon (#443), and the
+/// compiler probe when there is no `cc` at all to diagnose (#626).
+fn doctor_check_is_optional(label: &str, daemon_optional: bool, probe_no_compiler: bool) -> bool {
+    (daemon_optional && DAEMON_CHECK_LABELS.contains(&label))
+        || (label == "Compiler probe" && probe_no_compiler)
+}
+
+/// The daemon footnote prints when at least one daemon check failed but was
+/// downgraded to informational; other downgrades (the compiler probe) carry
+/// self-explanatory detail lines and get no footnote.
+fn daemon_footnote_needed(daemon_optional: bool, results: &[(&str, bool)]) -> bool {
+    daemon_optional
+        && results
+            .iter()
+            .any(|(label, pass)| !pass && DAEMON_CHECK_LABELS.contains(label))
+}
+
 pub fn doctor(
     fix: bool,
     purge_sccache: bool,
@@ -2314,16 +2343,6 @@ pub fn doctor(
         fix: Option<String>,
     }
 
-    // Labels of the daemon-related checks that become informational when the
-    // daemon is optional. Kept in sync with the check constructions below.
-    const DAEMON_CHECK_LABELS: [&str; 5] = [
-        "Daemon version",
-        "Daemon service",
-        "Daemon processes",
-        "Stale locks",
-        "Service exe",
-    ];
-
     // Live compiler probe (#626): a toolchain whose `cc -###` resolves no
     // compile line makes every probe-keyed C/C++ flag refuse to cache —
     // builds stay correct but silently lose caching, with zero signal. Run
@@ -2332,10 +2351,8 @@ pub fn doctor(
     let probe_diag = crate::probe::live_probe_diagnostic();
     let probe_no_compiler = matches!(probe_diag, crate::probe::LiveProbeDiagnostic::NoCompiler);
 
-    let check_is_optional = |label: &str| {
-        (daemon_optional && DAEMON_CHECK_LABELS.contains(&label))
-            || (label == "Compiler probe" && probe_no_compiler)
-    };
+    let check_is_optional =
+        |label: &str| doctor_check_is_optional(label, daemon_optional, probe_no_compiler);
 
     let mut checks: Vec<Check> = Vec::new();
 
@@ -2859,7 +2876,8 @@ pub fn doctor(
 
     let label_width = checks.iter().map(|c| c.label.len()).max().unwrap_or(0);
 
-    let mut downgraded_daemon = false;
+    let check_results: Vec<(&str, bool)> = checks.iter().map(|c| (c.label, c.pass)).collect();
+    let downgraded_daemon = daemon_footnote_needed(daemon_optional, &check_results);
     for check in &checks {
         let optional = check_is_optional(check.label);
         // A failing optional check is informational, not a problem: render it
@@ -2867,9 +2885,6 @@ pub fn doctor(
         let icon = if check.pass {
             "\x1b[32m✓\x1b[0m"
         } else if optional {
-            // The footnote below explains only the daemon downgrades; the
-            // compiler-probe downgrade's detail line is self-explanatory.
-            downgraded_daemon |= DAEMON_CHECK_LABELS.contains(&check.label);
             "\x1b[2m•\x1b[0m"
         } else {
             "\x1b[31m✗\x1b[0m"
@@ -4045,6 +4060,48 @@ pub fn verify(config: &Config, checksums: bool, repair: bool) -> Result<()> {
 mod tests {
     use super::*;
     use std::fs;
+
+    // ── Doctor check dispositions (kunobi-ninja/kache#443, #626) ──────────
+
+    /// Which failing checks are informational: the full truth table for
+    /// daemon-optional and probe-no-compiler downgrades.
+    #[test]
+    fn doctor_check_optionality_truth_table() {
+        // Daemon labels downgrade exactly when the daemon is optional.
+        assert!(doctor_check_is_optional("Daemon version", true, false));
+        assert!(!doctor_check_is_optional("Daemon version", false, false));
+        // The compiler probe downgrades exactly when there is no cc at all.
+        assert!(doctor_check_is_optional("Compiler probe", false, true));
+        assert!(!doctor_check_is_optional("Compiler probe", false, false));
+        // probe_no_compiler must not leak onto other labels, nor
+        // daemon_optional onto the probe.
+        assert!(!doctor_check_is_optional("Binary", true, true));
+        assert!(!doctor_check_is_optional("Daemon version", false, true));
+        assert!(!doctor_check_is_optional("Compiler probe", true, false));
+        // Non-daemon, non-probe labels are never optional.
+        assert!(!doctor_check_is_optional("Remote", true, true));
+    }
+
+    /// The daemon footnote prints only for a FAILING daemon check under an
+    /// optional daemon — never for passing daemon checks, failing non-daemon
+    /// checks, or a required daemon.
+    #[test]
+    fn daemon_footnote_only_for_downgraded_daemon_failures() {
+        assert!(daemon_footnote_needed(
+            true,
+            &[("Daemon service", false), ("Binary", true)]
+        ));
+        assert!(!daemon_footnote_needed(false, &[("Daemon service", false)]));
+        assert!(!daemon_footnote_needed(
+            true,
+            &[("Daemon service", true), ("Binary", true)]
+        ));
+        assert!(!daemon_footnote_needed(
+            true,
+            &[("Compiler probe", false), ("Binary", false)]
+        ));
+        assert!(!daemon_footnote_needed(true, &[]));
+    }
 
     // ── Eviction reporting (kunobi-ninja/kache#509) ────────────────────────
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2816,8 +2816,14 @@ pub fn doctor(
         crate::probe::LiveProbeDiagnostic::NoCompiler => Check {
             label: "Compiler probe",
             pass: false,
-            detail: "no usable `cc` on PATH (C/C++ caching not in play)".into(),
+            detail: "no `cc` on PATH; configured or cross compilers were not checked".into(),
             fix: None,
+        },
+        crate::probe::LiveProbeDiagnostic::ProbeError { detail } => Check {
+            label: "Compiler probe",
+            pass: false,
+            detail,
+            fix: Some("fix the compiler diagnostic failure and rerun `kache doctor`".into()),
         },
         crate::probe::LiveProbeDiagnostic::Unresolved {
             version_line,

--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -423,9 +423,13 @@ fn probe_stderr_head(stderr: &str) -> String {
 /// C/C++ flag refuse to cache — correct but silent, which is how #607's
 /// Windows regressions shipped unnoticed (#626).
 pub enum LiveProbeDiagnostic {
-    /// `cc` is missing from PATH or won't identify itself; there is no C
-    /// toolchain to diagnose.
+    /// `cc` is missing from PATH; there is no system C toolchain to diagnose.
     NoCompiler,
+    /// `cc` exists, but the diagnostic itself could not run reliably. Kept
+    /// distinct from [`Self::NoCompiler`]: only genuine absence is
+    /// informational, everything else can hide exactly the silent caching
+    /// loss this check exists to expose (#626).
+    ProbeError { detail: String },
     /// `cc -###` resolved a compile line: probe-keyed flags can cache.
     Resolved { version_line: String },
     /// The compiler runs but its `-###` output yielded no compile line:
@@ -443,12 +447,37 @@ pub enum LiveProbeDiagnostic {
 /// and doctor's job is to report what the compiler does NOW (#626).
 pub fn live_probe_diagnostic() -> LiveProbeDiagnostic {
     const COMPILER: &str = "cc";
-    let Ok(dir) = tempfile::tempdir() else {
-        return LiveProbeDiagnostic::NoCompiler;
+    // Absence is the one informational state; every other failure below is a
+    // diagnostic that could not run and must surface as such.
+    match Command::new(COMPILER).arg("--version").output() {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return LiveProbeDiagnostic::NoCompiler;
+        }
+        Err(error) => {
+            return LiveProbeDiagnostic::ProbeError {
+                detail: format!("could not run `cc --version`: {error}"),
+            };
+        }
+        Ok(output) if !output.status.success() => {
+            return LiveProbeDiagnostic::ProbeError {
+                detail: format!("`cc --version` exited {}", output.status),
+            };
+        }
+        Ok(_) => {}
+    }
+    let dir = match tempfile::tempdir() {
+        Ok(dir) => dir,
+        Err(error) => {
+            return LiveProbeDiagnostic::ProbeError {
+                detail: format!("could not create compiler-probe directory: {error}"),
+            };
+        }
     };
     let source = dir.path().join("kache-doctor-probe.c");
-    if std::fs::write(&source, "int kache_doctor_probe(void) { return 0; }\n").is_err() {
-        return LiveProbeDiagnostic::NoCompiler;
+    if let Err(error) = std::fs::write(&source, "int kache_doctor_probe(void) { return 0; }\n") {
+        return LiveProbeDiagnostic::ProbeError {
+            detail: format!("could not write compiler-probe source: {error}"),
+        };
     }
     let args: Vec<String> = ["-O2", "-x", "c", "-c"]
         .iter()
@@ -462,8 +491,13 @@ pub fn live_probe_diagnostic() -> LiveProbeDiagnostic {
         per_tu_paths: &[],
         windows_aware: true,
     };
-    let Ok(config) = CcProber.probe(&req) else {
-        return LiveProbeDiagnostic::NoCompiler;
+    let config = match CcProber.probe(&req) {
+        Ok(config) => config,
+        Err(error) => {
+            return LiveProbeDiagnostic::ProbeError {
+                detail: format!("compiler probe failed: {error:#}"),
+            };
+        }
     };
     if config.resolved_tokens.is_some() {
         return LiveProbeDiagnostic::Resolved {

--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -467,7 +467,7 @@ fn live_probe_diagnostic_for(compiler: &str) -> LiveProbeDiagnostic {
         }
         Ok(output) if !output.status.success() => {
             return LiveProbeDiagnostic::ProbeError {
-                detail: format!("`cc --version` exited {}", output.status),
+                detail: format!("`{compiler} --version` exited {}", output.status),
             };
         }
         Ok(_) => {}
@@ -705,9 +705,14 @@ mod tests {
         std::fs::set_permissions(&failing, std::fs::Permissions::from_mode(0o755)).unwrap();
         match live_probe_diagnostic_for(&failing.to_string_lossy()) {
             LiveProbeDiagnostic::ProbeError { detail } => {
+                // Specifically the PREFLIGHT's report, not the prober's later
+                // "compiler probe failed" fallback: skipping the preflight
+                // reaches the same variant with a different story, and the
+                // preflight is what keeps the failure attributable.
                 assert!(
-                    detail.contains("--version` exited"),
-                    "unexpected detail: {detail}"
+                    detail.contains("--version` exited")
+                        && !detail.contains("compiler probe failed"),
+                    "expected the --version preflight to report the failure, got: {detail}"
                 );
             }
             other => panic!("--version failure must be ProbeError, got {other:?}"),

--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -422,6 +422,7 @@ fn probe_stderr_head(stderr: &str) -> String {
 /// but `-###` resolves no compile line". The latter makes every probe-keyed
 /// C/C++ flag refuse to cache — correct but silent, which is how #607's
 /// Windows regressions shipped unnoticed (#626).
+#[derive(Debug)]
 pub enum LiveProbeDiagnostic {
     /// `cc` is missing from PATH; there is no system C toolchain to diagnose.
     NoCompiler,
@@ -446,10 +447,16 @@ pub enum LiveProbeDiagnostic {
 /// record may hold `resolved_tokens: None` from before a toolchain change,
 /// and doctor's job is to report what the compiler does NOW (#626).
 pub fn live_probe_diagnostic() -> LiveProbeDiagnostic {
-    const COMPILER: &str = "cc";
+    live_probe_diagnostic_for("cc")
+}
+
+/// [`live_probe_diagnostic`] against an explicit compiler, so the
+/// absent / broken / unresolvable classifications are testable with
+/// stand-in compilers.
+fn live_probe_diagnostic_for(compiler: &str) -> LiveProbeDiagnostic {
     // Absence is the one informational state; every other failure below is a
     // diagnostic that could not run and must surface as such.
-    match Command::new(COMPILER).arg("--version").output() {
+    match Command::new(compiler).arg("--version").output() {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return LiveProbeDiagnostic::NoCompiler;
         }
@@ -485,7 +492,7 @@ pub fn live_probe_diagnostic() -> LiveProbeDiagnostic {
         .chain([source.to_string_lossy().into_owned()])
         .collect();
     let req = ProbeRequest {
-        compiler: COMPILER,
+        compiler,
         args: &args,
         key_args: &args,
         per_tu_paths: &[],
@@ -506,7 +513,7 @@ pub fn live_probe_diagnostic() -> LiveProbeDiagnostic {
     }
     // The prober discards the raw `-###` output; re-run it for the head,
     // which is the one fact an "unresolvable probe" report needs.
-    let stderr_head = Command::new(COMPILER)
+    let stderr_head = Command::new(compiler)
         .arg("-###")
         .args(&args)
         .output()
@@ -658,6 +665,83 @@ mod tests {
         );
         assert_eq!(config.prober, "cc");
         assert_eq!(config.schema_version, PROBE_SCHEMA_VERSION);
+    }
+
+    /// The doctor diagnostic's classification boundaries (#626): only a
+    /// genuinely absent compiler is `NoCompiler`; a present-but-broken one is
+    /// a `ProbeError` that doctor must flag, never silently downgrade.
+    #[test]
+    fn live_probe_diagnostic_classifies_an_absent_compiler() {
+        match live_probe_diagnostic_for("kache-test-definitely-not-a-compiler") {
+            LiveProbeDiagnostic::NoCompiler => {}
+            other => panic!("absent compiler must classify NoCompiler, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn live_probe_diagnostic_flags_a_broken_compiler_as_probe_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+
+        // Present but not executable: spawn fails with a non-NotFound error.
+        let unexecutable = dir.path().join("cc-unexecutable");
+        std::fs::write(&unexecutable, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&unexecutable, std::fs::Permissions::from_mode(0o644)).unwrap();
+        match live_probe_diagnostic_for(&unexecutable.to_string_lossy()) {
+            LiveProbeDiagnostic::ProbeError { detail } => {
+                assert!(
+                    detail.contains("could not run"),
+                    "unexpected detail: {detail}"
+                );
+            }
+            other => panic!("unexecutable compiler must be ProbeError, got {other:?}"),
+        }
+
+        // Present and executable but --version fails.
+        let failing = dir.path().join("cc-version-fails");
+        std::fs::write(&failing, "#!/bin/sh\nexit 1\n").unwrap();
+        std::fs::set_permissions(&failing, std::fs::Permissions::from_mode(0o755)).unwrap();
+        match live_probe_diagnostic_for(&failing.to_string_lossy()) {
+            LiveProbeDiagnostic::ProbeError { detail } => {
+                assert!(
+                    detail.contains("--version` exited"),
+                    "unexpected detail: {detail}"
+                );
+            }
+            other => panic!("--version failure must be ProbeError, got {other:?}"),
+        }
+    }
+
+    /// A fake compiler whose `--version` succeeds but whose `-###` resolves
+    /// nothing classifies `Unresolved` — the state #626 exists to surface —
+    /// and a real gcc/clang-family `cc` never lands in the error states.
+    #[cfg(unix)]
+    #[test]
+    fn live_probe_diagnostic_classifies_unresolvable_and_real_compilers() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let fake = dir.path().join("cc-resolves-nothing");
+        std::fs::write(&fake, "#!/bin/sh\necho fake-cc 1.0\nexit 0\n").unwrap();
+        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).unwrap();
+        match live_probe_diagnostic_for(&fake.to_string_lossy()) {
+            LiveProbeDiagnostic::Unresolved { version_line, .. } => {
+                assert_eq!(version_line, "fake-cc 1.0");
+            }
+            other => panic!("resolving nothing must be Unresolved, got {other:?}"),
+        }
+
+        // The real host compiler, when present, must reach a live verdict —
+        // never NoCompiler/ProbeError (kills the inverted-success mutants).
+        match live_probe_diagnostic_for("cc") {
+            LiveProbeDiagnostic::Resolved { .. } | LiveProbeDiagnostic::Unresolved { .. } => {}
+            LiveProbeDiagnostic::NoCompiler => eprintln!("skipping: no `cc` on PATH"),
+            LiveProbeDiagnostic::ProbeError { detail } => {
+                panic!("a working host `cc` must not classify as ProbeError: {detail}")
+            }
+        }
     }
 
     #[test]

--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -416,6 +416,74 @@ fn probe_stderr_head(stderr: &str) -> String {
         .join("\n")
 }
 
+/// What running the compiler probe against the live toolchain found.
+///
+/// Distinguishes "no compiler" (nothing to diagnose) from "compiler present
+/// but `-###` resolves no compile line". The latter makes every probe-keyed
+/// C/C++ flag refuse to cache — correct but silent, which is how #607's
+/// Windows regressions shipped unnoticed (#626).
+pub enum LiveProbeDiagnostic {
+    /// `cc` is missing from PATH or won't identify itself; there is no C
+    /// toolchain to diagnose.
+    NoCompiler,
+    /// `cc -###` resolved a compile line: probe-keyed flags can cache.
+    Resolved { version_line: String },
+    /// The compiler runs but its `-###` output yielded no compile line:
+    /// probe-keyed flags will refuse to cache on this toolchain.
+    Unresolved {
+        version_line: String,
+        stderr_head: String,
+    },
+}
+
+/// Run the compiler probe against the live toolchain, for `kache doctor`.
+///
+/// Calls [`CcProber`] directly rather than through [`probe`]: the on-disk
+/// record may hold `resolved_tokens: None` from before a toolchain change,
+/// and doctor's job is to report what the compiler does NOW (#626).
+pub fn live_probe_diagnostic() -> LiveProbeDiagnostic {
+    const COMPILER: &str = "cc";
+    let Ok(dir) = tempfile::tempdir() else {
+        return LiveProbeDiagnostic::NoCompiler;
+    };
+    let source = dir.path().join("kache-doctor-probe.c");
+    if std::fs::write(&source, "int kache_doctor_probe(void) { return 0; }\n").is_err() {
+        return LiveProbeDiagnostic::NoCompiler;
+    }
+    let args: Vec<String> = ["-O2", "-x", "c", "-c"]
+        .iter()
+        .map(|s| s.to_string())
+        .chain([source.to_string_lossy().into_owned()])
+        .collect();
+    let req = ProbeRequest {
+        compiler: COMPILER,
+        args: &args,
+        key_args: &args,
+        per_tu_paths: &[],
+        windows_aware: true,
+    };
+    let Ok(config) = CcProber.probe(&req) else {
+        return LiveProbeDiagnostic::NoCompiler;
+    };
+    if config.resolved_tokens.is_some() {
+        return LiveProbeDiagnostic::Resolved {
+            version_line: config.version_line,
+        };
+    }
+    // The prober discards the raw `-###` output; re-run it for the head,
+    // which is the one fact an "unresolvable probe" report needs.
+    let stderr_head = Command::new(COMPILER)
+        .arg("-###")
+        .args(&args)
+        .output()
+        .map(|o| probe_stderr_head(&String::from_utf8_lossy(&o.stderr)))
+        .unwrap_or_default();
+    LiveProbeDiagnostic::Unresolved {
+        version_line: config.version_line,
+        stderr_head,
+    }
+}
+
 /// Probe a compiler, memoized through an on-disk cache under
 /// `cache_dir`.
 ///

--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -560,10 +560,13 @@ mod tests {
 
     #[test]
     fn cc_prober_resolves_the_invocation_with_flags() {
-        // Forks `cc -### -O2 -x c -c <file>`. On clang this resolves a
-        // `-cc1` line; on gcc the resolved-line shape differs and
-        // `resolved_tokens` is `None` until the gcc prober lands — so
-        // the token assertion only runs when resolution succeeded.
+        // Forks `cc -### -O2 -x c -c <file>` against the LIVE host compiler.
+        // Both gcc- and clang-family drivers support `-###` and both have an
+        // extractor in `resolve`, so on a family driver `resolved_tokens ==
+        // None` is a FAILURE, never a skip: #607 shipped with the extractors
+        // resolving nothing on Windows, and this test's old "assert only if
+        // Some" shape waved it through (#626). Only a missing `cc` or a
+        // non-gnu/clang driver skips.
         let src = NamedTempFile::new().unwrap();
         let args: Vec<String> = ["-O2", "-x", "c", "-c", src.path().to_str().unwrap()]
             .iter()
@@ -577,14 +580,36 @@ mod tests {
             windows_aware: true,
         };
         let Ok(config) = CcProber.probe(&request) else {
+            eprintln!("skipping: no `cc` on PATH");
             return;
         };
-        if let Some(tokens) = config.resolved_tokens {
-            assert!(
-                tokens.iter().any(|t| t == "-O2"),
-                "resolved `-cc1` tokens should carry -O2: {tokens:?}"
+        // Family via the live `-E` probe, not the disk cache: the test's
+        // subject is the host compiler, not a stored record.
+        let family = match run_family_probe("cc") {
+            Ok(Some(f)) => f,
+            _ => {
+                eprintln!("skipping: `cc` is not a gcc/clang-family driver");
+                return;
+            }
+        };
+        let Some(tokens) = config.resolved_tokens else {
+            let head = Command::new("cc")
+                .arg("-###")
+                .args(&args)
+                .output()
+                .map(|o| probe_stderr_head(&String::from_utf8_lossy(&o.stderr)))
+                .unwrap_or_else(|e| format!("(could not re-run cc -###: {e})"));
+            panic!(
+                "`cc -###` resolved no compile line on a {family:?}-family driver \
+                 ({}); every probe-keyed flag would silently refuse to cache (#626).\n\
+                 -### head:\n{head}",
+                config.version_line
             );
-        }
+        };
+        assert!(
+            tokens.iter().any(|t| t == "-O2"),
+            "resolved tokens should carry -O2: {tokens:?}"
+        );
     }
 
     /// The head is what a future "unresolvable probe" investigation reads, so

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -5367,6 +5367,12 @@ exit 0
     /// `run_cc_probe` itself is left untested here because it runs a compiler.
     #[test]
     fn probe_forward_compiler_recovers_real_compiler_from_cc_env() {
+        // The probe cache key fingerprints the WHOLE process environment
+        // (`probe::cache::env_fingerprint`), so mutating `CC`/`TARGET` here
+        // mid-flight flips a concurrently-running probe test's key and makes
+        // its memoization assertion flake. Serialize behind the same lock the
+        // env-mutating probe tests hold.
+        let _lock = crate::config::config_path_lock();
         let self_stem = std::env::current_exe()
             .ok()
             .as_deref()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -619,6 +619,30 @@ fn cc_probe_stderr_head(cwd: &Path, args: &[&str]) -> String {
         .unwrap_or_else(|e| format!("(could not run cc -###: {e})"))
 }
 
+/// Do a real raw compile with each flag the #626 test keys on. Deliberately
+/// NOT gated on `-###` parsing — gating on the machinery under test would
+/// recreate the vacuity #626 is about. Old or vendor-derived drivers that
+/// reject one of these flags skip the test instead of false-failing.
+fn cc_accepts_probe_keyed_test_flags(dir: &Path) -> bool {
+    let source = dir.join("flag-support.c");
+    if std::fs::write(&source, "int flag_support(void) { return 0; }\n").is_err() {
+        return false;
+    }
+    ["-fstack-protector-strong", "-fwrapv", "-fno-wrapv"]
+        .iter()
+        .all(|flag| {
+            std::process::Command::new("cc")
+                .args(["-c", "-O0", "-g0"])
+                .arg(&source)
+                .arg("-o")
+                .arg(dir.join("flag-support.o"))
+                .arg(flag)
+                .output()
+                .map(|output| output.status.success())
+                .unwrap_or(false)
+        })
+}
+
 /// Live verification for #626: a probe-keyed flag must produce a real cache
 /// entry, and different values of a probe-keyed knob must key differently.
 ///
@@ -655,6 +679,10 @@ fn probe_keyed_flags_cache_and_key_on_value_live() {
         || !(family_out.contains("KACHE_TEST_CLANG") || family_out.contains("KACHE_TEST_GNU"))
     {
         eprintln!("skipping: `cc` is not a gcc/clang-family driver");
+        return;
+    }
+    if !cc_accepts_probe_keyed_test_flags(work.path()) {
+        eprintln!("skipping: `cc` does not accept the probe-keyed test flags");
         return;
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -601,6 +601,156 @@ fn cc_accepts_gnu_forced_include(dir: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// First lines of `cc -###` stderr for the given compile args — the one fact
+/// a probe-resolution failure report needs (#626).
+fn cc_probe_stderr_head(cwd: &Path, args: &[&str]) -> String {
+    std::process::Command::new("cc")
+        .arg("-###")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map(|o| {
+            String::from_utf8_lossy(&o.stderr)
+                .lines()
+                .take(12)
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_else(|e| format!("(could not run cc -###: {e})"))
+}
+
+/// Live verification for #626: a probe-keyed flag must produce a real cache
+/// entry, and different values of a probe-keyed knob must key differently.
+///
+/// #607's two bugs each made `resolve_invocation` return `None` on Windows,
+/// so every `CapturedByProbe` flag refused fail-closed and passed through —
+/// builds correct, caching silently gone, and every prior test either ran
+/// against frozen `-###` fixtures or skipped when resolution failed. On a
+/// gcc/clang-family `cc` (both families support `-###` and both have an
+/// extractor) this test therefore FAILS when the probe resolves nothing; it
+/// skips only for a missing `cc` or a non-gnu/clang driver, where `-###`
+/// resolution genuinely does not apply.
+#[test]
+fn probe_keyed_flags_cache_and_key_on_value_live() {
+    let work = TempDir::new().unwrap();
+
+    // Family gate, run-and-check like every other compiler gate here: a
+    // preprocessed marker TU says what the driver is, `which` does not.
+    let family_src = work.path().join("family.c");
+    std::fs::write(
+        &family_src,
+        "#if defined(__clang__)\nKACHE_TEST_CLANG\n#elif defined(__GNUC__)\nKACHE_TEST_GNU\n#endif\n",
+    )
+    .unwrap();
+    let Ok(family) = std::process::Command::new("cc")
+        .args(["-E", "-P", "-x", "c"])
+        .arg(&family_src)
+        .output()
+    else {
+        eprintln!("skipping: no `cc` on PATH");
+        return;
+    };
+    let family_out = String::from_utf8_lossy(&family.stdout);
+    if !family.status.success()
+        || !(family_out.contains("KACHE_TEST_CLANG") || family_out.contains("KACHE_TEST_GNU"))
+    {
+        eprintln!("skipping: `cc` is not a gcc/clang-family driver");
+        return;
+    }
+
+    build_kache();
+    let cache_dir = TempDir::new().unwrap();
+    std::fs::write(work.path().join("tu.c"), "int tu(void) { return 7; }\n").unwrap();
+
+    // `-fstack-protector-strong` is `CapturedByProbe`; a cold compile that
+    // records no miss means kache refused (unresolvable probe) and passed
+    // through — the #626 silent-refusal class this test exists to catch.
+    let strong = [
+        "cc",
+        "-c",
+        "tu.c",
+        "-o",
+        "tu.o",
+        "-fstack-protector-strong",
+        "-O0",
+        "-g0",
+    ];
+    run_kache_cc(work.path(), cache_dir.path(), &strong);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(
+        report["summary"]["misses"].as_u64(),
+        Some(1),
+        "probe-keyed flag was passed through instead of cached on a \
+         gcc/clang-family driver (#626).\n`cc -###` said:\n{}\nevents.jsonl:\n{}",
+        cc_probe_stderr_head(work.path(), &strong[1..]),
+        std::fs::read_to_string(cache_dir.path().join("events.jsonl"))
+            .unwrap_or_else(|e| format!("(unreadable: {e})"))
+    );
+
+    // The entry must be real: the same compile hits it. The output is
+    // removed before every re-run — an existing output file takes the #645
+    // passthrough path and would never consult the cache.
+    std::fs::remove_file(work.path().join("tu.o")).unwrap();
+    run_kache_cc(work.path(), cache_dir.path(), &strong);
+    let report = kache_report(cache_dir.path());
+    assert_cc_report_counts(&report, 1, 1);
+
+    // Two values of one probe-keyed knob must key differently. `-fwrapv` /
+    // `-fno-wrapv` are both `CapturedByProbe` (the stem list covers both
+    // polarities) and both clang and gcc resolve them to different cc1
+    // streams. Asserted as "local_hits did not grow", not "misses grew": a
+    // distinct key whose object comes out byte-identical records as a `dup`,
+    // and a false HIT is the only wrong answer (see the #580 test's note).
+    let wrapv = ["cc", "-c", "tu.c", "-o", "tu.o", "-fwrapv", "-O0", "-g0"];
+    let no_wrapv = ["cc", "-c", "tu.c", "-o", "tu.o", "-fno-wrapv", "-O0", "-g0"];
+    std::fs::remove_file(work.path().join("tu.o")).unwrap();
+    run_kache_cc(work.path(), cache_dir.path(), &wrapv);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(
+        report["summary"]["local_hits"].as_u64(),
+        Some(1),
+        "-fwrapv must not hit the -fstack-protector-strong entry: {report}"
+    );
+    std::fs::remove_file(work.path().join("tu.o")).unwrap();
+    run_kache_cc(work.path(), cache_dir.path(), &no_wrapv);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(
+        report["summary"]["local_hits"].as_u64(),
+        Some(1),
+        "-fno-wrapv must not hit the -fwrapv (or any earlier) entry: {report}"
+    );
+
+    // The distinct key stored something reusable: repeating the value hits.
+    std::fs::remove_file(work.path().join("tu.o")).unwrap();
+    run_kache_cc(work.path(), cache_dir.path(), &no_wrapv);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(
+        report["summary"]["local_hits"].as_u64(),
+        Some(2),
+        "repeated -fno-wrapv compile should hit its own entry: {report}"
+    );
+
+    // Key-level proof, straight from the events: five compiles, three flag
+    // sets, exactly three distinct cache keys.
+    let events = report["all_events"]
+        .as_array()
+        .expect("report should include all_events");
+    assert_eq!(events.len(), 5, "expected one event per compile: {report}");
+    let keys: std::collections::BTreeSet<&str> = events
+        .iter()
+        .map(|e| {
+            let key = e["cache_key"].as_str().unwrap_or_default();
+            assert!(!key.is_empty(), "every event should carry a cache key: {e}");
+            key
+        })
+        .collect();
+    assert_eq!(
+        keys.len(),
+        3,
+        "each probe-keyed flag value must map to its own cache key: {report}"
+    );
+}
+
 /// Regression for #645. Existing output symlink semantics differ by compiler:
 /// GCC writes through the link, while some clang versions replace it. Kache
 /// must passthrough and match the selected compiler instead of unlinking first.


### PR DESCRIPTION
## Summary

Fixes #626.

#607's two bugs each made `resolve_invocation` return None on Windows, so every `CapturedByProbe` flag refused fail-closed and passed through: builds correct, caching silently gone, and nothing in the suite noticed because probe parser tests run against frozen fixtures and the one live test was vacuous (`resolved_tokens == None` passed silently). This adds the verification layer the issue asked for:

- **Live unit test with teeth.** `cc_prober_resolves_the_invocation_with_flags` now determines the driver family via a live `-E` probe and panics with the version line and the `-###` stderr head when a gcc/clang-family driver resolves nothing. It skips only for a missing `cc` or a non-gnu/clang driver. The stale "gcc unsupported" comment is gone.
- **Integration proof that probe-keyed flags actually cache.** New `probe_keyed_flags_cache_and_key_on_value_live`: cold miss then hit for `-fstack-protector-strong`; `-fwrapv` vs `-fno-wrapv` never hit each other's entries (asserted as no false hit, since byte-identical objects legitimately record as dups); repeating a value hits; and exactly 3 distinct cache keys across 5 events, straight from the event log. On gcc/clang-family hosts a refusing probe FAILS this test loudly with the `-###` head. A raw-compile flag-acceptance gate (not `-###`-based, so the vacuity cannot return) lets old or vendor drivers skip.
- **Doctor check.** `kache doctor` gains a "Compiler probe" check that runs `CcProber` directly, bypassing the on-disk probe cache so a stale stored None cannot mask the live toolchain. Resolved is green with the version line; a missing `cc` is informational (with honest wording that configured or cross compilers were not checked); a present compiler that resolves nothing, or a diagnostic that could not run (`ProbeError`), is a flagged issue with the `-###` stderr head.
- **Flake fix found along the way.** `probe_forward_compiler_recovers_real_compiler_from_cc_env` mutates `CC`/`TARGET` unguarded while probe cache keys fingerprint the whole environment, which made a memoization test flake once test timing shifted. It now takes the same lock the env-mutating probe tests hold. A broader unification of test env locks (cache_key's separate ENV_LOCK, `CARGO_INCREMENTAL` writers) is a possible follow-up; kept out of scope here.

Notes on the flag choice: `-fstack-protector-all` could not serve as the second knob value because it is deliberately unclassified (pinned by an existing classifier test), so the value-keying assertion uses `-fwrapv`/`-fno-wrapv`, both `CapturedByProbe` via the codegen-knob stem list on both families.

## Test plan

- `cargo test --bin kache probe` (98 tests)
- `cargo test --test integration_test probe_keyed_flags_cache_and_key_on_value_live` (exercises the full wrapper against the real host compiler)
- `kache doctor` on this host: `Compiler probe  cc -### resolves (Apple clang 21)`
- flake fix validated: baseline 4/4 stable, without the lock the reordered schedule flaked ~2/5, with it 5/5 stable
- `cargo fmt --all -- --check`, `cargo clippy --all-targets` clean

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [x] Doctor output change is self-describing; no docs update needed