### PR TITLE
fix(key): support crate-scoped path-only environment entries

### DIFF
--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -107,7 +107,7 @@ for AWS SDK-specific cases that need attention.
 | `KACHE_EXPLAIN_MISS` | `cache.explain_miss` | `false` | Miss diagnostics: on a cache miss for a crate that previously hit in the same build tree, print which key input group changed (`key changed in: args, env_deps`) and record it on the miss event. Costs one event-log read per miss, so enable it only while investigating unexpected misses |
 | — (file-only) | `cache.ignore_env` | `false` | Make the config file authoritative by ignoring `KACHE_*` env overrides for file-backed settings (see [Pinning config against env](#pinning-config-against-env)) |
 | `KACHE_FALLBACK` | `cache.fallback` | — | Secondary compiler-wrapper for ordinary passed-through compiles; kache runs `<fallback> <compiler> <args>` when it declines to cache outside its directly owned adaptive lane. `off`/`none`/empty disables |
-| `KACHE_PATH_ONLY_ENV_VARS` | `cache.path_only_env_vars` | `[]` | Extra env vars (besides `OUT_DIR`) whose values only locate an `include!`'d file, so kache normalizes their absolute path in the cache key. Env value is comma/whitespace-separated and replaces the file list (see [Path-only env vars](#path-only-env-vars)) |
+| `KACHE_PATH_ONLY_ENV_VARS` | `cache.path_only_env_vars` | `[]` | Plain path-locator env vars, plus optional `rustc_crate_name:VAR` force assertions for one crate. Env value is comma/whitespace-separated and replaces the file list (see [Path-only env vars](#path-only-env-vars)) |
 | `KACHE_KEY_ENV_VARS` | `cache.key_env_vars` | `[]` | Env vars to fold into every cache key, for values a proc macro reads at expansion time that the compiler never reports. Exact names or a trailing-`*` prefix glob. Env value is comma/whitespace-separated and replaces the file list (see [Env vars that steer expansion](#env-vars-that-steer-expansion)) |
 | `KACHE_PLANNER_ENDPOINT` | `cache.planner.endpoint` | — | Prefetch-planner service URL; setting it enables the planner client. Empty/whitespace is treated as unset |
 | `KACHE_PLANNER_TIMEOUT_MS` | `cache.planner.timeout_ms` | `750` | Planner request timeout in milliseconds |
@@ -287,7 +287,14 @@ Or via the environment (comma- or whitespace-separated; replaces the file list e
 export KACHE_PATH_ONLY_ENV_VARS="BUILDCONFIG_RS MOZ_TOPOBJDIR"
 ```
 
-This is an advanced opt-in: only list vars whose value is purely a path locator. An empty list means only `OUT_DIR` is normalized.
+Plain `VAR` entries still require kache to prove that the value only locates an included source file. For a known false positive in one crate, `rustc_crate_name:VAR` explicitly bypasses the include and runtime-value scans for only that pair:
+
+```toml title=".kache.toml"
+[cache]
+path_only_env_vars = ["cef_dll_sys:OUT_DIR"]
+```
+
+Use rustc's crate name (hyphens become underscores). This force form is a correctness assertion: only use it when the compiled artifact cannot observe the value. `CARGO_MANIFEST_DIR` cannot be forced because erasing it can restore an artifact containing another checkout's path. An empty list leaves only the built-in `OUT_DIR` behavior.
 
 ## Env vars that steer expansion
 

--- a/docs/how-it-works/cache-key.mdx
+++ b/docs/how-it-works/cache-key.mdx
@@ -36,7 +36,7 @@ A few opt-in knobs, all no-ops by default:
 - **`paths.base_dirs`** — a deterministic file-config list for multiple container, sandbox, or custom roots. Each entry maps to its own sentinel; longest match wins. This is a correctness-sensitive key-merging option, so read the [safety warning](/getting-started/configuration#extra-path-prefixes).
 - **`KACHE_KEY_SALT` / `cache.key_salt`** — fold an opaque string into every key to force a cold cache when the toolchain changes in a way kache cannot observe (a custom/cross-target libc or sysroot change, a same-version distro libc patch, a Nix closure rebuild, or a hidden linker change). See [Configuration](/getting-started/configuration#cache-key-salt).
 - **`kache.toml` extra inputs** — declare files the compiler reads but never reports (sqlx's `.sqlx/`, `migrations/`, `include!`'d data) so editing them re-keys the crate. See [Configuration](/getting-started/configuration#extra-cache-key-inputs).
-- **`path_only_env_vars`** — extra env vars whose value is only a path locator, so kache normalizes their path out of the key for cross-machine hits. See [Configuration](/getting-started/configuration#path-only-env-vars).
+- **`path_only_env_vars`** — plain path-locator env vars, plus narrowly scoped `rustc_crate_name:VAR` assertions for known scan false positives. See [Configuration](/getting-started/configuration#path-only-env-vars).
 - **`key_env_vars`** — env vars a proc macro reads at expansion time. rustc reports only `env!`/`option_env!` reads, so a macro branching on `std::env::var` produces different code from an identical command line; declaring the var separates the two. See [Configuration](/getting-started/configuration#env-vars-that-steer-expansion).
 
 ## Cross-machine portability

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -4945,6 +4945,27 @@ include!(concat!(env!("OUT_DIR"), "/generated.rs"));
     }
 
     #[test]
+    fn env_dep_normalization_decision_trace_labels_are_stable() {
+        for (decision, expected) in [
+            (EnvDepNormalizationDecision::Unchanged, "unchanged"),
+            (
+                EnvDepNormalizationDecision::NormalizedPathOnly,
+                "normalized path-only",
+            ),
+            (
+                EnvDepNormalizationDecision::KeptAbsoluteRuntimePath,
+                "kept absolute runtime path",
+            ),
+            (
+                EnvDepNormalizationDecision::ForcedPathOnly,
+                "forced path-only (user-asserted)",
+            ),
+        ] {
+            assert_eq!(decision.as_str(), expected);
+        }
+    }
+
+    #[test]
     fn env_dep_policy_normalizes_out_dir_include_pattern() {
         let dir = tempfile::tempdir().unwrap();
         let workspace = dir.path().join("workspace");
@@ -5195,6 +5216,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         // A crate whose source uses env!("OUT_DIR") as a runtime value is
         // normally kept absolute — but a user-asserted force entry normalizes
         // it anyway (the deployment guarantees the embedding branch is dead).
+        let _lock = key_test_lock();
         let dir = tempfile::tempdir().unwrap();
         let out_dir = dir.path().join("out");
         std::fs::create_dir_all(&out_dir).unwrap();
@@ -5203,8 +5225,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         let out_dir_value = out_dir.to_string_lossy().to_string();
         let source_files = vec![src];
 
-        let old_out_dir = std::env::var_os("OUT_DIR");
-        unsafe { std::env::set_var("OUT_DIR", &out_dir) };
+        let _out_dir = ScopedEnv::set("OUT_DIR", &out_dir_value);
 
         let pn_plain = PathNormalizer::from_env(Some(dir.path()));
         let kept = normalize_env_dep_value(
@@ -5224,8 +5245,6 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             &source_files,
             &pn_forced,
         );
-
-        restore_env_var("OUT_DIR", old_out_dir);
 
         assert_eq!(
             kept.decision,
@@ -5248,6 +5267,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
     #[test]
     fn env_dep_policy_force_list_crate_scope_matches_only_that_crate() {
+        let _lock = key_test_lock();
         let dir = tempfile::tempdir().unwrap();
         let out_dir = dir.path().join("out");
         std::fs::create_dir_all(&out_dir).unwrap();
@@ -5256,8 +5276,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         let out_dir_value = out_dir.to_string_lossy().to_string();
         let source_files = vec![src];
 
-        let old_out_dir = std::env::var_os("OUT_DIR");
-        unsafe { std::env::set_var("OUT_DIR", &out_dir) };
+        let _out_dir = ScopedEnv::set("OUT_DIR", &out_dir_value);
 
         let pn = PathNormalizer::from_env(Some(dir.path()))
             .with_path_only_env_vars(vec!["cef_dll_sys:OUT_DIR".to_string()]);
@@ -5265,8 +5284,6 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             normalize_env_dep_value("cef_dll_sys", "OUT_DIR", &out_dir_value, &source_files, &pn);
         let scoped_other =
             normalize_env_dep_value("other_crate", "OUT_DIR", &out_dir_value, &source_files, &pn);
-
-        restore_env_var("OUT_DIR", old_out_dir);
 
         assert_eq!(
             scoped_match.decision,

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -1728,9 +1728,13 @@ fn normalize_env_dep_value(
     // FORCE form: it bypasses the include-proof and runtime-value scans for
     // exactly that (crate, var) pair. Plain entries keep the scan-gated
     // semantics below. rustc crate-name form (underscores).
-    let forced = path_normalizer.path_only_env_vars().iter().any(|entry| {
-        matches!(entry.split_once(':'), Some((krate, v)) if krate == crate_name && v == var)
-    });
+    // CARGO_MANIFEST_DIR is never forceable: rustc can embed it in crate
+    // metadata and generated code, so erasing it from the key can restore an
+    // rlib containing another checkout's path (#167).
+    let forced = var != "CARGO_MANIFEST_DIR"
+        && path_normalizer.path_only_env_vars().iter().any(|entry| {
+            matches!(entry.split_once(':'), Some((krate, v)) if krate == crate_name && v == var)
+        });
     if forced {
         return NormalizedEnvDep {
             value: sentinelized_env_dep_value(&resolved, &normalized),
@@ -5295,8 +5299,9 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             "a crate-scoped force entry must not leak to other crates: {scoped_other:?}"
         );
     }
+
     #[test]
-    fn env_dep_policy_keeps_manifest_dir_absolute_even_with_sources_under_it() {
+    fn env_dep_policy_refuses_to_force_manifest_dir() {
         let dir = tempfile::tempdir().unwrap();
         let workspace = dir.path().join("workspace");
         let manifest_dir = workspace.join("helper");
@@ -5310,7 +5315,8 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         .unwrap();
 
         let source_files = vec![lib];
-        let path_normalizer = PathNormalizer::from_env(Some(&workspace));
+        let path_normalizer = PathNormalizer::from_env(Some(&workspace))
+            .with_path_only_env_vars(vec!["test_crate:CARGO_MANIFEST_DIR".to_string()]);
         let manifest_dir_value = manifest_dir
             .canonicalize()
             .unwrap()
@@ -5326,7 +5332,8 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
         assert_eq!(
             env_dep.decision,
-            EnvDepNormalizationDecision::KeptAbsoluteRuntimePath
+            EnvDepNormalizationDecision::KeptAbsoluteRuntimePath,
+            "CARGO_MANIFEST_DIR must stay absolute even when crate-scoped forcing is requested"
         );
         assert_eq!(env_dep.value, manifest_dir_value);
     }

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -1015,8 +1015,13 @@ pub fn compute_cache_key(
 
         hasher.set_group("env_deps");
         for (var, val) in &dep_info.env_deps {
-            let normalized_env_dep =
-                normalize_env_dep_value(var, val, &dep_info.source_files, path_normalizer);
+            let normalized_env_dep = normalize_env_dep_value(
+                crate_name,
+                var,
+                val,
+                &dep_info.source_files,
+                path_normalizer,
+            );
             fold_field(&mut hasher, b"env_dep_var:", var.as_bytes());
             fold_field(
                 &mut hasher,
@@ -1493,6 +1498,9 @@ enum EnvDepNormalizationDecision {
     Unchanged,
     NormalizedPathOnly,
     KeptAbsoluteRuntimePath,
+    /// Normalized because the var (optionally crate-scoped) is in the
+    /// user-asserted force list, bypassing the source scans.
+    ForcedPathOnly,
 }
 
 impl EnvDepNormalizationDecision {
@@ -1501,6 +1509,7 @@ impl EnvDepNormalizationDecision {
             Self::Unchanged => "unchanged",
             Self::NormalizedPathOnly => "normalized path-only",
             Self::KeptAbsoluteRuntimePath => "kept absolute runtime path",
+            Self::ForcedPathOnly => "forced path-only (user-asserted)",
         }
     }
 }
@@ -1658,7 +1667,30 @@ fn clean_static_lib_name(spec: &str) -> Option<&str> {
     Some(name)
 }
 
+/// The normalized key value for a path-only env dep: the `<OUT_DIR:unit>`
+/// sentinel form when the value lives under the build's own OUT_DIR
+/// (kunobi-ninja/kache#330 — the unit-hash component stays observable), else
+/// the generic prefix-rule normalization.
+fn sentinelized_env_dep_value(resolved: &str, normalized: &str) -> String {
+    if let Some(rel) = out_dir_relative_suffix(resolved) {
+        let unit = std::env::var_os("OUT_DIR")
+            .map(std::path::PathBuf::from)
+            .as_deref()
+            .and_then(|p| p.parent().and_then(|d| d.file_name().map(|n| n.to_owned())))
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if rel.is_empty() {
+            format!("<OUT_DIR:{unit}>")
+        } else {
+            format!("<OUT_DIR:{unit}>/{}", rel.trim_start_matches('/'))
+        }
+    } else {
+        normalized.to_string()
+    }
+}
+
 fn normalize_env_dep_value(
+    crate_name: &str,
     var: &str,
     val: &str,
     source_files: &[std::path::PathBuf],
@@ -1692,6 +1724,26 @@ fn normalize_env_dep_value(
         };
     }
 
+    // User-asserted force list: `VAR` or `crate_name:VAR` (rustc crate-name
+    // form, underscores). Bypasses the include-proof and runtime-value scans —
+    // the user asserts the artifact does not observably embed the value (e.g.
+    // an `env!("OUT_DIR")` in a fallback branch the deployment never takes).
+    // Restores then converge every checkout on the donor artifact's bytes,
+    // healing downstream extern-content cascades.
+    // A `crate_name:VAR` entry in the path-only allowlist is the user-asserted
+    // FORCE form: it bypasses the include-proof and runtime-value scans for
+    // exactly that (crate, var) pair. Plain entries keep the scan-gated
+    // semantics below. rustc crate-name form (underscores).
+    let forced = path_normalizer.path_only_env_vars().iter().any(|entry| {
+        matches!(entry.split_once(':'), Some((krate, v)) if krate == crate_name && v == var)
+    });
+    if forced {
+        return NormalizedEnvDep {
+            value: sentinelized_env_dep_value(&resolved, &normalized),
+            decision: EnvDepNormalizationDecision::ForcedPathOnly,
+        };
+    }
+
     if env_dep_is_safe_to_normalize(
         var,
         &resolved,
@@ -1709,25 +1761,8 @@ fn normalize_env_dep_value(
         // locations), and rustc's remap keeps the unit component in that
         // observable value, so two units whose OUT_DIRs differ only by
         // unit hash are not interchangeable (cross-model review finding).
-        if let Some(rel) = out_dir_relative_suffix(&resolved) {
-            let unit = std::env::var_os("OUT_DIR")
-                .map(std::path::PathBuf::from)
-                .as_deref()
-                .and_then(|p| p.parent().and_then(|d| d.file_name().map(|n| n.to_owned())))
-                .map(|n| n.to_string_lossy().into_owned())
-                .unwrap_or_default();
-            let value = if rel.is_empty() {
-                format!("<OUT_DIR:{unit}>")
-            } else {
-                format!("<OUT_DIR:{unit}>/{}", rel.trim_start_matches('/'))
-            };
-            return NormalizedEnvDep {
-                value,
-                decision: EnvDepNormalizationDecision::NormalizedPathOnly,
-            };
-        }
         return NormalizedEnvDep {
-            value: normalized,
+            value: sentinelized_env_dep_value(&resolved, &normalized),
             decision: EnvDepNormalizationDecision::NormalizedPathOnly,
         };
     }
@@ -4503,7 +4538,7 @@ mod tests {
                 .into_owned();
 
             let pn = PathNormalizer::from_env(Some(&target));
-            normalize_env_dep_value("OUT_DIR", &value, &[generated], &pn).value
+            normalize_env_dep_value("test_crate", "OUT_DIR", &value, &[generated], &pn).value
         }
 
         let cold = tempfile::tempdir().unwrap();
@@ -4940,7 +4975,7 @@ include!(concat!(env!("OUT_DIR"), "/generated.rs"));
             .to_string_lossy()
             .to_string();
         let env_dep =
-            normalize_env_dep_value("OUT_DIR", &out_dir_value, &source_files, &path_normalizer);
+            normalize_env_dep_value("test_crate", "OUT_DIR", &out_dir_value, &source_files, &path_normalizer);
 
         assert_eq!(
             env_dep.decision,
@@ -4981,7 +5016,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             .to_string_lossy()
             .to_string();
         let env_dep =
-            normalize_env_dep_value("OUT_DIR", &out_dir_value, &source_files, &path_normalizer);
+            normalize_env_dep_value("test_crate", "OUT_DIR", &out_dir_value, &source_files, &path_normalizer);
 
         assert_eq!(
             env_dep.decision,
@@ -5015,7 +5050,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
         // Not allowlisted -> kept absolute.
         let pn_off = PathNormalizer::from_env(Some(&workspace));
-        let off = normalize_env_dep_value("BUILDCONFIG_RS", &value, &source_files, &pn_off);
+        let off = normalize_env_dep_value("test_crate", "BUILDCONFIG_RS", &value, &source_files, &pn_off);
         assert_eq!(
             off.decision,
             EnvDepNormalizationDecision::KeptAbsoluteRuntimePath
@@ -5025,7 +5060,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         // Allowlisted -> normalized (the same gate as OUT_DIR still applies).
         let pn_on = PathNormalizer::from_env(Some(&workspace))
             .with_path_only_env_vars(vec!["BUILDCONFIG_RS".to_string()]);
-        let on = normalize_env_dep_value("BUILDCONFIG_RS", &value, &source_files, &pn_on);
+        let on = normalize_env_dep_value("test_crate", "BUILDCONFIG_RS", &value, &source_files, &pn_on);
         assert_eq!(on.decision, EnvDepNormalizationDecision::NormalizedPathOnly);
         assert!(
             on.value.contains("<WORKSPACE>"),
@@ -5064,12 +5099,12 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         // SAFETY: serialized by key_test_lock; restored below.
         unsafe { std::env::set_var("OUT_DIR", &out_dir) };
         let under =
-            normalize_env_dep_value("GEN_BUILD_CONSTS", &value, &source_files, &path_normalizer);
+            normalize_env_dep_value("test_crate", "GEN_BUILD_CONSTS", &value, &source_files, &path_normalizer);
         // With OUT_DIR unset there is no anchor, so the same var must stay
         // absolute — proves the gate is the under-OUT_DIR test, not the var name.
         unsafe { std::env::remove_var("OUT_DIR") };
         let no_anchor =
-            normalize_env_dep_value("GEN_BUILD_CONSTS", &value, &source_files, &path_normalizer);
+            normalize_env_dep_value("test_crate", "GEN_BUILD_CONSTS", &value, &source_files, &path_normalizer);
         restore_env_var("OUT_DIR", old_out_dir);
 
         assert_eq!(
@@ -5115,7 +5150,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             .to_string_lossy()
             .to_string();
         let env_dep =
-            normalize_env_dep_value("OUT_DIR", &out_dir_value, &source_files, &path_normalizer);
+            normalize_env_dep_value("test_crate", "OUT_DIR", &out_dir_value, &source_files, &path_normalizer);
 
         assert_eq!(
             env_dep.decision,
@@ -5124,6 +5159,89 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         assert_eq!(env_dep.value, out_dir_value);
     }
 
+
+    #[test]
+    fn env_dep_policy_force_list_overrides_runtime_value_scan() {
+        // A crate whose source uses env!("OUT_DIR") as a runtime value is
+        // normally kept absolute — but a user-asserted force entry normalizes
+        // it anyway (the deployment guarantees the embedding branch is dead).
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join("out");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        let src = dir.path().join("lib.rs");
+        std::fs::write(&src, b"pub fn p() -> &'static str { env!(\"OUT_DIR\") }").unwrap();
+        let out_dir_value = out_dir.to_string_lossy().to_string();
+        let source_files = vec![src];
+
+        let old_out_dir = std::env::var_os("OUT_DIR");
+        unsafe { std::env::set_var("OUT_DIR", &out_dir) };
+
+        let pn_plain = PathNormalizer::from_env(Some(dir.path()));
+        let kept = normalize_env_dep_value(
+            "cef_dll_sys",
+            "OUT_DIR",
+            &out_dir_value,
+            &source_files,
+            &pn_plain,
+        );
+
+        let pn_forced = PathNormalizer::from_env(Some(dir.path()))
+            .with_path_only_env_vars(vec!["cef_dll_sys:OUT_DIR".to_string()]);
+        let forced = normalize_env_dep_value(
+            "cef_dll_sys",
+            "OUT_DIR",
+            &out_dir_value,
+            &source_files,
+            &pn_forced,
+        );
+
+        restore_env_var("OUT_DIR", old_out_dir);
+
+        assert_eq!(kept.decision, EnvDepNormalizationDecision::KeptAbsoluteRuntimePath);
+        assert_eq!(
+            forced.decision,
+            EnvDepNormalizationDecision::ForcedPathOnly,
+            "a force-listed var must normalize despite the runtime-value scan: {forced:?}"
+        );
+        assert!(
+            forced.value.starts_with("<OUT_DIR:") || forced.value.starts_with("<WORKSPACE>"),
+            "forced OUT_DIR normalizes to a location-free sentinel form              (either the #330 OUT_DIR sentinel or a generic prefix rule): {forced:?}"
+        );
+        assert!(
+            !forced.value.contains(dir.path().to_string_lossy().as_ref()),
+            "no absolute build location may survive in a forced value: {forced:?}"
+        );
+    }
+
+    #[test]
+    fn env_dep_policy_force_list_crate_scope_matches_only_that_crate() {
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join("out");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        let src = dir.path().join("lib.rs");
+        std::fs::write(&src, b"pub fn p() -> &'static str { env!(\"OUT_DIR\") }").unwrap();
+        let out_dir_value = out_dir.to_string_lossy().to_string();
+        let source_files = vec![src];
+
+        let old_out_dir = std::env::var_os("OUT_DIR");
+        unsafe { std::env::set_var("OUT_DIR", &out_dir) };
+
+        let pn = PathNormalizer::from_env(Some(dir.path()))
+            .with_path_only_env_vars(vec!["cef_dll_sys:OUT_DIR".to_string()]);
+        let scoped_match =
+            normalize_env_dep_value("cef_dll_sys", "OUT_DIR", &out_dir_value, &source_files, &pn);
+        let scoped_other =
+            normalize_env_dep_value("other_crate", "OUT_DIR", &out_dir_value, &source_files, &pn);
+
+        restore_env_var("OUT_DIR", old_out_dir);
+
+        assert_eq!(scoped_match.decision, EnvDepNormalizationDecision::ForcedPathOnly);
+        assert_eq!(
+            scoped_other.decision,
+            EnvDepNormalizationDecision::KeptAbsoluteRuntimePath,
+            "a crate-scoped force entry must not leak to other crates: {scoped_other:?}"
+        );
+    }
     #[test]
     fn env_dep_policy_keeps_manifest_dir_absolute_even_with_sources_under_it() {
         let dir = tempfile::tempdir().unwrap();
@@ -5146,6 +5264,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             .to_string_lossy()
             .to_string();
         let env_dep = normalize_env_dep_value(
+            "test_crate",
             "CARGO_MANIFEST_DIR",
             &manifest_dir_value,
             &source_files,
@@ -5174,6 +5293,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             .to_string_lossy()
             .to_string();
         let env_dep = normalize_env_dep_value(
+            "test_crate",
             "CUSTOM_CONFIG_DIR",
             &config_dir_value,
             &source_files,

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -1724,12 +1724,6 @@ fn normalize_env_dep_value(
         };
     }
 
-    // User-asserted force list: `VAR` or `crate_name:VAR` (rustc crate-name
-    // form, underscores). Bypasses the include-proof and runtime-value scans —
-    // the user asserts the artifact does not observably embed the value (e.g.
-    // an `env!("OUT_DIR")` in a fallback branch the deployment never takes).
-    // Restores then converge every checkout on the donor artifact's bytes,
-    // healing downstream extern-content cascades.
     // A `crate_name:VAR` entry in the path-only allowlist is the user-asserted
     // FORCE form: it bypasses the include-proof and runtime-value scans for
     // exactly that (crate, var) pair. Plain entries keep the scan-gated
@@ -4974,8 +4968,13 @@ include!(concat!(env!("OUT_DIR"), "/generated.rs"));
             .unwrap()
             .to_string_lossy()
             .to_string();
-        let env_dep =
-            normalize_env_dep_value("test_crate", "OUT_DIR", &out_dir_value, &source_files, &path_normalizer);
+        let env_dep = normalize_env_dep_value(
+            "test_crate",
+            "OUT_DIR",
+            &out_dir_value,
+            &source_files,
+            &path_normalizer,
+        );
 
         assert_eq!(
             env_dep.decision,
@@ -5015,8 +5014,13 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             .unwrap()
             .to_string_lossy()
             .to_string();
-        let env_dep =
-            normalize_env_dep_value("test_crate", "OUT_DIR", &out_dir_value, &source_files, &path_normalizer);
+        let env_dep = normalize_env_dep_value(
+            "test_crate",
+            "OUT_DIR",
+            &out_dir_value,
+            &source_files,
+            &path_normalizer,
+        );
 
         assert_eq!(
             env_dep.decision,
@@ -5050,7 +5054,13 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
         // Not allowlisted -> kept absolute.
         let pn_off = PathNormalizer::from_env(Some(&workspace));
-        let off = normalize_env_dep_value("test_crate", "BUILDCONFIG_RS", &value, &source_files, &pn_off);
+        let off = normalize_env_dep_value(
+            "test_crate",
+            "BUILDCONFIG_RS",
+            &value,
+            &source_files,
+            &pn_off,
+        );
         assert_eq!(
             off.decision,
             EnvDepNormalizationDecision::KeptAbsoluteRuntimePath
@@ -5060,7 +5070,13 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         // Allowlisted -> normalized (the same gate as OUT_DIR still applies).
         let pn_on = PathNormalizer::from_env(Some(&workspace))
             .with_path_only_env_vars(vec!["BUILDCONFIG_RS".to_string()]);
-        let on = normalize_env_dep_value("test_crate", "BUILDCONFIG_RS", &value, &source_files, &pn_on);
+        let on = normalize_env_dep_value(
+            "test_crate",
+            "BUILDCONFIG_RS",
+            &value,
+            &source_files,
+            &pn_on,
+        );
         assert_eq!(on.decision, EnvDepNormalizationDecision::NormalizedPathOnly);
         assert!(
             on.value.contains("<WORKSPACE>"),
@@ -5098,13 +5114,23 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         let old_out_dir = std::env::var_os("OUT_DIR");
         // SAFETY: serialized by key_test_lock; restored below.
         unsafe { std::env::set_var("OUT_DIR", &out_dir) };
-        let under =
-            normalize_env_dep_value("test_crate", "GEN_BUILD_CONSTS", &value, &source_files, &path_normalizer);
+        let under = normalize_env_dep_value(
+            "test_crate",
+            "GEN_BUILD_CONSTS",
+            &value,
+            &source_files,
+            &path_normalizer,
+        );
         // With OUT_DIR unset there is no anchor, so the same var must stay
         // absolute — proves the gate is the under-OUT_DIR test, not the var name.
         unsafe { std::env::remove_var("OUT_DIR") };
-        let no_anchor =
-            normalize_env_dep_value("test_crate", "GEN_BUILD_CONSTS", &value, &source_files, &path_normalizer);
+        let no_anchor = normalize_env_dep_value(
+            "test_crate",
+            "GEN_BUILD_CONSTS",
+            &value,
+            &source_files,
+            &path_normalizer,
+        );
         restore_env_var("OUT_DIR", old_out_dir);
 
         assert_eq!(
@@ -5149,8 +5175,13 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             .unwrap()
             .to_string_lossy()
             .to_string();
-        let env_dep =
-            normalize_env_dep_value("test_crate", "OUT_DIR", &out_dir_value, &source_files, &path_normalizer);
+        let env_dep = normalize_env_dep_value(
+            "test_crate",
+            "OUT_DIR",
+            &out_dir_value,
+            &source_files,
+            &path_normalizer,
+        );
 
         assert_eq!(
             env_dep.decision,
@@ -5158,7 +5189,6 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         );
         assert_eq!(env_dep.value, out_dir_value);
     }
-
 
     #[test]
     fn env_dep_policy_force_list_overrides_runtime_value_scan() {
@@ -5197,7 +5227,10 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
         restore_env_var("OUT_DIR", old_out_dir);
 
-        assert_eq!(kept.decision, EnvDepNormalizationDecision::KeptAbsoluteRuntimePath);
+        assert_eq!(
+            kept.decision,
+            EnvDepNormalizationDecision::KeptAbsoluteRuntimePath
+        );
         assert_eq!(
             forced.decision,
             EnvDepNormalizationDecision::ForcedPathOnly,
@@ -5235,7 +5268,10 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
         restore_env_var("OUT_DIR", old_out_dir);
 
-        assert_eq!(scoped_match.decision, EnvDepNormalizationDecision::ForcedPathOnly);
+        assert_eq!(
+            scoped_match.decision,
+            EnvDepNormalizationDecision::ForcedPathOnly
+        );
         assert_eq!(
             scoped_other.decision,
             EnvDepNormalizationDecision::KeptAbsoluteRuntimePath,

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,16 +109,15 @@ pub struct Config {
     /// stale hit. `None`/empty = no effect (keys are byte-identical to
     /// not setting it). Set via `KACHE_KEY_SALT` or `[cache] key_salt`.
     pub key_salt: Option<String>,
-    /// Env vars (besides OUT_DIR) whose values are only ever used to locate
-    /// an `include!`'d file, so their absolute path may be normalized in the
-    /// cache key — the OUT_DIR path-only contract, still gated by the same
-    /// "a source file lives under the value" check. Lets a build opt in
-    /// project-specific generated-file locators (e.g. Firefox's
-    /// `BUILDCONFIG_RS` / `MOZ_TOPOBJDIR`) without kache hardcoding them, and
-    /// without endangering value-baked vars like `CARGO_MANIFEST_DIR` (the
-    /// gate keeps those absolute). Set via `KACHE_PATH_ONLY_ENV_VARS`
-    /// (comma/space-separated) or `[cache] path_only_env_vars`. Empty (the
-    /// default) = only OUT_DIR is normalized.
+    /// Env vars (besides OUT_DIR) whose values only locate an `include!`'d
+    /// file, so their absolute path may be normalized in the cache key. Plain
+    /// `VAR` entries remain gated by source/include safety checks. A scoped
+    /// `rustc_crate_name:VAR` entry is an explicit assertion that bypasses
+    /// those scans for exactly that crate and variable; crate names use
+    /// rustc's underscore form. `CARGO_MANIFEST_DIR` is never forceable.
+    /// Set via `KACHE_PATH_ONLY_ENV_VARS` (comma/space-separated) or
+    /// `[cache] path_only_env_vars`. Empty (the default) leaves only built-in
+    /// OUT_DIR normalization.
     pub path_only_env_vars: Vec<String>,
     /// Environment variables to fold into every cache key (kunobi-ninja/kache#635).
     ///

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -153,8 +153,9 @@ pub struct PathNormalizer {
     /// from the expanded/deduplicated rules: two configured symlinks may
     /// resolve to the same prefix without ceasing to be two configured slots.
     configured_base_dir_count: usize,
-    /// Env vars (besides the built-in OUT_DIR) opted into path-only cache-key
-    /// normalization. See [`crate::config::Config::path_only_env_vars`].
+    /// Plain env vars and scoped `rustc_crate_name:VAR` assertions opted into
+    /// path-only cache-key normalization. See
+    /// [`crate::config::Config::path_only_env_vars`].
     path_only_env_vars: Vec<String>,
 }
 
@@ -301,8 +302,8 @@ impl PathNormalizer {
         }
     }
 
-    /// Opt the given env vars into path-only key normalization (in addition to
-    /// the built-in OUT_DIR), e.g. from `[cache] path_only_env_vars`.
+    /// Opt plain env vars or scoped `rustc_crate_name:VAR` assertions into
+    /// path-only key normalization, e.g. from `[cache] path_only_env_vars`.
     pub fn with_path_only_env_vars(mut self, vars: Vec<String>) -> Self {
         self.path_only_env_vars = vars;
         self
@@ -352,8 +353,8 @@ impl PathNormalizer {
         self.configured_base_dir_count
     }
 
-    /// The configured path-only env-var allowlist (excludes OUT_DIR, which is
-    /// always normalized).
+    /// The configured path-only env-var allowlist and scoped assertions
+    /// (excluding built-in OUT_DIR handling).
     pub fn path_only_env_vars(&self) -> &[String] {
         &self.path_only_env_vars
     }


### PR DESCRIPTION
## Summary

- preserve @valorkin's rebased implementation from #688
- support crate-scoped `path_only_env_vars` force entries
- pin every normalization trace label with mutation-sensitive tests
- serialize the new `OUT_DIR` environment tests and restore the variable safely
- refuse scoped `CARGO_MANIFEST_DIR` forcing to preserve the #167 stale-artifact guard
- document scoped `rustc_crate_name:VAR` syntax and its correctness contract

## Why

The original fork branch could be rebased through GitHub, but GitHub denied maintainer pushes to its organization-owned fork. This maintainer delivery keeps the contributor's original commits and authorship while allowing the mutation fix and fresh hosted CI to land together.

Closes #687.
Supersedes #688 after this PR merges.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --bin kache --tests --locked -- -D warnings`
- `cargo test --bin kache env_dep_policy`
- focused normalization trace-label test
- `git diff --check`

The full `cargo test --bin kache --locked` run had one existing load-sensitive incremental-policy failure; its exact rerun passed immediately. Fresh CI is authoritative.
