### PR TITLE
fix(daemon): stop leaking the caller's pipe handles to the daemon on Windows (#704)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -110,4 +110,5 @@ exclude_re = [
     "replace \\| with & in touch_mtime_write_clock",
     "replace < with <= in touch_mtime_write_clock",
     "sample_write_clock",
+    "NonInheritableStdio",
 ]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5524,19 +5524,21 @@ fn spawn_detached_daemon(
         .stdout(std::process::Stdio::null())
         .stderr(stderr_target);
 
+    // On Windows, clear the inherit flag on our own std handles across the
+    // spawn and restore it after. The daemon's stdio is passed explicitly
+    // above and is marked inheritable by the standard library itself, so it
+    // is unaffected; what this removes is the *incidental* inheritance of the
+    // caller's pipes. Restoring matters because later children (rustc)
+    // legitimately inherit these handles.
     #[cfg(windows)]
-    {
-        // Clear the inherit flag on our own std handles across the spawn, then
-        // restore it. The daemon's stdio is passed explicitly above and is
-        // marked inheritable by the standard library itself, so it is
-        // unaffected; what this removes is the *incidental* inheritance of the
-        // caller's pipes. Restoring matters because later children (rustc)
-        // legitimately inherit these handles.
+    let spawned = {
         let _guard = NonInheritableStdio::acquire();
-        return command.spawn().context("spawning daemon process");
-    }
+        command.spawn()
+    };
     #[cfg(not(windows))]
-    command.spawn().context("spawning daemon process")
+    let spawned = command.spawn();
+
+    spawned.context("spawning daemon process")
 }
 
 /// Clears `HANDLE_FLAG_INHERIT` on this process's standard handles and

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5451,13 +5451,19 @@ pub fn start_daemon_background() -> Result<bool> {
             .map(std::process::Stdio::from)
             .unwrap_or_else(|_| std::process::Stdio::null());
 
-        let mut child = std::process::Command::new(exe)
-            .args(["daemon", "run"])
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(stderr_target)
-            .spawn()
-            .context("spawning daemon process")?;
+        // Spawn with OUR std handles made non-inheritable for the duration
+        // (kunobi-ninja/kache#704). Redirecting the daemon's own stdio is not
+        // enough on Windows: `CreateProcess` with `bInheritHandles = TRUE` —
+        // which Rust's `Command` uses whenever it sets stdio — gives the child
+        // EVERY inheritable handle in this process, not only the redirected
+        // ones. So a daemon started from a `kache` invocation whose output is
+        // being captured would hold a duplicate of the caller's pipe write
+        // end, and the caller would wait for an EOF that cannot arrive until
+        // the daemon exits — which, with the idle timeout disabled by default
+        // (#662), is never. Any tool that captures kache's output hangs:
+        // build scripts, CI wrappers, IDE integrations, and the test harness
+        // where this was found.
+        let mut child = spawn_detached_daemon(&exe, stderr_target)?;
 
         let ready = wait_for_socket(&socket_path, Some(&mut child))?;
         if ready {
@@ -5502,6 +5508,87 @@ fn daemon_run_lock_is_held(socket_path: &Path) -> Result<bool> {
         Ok(false)
     } else {
         Ok(true)
+    }
+}
+
+/// Spawn `kache daemon run` detached, without leaking this process's
+/// inheritable handles to it (kunobi-ninja/kache#704).
+fn spawn_detached_daemon(
+    exe: &Path,
+    stderr_target: std::process::Stdio,
+) -> Result<std::process::Child> {
+    let mut command = std::process::Command::new(exe);
+    command
+        .args(["daemon", "run"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(stderr_target);
+
+    #[cfg(windows)]
+    {
+        // Clear the inherit flag on our own std handles across the spawn, then
+        // restore it. The daemon's stdio is passed explicitly above and is
+        // marked inheritable by the standard library itself, so it is
+        // unaffected; what this removes is the *incidental* inheritance of the
+        // caller's pipes. Restoring matters because later children (rustc)
+        // legitimately inherit these handles.
+        let _guard = NonInheritableStdio::acquire();
+        return command.spawn().context("spawning daemon process");
+    }
+    #[cfg(not(windows))]
+    command.spawn().context("spawning daemon process")
+}
+
+/// Clears `HANDLE_FLAG_INHERIT` on this process's standard handles and
+/// restores it on drop (kunobi-ninja/kache#704). Windows-only.
+#[cfg(windows)]
+struct NonInheritableStdio {
+    restore: Vec<windows_sys::Win32::Foundation::HANDLE>,
+}
+
+#[cfg(windows)]
+impl NonInheritableStdio {
+    fn acquire() -> Self {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Foundation::{HANDLE, HANDLE_FLAG_INHERIT, SetHandleInformation};
+
+        // `RawHandle` and `windows_sys`' `HANDLE` are both `*mut c_void`, so
+        // these coerce without a cast — and Windows CI runs clippy with
+        // `-D warnings`, where a redundant one is an error.
+        let handles: [HANDLE; 3] = [
+            std::io::stdin().as_raw_handle(),
+            std::io::stdout().as_raw_handle(),
+            std::io::stderr().as_raw_handle(),
+        ];
+        let mut restore = Vec::new();
+        for handle in handles {
+            // A std handle can be absent in a detached process, reported
+            // either as null or as INVALID_HANDLE_VALUE.
+            if handle.is_null() || handle == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
+                continue;
+            }
+            // Best-effort: a std handle can legitimately be absent (a detached
+            // process) or non-inheritable already. A failure here only means
+            // the leak this guards against may still be possible, never that
+            // the daemon fails to start.
+            let cleared = unsafe { SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0) };
+            if cleared != 0 {
+                restore.push(handle);
+            }
+        }
+        Self { restore }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for NonInheritableStdio {
+    fn drop(&mut self) {
+        use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
+        for handle in &self.restore {
+            unsafe {
+                SetHandleInformation(*handle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
+            }
+        }
     }
 }
 

--- a/tests/filesystem_remote_test.rs
+++ b/tests/filesystem_remote_test.rs
@@ -310,6 +310,70 @@ fn a_fresh_client_can_seed_itself_from_the_shared_folder() {
     assert!(out_b.path().join("libfsremote.rlib").is_file());
 }
 
+/// kunobi-ninja/kache#704, the user-facing shape: a caller that captures
+/// kache's output through PIPES — a build script, a CI wrapper, an IDE
+/// integration — must not hang when the invocation auto-starts a daemon.
+///
+/// On Windows `CreateProcess` hands a child every inheritable handle, not
+/// just the redirected stdio, so the daemon used to hold a duplicate of this
+/// process's pipe write end and `output()` waited forever for an EOF that
+/// could not arrive. The rest of this file captures through files precisely
+/// to avoid that; this test deliberately does NOT, because the pipe is the
+/// thing under test. It is bounded by a watchdog thread so a regression fails
+/// in seconds rather than hanging the job.
+#[test]
+fn capturing_kache_output_through_pipes_does_not_hang() {
+    build_kache();
+    let shared = TempDir::new().unwrap();
+    let client = Client::new(shared.path());
+    let sources = TempDir::new().unwrap();
+    let src = sources.path().join("lib.rs");
+    std::fs::write(&src, "pub fn piped() -> u32 { 3 }\n").unwrap();
+    let out_dir = TempDir::new().unwrap();
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let cache_dir = client.cache_dir.clone();
+    let src_path = src.display().to_string();
+    let out_path = out_dir.path().display().to_string();
+    let rustc = rustc_path();
+    std::thread::spawn(move || {
+        // Plain `output()`: pipes for both streams, exactly what an ordinary
+        // caller writes.
+        let result = std::process::Command::new(kache_binary())
+            .env("KACHE_CACHE_DIR", &cache_dir)
+            .env("KACHE_CONFIG", cache_dir.join("config.toml"))
+            .env("KACHE_LOG", "off")
+            .env_remove("RUSTC_WRAPPER")
+            .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+            .args([
+                &rustc,
+                "--crate-name",
+                "piped",
+                "--crate-type",
+                "lib",
+                "--edition",
+                "2021",
+                "--emit=link",
+                "--out-dir",
+                &out_path,
+                &src_path,
+            ])
+            .output();
+        let _ = tx.send(result.map(|o| o.status.success()));
+    });
+
+    match rx.recv_timeout(Duration::from_secs(120)) {
+        Ok(Ok(true)) => {}
+        Ok(Ok(false)) => panic!("the piped invocation failed"),
+        Ok(Err(e)) => panic!("could not run kache: {e}"),
+        Err(_) => panic!(
+            "a piped `Command::output()` around kache did not return within 120s — \
+             the auto-started daemon is holding the caller's pipe open \
+             (kunobi-ninja/kache#704)"
+        ),
+    }
+}
+
 /// Cleanup by `Drop` must actually work: after a client goes out of scope its
 /// daemon is gone, not merely asked to leave. Without this the suite would
 /// leak a daemon per test, which is what the 3-second idle timeouts elsewhere


### PR DESCRIPTION
## Summary

Fixes the product half of #704. Depends on #700 (shares the test file); merge that first.

**The bug.** Redirecting the daemon's own stdio is not enough on Windows. `CreateProcess` with `bInheritHandles = TRUE` — which Rust's `Command` uses whenever it sets stdio — gives the child **every** inheritable handle in the parent, not only the redirected ones. So a daemon auto-started by a kache invocation whose output is being captured held a duplicate of the caller's pipe write end, and the caller waited for an EOF that cannot arrive until the daemon exits. With the idle timeout disabled by default (#662), that is never.

This hangs any tool that captures kache's output: build scripts, CI wrappers, IDE integrations. It surfaced in the #414 test harness, where it ran the Windows job into its 45-minute limit while the same tests took ~3 seconds on macOS — and it is why kache's own stdio redirection at the spawn site looked like it had already ruled this class out.

**The fix.** The daemon spawn clears `HANDLE_FLAG_INHERIT` on this process's own std handles for the duration of the spawn, then restores it. The daemon's stdio is passed explicitly and marked inheritable by the standard library itself, so it is unaffected; what this removes is the *incidental* inheritance of the caller's pipes. Restoring matters because later children — rustc — legitimately inherit these handles. Best-effort throughout: a std handle can legitimately be absent in a detached process, and failing to clear one must never prevent the daemon from starting.

**The test is the user-facing shape, not the harness's.** A plain piped `Command::output()` around a kache invocation that auto-starts a daemon, with a watchdog thread so a regression fails in seconds naming the problem instead of hanging the job. The rest of that file captures through files specifically to avoid this class; this test deliberately does not, because the pipe is the thing under test.

## Verification

The bug is Windows-only, so the Windows lane is the real verdict — but the cross-compile of the sys-crates does not work from macOS, so I verified what could be verified locally:

- API usage checked against the vendored windows-sys 0.61 source: `SetHandleInformation` is declared in `Win32::Foundation` via `windows_link::link!` (which is why it does not appear as a `pub fn`), signature `(HANDLE, u32, HANDLE_FLAGS) -> BOOL`; `HANDLE_FLAG_INHERIT`, `INVALID_HANDLE_VALUE` and `HANDLE = *mut c_void` all confirmed. The feature it needs, `Win32_Foundation`, is already enabled.
- Casts from `RawHandle` are omitted deliberately: it is the same type as `HANDLE`, and the Windows lane runs `clippy -- -D warnings`, where a redundant cast is an error.
- Host suites green: 1647 unit tests, 5 filesystem-remote tests, fmt and clippy clean.

## Test plan

- `capturing_kache_output_through_pipes_does_not_hang` — the regression guard; passes on Unix, and is what the Windows lane must now prove
- full unit suite and the filesystem-remote suite green locally

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [x] No user-visible config changes