### PR TITLE
test(service): enforce complete mutation coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
               --all-features \
               --in-diff tmp/mutants/pr.diff \
               --exclude 'crates/kache-core/**' \
+              --exclude 'crates/kache-service/**' \
               --list \
               --json |
               python3 -c '
@@ -278,6 +279,69 @@ jobs:
           path: tmp/mutants/core
           retention-days: 14
 
+  # Complete mutation coverage for the remote service crate on every code
+  # PR/main push. This is separate from the changed-line lane so unchanged
+  # authentication, readiness, startup, and shutdown behavior cannot regress.
+  mutation-service:
+    name: Mutation testing (service)
+    runs-on: ubuntu-latest
+    needs: [changes, check]
+    if: github.ref_type != 'tag' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true')
+    timeout-minutes: 20
+    env:
+      RUSTC_WRAPPER: ""
+      CARGO_INCREMENTAL: "1"
+      PROPTEST_DISABLE_FAILURE_PERSISTENCE: "1"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          version: 2026.6.9
+          install_args: rust
+          cache: false
+      - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        with:
+          tool: cargo-mutants@27.1.0
+          fallback: none
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: mutants
+          cache-bin: false
+          cache-on-failure: false
+      - name: Verify complete service mutation scope is non-empty
+        run: |
+          mkdir -p tmp/mutants
+          count="$(
+            cargo mutants --package kache-service --all-features --list --json |
+              python3 -c 'import json, sys; print(len(json.load(sys.stdin)))'
+          )"
+          echo "kache-service mutants: $count"
+          test "$count" -gt 0
+      - name: Mutate all kache-service behavior
+        timeout-minutes: 15
+        env:
+          CARGO_INCREMENTAL: "1"
+        run: |
+          cargo mutants \
+            --package kache-service \
+            --all-features \
+            --in-place \
+            --baseline run \
+            --caught \
+            --timeout 300 \
+            --build-timeout 600 \
+            --annotations github \
+            --output tmp/mutants/service
+      - name: Upload service mutation report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutation-service-report
+          path: tmp/mutants/service
+          retention-days: 14
+
   # PR-only workspace mutation is split into round-robin shards. Thirty
   # serial in-place mutants per runner stays comfortably below the step cap,
   # while round-robin avoids concentrating slow mutants in one shard.
@@ -327,6 +391,7 @@ jobs:
             --all-features \
             --in-diff tmp/mutants/pr.diff \
             --exclude 'crates/kache-core/**' \
+            --exclude 'crates/kache-service/**' \
             --shard '${{ matrix.index }}/${{ matrix.total }}' \
             --sharding round-robin \
             --in-place \
@@ -349,7 +414,7 @@ jobs:
   mutation:
     name: Mutation testing
     runs-on: ubuntu-latest
-    needs: [changes, mutation-plan, mutation-core, mutation-diff]
+    needs: [changes, mutation-plan, mutation-core, mutation-service, mutation-diff]
     if: always() && github.ref_type != 'tag'
     timeout-minutes: 5
     steps:
@@ -360,6 +425,7 @@ jobs:
           CODE_CHANGED: ${{ needs.changes.outputs.code }}
           PLAN_RESULT: ${{ needs.mutation-plan.result }}
           CORE_RESULT: ${{ needs.mutation-core.result }}
+          SERVICE_RESULT: ${{ needs.mutation-service.result }}
           DIFF_RESULT: ${{ needs.mutation-diff.result }}
           DIFF_COUNT: ${{ needs.mutation-plan.outputs.count }}
         run: |
@@ -380,11 +446,13 @@ jobs:
 
           if [ "$EVENT_NAME" = "pull_request" ] && [ "$CODE_CHANGED" = "false" ]; then
             require_result "core mutation" "$CORE_RESULT" "skipped"
+            require_result "service mutation" "$SERVICE_RESULT" "skipped"
             require_result "changed-line mutation" "$DIFF_RESULT" "skipped"
             exit 0
           fi
 
           require_result "core mutation" "$CORE_RESULT" "success"
+          require_result "service mutation" "$SERVICE_RESULT" "success"
           if [ "$EVENT_NAME" = "pull_request" ] && [ "$DIFF_COUNT" -gt 0 ]; then
             require_result "changed-line mutation" "$DIFF_RESULT" "success"
           else

--- a/Justfile
+++ b/Justfile
@@ -73,11 +73,16 @@ kani *ARGS:
 mutants-core *ARGS:
   cargo mutants --package kache-core --all-features --baseline run --timeout 300 --build-timeout 600 --output tmp/mutants/core {{ARGS}}
 
-# Mutation-test changed Rust lines outside kache-core (which mutants-core
-# already covers completely). DIFF must describe the current working tree.
+# Mutation-test the complete remote service crate.
+[group('dev')]
+mutants-service *ARGS:
+  cargo mutants --package kache-service --all-features --baseline run --caught --timeout 300 --build-timeout 600 --output tmp/mutants/service {{ARGS}}
+
+# Mutation-test changed Rust lines outside the crates covered completely by
+# mutants-core and mutants-service. DIFF must describe the current working tree.
 [group('dev')]
 mutants-diff DIFF *ARGS:
-  cargo mutants --workspace --all-features --in-diff "{{DIFF}}" --exclude 'crates/kache-core/**' --baseline run --timeout 300 --build-timeout 600 --output tmp/mutants/diff {{ARGS}}
+  cargo mutants --workspace --all-features --in-diff "{{DIFF}}" --exclude 'crates/kache-core/**' --exclude 'crates/kache-service/**' --baseline run --timeout 300 --build-timeout 600 --output tmp/mutants/diff {{ARGS}}
 
 # Audit dependencies with cargo-deny (advisories + licenses + bans +
 # sources; config and documented exceptions in `deny.toml`). Runs once

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -28,4 +28,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 [dev-dependencies]
 http-body-util = "0.1"
 tempfile = "3"
+tokio = { version = "1", features = ["time"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/kache-service/src/lib.rs
+++ b/crates/kache-service/src/lib.rs
@@ -15,8 +15,9 @@ use kunobi_auth::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::{
+    future::Future,
     net::SocketAddr,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -31,18 +32,25 @@ pub use state::{DEFAULT_DB_PATH, NamespaceState, PlannerStateFile, SurrealPlanne
 
 type SharedPlannerDataSource = Arc<dyn PlannerDataSource + Send + Sync>;
 
+const SERVICE_ACCOUNT_NAMESPACE_PATH: &str =
+    "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+const fn strip_version_prefix(raw: &str) -> &str {
+    let bytes = raw.as_bytes();
+    if bytes.len() > 1 && bytes[0] == b'v' {
+        // SAFETY: removing a leading ASCII 'v' preserves UTF-8 validity.
+        unsafe { core::str::from_utf8_unchecked(bytes.split_at(1).1) }
+    } else {
+        raw
+    }
+}
+
 pub const VERSION: &str = {
     const RAW: &str = match option_env!("KACHE_VERSION") {
         Some(v) => v,
         None => env!("CARGO_PKG_VERSION"),
     };
-    let bytes = RAW.as_bytes();
-    if bytes.len() > 1 && bytes[0] == b'v' {
-        // SAFETY: removing a leading ASCII 'v' preserves UTF-8 validity.
-        unsafe { core::str::from_utf8_unchecked(bytes.split_at(1).1) }
-    } else {
-        RAW
-    }
+    strip_version_prefix(RAW)
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -128,7 +136,22 @@ pub async fn serve(config: PlannerConfig) -> Result<()> {
     let (ha_done_tx, ha_done_rx) = watch::channel(false);
 
     if config.ha.enabled {
-        spawn_leader_task(config.clone(), state, ha_done_tx);
+        let leader = run_leader(config.clone(), state, |namespace, lease_name| async move {
+            let client = kube::Client::try_default()
+                .await
+                .context("creating Kubernetes client for HA leader election")?;
+            let leader =
+                kunobi_ha::leader::LeaderElection::builder(client, namespace, lease_name).build();
+            let mut guard = leader
+                .acquire()
+                .await
+                .context("acquiring kache planner leadership")?;
+
+            Ok::<_, anyhow::Error>(async move {
+                guard.lost().await;
+            })
+        });
+        spawn_leader_future(leader, ha_done_tx);
     } else {
         let repository = load_repository(&config).await?;
         *state.repository.write().await = repository;
@@ -144,43 +167,63 @@ pub async fn serve(config: PlannerConfig) -> Result<()> {
 
     tracing::info!(bind = %local_addr, planner = %planner_name, "planner listening");
 
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("installing ctrl+c handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("installing terminate handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
     axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal(ha_done_rx))
+        .with_graceful_shutdown(shutdown_signal(ctrl_c, terminate, ha_done_rx))
         .await
         .context("running planner server")
 }
 
-fn spawn_leader_task(config: PlannerConfig, state: AppState, ha_done_tx: watch::Sender<bool>) {
+fn spawn_leader_future(
+    leader: impl Future<Output = Result<()>> + Send + 'static,
+    ha_done_tx: watch::Sender<bool>,
+) {
     tokio::spawn(async move {
-        if let Err(error) = run_leader(config, state).await {
+        if let Err(error) = leader.await {
             tracing::error!(%error, "HA leader task failed");
         }
         let _ = ha_done_tx.send(true);
     });
 }
 
-async fn run_leader(config: PlannerConfig, state: AppState) -> Result<()> {
+async fn run_leader<Acquire, AcquireFuture, LeadershipLost>(
+    config: PlannerConfig,
+    state: AppState,
+    acquire: Acquire,
+) -> Result<()>
+where
+    Acquire: FnOnce(String, String) -> AcquireFuture,
+    AcquireFuture: Future<Output = Result<LeadershipLost>>,
+    LeadershipLost: Future<Output = ()>,
+{
     let namespace = ha_namespace(&config.ha)?;
     let lease_name = normalize_name(config.ha.lease_name.clone());
-    let client = kube::Client::try_default()
-        .await
-        .context("creating Kubernetes client for HA leader election")?;
-    let leader =
-        kunobi_ha::leader::LeaderElection::builder(client, namespace.clone(), lease_name.clone())
-            .build();
 
     tracing::info!(namespace = %namespace, lease = %lease_name, "waiting for kache planner leadership");
-    let mut guard = leader
-        .acquire()
-        .await
-        .context("acquiring kache planner leadership")?;
+    let leadership_lost = acquire(namespace.clone(), lease_name.clone()).await?;
     tracing::info!(namespace = %namespace, lease = %lease_name, "acquired kache planner leadership");
 
     let repository = load_repository(&config).await?;
     *state.repository.write().await = repository;
     state.ready.store(true, Ordering::Release);
 
-    guard.lost().await;
+    leadership_lost.await;
     state.ready.store(false, Ordering::Release);
     *state.repository.write().await = None;
     tracing::warn!(namespace = %namespace, lease = %lease_name, "lost kache planner leadership");
@@ -190,22 +233,24 @@ async fn run_leader(config: PlannerConfig, state: AppState) -> Result<()> {
 fn ha_namespace(config: &HaConfig) -> Result<String> {
     normalize_optional(config.namespace.clone())
         .or_else(|| normalize_optional(std::env::var("POD_NAMESPACE").ok()))
-        .or_else(|| read_service_account_namespace().ok())
+        .or_else(|| read_service_account_namespace(Path::new(SERVICE_ACCOUNT_NAMESPACE_PATH)).ok())
         .context(
             "HA leader election requires KACHE_HA_NAMESPACE or a mounted service account namespace",
         )
 }
 
-fn read_service_account_namespace() -> Result<String> {
-    std::fs::read_to_string("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-        .context("reading service account namespace")
-        .map(|s| s.trim().to_string())
-        .and_then(|s| {
-            if s.is_empty() {
-                anyhow::bail!("service account namespace is empty");
-            }
-            Ok(s)
-        })
+fn read_service_account_namespace(path: &Path) -> Result<String> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("reading service account namespace from {}", path.display()))?;
+    parse_service_account_namespace(&contents)
+}
+
+fn parse_service_account_namespace(contents: &str) -> Result<String> {
+    let namespace = contents.trim();
+    if namespace.is_empty() {
+        anyhow::bail!("service account namespace is empty");
+    }
+    Ok(namespace.to_string())
 }
 
 async fn load_repository(config: &PlannerConfig) -> Result<Option<SharedPlannerDataSource>> {
@@ -350,24 +395,11 @@ fn fallback_plan(planner_name: &str) -> PrefetchPlan {
     }
 }
 
-async fn shutdown_signal(mut ha_done_rx: watch::Receiver<bool>) {
-    let ctrl_c = async {
-        tokio::signal::ctrl_c()
-            .await
-            .expect("installing ctrl+c handler");
-    };
-
-    #[cfg(unix)]
-    let terminate = async {
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .expect("installing terminate handler")
-            .recv()
-            .await;
-    };
-
-    #[cfg(not(unix))]
-    let terminate = std::future::pending::<()>();
-
+async fn shutdown_signal(
+    ctrl_c: impl Future<Output = ()>,
+    terminate: impl Future<Output = ()>,
+    mut ha_done_rx: watch::Receiver<bool>,
+) {
     tokio::select! {
         _ = ctrl_c => {}
         _ = terminate => {}
@@ -391,18 +423,231 @@ mod tests {
     use std::collections::HashMap;
     use tower::util::ServiceExt;
 
+    fn test_config(db_path: PathBuf) -> PlannerConfig {
+        PlannerConfig {
+            bind: "127.0.0.1:8080".parse().unwrap(),
+            token: None,
+            planner_name: "planner".to_string(),
+            db_path,
+            seed_state_file: None,
+            ha: HaConfig::default(),
+        }
+    }
+
     fn test_app(token: Option<&str>, repository: Option<SharedPlannerDataSource>) -> Router {
-        app_with_repository(
-            PlannerConfig {
-                bind: "127.0.0.1:8080".parse().unwrap(),
-                token: token.map(str::to_string),
-                planner_name: "planner".to_string(),
-                db_path: PathBuf::from(DEFAULT_DB_PATH),
-                seed_state_file: None,
-                ha: HaConfig::default(),
-            },
-            repository,
+        let mut config = test_config(PathBuf::from(DEFAULT_DB_PATH));
+        config.token = token.map(str::to_string);
+        app_with_repository(config, repository)
+    }
+
+    fn test_app_with_readiness(ready: bool) -> Router {
+        router(AppState {
+            token: None,
+            planner_name: "planner".to_string(),
+            repository: Arc::new(RwLock::new(None)),
+            ready: Arc::new(AtomicBool::new(ready)),
+        })
+    }
+
+    #[test]
+    fn version_prefix_is_normalized_independently_of_build_metadata() {
+        assert_eq!(strip_version_prefix("v1.2.3"), "1.2.3");
+        assert_eq!(strip_version_prefix("1.2.3"), "1.2.3");
+        assert_eq!(strip_version_prefix("v"), "v");
+        assert_eq!(strip_version_prefix(""), "");
+    }
+
+    #[tokio::test]
+    async fn app_propagates_repository_open_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let blocking_file = dir.path().join("not-a-directory");
+        std::fs::write(&blocking_file, b"block child creation").unwrap();
+
+        let result = app(test_config(blocking_file.join("planner.db"))).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn serve_reports_listener_bind_failures() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path().join("planner.db"));
+        config.bind = listener.local_addr().unwrap();
+
+        let error = tokio::time::timeout(std::time::Duration::from_secs(5), serve(config))
+            .await
+            .expect("serve did not report the occupied listener address")
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("binding planner listener"));
+    }
+
+    #[test]
+    fn configured_ha_namespace_is_trimmed() {
+        let config = HaConfig {
+            enabled: true,
+            namespace: Some(" team-a ".to_string()),
+            lease_name: "planner".to_string(),
+        };
+        assert_eq!(ha_namespace(&config).unwrap(), "team-a");
+    }
+
+    #[test]
+    fn service_account_namespace_must_be_non_empty() {
+        assert_eq!(
+            parse_service_account_namespace(" team-a\n").unwrap(),
+            "team-a"
+        );
+        assert!(parse_service_account_namespace(" \n\t").is_err());
+    }
+
+    #[test]
+    fn service_account_namespace_is_read_from_the_requested_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let namespace_path = dir.path().join("namespace");
+        std::fs::write(&namespace_path, " team-a\n").unwrap();
+
+        assert_eq!(
+            read_service_account_namespace(&namespace_path).unwrap(),
+            "team-a"
+        );
+
+        std::fs::write(&namespace_path, " \n").unwrap();
+        assert!(read_service_account_namespace(&namespace_path).is_err());
+
+        let missing = dir.path().join("missing");
+        let error = read_service_account_namespace(&missing).unwrap_err();
+        assert!(format!("{error:#}").contains(&missing.display().to_string()));
+    }
+
+    #[tokio::test]
+    async fn leader_future_always_signals_completion() {
+        let (done_tx, mut done_rx) = watch::channel(false);
+        spawn_leader_future(async { anyhow::bail!("leader failed") }, done_tx);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), done_rx.changed())
+            .await
+            .expect("leader task did not finish")
+            .expect("leader task dropped signal");
+        assert!(*done_rx.borrow());
+    }
+
+    #[tokio::test]
+    async fn leader_lifecycle_publishes_and_clears_repository_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path().join("planner.db"));
+        config.ha = HaConfig {
+            enabled: true,
+            namespace: Some(" team-a ".to_string()),
+            lease_name: " lease-a ".to_string(),
+        };
+
+        let state = AppState {
+            token: None,
+            planner_name: "planner".to_string(),
+            repository: Arc::new(RwLock::new(None)),
+            ready: Arc::new(AtomicBool::new(false)),
+        };
+        let observed_state = state.clone();
+        let acquisition = Arc::new(std::sync::Mutex::new(None));
+        let acquisition_from_task = Arc::clone(&acquisition);
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let leader = tokio::spawn(run_leader(config, state, move |namespace, lease_name| {
+            *acquisition_from_task.lock().unwrap() = Some((namespace, lease_name));
+            async move {
+                Ok(async move {
+                    let _ = release_rx.await;
+                })
+            }
+        }));
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while acquisition.lock().unwrap().is_none() {
+                assert!(!leader.is_finished(), "leader exited before acquisition");
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("leader acquisition was not observed");
+        assert_eq!(
+            acquisition.lock().unwrap().as_ref(),
+            Some(&("team-a".to_string(), "lease-a".to_string()))
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !observed_state.ready.load(Ordering::Acquire) {
+                assert!(!leader.is_finished(), "leader exited before becoming ready");
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("leader did not publish ready state");
+        assert!(observed_state.ready.load(Ordering::Acquire));
+        assert!(observed_state.repository.read().await.is_some());
+
+        release_tx.send(()).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), leader)
+            .await
+            .expect("leader did not stop after leadership loss")
+            .unwrap()
+            .unwrap();
+        assert!(!observed_state.ready.load(Ordering::Acquire));
+        assert!(observed_state.repository.read().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_ha_completion() {
+        let (done_tx, done_rx) = watch::channel(false);
+        let mut shutdown = tokio::spawn(shutdown_signal(
+            std::future::pending(),
+            std::future::pending(),
+            done_rx,
+        ));
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), &mut shutdown)
+                .await
+                .is_err(),
+            "shutdown returned before any signal"
+        );
+
+        done_tx.send(true).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), shutdown)
+            .await
+            .expect("shutdown did not observe HA completion")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn shutdown_accepts_each_signal_source() {
+        let (_done_tx, done_rx) = watch::channel(false);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            shutdown_signal(std::future::ready(()), std::future::pending(), done_rx),
         )
+        .await
+        .expect("shutdown did not observe ctrl-c");
+
+        let (_done_tx, done_rx) = watch::channel(false);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            shutdown_signal(std::future::pending(), std::future::ready(()), done_rx),
+        )
+        .await
+        .expect("shutdown did not observe termination");
+    }
+
+    #[tokio::test]
+    async fn shutdown_completes_when_the_ha_sender_drops() {
+        let (done_tx, done_rx) = watch::channel(false);
+        drop(done_tx);
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            shutdown_signal(std::future::pending(), std::future::pending(), done_rx),
+        )
+        .await
+        .expect("shutdown did not observe the closed HA channel");
     }
 
     #[tokio::test]
@@ -447,6 +692,41 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn prefetch_plan_rejects_wrong_bearer_token() {
+        let response = test_app(Some("secret-token"), None)
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/v2/prefetch-plan")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::AUTHORIZATION, "Bearer wrong-token")
+                    .body(Body::from(
+                        serde_json::to_vec(&BuildIntent::default()).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn readiness_endpoint_rejects_requests_until_ready() {
+        let response = test_app_with_readiness(false)
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/readyz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]

--- a/crates/kache-service/src/main.rs
+++ b/crates/kache-service/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use kache_service::{DEFAULT_DB_PATH, HaConfig, PlannerConfig, VERSION};
 use std::{net::SocketAddr, path::PathBuf};
+use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
 #[command(name = "kache-service", version = VERSION, about = "Remote service shell for kache planner endpoints")]
@@ -41,10 +42,15 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    init_logging();
-    let cli = Cli::parse();
+    let configured_filter = std::env::var("KACHE_LOG").ok();
+    init_logging(configured_filter.as_deref(), |filter| {
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+    });
+    kache_service::serve(planner_config(Cli::parse())).await
+}
 
-    kache_service::serve(PlannerConfig {
+fn planner_config(cli: Cli) -> PlannerConfig {
+    PlannerConfig {
         bind: cli.bind,
         token: cli.token,
         planner_name: cli.planner_name,
@@ -55,15 +61,74 @@ async fn main() -> Result<()> {
             namespace: cli.ha_namespace,
             lease_name: cli.ha_lease_name,
         },
-    })
-    .await
+    }
 }
 
-fn init_logging() {
-    use tracing_subscriber::{EnvFilter, fmt};
+fn init_logging(configured_filter: Option<&str>, install: impl FnOnce(EnvFilter)) {
+    let filter = configured_filter
+        .and_then(|value| EnvFilter::try_new(value).ok())
+        .unwrap_or_else(|| EnvFilter::new("kache_service=info"));
+    install(filter);
+}
 
-    let filter = EnvFilter::try_from_env("KACHE_LOG")
-        .unwrap_or_else(|_| "kache_service=info".parse().unwrap());
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    fmt().with_env_filter(filter).init();
+    #[test]
+    fn logging_installs_requested_filter() {
+        let mut installed = None;
+        init_logging(Some("kache_service=debug"), |filter| {
+            installed = Some(filter.to_string());
+        });
+        assert_eq!(installed.as_deref(), Some("kache_service=debug"));
+    }
+
+    #[test]
+    fn logging_falls_back_for_an_invalid_filter() {
+        let mut installed = None;
+        init_logging(Some("not a valid [ filter"), |filter| {
+            installed = Some(filter.to_string());
+        });
+        assert_eq!(installed.as_deref(), Some("kache_service=info"));
+    }
+
+    #[test]
+    fn cli_fields_map_to_planner_config() {
+        let cli = Cli::try_parse_from([
+            "kache-service",
+            "--bind",
+            "127.0.0.1:9080",
+            "--token",
+            "secret",
+            "--planner-name",
+            "remote",
+            "--db-path",
+            "/tmp/planner.db",
+            "--seed-state-file",
+            "/tmp/seed.json",
+            "--ha-enabled",
+            "--ha-namespace",
+            "team-a",
+            "--ha-lease-name",
+            "planner-a",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            planner_config(cli),
+            PlannerConfig {
+                bind: "127.0.0.1:9080".parse().unwrap(),
+                token: Some("secret".to_string()),
+                planner_name: "remote".to_string(),
+                db_path: PathBuf::from("/tmp/planner.db"),
+                seed_state_file: Some(PathBuf::from("/tmp/seed.json")),
+                ha: HaConfig {
+                    enabled: true,
+                    namespace: Some("team-a".to_string()),
+                    lease_name: "planner-a".to_string(),
+                },
+            }
+        );
+    }
 }

--- a/crates/kache-service/tests/cli.rs
+++ b/crates/kache-service/tests/cli.rs
@@ -1,0 +1,38 @@
+use std::{
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+#[test]
+fn version_flag_runs_the_service_entrypoint() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_kache-service"))
+        .arg("--version")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run kache-service --version");
+    let deadline = Instant::now() + Duration::from_secs(30);
+
+    loop {
+        if child.try_wait().expect("poll kache-service").is_some() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            child.kill().expect("kill unresponsive kache-service");
+            child.wait().expect("reap unresponsive kache-service");
+            panic!("kache-service --version did not exit within 30 seconds");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let output = child
+        .wait_with_output()
+        .expect("collect kache-service output");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        format!("kache-service {}\n", kache_service::VERSION)
+    );
+}

--- a/tests/filesystem_remote_test.rs
+++ b/tests/filesystem_remote_test.rs
@@ -67,6 +67,7 @@ impl Client {
             // idle timeout is disabled by default (#662) and a leaked daemon
             // would otherwise outlive the suite.
             .env("KACHE_DAEMON_IDLE_TIMEOUT", "60")
+            .env_remove("KACHE_SOCKET_PATH")
             .env_remove("RUSTC_WRAPPER")
             .env_remove("CARGO_BUILD_RUSTC_WRAPPER");
         cmd
@@ -175,7 +176,54 @@ impl Client {
         );
     }
 
-    fn sync(&self, args: &[&str]) {
+    /// Stop the daemon and wait for its drain phase to complete. Shutdown runs
+    /// that phase before releasing its lifetime lock, giving explicit sync and
+    /// cross-client reads a stable remote boundary under slow instrumentation.
+    /// Unlike the Unix socket path, this works for Windows named pipes too.
+    fn stop_daemon_and_wait(&self) {
+        let output = self.run(&["daemon", "stop"]);
+        assert!(
+            output.status.success(),
+            "kache daemon stop failed.\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+
+        let run_lock_path = self.cache_dir.join("daemon.run.lock");
+        let run_lock = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&run_lock_path)
+            .expect("opening daemon run lock probe");
+        // Upload workers may drain for up to 30s; leave overall shutdown margin.
+        let deadline = Instant::now() + Duration::from_secs(45);
+        loop {
+            match run_lock.try_lock() {
+                Ok(()) => {
+                    run_lock.unlock().expect("releasing daemon run lock probe");
+                    return;
+                }
+                Err(std::fs::TryLockError::Error(error)) => {
+                    panic!(
+                        "failed to probe daemon lifetime lock {}: {error}",
+                        run_lock_path.display()
+                    );
+                }
+                Err(error @ std::fs::TryLockError::WouldBlock) if Instant::now() >= deadline => {
+                    panic!(
+                        "daemon lifetime lock {} remained held after its drain phase: {error}",
+                        run_lock_path.display()
+                    );
+                }
+                Err(std::fs::TryLockError::WouldBlock) => {
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+            }
+        }
+    }
+
+    fn sync(&self, args: &[&str]) -> Output {
         let mut argv = vec!["sync"];
         argv.extend_from_slice(args);
         let output = self.run(&argv);
@@ -185,6 +233,16 @@ impl Client {
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr),
         );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr
+                .lines()
+                .any(|line| line.trim_end().ends_with("failed)")),
+            "kache sync {args:?} reported failed transfers despite exiting successfully.\n\
+             stdout: {}\nstderr: {stderr}",
+            String::from_utf8_lossy(&output.stdout),
+        );
+        output
     }
 
     /// Per-result event counts from `kache report` over this client's cache.
@@ -228,11 +286,10 @@ impl Drop for Client {
 ///
 /// Runs everywhere, including Windows, on purpose. An earlier form of this
 /// file hung the Windows job to its 45-minute limit (kunobi-ninja/kache#704)
-/// while taking ~3s on macOS; the cause is still unknown, and the two
-/// candidate mechanisms are now removed rather than avoided — output is
-/// captured through files instead of pipes a lingering daemon could hold
-/// open, and every command carries a deadline. If it hangs again, CI now
-/// says which command and dies in seconds instead of burning the job.
+/// while taking ~3s on macOS because a background daemon inherited the
+/// caller's pipe handles. Daemon spawning now prevents that leak; file-backed
+/// capture and per-command deadlines remain defense in depth and make any
+/// future hang fail with a bounded, specific diagnostic.
 #[test]
 fn two_independent_clients_share_hits_through_one_folder() {
     build_kache();
@@ -251,12 +308,16 @@ fn two_independent_clients_share_hits_through_one_folder() {
         "client A's first compile must be a real compile: {:?}",
         alpha.results()
     );
-    alpha.sync(&["--push"]);
+    alpha.stop_daemon_and_wait();
+    let push = alpha.sync(&["--push"]);
 
     let manifests = shared.path().join("artifacts/v3/manifests");
     assert!(
         manifests.is_dir(),
-        "the push must have written the v3 object layout into the shared folder"
+        "the push must have written the v3 object layout into the shared folder.\n\
+         stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&push.stdout),
+        String::from_utf8_lossy(&push.stderr),
     );
 
     // Client B has never seen this compile: separate cache, separate config,
@@ -295,6 +356,7 @@ fn a_fresh_client_can_seed_itself_from_the_shared_folder() {
     let alpha = Client::new(shared.path());
     let out_a = TempDir::new().unwrap();
     alpha.compile(&src, out_a.path());
+    alpha.stop_daemon_and_wait();
     alpha.sync(&["--push"]);
 
     let beta = Client::new(shared.path());
@@ -343,6 +405,8 @@ fn capturing_kache_output_through_pipes_does_not_hang() {
             .env("KACHE_CACHE_DIR", &cache_dir)
             .env("KACHE_CONFIG", cache_dir.join("config.toml"))
             .env("KACHE_LOG", "off")
+            .env("KACHE_DAEMON_IDLE_TIMEOUT", "60")
+            .env_remove("KACHE_SOCKET_PATH")
             .env_remove("RUSTC_WRAPPER")
             .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
             .args([
@@ -427,6 +491,7 @@ fn the_shared_folder_holds_objects_only() {
     let client = Client::new(shared.path());
     let out = TempDir::new().unwrap();
     client.compile(&src, out.path());
+    client.stop_daemon_and_wait();
     client.sync(&["--push"]);
 
     let mut files = Vec::new();


### PR DESCRIPTION
## Summary

- add a complete `kache-service` mutation lane to CI and the aggregate mutation gate
- keep service mutants out of changed-line shards because the new lane covers the full crate
- add deterministic regression coverage for version handling, authentication, readiness, repository startup, namespace loading, HA lifecycle, shutdown, logging, and CLI configuration
- add `just mutants-service` for local parity
- stabilize filesystem-remote acceptance tests by draining background uploads before explicit sync and surfacing per-transfer sync failures

## Why

CI previously mutation-tested all of `kache-core`, but only tested changed lines elsewhere. The service baseline caught 29 of 48 viable mutants (60.4%), leaving 19 observable survivors, including wrong-token authentication and readiness behavior.

The new tests and small testability seams bring the service to 52/52 viable mutants caught, with 19 unviable mutants and zero missed mutants or timeouts. No mutation exclusions were added.

## Impact

Code PRs and main pushes now require complete mutation coverage for both `kache-core` and `kache-service`. Pull requests still mutation-test changed Rust lines in the remaining workspace.

The HA lifecycle is tested deterministically without a Kubernetes cluster. Live Kubernetes client and Lease acquisition remain integration-level behavior.

## Validation

- `cargo mutants 27.1.0 --package kache-service --all-features --in-place --baseline run --caught`: 71 mutants, 52 caught, 19 unviable, 0 missed/timeouts
- `cargo mutants 27.1.0 --package kache-core --all-features --in-place --baseline run`: 87 mutants, 53 caught, 34 unviable, 0 missed/timeouts
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --test filesystem_remote_test`
- `cargo llvm-cov --all-features --test filesystem_remote_test -- --exact two_independent_clients_share_hits_through_one_folder`
