### PR TITLE
fix(store): guard entry removal against a concurrent same-key publication (#670)

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -2866,10 +2866,29 @@ impl Store {
     ///
     /// `None` (the plain `remove_entry` path) always removes — explicit purge /
     /// `doctor` must not be blocked by recency.
+    ///
+    /// Concurrent same-key *publication* is guarded too (#670): the entry's
+    /// references are decremented only if `meta.json` is byte-identical, under
+    /// the write transaction, to what was read before it — a republication in
+    /// between rolls the removal back — and a remover that deleted no row
+    /// never touches the entry directory, since a fresh `meta.json` there may
+    /// belong to a publisher whose row registration has not committed yet.
     fn remove_entry_guarded(
         &self,
         cache_key: &str,
         skip_if_idle_lt: Option<Duration>,
+    ) -> Result<Option<RemovalReclaim>> {
+        self.remove_entry_guarded_with_hook(cache_key, skip_if_idle_lt, || {})
+    }
+
+    /// [`Self::remove_entry_guarded`] with a test seam: `after_meta_read` runs
+    /// between the pre-transaction `meta.json` read and the write transaction,
+    /// which is exactly the window the #670 republication guard defends.
+    fn remove_entry_guarded_with_hook(
+        &self,
+        cache_key: &str,
+        skip_if_idle_lt: Option<Duration>,
+        after_meta_read: impl FnOnce(),
     ) -> Result<Option<RemovalReclaim>> {
         let entry_dir = self.entry_dir(cache_key);
         let meta_path = entry_dir.join("meta.json");
@@ -2881,6 +2900,7 @@ impl Store {
         // the removal so a corrupt entry never silently leaks (#276); callers
         // (GC / purge / `doctor --repair`) log and move on, and the entry stays
         // accounted-for until a fresh `put` (INSERT OR REPLACE) overwrites it.
+        let meta_content: String;
         let hashes: Vec<String> = match fs::read_to_string(&meta_path) {
             Ok(content) => {
                 let meta: EntryMeta = serde_json::from_str(&content).with_context(|| {
@@ -2889,6 +2909,7 @@ impl Store {
                          refcounts are not leaked (#276)"
                     )
                 })?;
+                meta_content = content;
                 meta.files.iter().map(|f| f.hash.clone()).collect()
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -2918,6 +2939,8 @@ impl Store {
                 });
             }
         };
+
+        after_meta_read();
 
         let removed = {
             let tx = self.db.unchecked_transaction()?;
@@ -2952,6 +2975,23 @@ impl Store {
 
             let mut reclaim = RemovalReclaim::default();
             if rows_affected > 0 {
+                // Republication guard (#670): `put` writes meta.json BEFORE
+                // its registration transaction, so the row just deleted may
+                // belong to a NEWER publication than the meta.json this
+                // removal read its hash list from — decrementing the old
+                // hashes against the new row's refcounts corrupts the store.
+                // The write lock this transaction holds excludes the
+                // publisher's own transaction, so re-reading meta.json here
+                // pins the row↔meta pairing: any difference means a
+                // republication won, and the removal rolls back untouched.
+                // A meta.json that vanished or went corrupt in the window
+                // takes the same rollback; the NEXT removal attempt reports
+                // it properly through the #276 guards above.
+                let still_ours =
+                    matches!(fs::read_to_string(&meta_path), Ok(now) if now == meta_content);
+                if !still_ours {
+                    return Ok(None);
+                }
                 tx.execute(
                     "DELETE FROM entry_blobs WHERE cache_key = ?1",
                     params![cache_key],
@@ -2988,16 +3028,21 @@ impl Store {
         };
 
         // Remove the entry directory (just meta.json in new format, may have
-        // artifacts in legacy entries). Two removers may race here — the row
-        // race above decided ownership of the references, not of the
-        // directory — and the loser must converge without an error (#510).
-        // `NotFound` is the Unix shape of that race; Windows surfaces a
-        // concurrent delete as delete-pending errors (sharing violations,
-        // directory-not-empty after a competitor unlinked mid-walk), so on
-        // any other error re-check whether the directory is actually gone,
-        // with a brief bounded retry while a competitor is still mid-walk.
-        // A directory that persists past the retries is a real failure
-        // (permissions, open handles) and propagates.
+        // artifacts in legacy entries) — but only when THIS call deleted the
+        // row (#670): a remover that deleted nothing must not touch the
+        // directory, because a fresh `meta.json` there may belong to a
+        // publisher whose registration transaction has not committed yet, and
+        // deleting it strands the publisher's row with no artifacts. A
+        // winner-crashed-before-cleanup leftover (meta.json, no row) is
+        // recoverable by design: `rebuild_index_from_store` re-adopts it.
+        if removed.is_none() {
+            return Ok(None);
+        }
+        // Windows can still surface external interference as delete-pending
+        // errors (sharing violations from readers mid-hardlink), so on any
+        // error re-check whether the directory is actually gone, with a brief
+        // bounded retry. A directory that persists past the retries is a real
+        // failure (permissions, open handles) and propagates (#510).
         if let Ok(entries) = fs::read_dir(&entry_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
@@ -7030,6 +7075,127 @@ mod tests {
         // All entries removed → the shared blob is fully reclaimed.
         let store = Store::open(&config).unwrap();
         assert_eq!(store.blob_stats().unwrap().total_blobs, 0);
+    }
+
+    /// kunobi-ninja/kache#670: a remover that deleted no row must not touch
+    /// the entry directory — a fresh meta.json there may belong to a
+    /// publisher whose registration transaction has not committed yet, and
+    /// deleting it strands the publication.
+    #[test]
+    fn losing_remover_leaves_a_publishers_directory_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let src = dir.path().join("x.rlib");
+        std::fs::write(&src, b"mid-publication content").unwrap();
+        store
+            .put(
+                "pub",
+                "c",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(src, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+        // Simulate the publisher's window: meta.json is on disk, the entry
+        // row is not committed yet.
+        store
+            .db
+            .execute("DELETE FROM entries WHERE cache_key = 'pub'", [])
+            .unwrap();
+        store
+            .db
+            .execute("DELETE FROM entry_blobs WHERE cache_key = 'pub'", [])
+            .unwrap();
+
+        store.remove_entry("pub").unwrap();
+        assert!(
+            store.entry_dir("pub").join("meta.json").exists(),
+            "the loser deleted no row and must leave the publisher's meta.json alone"
+        );
+    }
+
+    /// kunobi-ninja/kache#670: the row a removal deletes may belong to a
+    /// NEWER publication than the meta.json it read its hash list from
+    /// (`put` writes meta.json before its registration transaction).
+    /// Decrementing the old hashes against the new row corrupts refcounts;
+    /// the in-transaction meta re-read must detect the republication and
+    /// roll the removal back untouched.
+    #[test]
+    fn removal_rolls_back_when_the_entry_was_republished_mid_flight() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let src_a = dir.path().join("a.rlib");
+        std::fs::write(&src_a, b"generation A").unwrap();
+        store
+            .put(
+                "aba",
+                "c",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(src_a, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        let outcome = store
+            .remove_entry_guarded_with_hook("aba", None, || {
+                // Republish the same key with different content between the
+                // removal's meta read and its transaction.
+                let src_b = dir.path().join("b.rlib");
+                std::fs::write(&src_b, b"generation B, longer content").unwrap();
+                store
+                    .put(
+                        "aba",
+                        "c",
+                        &["lib".into()],
+                        &[],
+                        "",
+                        "dev",
+                        &[(src_b, "lib.rlib".into())],
+                        "",
+                        "",
+                    )
+                    .unwrap();
+            })
+            .unwrap();
+
+        assert!(
+            outcome.is_none(),
+            "a removal that lost to a republication must report nothing removed"
+        );
+        assert!(
+            store.contains("aba"),
+            "generation B's row must survive the rolled-back removal"
+        );
+        let meta = store.get("aba").unwrap().expect("B must stay restorable");
+        let hash = &meta.files[0].hash;
+        assert!(
+            store.blob_path(hash).is_file(),
+            "generation B's blob must remain on disk"
+        );
+        let refcount: i64 = store
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            refcount, 1,
+            "B's refcounts must be untouched by the rollback"
+        );
     }
 
     /// kunobi-ninja/kache#510: directory-cleanup tolerance is for the

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -5895,8 +5895,26 @@ exit 0
             vec![cached_file("libfoo.rmeta", "0123456789abcdef")],
             &["metadata"],
         );
+        // Production reaches this path through `get()`, so the entry always
+        // has a DB row — and removal only cleans a directory whose row it
+        // owns (#670). Register a real entry, then overwrite its meta.json
+        // with the partial one under test.
+        let seed = dir.path().join("seed.rmeta");
+        std::fs::write(&seed, b"seed").unwrap();
+        store
+            .put(
+                &meta.cache_key,
+                "foo",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(seed, "libfoo.rmeta".into())],
+                "",
+                "",
+            )
+            .unwrap();
         let entry_dir = store.entry_dir(&meta.cache_key);
-        std::fs::create_dir_all(&entry_dir).unwrap();
         std::fs::write(
             entry_dir.join("meta.json"),
             serde_json::to_string(&meta).unwrap(),


### PR DESCRIPTION
## Summary

Addresses the two harmful interleavings in #670. `put` writes `meta.json` (with fsync) before opening its registration transaction, so a remover could interleave with a publisher two ways:

1. **Mid-publication directory deletion.** A remover whose row DELETE affected nothing still removed the entry directory, destroying the `meta.json` a mid-flight publisher had just written and stranding its row once the registration committed. Directory cleanup is now owned by the row: a remover that deleted no row never touches the directory.
2. **ABA refcount corruption.** A remover could read generation A's hash list, lose the row to a republication, then delete generation B's row while decrementing A's hashes against B's refcounts. The removal transaction now re-reads `meta.json` after the row DELETE and rolls back untouched unless it is byte-identical to the pre-transaction read. The write lock the removal holds excludes the publisher's own transaction, so the check pins the row-to-meta pairing. An identical-byte republication is invisible to the check by design and is safe: the hash list and multiplicities are fully determined by the meta bytes, so the decrements match the surviving row exactly (linearizes as removing the equivalent entry).

Caller audit for the ownership change: every production remover reaches removal through a DB row (purge via `list_entries`, `doctor --repair` via a DB scan, wrapper poisoned/partial-entry eviction via `get()`, and the eviction sweeps via `eviction_candidates`), so nothing relied on `remove_entry` deleting an unindexed directory. A winner-crashed-before-cleanup leftover (meta.json, no row) is recoverable by design: `rebuild_index_from_store` re-adopts it. The partial-entry wrapper test now registers a real row first, matching how production reaches that path.

**Residual window (documented in the code, left open on #670):** a publisher whose meta write lands after the in-transaction re-read but before the winner's post-commit directory removal can still lose its `meta.json` — the row then points at a missing directory, which reads as a miss and leaks that row's refcounts until doctor/rebuild. The blobs themselves are safe: `put` materializes blobs inside its own write transaction with an explicit re-materialize guard for exactly this unlink race, so only the meta file is exposed. Fully closing it means moving `put`'s meta write inside the registration critical section, which puts an fsync inside the SQLite write lock and deserves its own latency discussion — proposed as the follow-up on the issue rather than bundled here.

Both fixes verified red on the pre-fix code via a hook seam that runs between the pre-transaction meta read and the transaction — the exact window under test. Cross-model review confirmed the rollback and lock analysis and sharpened the residual-window characterization reflected above.

## Test plan

- new tests: `losing_remover_leaves_a_publishers_directory_alone` and `removal_rolls_back_when_the_entry_was_republished_mid_flight` (both red with the guards toggled off, green with them on; the republished generation's row, blob, and refcount asserted untouched)
- full suites: 1612 unit, 25 integration, 51 CLI tests green; `cargo fmt --all -- --check`, `cargo clippy --all-targets` clean

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [x] No user-visible changes