### PR TITLE
test(remote): pin the filesystem remote's cross-client contract; document share GC (#414)

### DIFF
--- a/docs/remote-cache/filesystem-setup.mdx
+++ b/docs/remote-cache/filesystem-setup.mdx
@@ -91,3 +91,33 @@ path or alternate data stream.
 Keep `KACHE_CACHE_DIR` on fast local storage for each machine. Only
 `cache.remote.path` should point at the shared mount; the local store is not
 safe to share between machines.
+
+## Reclaiming space on the share
+
+Uploads are safe from any number of machines at once: objects are
+content-addressed and immutable, every write lands via a temp file plus atomic
+rename, and two machines publishing the same key are writing identical bytes.
+Deletion has no such story. Nothing coordinates a delete against another
+machine's in-flight read or upload of the same object, so **removing objects
+from the shared folder is a manual, single-writer operation**.
+
+`kache gc` and the automatic size-pressure eviction apply to a machine's own
+local store only. They never delete from the shared folder — a local eviction
+just means that machine pulls the object again on its next miss.
+
+When the share does need reclaiming, pick one of:
+
+- **A single designated host.** Nominate one machine (or a scheduled job) as
+  the only thing that ever deletes from the share, and run it when the fleet is
+  idle.
+- **Prune by age, offline.** Stop or pause the writers, then delete whole
+  `{cache_key}` pairs — the `.json` manifest and its `.tar.zst` pack — older
+  than your retention window. Deleting a pack while leaving its manifest makes
+  peers fetch a manifest whose pack 404s; they degrade to a compile, but you
+  are paying for a lookup that can never succeed.
+- **Start over.** For a small team, deleting the whole `artifacts/` subtree and
+  letting the next builds repopulate it is often simpler than partial pruning.
+
+Cross-host coordinated deletion is tracked as phase 2 of
+[#414](https://github.com/kunobi-ninja/kache/issues/414). Until it lands, treat
+the share as append-mostly.

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -976,6 +976,77 @@ mod tests {
         );
     }
 
+    /// kunobi-ninja/kache#414 acceptance: "concurrent uploads of the same key
+    /// are safe because the content is identical". Two clients that compiled
+    /// the same unit race to publish the same pack; every writer must succeed
+    /// and a reader must never observe a torn object — which is what the
+    /// same-filesystem staging + atomic rename buys.
+    #[tokio::test]
+    async fn filesystem_concurrent_same_key_puts_never_tear() {
+        let root = tempfile::tempdir().unwrap();
+        let remote = RemoteConfig {
+            prefix: "artifacts".to_string(),
+            backend: RemoteBackendConfig::Filesystem(FilesystemRemoteConfig {
+                root: root.path().to_path_buf(),
+                atomic_write_dir: root.path().join(".staging"),
+            }),
+        };
+        let backend = create_backend(&remote, 30).await.unwrap();
+
+        // Large enough that a non-atomic writer would be caught mid-write by
+        // a concurrent reader rather than finishing between polls.
+        const BODY: usize = 512 * 1024;
+        const WRITERS: usize = 8;
+        let payload = vec![b'p'; BODY];
+        let key = "artifacts/v3/packs/demo/samekey.tar.zst";
+
+        let mut writers = Vec::new();
+        for _ in 0..WRITERS {
+            let backend = backend.clone();
+            let payload = payload.clone();
+            writers.push(tokio::spawn(async move {
+                backend.put(key, payload, Some("application/zstd")).await
+            }));
+        }
+        // Read concurrently with the writers: any observation must be a whole
+        // object, never a partial one.
+        let reader = {
+            let backend = backend.clone();
+            tokio::spawn(async move {
+                let mut observed = Vec::new();
+                for _ in 0..64 {
+                    if let Some(object) = backend.get(key, None).await.unwrap() {
+                        observed.push(object.body.len());
+                    }
+                    tokio::task::yield_now().await;
+                }
+                observed
+            })
+        };
+
+        for writer in writers {
+            writer
+                .await
+                .unwrap()
+                .expect("every concurrent writer of identical content must succeed");
+        }
+        for len in reader.await.unwrap() {
+            assert_eq!(len, BODY, "a reader observed a torn object ({len} bytes)");
+        }
+
+        let final_object = backend.get(key, None).await.unwrap().unwrap();
+        assert_eq!(final_object.body.len(), BODY);
+        assert!(
+            final_object.body.iter().all(|b| *b == b'p'),
+            "the published object must be exactly one writer's content"
+        );
+        // Staging must not leak: every temp file is renamed away.
+        let staged: Vec<_> = std::fs::read_dir(root.path().join(".staging"))
+            .map(|entries| entries.flatten().map(|e| e.path()).collect())
+            .unwrap_or_default();
+        assert!(staged.is_empty(), "staging left debris: {staged:?}");
+    }
+
     #[tokio::test]
     async fn filesystem_backend_rejects_parent_traversal() {
         let root = tempfile::tempdir().unwrap();

--- a/tests/filesystem_remote_test.rs
+++ b/tests/filesystem_remote_test.rs
@@ -13,6 +13,9 @@
 //! would be separate.
 
 use std::path::{Path, PathBuf};
+use std::process::Output;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 mod common;
@@ -27,6 +30,7 @@ fn rustc_path() -> String {
 struct Client {
     _cache: TempDir,
     cache_dir: PathBuf,
+    command_seq: AtomicUsize,
 }
 
 impl Client {
@@ -47,6 +51,7 @@ impl Client {
         Client {
             _cache: cache,
             cache_dir,
+            command_seq: AtomicUsize::new(0),
         }
     }
 
@@ -67,37 +72,87 @@ impl Client {
         cmd
     }
 
-    /// Run a kache command to completion, with stdio pipes that a spawned
-    /// daemon cannot hold open: the daemon inherits handles, so an inherited
-    /// stdout would keep `output()` waiting for an EOF that never comes.
-    fn run(&self, args: &[&str]) -> std::process::Output {
-        self.kache()
+    /// Run a kache command with a deadline, capturing output through FILES
+    /// rather than pipes.
+    ///
+    /// Two deliberate choices, both from kunobi-ninja/kache#704, where these
+    /// tests hung the Windows job to its 45-minute limit:
+    ///
+    /// - **Files, not pipes.** `Command::output()` waits for EOF on the
+    ///   child's pipes, and EOF only arrives once *every* process holding the
+    ///   write end exits — including a background daemon that inherited them.
+    ///   A file has no such semantics, so a lingering daemon cannot wedge the
+    ///   test.
+    /// - **A deadline.** If something still blocks, the test fails in seconds
+    ///   naming the exact command, instead of burning the job's whole budget
+    ///   and reporting only "timed out".
+    fn run_within(&self, args: &[&str], deadline: Duration) -> Output {
+        // Counter, not the args: an argv carries paths and slashes, which do
+        // not belong in a file name.
+        let seq = self.command_seq.fetch_add(1, Ordering::Relaxed);
+        let out_path = self.cache_dir.join(format!("cmd-{seq}.out"));
+        let err_path = self.cache_dir.join(format!("cmd-{seq}.err"));
+        let stdout = std::fs::File::create(&out_path).expect("creating stdout capture");
+        let stderr = std::fs::File::create(&err_path).expect("creating stderr capture");
+
+        let mut child = self
+            .kache()
             .args(args)
             .stdin(std::process::Stdio::null())
-            .output()
-            .expect("failed to run kache")
+            .stdout(stdout)
+            .stderr(stderr)
+            .spawn()
+            .expect("failed to spawn kache");
+
+        let start = Instant::now();
+        let status = loop {
+            match child.try_wait().expect("polling kache") {
+                Some(status) => break status,
+                None if start.elapsed() >= deadline => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!(
+                        "`kache {}` did not finish within {deadline:?} (kunobi-ninja/kache#704).\n\
+                         stdout: {}\nstderr: {}",
+                        args.join(" "),
+                        std::fs::read_to_string(&out_path).unwrap_or_default(),
+                        std::fs::read_to_string(&err_path).unwrap_or_default(),
+                    );
+                }
+                None => std::thread::sleep(Duration::from_millis(50)),
+            }
+        };
+
+        Output {
+            status,
+            stdout: std::fs::read(&out_path).unwrap_or_default(),
+            stderr: std::fs::read(&err_path).unwrap_or_default(),
+        }
+    }
+
+    /// A kache command that should complete promptly.
+    fn run(&self, args: &[&str]) -> Output {
+        self.run_within(args, Duration::from_secs(90))
     }
 
     /// Compile a trivial rlib through kache-as-RUSTC_WRAPPER.
     fn compile(&self, src: &Path, out_dir: &Path) {
-        let output = self
-            .kache()
-            .stdin(std::process::Stdio::null())
-            .args([
-                rustc_path(),
-                "--crate-name".into(),
-                "fsremote".into(),
-                "--crate-type".into(),
-                "lib".into(),
-                "--edition".into(),
-                "2021".into(),
-                "--emit=link".into(),
-                "--out-dir".into(),
-                out_dir.display().to_string(),
-                src.display().to_string(),
-            ])
-            .output()
-            .expect("failed to run kache rustc");
+        let out_dir = out_dir.display().to_string();
+        let src = src.display().to_string();
+        let rustc = rustc_path();
+        let output = self.run(&[
+            &rustc,
+            "--crate-name",
+            "fsremote",
+            "--crate-type",
+            "lib",
+            "--edition",
+            "2021",
+            "--emit=link",
+            "--out-dir",
+            &out_dir,
+            &src,
+        ]);
         assert!(
             output.status.success(),
             "kache rustc failed.\nstderr: {}",
@@ -157,7 +212,12 @@ impl Drop for Client {
     /// daemons from piling up across the suite without making them die
     /// between commands.
     fn drop(&mut self) {
-        let _ = self.kache().args(["daemon", "stop"]).output();
+        // Bounded, and through the same file-backed runner: cleanup must
+        // never be the thing that wedges a test run (#704). Nothing waits on
+        // the daemon's own exit — `stop` is a request.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.run_within(&["daemon", "stop"], Duration::from_secs(30))
+        }));
     }
 }
 
@@ -166,14 +226,13 @@ impl Drop for Client {
 /// no S3 server anywhere. Exercises the **pull-on-miss** path: client B never
 /// syncs explicitly, it just compiles and its daemon fetches A's artifact.
 ///
-/// Unix-only, and deliberately so: this is the suite's only test that drives
-/// `kache daemon start`, and doing that under the Windows named-pipe
-/// lifecycle hung the workspace test job to its 45-minute limit. The
-/// cross-client contract itself is not platform-specific and is covered on
-/// every platform by the daemon-free sync test below; what is unproven is
-/// starting and stopping a daemon from inside the Windows test harness,
-/// which is worth its own investigation rather than a hung CI job.
-#[cfg(unix)]
+/// Runs everywhere, including Windows, on purpose. An earlier form of this
+/// file hung the Windows job to its 45-minute limit (kunobi-ninja/kache#704)
+/// while taking ~3s on macOS; the cause is still unknown, and the two
+/// candidate mechanisms are now removed rather than avoided — output is
+/// captured through files instead of pipes a lingering daemon could hold
+/// open, and every command carries a deadline. If it hangs again, CI now
+/// says which command and dies in seconds instead of burning the job.
 #[test]
 fn two_independent_clients_share_hits_through_one_folder() {
     build_kache();
@@ -249,6 +308,44 @@ fn a_fresh_client_can_seed_itself_from_the_shared_folder() {
         "after --pull --all the artifact is local, so the compile is a local hit: {beta_results:?}"
     );
     assert!(out_b.path().join("libfsremote.rlib").is_file());
+}
+
+/// Cleanup by `Drop` must actually work: after a client goes out of scope its
+/// daemon is gone, not merely asked to leave. Without this the suite would
+/// leak a daemon per test, which is what the 3-second idle timeouts elsewhere
+/// were compensating for (kunobi-ninja/kache#704).
+#[cfg(unix)]
+#[test]
+fn dropping_a_client_stops_its_daemon() {
+    build_kache();
+    let shared = TempDir::new().unwrap();
+
+    let socket = {
+        let client = Client::new(shared.path());
+        client.start_daemon();
+        let socket = client.cache_dir.join("daemon.sock");
+        assert!(
+            socket.exists(),
+            "the daemon should have published its socket at {}",
+            socket.display()
+        );
+        socket
+        // `client` drops here — its Drop issues `daemon stop`.
+    };
+
+    // The socket is removed on shutdown; allow a moment for the daemon to
+    // finish unlinking it, then assert it is really gone.
+    for _ in 0..50 {
+        if !socket.exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    panic!(
+        "daemon socket {} still present after the client was dropped — \
+         Drop cleanup did not stop the daemon",
+        socket.display()
+    );
 }
 
 /// The shared folder must stay a pure object store: no SQLite index and no

--- a/tests/filesystem_remote_test.rs
+++ b/tests/filesystem_remote_test.rs
@@ -54,16 +54,35 @@ impl Client {
         let mut cmd = std::process::Command::new(kache_binary());
         cmd.env("KACHE_CACHE_DIR", &self.cache_dir)
             .env("KACHE_CONFIG", isolated_config_path(&self.cache_dir))
-            .env("KACHE_LOG", "kache=info")
+            .env("KACHE_LOG", "off")
+            // A BACKSTOP, not the cleanup mechanism: `Client`'s `Drop` stops
+            // the daemon explicitly, which keeps it warm for the whole test
+            // instead of tearing it down between commands. This only bounds
+            // the damage if that stop is ever missed (a hard abort), since the
+            // idle timeout is disabled by default (#662) and a leaked daemon
+            // would otherwise outlive the suite.
+            .env("KACHE_DAEMON_IDLE_TIMEOUT", "60")
             .env_remove("RUSTC_WRAPPER")
             .env_remove("CARGO_BUILD_RUSTC_WRAPPER");
         cmd
+    }
+
+    /// Run a kache command to completion, with stdio pipes that a spawned
+    /// daemon cannot hold open: the daemon inherits handles, so an inherited
+    /// stdout would keep `output()` waiting for an EOF that never comes.
+    fn run(&self, args: &[&str]) -> std::process::Output {
+        self.kache()
+            .args(args)
+            .stdin(std::process::Stdio::null())
+            .output()
+            .expect("failed to run kache")
     }
 
     /// Compile a trivial rlib through kache-as-RUSTC_WRAPPER.
     fn compile(&self, src: &Path, out_dir: &Path) {
         let output = self
             .kache()
+            .stdin(std::process::Stdio::null())
             .args([
                 rustc_path(),
                 "--crate-name".into(),
@@ -92,12 +111,7 @@ impl Client {
     /// a real host would have, started by an earlier build or the installed
     /// service.
     fn start_daemon(&self) {
-        let output = self
-            .kache()
-            .env("KACHE_DAEMON_IDLE_TIMEOUT", "20")
-            .args(["daemon", "start"])
-            .output()
-            .expect("failed to run kache daemon start");
+        let output = self.run(&["daemon", "start"]);
         assert!(
             output.status.success(),
             "kache daemon start failed.\nstdout: {}\nstderr: {}",
@@ -106,17 +120,10 @@ impl Client {
         );
     }
 
-    fn stop_daemon(&self) {
-        let _ = self.kache().args(["daemon", "stop"]).output();
-    }
-
     fn sync(&self, args: &[&str]) {
-        let output = self
-            .kache()
-            .arg("sync")
-            .args(args)
-            .output()
-            .expect("failed to run kache sync");
+        let mut argv = vec!["sync"];
+        argv.extend_from_slice(args);
+        let output = self.run(&argv);
         assert!(
             output.status.success(),
             "kache sync {args:?} failed.\nstdout: {}\nstderr: {}",
@@ -127,11 +134,7 @@ impl Client {
 
     /// Per-result event counts from `kache report` over this client's cache.
     fn results(&self) -> Vec<String> {
-        let output = self
-            .kache()
-            .args(["report", "--format", "json", "--since", "1h"])
-            .output()
-            .expect("failed to run kache report");
+        let output = self.run(&["report", "--format", "json", "--since", "1h"]);
         assert!(output.status.success(), "kache report failed");
         let report: serde_json::Value =
             serde_json::from_slice(&output.stdout).expect("report should be valid json");
@@ -147,10 +150,30 @@ impl Client {
     }
 }
 
+impl Drop for Client {
+    /// Stop this client's daemon when the test ends — including on panic.
+    /// Nothing waits on the daemon's exit: `stop` is a request, and the test
+    /// has no reason to block on the shutdown completing. This is what keeps
+    /// daemons from piling up across the suite without making them die
+    /// between commands.
+    fn drop(&mut self) {
+        let _ = self.kache().args(["daemon", "stop"]).output();
+    }
+}
+
 /// kunobi-ninja/kache#414 acceptance: two independently configured clients
 /// sharing one folder — and nothing else — get a cross-client cache hit with
 /// no S3 server anywhere. Exercises the **pull-on-miss** path: client B never
 /// syncs explicitly, it just compiles and its daemon fetches A's artifact.
+///
+/// Unix-only, and deliberately so: this is the suite's only test that drives
+/// `kache daemon start`, and doing that under the Windows named-pipe
+/// lifecycle hung the workspace test job to its 45-minute limit. The
+/// cross-client contract itself is not platform-specific and is covered on
+/// every platform by the daemon-free sync test below; what is unproven is
+/// starting and stopping a daemon from inside the Windows test harness,
+/// which is worth its own investigation rather than a hung CI job.
+#[cfg(unix)]
 #[test]
 fn two_independent_clients_share_hits_through_one_folder() {
     build_kache();
@@ -170,7 +193,6 @@ fn two_independent_clients_share_hits_through_one_folder() {
         alpha.results()
     );
     alpha.sync(&["--push"]);
-    alpha.stop_daemon();
 
     let manifests = shared.path().join("artifacts/v3/manifests");
     assert!(
@@ -187,7 +209,6 @@ fn two_independent_clients_share_hits_through_one_folder() {
     beta.start_daemon();
     beta.compile(&src, out_b.path());
     let beta_results = beta.results();
-    beta.stop_daemon();
 
     assert!(
         beta_results.iter().any(|r| r == "remote_hit"),
@@ -216,14 +237,12 @@ fn a_fresh_client_can_seed_itself_from_the_shared_folder() {
     let out_a = TempDir::new().unwrap();
     alpha.compile(&src, out_a.path());
     alpha.sync(&["--push"]);
-    alpha.stop_daemon();
 
     let beta = Client::new(shared.path());
     let out_b = TempDir::new().unwrap();
     beta.sync(&["--pull", "--all"]);
     beta.compile(&src, out_b.path());
     let beta_results = beta.results();
-    beta.stop_daemon();
 
     assert!(
         beta_results.iter().any(|r| r == "local_hit"),
@@ -248,7 +267,6 @@ fn the_shared_folder_holds_objects_only() {
     let out = TempDir::new().unwrap();
     client.compile(&src, out.path());
     client.sync(&["--push"]);
-    client.stop_daemon();
 
     let mut files = Vec::new();
     collect_files(shared.path(), &mut files);

--- a/tests/filesystem_remote_test.rs
+++ b/tests/filesystem_remote_test.rs
@@ -1,0 +1,300 @@
+//! Acceptance tests for the filesystem remote backend (kunobi-ninja/kache#414).
+//!
+//! The issue's headline criterion is a *cross-client* one: "two or more hosts
+//! sharing one folder get cross-host cache hits with no S3 server", with "no
+//! SQLite file and no hardlink/reflink ever touching the shared folder". Unit
+//! tests over the transport cannot show that — they exercise one process's
+//! view of the object store, not the property that a SECOND, independently
+//! configured client can turn another client's upload into a hit.
+//!
+//! So these drive the real binary twice over two fully isolated caches that
+//! share only the folder: separate `KACHE_CACHE_DIR`, separate config, and a
+//! separate build directory, the way two machines mounting one NFS share
+//! would be separate.
+
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+mod common;
+use common::{build_kache, isolated_config_path, kache_binary};
+
+fn rustc_path() -> String {
+    std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string())
+}
+
+/// One independently configured client: its own local cache and config, both
+/// pointing at the shared folder as a filesystem remote.
+struct Client {
+    _cache: TempDir,
+    cache_dir: PathBuf,
+}
+
+impl Client {
+    fn new(shared_folder: &Path) -> Self {
+        let cache = TempDir::new().unwrap();
+        let cache_dir = cache.path().to_path_buf();
+        std::fs::write(
+            isolated_config_path(&cache_dir),
+            format!(
+                "[cache.remote]\n\
+                 type = \"filesystem\"\n\
+                 path = \"{}\"\n\
+                 prefix = \"artifacts\"\n",
+                shared_folder.display().to_string().replace('\\', "\\\\"),
+            ),
+        )
+        .unwrap();
+        Client {
+            _cache: cache,
+            cache_dir,
+        }
+    }
+
+    fn kache(&self) -> std::process::Command {
+        let mut cmd = std::process::Command::new(kache_binary());
+        cmd.env("KACHE_CACHE_DIR", &self.cache_dir)
+            .env("KACHE_CONFIG", isolated_config_path(&self.cache_dir))
+            .env("KACHE_LOG", "kache=info")
+            .env_remove("RUSTC_WRAPPER")
+            .env_remove("CARGO_BUILD_RUSTC_WRAPPER");
+        cmd
+    }
+
+    /// Compile a trivial rlib through kache-as-RUSTC_WRAPPER.
+    fn compile(&self, src: &Path, out_dir: &Path) {
+        let output = self
+            .kache()
+            .args([
+                rustc_path(),
+                "--crate-name".into(),
+                "fsremote".into(),
+                "--crate-type".into(),
+                "lib".into(),
+                "--edition".into(),
+                "2021".into(),
+                "--emit=link".into(),
+                "--out-dir".into(),
+                out_dir.display().to_string(),
+                src.display().to_string(),
+            ])
+            .output()
+            .expect("failed to run kache rustc");
+        assert!(
+            output.status.success(),
+            "kache rustc failed.\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    /// Start this client's daemon and wait until it is ready. The remote
+    /// pull path is daemon-mediated by design (`send_remote_check` no-ops
+    /// when the socket is unreachable), so a cross-client hit needs one — as
+    /// a real host would have, started by an earlier build or the installed
+    /// service.
+    fn start_daemon(&self) {
+        let output = self
+            .kache()
+            .env("KACHE_DAEMON_IDLE_TIMEOUT", "20")
+            .args(["daemon", "start"])
+            .output()
+            .expect("failed to run kache daemon start");
+        assert!(
+            output.status.success(),
+            "kache daemon start failed.\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    fn stop_daemon(&self) {
+        let _ = self.kache().args(["daemon", "stop"]).output();
+    }
+
+    fn sync(&self, args: &[&str]) {
+        let output = self
+            .kache()
+            .arg("sync")
+            .args(args)
+            .output()
+            .expect("failed to run kache sync");
+        assert!(
+            output.status.success(),
+            "kache sync {args:?} failed.\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    /// Per-result event counts from `kache report` over this client's cache.
+    fn results(&self) -> Vec<String> {
+        let output = self
+            .kache()
+            .args(["report", "--format", "json", "--since", "1h"])
+            .output()
+            .expect("failed to run kache report");
+        assert!(output.status.success(), "kache report failed");
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("report should be valid json");
+        report["all_events"]
+            .as_array()
+            .map(|events| {
+                events
+                    .iter()
+                    .filter_map(|e| e["result"].as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+/// kunobi-ninja/kache#414 acceptance: two independently configured clients
+/// sharing one folder — and nothing else — get a cross-client cache hit with
+/// no S3 server anywhere. Exercises the **pull-on-miss** path: client B never
+/// syncs explicitly, it just compiles and its daemon fetches A's artifact.
+#[test]
+fn two_independent_clients_share_hits_through_one_folder() {
+    build_kache();
+
+    let shared = TempDir::new().unwrap();
+    let sources = TempDir::new().unwrap();
+    let src = sources.path().join("lib.rs");
+    std::fs::write(&src, "pub fn answer() -> u32 { 42 }\n").unwrap();
+
+    // Client A compiles cold and publishes to the shared folder.
+    let alpha = Client::new(shared.path());
+    let out_a = TempDir::new().unwrap();
+    alpha.compile(&src, out_a.path());
+    assert!(
+        alpha.results().iter().any(|r| r == "miss" || r == "dup"),
+        "client A's first compile must be a real compile: {:?}",
+        alpha.results()
+    );
+    alpha.sync(&["--push"]);
+    alpha.stop_daemon();
+
+    let manifests = shared.path().join("artifacts/v3/manifests");
+    assert!(
+        manifests.is_dir(),
+        "the push must have written the v3 object layout into the shared folder"
+    );
+
+    // Client B has never seen this compile: separate cache, separate config,
+    // separate output dir. Its only connection to A is the folder. Its daemon
+    // is up, as a real host's would be — the remote pull path is
+    // daemon-mediated by design.
+    let beta = Client::new(shared.path());
+    let out_b = TempDir::new().unwrap();
+    beta.start_daemon();
+    beta.compile(&src, out_b.path());
+    let beta_results = beta.results();
+    beta.stop_daemon();
+
+    assert!(
+        beta_results.iter().any(|r| r == "remote_hit"),
+        "client B must pull A's artifact from the shared folder on miss: {beta_results:?}"
+    );
+    assert!(
+        out_b.path().join("libfsremote.rlib").is_file(),
+        "client B must end up with the artifact materialized"
+    );
+}
+
+/// The same cross-client property through the **explicit sync** path, which
+/// needs no daemon: `kache sync --pull --all` seeds a fresh client's local
+/// store from the shared folder, and the next compile is a plain local hit
+/// (kunobi-ninja/kache#414).
+#[test]
+fn a_fresh_client_can_seed_itself_from_the_shared_folder() {
+    build_kache();
+
+    let shared = TempDir::new().unwrap();
+    let sources = TempDir::new().unwrap();
+    let src = sources.path().join("lib.rs");
+    std::fs::write(&src, "pub fn seeded() -> u32 { 11 }\n").unwrap();
+
+    let alpha = Client::new(shared.path());
+    let out_a = TempDir::new().unwrap();
+    alpha.compile(&src, out_a.path());
+    alpha.sync(&["--push"]);
+    alpha.stop_daemon();
+
+    let beta = Client::new(shared.path());
+    let out_b = TempDir::new().unwrap();
+    beta.sync(&["--pull", "--all"]);
+    beta.compile(&src, out_b.path());
+    let beta_results = beta.results();
+    beta.stop_daemon();
+
+    assert!(
+        beta_results.iter().any(|r| r == "local_hit"),
+        "after --pull --all the artifact is local, so the compile is a local hit: {beta_results:?}"
+    );
+    assert!(out_b.path().join("libfsremote.rlib").is_file());
+}
+
+/// The shared folder must stay a pure object store: no SQLite index and no
+/// shared inodes, which is what lets it live on NFS/SMB at all (the two
+/// reasons #414 gives for why pointing `KACHE_CACHE_DIR` at a share fails).
+#[test]
+fn the_shared_folder_holds_objects_only() {
+    build_kache();
+
+    let shared = TempDir::new().unwrap();
+    let sources = TempDir::new().unwrap();
+    let src = sources.path().join("lib.rs");
+    std::fs::write(&src, "pub fn only_objects() -> u32 { 7 }\n").unwrap();
+
+    let client = Client::new(shared.path());
+    let out = TempDir::new().unwrap();
+    client.compile(&src, out.path());
+    client.sync(&["--push"]);
+    client.stop_daemon();
+
+    let mut files = Vec::new();
+    collect_files(shared.path(), &mut files);
+    assert!(
+        !files.is_empty(),
+        "the push should have written objects to the shared folder"
+    );
+    for file in &files {
+        let name = file.file_name().unwrap_or_default().to_string_lossy();
+        assert!(
+            !name.contains("index.db"),
+            "a SQLite index must never live on the shared folder: {}",
+            file.display()
+        );
+        assert!(
+            !name.ends_with("-wal") && !name.ends_with("-shm"),
+            "SQLite WAL sidecars must never live on the shared folder: {}",
+            file.display()
+        );
+
+        // Nothing on the share may be an inode shared with the local store:
+        // hardlinks are exactly what does not work across a network mount.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let meta = std::fs::metadata(file).unwrap();
+            assert_eq!(
+                meta.nlink(),
+                1,
+                "shared-folder object must not be a hardlink: {}",
+                file.display()
+            );
+        }
+    }
+}
+
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(&path, out);
+        } else {
+            out.push(path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #414 by closing the three acceptance gaps its own re-audit listed. The backend landed in #515 (transport trait) and #593 (configured filesystem remotes); what was missing was evidence for the criteria the issue actually states.

**Two-client cross-hit — the headline criterion.** A new integration binary runs two independently configured clients: separate `KACHE_CACHE_DIR`, separate config, separate output directory, sharing nothing but the folder — the way two machines mounting one NFS share are separate. Client A compiles and pushes; client B turns that into a hit two different ways, because both are real deployments:

- **pull-on-miss** through its daemon, asserting a `remote_hit`. Worth recording for whoever reads this later: the remote pull path is daemon-mediated by design — `send_remote_check` returns `None` when the socket is unreachable — so a client whose daemon has never started will miss even with the artifact sitting in the share. The test starts one, as a real host would have from an earlier build or the installed service.
- **explicit `sync --pull --all`**, which seeds a fresh local store with no daemon at all, asserting a `local_hit`.

A third test pins what makes a network share viable at all, and is the "no SQLite file and no hardlink/reflink ever touches the shared folder" criterion: the folder holds objects only — no `index.db`, no WAL/SHM sidecars, and (on Unix) every object has `nlink == 1`.

**Concurrent same-key PUT.** Eight writers publish identical content to one key while a reader polls it. Every writer succeeds, no read observes a torn object, and the staging directory is left clean — the atomic temp-plus-rename contract the acceptance criteria rest on.

**Share GC documentation.** A new "Reclaiming space on the share" section states plainly that uploads are safe from any number of machines while deletion is not coordinated, that `kache gc` and size-pressure eviction apply to the local store and never touch the share, and what the actual options are: a single designated host, an offline age-prune that deletes manifest and pack together (deleting a pack while leaving its manifest makes peers fetch a manifest whose pack 404s), or starting over. Phase 2 is referenced as the tracking item.

## Test plan

- `cargo test --test filesystem_remote_test` — 3 tests, all green
- **Verified non-vacuous**: with the filesystem `put` sabotaged to a silent no-op, all three fail; restored, all three pass
- `cargo test --bin kache remote_backend` (25 tests) including the new concurrent-PUT regression
- full unit suite green (1647); fmt and clippy clean

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [x] Docs updated (filesystem-setup gains the share-GC section)