### PR TITLE
fix(stats): render the daemon's effective config and surface CLI/daemon config mismatch (#689)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,10 @@ pub(crate) struct StatsSnapshot {
     /// In-flight miss compiles (kunobi-ninja/kache#131); empty when the
     /// daemon is unreachable (the TUI then falls back to tailed heartbeats).
     pub in_flight: Vec<daemon::InFlightEntry>,
+    /// The daemon's effective config from the stats response
+    /// (kunobi-ninja/kache#689); `None` when the daemon is unreachable or
+    /// predates effective-config reporting.
+    pub daemon_effective_config: Option<daemon::EffectiveConfig>,
 }
 
 impl Default for StatsSnapshot {
@@ -85,6 +89,7 @@ impl Default for StatsSnapshot {
             blob_stats: None,
             prefetch: daemon::PrefetchStatsSnapshot::default(),
             in_flight: Vec::new(),
+            daemon_effective_config: None,
         }
     }
 }
@@ -108,11 +113,19 @@ pub fn compile_weighted_hit_rate(es: &daemon::EventStatsResponse) -> Option<f64>
 }
 
 /// Try daemon first, fall back to direct reads.
+///
+/// With `announce_auto_start` set, the daemon-unreachable path says on stderr
+/// that it is starting a daemon inheriting this process's environment
+/// (kunobi-ninja/kache#689) — otherwise the same command silently flips from
+/// "daemon's config" to "my config" depending on daemon liveness. The CLI
+/// passes true; the TUI passes false because its raw-mode alternate screen
+/// owns the terminal.
 pub(crate) fn fetch_stats_snapshot(
     config: &Config,
     include_entries: bool,
     sort_by: &str,
     hours: Option<u64>,
+    announce_auto_start: bool,
 ) -> StatsSnapshot {
     let event_hours = hours.or(Some(24));
     let blob_stats = || {
@@ -149,11 +162,18 @@ pub(crate) fn fetch_stats_snapshot(
             blob_stats: blob_stats(),
             prefetch: resp.prefetch,
             in_flight: resp.in_flight,
+            daemon_effective_config: resp.effective_config,
         };
     }
 
     // Daemon unreachable or stale socket: best-effort auto-start for monitor/stats UX.
     // This path is not used by compile-time hot operations.
+    if announce_auto_start {
+        eprintln!(
+            "kache: no daemon reachable at {}; starting one inheriting this process's environment",
+            config.socket_path().display()
+        );
+    }
     if daemon::start_daemon_background().unwrap_or(false)
         && let Ok(resp) =
             daemon::send_stats_request(config, include_entries, Some(sort_by), event_hours)
@@ -182,6 +202,7 @@ pub(crate) fn fetch_stats_snapshot(
             blob_stats: blob_stats(),
             prefetch: resp.prefetch,
             in_flight: resp.in_flight,
+            daemon_effective_config: resp.effective_config,
         };
     }
 
@@ -274,6 +295,7 @@ pub(crate) fn snapshot_from_direct_reads(
         blob_stats: store.as_ref().and_then(|s| s.blob_stats().ok()),
         prefetch: daemon::PrefetchStatsSnapshot::default(),
         in_flight: Vec::new(),
+        daemon_effective_config: None,
     }
 }
 
@@ -282,9 +304,20 @@ pub(crate) fn snapshot_from_direct_reads(
 /// Print a one-shot stats summary to stdout.
 pub fn stats(config: &Config, hours: Option<u64>) -> Result<()> {
     let hours = hours.unwrap_or(24);
-    let snap = fetch_stats_snapshot(config, false, "size", Some(hours));
+    let snap = fetch_stats_snapshot(config, false, "size", Some(hours), true);
     let store = Store::open(config)?;
     let blob_stats = store.blob_stats()?;
+
+    // #689: the numbers below are daemon-first, so before rendering them say
+    // when the daemon's effective config disagrees with this invocation's —
+    // otherwise a config edit that has not reached the daemon masquerades as
+    // "kache ignores config files".
+    if let Some(eff) = &snap.daemon_effective_config {
+        for warning in config_mismatch_warnings(config, &crate::config::resolve_config_path(), eff)
+        {
+            eprintln!("{warning}");
+        }
+    }
 
     for line in render_stats(&snap, &blob_stats, config, hours) {
         println!("{line}");
@@ -397,8 +430,16 @@ pub(crate) fn render_stats(
         } else {
             ""
         };
+        // Name the config file the daemon loaded (#689): the store cap and
+        // policy lines describe THAT file, which need not be the one this
+        // invocation resolved.
+        let config_note = snap
+            .daemon_effective_config
+            .as_ref()
+            .map(|eff| format!(", config {}", eff.config_path))
+            .unwrap_or_default();
         lines.push(format!(
-            "Daemon:     v{} (epoch {}){mismatch}",
+            "Daemon:     v{} (epoch {}{config_note}){mismatch}",
             snap.daemon_version, snap.daemon_build_epoch,
         ));
     } else {
@@ -421,10 +462,22 @@ pub(crate) fn render_stats(
     // Prefetch/planning baseline (#485 Phase 0). Shown only when the daemon
     // has something to report, so local-only output stays unchanged.
     let pf = &snap.prefetch;
-    if snap.daemon_connected && config.remote.is_some() && !config.prefetch_enabled {
-        lines.push(
-            "Prefetch:   disabled (exact remote lookup and uploads remain enabled)".to_string(),
-        );
+    // The policy line states what the DAEMON is doing, so it renders the
+    // daemon's effective policy (#652/#689) — this process's config may say
+    // "disabled" while a long-lived daemon is still LISTing and planning.
+    // Only a daemon too old to report a policy falls back to client config,
+    // labeled, because then the line is a guess rather than a daemon fact.
+    let (prefetch_enabled, prefetch_source) = match &snap.daemon_effective_config {
+        Some(eff) => (eff.prefetch_enabled, ""),
+        None => (
+            config.prefetch_enabled,
+            " [client config — daemon did not report its policy]",
+        ),
+    };
+    if snap.daemon_connected && config.remote.is_some() && !prefetch_enabled {
+        lines.push(format!(
+            "Prefetch:   disabled (exact remote lookup and uploads remain enabled){prefetch_source}"
+        ));
     } else if snap.daemon_connected
         && (pf.downloads_completed > 0
             || pf.plans_advisory + pf.plans_fallback > 0
@@ -480,6 +533,63 @@ pub(crate) fn render_stats(
     }
 
     lines
+}
+
+/// One warning line per rendered stats field where this process's resolved
+/// config disagrees with the daemon's effective config
+/// (kunobi-ninja/kache#689). Each line names both values and both sources, so
+/// "the daemon shows 50 GiB after I set 117 GiB" reads as the config-delivery
+/// problem it is, never as "kache ignores config files". Empty when the two
+/// agree — matching paths are not required, only matching rendered values.
+/// Pure (no I/O) so every divergence branch is unit-testable without a daemon.
+pub(crate) fn config_mismatch_warnings(
+    config: &Config,
+    client_config_path: &std::path::Path,
+    eff: &daemon::EffectiveConfig,
+) -> Vec<String> {
+    let daemon_side = format!(
+        "daemon (started {}, config {})",
+        format_epoch_ms_utc(eff.started_at_ms),
+        eff.config_path
+    );
+    let client_side = format!("this process's config ({})", client_config_path.display());
+    let remedy = "the daemon's value is in effect; `kache daemon restart` to apply yours";
+
+    let mut warnings = Vec::new();
+    if eff.max_size != config.max_size {
+        warnings.push(format!(
+            "warning: {daemon_side} has local_max_size={}; {client_side} says {} — {remedy}",
+            ByteSize(eff.max_size),
+            ByteSize(config.max_size),
+        ));
+    }
+    if eff.cache_dir != config.cache_dir.display().to_string() {
+        warnings.push(format!(
+            "warning: {daemon_side} has local_store={}; {client_side} says {} — the daemon's \
+             numbers describe ITS store; `kache daemon restart` to apply yours",
+            eff.cache_dir,
+            config.cache_dir.display(),
+        ));
+    }
+    if eff.prefetch_enabled != config.prefetch_enabled {
+        warnings.push(format!(
+            "warning: {daemon_side} has prefetch_enabled={}; {client_side} says {} — {remedy}",
+            eff.prefetch_enabled, config.prefetch_enabled,
+        ));
+    }
+    warnings
+}
+
+/// Format a Unix-millisecond timestamp as a short UTC datetime for the
+/// mismatch warnings; `0` (an old daemon's serde default) stays honest as
+/// "unknown time" instead of claiming 1970.
+fn format_epoch_ms_utc(ms: u64) -> String {
+    if ms == 0 {
+        return "unknown time".to_string();
+    }
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms as i64)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M UTC").to_string())
+        .unwrap_or_else(|| "unknown time".to_string())
 }
 
 // ── kache report ──────────────────────────────────────────────────────────
@@ -5802,6 +5912,145 @@ mod tests {
         );
         assert!(!out.contains("Planning:"));
         assert!(!out.contains("Key LIST:"));
+    }
+
+    /// A daemon-shaped [`crate::daemon::EffectiveConfig`] mirroring `config`,
+    /// with a distinct config path so tests can tell daemon-side rendering
+    /// from client-side rendering.
+    fn effective_config_like(config: &Config) -> crate::daemon::EffectiveConfig {
+        crate::daemon::EffectiveConfig {
+            max_size: config.max_size,
+            cache_dir: config.cache_dir.display().to_string(),
+            config_path: "/daemon-home/.config/kache/config.toml".to_string(),
+            prefetch_enabled: config.prefetch_enabled,
+            socket_path: config.socket_path().display().to_string(),
+            started_at_ms: 1_700_000_000_000,
+        }
+    }
+
+    /// #652/#689: the prefetch policy line renders the DAEMON's effective
+    /// policy. A client config saying "disabled" must not produce a disabled
+    /// line while the daemon reports prefetch enabled — and the daemon's
+    /// config path is surfaced on the Daemon line.
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn render_stats_prefetch_policy_prefers_daemon_effective() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = save_manifest_config(dir.path().join("cache"), Some(test_remote_cfg()));
+        config.prefetch_enabled = false; // client says disabled…
+
+        let mut snap = StatsSnapshot::default();
+        snap.daemon_connected = true;
+        let mut eff = effective_config_like(&config);
+        eff.prefetch_enabled = true; // …but the daemon is still planning
+        snap.daemon_effective_config = Some(eff);
+
+        let blobs = crate::store::BlobStats::default();
+        let out = render_stats(&snap, &blobs, &config, 24).join("\n");
+        assert!(
+            !out.contains("Prefetch:   disabled"),
+            "must not claim disabled while the daemon reports enabled: {out}"
+        );
+        assert!(out.contains("config /daemon-home/.config/kache/config.toml"));
+
+        // And the inverse: the daemon reports disabled, so the line shows it
+        // even though this process's config says enabled — unlabeled, because
+        // it is a daemon fact.
+        config.prefetch_enabled = true;
+        let mut eff = effective_config_like(&config);
+        eff.prefetch_enabled = false;
+        snap.daemon_effective_config = Some(eff);
+        let out = render_stats(&snap, &blobs, &config, 24).join("\n");
+        assert!(
+            out.contains("Prefetch:   disabled (exact remote lookup and uploads remain enabled)")
+        );
+        assert!(!out.contains("client config"));
+    }
+
+    /// Old-daemon fallback (#689): a daemon that predates effective-config
+    /// reporting leaves `daemon_effective_config` empty, so the policy line
+    /// falls back to this process's config — labeled as such, because it can
+    /// disagree with what the daemon is actually doing.
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn render_stats_prefetch_policy_labels_client_fallback_for_old_daemon() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = save_manifest_config(dir.path().join("cache"), Some(test_remote_cfg()));
+        config.prefetch_enabled = false;
+
+        let mut snap = StatsSnapshot::default();
+        snap.daemon_connected = true; // reachable, but reported no config
+
+        let blobs = crate::store::BlobStats::default();
+        let out = render_stats(&snap, &blobs, &config, 24).join("\n");
+        assert!(out.contains(
+            "Prefetch:   disabled (exact remote lookup and uploads remain enabled) \
+             [client config — daemon did not report its policy]"
+        ));
+        assert!(
+            !out.contains(", config "),
+            "no daemon config path to show without a report: {out}"
+        );
+    }
+
+    /// #689: each rendered field that differs between the daemon's effective
+    /// config and this process's resolved config produces one warning naming
+    /// both values and both sources; agreement produces none.
+    #[test]
+    fn config_mismatch_warnings_name_both_sides_per_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = save_manifest_config(dir.path().join("cache"), None);
+        let client_path = std::path::Path::new("/cli-home/kache-repro.toml");
+
+        // Agreement (paths differing is fine — only rendered values count).
+        let eff = effective_config_like(&config);
+        assert!(config_mismatch_warnings(&config, client_path, &eff).is_empty());
+
+        // Store cap differs.
+        let mut eff = effective_config_like(&config);
+        eff.max_size = config.max_size * 2;
+        let warnings = config_mismatch_warnings(&config, client_path, &eff);
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains("local_max_size=2.0 MiB"),
+            "{warnings:?}"
+        );
+        assert!(warnings[0].contains("says 1.0 MiB"), "{warnings:?}");
+        assert!(
+            warnings[0].contains("daemon (started 2023-11-14 22:13 UTC, config /daemon-home/.config/kache/config.toml)"),
+            "{warnings:?}"
+        );
+        assert!(
+            warnings[0].contains("this process's config (/cli-home/kache-repro.toml)"),
+            "{warnings:?}"
+        );
+        assert!(
+            warnings[0].contains("the daemon's value is in effect"),
+            "{warnings:?}"
+        );
+
+        // Every rendered field differs -> one warning per field, and the
+        // store divergence calls out that the numbers describe another store.
+        let mut eff = effective_config_like(&config);
+        eff.max_size += 1;
+        eff.cache_dir = "/somewhere/else".to_string();
+        eff.prefetch_enabled = !config.prefetch_enabled;
+        eff.started_at_ms = 0; // old field default must not claim 1970
+        let warnings = config_mismatch_warnings(&config, client_path, &eff);
+        assert_eq!(warnings.len(), 3);
+        assert!(
+            warnings[1].contains("local_store=/somewhere/else"),
+            "{warnings:?}"
+        );
+        assert!(
+            warnings[1].contains("the daemon's numbers describe ITS store"),
+            "{warnings:?}"
+        );
+        assert!(
+            warnings[2].contains("prefetch_enabled=false"),
+            "{warnings:?}"
+        );
+        assert!(warnings[0].contains("started unknown time"), "{warnings:?}");
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -622,6 +622,58 @@ pub struct StatsResponse {
     /// (kunobi-ninja/kache#131). Defaulted for old-daemon/new-client mixes.
     #[serde(default)]
     pub in_flight: Vec<InFlightEntry>,
+    /// The configuration this daemon actually loaded (kunobi-ninja/kache#689).
+    /// Defaulted to `None` so a daemon that predates the field is
+    /// distinguishable from one that reported it — the CLI then falls back to
+    /// its own config and labels the affected lines as client-derived.
+    #[serde(default)]
+    pub effective_config: Option<EffectiveConfig>,
+}
+
+/// The configuration the daemon loaded at startup, carried in every
+/// [`StatsResponse`] (kunobi-ninja/kache#689).
+///
+/// Daemon-backed CLI reads render these values instead of re-resolving config
+/// in the invoking process — whose `KACHE_CONFIG` / `XDG_CONFIG_HOME` /
+/// `KACHE_*` env may resolve differently — and name both sides when the two
+/// disagree, instead of silently presenting daemon values as if they were the
+/// invocation's own.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EffectiveConfig {
+    /// `[cache] local_max_size` / `KACHE_MAX_SIZE` as the daemon resolved it.
+    pub max_size: u64,
+    /// The store directory the daemon's numbers describe.
+    pub cache_dir: String,
+    /// The config-file path the daemon resolved at startup (the file its
+    /// fingerprint watcher tracks). The file may not exist — defaults then
+    /// applied — but the path still names where the daemon would read one.
+    pub config_path: String,
+    /// `[cache] prefetch_enabled` / `KACHE_PREFETCH_ENABLED` as resolved.
+    pub prefetch_enabled: bool,
+    /// The socket endpoint the daemon serves on.
+    pub socket_path: String,
+    /// Unix millis when the daemon captured this config (process startup),
+    /// so a mismatch warning can say how old the in-effect config is.
+    #[serde(default)]
+    pub started_at_ms: u64,
+}
+
+impl EffectiveConfig {
+    /// Snapshot the reportable view of `config`, plus the config-file path the
+    /// current process resolves. Called from the daemon at startup: env and
+    /// cwd are fixed for the process's lifetime, and the config-file
+    /// fingerprint watcher restarts the daemon on content changes, so a
+    /// startup capture cannot go stale while the daemon lives.
+    pub(crate) fn capture(config: &Config) -> Self {
+        Self {
+            max_size: config.max_size,
+            cache_dir: config.cache_dir.display().to_string(),
+            config_path: crate::config::resolve_config_path().display().to_string(),
+            prefetch_enabled: config.prefetch_enabled,
+            socket_path: config.socket_path().display().to_string(),
+            started_at_ms: now_millis(),
+        }
+    }
 }
 
 /// One in-flight compile as reported to stats consumers (`kache monitor`'s
@@ -1428,6 +1480,10 @@ pub(crate) struct Daemon {
     in_flight_compiles: std::sync::Mutex<HashMap<u32, CompileStartedRequest>>,
     version: String,
     build_epoch: u64,
+    /// What this daemon actually loaded, reported in every stats response so
+    /// daemon-backed CLI reads can render the daemon's view and name a
+    /// CLI/daemon config divergence (kunobi-ninja/kache#689).
+    effective_config: EffectiveConfig,
     transfer_counters: TransferCounters,
     recent_transfers: std::sync::Mutex<std::collections::VecDeque<TransferEvent>>,
     file_hash_cache: Arc<Mutex<HashMap<FileHashCacheKey, String>>>,
@@ -1470,6 +1526,7 @@ impl Daemon {
             in_flight_compiles: std::sync::Mutex::new(HashMap::new()),
             version: VERSION.to_string(),
             build_epoch: build_epoch(),
+            effective_config: EffectiveConfig::capture(&config),
             transfer_counters: TransferCounters::new(),
             recent_transfers: std::sync::Mutex::new(std::collections::VecDeque::new()),
             file_hash_cache: Arc::new(Mutex::new(HashMap::new())),
@@ -1723,6 +1780,7 @@ impl Daemon {
                 list_keys_total: ps.list_keys_total.load(Ordering::Relaxed),
             },
             in_flight,
+            effective_config: Some(self.effective_config.clone()),
         })
     }
 
@@ -5942,11 +6000,24 @@ mod tests {
                 typical_s: None,
                 eta_s: None,
             }],
+            effective_config: Some(EffectiveConfig {
+                max_size: 1,
+                cache_dir: "/c".into(),
+                config_path: "/c/config.toml".into(),
+                prefetch_enabled: true,
+                socket_path: "/c/daemon.sock".into(),
+                started_at_ms: 1,
+            }),
         })
         .unwrap();
         old.as_object_mut().unwrap().remove("in_flight");
+        // A pre-#689 daemon reports no effective config either; the CLI must
+        // see `None` (and fall back to labeled client-config values), not a
+        // parse error or a zeroed report.
+        old.as_object_mut().unwrap().remove("effective_config");
         let parsed: StatsResponse = serde_json::from_value(old).unwrap();
         assert!(parsed.in_flight.is_empty());
+        assert!(parsed.effective_config.is_none());
     }
 
     #[tokio::test]
@@ -7312,6 +7383,7 @@ mod tests {
             recent_transfers: Vec::new(),
             prefetch: PrefetchStatsSnapshot::default(),
             in_flight: Vec::new(),
+            effective_config: None,
         };
         let resp = Response::ok_stats(stats.clone());
         let json = serde_json::to_string(&resp).unwrap();
@@ -7384,6 +7456,7 @@ mod tests {
             recent_transfers: Vec::new(),
             prefetch: PrefetchStatsSnapshot::default(),
             in_flight: Vec::new(),
+            effective_config: None,
         };
         let resp = Response::ok_stats(stats);
         let json = serde_json::to_string(&resp).unwrap();
@@ -7414,6 +7487,21 @@ mod tests {
         assert_eq!(stats.entries.unwrap().len(), 0);
         assert_eq!(stats.events.local_hits, 0);
         assert_eq!(stats.events.misses, 0);
+
+        // #689: the daemon reports what IT loaded, so a CLI resolving a
+        // different config can render daemon truth and name the divergence.
+        let eff = stats.effective_config.expect("effective config reported");
+        assert_eq!(eff.max_size, 50 * 1024 * 1024);
+        assert_eq!(eff.cache_dir, dir.path().display().to_string());
+        assert_eq!(
+            eff.socket_path,
+            dir.path().join("daemon.sock").display().to_string()
+        );
+        assert!(eff.started_at_ms > 0, "startup capture stamps a time");
+        assert!(
+            !eff.config_path.is_empty(),
+            "resolved config path is always reportable, even when the file is absent"
+        );
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -706,6 +706,12 @@ pub fn status() -> Result<()> {
         {
             println!("{line}");
         }
+        // The config file the DAEMON loaded (kunobi-ninja/kache#689) — not
+        // necessarily the one this invocation resolves, which is what
+        // `kache stats` warns about when the two disagree on rendered values.
+        if let Some(eff) = &stats.effective_config {
+            println!("  Config:   {} (loaded by the daemon)", eff.config_path);
+        }
     }
 
     // 6. Exe path mismatch warning

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -145,8 +145,10 @@ fn shorten_home(path: &std::path::Path) -> String {
 }
 
 /// Try daemon first, fall back to direct reads. Wrapper for the TUI's 24h default.
+/// Auto-start stays silent here (`announce_auto_start: false`): the raw-mode
+/// alternate screen owns the terminal, so a stderr notice would corrupt it.
 fn fetch_stats(config: &Config, include_entries: bool, sort_by: &str) -> StatsSnapshot {
-    cli::fetch_stats_snapshot(config, include_entries, sort_by, Some(24))
+    cli::fetch_stats_snapshot(config, include_entries, sort_by, Some(24), false)
 }
 
 // ── App state ──────────────────────────────────────────────────────────────

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -323,6 +323,85 @@ fn stats_on_empty_cache_succeeds() {
     e.cmd().args(["stats", "--since", "1h"]).assert().success();
 }
 
+/// #689 end-to-end: `stats` announces a daemon auto-start on stderr, and a
+/// later invocation pointing `KACHE_CONFIG` at a different file still renders
+/// the daemon's values — now with a warning naming both values and both
+/// config paths, instead of silently presenting daemon config as the CLI's.
+#[test]
+fn stats_announces_auto_start_and_warns_on_daemon_config_mismatch() {
+    let e = env();
+    std::fs::write(
+        e.cache.join("config.toml"),
+        "[cache]\nlocal_max_size = \"1GiB\"\n",
+    )
+    .unwrap();
+
+    // No daemon yet: the fallback must say it is starting one (the
+    // liveness-dependent semantics flip from #689, made visible). The daemon
+    // it starts inherits THIS invocation's environment: 1 GiB cap.
+    e.cmd()
+        .env("KACHE_DAEMON_IDLE_TIMEOUT", "30")
+        .arg("stats")
+        .assert()
+        .success()
+        .stderr(
+            predicates::str::contains("no daemon reachable at").and(predicates::str::contains(
+                "starting one inheriting this process's environment",
+            )),
+        )
+        .stdout(predicates::str::contains("/ 1.0 GiB"));
+
+    // Same daemon, different CLI config: the daemon's cap still renders (it
+    // is the value in effect), and the divergence is named on stderr.
+    let other = e.cache.join("other-config.toml");
+    std::fs::write(&other, "[cache]\nlocal_max_size = \"2GiB\"\n").unwrap();
+    e.cmd()
+        .env("KACHE_DAEMON_IDLE_TIMEOUT", "30")
+        .env("KACHE_CONFIG", &other)
+        .arg("stats")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("/ 1.0 GiB"))
+        .stderr(
+            predicates::str::contains("local_max_size=1.0 GiB")
+                .and(predicates::str::contains("says 2.0 GiB"))
+                .and(predicates::str::contains("the daemon's value is in effect"))
+                .and(predicates::str::contains(other.display().to_string()))
+                .and(predicates::str::contains(
+                    e.cache.join("config.toml").display().to_string(),
+                )),
+        );
+
+    // A probe session must not leave its daemon behind.
+    e.cmd().args(["daemon", "stop"]).assert().success();
+}
+
+/// #652 stats slice: the prefetch policy line may not disagree with the
+/// daemon. The daemon here inherited prefetch enabled, so a later
+/// `KACHE_PREFETCH_ENABLED=0` invocation gets a mismatch warning instead of
+/// a wrong "disabled" line computed from its own environment.
+#[test]
+fn stats_warns_when_daemon_prefetch_policy_differs() {
+    let e = env();
+    e.cmd()
+        .env("KACHE_DAEMON_IDLE_TIMEOUT", "30")
+        .arg("stats")
+        .assert()
+        .success();
+    e.cmd()
+        .env("KACHE_DAEMON_IDLE_TIMEOUT", "30")
+        .env("KACHE_PREFETCH_ENABLED", "0")
+        .arg("stats")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Prefetch:   disabled").not())
+        .stderr(
+            predicates::str::contains("prefetch_enabled=true")
+                .and(predicates::str::contains("says false")),
+        );
+    e.cmd().args(["daemon", "stop"]).assert().success();
+}
+
 #[test]
 fn report_emits_each_format() {
     for format in ["text", "json", "markdown", "github"] {


### PR DESCRIPTION
## Problem

`kache stats` mixes two sources of truth without saying so: the numbers come from the daemon, but config-derived lines (store cap, prefetch policy) are re-resolved from the invoking process's own `KACHE_CONFIG` / `XDG_CONFIG_HOME` / `KACHE_*` env. A `KACHE_CONFIG` pointing at a different file is silently ignored — and when no daemon is reachable, the CLI silently auto-starts one that inherits the CLI's env, so the exact same command produces opposite results depending on daemon liveness. A debugging session of such probes leaves extra daemons behind (`kache doctor`: "3 daemon processes running"), and an operator's config mistake escalates into "kache ignores config files entirely" (#689's real-world case).

## Fix design

Reporting only — no change to daemon config loading, restart, or auto-start behavior:

1. **The daemon reports what it loaded.** `StatsResponse` gains an `effective_config` block (`max_size`, `cache_dir`, resolved config-file path, `prefetch_enabled`, socket path, startup timestamp), captured once at `Daemon::new`. Startup capture cannot go stale: env/cwd are fixed for the process's lifetime and the existing config-file fingerprint watcher restarts the daemon on content changes.
2. **Daemon-backed lines render the daemon's view.** The `Prefetch: disabled` line — previously computed from the *client's* config (the #652 stats item) — now renders the daemon's effective policy, and the `Daemon:` line names the config file the daemon loaded. The store cap already came from the daemon; now its source is visible.
3. **Divergence warns, one line per rendered field**, naming both values and both sources (`config_mismatch_warnings` is pure, so every branch is unit-testable without a daemon). Matching values with differing paths stays quiet on purpose — the rendered output is correct then, and project-file resolution from different cwds would otherwise warn constantly.
4. **Auto-start announces itself** on stderr, so the liveness-dependent semantics flip becomes visible. The TUI passes `announce_auto_start: false` — its raw-mode alternate screen owns the terminal.
5. **Version-skew tolerant both ways**, following the `in_flight`/`prefetch` precedent: the new field is `#[serde(default)]`; an old daemon yields `None` and the CLI falls back to its own config with an explicit label (`[client config — daemon did not report its policy]`) instead of presenting a guess as a daemon fact. An old client ignores the unknown field. `kache daemon status` also prints the daemon-loaded config path when reported.

## Measured before/after

macOS (APFS, M4 Max), release builds, isolated store/socket/config (`KACHE_CACHE_DIR=/tmp/kache-store-wd-*`, own socket paths, `KACHE_S3_*` unset). Baseline = pristine `upstream/main` @ 4961602. Daemon started with `local_max_size = "50GiB"`; probe uses `KACHE_CONFIG=/tmp/kache-wd-repro.toml` (117 GiB) — the exact repro from #689.

**Before — silent wrong attribution (daemon alive):**
```
$ KACHE_CONFIG=/tmp/kache-wd-repro.toml kache stats
Store:      0 B / 50.0 GiB (0 entries, 0%)          # 117 GiB config silently ignored, no warning
Daemon:     v0.13.0 (epoch 1786229374)
```

**After — same command:**
```
warning: daemon (started 2026-08-08 23:01 UTC, config /tmp/kache-wd-daemon.toml) has local_max_size=50.0 GiB; this process's config (/tmp/kache-wd-repro.toml) says 117.0 GiB — the daemon's value is in effect; `kache daemon restart` to apply yours
Store:      0 B / 50.0 GiB (0 entries, 0%)
Daemon:     v0.13.0 (epoch 1786230081, config /tmp/kache-wd-daemon.toml)
```

**Before — dead socket flips the answer silently:**
```
$ KACHE_SOCKET_PATH=/tmp/kache-wd-nowhere/x.sock KACHE_CONFIG=/tmp/kache-wd-repro.toml kache stats
Store:      0 B / 117.0 GiB (0 entries, 0%)         # auto-started daemon inherited CLI env, nothing said
```
(and `ps` then shows 2 leftover `kache daemon run` processes — the #689 doctor complaint)

**After — same command:**
```
kache: no daemon reachable at /tmp/kache-wd-nowhere-after/x.sock; starting one inheriting this process's environment
Store:      0 B / 117.0 GiB (0 entries, 0%)
Daemon:     v0.13.0 (epoch 1786230081, config /tmp/kache-wd-repro.toml)
```
The flip still happens (auto-start behavior unchanged, out of scope) but is announced and correctly attributed.

**Prefetch policy (the #652 stats item), after:** `KACHE_PREFETCH_ENABLED=0 kache stats` against an enabled daemon no longer renders a wrong `Prefetch: disabled` line; instead:
```
warning: daemon (started …, config …) has prefetch_enabled=true; this process's config (…) says false — the daemon's value is in effect; `kache daemon restart` to apply yours
```

## Tests

- `handle_stats` carries the effective config (values, non-empty config path, startup stamp).
- Wire compat: a `StatsResponse` without `effective_config` parses to `None` (extends the existing #131 old-daemon default test).
- `render_stats`: daemon-reported policy wins in both directions; old-daemon fallback is labeled; daemon config path shown on the `Daemon:` line.
- `config_mismatch_warnings`: silent on agreement (even with differing paths), one warning per differing field naming both sources, `started_at_ms = 0` renders "unknown time" instead of 1970.
- Integration (real binary, real auto-started daemon): auto-start notice on stderr; cross-config `kache stats` renders the daemon's cap and warns naming both files; `KACHE_PREFETCH_ENABLED=0` against an enabled daemon warns; both tests stop their daemon.

Gates on this branch (macOS, toolchain-pinned 1.95.0):
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — **zero findings introduced**: my local 1.95.0 clippy flags 3 pre-existing lints (`src/remote_backend.rs:191`, `src/tui.rs`, `src/wrapper.rs:3627`) on pristine `upstream/main` too (your CI is green there, so this looks like local-vs-CI clippy skew); the before/after error sets are byte-identical apart from a 2-line shift in `tui.rs` from a doc comment.
- `cargo test --workspace --no-fail-fast` — **1911 passed / 2 failed** across 26 suites: unit binary 1647/2, all other suites green (90, 54, 32, 27, 14, 12, 10, 7, 4, 3, 3, 2, 2, 1, 1, 1, 1 passed; 8 empty). The 2 failures are `incremental_policy::tests` lock/reset tests — a module this PR does not touch; the failing names rotate between runs, and the module passes 26/26 when run alone, so this looks like a load-sensitive local flake, not a regression (happy to dig if it's not known).
- E2E gate harness (`kache-scenario --select suite:e2e --select tier:gate`, as CI's macOS smoke runs): **40 fixtures pass, 2 skip** (`e2e-cc-bench-flags-gnu`, `e2e-cc-cl-debug` — not applicable on this host), `PASS: all executed fixtures green`.

## Scope cuts / follow-ups (deliberate)

- The `Remote:` line and the key-LIST refresh cadence still render client config: extending `EffectiveConfig` with a remote descriptor is more wire surface than the issue needs, and the fields the issue names (cap, store dir, config path, prefetch policy) are covered. Happy to follow up if you want the remote block carried too.
- Auto-start/daemon lifecycle behavior is intentionally untouched (announcement only), per the issue's reporting-only framing.
- `kache doctor` could reuse `effective_config` for a config-divergence check; left out to keep this PR one change.

Fork CI note: workflow runs need maintainer approval, and the Windows jobs run on your self-hosted runners.

Fixes #689. Addresses the stats-reporting item of #652 ("Carry the effective policy in the stats snapshot and render that instead of client config").
