### PR TITLE
fix(rustc): cache wasm link outputs; stop truncating key-error causes (#431)

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -5777,9 +5777,21 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             "2021".to_string(),
         ];
 
+        let Err(err) = run_dep_info_pass(&rustc, None, &source, &args, false) else {
+            panic!("expected Err on a failing dep-info pass (source has a syntax error)");
+        };
+        // The error must CARRY rustc's own reason, not just say the pass
+        // failed: the wrapper logs `{e:#}`, and a diagnostic that drops the
+        // cause is how the substrate bench's 60 refusals stayed unexplained
+        // for two months (kunobi-ninja/kache#431).
+        let rendered = format!("{err:#}");
         assert!(
-            run_dep_info_pass(&rustc, None, &source, &args, false).is_err(),
-            "expected Err on a failing dep-info pass (source has a syntax error)"
+            rendered.contains("dep-info pre-pass failed (exit"),
+            "the cause must name the failing exit status: {rendered}"
+        );
+        assert!(
+            rendered.contains("error"),
+            "the cause must carry rustc's own first stderr line: {rendered}"
         );
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -208,6 +208,16 @@ pub enum ArtifactKind {
     DepInfo,
     /// Executable. Mutable post-build (codesigning, stripping).
     Executable,
+    /// A wasm target's linked module (`.wasm`) — the shape a `bin` or
+    /// `cdylib` built for `wasm32-*` takes (kunobi-ninja/kache#431).
+    ///
+    /// Deliberately its own kind rather than a [`Self::DynamicLibrary`]:
+    /// it shares that kind's *mutation* profile (build tooling such as
+    /// substrate's wasm-builder post-processes the emitted module, so it
+    /// must restore as an independent file, never a shared inode) but not
+    /// its *loader* profile — a wasm module is never mapped by the OS
+    /// loader, so it must not pick up the codesign post-restore action.
+    WasmModule,
     /// Debug info sidecar (`.dwo`, `.pdb`, `.dSYM`).
     DebugSidecar,
     /// A kache-produced tar of a debug-info bundle *directory* — today the
@@ -229,7 +239,9 @@ impl ArtifactKind {
     /// cache blob. Immutable kinds may share an inode (hardlink fallback).
     pub fn link_strategy(self) -> LinkStrategy {
         match self {
-            ArtifactKind::Executable | ArtifactKind::DynamicLibrary => LinkStrategy::Copy,
+            ArtifactKind::Executable | ArtifactKind::DynamicLibrary | ArtifactKind::WasmModule => {
+                LinkStrategy::Copy
+            }
             _ => LinkStrategy::Hardlink,
         }
     }
@@ -357,6 +369,7 @@ pub fn classify_by_filename(name: &str) -> ArtifactKind {
         // shortest tail, which is "o" for both).
         "o" | "obj" => ArtifactKind::Object,
         "dylib" | "so" | "dll" => ArtifactKind::DynamicLibrary,
+        "wasm" => ArtifactKind::WasmModule,
         "dwo" | "pdb" | "dSYM" => ArtifactKind::DebugSidecar,
         "exe" => ArtifactKind::Executable,
         "" => ArtifactKind::Other("extensionless"),
@@ -393,7 +406,13 @@ pub fn emit_kind_for_filename(name: &str) -> Option<&'static str> {
         .unwrap_or("");
     match ext {
         // Linked output: rlib / staticlib / dylib / cdylib / bin / proc-macro.
-        "rlib" | "so" | "dylib" | "dll" | "exe" | "a" | "lib" => Some("link"),
+        // Linked output, plus `wasm` — a wasm32 target's `bin`/`cdylib`
+        // link product (kunobi-ninja/kache#431). Without `wasm` here the
+        // coverage gate saw an entry as not covering the `--emit=link` it
+        // was built for, so every wasm module refused to store: on the
+        // substrate bench that silently blocked the runtime crates, the
+        // most expensive compiles in the build.
+        "rlib" | "so" | "dylib" | "dll" | "exe" | "a" | "lib" | "wasm" => Some("link"),
         "rmeta" => Some("metadata"),
         "o" | "obj" => Some("obj"),
         "d" | "pp" => Some("dep-info"),
@@ -1291,6 +1310,9 @@ mod tests {
             ArtifactKind::Library,
             ArtifactKind::Metadata,
             ArtifactKind::DebugSidecar,
+            // A wasm module is never OS-loaded, so it must NOT pick up the
+            // codesign action its Copy-strategy siblings get (#431).
+            ArtifactKind::WasmModule,
             ArtifactKind::Other("test"),
         ] {
             assert!(
@@ -1734,6 +1756,10 @@ mod tests {
             ArtifactKind::DynamicLibrary
         );
         assert_eq!(
+            classify_by_filename("rococo_runtime.wasm"),
+            ArtifactKind::WasmModule
+        );
+        assert_eq!(
             classify_by_filename("foo.dll"),
             ArtifactKind::DynamicLibrary
         );
@@ -1789,6 +1815,10 @@ mod tests {
             ("libfoo.dylib", Some("link")),
             ("foo.dll", Some("link")),
             ("foo.exe", Some("link")),
+            // A wasm32 target's link product (#431): before this, the
+            // coverage gate saw a `--emit=link` wasm entry as covering
+            // nothing, so every wasm module refused to store.
+            ("rococo_runtime.wasm", Some("link")),
             ("my_bin-abc123", Some("link")), // extensionless bin
             ("libfoo-abc.rmeta", Some("metadata")),
             ("foo-abc.123.rcgu.o", Some("obj")),

--- a/src/store.rs
+++ b/src/store.rs
@@ -8919,6 +8919,54 @@ mod tests {
         assert!(mk(&["link"]).covers_requested_emit(&req(&["link", "future-exotic"])));
     }
 
+    /// kunobi-ninja/kache#431: a wasm32 target's link product is a `.wasm`
+    /// file. Until it mapped to the `link` emit kind, an entry built for
+    /// `--emit=link,dep-info` derived only `["dep-info"]`, so the coverage
+    /// gate refused to store it — silently blocking every wasm module,
+    /// including substrate's runtime crates (the bench's most expensive
+    /// compiles).
+    #[test]
+    fn wasm_link_output_satisfies_the_emit_coverage_gate() {
+        let files = vec![
+            CachedFile {
+                name: "rococo_runtime.wasm".into(),
+                size: 4,
+                hash: "h1".into(),
+                executable: false,
+            },
+            CachedFile {
+                name: "rococo_runtime.d".into(),
+                size: 4,
+                hash: "h2".into(),
+                executable: false,
+            },
+        ];
+        let kinds = emit_kinds_for_files(&files);
+        assert_eq!(
+            kinds,
+            vec!["dep-info".to_string(), "link".to_string()],
+            "a .wasm module is the link product of a wasm32 target"
+        );
+
+        let meta = EntryMeta {
+            cache_key: "k".into(),
+            crate_name: "rococo_runtime".into(),
+            crate_types: vec!["cdylib".into()],
+            files,
+            stdout: String::new(),
+            stderr: String::new(),
+            features: vec![],
+            target: "wasm32-unknown-unknown".into(),
+            profile: "release".into(),
+            compile_time_ms: 62_000,
+            emit_kinds: kinds,
+        };
+        assert!(
+            meta.covers_requested_emit(&["link".to_string(), "dep-info".to_string()]),
+            "the entry must satisfy the --emit it was built for"
+        );
+    }
+
     #[test]
     fn test_put_stores_content_hash() {
         let tmp = tempfile::tempdir().unwrap();

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1420,14 +1420,19 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     ) {
         Ok(keyed) => keyed,
         Err(e) => {
-            tracing::warn!("failed to compute cache key for {}: {}", crate_name, e);
+            // `{e:#}` — the alternate form walks the cause chain. Plain
+            // `{e}` prints only the outermost context, which is how the
+            // substrate bench's 60 dep-info refusals stayed undiagnosable:
+            // the log said "dep-info pre-pass failed for src/lib.rs" and
+            // dropped rustc's own reason underneath it (kunobi-ninja/kache#431).
+            tracing::warn!("failed to compute cache key for {}: {:#}", crate_name, e);
             return passthrough_with_event(
                 config,
                 &args,
                 crate_name,
                 &event_root,
                 start,
-                format!("uncacheable|{e}"),
+                format!("uncacheable|{e:#}"),
             );
         }
     };


### PR DESCRIPTION
## Summary

Re-measuring #431's three gap classes against today's nightly artifacts (run 31241532191) turned up one real bug with large cost, one diagnostic defect that explains why a second class was never understood, and confirmation that a third class is already fixed.

**A wasm32 target's link product could never be cached.** rustc names a `bin`/`cdylib` built for `wasm32-*` `<name>.wasm`, and that extension mapped to no `--emit` kind. An entry built for `--emit=link,dep-info` therefore derived only `["dep-info"]`, so the #325 coverage gate saw it as not covering the `link` it was built for and refused to store — silently, on every wasm module. In the substrate bench that blocked `rococo_runtime` (62s), `westend_runtime` (40s) and `frame_storage_access_test_runtime`: the most expensive compiles in the build, uncacheable by construction and sitting right at the top of `top_misses`. `.wasm` now maps to `link`.

Classification gets a dedicated `ArtifactKind::WasmModule` rather than reusing `DynamicLibrary`. It shares that kind's *mutation* profile — build tooling such as substrate's wasm-builder post-processes the emitted module, so it must restore as an independent file and never a shared inode — but not its *loader* profile: a wasm module is never mapped by the OS loader, so it must not pick up the codesign post-restore action. (Discovery already probed the `wasm` suffix; only classification and the emit mapping were missing.)

**Cache-key failures logged only their outermost context.** The wrapper used `{e}`, which drops anyhow's cause chain. That is exactly why #431's class 3 says "worth understanding why the pre-pass fails for these specific crates" and nobody could: the log said `dep-info pre-pass failed for src/lib.rs` and threw away rustc's own reason underneath it. Both the log line and the passthrough reason now use `{e:#}`, so the next nightly explains itself.

## What the re-measurement showed (for the issue's record)

| Class | June 2026 | Today (run 31241532191) |
|---|---|---|
| 2 — uncached executables | 255 | **0** — fixed by #603's Linux default-on; total passthrough is now 2.3% against a 40% gate |
| 3 — dep-info refusals | 60 "crates" | 60 invocations of **one** crate: `dummy_crate`, the throwaway probe `substrate-wasm-builder` generates. Its cause is now loggable rather than swallowed |
| 1 — key divergence | 74.2% stable | 74.1% stable — but that run predates #684 (merged today), which fixed the out-of-workspace `CARGO_TARGET_DIR` divergence that substrate's nested wasm builds sit squarely in |

Class 1 needs the next nightly to re-measure, since substrate's wasm-runtime builds are nested child cargos whose target dir is deep under the parent's — precisely the shape #684 addressed. The divergence pattern supports that reading: misses cluster at exactly 4 per crate across the runtime and proc-macro crates, matching substrate's four wasm runtime builds.

## Test plan

- `wasm_link_output_satisfies_the_emit_coverage_gate`: a `.wasm` + `.d` entry derives `["dep-info", "link"]` and satisfies the `--emit` it was built for — verified red with `wasm` removed from the emit map
- extended the classification, emit-map and passive-kinds pin tests: `.wasm` classifies as `WasmModule`, maps to `link`, and takes **no** post-restore action (guarding against the codesign regression a `DynamicLibrary` classification would have introduced)
- `run_dep_info_pass_errors_on_compile_failure` now asserts the error carries rustc's exit status and its own stderr line, so a future refactor cannot silently re-truncate the diagnostic
- full suites green: 1642 unit, 27 integration; fmt and clippy clean

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [x] No user-visible config changes