### PR TITLE
fix(key): cross-clone convergence — OUT_DIR-relative env-dep sentinel, portable dep-info, validate-on-hit (#330)

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -167,7 +167,19 @@ use std::path::{Path, PathBuf};
 // #647 deliberately needs no bump: rustc response files were refused under
 // every existing version, while their expanded effective arguments key exactly
 // like the equivalent inline argv and leave ordinary invocation keys unchanged.
-pub(crate) const CACHE_KEY_VERSION: u32 = 22;
+//
+// v23 (kunobi-ninja/kache#330): env-dep values under the build's own OUT_DIR
+// (the literal OUT_DIR and typenum-style locator vars) now normalize to an
+// `<OUT_DIR:{unit-dir}>`-relative sentinel instead of running through the
+// generic prefix rules. The generic rules kept per-location components inside
+// the value when `CARGO_TARGET_DIR` sits outside the workspace (the derived
+// workspace root is the target dir's parent, so `<WORKSPACE>` swallowed the
+// target path), diverging keys across build locations for content-identical
+// compiles. Cargo's per-unit directory component stays in the sentinel — a
+// generated file can observe its own remapped path via `file!()`, so units
+// differing only by unit hash must not collide. Bump so v22 entries with the
+// old spelling invalidate cleanly.
+pub(crate) const CACHE_KEY_VERSION: u32 = 23;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
 /// Collapse runs of ASCII whitespace into single spaces and trim
@@ -1686,6 +1698,34 @@ fn normalize_env_dep_value(
         source_files,
         path_normalizer.path_only_env_vars(),
     ) {
+        // A value under the build's own OUT_DIR normalizes relative to
+        // OUT_DIR itself (kunobi-ninja/kache#330): the generic prefix rules
+        // keep per-LOCATION path components inside the sentinel'd value
+        // (see `out_dir_relative_suffix`), diverging keys across build
+        // locations, while the include'd CONTENT the locator points at is
+        // already content-hashed through the source list. Cargo's per-unit
+        // directory (`<pkg>-<unit hash>`) stays IN the sentinel: a
+        // generated file can observe its own path (`file!()`, panic
+        // locations), and rustc's remap keeps the unit component in that
+        // observable value, so two units whose OUT_DIRs differ only by
+        // unit hash are not interchangeable (cross-model review finding).
+        if let Some(rel) = out_dir_relative_suffix(&resolved) {
+            let unit = std::env::var_os("OUT_DIR")
+                .map(std::path::PathBuf::from)
+                .as_deref()
+                .and_then(|p| p.parent().and_then(|d| d.file_name().map(|n| n.to_owned())))
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let value = if rel.is_empty() {
+                format!("<OUT_DIR:{unit}>")
+            } else {
+                format!("<OUT_DIR:{unit}>/{}", rel.trim_start_matches('/'))
+            };
+            return NormalizedEnvDep {
+                value,
+                decision: EnvDepNormalizationDecision::NormalizedPathOnly,
+            };
+        }
         return NormalizedEnvDep {
             value: normalized,
             decision: EnvDepNormalizationDecision::NormalizedPathOnly,
@@ -1760,20 +1800,35 @@ fn env_dep_is_safe_to_normalize(
 /// script, so no such var exists) or the value is not under it — in particular
 /// `CARGO_MANIFEST_DIR`, which lives above OUT_DIR, never qualifies here.
 fn value_is_under_out_dir(val: &str) -> bool {
-    let Some(out_dir) = std::env::var_os("OUT_DIR") else {
-        return false;
-    };
+    out_dir_relative_suffix(val).is_some()
+}
+
+/// The value's path relative to the build's own `OUT_DIR`, when it lives
+/// under it (`Some("")` for `OUT_DIR` itself). This is the anchor for the
+/// `<OUT_DIR>` sentinel (kunobi-ninja/kache#330): an OUT_DIR-locator value
+/// must normalize relative to OUT_DIR, not through the generic prefix rules
+/// — an out-of-workspace `CARGO_TARGET_DIR` makes the derived workspace
+/// root the target dir's PARENT, so the generic `<WORKSPACE>` rule matches
+/// first and keeps the per-location target-dir component inside the
+/// sentinel'd value, diverging the key across build locations. Anchoring on
+/// OUT_DIR itself also drops cargo's per-unit hash from the value, which
+/// the generic rules preserve.
+fn out_dir_relative_suffix(val: &str) -> Option<String> {
+    let out_dir = std::env::var_os("OUT_DIR")?;
     let out_dir = Path::new(&out_dir);
     let out_canonical = std::fs::canonicalize(out_dir).ok();
     let out_probe = out_canonical.as_deref().unwrap_or(out_dir);
     // An empty/relative OUT_DIR can't anchor a meaningful "under" test.
     if !out_probe.is_absolute() {
-        return false;
+        return None;
     }
     let val_path = Path::new(val);
     let val_canonical = std::fs::canonicalize(val_path).ok();
     let val_probe = val_canonical.as_deref().unwrap_or(val_path);
-    val_probe.starts_with(out_probe)
+    val_probe
+        .strip_prefix(out_probe)
+        .ok()
+        .map(|rel| rel.to_string_lossy().replace('\\', "/"))
 }
 
 /// Decide whether dep-info shows the env_dep value acting as the parent dir
@@ -2767,7 +2822,7 @@ pub fn run_dep_info_pass(
 ///
 /// Format: `target: dep1 dep2 dep3`
 /// Handles `\ ` escaped spaces in paths. Returns sorted paths.
-fn parse_dep_info(dep_info: &str) -> Vec<std::path::PathBuf> {
+pub(crate) fn parse_dep_info(dep_info: &str) -> Vec<std::path::PathBuf> {
     let line = match dep_info.lines().next() {
         Some(l) => l,
         None => return vec![],
@@ -5023,10 +5078,20 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             "a rustc-env var pointing under OUT_DIR, used only as an include locator, \
              must normalize: {under:?}"
         );
-        assert!(
-            under.value.contains("<WORKSPACE>") && under.value != value,
-            "normalized value should replace the absolute workspace prefix with a \
-             sentinel so it is stable cross-clone: {under:?}"
+        let unit = out_dir
+            .canonicalize()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            under.value,
+            format!("<OUT_DIR:{unit}>/consts.rs"),
+            "an OUT_DIR-locator value normalizes relative to OUT_DIR (#330), keeping \
+             the per-unit component (file!() observability) but not the location: {under:?}"
         );
         assert_eq!(
             no_anchor.decision,

--- a/src/link.rs
+++ b/src/link.rs
@@ -993,7 +993,29 @@ const DEPINFO_ROOT_SENTINEL: &str = "__kache_root__/";
 pub fn rewrite_depinfo_content(content: &str, project_dir: &Path, mode: DepInfoMode) -> String {
     let project_prefix = format!("{}/", project_dir.display());
     match mode {
-        DepInfoMode::Relativize => content.replace(&project_prefix, DEPINFO_ROOT_SENTINEL),
+        DepInfoMode::Relativize => {
+            // Windows dep-info paths use backslash separators — and often
+            // mix them (`...\out/generated.rs` from an env-var join). A
+            // prefix built with one separator silently fails to match the
+            // other, so the builder's absolute paths shipped verbatim in
+            // the cached entry and poisoned every other project sharing it
+            // (kunobi-ninja/kache#330). Relativize both spellings there; the
+            // sentinel expands with `/`, which every Windows API accepts.
+            // On Unix a backslash is a legal FILENAME character, not a
+            // separator, so the extra spelling must not run there — it
+            // could rewrite a sibling like `target\gen.rs` that lives
+            // outside the directory (cross-model review finding).
+            let rewritten = content.replace(&project_prefix, DEPINFO_ROOT_SENTINEL);
+            #[cfg(windows)]
+            {
+                let backslash_prefix = format!("{}\\", project_dir.display());
+                rewritten.replace(&backslash_prefix, DEPINFO_ROOT_SENTINEL)
+            }
+            #[cfg(not(windows))]
+            {
+                rewritten
+            }
+        }
         DepInfoMode::Expand => content.replace(DEPINFO_ROOT_SENTINEL, &project_prefix),
     }
 }
@@ -1442,6 +1464,44 @@ mod tests {
 
         let content = fs::read_to_string(&depfile).unwrap();
         assert!(content.contains("/home/user/project/"));
+    }
+
+    /// kunobi-ninja/kache#330: Windows dep-info uses backslash separators and
+    /// often mixes them (an env-var join appends with `/`). Relativize must
+    /// catch both spellings of the prefix, or the builder's absolute paths
+    /// ship in the cached entry and poison every other project sharing it.
+    #[test]
+    #[cfg(windows)]
+    fn test_depinfo_relativize_handles_windows_separators() {
+        let input = "S:\\proj\\target\\debug\\deps\\demo.d: \
+S:\\proj\\target\\debug\\build\\demo-8a22\\out/generated.rs\n";
+
+        let rewritten = rewrite_depinfo_content(
+            input,
+            Path::new("S:\\proj\\target"),
+            DepInfoMode::Relativize,
+        );
+        assert!(
+            !rewritten.contains("S:\\proj\\target"),
+            "the builder's absolute prefix must not survive: {rewritten}"
+        );
+        assert_eq!(
+            rewritten.matches(DEPINFO_ROOT_SENTINEL).count(),
+            2,
+            "both references relativize: {rewritten}"
+        );
+
+        // Expansion re-roots at the consumer with `/`, which Windows accepts.
+        let expanded = rewrite_depinfo_content(
+            &rewritten,
+            Path::new("T:\\other\\target"),
+            DepInfoMode::Expand,
+        );
+        assert!(
+            expanded.contains("T:\\other\\target/debug\\build\\demo-8a22\\out/generated.rs"),
+            "consumer-rooted mixed-separator path: {expanded}"
+        );
+        assert!(!expanded.contains(DEPINFO_ROOT_SENTINEL));
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -3179,6 +3179,20 @@ impl Store {
         Ok(removed)
     }
 
+    /// Test-only: insert a bare committed entry row, for tests that stage a
+    /// synthetic `meta.json` and need removal to own the directory (#670
+    /// made directory cleanup conditional on owning the row).
+    #[cfg(test)]
+    pub(crate) fn insert_entry_row_for_test(&self, cache_key: &str) {
+        self.db
+            .execute(
+                "INSERT OR REPLACE INTO entries (cache_key, crate_name, size, committed) \
+                 VALUES (?1, 'test', 1, 1)",
+                params![cache_key],
+            )
+            .expect("test entry row insert");
+    }
+
     /// Test-only: backdate an entry's `last_accessed` (via a SQLite datetime
     /// modifier like `"-1 hour"`) so eviction tests can move an entry past the
     /// active-pin grace without sleeping (kunobi-ninja/kache#326).

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2459,6 +2459,44 @@ fn restore_from_cache(
         .or_else(|| std::env::current_dir().ok())
         .unwrap_or_else(|| Path::new(".").to_path_buf());
 
+    // Dep-info validation gate (kunobi-ninja/kache#330): a restored `.d`
+    // whose paths do not resolve for THIS consumer poisons cargo's
+    // freshness check with MissingFile and the crate recompiles on every
+    // subsequent build, forever — the recompile is served by the same
+    // entry, restoring the same broken `.d`, so the loop never breaks.
+    // Field report: entries stored before the Windows separator fix in
+    // `rewrite_depinfo_content` carry the builder's absolute paths.
+    // Validate every referenced path BEFORE materializing anything; a
+    // miss evicts the entry so the recompile stores a portable one —
+    // self-healing, mirroring the emit-coverage gate above.
+    for cached_file in &meta.files {
+        if !matches!(
+            crate::compiler::classify_by_filename(&cached_file.name),
+            crate::compiler::ArtifactKind::DepInfo
+        ) {
+            continue;
+        }
+        let blob = blobs.blob_path(&cached_file.hash);
+        let Ok(raw) = std::fs::read_to_string(&blob) else {
+            // Missing/unreadable blob is the materialize loop's concern;
+            // it reports a clean miss for it below.
+            continue;
+        };
+        let expanded =
+            crate::link::rewrite_depinfo_content(&raw, &depinfo_anchor, link::DepInfoMode::Expand);
+        for dep in crate::cache_key::parse_dep_info(&expanded) {
+            if !dep.exists() {
+                blobs.remove_entry(&meta.cache_key);
+                anyhow::bail!(
+                    "cached dep-info for {} references {} which does not resolve here — \
+                     evicting the entry and recompiling (#330)",
+                    meta.crate_name,
+                    dep.display()
+                );
+            }
+        }
+    }
+
     // One platform per restore, shared across every cached file. The
     // detect call is cheap (cfg cascade) but doing it once keeps the
     // tracing context coherent and lets a future per-restore override
@@ -5875,6 +5913,85 @@ exit 0
 
     /// An entry whose recorded emit set is narrower than the invocation is
     /// evicted and reported as a restore miss instead of serving a partial hit.
+    /// kunobi-ninja/kache#330: a cached `.d` whose expanded paths do not
+    /// resolve for THIS consumer poisons cargo's freshness check into a
+    /// permanent recompile loop (the recompile restores the same broken
+    /// `.d`). The restore gate must evict the entry and miss so the
+    /// recompile stores a portable one.
+    #[test]
+    fn restore_evicts_entry_whose_depinfo_references_missing_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+        let store = Store::open(&config).unwrap();
+        let out_dir = dir.path().join("target/debug/deps");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        let args = rustc_args(&[
+            "rustc",
+            "src/lib.rs",
+            "--crate-name",
+            "foo",
+            "--emit",
+            "dep-info,link",
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+        ]);
+
+        // A real source the .d also lists, so only the donor-absolute path
+        // is missing — the exact field-report shape.
+        let real_src = dir.path().join("lib.rs");
+        std::fs::write(&real_src, "pub fn f() {}\n").unwrap();
+        let dep_content = format!(
+            "{}/foo.rlib: {} /donor/project/target/debug/build/gen-8a22/out/generated.rs\n",
+            out_dir.display(),
+            real_src.display(),
+        );
+        let dep_hash = blake3::hash(dep_content.as_bytes()).to_hex().to_string();
+        let rlib_hash = blake3::hash(b"rlib bytes").to_hex().to_string();
+        create_blob(&store, &dep_hash, dep_content.as_bytes());
+        create_blob(&store, &rlib_hash, b"rlib bytes");
+
+        let mut dep_file = cached_file("foo.d", &dep_hash);
+        dep_file.size = dep_content.len() as u64;
+        let mut rlib_file = cached_file("libfoo.rlib", &rlib_hash);
+        rlib_file.size = "rlib bytes".len() as u64;
+        let meta = entry_meta(
+            "poisoned-key",
+            vec![dep_file, rlib_file],
+            &["dep-info", "link"],
+        );
+        let entry_dir = store.entry_dir(&meta.cache_key);
+        std::fs::create_dir_all(&entry_dir).unwrap();
+        std::fs::write(
+            entry_dir.join("meta.json"),
+            serde_json::to_string(&meta).unwrap(),
+        )
+        .unwrap();
+        store.insert_entry_row_for_test("poisoned-key");
+
+        let err = restore_from_cache(
+            &config,
+            &RustcCompiler::new(),
+            &BlobSource::Store(&store),
+            &args,
+            &meta,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("does not resolve here"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            !store.entry_dir(&meta.cache_key).join("meta.json").exists(),
+            "the poisoned entry must be evicted so the recompile stores a portable one"
+        );
+        assert!(
+            !out_dir.join("foo.d").exists(),
+            "nothing may be materialized before the gate"
+        );
+    }
+
     #[test]
     fn restore_from_cache_rejects_entry_missing_requested_emit_kind() {
         let dir = tempfile::tempdir().unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -437,6 +437,136 @@ fn test_manifest_dir_env_dep_does_not_restore_stale_rlib_across_worktrees() {
     );
 }
 
+/// kunobi-ninja/kache#330: the classic cross-clone `.rmeta` cascade — an
+/// upstream crate's metadata embedding clone-local paths, diverging its
+/// bytes, and cascading through every dependent's `extern:` content hash —
+/// converges on current rustc with kache's injected `--remap-path-prefix`.
+/// This pins that convergence: both the dependency and its dependent must
+/// hit when the identical workspace builds at a second absolute path.
+#[test]
+fn test_rust_extern_cascade_converges_across_clones() {
+    build_kache();
+
+    let root = TempDir::new().unwrap();
+    let write_ws = |ws: &Path| {
+        std::fs::create_dir_all(ws.join("dep/src")).unwrap();
+        std::fs::create_dir_all(ws.join("app/src")).unwrap();
+        std::fs::write(
+            ws.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"dep\", \"app\"]\nresolver = \"2\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ws.join("dep/Cargo.toml"),
+            "[package]\nname = \"dep\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::write(ws.join("dep/src/lib.rs"), "pub fn f() -> u32 { 7 }\n").unwrap();
+        std::fs::write(
+            ws.join("app/Cargo.toml"),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\
+             [dependencies]\ndep = { path = \"../dep\" }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ws.join("app/src/lib.rs"),
+            "pub fn g() -> u32 { dep::f() + 1 }\n",
+        )
+        .unwrap();
+    };
+    let clone_a = root.path().join("clone-a");
+    let clone_b = root.path().join("clone-b-at-a-much-longer-absolute-path");
+    write_ws(&clone_a);
+    write_ws(&clone_b);
+
+    let cache_dir = TempDir::new().unwrap();
+    let target_a = TempDir::new().unwrap();
+    let target_b = TempDir::new().unwrap();
+
+    run_cargo_build_with_kache(&clone_a, cache_dir.path(), target_a.path());
+    let events_after_a = kache_report(cache_dir.path())["all_events"]
+        .as_array()
+        .expect("report should include all_events")
+        .len();
+
+    run_cargo_build_with_kache(&clone_b, cache_dir.path(), target_b.path());
+    let report = kache_report(cache_dir.path());
+    let all_events = report["all_events"]
+        .as_array()
+        .expect("report should include all_events");
+    let clone_b_events = &all_events[events_after_a..];
+
+    for krate in ["dep", "app"] {
+        assert!(
+            clone_b_events
+                .iter()
+                .any(|e| e["crate_name"].as_str() == Some(krate)
+                    && e["result"].as_str() == Some("local_hit")),
+            "{krate} must hit in clone B — the extern cascade regressed: {clone_b_events:?}"
+        );
+    }
+}
+
+/// kunobi-ninja/kache#330: the build-script `include!(env!("OUT_DIR"))`
+/// pattern — the shape the issue's field report reduced to — also converges
+/// across clones: the generated file's path differs per clone but the
+/// content-hashed key and the normalized env-dep (cache-key v18) line up.
+#[test]
+fn test_rust_out_dir_include_converges_across_clones() {
+    build_kache();
+
+    let root = TempDir::new().unwrap();
+    let write_proj = |proj: &Path| {
+        std::fs::create_dir_all(proj.join("src")).unwrap();
+        std::fs::write(
+            proj.join("Cargo.toml"),
+            "[package]\nname = \"genlib\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[workspace]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            proj.join("build.rs"),
+            "fn main() {\n    let out = std::env::var(\"OUT_DIR\").unwrap();\n    \
+             std::fs::write(std::path::Path::new(&out).join(\"generated.rs\"),\n        \
+             \"pub const G: u32 = 9;\\n\").unwrap();\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            proj.join("src/lib.rs"),
+            "include!(concat!(env!(\"OUT_DIR\"), \"/generated.rs\"));\npub fn h() -> u32 { G }\n",
+        )
+        .unwrap();
+    };
+    let clone_a = root.path().join("clone-a");
+    let clone_b = root.path().join("clone-b-at-a-much-longer-absolute-path");
+    write_proj(&clone_a);
+    write_proj(&clone_b);
+
+    let cache_dir = TempDir::new().unwrap();
+    let target_a = TempDir::new().unwrap();
+    let target_b = TempDir::new().unwrap();
+
+    run_cargo_build_with_kache(&clone_a, cache_dir.path(), target_a.path());
+    let events_after_a = kache_report(cache_dir.path())["all_events"]
+        .as_array()
+        .expect("report should include all_events")
+        .len();
+
+    run_cargo_build_with_kache(&clone_b, cache_dir.path(), target_b.path());
+    let report = kache_report(cache_dir.path());
+    let all_events = report["all_events"]
+        .as_array()
+        .expect("report should include all_events");
+    let clone_b_events = &all_events[events_after_a..];
+
+    assert!(
+        clone_b_events
+            .iter()
+            .any(|e| e["crate_name"].as_str() == Some("genlib")
+                && e["result"].as_str() == Some("local_hit")),
+        "genlib must hit in clone B despite its OUT_DIR-generated include: {clone_b_events:?}"
+    );
+}
+
 #[test]
 fn test_rust_depinfo_restore_preserves_include_str_parent_relative_path() {
     build_kache();


### PR DESCRIPTION
## Summary

Addresses #330 with what the evidence, rather than the original framing, turned out to require.

**Empirical findings that reshaped the issue.** On current rustc, kache's injected `--remap-path-prefix` already makes the `.rmeta` byte-identical across clones: the classic extern-content cascade converges (verified: two clones of a dep+app workspace, 2/2 hits in clone B; same for the build-script `include!(env!("OUT_DIR"))` shape). Byte-masking the rmeta for hashing — the issue's original direction — is intractable regardless: a path-length delta shifts encoded offsets starting in the header, so a masker would have to reimplement rustc's metadata serialization per version.

**What the new harness caught still diverging, and the fixes:**

1. **Out-of-workspace `CARGO_TARGET_DIR` diverges keys.** The wrapper derives its workspace root as the target dir's parent, so with an external target dir the `<WORKSPACE>` prefix rule (higher precedence than `<TARGET>`) swallows the target path and keeps the per-location component inside the sentinel'd env-dep value. OUT_DIR-locator values now normalize to an `<OUT_DIR:{unit-dir}>`-relative sentinel: location-invariant, while cargo's per-unit directory stays in the sentinel because a generated file can observe its own remapped path via `file!()` — units differing only by unit hash must not collide. The existing safety gates (include-only proof, no runtime env-value use) are unchanged and checked first. `CACHE_KEY_VERSION` 22 to 23.
2. **Windows dep-info poisoning at the source.** Relativization built its prefix with a trailing `/` only, which never matches backslash-separated Windows `.d` content — the builder's absolute paths shipped verbatim and poisoned every project sharing the entry (the issue's field report, including the permanent recompile loop). The backslash spelling is now handled on Windows only: on Unix a backslash is a legal filename character and the extra replacement could rewrite a sibling path (cross-model review finding).
3. **Mandatory dep-info validate-on-hit.** Before materializing anything, restore expands each cached `.d` against this consumer's anchor and stats every referenced path; any missing path evicts the entry and recompiles. This is the issue's "a too-coarse digest can only cause a recompute, never a false hit" contract applied where it demonstrably bites, and it self-heals entries already poisoned by (2): the recompile stores a portable entry under the same key. Eviction rather than a local miss is deliberate — a keyed entry promises portability to every invocation producing that key, and an unresolvable path breaks that contract.

**Known residual, recorded on the issue:** allowlisted path-only env vars pointing under `CARGO_TARGET_DIR` but outside `OUT_DIR` still route through the generic rules and can retain the per-location component; the general fix is most-specific-prefix matching in the normalizer, which needs its own collision analysis.

## Test plan

- new cross-clone regression harness (the gap #330's plan called for): `test_rust_extern_cascade_converges_across_clones` and `test_rust_out_dir_include_converges_across_clones` — two checkouts, shared cache, dependents must hit; the OUT_DIR test failed before the sentinel fix and passes after
- Windows-separator round-trip test (`#[cfg(windows)]`, runs on the Windows CI lane), eviction test for the poisoned-dep-info shape, updated OUT_DIR-locator unit test pinning the exact sentinel spelling — each verified red with its fix toggled off
- full suites green: 1619 unit, 27 integration; fmt and clippy clean
- cross-model adversarial review applied: the Unix backslash corruption fix and the unit-hash-preserving sentinel both came out of it

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [x] Key-version bump documented in the version-note convention; no user-visible config changes