### PR TITLE
feat(gc): shadow-evaluate the value-density eviction candidate (#594)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -47,8 +47,11 @@ gitignore = true
 # a gate: which cosmetic string prints is unobservable from `cargo test`
 # (stdout of the spawned CLI, daemon tracing output), while the counts
 # themselves come from `Store::backfill_*` / eviction, which are
-# mutation-tested directly. Revisit if either function ever grows a `>` with
-# semantic weight.
+# mutation-tested directly. The `+` in `Daemon::run_gc` is the same shape:
+# it sums two cohort counts purely to decide whether the shadow-demand info
+# line prints (#594); the counts come from `shadow_demand_split`, which is
+# tested directly. Revisit if either function ever grows a comparison or sum
+# with semantic weight.
 #
 # `join_inflight_download` compares `Instant::now() < deadline` to decide
 # whether a waiter may still adopt a newer leader generation. Flipping `<` to
@@ -67,5 +70,6 @@ exclude_re = [
     "kani_proofs::",
     "replace > with (>=|<|==) in run_gc_local",
     "replace > with (>=|<|==) in Daemon::run_gc",
+    "replace \\+ with . in Daemon::run_gc",
     "replace < with <= in join_inflight_download",
 ]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3230,6 +3230,22 @@ impl Daemon {
                         "gc: post-eviction demand"
                     );
                 }
+                // The #594 policy comparison: demand rate on entries the
+                // value-density shadow would have KEPT vs entries it agreed
+                // to evict. A markedly higher rate on the kept cohort is the
+                // evidence for flipping the live policy; comparable rates
+                // are the evidence against.
+                if let Ok(split) = store.shadow_demand_split()
+                    && split.agreed + split.shadow_kept > 0
+                {
+                    tracing::info!(
+                        shadow_agreed = split.agreed,
+                        shadow_agreed_demanded = split.agreed_demanded,
+                        shadow_kept = split.shadow_kept,
+                        shadow_kept_demanded = split.shadow_kept_demanded,
+                        "gc: post-eviction demand by shadow verdict (value-density, #594)"
+                    );
+                }
 
                 // Evict duplicate entries (same content, different cache keys)
                 let dedup_stats = store.evict_duplicate_entries().unwrap_or_default();

--- a/src/eviction.rs
+++ b/src/eviction.rs
@@ -370,6 +370,22 @@ mod tests {
         assert_eq!(value_density_score(&unbackfilled), 0.0);
     }
 
+    /// Below the 0.001 MB clamp the size term saturates, so sub-clamp
+    /// entries order purely by rebuild cost. Pins the clamp's placement on
+    /// the MB-converted value: mis-scaling the conversion (which is
+    /// order-preserving everywhere else) un-saturates these and flips them.
+    #[test]
+    fn value_density_orders_sub_clamp_entries_by_cost_alone() {
+        let mut a = feat("a", 500, 0, 1.0);
+        a.compile_time_ms = 1;
+        let mut b = feat("b", 1000, 0, 1.0);
+        b.compile_time_ms = 2;
+        // Both clamp to 0.001 MB: scores are 1000 vs 2000, cheaper first.
+        assert!(value_density_score(&a) < value_density_score(&b));
+        let order = ValueDensityPolicy.select(&[b, a]);
+        assert_eq!(order, vec!["a", "b"]);
+    }
+
     /// The budget walk takes the ranking's prefix whose expected reclaim
     /// covers `bytes_needed`, and no more.
     #[test]

--- a/src/eviction.rs
+++ b/src/eviction.rs
@@ -110,6 +110,83 @@ impl EvictionPolicy for SizePressurePolicy {
     }
 }
 
+/// Retention value per reclaimable byte; **lower is evicted first**
+/// (kunobi-ninja/kache#594, shadow candidate — never the live policy yet).
+///
+/// `compile_time_ms / reclaimable_mb`: what a re-miss on this entry costs to
+/// rebuild, per byte its eviction would actually free. This is deliberately
+/// the PURE density score from the #594 analysis, with no recency or
+/// hit-count terms bolted on: reuse probability belongs as a multiplier
+/// estimated from the tombstone demand stream, not as an arbitrary divisor —
+/// and the demand stream this shadow feeds is exactly what will estimate it.
+///
+/// Two knowingly rough edges, acceptable because this only ever shadows:
+/// entries whose `compile_time_ms` is still 0 (not yet backfilled, or a
+/// sub-millisecond compile) rank as worthless and become the shadow's first
+/// victims, and the serve-from-cache cost is treated as negligible rather
+/// than subtracted from the rebuild cost.
+pub(crate) fn value_density_score(e: &EntryFeatures) -> f64 {
+    let bytes = e.reclaimable_bytes.unwrap_or(e.size);
+    let size_mb = (bytes as f64 / 1_048_576.0).max(0.001);
+    e.compile_time_ms as f64 / size_mb
+}
+
+/// Pure rebuild-cost-density ranking — the #594 shadow candidate.
+pub(crate) struct ValueDensityPolicy;
+
+impl EvictionPolicy for ValueDensityPolicy {
+    fn name(&self) -> &'static str {
+        "value-density"
+    }
+
+    fn select(&self, candidates: &[EntryFeatures]) -> Vec<String> {
+        let mut ranked: Vec<&EntryFeatures> = candidates.iter().collect();
+        ranked.sort_by(|a, b| {
+            value_density_score(a)
+                .partial_cmp(&value_density_score(b))
+                .unwrap_or(Ordering::Equal)
+        });
+        ranked.into_iter().map(|e| e.key.clone()).collect()
+    }
+}
+
+/// The set of keys a policy's ranking would evict to free `bytes_needed` —
+/// the shadow half of a #594 comparison. Walks `order` accumulating each
+/// entry's *expected* reclaim (its marginal reclaimable bytes, logical size
+/// when unknown) until the budget is met.
+///
+/// An approximation over the pre-sweep snapshot, not a simulation: the live
+/// walk budgets on bytes each removal ACTUALLY freed, where a shared blob's
+/// bytes materialize only when its last surviving twin goes, while this walk
+/// sees every twin's marginal bytes as the snapshot reported them (zero for
+/// all of them) and never updates as it goes. Unknown reclaim falls back to
+/// logical size, which can overestimate progress and shorten the prefix, and
+/// entries the live sweep skips (recency-pinned, lost removal races) still
+/// consume this budget. Good enough for a per-entry agreement verdict;
+/// a faithful counterfactual sweep would need dynamically updated blob
+/// refcounts and the live eligibility rules (#594 follow-up territory).
+pub(crate) fn would_evict_for_budget(
+    candidates: &[EntryFeatures],
+    order: &[String],
+    bytes_needed: u64,
+) -> std::collections::HashSet<String> {
+    let by_key: HashMap<&str, &EntryFeatures> =
+        candidates.iter().map(|e| (e.key.as_str(), e)).collect();
+    let mut victims = std::collections::HashSet::new();
+    let mut freed: u64 = 0;
+    for key in order {
+        if freed >= bytes_needed {
+            break;
+        }
+        let Some(e) = by_key.get(key.as_str()) else {
+            continue;
+        };
+        freed += e.reclaimable_bytes.unwrap_or(e.size).max(0) as u64;
+        victims.insert(key.clone());
+    }
+    victims
+}
+
 /// Age-based eviction: every entry untouched for more than `hours`.
 ///
 /// Replaces `WHERE last_accessed < datetime('now', '-N hours')`. One deliberate
@@ -257,6 +334,63 @@ mod tests {
         let unknown = feat("unknown", 600 * 1024 * 1024, 0, 15.0);
         let small_hot = feat("small", 14 * 1024, 9, 0.1);
         assert!(size_pressure_score(&unknown) < size_pressure_score(&small_hot));
+    }
+
+    /// kunobi-ninja/kache#594: the shadow candidate ranks by rebuild cost per
+    /// reclaimable byte — a big cheap entry goes before a small expensive
+    /// one, the opposite of what size pressure prefers.
+    #[test]
+    fn value_density_evicts_cheap_per_byte_first() {
+        let mut big_cheap = feat("big_cheap", 600 * 1024 * 1024, 0, 15.0);
+        big_cheap.compile_time_ms = 300; // 0.3s for 600 MB
+        let mut small_expensive = feat("small_expensive", 3 * 1024 * 1024, 0, 15.0);
+        small_expensive.compile_time_ms = 6_000; // 6s for 3 MB
+
+        assert!(value_density_score(&big_cheap) < value_density_score(&small_expensive));
+        let order = ValueDensityPolicy.select(&[small_expensive, big_cheap]);
+        assert_eq!(order, vec!["big_cheap", "small_expensive"]);
+    }
+
+    /// Density divides by marginal reclaimable bytes when known: an entry
+    /// whose blobs are all shared frees nothing, so its retention costs
+    /// nothing and it ranks LAST (infinite-ish density from the clamp).
+    #[test]
+    fn value_density_uses_reclaimable_bytes_and_ranks_unknown_cost_first() {
+        let mut shared = feat("shared", 500 * 1024 * 1024, 0, 10.0);
+        shared.reclaimable_bytes = Some(0);
+        shared.compile_time_ms = 1_000;
+        let mut unique = feat("unique", 10 * 1024 * 1024, 0, 10.0);
+        unique.reclaimable_bytes = Some(10 * 1024 * 1024);
+        unique.compile_time_ms = 1_000;
+        assert!(value_density_score(&unique) < value_density_score(&shared));
+
+        // Zero compile time (not yet backfilled) ranks as worthless — a
+        // documented shadow-only rough edge.
+        let unbackfilled = feat("unbackfilled", 1024, 0, 10.0);
+        assert_eq!(value_density_score(&unbackfilled), 0.0);
+    }
+
+    /// The budget walk takes the ranking's prefix whose expected reclaim
+    /// covers `bytes_needed`, and no more.
+    #[test]
+    fn would_evict_for_budget_takes_the_covering_prefix() {
+        let mut a = feat("a", 100, 0, 1.0);
+        a.reclaimable_bytes = Some(100);
+        let mut b = feat("b", 100, 0, 1.0);
+        b.reclaimable_bytes = Some(0); // fully shared: frees nothing
+        let mut c = feat("c", 100, 0, 1.0);
+        c.reclaimable_bytes = Some(100);
+        let d = feat("d", 100, 0, 1.0); // unknown: expected reclaim = logical 100
+
+        let candidates = vec![a, b, c, d];
+        let order: Vec<String> = ["a", "b", "c", "d"].iter().map(|s| s.to_string()).collect();
+
+        let victims = would_evict_for_budget(&candidates, &order, 150);
+        // a frees 100 (< 150), b frees 0, c reaches 200 — d is spared.
+        assert!(victims.contains("a") && victims.contains("b") && victims.contains("c"));
+        assert!(!victims.contains("d"));
+
+        assert!(would_evict_for_budget(&candidates, &order, 0).is_empty());
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -595,6 +595,29 @@ pub(crate) struct RemovalReclaim {
     pub(crate) blobs_unlinked: usize,
 }
 
+/// A shadow policy's would-evict set for one size-driven sweep
+/// (kunobi-ninja/kache#594): the keys it would remove for the same byte
+/// budget the live policy is sweeping toward.
+struct ShadowSelection {
+    policy: &'static str,
+    victims: std::collections::HashSet<String>,
+}
+
+/// Post-eviction demand, split by whether the shadow policy agreed with the
+/// live one about each evicted entry (kunobi-ninja/kache#594).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ShadowDemandSplit {
+    /// Evicted entries the shadow policy would also have evicted.
+    pub agreed: usize,
+    /// …of which were later asked for again.
+    pub agreed_demanded: usize,
+    /// Evicted entries the shadow policy would have KEPT.
+    pub shadow_kept: usize,
+    /// …of which were later asked for again — the shadow's saves, had it
+    /// been live.
+    pub shadow_kept_demanded: usize,
+}
+
 /// Statistics returned by [`Store::sweep_orphan_blobs`].
 #[derive(Debug, Clone, Copy, Default)]
 pub struct OrphanSweepStats {
@@ -986,6 +1009,13 @@ fn initialize_db(db: &Connection) -> rusqlite::Result<()> {
             demanded_at     TEXT
         );",
     )?;
+    // Shadow-policy verdict per eviction (kunobi-ninja/kache#594): which
+    // candidate policy shadowed the sweep, and whether it agreed this entry
+    // should go. NULL on rows from sweeps without a shadow. Idempotent
+    // migrations, same pattern as the entries columns above.
+    let _ = db.execute_batch("ALTER TABLE eviction_tombstones ADD COLUMN shadow_policy TEXT");
+    let _ =
+        db.execute_batch("ALTER TABLE eviction_tombstones ADD COLUMN shadow_would_evict INTEGER");
 
     db.execute_batch(
         "CREATE TABLE IF NOT EXISTS incremental_dirs (
@@ -2380,6 +2410,7 @@ impl Store {
         by_key: &std::collections::HashMap<&str, &crate::eviction::EntryFeatures>,
         policy: &str,
         stop_at: Option<(u64, u64)>,
+        shadow: Option<&ShadowSelection>,
     ) -> GcStats {
         let mut stats = GcStats::default();
         let (mut current_size, target) = match stop_at {
@@ -2411,7 +2442,8 @@ impl Store {
                     // tombstone lost to a crash costs one observation, not
                     // correctness.
                     if let Some(f) = features {
-                        self.record_tombstone(f, policy);
+                        let verdict = shadow.map(|s| (s.policy, s.victims.contains(key.as_str())));
+                        self.record_tombstone(f, policy, verdict);
                     }
                 }
                 // Pinned by a recent access — a live build may be mid-restore
@@ -2439,6 +2471,12 @@ impl Store {
     ///
     /// `stop_at` is `Some((current_size, target))` for size-driven sweeps and
     /// `None` when the policy's whole selection should be removed.
+    ///
+    /// Size-driven sweeps are shadowed by the #594 value-density candidate:
+    /// it ranks the same candidate set for the same byte budget, and each
+    /// tombstone records whether it agreed — while the live policy alone
+    /// decides what actually goes. The demand stream then compares the two
+    /// on real reuse, the evidence step 5 of #594 is gated on.
     fn evict_with(
         &self,
         policy: &dyn crate::eviction::EvictionPolicy,
@@ -2466,9 +2504,22 @@ impl Store {
             selected_compile_time_ms = cost_ms,
             "gc: eviction selection"
         );
+        let shadow = stop_at.map(|(current, target)| {
+            use crate::eviction::EvictionPolicy as _;
+            let candidate = crate::eviction::ValueDensityPolicy;
+            let shadow_order = candidate.select(&candidates);
+            ShadowSelection {
+                policy: candidate.name(),
+                victims: crate::eviction::would_evict_for_budget(
+                    &candidates,
+                    &shadow_order,
+                    current.saturating_sub(target),
+                ),
+            }
+        });
         let by_key: std::collections::HashMap<&str, &crate::eviction::EntryFeatures> =
             candidates.iter().map(|e| (e.key.as_str(), e)).collect();
-        Ok(self.apply_eviction(&order, &by_key, policy.name(), stop_at))
+        Ok(self.apply_eviction(&order, &by_key, policy.name(), stop_at, shadow.as_ref()))
     }
 
     /// Weighted eviction: remove entries with lowest priority score until under the size limit.
@@ -2752,16 +2803,24 @@ impl Store {
     }
 
     /// Record that an entry was evicted, with the features the decision was
-    /// made on (kunobi-ninja/kache#594).
+    /// made on (kunobi-ninja/kache#594). `shadow` carries the shadow policy's
+    /// verdict on the same entry — `(policy_name, it_would_evict_this_too)` —
+    /// so later demand on the key splits by whether the candidate policy
+    /// agreed with the live one.
     ///
     /// Best-effort: telemetry must never fail or slow an eviction, so errors
     /// are logged at debug and swallowed.
-    fn record_tombstone(&self, features: &crate::eviction::EntryFeatures, policy: &str) {
+    fn record_tombstone(
+        &self,
+        features: &crate::eviction::EntryFeatures,
+        policy: &str,
+        shadow: Option<(&str, bool)>,
+    ) {
         let result = self.db.execute(
             "INSERT OR REPLACE INTO eviction_tombstones
                 (cache_key, evicted_at, policy, size, hit_count, idle_hours, compile_time_ms,
-                 demanded_at)
-             VALUES (?1, datetime('now'), ?2, ?3, ?4, ?5, ?6, NULL)",
+                 demanded_at, shadow_policy, shadow_would_evict)
+             VALUES (?1, datetime('now'), ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?8)",
             params![
                 features.key,
                 policy,
@@ -2769,6 +2828,8 @@ impl Store {
                 features.hit_count,
                 features.idle_hours,
                 features.compile_time_ms,
+                shadow.map(|(name, _)| name),
+                shadow.map(|(_, would)| would),
             ],
         );
         if let Err(e) = result {
@@ -2833,6 +2894,46 @@ impl Store {
             |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
         )?;
         Ok((row.0.max(0) as usize, row.1.max(0) as usize))
+    }
+
+    /// Post-eviction demand split by the shadow policy's verdict
+    /// (kunobi-ninja/kache#594): of the entries the live policy evicted, how
+    /// often was each cohort — "shadow agreed" vs "shadow would have kept" —
+    /// later asked for again? A markedly higher demand rate on the
+    /// would-have-kept cohort flags live-policy mistakes the shadow avoids.
+    /// Both cohorts come from the same evicted population, so the comparison
+    /// avoids the inventory-value circularity the issue warns about.
+    ///
+    /// This is a **live-victim diagnostic**, not flip evidence on its own:
+    /// the shadow's own victims that the live policy KEPT are invisible here
+    /// (their reuse shows up only as ordinary hits), rates are right-censored
+    /// by tombstone age, and a flip decision needs the cost-weighted
+    /// objective, not raw demand counts. Rows whose `compile_time_ms` is
+    /// still 0 are recorded but excluded from the headline numbers: the
+    /// density shadow ranks unknown-cost entries as worthless by
+    /// construction, and freshness correlates with not-yet-backfilled, so
+    /// counting them would bias the kept cohort with young, high-demand
+    /// keys.
+    pub fn shadow_demand_split(&self) -> Result<ShadowDemandSplit> {
+        let row = self.db.query_row(
+            "SELECT
+                COUNT(CASE WHEN shadow_would_evict = 1 THEN 1 END),
+                COUNT(CASE WHEN shadow_would_evict = 1 AND demanded_at IS NOT NULL THEN 1 END),
+                COUNT(CASE WHEN shadow_would_evict = 0 THEN 1 END),
+                COUNT(CASE WHEN shadow_would_evict = 0 AND demanded_at IS NOT NULL THEN 1 END)
+             FROM eviction_tombstones
+             WHERE shadow_policy = 'value-density' AND compile_time_ms > 0",
+            [],
+            |row| {
+                Ok(ShadowDemandSplit {
+                    agreed: row.get::<_, i64>(0)?.max(0) as usize,
+                    agreed_demanded: row.get::<_, i64>(1)?.max(0) as usize,
+                    shadow_kept: row.get::<_, i64>(2)?.max(0) as usize,
+                    shadow_kept_demanded: row.get::<_, i64>(3)?.max(0) as usize,
+                })
+            },
+        )?;
+        Ok(row)
     }
 
     /// Remove a single cache entry (files + DB record).
@@ -4716,7 +4817,7 @@ mod tests {
             compile_time_ms: 10,
             reclaimable_bytes: None,
         };
-        store.record_tombstone(&features, "size-pressure");
+        store.record_tombstone(&features, "size-pressure", Some(("value-density", false)));
         assert_eq!(
             store.tombstone_stats().unwrap(),
             (1, 0),
@@ -7501,6 +7602,114 @@ mod tests {
             "950 > 900 must trigger, and one 190-byte eviction reaches 760 <= 900"
         );
         assert_eq!(store.physical_size().unwrap(), 760);
+    }
+
+    /// kunobi-ninja/kache#594: a size-driven sweep records every tombstone
+    /// with the value-density shadow's verdict on the same entry, and the
+    /// demand stream splits by that verdict. The store here is built so the
+    /// two policies disagree: the live policy evicts the LARGEST stale entry
+    /// (huge but expensive to rebuild), while the shadow — ranking by
+    /// rebuild cost per reclaimable byte — would have kept it and evicted
+    /// the small cheap one instead.
+    #[test]
+    fn size_sweep_records_shadow_verdicts_and_demand_splits() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.max_size = 450_000; // target 405_000; physical 500_000
+        let store = Store::open(&config).unwrap();
+
+        for (key, bytes, fill, compile_ms) in [
+            ("huge_expensive", 400_000usize, b'a', 60_000u64),
+            ("small_cheap", 100_000usize, b'b', 1u64),
+        ] {
+            let src = dir.path().join(format!("{key}.rlib"));
+            std::fs::write(&src, vec![fill; bytes]).unwrap();
+            store
+                .put_with_compile_time(
+                    key,
+                    "c",
+                    &["lib".into()],
+                    &[],
+                    "",
+                    "dev",
+                    &[(src, "lib.rlib".into())],
+                    "",
+                    "",
+                    compile_ms,
+                )
+                .unwrap();
+        }
+        store
+            .db
+            .execute(
+                "UPDATE entries SET last_accessed = datetime('now', '-1 hour')",
+                [],
+            )
+            .unwrap();
+
+        let stats = store.evict().unwrap();
+        assert_eq!(
+            stats.entries_evicted, 1,
+            "the live policy evicts the largest entry and reaches its target"
+        );
+        assert!(!store.contains("huge_expensive"));
+        assert!(store.contains("small_cheap"));
+
+        // The tombstone carries the shadow's dissent: for the same 95 KB
+        // budget the value-density ranking would have taken small_cheap
+        // (density ~10 ms/MB) and kept huge_expensive (~150,000 ms/MB).
+        let (shadow_policy, shadow_would_evict): (String, i64) = store
+            .db
+            .query_row(
+                "SELECT shadow_policy, shadow_would_evict FROM eviction_tombstones
+                 WHERE cache_key = 'huge_expensive'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(shadow_policy, "value-density");
+        assert_eq!(shadow_would_evict, 0, "the shadow would have kept it");
+
+        // Demand on the evicted key lands in the shadow-kept cohort — the
+        // shadow's save, had it been live.
+        assert!(store.get("huge_expensive").unwrap().is_none());
+        assert_eq!(
+            store.shadow_demand_split().unwrap(),
+            ShadowDemandSplit {
+                agreed: 0,
+                agreed_demanded: 0,
+                shadow_kept: 1,
+                shadow_kept_demanded: 1,
+            }
+        );
+
+        // Pin the split query's cohort handling: an agreed row counts, a
+        // pre-shadow row (NULL verdict) enters neither cohort, and an
+        // unknown-cost row is recorded but excluded from the headline —
+        // the density shadow ranks unknown cost as worthless by
+        // construction, so counting it would bias the comparison.
+        store
+            .db
+            .execute_batch(
+                "INSERT INTO eviction_tombstones
+                    (cache_key, policy, compile_time_ms, shadow_policy, shadow_would_evict, demanded_at)
+                 VALUES ('agreed_row', 'size-pressure', 500, 'value-density', 1, datetime('now'));
+                 INSERT INTO eviction_tombstones (cache_key, policy, compile_time_ms)
+                 VALUES ('pre_shadow_row', 'size-pressure', 500);
+                 INSERT INTO eviction_tombstones
+                    (cache_key, policy, compile_time_ms, shadow_policy, shadow_would_evict)
+                 VALUES ('unknown_cost_row', 'size-pressure', 0, 'value-density', 0);",
+            )
+            .unwrap();
+        assert_eq!(
+            store.shadow_demand_split().unwrap(),
+            ShadowDemandSplit {
+                agreed: 1,
+                agreed_demanded: 1,
+                shadow_kept: 1,
+                shadow_kept_demanded: 1,
+            }
+        );
     }
 
     /// kunobi-ninja/kache#608 (honest accounting): a sweep over a fully-shared


### PR DESCRIPTION
## Summary

Step 4 of #594's plan, and only step 4: run the candidate policy over the same candidate set while the live policy alone decides what goes, so the tombstone demand stream can judge the two on real reuse. No default flip — that is step 5, gated on what this collects.

- **ValueDensityPolicy** ranks by `compile_time_ms` per marginal reclaimable byte. Deliberately the PURE density score from the issue's analysis, with no recency or hit-count terms bolted on: reuse probability belongs as a multiplier estimated from the demand stream this shadow feeds, not as an arbitrary divisor.
- Every size-driven sweep computes the shadow's would-evict set for the same byte budget (`would_evict_for_budget` walks the shadow ranking over the pre-sweep snapshot), and each tombstone records the verdict (`shadow_policy`, `shadow_would_evict`; idempotent migration, NULL on rows from non-size sweeps and older stores).
- **`shadow_demand_split()`** reports post-eviction demand split by verdict: of the entries the live policy evicted, the cohort the shadow would have KEPT versus the cohort it agreed on. A markedly higher demand rate on the kept cohort flags live-policy mistakes the shadow avoids. Both cohorts come from the same evicted population, which avoids the inventory-value circularity documented on the issue. The daemon GC sweep logs the split next to the existing demand line.

## What this is and is not

The split is a **live-victim diagnostic, not flip evidence on its own**, and the docs say so: the shadow's own victims that the live policy kept are invisible here (their reuse shows up only as ordinary hits), rates are right-censored by tombstone age, and the flip decision needs the cost-weighted objective rather than raw demand counts. Guardrails already applied from cross-model review of this change:

- the headline split filters to `shadow_policy = 'value-density'` and excludes rows with `compile_time_ms = 0`: the density shadow ranks unknown-cost entries as worthless by construction, and freshness correlates with not-yet-backfilled, so counting them would bias the kept cohort with young high-demand keys (rows are still recorded for deeper analysis)
- the budget walk's docs state its approximations honestly: it reads the pre-sweep snapshot (shared-blob twins all report zero marginal bytes; the live walk realizes them on the last twin), logical-size fallback can shorten the prefix, and live-side pins/races still consume shadow budget

The review's stronger proposal — an append-only, two-sided observation ledger that also records live-kept entries and stamps observations on hits — is the faithful counterfactual, but it replaces #604's deliberate latest-eviction tombstone design (re-eviction restarting the observation window is pinned behavior there). Proposing it on the issue as the follow-up rather than bundling a telemetry redesign here; same for a dynamically-updated counterfactual sweep.

## Test plan

- policy/budget unit tests: density ordering (big-cheap before small-expensive), reclaimable-bytes denominator, unknown-cost ranks worthless, covering-prefix budget walk
- store test `size_sweep_records_shadow_verdicts_and_demand_splits`: a store where live and shadow genuinely disagree (live evicts the huge expensive entry; the shadow would have kept it), asserting the tombstone verdict, the demand split, and the query's cohort handling (agreed / NULL / unknown-cost rows) — verified red with the shadow wiring toggled off
- full suites green: 1617 unit tests; `cargo fmt --all -- --check`, `cargo clippy --all-targets` clean

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [x] No user-visible behavior change (telemetry only; the live policy is untouched)