### PR TITLE
fix(extra_inputs): own Cargo warm-target invalidation

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -91,6 +91,10 @@ gitignore = true
 # every mutant inside it "survives" by construction. Its behavior is
 # exercised by the Windows arm of `Test (Windows)` (the write-clock
 # ordering test) and by the e2e lifecycle on the Windows runner.
+#
+# The two `windows_*` path adapters only translate host `Path` components into
+# platform-neutral classifiers. Ubuntu cannot compile their Windows bodies;
+# the classifiers remain in scope and have exhaustive Linux-runnable tests.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -111,4 +115,6 @@ exclude_re = [
     "replace < with <= in touch_mtime_write_clock",
     "sample_write_clock",
     "NonInheritableStdio",
+    "windows_pattern_has_ambiguous_root",
+    "windows_path_uses_device_namespace",
 ]

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -215,27 +215,54 @@ extra_inputs = [
 ]
 ```
 
-Globs are relative to the crate directory. A bare directory is fine — `.sqlx` and `.sqlx/` both mean "everything under it." The matched files' contents are folded into that crate's key.
+Globs are relative to the crate directory. A bare directory is fine — `.sqlx` and `.sqlx/` both mean "everything under it." The matched files' contents are folded into that crate's key. Patterns must use stable literal paths; `$ENV` and `~` expansion is rejected because Cargo cannot observe that expansion changing.
 
 A pattern **may** reach outside the crate with `..` or an absolute path when a build genuinely depends on a shared tree above the crates or a machine-specific file. That's allowed and stays fail-safe, but it makes the crate's key host- or layout-specific (kache logs a warning), so it no longer shares across machines or worktrees — prefer a co-located input where you can.
 
-This is **opt-in and scoped per crate**: a crate with no `kache.toml` is unaffected, and one crate's `extra_inputs` never *implicitly* touch a sibling crate's key. It is also **union-only** — a misdeclared glob can only cause an extra cache *miss* (a rebuild), never restore a wrong artifact. Each file is folded as its crate-relative path plus content hash, so moving the worktree doesn't bust the cache, but swapping two matched files' contents (where order matters, like sqlx migrations) does re-key. The declared patterns are folded too, so editing `kache.toml` itself re-keys — even when it currently matches nothing.
+This is **opt-in and scoped per crate**: a crate with no `kache.toml` is unaffected, and one crate's `extra_inputs` never *implicitly* touch a sibling crate's key. Declared matches only add inputs to the key, but the declaration must cover every hidden compile-time input; an omitted file cannot be tracked. Each file is folded as its crate-relative path plus content hash, so moving the worktree doesn't bust the cache, but swapping two matched files' contents (where order matters, like sqlx migrations) does re-key. The declared patterns are folded too, so editing `kache.toml` itself re-keys — even when it currently matches nothing.
+
+`extra_inputs = []` leaves the cache key unchanged but still makes Cargo watch
+`kache.toml`, so activating the declaration later works in an already-warm target.
 
 <Callout type="warn">
-  Keep patterns narrow. A glob that walks a huge tree (an absolute `/**`, or a
-  `**/*` that accidentally spans `target/`) re-keys on every change and re-walks
-  the tree on every compile — kache warns when a pattern matches the filesystem
-  root or an unusually large number of files.
+  Keep patterns narrow. Kache rejects watches rooted at the crate root, an
+  ancestor of it, or the filesystem root. A narrower watch that still matches
+  an unusually large number of files is allowed with a warning, but re-walks
+  that tree on every compile and re-keys on every matching change.
+</Callout>
+
+Invalid declarations, unreadable inputs, broad root watches, and symlinked
+dependencies fail closed with an actionable error; Kache never silently drops
+one from Cargo freshness tracking.
+
+After a Kache-instrumented build, Kache adds `kache.toml` and bounded watches for
+its declared inputs to rustc's Cargo-facing dep-info. Cargo can then notice an
+in-place edit, addition, deletion, or declaration change and invoke Kache to
+recompute the key; no Kache-specific `build.rs` is required.
+Older cache entries are completed when Kache restores them, so the artifact
+cache itself does not need to be cleared. If Kache must pass such a crate
+through, it bypasses the configured fallback cache because that wrapper cannot
+see Kache's extra-input digest.
+Adaptive and forced incremental lanes remain disabled for declared hidden
+inputs; Kache uses the normal cache or safe passthrough path instead.
+
+<Callout type="warn">
+  Cargo cannot retroactively learn dependencies for an already-fresh target.
+  After upgrading from Kache 0.13 or earlier—or after adding `kache.toml` to a
+  crate whose target is already warm—rebuild that crate once (for example,
+  `cargo clean -p <package> && cargo build`). Later declared-input changes are
+  tracked automatically.
 </Callout>
 
 <Callout type="warn">
-  `extra_inputs` is only evaluated **when cargo invokes the compiler**. Editing a
-  tracked file in a warm in-place target — changing `.sqlx/` without touching any
-  `.rs` — doesn't re-invoke rustc on its own, so the key isn't recomputed and the
-  prior artifact is restored. To make such edits re-key, your build script must
-  emit a matching `cargo:rerun-if-changed` for the path (cargo then re-runs the
-  crate when it changes). `kache doctor` flags crates that declare `extra_inputs`
-  but whose build script won't re-trigger the compiler.
+  Cargo's unstable checksum-freshness mode cannot checksum directory watches,
+  which are needed to detect glob additions and deletions. Kache currently
+  rejects an active `extra_inputs` declaration in that mode instead of risking
+  stale output. Use Cargo's normal freshness. If checksum freshness is required,
+  run the whole Cargo command with `KACHE_DISABLED=1`; because Kache then cannot
+  inject these dependencies, keep equivalent `cargo:rerun-if-changed` directives
+  until checksum support lands. Non-Cargo build systems must likewise provide
+  their own freshness mechanism.
 </Callout>
 
 <Callout type="info">

--- a/src/args.rs
+++ b/src/args.rs
@@ -209,6 +209,10 @@ pub struct RustcArgs {
     pub out_dir: Option<PathBuf>,
     /// Emit types (--emit): dep-info, metadata, link, etc.
     pub emit: Vec<String>,
+    /// Explicit output path from `--emit=dep-info=<path>`, when present.
+    /// Cargo normally leaves this implicit; direct-rustc layouts are retained
+    /// so cache admission can force a safe passthrough.
+    pub dep_info_output: Option<PathBuf>,
     /// Source file (positional argument, typically the .rs file)
     pub source_file: Option<PathBuf>,
     /// Extern dependencies (--extern name=path)
@@ -282,6 +286,16 @@ pub struct ExternDep {
     pub path: Option<PathBuf>,
 }
 
+fn parse_emit_value(value: &str, kinds: &mut Vec<String>, dep_info_output: &mut Option<PathBuf>) {
+    for part in value.split(',') {
+        let (kind, output) = part.split_once('=').unwrap_or((part, ""));
+        kinds.push(kind.to_string());
+        if kind == "dep-info" && !output.is_empty() {
+            *dep_info_output = Some(PathBuf::from(output));
+        }
+    }
+}
+
 impl RustcArgs {
     /// Parse RUSTC_WRAPPER-style arguments.
     /// In RUSTC_WRAPPER mode, argv[0] = kache, argv[1] = rustc path, argv[2..] = rustc args.
@@ -329,6 +343,7 @@ impl RustcArgs {
             output: None,
             out_dir: None,
             emit: Vec::new(),
+            dep_info_output: None,
             source_file: None,
             externs: Vec::new(),
             target: None,
@@ -379,11 +394,7 @@ impl RustcArgs {
                 "--emit" => {
                     i += 1;
                     if let Some(val) = rustc_args.get(i) {
-                        for part in val.split(',') {
-                            // emit can be "dep-info=path" or just "metadata"
-                            let kind = part.split('=').next().unwrap_or(part);
-                            parsed.emit.push(kind.to_string());
-                        }
+                        parse_emit_value(val, &mut parsed.emit, &mut parsed.dep_info_output);
                     }
                 }
                 "--target" => {
@@ -414,10 +425,7 @@ impl RustcArgs {
                 }
                 _ if arg.starts_with("--emit=") => {
                     let val = &arg["--emit=".len()..];
-                    for part in val.split(',') {
-                        let kind = part.split('=').next().unwrap_or(part);
-                        parsed.emit.push(kind.to_string());
-                    }
+                    parse_emit_value(val, &mut parsed.emit, &mut parsed.dep_info_output);
                 }
                 "--test" => {
                     parsed.is_test = true;
@@ -714,6 +722,40 @@ impl RustcArgs {
             self.crate_name.as_ref()?,
             self.extra_filename.as_deref().unwrap_or(""),
         ))
+    }
+
+    /// Path of the Cargo-facing rustc dep-info output for this invocation.
+    ///
+    /// Cargo's normal invocation uses `<out-dir>/<crate><extra>.d`. Explicit
+    /// `--emit=dep-info=<path>` and `-o` forms are direct-rustc layouts that the
+    /// cache restore model does not preserve; those invocations pass through
+    /// and retain their caller-owned freshness.
+    pub fn dep_info_path(&self) -> Option<PathBuf> {
+        if !self.emit.iter().any(|kind| kind == "dep-info") {
+            return None;
+        }
+        if self.dep_info_output.is_some() {
+            return None;
+        }
+        if self.output.is_some() {
+            return None;
+        }
+        let name = self.crate_name.as_deref()?;
+        let file_name = format!(
+            "{}.d",
+            format_crate_output_stem(name, self.extra_filename.as_deref().unwrap_or(""))
+        );
+        self.out_dir.as_ref().map(|dir| dir.join(file_name))
+    }
+
+    /// Cargo checksum freshness asks rustc to annotate every dep-info input.
+    /// Directories cannot carry those annotations, so extra-input directory
+    /// watches must currently reject this mode instead of staying perpetually
+    /// dirty or silently missing additions.
+    pub fn checksum_freshness_enabled(&self) -> bool {
+        self.unstable_flags
+            .iter()
+            .any(|flag| flag.starts_with("checksum-hash-algorithm"))
     }
 
     /// This compile's own unit identity, for diagnostics only
@@ -1628,6 +1670,102 @@ mod tests {
     #[test]
     fn test_target_dir_none_when_no_paths() {
         assert_eq!(RustcArgs::default().target_dir(), None);
+    }
+
+    #[test]
+    fn dep_info_path_uses_cargo_output_stem() {
+        let args = RustcArgs {
+            crate_name: Some("serde".to_string()),
+            extra_filename: Some("-abc123".to_string()),
+            out_dir: Some(PathBuf::from("/work/proj/target/debug/deps")),
+            emit: vec!["dep-info".to_string(), "metadata".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(
+            args.dep_info_path(),
+            Some(PathBuf::from("/work/proj/target/debug/deps/serde-abc123.d"))
+        );
+    }
+
+    #[test]
+    fn dep_info_path_skips_explicit_emit_path() {
+        let args: Vec<String> = [
+            "rustc",
+            "--crate-name",
+            "x",
+            "src/lib.rs",
+            "--emit=metadata,dep-info=custom/deps.mk",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        let parsed = RustcArgs::parse(&args).unwrap();
+        assert_eq!(
+            parsed.dep_info_output,
+            Some(PathBuf::from("custom/deps.mk"))
+        );
+        assert_eq!(parsed.dep_info_path(), None);
+    }
+
+    #[test]
+    fn dep_info_path_is_none_when_not_requested() {
+        let args = RustcArgs {
+            crate_name: Some("x".to_string()),
+            out_dir: Some(PathBuf::from("/tmp/out")),
+            emit: vec!["metadata".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(args.dep_info_path(), None);
+    }
+
+    #[test]
+    fn dep_info_path_does_not_guess_direct_rustc_o_naming() {
+        for emit in [vec!["dep-info"], vec!["dep-info", "link"]] {
+            let args = RustcArgs {
+                crate_name: Some("x".to_string()),
+                output: Some(PathBuf::from("named.bin")),
+                emit: emit.into_iter().map(str::to_string).collect(),
+                ..Default::default()
+            };
+            assert_eq!(args.dep_info_path(), None);
+        }
+    }
+
+    #[test]
+    fn dep_info_path_skips_stdout_and_out_dir_plus_o_forms() {
+        let stdout = RustcArgs {
+            emit: vec!["dep-info".to_string()],
+            dep_info_output: Some(PathBuf::from("-")),
+            ..Default::default()
+        };
+        assert_eq!(stdout.dep_info_path(), None);
+
+        let overridden = RustcArgs {
+            crate_name: Some("x".to_string()),
+            output: Some(PathBuf::from("named.bin")),
+            out_dir: Some(PathBuf::from("out")),
+            emit: vec!["dep-info".to_string(), "link".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(overridden.dep_info_path(), None);
+    }
+
+    #[test]
+    fn parses_checksum_freshness_rustc_flag() {
+        let args: Vec<String> = [
+            "rustc",
+            "src/lib.rs",
+            "-Z",
+            "checksum-hash-algorithm=blake3",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        assert!(
+            RustcArgs::parse(&args)
+                .unwrap()
+                .checksum_freshness_enabled()
+        );
     }
 
     #[test]

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -2471,7 +2471,22 @@ impl<'db> FileHasher<'db> {
     /// Hash a file's contents, using the persistent cache when available.
     pub fn hash(&self, path: &Path) -> Result<String> {
         let Some(cache) = &self.cache else {
-            return hash_file(path);
+            if self.too_new.invocation_start_ns == 0 {
+                return hash_file(path);
+            }
+            let before = FileFingerprint::from_path(path).ok();
+            if let Some(fingerprint) = &before {
+                self.note_too_new(fingerprint);
+            }
+            let hash = hash_file(path)?;
+            let after = FileFingerprint::from_path(path).ok();
+            if let Some(fingerprint) = &after {
+                self.note_too_new(fingerprint);
+            }
+            if before != after {
+                self.too_new.saw_too_new.set(true);
+            }
+            return Ok(hash);
         };
 
         let fingerprint = match FileFingerprint::from_path(path) {
@@ -6259,6 +6274,17 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         assert!(
             after.too_new(),
             "a file modified after the build started must be flagged too-new"
+        );
+
+        // The store-free/daemon wrapper path uses `FileHasher::new()`. Its
+        // guard must not silently become a no-op just because no local hash
+        // memo is open.
+        let mut cacheless = FileHasher::new();
+        cacheless.arm_too_new_guard(now_ns - 60_000_000_000, 0);
+        cacheless.hash(&file).unwrap();
+        assert!(
+            cacheless.too_new(),
+            "a cacheless hasher must enforce the same too-new guard"
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3121,57 +3121,6 @@ pub fn doctor(
         });
     }
 
-    // extra_inputs warm-target coverage: a crate that declares extra_inputs but
-    // whose build script won't re-trigger rustc gets stale artifacts when a
-    // tracked file changes in a warm target. Only surfaced when at least one
-    // crate in the tree declares extra_inputs (no noise for the common case).
-    if let Ok(cwd) = std::env::current_dir() {
-        let audit = crate::extra_inputs::audit_rerun_coverage(&cwd);
-        if audit.declaring > 0 {
-            if audit.gaps.is_empty() {
-                checks.push(Check {
-                    label: "extra_inputs",
-                    pass: true,
-                    detail: format!(
-                        "{} crate(s), build scripts re-trigger rustc",
-                        audit.declaring
-                    ),
-                    fix: None,
-                });
-            } else {
-                let listed: Vec<String> = audit
-                    .gaps
-                    .iter()
-                    .take(5)
-                    .map(|g| {
-                        let rel = g.crate_dir.strip_prefix(&cwd).unwrap_or(&g.crate_dir);
-                        let shown = if rel.as_os_str().is_empty() {
-                            ".".to_string()
-                        } else {
-                            rel.display().to_string()
-                        };
-                        format!("{shown} ({})", g.reason)
-                    })
-                    .collect();
-                let more = audit.gaps.len().saturating_sub(listed.len());
-                let mut detail = listed.join(", ");
-                if more > 0 {
-                    detail.push_str(&format!(", +{more} more"));
-                }
-                checks.push(Check {
-                    label: "extra_inputs",
-                    pass: false,
-                    detail,
-                    fix: Some(
-                        "edits to these tracked files won't re-key in a warm target; emit \
-                         cargo:rerun-if-changed for them from build.rs (see configuration docs)"
-                            .into(),
-                    ),
-                });
-            }
-        }
-    }
-
     // Compiler probe (#626): reported from the live toolchain, bypassing the
     // probe cache, so a stale stored "unresolved" record can't mask a fixed
     // toolchain — or a fresh breakage.

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -6681,6 +6681,7 @@ mod tests {
             cache_dir: &cache,
             key_salt: None,
             key_env_vars: &[],
+            extra_inputs_digest: None,
         };
 
         let key_a = compiler.cache_key(&parse("/mapped-a"), &ctx).unwrap();
@@ -7267,6 +7268,7 @@ mod tests {
             cache_dir: cache.path(),
             key_salt: None,
             key_env_vars: &[],
+            extra_inputs_digest: None,
         };
 
         let err = compiler.cache_key(&parsed, &ctx).unwrap_err().to_string();

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -176,6 +176,10 @@ pub struct KeyCtx<'a, 'db> {
     /// (see [`crate::cache_key::apply_key_env_vars`]). Empty leaves the key
     /// byte-identical to the undeclared case.
     pub key_env_vars: &'a [String],
+    /// Digest from the invocation's already-resolved extra-input snapshot.
+    /// Rustc folds it into the key; other compiler families currently resolve
+    /// their own declaration because Cargo dep-info completion is Rust-only.
+    pub extra_inputs_digest: Option<&'a str>,
 }
 
 /// Categorization of a compiler output file.

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -180,13 +180,10 @@ impl Compiler for RustcCompiler {
     fn cache_key(&self, parsed: &RustcArgs, ctx: &KeyCtx<'_, '_>) -> Result<String> {
         let crate_name = parsed.crate_name.as_deref().unwrap_or("unknown");
         let key = compute_cache_key(parsed, ctx.file_hasher, ctx.path_normalizer)?;
-        let key = crate::extra_inputs::apply_extra_inputs(
-            key,
-            parsed.source_file.as_deref(),
-            crate_name,
-            parsed.is_primary,
-            ctx.file_hasher,
-        );
+        let key = match ctx.extra_inputs_digest {
+            Some(digest) => crate::cache_key::fold_labeled(key, "extra_inputs", digest),
+            None => key,
+        };
         let key = crate::cache_key::apply_key_env_vars(key, ctx.key_env_vars, crate_name);
         Ok(crate::cache_key::apply_key_salt(
             key,
@@ -255,6 +252,11 @@ fn rustc_refuse_reasons(
     if parsed.argfile_expansion_failed() {
         reasons.push(RefuseReason::Unsupported(
             "rustc response file could not be safely expanded — not yet supported",
+        ));
+    }
+    if parsed.dep_info_output.is_some() {
+        reasons.push(RefuseReason::Unsupported(
+            "rustc explicit --emit=dep-info=<path> output — not cacheable",
         ));
     }
     // `--pretty`/`--unpretty` (and the `-Z unpretty=…` form) make rustc dump
@@ -420,6 +422,24 @@ mod tests {
             )),
             "expected a response-file refusal, got {reasons:?}"
         );
+    }
+
+    #[test]
+    fn refuse_reasons_refuses_explicit_dep_info_output_path() {
+        let parsed = RustcCompiler::new()
+            .parse(&s(&[
+                "rustc",
+                "src/lib.rs",
+                "--crate-name",
+                "foo",
+                "--emit=metadata,dep-info=custom/deps.mk",
+            ]))
+            .unwrap();
+        let reasons = RustcCompiler::new().refuse_reasons(&parsed);
+        assert!(reasons.iter().any(|reason| matches!(
+            reason,
+            RefuseReason::Unsupported(detail) if detail.contains("explicit --emit=dep-info")
+        )));
     }
 
     #[test]

--- a/src/extra_inputs.rs
+++ b/src/extra_inputs.rs
@@ -42,6 +42,8 @@
 //!   never collapses to the unconfigured key).
 
 use crate::cache_key::FileHasher;
+use anyhow::{Context, Result};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Component, Path, PathBuf};
 
 /// The co-located per-crate config file. Deliberately distinct from the
@@ -55,6 +57,11 @@ const COLOCATED_NAME: &str = "kache.toml";
 /// tree each compile. Warn so it's visible under default verbosity without
 /// failing the build — over-folding is fail-safe, just slow.
 const OVER_BROAD_FILE_WARN: usize = 1000;
+
+/// A declaration with more distinct Cargo directory dependencies than this is
+/// almost certainly being used as a generated watch list rather than a small
+/// set of input globs. Keep the consumer fingerprint bounded.
+const MAX_WATCH_PATHS: usize = 256;
 
 /// Whether this crate has a co-located extra-input declaration.
 ///
@@ -81,6 +88,91 @@ struct ColocatedConfig {
     extra_inputs: Vec<String>,
 }
 
+/// One invocation's fully-resolved extra-input declaration.
+///
+/// The wrapper resolves this once, passes [`Self::digest`] into key
+/// computation, then uses [`Self::merge_into_dep_info`] on the consumer-facing
+/// dep-info after either compilation or restore. Paths are those of the
+/// current consumer worktree; nothing in this value comes from a cached
+/// producer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExtraInputsSnapshot {
+    config_path: PathBuf,
+    normalized_patterns: Vec<String>,
+    /// `None` for an explicit empty declaration: Cargo still watches the
+    /// config so later activation is visible, while the cache key remains
+    /// byte-identical to an unconfigured crate.
+    digest: Option<String>,
+    matched_files: Vec<PathBuf>,
+    /// Narrow directories Cargo may recursively fingerprint to notice a glob
+    /// addition/deletion, or creation of a currently-missing literal input.
+    watch_paths: Vec<PathBuf>,
+    /// Metadata observed after resolution. This is deliberately outside the
+    /// cache-key digest: it detects ABA races (v1 -> transient -> v1, or a
+    /// glob member added then removed) before Cargo accepts compiler output.
+    observations: Vec<InputObservation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InputObservation {
+    path: PathBuf,
+    size: u64,
+    mtime_ns: i64,
+    ctime_ns: i64,
+    inode: i64,
+}
+
+fn observe_dependency(path: &Path) -> Result<InputObservation> {
+    let metadata = std::fs::metadata(path)
+        .with_context(|| format!("reading extra_inputs metadata for {}", path.display()))?;
+    Ok(InputObservation {
+        path: path.to_path_buf(),
+        size: metadata.len(),
+        mtime_ns: crate::cache_key::metadata_mtime_ns(&metadata),
+        ctime_ns: crate::cache_key::metadata_ctime_ns(&metadata),
+        inode: crate::cache_key::metadata_inode(&metadata),
+    })
+}
+
+impl ExtraInputsSnapshot {
+    /// Resolve a crate's active declaration exactly once.
+    ///
+    /// `Ok(None)` retains the old no-op cases: non-primary invocation or no
+    /// co-located config. An explicit empty declaration returns a config-only
+    /// snapshot so Cargo can observe later activation without changing the
+    /// cache key. Invalid declarations and unsafe watches fail closed.
+    pub(crate) fn resolve(
+        source_file: Option<&Path>,
+        crate_name: &str,
+        is_primary: bool,
+        file_hasher: &FileHasher<'_>,
+    ) -> Result<Option<Self>> {
+        resolve_snapshot(source_file, crate_name, is_primary, file_hasher, true)
+    }
+
+    pub(crate) fn digest(&self) -> Option<&str> {
+        self.digest.as_deref()
+    }
+
+    /// Merge config, matched files, and narrow directory watches into the
+    /// first dependency rule of a rustc/Cargo dep-info file.
+    ///
+    /// Only consumer-facing dep-info should be passed here (after a cache
+    /// store/restore boundary), so a restored file never retains a producer's
+    /// absolute worktree paths. Current-consumer paths are emitted absolute so
+    /// Cargo resolves them correctly even when rustc runs from a workspace root.
+    pub(crate) fn merge_into_dep_info(&self, dep_info_path: &Path) -> Result<()> {
+        merge_snapshot_into_dep_info(self, dep_info_path)
+    }
+
+    /// Pure form used by cache restore: complete and validate the expanded
+    /// consumer bytes before any cached artifact is materialized or reported
+    /// as a hit.
+    pub(crate) fn merge_dep_info_content(&self, content: &str) -> Result<String> {
+        merge_snapshot_dep_info_content(self, content)
+    }
+}
+
 /// Compute a digest of a crate's co-located extra inputs, or `None` when the
 /// crate declares none (no `kache.toml`, empty list, or non-cacheable
 /// invocation). Fold the returned digest into the crate's key via
@@ -95,43 +187,17 @@ pub(crate) fn digest(
     is_primary: bool,
     file_hasher: &FileHasher<'_>,
 ) -> Option<String> {
-    // Only cacheable compiles pay any cost; everything else short-circuits
-    // before the `stat`.
-    if !is_primary {
-        return None;
-    }
-
-    let crate_dir = crate_dir_from_source(source_file?)?;
-    let config_path = crate_dir.join(COLOCATED_NAME);
-
-    // Cheap existence check first — the cost paid by the vast majority of
-    // crates that don't use the feature is this one `stat`.
-    let raw = match std::fs::read(&config_path) {
-        Ok(bytes) => bytes,
-        Err(_) => return None,
-    };
-
-    let text = match std::str::from_utf8(&raw) {
-        Ok(t) => t,
-        Err(_) => return Some(unparseable_digest(crate_name, &config_path, &raw)),
-    };
-
-    let config: ColocatedConfig = match toml::from_str(text) {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::warn!(
-                "[key:{crate_name}] {} is invalid ({e}); folding it as an opaque \
-                 input so the crate rebuilds until fixed",
-                config_path.display()
-            );
-            // We can't know the real inputs, so don't risk a stale hit: fold
-            // the raw bytes as an opaque, deterministic component. Same broken
-            // file → same key; any edit re-keys.
-            return Some(unparseable_digest(crate_name, &config_path, &raw));
+    // Compatibility API for C/C++ and any out-of-tree callers. It deliberately
+    // does not enforce Cargo watch-root policy: that policy is Rust/Cargo-only,
+    // while the digest bytes must retain their existing semantics. New Rust
+    // code should resolve `ExtraInputsSnapshot` and propagate its `Result`.
+    match resolve_snapshot(source_file, crate_name, is_primary, file_hasher, false) {
+        Ok(snapshot) => snapshot.and_then(|snapshot| snapshot.digest),
+        Err(error) => {
+            tracing::warn!("[key:{crate_name}] failed to resolve extra_inputs: {error:#}");
+            None
         }
-    };
-
-    fold_extra_inputs(crate_name, &crate_dir, &config.extra_inputs, file_hasher)
+    }
 }
 
 /// Fold a crate's co-located extra inputs into an already-computed key.
@@ -173,32 +239,230 @@ fn crate_dir_from_source(source_file: &Path) -> Option<PathBuf> {
     None
 }
 
+#[derive(Debug, Clone)]
+struct NormalizedInputPattern {
+    glob: String,
+    watch: WatchIntent,
+}
+
+#[derive(Debug, Clone)]
+enum WatchIntent {
+    /// A matched literal file catches edits/deletion itself. If currently
+    /// missing, Cargo watches its nearest narrow existing parent directory.
+    Literal(PathBuf),
+    /// Cargo recursively fingerprints this literal root directory so a glob
+    /// catches edits, additions, and deletions below it.
+    DirectoryRoot(PathBuf),
+}
+
+fn resolve_snapshot(
+    source_file: Option<&Path>,
+    crate_name: &str,
+    is_primary: bool,
+    file_hasher: &FileHasher<'_>,
+    strict_watches: bool,
+) -> Result<Option<ExtraInputsSnapshot>> {
+    if !is_primary {
+        return Ok(None);
+    }
+    let Some(source_file) = source_file else {
+        return Ok(None);
+    };
+    let Some(crate_dir) = crate_dir_from_source(source_file) else {
+        return Ok(None);
+    };
+    let crate_dir = lexical_normalize(&crate_dir);
+    let config_path = crate_dir.join(COLOCATED_NAME);
+
+    if strict_watches {
+        match std::fs::symlink_metadata(&config_path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                anyhow::bail!(
+                    "active extra_inputs config {} is a symlink; Cargo canonicalizes dep-info and \
+                     cannot notice that link being retargeted safely",
+                    config_path.display()
+                );
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "reading active extra_inputs config metadata {}",
+                        config_path.display()
+                    )
+                });
+            }
+        }
+    }
+
+    let raw = match std::fs::read(&config_path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) if !strict_watches => {
+            // Preserve the legacy digest API's unreadable-config no-op. The
+            // strict snapshot API fails closed instead.
+            tracing::warn!(
+                "[key:{crate_name}] cannot read {}: {error}",
+                config_path.display()
+            );
+            return Ok(None);
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "reading active extra_inputs config {}",
+                    config_path.display()
+                )
+            });
+        }
+    };
+    if strict_watches && windows_path_uses_device_namespace(&crate_dir) {
+        anyhow::bail!(
+            "active extra_inputs cannot enumerate a crate through a Windows verbatim/device \
+             namespace path safely; use the ordinary drive or UNC spelling"
+        );
+    }
+    if strict_watches {
+        // The parsed pattern set, rather than formatting/comments, defines the
+        // key. Still observe the config through the guarded hasher so a rewrite
+        // racing this snapshot suppresses cache publication.
+        file_hasher.hash(&config_path).with_context(|| {
+            format!(
+                "hashing active extra_inputs config {}",
+                config_path.display()
+            )
+        })?;
+    }
+
+    let opaque_snapshot = |raw: &[u8]| ExtraInputsSnapshot {
+        config_path: config_path.clone(),
+        normalized_patterns: Vec::new(),
+        digest: Some(unparseable_digest(crate_name, &config_path, raw)),
+        matched_files: Vec::new(),
+        watch_paths: Vec::new(),
+        observations: Vec::new(),
+    };
+    let text = match std::str::from_utf8(&raw) {
+        Ok(text) => text,
+        Err(_) if !strict_watches => return Ok(Some(opaque_snapshot(&raw))),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "active extra_inputs config {} must be valid UTF-8",
+                    config_path.display()
+                )
+            });
+        }
+    };
+    let config: ColocatedConfig = match toml::from_str(text) {
+        Ok(config) => config,
+        Err(error) if strict_watches => {
+            return Err(error).with_context(|| {
+                format!(
+                    "parsing active extra_inputs config {}",
+                    config_path.display()
+                )
+            });
+        }
+        Err(error) => {
+            tracing::warn!(
+                "[key:{crate_name}] {} is invalid ({error}); folding it as an opaque \
+                 input so the crate rebuilds until fixed",
+                config_path.display()
+            );
+            return Ok(Some(opaque_snapshot(&raw)));
+        }
+    };
+
+    resolve_declared_inputs(
+        crate_name,
+        crate_dir,
+        config_path,
+        &config.extra_inputs,
+        file_hasher,
+        strict_watches,
+    )
+}
+
 /// Fold the declared pattern set and the content hashes of every matched file
 /// into a single hex digest. Returns `None` only for the genuinely-empty
 /// declaration (`extra_inputs = []`), an explicit opt-out that must stay
 /// byte-identical to having no `kache.toml`. A non-empty declaration always
 /// folds *something* — even if every pattern is rejected — so it can never
 /// collapse back to the no-config key.
-fn fold_extra_inputs(
+fn resolve_declared_inputs(
     crate_name: &str,
-    crate_dir: &Path,
+    crate_dir: PathBuf,
+    config_path: PathBuf,
     patterns: &[String],
     file_hasher: &FileHasher<'_>,
-) -> Option<String> {
+    strict_watches: bool,
+) -> Result<Option<ExtraInputsSnapshot>> {
     // An explicit empty list is the opt-out: byte-identical to no `kache.toml`.
     if patterns.is_empty() {
-        return None;
+        return if strict_watches {
+            let observations = vec![observe_dependency(&config_path)?];
+            Ok(Some(ExtraInputsSnapshot {
+                config_path,
+                normalized_patterns: Vec::new(),
+                digest: None,
+                matched_files: Vec::new(),
+                watch_paths: Vec::new(),
+                observations,
+            }))
+        } else {
+            Ok(None)
+        };
     }
 
     // Normalize the declared patterns. Out-of-crate patterns (absolute / `..`)
     // are kept (with a portability warning); only a pattern smuggling in the
     // fold separator is skipped.
-    let mut normalized: Vec<String> = patterns
+    let mut by_glob = BTreeMap::new();
+    let mut rejected_patterns = Vec::new();
+    for pattern in patterns {
+        if strict_watches && pattern_uses_dynamic_expansion(pattern) {
+            anyhow::bail!(
+                "active extra_inputs pattern {pattern:?} uses `$ENV` or `~` expansion; Cargo \
+                 cannot notice that expansion changing, so use a stable literal path"
+            );
+        }
+        if strict_watches && windows_pattern_has_ambiguous_root(Path::new(pattern)) {
+            anyhow::bail!(
+                "active extra_inputs pattern {pattern:?} uses a Windows rooted-without-drive or \
+                 drive-relative path; use a fully-qualified absolute path or a crate-relative path"
+            );
+        }
+        if strict_watches && windows_path_uses_device_namespace(Path::new(pattern)) {
+            anyhow::bail!(
+                "active extra_inputs pattern {pattern:?} uses a Windows verbatim/device namespace \
+                 that glob enumeration cannot track safely; use an ordinary drive or UNC path"
+            );
+        }
+        if strict_watches && parent_traversal_follows_glob(pattern) {
+            anyhow::bail!(
+                "active extra_inputs pattern {pattern:?} traverses `..` after a wildcard; \
+                 Cargo cannot derive a bounded watch root that sees new matches"
+            );
+        }
+        if let Some(normalized) = normalize_pattern_info(crate_name, &crate_dir, pattern) {
+            by_glob.entry(normalized.glob.clone()).or_insert(normalized);
+        } else {
+            rejected_patterns.push(pattern);
+        }
+    }
+    if strict_watches && !rejected_patterns.is_empty() {
+        anyhow::bail!(
+            "active extra_inputs contains {} invalid pattern(s); fix the declaration before Cargo freshness can be completed safely",
+            rejected_patterns.len()
+        );
+    }
+    let normalized: Vec<NormalizedInputPattern> = by_glob.into_values().collect();
+    let normalized_patterns: Vec<String> = normalized
         .iter()
-        .filter_map(|p| normalize_pattern(crate_name, crate_dir, p))
+        .map(|pattern| pattern.glob.clone())
         .collect();
-    normalized.sort();
-    normalized.dedup();
 
     // The author DECLARED inputs (non-empty list) but every pattern was
     // rejected. Collapsing to `None` here would make the key byte-identical to
@@ -206,7 +470,7 @@ fn fold_extra_inputs(
     // the feature exists to prevent, while the author believes the file is
     // tracked. Fold the raw declared patterns instead: the key is distinct
     // from no-config and any edit to `kache.toml` re-keys.
-    if normalized.is_empty() {
+    if normalized_patterns.is_empty() {
         tracing::warn!(
             "[key:{crate_name}] every extra_inputs pattern was rejected; folding the raw \
              declaration so the crate stays distinct from an unconfigured one"
@@ -220,14 +484,43 @@ fn fold_extra_inputs(
             hasher.update(p.as_bytes());
             hasher.update(b"\x1f");
         }
-        return Some(hasher.finalize().to_hex().to_string());
+        return Ok(Some(ExtraInputsSnapshot {
+            config_path,
+            normalized_patterns,
+            digest: Some(hasher.finalize().to_hex().to_string()),
+            matched_files: Vec::new(),
+            watch_paths: Vec::new(),
+            observations: Vec::new(),
+        }));
+    }
+
+    // Reject broad recursive directory dependencies before globbing. Cargo
+    // fingerprints a directory recursively; injecting the crate root or a
+    // filesystem root would turn every build into an unbounded tree walk.
+    let watch_paths = match resolve_watch_paths(&crate_dir, &normalized) {
+        Ok(paths) => paths,
+        Err(error) if !strict_watches => {
+            tracing::warn!("[key:{crate_name}] unsafe Cargo extra_inputs watch: {error:#}");
+            Vec::new()
+        }
+        Err(error) => return Err(error),
+    };
+    if strict_watches {
+        for watch in &watch_paths {
+            inspect_safe_watch_tree(watch).with_context(|| {
+                format!(
+                    "checking active extra_inputs watch {} for byte-preserving enumeration",
+                    watch.display()
+                )
+            })?;
+        }
     }
 
     let mut hasher = blake3::Hasher::new();
 
     // (1) The declared pattern set itself — so editing `kache.toml` re-keys
     // even when it currently matches zero files.
-    for pat in &normalized {
+    for pat in &normalized_patterns {
         hasher.update(b"extra_input_pattern:");
         hasher.update(pat.as_bytes());
         hasher.update(b"\x1f");
@@ -239,7 +532,8 @@ fn fold_extra_inputs(
     // — the same fail-safe stance as the per-file `unreadable` sentinel.
     let mut matched: Vec<PathBuf> = Vec::new();
     let mut glob_errors: Vec<String> = Vec::new();
-    for pat in &normalized {
+    for normalized in &normalized {
+        let pat = &normalized.glob;
         // An absolute pattern is used as-is; a relative one anchors at the
         // crate dir (whose literal bytes are escaped so a `[`/`?` in the path
         // can't be read as a glob metachar — the user's pattern is appended
@@ -264,6 +558,11 @@ fn fold_extra_inputs(
         }
         let entries = match glob::glob(&full) {
             Ok(entries) => entries,
+            Err(error) if strict_watches => {
+                return Err(error).with_context(|| {
+                    format!("parsing active extra_inputs glob {pat:?} for {crate_name}")
+                });
+            }
             Err(e) => {
                 tracing::warn!("[key:{crate_name}] bad extra_inputs glob {pat:?}: {e}");
                 continue;
@@ -273,8 +572,13 @@ fn fold_extra_inputs(
             match entry {
                 Ok(p) if p.is_file() => matched.push(p),
                 Ok(_) => {}
+                Err(error) if strict_watches => {
+                    return Err(error).with_context(|| {
+                        format!("enumerating active extra_inputs glob {pat:?} for {crate_name}")
+                    });
+                }
                 Err(e) => {
-                    let rel = crate_relative_path(crate_dir, e.path());
+                    let rel = crate_relative_path(&crate_dir, e.path());
                     tracing::warn!(
                         "[key:{crate_name}] extra_inputs enumeration error at {rel:?}: {e}"
                     );
@@ -285,6 +589,24 @@ fn fold_extra_inputs(
     }
     matched.sort();
     matched.dedup();
+
+    // Recheck after globbing. A symlink inserted between the first preflight
+    // and enumeration must not let `glob` follow an unbounded/non-UTF-8 tree
+    // that was absent from the key's safety check.
+    let observed_watch_dirs = if strict_watches {
+        let mut directories = BTreeSet::new();
+        for watch in &watch_paths {
+            directories.extend(inspect_safe_watch_tree(watch).with_context(|| {
+                format!(
+                    "rechecking active extra_inputs watch {} after enumeration",
+                    watch.display()
+                )
+            })?);
+        }
+        directories
+    } else {
+        BTreeSet::new()
+    };
 
     // Empirical breadth guard: catches an over-broad glob regardless of shape
     // (an absolute `/**`, or a relative `**/*` that accidentally spans
@@ -316,9 +638,24 @@ fn fold_extra_inputs(
     let mut readable: Vec<String> = Vec::new();
     let mut unreadable: Vec<String> = Vec::new();
     for path in &matched {
-        let rel = crate_relative_path(crate_dir, path);
+        let rel = crate_relative_path(&crate_dir, path);
+        if strict_watches && rel.contains('\x1f') {
+            anyhow::bail!(
+                "active extra_inputs dependency {} contains the cache-key control separator; \
+                 rename it before the declaration can be keyed unambiguously",
+                path.display()
+            );
+        }
         match file_hasher.hash(path) {
             Ok(h) => readable.push(format!("{rel}={h}")),
+            Err(error) if strict_watches => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "hashing active extra_inputs dependency {} for {crate_name}",
+                        path.display()
+                    )
+                });
+            }
             Err(e) => {
                 tracing::warn!("[key:{crate_name}] extra_input unreadable {rel:?}: {e}");
                 unreadable.push(rel);
@@ -371,7 +708,43 @@ fn fold_extra_inputs(
         normalized.len()
     );
 
-    Some(hasher.finalize().to_hex().to_string())
+    let dependencies: BTreeSet<PathBuf> = std::iter::once(config_path.clone())
+        .chain(matched.iter().cloned())
+        .chain(watch_paths.iter().cloned())
+        .collect();
+    if strict_watches {
+        for dependency in &dependencies {
+            if let Some(symlink) = first_symlink_below_common(&crate_dir, dependency) {
+                anyhow::bail!(
+                    "active extra_inputs dependency {} crosses symlink {}; Cargo canonicalizes \
+                     dep-info and cannot notice that link being retargeted safely",
+                    dependency.display(),
+                    symlink.display()
+                );
+            }
+        }
+    }
+    let observation_paths: BTreeSet<PathBuf> = std::iter::once(config_path.clone())
+        .chain(matched.iter().cloned())
+        .chain(observed_watch_dirs)
+        .collect();
+    let observations = if strict_watches {
+        observation_paths
+            .iter()
+            .map(|path| observe_dependency(path))
+            .collect::<Result<Vec<_>>>()?
+    } else {
+        Vec::new()
+    };
+
+    Ok(Some(ExtraInputsSnapshot {
+        config_path,
+        normalized_patterns,
+        digest: Some(hasher.finalize().to_hex().to_string()),
+        matched_files: matched,
+        watch_paths,
+        observations,
+    }))
 }
 
 /// A matched file's path as a stable, crate-relative, `/`-separated string for
@@ -394,7 +767,16 @@ fn crate_relative_path(crate_dir: &Path, path: &Path) -> String {
 /// Out-of-crate patterns (absolute / `..`) are *folded*, with a portability
 /// warning: reaching outside the crate is the author's explicit, fail-safe
 /// choice, but it makes the key host-/layout-specific.
+#[cfg(test)]
 fn normalize_pattern(crate_name: &str, crate_dir: &Path, pattern: &str) -> Option<String> {
+    normalize_pattern_info(crate_name, crate_dir, pattern).map(|pattern| pattern.glob)
+}
+
+fn normalize_pattern_info(
+    crate_name: &str,
+    crate_dir: &Path,
+    pattern: &str,
+) -> Option<NormalizedInputPattern> {
     let (normalized, unset_vars) = crate::config::expand_exclude_pattern_collecting(pattern);
 
     // An unset `$VAR` in a pattern is the one failure mode the rest of this
@@ -457,14 +839,279 @@ fn normalize_pattern(crate_name: &str, crate_dir: &Path, pattern: &str) -> Optio
     // force-normalize the pattern: that can only break a match the author's
     // editor already aligned with the on-disk bytes.
     let trimmed = normalized.strip_suffix('/').unwrap_or(&normalized);
-    let reshaped = if crate_dir.join(trimmed).is_dir() {
-        format!("{}/**/*", glob::Pattern::escape(trimmed))
+    let literal_path = anchor_input_path(crate_dir, Path::new(trimmed));
+    let (glob, watch) = if literal_path.is_dir() {
+        (
+            format!("{}/**/*", glob::Pattern::escape(trimmed)),
+            WatchIntent::DirectoryRoot(literal_path),
+        )
     } else if normalized.ends_with('/') {
-        format!("{normalized}**/*")
+        (
+            format!("{normalized}**/*"),
+            WatchIntent::DirectoryRoot(literal_path),
+        )
+    } else if normalized.contains(['*', '?', '[']) {
+        let root = literal_glob_root(&normalized);
+        (
+            normalized,
+            WatchIntent::DirectoryRoot(anchor_input_path(crate_dir, &root)),
+        )
     } else {
-        normalized
+        (normalized, WatchIntent::Literal(literal_path))
     };
-    Some(reshaped)
+    Some(NormalizedInputPattern { glob, watch })
+}
+
+fn pattern_uses_dynamic_expansion(pattern: &str) -> bool {
+    if pattern == "~" || pattern.starts_with("~/") {
+        return true;
+    }
+    let mut chars = pattern.chars().peekable();
+    while let Some(character) = chars.next() {
+        if character == '$'
+            && chars
+                .peek()
+                .is_some_and(|next| *next == '{' || *next == '_' || next.is_ascii_alphanumeric())
+        {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(windows)]
+fn windows_pattern_has_ambiguous_root(path: &Path) -> bool {
+    let has_prefix = matches!(path.components().next(), Some(Component::Prefix(_)));
+    !path.is_absolute() && (path.has_root() || has_prefix)
+}
+
+#[cfg(not(windows))]
+fn windows_pattern_has_ambiguous_root(_path: &Path) -> bool {
+    false
+}
+
+#[cfg(windows)]
+fn windows_path_uses_device_namespace(path: &Path) -> bool {
+    use std::path::Prefix;
+
+    matches!(
+        path.components().next(),
+        Some(Component::Prefix(prefix))
+            if matches!(
+                prefix.kind(),
+                Prefix::Verbatim(_)
+                    | Prefix::VerbatimUNC(_, _)
+                    | Prefix::VerbatimDisk(_)
+                    | Prefix::DeviceNS(_)
+            )
+    )
+}
+
+#[cfg(not(windows))]
+fn windows_path_uses_device_namespace(_path: &Path) -> bool {
+    false
+}
+
+fn parent_traversal_follows_glob(pattern: &str) -> bool {
+    let mut saw_glob = false;
+    for component in Path::new(pattern).components() {
+        match component {
+            Component::ParentDir if saw_glob => return true,
+            Component::Normal(text) => {
+                let text = text.to_string_lossy();
+                saw_glob |= text.contains(['*', '?', '[']);
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Literal directory prefix before the first component carrying glob syntax.
+/// A pattern such as `migrations/**/*.sql` yields `migrations`; `**/*.sql`
+/// yields an empty relative path, which anchors to the crate root and is
+/// rejected before enumeration.
+fn literal_glob_root(pattern: &str) -> PathBuf {
+    let mut root = PathBuf::new();
+    for component in Path::new(pattern).components() {
+        let text = component.as_os_str().to_string_lossy();
+        if text.contains(['*', '?', '[']) {
+            break;
+        }
+        root.push(component.as_os_str());
+    }
+    root
+}
+
+fn anchor_input_path(crate_dir: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        lexical_normalize(path)
+    } else {
+        lexical_normalize(&crate_dir.join(path))
+    }
+}
+
+/// Normalize `.`/`..` without requiring the path to exist or resolving
+/// symlinks. Missing literal inputs still need a stable parent watch.
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() && !normalized.has_root() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+/// Find a user-controlled symlink component between the crate and one of its
+/// declared dependencies. Cargo canonicalizes dep-info paths, so watching only
+/// the symlink target would miss a later retarget of the link itself.
+fn first_symlink_below_common(crate_dir: &Path, dependency: &Path) -> Option<PathBuf> {
+    let crate_components: Vec<_> = crate_dir.components().collect();
+    let dependency_components: Vec<_> = dependency.components().collect();
+    let common_len = crate_components
+        .iter()
+        .zip(&dependency_components)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let mut probe = PathBuf::new();
+    for component in &dependency_components[..common_len] {
+        probe.push(component.as_os_str());
+    }
+    for component in &dependency_components[common_len..] {
+        probe.push(component.as_os_str());
+        if std::fs::symlink_metadata(&probe).is_ok_and(|metadata| metadata.file_type().is_symlink())
+        {
+            return Some(probe);
+        }
+    }
+    None
+}
+
+/// `glob` works through UTF-8 patterns and silently omits non-UTF-8 directory
+/// entries on Unix. Preflight each bounded watch tree with `read_dir`, which
+/// preserves `OsStr`, and fail closed instead of keying an incomplete set.
+fn inspect_safe_watch_tree(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut pending = vec![root.to_path_buf()];
+    let mut directories = Vec::new();
+    while let Some(directory) = pending.pop() {
+        directories.push(directory.clone());
+        for entry in std::fs::read_dir(&directory)
+            .with_context(|| format!("reading directory {}", directory.display()))?
+        {
+            let entry =
+                entry.with_context(|| format!("reading an entry under {}", directory.display()))?;
+            if entry.file_name().to_str().is_none() {
+                anyhow::bail!(
+                    "directory {} contains a non-UTF-8 name that the configured glob cannot enumerate safely",
+                    directory.display()
+                );
+            }
+            let file_type = entry
+                .file_type()
+                .with_context(|| format!("reading file type for {}", entry.path().display()))?;
+            if file_type.is_symlink() {
+                anyhow::bail!(
+                    "directory {} contains symlink {} that Cargo/glob cannot follow with bounded, byte-preserving freshness semantics",
+                    directory.display(),
+                    entry.path().display()
+                );
+            }
+            if file_type.is_dir() {
+                pending.push(entry.path());
+            }
+        }
+    }
+    directories.sort();
+    directories.dedup();
+    Ok(directories)
+}
+
+fn nearest_existing_directory(start: &Path) -> Option<PathBuf> {
+    let mut candidate = Some(start);
+    while let Some(path) = candidate {
+        if path.is_dir() {
+            return Some(lexical_normalize(path));
+        }
+        candidate = path.parent();
+    }
+    None
+}
+
+fn is_filesystem_root(path: &Path) -> bool {
+    path.has_root() && path.parent().is_none()
+}
+
+fn resolve_watch_paths(
+    crate_dir: &Path,
+    patterns: &[NormalizedInputPattern],
+) -> Result<Vec<PathBuf>> {
+    let crate_dir = lexical_normalize(crate_dir);
+    let canonical_crate_dir =
+        std::fs::canonicalize(&crate_dir).unwrap_or_else(|_| crate_dir.clone());
+    let mut watches = BTreeSet::new();
+
+    for pattern in patterns {
+        // Invalid globs retain their existing digest semantics and are skipped
+        // during enumeration; they do not justify a broad directory watch.
+        if glob::Pattern::new(&pattern.glob).is_err() {
+            continue;
+        }
+        let start = match &pattern.watch {
+            WatchIntent::Literal(path) if path.is_file() => continue,
+            WatchIntent::Literal(path) => path.parent(),
+            WatchIntent::DirectoryRoot(path) => Some(path.as_path()),
+        };
+        let Some(start) = start else {
+            anyhow::bail!(
+                "extra_inputs pattern {:?} has no directory that Cargo can watch; \
+                 place the input under a narrow existing directory",
+                pattern.glob
+            );
+        };
+        let Some(watch) = nearest_existing_directory(start) else {
+            anyhow::bail!(
+                "extra_inputs pattern {:?} has no existing directory to watch; \
+                 create a narrow parent directory first",
+                pattern.glob
+            );
+        };
+
+        // Watching the crate root, an ancestor of it, or the filesystem root
+        // makes Cargo recursively fingerprint an unrelated/unbounded tree.
+        // Check the resolved directory too: an in-crate symlink to `/` must
+        // not bypass the lexical guard and hand Cargo a filesystem-root scan.
+        let canonical_watch = std::fs::canonicalize(&watch).unwrap_or_else(|_| watch.clone());
+        if is_filesystem_root(&watch)
+            || is_filesystem_root(&canonical_watch)
+            || crate_dir.starts_with(&watch)
+            || canonical_crate_dir.starts_with(&canonical_watch)
+        {
+            anyhow::bail!(
+                "extra_inputs pattern {:?} would make Cargo recursively watch broad directory {} \
+                 (the crate root or an ancestor); add a literal subdirectory to the pattern, or \
+                 create a narrow parent directory for a missing literal input",
+                pattern.glob,
+                watch.display()
+            );
+        }
+
+        watches.insert(watch);
+        if watches.len() > MAX_WATCH_PATHS {
+            anyhow::bail!(
+                "extra_inputs resolves to more than {MAX_WATCH_PATHS} directory watches; \
+                 consolidate patterns under a smaller set of narrow literal roots"
+            );
+        }
+    }
+
+    Ok(watches.into_iter().collect())
 }
 
 /// True if a glob's literal prefix (the part before the first glob
@@ -491,6 +1138,203 @@ fn walks_filesystem_root(glob_pattern: &str) -> bool {
     rooted && base.parent().is_none()
 }
 
+#[derive(Debug, Clone, Copy)]
+struct FirstMakeRule {
+    colon: usize,
+    insertion: usize,
+}
+
+fn merge_snapshot_into_dep_info(
+    snapshot: &ExtraInputsSnapshot,
+    dep_info_path: &Path,
+) -> Result<()> {
+    let metadata = std::fs::metadata(dep_info_path).with_context(|| {
+        format!(
+            "reading required consumer dep-info {} for active extra_inputs declaration",
+            dep_info_path.display()
+        )
+    })?;
+    if !metadata.is_file() {
+        anyhow::bail!(
+            "required consumer dep-info {} is not a regular file; refusing to return with an \
+             incomplete Cargo fingerprint for active extra_inputs",
+            dep_info_path.display()
+        );
+    }
+    let original = std::fs::read_to_string(dep_info_path).with_context(|| {
+        format!(
+            "reading required consumer dep-info {} for active extra_inputs declaration",
+            dep_info_path.display()
+        )
+    })?;
+    let updated = merge_snapshot_dep_info_content(snapshot, &original).with_context(|| {
+        format!(
+            "malformed consumer dep-info {} for active extra_inputs declaration",
+            dep_info_path.display()
+        )
+    })?;
+    if updated == original {
+        return Ok(());
+    }
+    crate::atomic::atomic_replace(dep_info_path, updated.as_bytes()).with_context(|| {
+        format!(
+            "atomically updating consumer dep-info {} for active extra_inputs declaration",
+            dep_info_path.display()
+        )
+    })
+}
+
+fn merge_snapshot_dep_info_content(
+    snapshot: &ExtraInputsSnapshot,
+    original: &str,
+) -> Result<String> {
+    tracing::trace!(
+        "merging extra_inputs dep-info: {} normalized pattern(s), {} matched file(s), {} watch path(s)",
+        snapshot.normalized_patterns.len(),
+        snapshot.matched_files.len(),
+        snapshot.watch_paths.len()
+    );
+    let rule = first_make_dependency_rule(original)?;
+    let existing_words = parse_make_words(&original[rule.colon + 1..rule.insertion])
+        .context("parsing Cargo dependency rule")?;
+    let compiler_cwd = std::env::current_dir()
+        .context("resolving compiler working directory for extra_inputs dep-info")?;
+    let existing: BTreeSet<PathBuf> = existing_words
+        .iter()
+        .map(|word| anchor_input_path(&compiler_cwd, Path::new(word)))
+        .collect();
+
+    let mut dependency_paths = BTreeSet::new();
+    dependency_paths.insert(lexical_normalize(&snapshot.config_path));
+    dependency_paths.extend(
+        snapshot
+            .matched_files
+            .iter()
+            .map(|path| lexical_normalize(path)),
+    );
+    dependency_paths.extend(
+        snapshot
+            .watch_paths
+            .iter()
+            .map(|path| lexical_normalize(path)),
+    );
+
+    let mut additions = Vec::new();
+    for path in dependency_paths {
+        if existing.contains(&path) {
+            continue;
+        }
+        // Cargo interprets rustc dep-info paths relative to rustc's working
+        // directory, which is normally the workspace root rather than the
+        // member crate. Absolute consumer paths are unambiguous and are added
+        // only after cache storage/restoration, so they never leak producer
+        // worktree paths into cached blobs.
+        let text = path.to_str().ok_or_else(|| {
+            anyhow::anyhow!(
+                "extra_inputs dependency {} is not valid UTF-8 and cannot be represented safely \
+                 in Cargo dep-info",
+                path.display()
+            )
+        })?;
+        additions.push(make_escape_word(text)?);
+    }
+    additions.sort();
+    additions.dedup();
+    if additions.is_empty() {
+        return Ok(original.to_string());
+    }
+
+    let mut updated = String::with_capacity(
+        original.len() + additions.iter().map(String::len).sum::<usize>() + additions.len(),
+    );
+    updated.push_str(&original[..rule.insertion]);
+    updated.push(' ');
+    updated.push_str(&additions.join(" "));
+    updated.push_str(&original[rule.insertion..]);
+
+    Ok(updated)
+}
+
+/// Locate the first line Cargo will parse as rustc dep-info. Cargo recognizes
+/// the first line containing `: `; drive-letter colons and `#` remain literal.
+fn first_make_dependency_rule(input: &str) -> Result<FirstMakeRule> {
+    let mut offset = 0usize;
+    for line_with_newline in input.split_inclusive('\n') {
+        let line = line_with_newline
+            .strip_suffix('\n')
+            .unwrap_or(line_with_newline);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+        // Cargo handles rustc's environment records before looking for the
+        // dependency rule. An env value may itself contain `: ` and must not
+        // be mistaken for the Make target/dependency separator.
+        if line.starts_with("# env-dep:") {
+            offset += line_with_newline.len();
+            continue;
+        }
+        if let Some(relative_colon) = line.find(": ") {
+            let colon = offset + relative_colon;
+            let mut insertion = offset + line.len();
+            let bytes = input.as_bytes();
+            while insertion > colon + 2 && matches!(bytes[insertion - 1], b' ' | b'\t') {
+                insertion -= 1;
+            }
+            return Ok(FirstMakeRule { colon, insertion });
+        }
+        offset += line_with_newline.len();
+    }
+
+    anyhow::bail!("dep-info contains no Make dependency rule")
+}
+
+/// Parse dependency words exactly as Cargo 0.98 / Rust 1.97 does: split on
+/// whitespace, then join the next token while the current token ends in `\\`.
+fn parse_make_words(input: &str) -> Result<Vec<String>> {
+    let mut words = Vec::new();
+    let mut tokens = input.split_whitespace();
+    while let Some(token) = tokens.next() {
+        let mut word = token.to_string();
+        while word.ends_with('\\') {
+            word.pop();
+            word.push(' ');
+            word.push_str(
+                tokens
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("malformed dep-info format, trailing \\"))?,
+            );
+        }
+        words.push(word);
+    }
+    Ok(words)
+}
+
+/// Parse the dependency side of the same rustc dep-info rule Cargo consumes.
+///
+/// Keep cache-restore validation on the exact grammar used by
+/// [`merge_snapshot_dep_info_content`]: Cargo skips leading metadata records
+/// and consumes the first line containing `: `.
+pub(crate) fn parse_dep_info_dependencies(input: &str) -> Result<Vec<PathBuf>> {
+    let rule = first_make_dependency_rule(input)?;
+    parse_make_words(&input[rule.colon + 1..rule.insertion])
+        .map(|words| words.into_iter().map(PathBuf::from).collect())
+}
+
+fn make_escape_word(input: &str) -> Result<String> {
+    if input
+        .chars()
+        .any(|character| character.is_whitespace() && character != ' ')
+    {
+        anyhow::bail!(
+            "extra_inputs dependency contains unsupported whitespace and cannot enter Cargo dep-info"
+        );
+    }
+    if input.ends_with([' ', '\\']) {
+        anyhow::bail!(
+            "extra_inputs dependency ends in a space or backslash, which Cargo dep-info cannot represent"
+        );
+    }
+    Ok(input.replace(' ', "\\ "))
+}
+
 /// Deterministic opaque digest for an unreadable / unparseable `kache.toml`:
 /// the build re-keys on any edit and never aliases "no file present".
 fn unparseable_digest(crate_name: &str, config_path: &Path, raw: &[u8]) -> String {
@@ -502,103 +1346,6 @@ fn unparseable_digest(crate_name: &str, config_path: &Path, raw: &[u8]) -> Strin
         config_path.display()
     );
     hasher.finalize().to_hex().to_string()
-}
-
-/// A crate whose co-located `kache.toml` declares `extra_inputs` but whose
-/// build script won't re-invoke rustc when those files change. Because the key
-/// is only (re)computed when cargo spawns rustc, editing a tracked file in a
-/// warm in-place target restores the stale artifact instead of re-keying —
-/// unless a build script emits a matching `cargo:rerun-if-changed`. Surfaced by
-/// `kache doctor` (rio-build#51 point 1).
-pub(crate) struct RerunGap {
-    pub crate_dir: PathBuf,
-    pub reason: &'static str,
-}
-
-/// Result of [`audit_rerun_coverage`].
-pub(crate) struct RerunAudit {
-    /// Crates found with a non-empty `extra_inputs` declaration.
-    pub declaring: usize,
-    /// Of those, the ones whose build script won't re-trigger rustc.
-    pub gaps: Vec<RerunGap>,
-}
-
-/// Cap on directory entries visited by [`audit_rerun_coverage`], so a `doctor`
-/// run in a huge tree can't walk forever. Generous for any real workspace.
-const AUDIT_WALK_LIMIT: usize = 50_000;
-
-/// Walk `root` for crates that declare `extra_inputs` without a build script
-/// that re-triggers rustc on a tracked-file change.
-///
-/// Heuristic and advisory: a static scan can't know what a build script emits
-/// at runtime, so this only checks whether a `build.rs` exists and mentions
-/// `rerun-if-changed` at all — it can't confirm the rerun path actually covers
-/// the declared globs, nor see a script that emits the directive without the
-/// literal string. Skips `target`, `.git`, and hidden directories.
-pub(crate) fn audit_rerun_coverage(root: &Path) -> RerunAudit {
-    let mut declaring = 0usize;
-    let mut gaps = Vec::new();
-    let mut visited = 0usize;
-    let mut stack = vec![root.to_path_buf()];
-
-    while let Some(dir) = stack.pop() {
-        let Ok(entries) = std::fs::read_dir(&dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            visited += 1;
-            if visited > AUDIT_WALK_LIMIT {
-                return RerunAudit { declaring, gaps };
-            }
-            let path = entry.path();
-            let file_type = entry.file_type();
-            if file_type.map(|t| t.is_dir()).unwrap_or(false) {
-                let name = entry.file_name();
-                let name = name.to_string_lossy();
-                // Skip build output, VCS metadata, and hidden dirs — none hold
-                // a crate root we'd warn about, and `target/` is enormous.
-                if name == "target" || name.starts_with('.') {
-                    continue;
-                }
-                stack.push(path);
-                continue;
-            }
-            if entry.file_name() != COLOCATED_NAME {
-                continue;
-            }
-            // A co-located kache.toml: check its declaration.
-            let Some(crate_dir) = path.parent().map(Path::to_path_buf) else {
-                continue;
-            };
-            let Ok(text) = std::fs::read_to_string(&path) else {
-                continue;
-            };
-            let Ok(config) = toml::from_str::<ColocatedConfig>(&text) else {
-                continue;
-            };
-            if config.extra_inputs.is_empty() {
-                continue;
-            }
-            declaring += 1;
-
-            let build_rs = crate_dir.join("build.rs");
-            let reason = if !build_rs.is_file() {
-                Some("no build.rs to emit cargo:rerun-if-changed")
-            } else {
-                match std::fs::read_to_string(&build_rs) {
-                    Ok(src) if src.contains("rerun-if-changed") => None,
-                    Ok(_) => Some("build.rs emits no cargo:rerun-if-changed"),
-                    Err(_) => None,
-                }
-            };
-            if let Some(reason) = reason {
-                gaps.push(RerunGap { crate_dir, reason });
-            }
-        }
-    }
-
-    gaps.sort_by(|a, b| a.crate_dir.cmp(&b.crate_dir));
-    RerunAudit { declaring, gaps }
 }
 
 #[cfg(test)]
@@ -798,6 +1545,468 @@ mod tests {
         let (_d2, src2) = crate_fixture(files);
         assert_eq!(dig(&src1), dig(&src2));
         assert!(dig(&src1).is_some());
+    }
+
+    fn snap(src: &Path) -> ExtraInputsSnapshot {
+        let file_hasher = FileHasher::new();
+        ExtraInputsSnapshot::resolve(Some(src), "x", true, &file_hasher)
+            .expect("snapshot resolution succeeds")
+            .expect("fixture has an active declaration")
+    }
+
+    #[test]
+    fn snapshot_tracks_config_matches_and_narrow_watch_across_add_delete() {
+        let (dir, src) = crate_fixture(&[
+            ("kache.toml", "extra_inputs = [\"data/**/*.txt\"]"),
+            ("data/a.txt", "a"),
+            ("data/nested/b.txt", "b"),
+        ]);
+        let root = dir.path();
+
+        let initial = snap(&src);
+        assert_eq!(initial.config_path, root.join("kache.toml"));
+        assert_eq!(
+            initial.matched_files,
+            vec![root.join("data/a.txt"), root.join("data/nested/b.txt")]
+        );
+        assert_eq!(initial.watch_paths, vec![root.join("data")]);
+
+        // The literal root stays the watch dependency while the matched-file
+        // set follows additions and deletions. Cargo recursively fingerprints
+        // that one narrow directory, so either transition makes the unit dirty.
+        std::fs::write(root.join("data/added.txt"), "added").unwrap();
+        let after_add = snap(&src);
+        assert!(
+            after_add
+                .matched_files
+                .contains(&root.join("data/added.txt"))
+        );
+        assert_eq!(after_add.watch_paths, vec![root.join("data")]);
+
+        std::fs::remove_file(root.join("data/a.txt")).unwrap();
+        let after_delete = snap(&src);
+        assert!(
+            !after_delete
+                .matched_files
+                .contains(&root.join("data/a.txt"))
+        );
+        assert_eq!(after_delete.watch_paths, vec![root.join("data")]);
+    }
+
+    #[test]
+    fn snapshot_observes_nested_watch_directories_against_transient_aba() {
+        let (dir, src) = crate_fixture(&[
+            ("kache.toml", "extra_inputs = [\"data/**/*.txt\"]"),
+            ("data/stable.txt", "v1"),
+            ("data/deep/.keep", ""),
+        ]);
+        let nested = dir.path().join("data/deep");
+        let before = snap(&src);
+        assert!(
+            before
+                .observations
+                .iter()
+                .any(|observation| observation.path == nested),
+            "every traversed directory must participate in hit/publication revalidation"
+        );
+
+        // The compiler could observe this member while it exists even though
+        // the final matched-file set and content digest return to the original
+        // state. A changed nested-directory observation must still reject that
+        // result instead of publishing it under the old key.
+        let transient = nested.join("transient.txt");
+        std::fs::write(&transient, "transient").unwrap();
+        std::fs::remove_file(&transient).unwrap();
+        filetime::set_file_mtime(
+            &nested,
+            filetime::FileTime::from_unix_time(2_000_000_000, 123),
+        )
+        .unwrap();
+
+        let after = snap(&src);
+        assert_eq!(before.digest, after.digest, "semantic state returned to v1");
+        assert_eq!(before.matched_files, after.matched_files);
+        assert_ne!(
+            before, after,
+            "nested directory metadata must expose an add/remove ABA race"
+        );
+    }
+
+    #[test]
+    fn empty_declaration_watches_config_without_changing_the_key() {
+        let (dir, src) = crate_fixture(&[("kache.toml", "extra_inputs = []")]);
+        assert_eq!(dig(&src), None, "legacy key semantics stay byte-identical");
+
+        let snapshot = snap(&src);
+        assert_eq!(snapshot.digest(), None);
+        assert_eq!(snapshot.config_path, dir.path().join("kache.toml"));
+        assert!(snapshot.matched_files.is_empty());
+        assert!(snapshot.watch_paths.is_empty());
+    }
+
+    #[test]
+    fn active_snapshot_rejects_dynamic_pattern_expansion() {
+        let (_dir, src) =
+            crate_fixture(&[("kache.toml", "extra_inputs = [\"$HOME/data/**/*.txt\"]")]);
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+            .expect_err("environment-dependent paths cannot stay Cargo-fresh");
+        assert!(
+            format!("{error:#}").contains("uses `$ENV` or `~` expansion"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn active_snapshot_rejects_parent_traversal_after_wildcard() {
+        let (_dir, src) = crate_fixture(&[(
+            "kache.toml",
+            "extra_inputs = [\"data/*/../../generated/*.json\"]",
+        )]);
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+            .expect_err("a wildcard must not escape the bounded Cargo watch root");
+        assert!(
+            format!("{error:#}").contains("traverses `..` after a wildcard"),
+            "{error:#}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn active_snapshot_rejects_ambiguous_windows_root_shapes() {
+        for pattern in ["/shared/**/*.json", "C:shared/**/*.json"] {
+            let config = format!("extra_inputs = ['{pattern}']");
+            let (_dir, src) = crate_fixture(&[("kache.toml", config.as_str())]);
+            let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+                .expect_err("ambiguous Windows anchoring must fail closed");
+            assert!(
+                format!("{error:#}").contains("rooted-without-drive or drive-relative"),
+                "{error:#}"
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn active_snapshot_rejects_windows_device_namespace_patterns() {
+        for pattern in [
+            r"\\?\C:\shared\**\*.json",
+            r"\\?\UNC\server\share\**\*.json",
+        ] {
+            let config = format!("extra_inputs = ['{pattern}']");
+            let (_dir, src) = crate_fixture(&[("kache.toml", config.as_str())]);
+            let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+                .expect_err("glob cannot safely enumerate a device namespace");
+            assert!(
+                format!("{error:#}").contains("verbatim/device namespace"),
+                "{error:#}"
+            );
+        }
+        assert!(windows_path_uses_device_namespace(Path::new(
+            r"\\?\C:\repo\crate"
+        )));
+        assert!(!windows_path_uses_device_namespace(Path::new(
+            r"C:\repo\crate"
+        )));
+        assert!(!windows_path_uses_device_namespace(Path::new(
+            r"\\server\share\crate"
+        )));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn active_glob_rejects_non_utf8_names_in_its_watch_tree() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let (dir, src) = crate_fixture(&[("kache.toml", "extra_inputs = [\"data/**/*.txt\"]")]);
+        let data = dir.path().join("data");
+        std::fs::create_dir_all(&data).unwrap();
+        std::fs::write(
+            data.join(std::ffi::OsString::from_vec(vec![0xff])),
+            "hidden",
+        )
+        .unwrap();
+
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+            .expect_err("glob must not silently omit non-UTF-8 names");
+        assert!(format!("{error:#}").contains("non-UTF-8"), "{error:#}");
+    }
+
+    #[test]
+    fn missing_literal_watches_existing_narrow_parent() {
+        let (dir, src) = crate_fixture(&[
+            ("kache.toml", "extra_inputs = [\"inputs/missing.json\"]"),
+            ("inputs/.keep", ""),
+        ]);
+        let snapshot = snap(&src);
+        assert!(snapshot.matched_files.is_empty());
+        assert_eq!(snapshot.watch_paths, vec![dir.path().join("inputs")]);
+    }
+
+    #[test]
+    fn broad_crate_root_watch_is_rejected_before_globbing() {
+        let (_dir, src) = crate_fixture(&[("kache.toml", "extra_inputs = [\"**/*.json\"]")]);
+        let file_hasher = FileHasher::new();
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &file_hasher)
+            .expect_err("crate-root recursive watch must be rejected");
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("recursively watch broad directory"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("literal subdirectory"), "{rendered}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn filesystem_root_watch_is_rejected_without_enumeration() {
+        let (_dir, src) = crate_fixture(&[("kache.toml", "extra_inputs = [\"/**/*.json\"]")]);
+        let file_hasher = FileHasher::new();
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &file_hasher)
+            .expect_err("filesystem-root recursive watch must be rejected");
+        assert!(
+            format!("{error:#}").contains("recursively watch broad directory"),
+            "{error:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_to_filesystem_root_cannot_bypass_watch_guard() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, src) =
+            crate_fixture(&[("kache.toml", "extra_inputs = [\"root-link/**/*.json\"]")]);
+        symlink("/", dir.path().join("root-link")).unwrap();
+        let file_hasher = FileHasher::new();
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &file_hasher)
+            .expect_err("a symlink to the filesystem root must be rejected before globbing");
+        assert!(
+            format!("{error:#}").contains("recursively watch broad directory"),
+            "{error:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn active_snapshot_rejects_symlinked_input_that_cargo_would_canonicalize() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, src) = crate_fixture(&[("kache.toml", "extra_inputs = [\"data/value.txt\"]")]);
+        std::fs::create_dir_all(dir.path().join("data")).unwrap();
+        let target = dir.path().join("target-value.txt");
+        std::fs::write(&target, "v1").unwrap();
+        symlink(&target, dir.path().join("data/value.txt")).unwrap();
+
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+            .expect_err("symlink retargeting cannot be represented safely in Cargo dep-info");
+        assert!(
+            format!("{error:#}").contains("crosses symlink"),
+            "{error:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn active_snapshot_rejects_symlinked_empty_config() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, src) = crate_fixture(&[]);
+        let target = dir.path().join("empty-config.toml");
+        std::fs::write(&target, "extra_inputs = []\n").unwrap();
+        symlink(&target, dir.path().join("kache.toml")).unwrap();
+
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+            .expect_err("retargetable empty config must fail closed");
+        assert!(
+            format!("{error:#}").contains("config") && format!("{error:#}").contains("symlink"),
+            "{error:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn active_glob_rejects_symlink_nested_under_its_watch_root() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, src) = crate_fixture(&[("kache.toml", "extra_inputs = [\"data/**/*.txt\"]")]);
+        let external = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("data")).unwrap();
+        std::fs::write(external.path().join("value.txt"), "v1").unwrap();
+        symlink(external.path(), dir.path().join("data/external")).unwrap();
+
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+            .expect_err("a glob must not follow a nested symlink outside its bounded watch tree");
+        assert!(
+            format!("{error:#}").contains("contains symlink"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn active_snapshot_rejects_invalid_config_instead_of_watching_only_config() {
+        let (_dir, src) = crate_fixture(&[("kache.toml", "extra_inputs = [")]);
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+            .expect_err("invalid active config must fail closed");
+        assert!(
+            format!("{error:#}").contains("parsing active extra_inputs config"),
+            "{error:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn active_snapshot_rejects_control_separator_in_matched_filename() {
+        let (dir, src) = crate_fixture(&[("kache.toml", "extra_inputs = [\"data/**/*\"]")]);
+        std::fs::create_dir_all(dir.path().join("data")).unwrap();
+        std::fs::write(dir.path().join("data/bad\u{1f}name.txt"), "v1").unwrap();
+
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+            .expect_err("matched paths must not cross cache-key framing");
+        assert!(
+            format!("{error:#}").contains("cache-key control separator"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn dep_info_merge_escapes_dedupes_and_preserves_later_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let dep_info = root.join("crate.d");
+        let original = concat!(
+            "# generated by rustc\n",
+            "artifact: src/lib.rs\n",
+            "later: keep\\ this\n",
+            "# env-dep:VALUE=unchanged\n",
+        );
+        std::fs::write(&dep_info, original).unwrap();
+        let snapshot = ExtraInputsSnapshot {
+            config_path: root.join("kache.toml"),
+            normalized_patterns: vec!["inputs/**/*".to_string()],
+            digest: Some("digest".to_string()),
+            matched_files: vec![root.join("space #colon:slash\\name.txt")],
+            watch_paths: vec![root.join("watched dir")],
+            observations: Vec::new(),
+        };
+
+        assert_eq!(
+            make_escape_word("space #colon:slash\\name.txt").unwrap(),
+            "space\\ #colon:slash\\name.txt"
+        );
+        snapshot.merge_into_dep_info(&dep_info).unwrap();
+        let once = std::fs::read_to_string(&dep_info).unwrap();
+        assert!(once.contains("space\\ #colon:slash\\name.txt"), "{once}");
+        assert!(once.contains("watched\\ dir"), "{once}");
+        assert_eq!(once.matches("kache.toml").count(), 1, "{once}");
+        assert!(
+            once.ends_with("later: keep\\ this\n# env-dep:VALUE=unchanged\n"),
+            "later rules/comments changed:\n{once}"
+        );
+
+        // Idempotence is the strongest dedupe check: a second merge performs
+        // no rewrite and leaves the complete file byte-identical.
+        snapshot.merge_into_dep_info(&dep_info).unwrap();
+        assert_eq!(once, std::fs::read_to_string(&dep_info).unwrap());
+    }
+
+    #[test]
+    fn dep_info_merge_fails_closed_on_missing_and_malformed() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let snapshot = ExtraInputsSnapshot {
+            config_path: root.join("kache.toml"),
+            normalized_patterns: vec!["inputs/**/*".to_string()],
+            digest: Some("digest".to_string()),
+            matched_files: Vec::new(),
+            watch_paths: vec![root.join("inputs")],
+            observations: Vec::new(),
+        };
+
+        let missing = root.join("missing.d");
+        let missing_error = snapshot.merge_into_dep_info(&missing).unwrap_err();
+        assert!(format!("{missing_error:#}").contains("required consumer dep-info"));
+
+        let malformed = root.join("malformed.d");
+        let malformed_bytes = "not a dependency rule\nstill not a dependency rule\n";
+        std::fs::write(&malformed, malformed_bytes).unwrap();
+        let malformed_error = snapshot.merge_into_dep_info(&malformed).unwrap_err();
+        assert!(format!("{malformed_error:#}").contains("malformed consumer dep-info"));
+        assert_eq!(
+            std::fs::read_to_string(&malformed).unwrap(),
+            malformed_bytes
+        );
+    }
+
+    #[test]
+    fn make_escape_round_trips_windows_drive_space_hash_and_backslashes() {
+        let windows = r"C:\work tree\generated#1:file.rs";
+        let escaped = make_escape_word(windows).unwrap();
+        assert_eq!(escaped, r"C:\work\ tree\generated#1:file.rs");
+        assert_eq!(parse_make_words(&escaped).unwrap(), vec![windows]);
+        assert!(make_escape_word("unix-name-ending-in-backslash\\").is_err());
+        assert!(make_escape_word("unix-name-ending-in-space ").is_err());
+    }
+
+    #[test]
+    fn dep_info_codec_treats_hash_and_windows_drive_colons_as_literals() {
+        let input = concat!(
+            "# generated metadata stays literal\n",
+            r"C:\target\crate.d: C:\work\ tree\#member\src\lib.rs C:\work\data:1.txt",
+            "\nsecond: ignored\n",
+        );
+        let rule = first_make_dependency_rule(input).unwrap();
+        assert_eq!(&input[rule.colon..rule.colon + 2], ": ");
+        assert_eq!(
+            parse_make_words(&input[rule.colon + 2..rule.insertion]).unwrap(),
+            vec![r"C:\work tree\#member\src\lib.rs", r"C:\work\data:1.txt"]
+        );
+    }
+
+    #[test]
+    fn dep_info_codec_skips_env_record_containing_colon_space() {
+        let input = concat!(
+            "# env-dep:CFG=foo: bar\n",
+            "artifact: src/lib.rs data/value.txt\n",
+        );
+        let rule = first_make_dependency_rule(input).unwrap();
+        assert_eq!(
+            &input[rule.colon - "artifact".len()..rule.colon],
+            "artifact"
+        );
+        assert_eq!(
+            parse_dep_info_dependencies(input).unwrap(),
+            vec![PathBuf::from("src/lib.rs"), PathBuf::from("data/value.txt")]
+        );
+    }
+
+    #[test]
+    fn relocated_dep_info_uses_unambiguous_consumer_absolute_paths() {
+        let files = &[
+            ("kache.toml", "extra_inputs = [\"data/**/*.json\"]"),
+            ("data/q.json", "v1"),
+        ];
+        let (dir_a, src_a) = crate_fixture(files);
+        let (dir_b, src_b) = crate_fixture(files);
+        let snapshot_a = snap(&src_a);
+        let snapshot_b = snap(&src_b);
+        assert_eq!(snapshot_a.digest, snapshot_b.digest);
+
+        let dep_a = dir_a.path().join("crate.d");
+        let dep_b = dir_b.path().join("crate.d");
+        std::fs::write(&dep_a, "artifact: src/lib.rs\n").unwrap();
+        std::fs::write(&dep_b, "artifact: src/lib.rs\n").unwrap();
+        snapshot_a.merge_into_dep_info(&dep_a).unwrap();
+        snapshot_b.merge_into_dep_info(&dep_b).unwrap();
+        let output_a = std::fs::read_to_string(&dep_a).unwrap();
+        let output_b = std::fs::read_to_string(&dep_b).unwrap();
+
+        assert_ne!(output_a, output_b);
+        assert!(output_a.contains("data/q.json"), "{output_a}");
+        assert!(output_a.contains("kache.toml"), "{output_a}");
+        assert!(output_a.contains(&dir_a.path().to_string_lossy().to_string()));
+        assert!(output_b.contains(&dir_b.path().to_string_lossy().to_string()));
+        assert!(!output_a.contains(&dir_b.path().to_string_lossy().to_string()));
+        assert!(!output_b.contains(&dir_a.path().to_string_lossy().to_string()));
     }
 
     #[test]
@@ -1020,59 +2229,5 @@ mod tests {
             unreadable, absent,
             "unreadable must not alias absent (false-hit guard)"
         );
-    }
-
-    #[test]
-    fn audit_rerun_coverage_flags_only_uncovered_declaring_crates() {
-        let root = tempfile::tempdir().unwrap();
-        let r = root.path();
-
-        // A: declares extra_inputs, no build.rs -> gap.
-        std::fs::create_dir_all(r.join("a")).unwrap();
-        std::fs::write(r.join("a/kache.toml"), "extra_inputs = [\".sqlx/**\"]").unwrap();
-
-        // B: declares extra_inputs, build.rs WITH rerun-if-changed -> covered.
-        std::fs::create_dir_all(r.join("b")).unwrap();
-        std::fs::write(r.join("b/kache.toml"), "extra_inputs = [\".sqlx/**\"]").unwrap();
-        std::fs::write(
-            r.join("b/build.rs"),
-            "fn main() { println!(\"cargo:rerun-if-changed=.sqlx\"); }",
-        )
-        .unwrap();
-
-        // C: declares extra_inputs, build.rs WITHOUT rerun-if-changed -> gap.
-        std::fs::create_dir_all(r.join("c")).unwrap();
-        std::fs::write(r.join("c/kache.toml"), "extra_inputs = [\"migrations/**\"]").unwrap();
-        std::fs::write(r.join("c/build.rs"), "fn main() {}").unwrap();
-
-        // D: empty declaration (opt-out) -> not counted at all.
-        std::fs::create_dir_all(r.join("d")).unwrap();
-        std::fs::write(r.join("d/kache.toml"), "extra_inputs = []").unwrap();
-
-        // target/ must be skipped even if it holds a kache.toml.
-        std::fs::create_dir_all(r.join("target/x")).unwrap();
-        std::fs::write(r.join("target/x/kache.toml"), "extra_inputs = [\"z/**\"]").unwrap();
-
-        // E: a malformed kache.toml is skipped (not counted, no panic).
-        std::fs::create_dir_all(r.join("e")).unwrap();
-        std::fs::write(r.join("e/kache.toml"), "this = = not valid toml").unwrap();
-
-        let audit = audit_rerun_coverage(r);
-        assert_eq!(
-            audit.declaring, 3,
-            "A, B, C declare; D opts out; E is malformed; target skipped"
-        );
-        let gap_dirs: Vec<_> = audit
-            .gaps
-            .iter()
-            .map(|g| {
-                g.crate_dir
-                    .file_name()
-                    .unwrap()
-                    .to_string_lossy()
-                    .into_owned()
-            })
-            .collect();
-        assert_eq!(gap_dirs, vec!["a".to_string(), "c".to_string()]);
     }
 }

--- a/src/extra_inputs.rs
+++ b/src/extra_inputs.rs
@@ -1438,7 +1438,11 @@ mod tests {
         let file = dir.path().join("regular-file");
         std::fs::write(&file, b"contents").unwrap();
         let missing = dir.path().join("missing");
-        let not_a_directory = file.join("child");
+        // Platform filesystems disagree on whether `file/child` is
+        // NotFound or NotADirectory. An embedded NUL is rejected before the
+        // filesystem lookup everywhere, so it exercises the non-NotFound
+        // branch portably.
+        let invalid = dir.path().join("invalid\0path");
 
         assert!(
             symlink_metadata_if_present(&file)
@@ -1447,11 +1451,9 @@ mod tests {
                 .is_file()
         );
         assert!(symlink_metadata_if_present(&missing).unwrap().is_none());
-        assert_eq!(
-            symlink_metadata_if_present(&not_a_directory)
-                .unwrap_err()
-                .kind(),
-            std::io::ErrorKind::NotADirectory
+        assert_ne!(
+            symlink_metadata_if_present(&invalid).unwrap_err().kind(),
+            std::io::ErrorKind::NotFound
         );
 
         assert_eq!(
@@ -1459,9 +1461,9 @@ mod tests {
             Some(b"contents".to_vec())
         );
         assert!(read_file_if_present(&missing).unwrap().is_none());
-        assert_eq!(
-            read_file_if_present(&not_a_directory).unwrap_err().kind(),
-            std::io::ErrorKind::NotADirectory
+        assert_ne!(
+            read_file_if_present(&invalid).unwrap_err().kind(),
+            std::io::ErrorKind::NotFound
         );
     }
 

--- a/src/extra_inputs.rs
+++ b/src/extra_inputs.rs
@@ -1999,14 +1999,24 @@ mod tests {
         snapshot_b.merge_into_dep_info(&dep_b).unwrap();
         let output_a = std::fs::read_to_string(&dep_a).unwrap();
         let output_b = std::fs::read_to_string(&dep_b).unwrap();
+        let dependencies_a = parse_dep_info_dependencies(&output_a).unwrap();
+        let dependencies_b = parse_dep_info_dependencies(&output_b).unwrap();
 
         assert_ne!(output_a, output_b);
-        assert!(output_a.contains("data/q.json"), "{output_a}");
-        assert!(output_a.contains("kache.toml"), "{output_a}");
-        assert!(output_a.contains(&dir_a.path().to_string_lossy().to_string()));
-        assert!(output_b.contains(&dir_b.path().to_string_lossy().to_string()));
-        assert!(!output_a.contains(&dir_b.path().to_string_lossy().to_string()));
-        assert!(!output_b.contains(&dir_a.path().to_string_lossy().to_string()));
+        assert!(dependencies_a.contains(&dir_a.path().join("data/q.json")));
+        assert!(dependencies_a.contains(&dir_a.path().join("kache.toml")));
+        assert!(dependencies_b.contains(&dir_b.path().join("data/q.json")));
+        assert!(dependencies_b.contains(&dir_b.path().join("kache.toml")));
+        assert!(
+            !dependencies_a
+                .iter()
+                .any(|path| path.starts_with(dir_b.path()))
+        );
+        assert!(
+            !dependencies_b
+                .iter()
+                .any(|path| path.starts_with(dir_a.path()))
+        );
     }
 
     #[test]

--- a/src/extra_inputs.rs
+++ b/src/extra_inputs.rs
@@ -255,6 +255,34 @@ enum WatchIntent {
     DirectoryRoot(PathBuf),
 }
 
+fn io_error_is_not_found(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::NotFound
+}
+
+fn symlink_metadata_if_present(path: &Path) -> std::io::Result<Option<std::fs::Metadata>> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(error) if io_error_is_not_found(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn read_file_if_present(path: &Path) -> std::io::Result<Option<Vec<u8>>> {
+    match std::fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if io_error_is_not_found(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn legacy_digest_mode(strict_watches: bool) -> bool {
+    !strict_watches
+}
+
+fn strict_input_error<E>(strict_watches: bool, error: E) -> std::result::Result<(), E> {
+    if strict_watches { Err(error) } else { Ok(()) }
+}
+
 fn resolve_snapshot(
     source_file: Option<&Path>,
     crate_name: &str,
@@ -275,16 +303,16 @@ fn resolve_snapshot(
     let config_path = crate_dir.join(COLOCATED_NAME);
 
     if strict_watches {
-        match std::fs::symlink_metadata(&config_path) {
-            Ok(metadata) if metadata.file_type().is_symlink() => {
+        match symlink_metadata_if_present(&config_path) {
+            Ok(Some(metadata)) if metadata.file_type().is_symlink() => {
                 anyhow::bail!(
                     "active extra_inputs config {} is a symlink; Cargo canonicalizes dep-info and \
                      cannot notice that link being retargeted safely",
                     config_path.display()
                 );
             }
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Ok(Some(_)) => {}
+            Ok(None) => return Ok(None),
             Err(error) => {
                 return Err(error).with_context(|| {
                     format!(
@@ -296,10 +324,10 @@ fn resolve_snapshot(
         }
     }
 
-    let raw = match std::fs::read(&config_path) {
-        Ok(bytes) => bytes,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) if !strict_watches => {
+    let raw = match read_file_if_present(&config_path) {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => return Ok(None),
+        Err(error) if legacy_digest_mode(strict_watches) => {
             // Preserve the legacy digest API's unreadable-config no-op. The
             // strict snapshot API fails closed instead.
             tracing::warn!(
@@ -345,7 +373,7 @@ fn resolve_snapshot(
     };
     let text = match std::str::from_utf8(&raw) {
         Ok(text) => text,
-        Err(_) if !strict_watches => return Ok(Some(opaque_snapshot(&raw))),
+        Err(_) if legacy_digest_mode(strict_watches) => return Ok(Some(opaque_snapshot(&raw))),
         Err(error) => {
             return Err(error).with_context(|| {
                 format!(
@@ -558,13 +586,12 @@ fn resolve_declared_inputs(
         }
         let entries = match glob::glob(&full) {
             Ok(entries) => entries,
-            Err(error) if strict_watches => {
-                return Err(error).with_context(|| {
+            Err(error) => {
+                let rendered = error.to_string();
+                strict_input_error(strict_watches, error).with_context(|| {
                     format!("parsing active extra_inputs glob {pat:?} for {crate_name}")
-                });
-            }
-            Err(e) => {
-                tracing::warn!("[key:{crate_name}] bad extra_inputs glob {pat:?}: {e}");
+                })?;
+                tracing::warn!("[key:{crate_name}] bad extra_inputs glob {pat:?}: {rendered}");
                 continue;
             }
         };
@@ -572,15 +599,14 @@ fn resolve_declared_inputs(
             match entry {
                 Ok(p) if p.is_file() => matched.push(p),
                 Ok(_) => {}
-                Err(error) if strict_watches => {
-                    return Err(error).with_context(|| {
+                Err(error) => {
+                    let rel = crate_relative_path(&crate_dir, error.path());
+                    let rendered = error.to_string();
+                    strict_input_error(strict_watches, error).with_context(|| {
                         format!("enumerating active extra_inputs glob {pat:?} for {crate_name}")
-                    });
-                }
-                Err(e) => {
-                    let rel = crate_relative_path(&crate_dir, e.path());
+                    })?;
                     tracing::warn!(
-                        "[key:{crate_name}] extra_inputs enumeration error at {rel:?}: {e}"
+                        "[key:{crate_name}] extra_inputs enumeration error at {rel:?}: {rendered}"
                     );
                     glob_errors.push(rel);
                 }
@@ -648,16 +674,15 @@ fn resolve_declared_inputs(
         }
         match file_hasher.hash(path) {
             Ok(h) => readable.push(format!("{rel}={h}")),
-            Err(error) if strict_watches => {
-                return Err(error).with_context(|| {
+            Err(error) => {
+                let rendered = error.to_string();
+                strict_input_error(strict_watches, error).with_context(|| {
                     format!(
                         "hashing active extra_inputs dependency {} for {crate_name}",
                         path.display()
                     )
-                });
-            }
-            Err(e) => {
-                tracing::warn!("[key:{crate_name}] extra_input unreadable {rel:?}: {e}");
+                })?;
+                tracing::warn!("[key:{crate_name}] extra_input unreadable {rel:?}: {rendered}");
                 unreadable.push(rel);
             }
         }
@@ -879,10 +904,18 @@ fn pattern_uses_dynamic_expansion(pattern: &str) -> bool {
     false
 }
 
+#[cfg(any(windows, test))]
+fn windows_root_shape_is_ambiguous(is_absolute: bool, has_root: bool, has_prefix: bool) -> bool {
+    !is_absolute && (has_root || has_prefix)
+}
+
 #[cfg(windows)]
 fn windows_pattern_has_ambiguous_root(path: &Path) -> bool {
-    let has_prefix = matches!(path.components().next(), Some(Component::Prefix(_)));
-    !path.is_absolute() && (path.has_root() || has_prefix)
+    windows_root_shape_is_ambiguous(
+        path.is_absolute(),
+        path.has_root(),
+        matches!(path.components().next(), Some(Component::Prefix(_))),
+    )
 }
 
 #[cfg(not(windows))]
@@ -890,20 +923,23 @@ fn windows_pattern_has_ambiguous_root(_path: &Path) -> bool {
     false
 }
 
+#[cfg(any(windows, test))]
+fn windows_prefix_uses_device_namespace(prefix: std::path::Prefix<'_>) -> bool {
+    use std::path::Prefix;
+    matches!(
+        prefix,
+        Prefix::Verbatim(_)
+            | Prefix::VerbatimUNC(_, _)
+            | Prefix::VerbatimDisk(_)
+            | Prefix::DeviceNS(_)
+    )
+}
+
 #[cfg(windows)]
 fn windows_path_uses_device_namespace(path: &Path) -> bool {
-    use std::path::Prefix;
-
     matches!(
         path.components().next(),
-        Some(Component::Prefix(prefix))
-            if matches!(
-                prefix.kind(),
-                Prefix::Verbatim(_)
-                    | Prefix::VerbatimUNC(_, _)
-                    | Prefix::VerbatimDisk(_)
-                    | Prefix::DeviceNS(_)
-            )
+        Some(Component::Prefix(prefix)) if windows_prefix_uses_device_namespace(prefix.kind())
     )
 }
 
@@ -1048,6 +1084,10 @@ fn is_filesystem_root(path: &Path) -> bool {
     path.has_root() && path.parent().is_none()
 }
 
+fn any_broad_watch_condition(conditions: [bool; 4]) -> bool {
+    conditions.into_iter().any(|condition| condition)
+}
+
 fn resolve_watch_paths(
     crate_dir: &Path,
     patterns: &[NormalizedInputPattern],
@@ -1088,11 +1128,12 @@ fn resolve_watch_paths(
         // Check the resolved directory too: an in-crate symlink to `/` must
         // not bypass the lexical guard and hand Cargo a filesystem-root scan.
         let canonical_watch = std::fs::canonicalize(&watch).unwrap_or_else(|_| watch.clone());
-        if is_filesystem_root(&watch)
-            || is_filesystem_root(&canonical_watch)
-            || crate_dir.starts_with(&watch)
-            || canonical_crate_dir.starts_with(&canonical_watch)
-        {
+        if any_broad_watch_condition([
+            is_filesystem_root(&watch),
+            is_filesystem_root(&canonical_watch),
+            crate_dir.starts_with(&watch),
+            canonical_crate_dir.starts_with(&canonical_watch),
+        ]) {
             anyhow::bail!(
                 "extra_inputs pattern {:?} would make Cargo recursively watch broad directory {} \
                  (the crate root or an ancestor); add a literal subdirectory to the pattern, or \
@@ -1195,8 +1236,11 @@ fn merge_snapshot_dep_info_content(
         snapshot.watch_paths.len()
     );
     let rule = first_make_dependency_rule(original)?;
-    let existing_words = parse_make_words(&original[rule.colon + 1..rule.insertion])
-        .context("parsing Cargo dependency rule")?;
+    let rule_tail = &original[rule.colon..rule.insertion];
+    let dependencies = rule_tail
+        .strip_prefix(':')
+        .expect("first_make_dependency_rule points at a colon");
+    let existing_words = parse_make_words(dependencies).context("parsing Cargo dependency rule")?;
     let compiler_cwd = std::env::current_dir()
         .context("resolving compiler working directory for extra_inputs dep-info")?;
     let existing: BTreeSet<PathBuf> = existing_words
@@ -1273,11 +1317,9 @@ fn first_make_dependency_rule(input: &str) -> Result<FirstMakeRule> {
         }
         if let Some(relative_colon) = line.find(": ") {
             let colon = offset + relative_colon;
-            let mut insertion = offset + line.len();
-            let bytes = input.as_bytes();
-            while insertion > colon + 2 && matches!(bytes[insertion - 1], b' ' | b'\t') {
-                insertion -= 1;
-            }
+            let dependency_start = relative_colon + 2;
+            let trimmed_dependencies = line[dependency_start..].trim_end_matches([' ', '\t']);
+            let insertion = offset + dependency_start + trimmed_dependencies.len();
             return Ok(FirstMakeRule { colon, insertion });
         }
         offset += line_with_newline.len();
@@ -1372,6 +1414,176 @@ mod tests {
     fn dig(src: &Path) -> Option<String> {
         let fh = FileHasher::new();
         digest(Some(src), "x", true, &fh)
+    }
+
+    #[test]
+    fn strict_and_legacy_error_policies_are_complementary() {
+        let missing = std::io::Error::from(std::io::ErrorKind::NotFound);
+        let denied = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        assert!(io_error_is_not_found(&missing));
+        assert!(!io_error_is_not_found(&denied));
+
+        assert!(legacy_digest_mode(false));
+        assert!(!legacy_digest_mode(true));
+        assert_eq!(strict_input_error(false, "legacy-error"), Ok(()));
+        assert_eq!(
+            strict_input_error(true, "strict-error"),
+            Err("strict-error")
+        );
+    }
+
+    #[test]
+    fn file_presence_helpers_distinguish_missing_paths_from_other_io_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("regular-file");
+        std::fs::write(&file, b"contents").unwrap();
+        let missing = dir.path().join("missing");
+        let not_a_directory = file.join("child");
+
+        assert!(
+            symlink_metadata_if_present(&file)
+                .unwrap()
+                .expect("existing file has metadata")
+                .is_file()
+        );
+        assert!(symlink_metadata_if_present(&missing).unwrap().is_none());
+        assert_eq!(
+            symlink_metadata_if_present(&not_a_directory)
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::NotADirectory
+        );
+
+        assert_eq!(
+            read_file_if_present(&file).unwrap(),
+            Some(b"contents".to_vec())
+        );
+        assert!(read_file_if_present(&missing).unwrap().is_none());
+        assert_eq!(
+            read_file_if_present(&not_a_directory).unwrap_err().kind(),
+            std::io::ErrorKind::NotADirectory
+        );
+    }
+
+    #[test]
+    fn missing_config_is_a_strict_snapshot_noop() {
+        let (_dir, src) = crate_fixture(&[]);
+        assert!(
+            ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn config_read_errors_preserve_the_strict_legacy_boundary() {
+        let (dir, src) = crate_fixture(&[]);
+        std::fs::create_dir(dir.path().join("kache.toml")).unwrap();
+
+        let strict = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new());
+        assert!(strict.is_err(), "strict resolution must fail closed");
+        assert!(
+            resolve_snapshot(Some(&src), "x", true, &FileHasher::new(), false)
+                .unwrap()
+                .is_none(),
+            "the compatibility digest keeps its unreadable-config no-op"
+        );
+    }
+
+    #[test]
+    fn strict_snapshot_rejects_non_utf8_config() {
+        let (dir, src) = crate_fixture(&[]);
+        std::fs::write(dir.path().join("kache.toml"), b"\xff\xfe extra_inputs").unwrap();
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+            .expect_err("strict active declarations must be UTF-8");
+        assert!(format!("{error:#}").contains("valid UTF-8"), "{error:#}");
+    }
+
+    #[test]
+    fn strict_snapshot_rejects_invalid_glob_syntax() {
+        let (_dir, src) = crate_fixture(&[("kache.toml", "extra_inputs = [\"data/[bad\"]")]);
+        let error = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new())
+            .expect_err("strict active declarations must reject invalid globs");
+        assert!(
+            format!("{error:#}").contains("parsing active extra_inputs glob"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn pattern_safety_helpers_cover_both_sides_of_each_boundary() {
+        for pattern in ["~", "~/data", "${DATA}/x", "$_DATA/x", "$DATA/x"] {
+            assert!(pattern_uses_dynamic_expansion(pattern), "{pattern:?}");
+        }
+        for pattern in ["$", "$-", "cash$-value", "path/~"] {
+            assert!(!pattern_uses_dynamic_expansion(pattern), "{pattern:?}");
+        }
+
+        assert!(!parent_traversal_follows_glob("../shared/*.json"));
+        assert!(!parent_traversal_follows_glob("data/../shared/*.json"));
+        assert!(parent_traversal_follows_glob("data/*/../shared.json"));
+
+        assert_eq!(
+            lexical_normalize(Path::new("./x")).as_os_str(),
+            std::ffi::OsStr::new("x")
+        );
+        assert_eq!(
+            lexical_normalize(Path::new("foo/../bar")),
+            PathBuf::from("bar")
+        );
+        assert_eq!(lexical_normalize(Path::new("foo/..")), PathBuf::new());
+        assert_eq!(lexical_normalize(Path::new("../x")), PathBuf::from("../x"));
+
+        assert!(is_filesystem_root(Path::new(std::path::MAIN_SEPARATOR_STR)));
+        assert!(!is_filesystem_root(Path::new("not-a-root")));
+        assert!(!any_broad_watch_condition([false; 4]));
+        for index in 0..4 {
+            let mut conditions = [false; 4];
+            conditions[index] = true;
+            assert!(any_broad_watch_condition(conditions));
+        }
+
+        for (is_absolute, has_root, has_prefix, expected) in [
+            (false, false, false, false),
+            (false, false, true, true),
+            (false, true, false, true),
+            (false, true, true, true),
+            (true, false, false, false),
+            (true, false, true, false),
+            (true, true, false, false),
+            (true, true, true, false),
+        ] {
+            assert_eq!(
+                windows_root_shape_is_ambiguous(is_absolute, has_root, has_prefix),
+                expected
+            );
+        }
+
+        use std::path::Prefix;
+        let server = std::ffi::OsStr::new("server");
+        let share = std::ffi::OsStr::new("share");
+        for prefix in [
+            Prefix::Verbatim(server),
+            Prefix::VerbatimUNC(server, share),
+            Prefix::VerbatimDisk(b'C'),
+            Prefix::DeviceNS(server),
+        ] {
+            assert!(windows_prefix_uses_device_namespace(prefix));
+        }
+        for prefix in [Prefix::Disk(b'C'), Prefix::UNC(server, share)] {
+            assert!(!windows_prefix_uses_device_namespace(prefix));
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn windows_only_path_rejections_stay_disabled_on_other_platforms() {
+        assert!(!windows_pattern_has_ambiguous_root(Path::new(
+            r"C:\relative"
+        )));
+        assert!(!windows_path_uses_device_namespace(Path::new(
+            r"\\?\C:\repo"
+        )));
     }
 
     #[test]
@@ -1673,6 +1885,16 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn active_snapshot_rejects_ambiguous_windows_root_shapes() {
+        assert!(windows_pattern_has_ambiguous_root(Path::new(
+            r"\shared\data.json"
+        )));
+        assert!(windows_pattern_has_ambiguous_root(Path::new(
+            r"C:shared\data.json"
+        )));
+        assert!(!windows_pattern_has_ambiguous_root(Path::new(
+            r"C:\shared\data.json"
+        )));
+
         for pattern in ["/shared/**/*.json", "C:shared/**/*.json"] {
             let config = format!("extra_inputs = ['{pattern}']");
             let (_dir, src) = crate_fixture(&[("kache.toml", config.as_str())]);
@@ -1782,6 +2004,55 @@ mod tests {
             .expect_err("a symlink to the filesystem root must be rejected before globbing");
         assert!(
             format!("{error:#}").contains("recursively watch broad directory"),
+            "{error:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_symlink_ancestor_is_not_below_the_crate_dependency_boundary() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let crate_dir = target.join("crate");
+        let dependency = crate_dir.join("data/value.txt");
+        std::fs::create_dir_all(dependency.parent().unwrap()).unwrap();
+        std::fs::write(&dependency, "v1").unwrap();
+
+        let alias = dir.path().join("alias");
+        symlink(&target, &alias).unwrap();
+        let aliased_crate = alias.join("crate");
+        let aliased_dependency = aliased_crate.join("data/value.txt");
+        assert_eq!(
+            first_symlink_below_common(&aliased_crate, &aliased_dependency),
+            None,
+            "only symlinks below the shared crate prefix are unsafe"
+        );
+    }
+
+    #[test]
+    fn watch_path_limit_accepts_the_limit_and_rejects_one_more() {
+        let dir = tempfile::tempdir().unwrap();
+        let crate_dir = dir.path().join("crate");
+        std::fs::create_dir(&crate_dir).unwrap();
+
+        let mut patterns = Vec::with_capacity(MAX_WATCH_PATHS + 1);
+        for index in 0..=MAX_WATCH_PATHS {
+            let watch = crate_dir.join(format!("watch-{index}"));
+            std::fs::create_dir(&watch).unwrap();
+            patterns.push(NormalizedInputPattern {
+                glob: format!("watch-{index}/**/*"),
+                watch: WatchIntent::DirectoryRoot(watch),
+            });
+        }
+
+        let accepted = resolve_watch_paths(&crate_dir, &patterns[..MAX_WATCH_PATHS]).unwrap();
+        assert_eq!(accepted.len(), MAX_WATCH_PATHS);
+        let error = resolve_watch_paths(&crate_dir, &patterns)
+            .expect_err("one watch beyond the bound must fail closed");
+        assert!(
+            format!("{error:#}").contains(&format!("more than {MAX_WATCH_PATHS}")),
             "{error:#}"
         );
     }
@@ -1959,6 +2230,34 @@ mod tests {
         assert_eq!(
             parse_make_words(&input[rule.colon + 2..rule.insertion]).unwrap(),
             vec![r"C:\work tree\#member\src\lib.rs", r"C:\work\data:1.txt"]
+        );
+    }
+
+    #[test]
+    fn first_make_rule_preserves_separator_and_trims_only_trailing_padding() {
+        let separator_only = "foo: ";
+        assert_eq!(
+            first_make_dependency_rule(separator_only)
+                .unwrap()
+                .insertion,
+            separator_only.len(),
+            "the separator's required space is not trailing dependency padding"
+        );
+
+        let extra_separator_padding = "foo:  ";
+        assert_eq!(
+            first_make_dependency_rule(extra_separator_padding)
+                .unwrap()
+                .insertion,
+            "foo: ".len()
+        );
+
+        let padded_dependencies = "foo: dep \t";
+        assert_eq!(
+            first_make_dependency_rule(padded_dependencies)
+                .unwrap()
+                .insertion,
+            "foo: dep".len()
         );
     }
 
@@ -2210,6 +2509,31 @@ mod tests {
         assert_ne!(
             before, after,
             "editing a declared header must re-key the cc crate"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn strict_snapshot_fails_when_a_matched_input_cannot_be_hashed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (dir, src) = crate_fixture(&[
+            ("kache.toml", "extra_inputs = [\"data/**/*\"]"),
+            ("data/secret.bin", "v1"),
+        ]);
+        let input = dir.path().join("data/secret.bin");
+        std::fs::set_permissions(&input, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::read(&input).is_ok() {
+            std::fs::set_permissions(&input, std::fs::Permissions::from_mode(0o644)).unwrap();
+            return;
+        }
+
+        let result = ExtraInputsSnapshot::resolve(Some(&src), "x", true, &FileHasher::new());
+        std::fs::set_permissions(&input, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let error = result.expect_err("strict hashing failures must propagate");
+        assert!(
+            format!("{error:#}").contains("hashing active extra_inputs dependency"),
+            "{error:#}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -624,10 +624,18 @@ fn is_cc_compiler_invocation(args: &[String]) -> bool {
 
 /// Run a Cargo `RUSTC_WRAPPER + RUSTC_WORKSPACE_WRAPPER` chain uncached while
 /// retaining Kache-owned freshness for an active `extra_inputs` declaration.
+fn preserve_workspace_wrapper_incremental(
+    preserve_requested: bool,
+    extra_inputs_active: bool,
+) -> bool {
+    preserve_requested && !extra_inputs_active
+}
+
 fn run_workspace_wrapper_chain(config: &config::Config, args: &[String]) -> Result<i32> {
     let parsed = args::RustcArgs::parse(args).context("parsing workspace-wrapper rustc chain")?;
     let extra_inputs = wrapper::resolve_extra_inputs_for_passthrough(config, &parsed)?;
-    let preserve_incremental = config.preserve_incremental && extra_inputs.is_none();
+    let preserve_incremental =
+        preserve_workspace_wrapper_incremental(config.preserve_incremental, extra_inputs.is_some());
     let exit = run_compiler_directly(config, args, preserve_incremental)?;
     if exit == 0 {
         wrapper::complete_current_extra_inputs_after_success(
@@ -919,6 +927,21 @@ mod tests {
         assert_eq!(parse_duration_hours("48"), Some(48));
         assert_eq!(parse_duration_hours("invalid"), None);
         assert_eq!(parse_duration_hours("18446744073709551615d"), None);
+    }
+
+    #[test]
+    fn workspace_wrapper_incremental_preservation_requires_opt_in_and_no_extra_inputs() {
+        for (requested, extra_inputs_active, expected) in [
+            (false, false, false),
+            (false, true, false),
+            (true, false, true),
+            (true, true, false),
+        ] {
+            assert_eq!(
+                preserve_workspace_wrapper_incremental(requested, extra_inputs_active),
+                expected
+            );
+        }
     }
 
     #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -622,6 +622,23 @@ fn is_cc_compiler_invocation(args: &[String]) -> bool {
     compiler::detect_compiler(args).is_some_and(|adapter| adapter.id() == compiler::cc::CC_ID)
 }
 
+/// Run a Cargo `RUSTC_WRAPPER + RUSTC_WORKSPACE_WRAPPER` chain uncached while
+/// retaining Kache-owned freshness for an active `extra_inputs` declaration.
+fn run_workspace_wrapper_chain(config: &config::Config, args: &[String]) -> Result<i32> {
+    let parsed = args::RustcArgs::parse(args).context("parsing workspace-wrapper rustc chain")?;
+    let extra_inputs = wrapper::resolve_extra_inputs_for_passthrough(config, &parsed)?;
+    let preserve_incremental = config.preserve_incremental && extra_inputs.is_none();
+    let exit = run_compiler_directly(config, args, preserve_incremental)?;
+    if exit == 0 {
+        wrapper::complete_current_extra_inputs_after_success(
+            config,
+            &parsed,
+            extra_inputs.as_ref(),
+        )?;
+    }
+    Ok(exit)
+}
+
 fn run_compiler_process_directly(args: &[String], preserve_incremental: bool) -> Result<i32> {
     // A previous cache-on build may have restored this crate's outputs
     // as read-only hardlinks into the store (0o444, shared inode).
@@ -805,9 +822,16 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
         std::process::exit(wrapper::run_cc_probe(args)?);
     }
 
-    let direct_passthrough = compiler::is_workspace_wrapper_chain(args)
-        || (compiler::is_passthrough_compiler_invocation(args)
-            && !compiler::rustc::RustcCompiler::recognizes(args));
+    if compiler::is_workspace_wrapper_chain(args) {
+        tracing::debug!(
+            program = ?args.first(),
+            "workspace-wrapper chain is uncached; retaining extra-input Cargo freshness"
+        );
+        std::process::exit(run_workspace_wrapper_chain(&config, args)?);
+    }
+
+    let direct_passthrough = compiler::is_passthrough_compiler_invocation(args)
+        && !compiler::rustc::RustcCompiler::recognizes(args);
     if direct_passthrough {
         tracing::debug!(
             program = ?args.first(),

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2127,7 +2127,11 @@ fn run_parsed_rustc(
     // the lookup above still ran, so a sound prior entry can still be served.
     let extra_inputs_racy = args.is_primary
         && extra_inputs_changed_during_compile(config, args, extra_inputs, invocation_start_ns);
-    if extra_inputs_racy || (config.modified_input_guard && key_too_new) {
+    if should_skip_cache_store_for_input_race(
+        extra_inputs_racy,
+        config.modified_input_guard,
+        key_too_new,
+    ) {
         let elapsed = start.elapsed().as_millis() as u64;
         log_event_with_hash_stats(
             config,
@@ -2755,6 +2759,33 @@ struct ComputedKey {
     key_too_new: bool,
 }
 
+fn should_skip_cache_store_for_input_race(
+    extra_inputs_racy: bool,
+    modified_input_guard: bool,
+    key_too_new: bool,
+) -> bool {
+    extra_inputs_racy || (modified_input_guard && key_too_new)
+}
+
+fn combine_key_measurements(
+    key_ms: u64,
+    extra_inputs_key_ms: u64,
+    key_hash_stats: FileHashStats,
+    extra_inputs_hash_stats: FileHashStats,
+    key_too_new: bool,
+    extra_inputs_too_new: bool,
+) -> (u64, FileHashStats, bool) {
+    (
+        key_ms + extra_inputs_key_ms,
+        FileHashStats {
+            cache_hits: key_hash_stats.cache_hits + extra_inputs_hash_stats.cache_hits,
+            cache_misses: key_hash_stats.cache_misses + extra_inputs_hash_stats.cache_misses,
+            bytes_hashed: key_hash_stats.bytes_hashed + extra_inputs_hash_stats.bytes_hashed,
+        },
+        key_too_new || extra_inputs_too_new,
+    )
+}
+
 /// Compute the rustc cache key. With `store` present the hasher is backed by
 /// the persistent SQLite hash cache; without it (daemon fast path,
 /// kunobi-ninja/kache#565) a store-free hasher still batches hashing through
@@ -2809,15 +2840,19 @@ fn compute_rustc_cache_key(
     };
     let cache_key = compiler.cache_key(args, &key_ctx)?;
     let key_hash_stats = file_hasher.stats();
+    let (key_ms, key_hash_stats, key_too_new) = combine_key_measurements(
+        key_start.elapsed().as_millis() as u64,
+        extra_inputs_key_ms,
+        key_hash_stats,
+        extra_inputs_hash_stats,
+        file_hasher.too_new(),
+        extra_inputs_too_new,
+    );
     Ok(ComputedKey {
         cache_key,
-        key_ms: key_start.elapsed().as_millis() as u64 + extra_inputs_key_ms,
-        key_hash_stats: FileHashStats {
-            cache_hits: key_hash_stats.cache_hits + extra_inputs_hash_stats.cache_hits,
-            cache_misses: key_hash_stats.cache_misses + extra_inputs_hash_stats.cache_misses,
-            bytes_hashed: key_hash_stats.bytes_hashed + extra_inputs_hash_stats.bytes_hashed,
-        },
-        key_too_new: file_hasher.too_new() || extra_inputs_too_new,
+        key_ms,
+        key_hash_stats,
+        key_too_new,
     })
 }
 
@@ -3054,9 +3089,10 @@ fn restore_from_cache(
             continue;
         }
         let blob = blobs.blob_path(&cached_file.hash);
-        let raw = match std::fs::read_to_string(&blob) {
-            Ok(raw) => raw,
-            Err(error) if extra_inputs.is_some() => {
+        let raw = match read_cached_dep_info_blob(&blob, extra_inputs.is_some()) {
+            Ok(Some(raw)) => raw,
+            Ok(None) => continue,
+            Err(error) => {
                 blobs.remove_entry(&meta.cache_key);
                 return Err(error).with_context(|| {
                     format!(
@@ -3064,11 +3100,6 @@ fn restore_from_cache(
                         meta.crate_name
                     )
                 });
-            }
-            Err(_) => {
-                // Missing/unreadable blobs without an active declaration are
-                // the materialize loop's existing clean-miss concern.
-                continue;
             }
         };
         let expanded =
@@ -3175,6 +3206,17 @@ fn restore_from_cache(
     }
 
     Ok(())
+}
+
+fn read_cached_dep_info_blob(
+    path: &Path,
+    extra_inputs_active: bool,
+) -> std::io::Result<Option<String>> {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => Ok(Some(raw)),
+        Err(error) if extra_inputs_active => Err(error),
+        Err(_) => Ok(None),
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4395,6 +4437,7 @@ fn clean_incremental_dir(config: &Config, args: &RustcArgs) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cache_key::FileHasher;
     use std::ffi::OsString;
     use std::path::PathBuf;
 
@@ -4887,6 +4930,69 @@ mod tests {
     }
 
     #[test]
+    fn input_race_store_suppression_truth_table() {
+        for (extra_inputs_racy, guard_enabled, key_too_new, expected) in [
+            (false, false, false, false),
+            (false, false, true, false),
+            (false, true, false, false),
+            (false, true, true, true),
+            (true, false, false, true),
+            (true, false, true, true),
+            (true, true, false, true),
+            (true, true, true, true),
+        ] {
+            assert_eq!(
+                should_skip_cache_store_for_input_race(
+                    extra_inputs_racy,
+                    guard_enabled,
+                    key_too_new,
+                ),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn key_measurements_include_extra_input_time_stats_and_races() {
+        let local = FileHashStats {
+            cache_hits: 11,
+            cache_misses: 13,
+            bytes_hashed: 17,
+        };
+        let extra = FileHashStats {
+            cache_hits: 2,
+            cache_misses: 3,
+            bytes_hashed: 5,
+        };
+
+        let (key_ms, combined, too_new) =
+            combine_key_measurements(19, 7, local, extra, false, true);
+        assert_eq!(key_ms, 26);
+        assert_eq!(combined.cache_hits, 13);
+        assert_eq!(combined.cache_misses, 16);
+        assert_eq!(combined.bytes_hashed, 22);
+        assert!(too_new, "an extra input race must propagate");
+
+        assert!(combine_key_measurements(0, 0, local, extra, true, false).2);
+        assert!(!combine_key_measurements(0, 0, local, extra, false, false).2);
+    }
+
+    #[test]
+    fn only_active_extra_inputs_make_unreadable_cached_dep_info_immediately_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.d");
+        assert_eq!(read_cached_dep_info_blob(&missing, false).unwrap(), None);
+        assert!(read_cached_dep_info_blob(&missing, true).is_err());
+
+        let readable = dir.path().join("readable.d");
+        std::fs::write(&readable, "foo: src/lib.rs\n").unwrap();
+        assert_eq!(
+            read_cached_dep_info_blob(&readable, true).unwrap(),
+            Some("foo: src/lib.rs\n".to_string())
+        );
+    }
+
+    #[test]
     fn adaptive_mode_requires_opt_in_without_explicit_preservation() {
         let mut config = test_config(PathBuf::from("cache"));
         for (adaptive, preserve, expected) in [
@@ -5162,6 +5268,154 @@ mod tests {
         let blob = store.blob_path(hash);
         std::fs::create_dir_all(blob.parent().unwrap()).unwrap();
         std::fs::write(blob, content).unwrap();
+    }
+
+    #[test]
+    fn active_extra_inputs_store_requires_the_expected_dep_info_artifact() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        let source = project.join("src/lib.rs");
+        let out_dir = dir.path().join("target/debug/deps");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&out_dir).unwrap();
+        std::fs::write(
+            project.join("Cargo.toml"),
+            "[package]\nname='foo'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        std::fs::write(project.join("kache.toml"), "extra_inputs = []\n").unwrap();
+        std::fs::write(&source, "pub fn f() {}\n").unwrap();
+
+        let args = rustc_args(&[
+            "rustc",
+            source.to_str().unwrap(),
+            "--crate-name",
+            "foo",
+            "--emit",
+            "dep-info",
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+        ]);
+        let snapshot = crate::extra_inputs::ExtraInputsSnapshot::resolve(
+            args.source_file.as_deref(),
+            "foo",
+            args.is_primary,
+            &FileHasher::new(),
+        )
+        .unwrap()
+        .unwrap();
+        let artifacts = ArtifactSet::new(Vec::new());
+        let error = validate_extra_inputs_dep_info_before_store(&args, &artifacts, None, &snapshot)
+            .expect_err("active extra_inputs requires the dep-info Cargo requested");
+        assert!(
+            format!("{error:#}").contains("no expected dep-info artifact"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn active_extra_inputs_store_accepts_the_expected_dep_info_artifact() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        let source = project.join("src/lib.rs");
+        let out_dir = dir.path().join("target/debug/deps");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&out_dir).unwrap();
+        std::fs::write(
+            project.join("Cargo.toml"),
+            "[package]\nname='foo'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        std::fs::write(project.join("kache.toml"), "extra_inputs = []\n").unwrap();
+        std::fs::write(&source, "pub fn f() {}\n").unwrap();
+
+        let args = rustc_args(&[
+            "rustc",
+            source.to_str().unwrap(),
+            "--crate-name",
+            "foo",
+            "--emit",
+            "dep-info",
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+        ]);
+        let snapshot = crate::extra_inputs::ExtraInputsSnapshot::resolve(
+            args.source_file.as_deref(),
+            "foo",
+            args.is_primary,
+            &FileHasher::new(),
+        )
+        .unwrap()
+        .unwrap();
+        let metadata = out_dir.join("libfoo.rmeta");
+        std::fs::write(&metadata, b"metadata").unwrap();
+        let dep_info = out_dir.join("foo.d");
+        std::fs::write(&dep_info, format!("foo: {}\n", source.display())).unwrap();
+        let artifacts = ArtifactSet::new(vec![
+            crate::compiler::Artifact {
+                path: metadata,
+                store_name: "libfoo.rmeta".to_string(),
+                kind: ArtifactKind::Metadata,
+                required: true,
+            },
+            crate::compiler::Artifact {
+                path: dep_info,
+                store_name: "foo.d".to_string(),
+                kind: ArtifactKind::DepInfo,
+                required: true,
+            },
+        ]);
+
+        validate_extra_inputs_dep_info_before_store(&args, &artifacts, None, &snapshot)
+            .expect("the expected producer dep-info artifact is valid");
+    }
+
+    #[test]
+    fn restore_rejects_dep_info_with_no_dependencies() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+        let store = Store::open(&config).unwrap();
+        let project = dir.path().join("project");
+        let source = project.join("src/lib.rs");
+        let out_dir = dir.path().join("target/debug/deps");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(
+            project.join("Cargo.toml"),
+            "[package]\nname='foo'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        std::fs::write(&source, "pub fn f() {}\n").unwrap();
+
+        let args = rustc_args(&[
+            "rustc",
+            source.to_str().unwrap(),
+            "--crate-name",
+            "foo",
+            "--emit",
+            "dep-info",
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+        ]);
+        let dep_info = "foo: \n";
+        let hash = blake3::hash(dep_info.as_bytes()).to_hex().to_string();
+        create_blob(&store, &hash, dep_info.as_bytes());
+        let mut file = cached_file("foo.d", &hash);
+        file.size = dep_info.len() as u64;
+        let meta = entry_meta("empty-dependencies", vec![file], &["dep-info"]);
+
+        let error = restore_from_cache(
+            &config,
+            &RustcCompiler::new(),
+            &BlobSource::Store(&store),
+            &args,
+            &meta,
+            None,
+        )
+        .expect_err("empty dependency rules must be evicted");
+        assert!(
+            format!("{error:#}").contains("has no dependencies"),
+            "{error:#}"
+        );
     }
 
     /// Regression for kache #348: the build-session marker must record a fresh

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -680,6 +680,7 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         cache_dir: &config.cache_dir,
         key_salt: config.key_salt.as_deref(),
         key_env_vars: &config.key_env_vars,
+        extra_inputs_digest: None,
     };
     let cache_key = match compiler.cache_key(&parsed, &key_ctx) {
         Ok(k) => k,
@@ -1330,8 +1331,182 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let args = compiler
         .parse(wrapper_args)
         .context("parsing rustc arguments")?;
+    // Resolve once before any cache/passthrough fast path. The same snapshot
+    // drives the key and the final Cargo-facing dep-info, so a concurrent
+    // config/glob change cannot make those two views disagree.
+    let extra_inputs_key_start = std::time::Instant::now();
+    let mut extra_inputs_hasher =
+        crate::cache_key::FileHasher::new().with_daemon(config.socket_path());
+    if config.modified_input_guard {
+        extra_inputs_hasher.arm_too_new_guard(invocation_start_ns, 0);
+    }
     let crate_name = args.crate_name.as_deref().unwrap_or("unknown");
-    let event_root = rustc_event_root(&args);
+    let extra_inputs = crate::extra_inputs::ExtraInputsSnapshot::resolve(
+        args.source_file.as_deref(),
+        crate_name,
+        args.is_primary,
+        &extra_inputs_hasher,
+    )
+    .with_context(|| format!("resolving extra_inputs for {crate_name}"))?;
+
+    validate_extra_inputs_freshness_mode(&args, extra_inputs.is_some())?;
+
+    let extra_inputs_hash_stats = extra_inputs_hasher.stats();
+    let extra_inputs_too_new = extra_inputs_hasher.too_new();
+    let extra_inputs_key_ms = extra_inputs_key_start.elapsed().as_millis() as u64;
+    // A fallback cache does not know Kache's extra-input digest. If Kache
+    // declines an invocation, delegating it could restore the exact stale
+    // artifact this declaration is meant to prevent. Keep the fallback for
+    // ordinary crates, but use a plain compiler passthrough for this one.
+    let mut safe_extra_inputs_config = None;
+    if extra_inputs.is_some() && (config.fallback.is_some() || config.preserve_incremental) {
+        let mut safe = config.clone();
+        if safe.fallback.take().is_some() {
+            tracing::debug!("disabling fallback cache for active extra_inputs crate {crate_name}");
+        }
+        if safe.preserve_incremental {
+            tracing::debug!(
+                "disabling preserved incremental state for active extra_inputs crate {crate_name}"
+            );
+            safe.preserve_incremental = false;
+        }
+        safe_extra_inputs_config = Some(safe);
+    }
+    let effective_config = safe_extra_inputs_config.as_ref().unwrap_or(config);
+    let exit = run_parsed_rustc(
+        effective_config,
+        &compiler,
+        &args,
+        start,
+        invocation_start_ns,
+        extra_inputs.as_ref(),
+        extra_inputs_hash_stats,
+        extra_inputs_too_new,
+        extra_inputs_key_ms,
+    )?;
+
+    if exit == 0 {
+        complete_current_extra_inputs_after_success(
+            effective_config,
+            &args,
+            extra_inputs.as_ref(),
+        )?;
+    }
+    Ok(exit)
+}
+
+pub(crate) fn resolve_extra_inputs_for_passthrough(
+    config: &Config,
+    args: &RustcArgs,
+) -> Result<Option<crate::extra_inputs::ExtraInputsSnapshot>> {
+    let crate_name = args.crate_name.as_deref().unwrap_or("unknown");
+    let hasher = crate::cache_key::FileHasher::new().with_daemon(config.socket_path());
+    let snapshot = crate::extra_inputs::ExtraInputsSnapshot::resolve(
+        args.source_file.as_deref(),
+        crate_name,
+        args.is_primary,
+        &hasher,
+    )
+    .with_context(|| format!("resolving extra_inputs for {crate_name}"))?;
+    validate_extra_inputs_freshness_mode(args, snapshot.is_some())?;
+    Ok(snapshot)
+}
+
+fn validate_extra_inputs_freshness_mode(args: &RustcArgs, active: bool) -> Result<()> {
+    if active && args.checksum_freshness_enabled() {
+        anyhow::bail!(
+            "extra_inputs cannot safely complete Cargo checksum-freshness dep-info yet; \
+             disable -Z checksum-freshness, or run the whole Cargo command with \
+             KACHE_DISABLED=1 while retaining matching cargo:rerun-if-changed directives"
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn complete_current_extra_inputs_after_success(
+    config: &Config,
+    args: &RustcArgs,
+    original: Option<&crate::extra_inputs::ExtraInputsSnapshot>,
+) -> Result<()> {
+    let current = resolve_extra_inputs_for_passthrough(config, args)?;
+    if current.as_ref() != original {
+        anyhow::bail!(
+            "extra_inputs declaration changed while the compiler wrapper was running; retry the build"
+        );
+    }
+    match current.as_ref() {
+        Some(snapshot) => complete_extra_inputs_dep_info(args, snapshot),
+        None => Ok(()),
+    }
+}
+
+pub(crate) fn complete_extra_inputs_dep_info(
+    args: &RustcArgs,
+    snapshot: &crate::extra_inputs::ExtraInputsSnapshot,
+) -> Result<()> {
+    let crate_name = args.crate_name.as_deref().unwrap_or("unknown");
+    let Some(dep_info_path) = args.dep_info_path() else {
+        tracing::debug!(
+            "extra_inputs dep-info completion skipped because rustc did not request a supported \
+             dep-info path for {crate_name}; non-Cargo callers retain their own freshness mechanism"
+        );
+        return Ok(());
+    };
+    snapshot
+        .merge_into_dep_info(&dep_info_path)
+        .with_context(|| {
+            format!(
+                "completing Cargo dep-info {} for extra_inputs",
+                dep_info_path.display()
+            )
+        })
+}
+
+fn extra_inputs_changed_during_compile(
+    config: &Config,
+    args: &RustcArgs,
+    before: Option<&crate::extra_inputs::ExtraInputsSnapshot>,
+    invocation_start_ns: i64,
+) -> bool {
+    let crate_name = args.crate_name.as_deref().unwrap_or("unknown");
+    let mut hasher = crate::cache_key::FileHasher::new().with_daemon(config.socket_path());
+    hasher.arm_too_new_guard(invocation_start_ns, 0);
+    let after = match crate::extra_inputs::ExtraInputsSnapshot::resolve(
+        args.source_file.as_deref(),
+        crate_name,
+        args.is_primary,
+        &hasher,
+    ) {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            tracing::warn!(
+                "not caching {crate_name}: extra_inputs could not be revalidated after compile: {error:#}"
+            );
+            return true;
+        }
+    };
+    if before != after.as_ref() || hasher.too_new() {
+        tracing::warn!(
+            "not caching {crate_name}: extra_inputs changed while the compiler was running"
+        );
+        return true;
+    }
+    false
+}
+
+fn run_parsed_rustc(
+    config: &Config,
+    compiler: &RustcCompiler,
+    args: &RustcArgs,
+    start: std::time::Instant,
+    invocation_start_ns: i64,
+    extra_inputs: Option<&crate::extra_inputs::ExtraInputsSnapshot>,
+    extra_inputs_hash_stats: FileHashStats,
+    extra_inputs_too_new: bool,
+    extra_inputs_key_ms: u64,
+) -> Result<i32> {
+    let crate_name = args.crate_name.as_deref().unwrap_or("unknown");
+    let event_root = rustc_event_root(args);
     // In-flight heartbeats (kunobi-ninja/kache#131): armed once per wrapper
     // process; the monitor only actually starts if this invocation reaches a
     // miss compile, and only beats once the compile outlives one cadence.
@@ -1347,10 +1522,10 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // mutant, while rustc's incremental state is designed for this workload.
     // In the explicit hybrid mode, bypass before opening the store or running
     // the dep-info key pass; non-incremental dependencies still use kache.
-    let preserve_incremental = preserve_incremental_requested(config, &args);
+    let preserve_incremental = preserve_incremental_requested(config, args);
     if preserve_incremental && compile::isolate_incremental_flags(&args.all_args).is_some() {
         tracing::debug!("preserving incremental compilation for {crate_name}");
-        return preserved_incremental_with_event(config, &args, crate_name, &event_root, start);
+        return preserved_incremental_with_event(config, args, crate_name, &event_root, start);
     }
     if preserve_incremental {
         tracing::warn!(
@@ -1362,11 +1537,11 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // hidden inputs, and lease contention simply leave `adaptive_unit` empty
     // (or fail to grant a lease) and continue through the normal cache path,
     // where Cargo's original incremental argument is stripped.
-    let force_incremental = force_incremental_requested(config, &args);
-    let adaptive_policy_for_invocation = adaptive_seed_allowed(config, &args);
+    let force_incremental = force_incremental_requested(config, args);
+    let adaptive_policy_for_invocation = adaptive_seed_allowed(config, args);
     let adaptive_unit = managed_incremental_unit(
         config,
-        &args,
+        args,
         std::env::var_os("CARGO_PRIMARY_PACKAGE").is_some(),
         || crate::extra_inputs::declared(args.source_file.as_deref()),
     );
@@ -1374,7 +1549,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // Evaluate every cheap cache-eligibility gate before the learned fast
     // path. In particular, changing an exclusion or executable-cache policy
     // must take effect immediately even when this unit was already active.
-    let refuse = compiler.refuse_reasons(&args);
+    let refuse = compiler.refuse_reasons(args);
     let current_dir = std::env::current_dir().ok();
     let workspace_root = args.workspace_root().or_else(|| current_dir.clone());
     let exclude_roots: Vec<_> = workspace_root
@@ -1397,7 +1572,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             if let Some(lease) = adaptive_unit.as_ref().and_then(AdaptiveUnit::try_immediate) {
                 return adaptive_incremental_with_event(
                     config,
-                    &args,
+                    args,
                     crate_name,
                     &event_root,
                     start,
@@ -1409,7 +1584,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         } else if let Some(lease) = adaptive_unit.as_ref().and_then(AdaptiveUnit::try_active) {
             return adaptive_incremental_with_event(
                 config,
-                &args,
+                args,
                 crate_name,
                 &event_root,
                 start,
@@ -1464,7 +1639,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         reset_adaptive_unit(adaptive_unit.as_ref());
         return passthrough_with_event(
             config,
-            &args,
+            args,
             crate_name,
             &event_root,
             start,
@@ -1477,7 +1652,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         reset_adaptive_unit(adaptive_unit.as_ref());
         return passthrough_with_event(
             config,
-            &args,
+            args,
             crate_name,
             &event_root,
             start,
@@ -1496,7 +1671,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         tracing::debug!("skipping cache for user-facing executable: {}", crate_name);
         return intentional_passthrough_with_event(
             config,
-            &args,
+            args,
             crate_name,
             &event_root,
             start,
@@ -1508,7 +1683,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     if !daemon_local && store.is_none() {
         return passthrough_with_event(
             config,
-            &args,
+            args,
             crate_name,
             &event_root,
             start,
@@ -1519,11 +1694,15 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // Compute the cache key (store-free on the daemon fast path).
     let keyed = match compute_rustc_cache_key(
         config,
-        &compiler,
-        &args,
+        compiler,
+        args,
         workspace_root.as_deref(),
         invocation_start_ns,
         store.as_ref(),
+        extra_inputs.and_then(crate::extra_inputs::ExtraInputsSnapshot::digest),
+        extra_inputs_hash_stats,
+        extra_inputs_too_new,
+        extra_inputs_key_ms,
     ) {
         Ok(keyed) => keyed,
         Err(e) => {
@@ -1535,7 +1714,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             tracing::warn!("failed to compute cache key for {}: {:#}", crate_name, e);
             return passthrough_with_event(
                 config,
-                &args,
+                args,
                 crate_name,
                 &event_root,
                 start,
@@ -1568,14 +1747,15 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     if daemon_local {
         if let Some(exit) = try_daemon_local_hit(
             config,
-            &compiler,
-            &args,
+            compiler,
+            args,
             &cache_key,
             crate_name,
             &event_root,
             start,
             key_ms,
             key_hash_stats,
+            extra_inputs,
         ) {
             reset_adaptive_unit(adaptive_unit.as_ref());
             return Ok(exit);
@@ -1590,7 +1770,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         None => {
             return passthrough_with_event(
                 config,
-                &args,
+                args,
                 crate_name,
                 &event_root,
                 start,
@@ -1613,7 +1793,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             );
             return passthrough_with_event(
                 config,
-                &args,
+                args,
                 crate_name,
                 &event_root,
                 start,
@@ -1633,9 +1813,14 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         } else {
             tracing::debug!("local cache hit for {} ({})", crate_name, &cache_key[..16]);
             let restore_start = std::time::Instant::now();
-            if let Err(e) =
-                restore_from_cache(config, &compiler, &BlobSource::Store(&store), &args, &meta)
-            {
+            if let Err(e) = restore_from_cache(
+                config,
+                compiler,
+                &BlobSource::Store(&store),
+                args,
+                &meta,
+                extra_inputs,
+            ) {
                 tracing::warn!(
                     "restoring local cache hit for {} failed: {} — recompiling",
                     crate_name,
@@ -1643,7 +1828,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                 );
                 return passthrough_with_event(
                     config,
-                    &args,
+                    args,
                     crate_name,
                     &event_root,
                     start,
@@ -1676,7 +1861,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             if !meta.stderr.is_empty() {
                 eprint!("{}", meta.stderr);
             }
-            clean_incremental_dir(config, &args);
+            clean_incremental_dir(config, args);
             reset_adaptive_unit(adaptive_unit.as_ref());
 
             return Ok(0);
@@ -1685,7 +1870,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     // Build-session detection: send prefetch hint before remote work.
     // Placed after local-hit check so warm-cache invocations skip this entirely.
-    maybe_trigger_prefetch(config, &args);
+    maybe_trigger_prefetch(config, args);
 
     // 2. Check remote cache via daemon (if configured)
     if config.remote.is_some() {
@@ -1712,10 +1897,11 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                     let restore_start = std::time::Instant::now();
                     if let Err(e) = restore_from_cache(
                         config,
-                        &compiler,
+                        compiler,
                         &BlobSource::Store(&store),
-                        &args,
+                        args,
                         &meta,
+                        extra_inputs,
                     ) {
                         tracing::warn!(
                             "restoring cache hit for {} failed: {} — recompiling",
@@ -1724,7 +1910,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                         );
                         return passthrough_with_event(
                             config,
-                            &args,
+                            args,
                             crate_name,
                             &event_root,
                             start,
@@ -1756,7 +1942,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                     if !meta.stderr.is_empty() {
                         eprint!("{}", meta.stderr);
                     }
-                    clean_incremental_dir(config, &args);
+                    clean_incremental_dir(config, args);
                     reset_adaptive_unit(adaptive_unit.as_ref());
                     return Ok(0);
                 }
@@ -1774,7 +1960,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     {
         return adaptive_incremental_with_event(
             config,
-            &args,
+            args,
             crate_name,
             &event_root,
             start,
@@ -1796,7 +1982,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             );
             return passthrough_with_event(
                 config,
-                &args,
+                args,
                 crate_name,
                 &event_root,
                 start,
@@ -1817,9 +2003,14 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     if let Some(meta) = committed {
         let restore_start = std::time::Instant::now();
-        if let Err(e) =
-            restore_from_cache(config, &compiler, &BlobSource::Store(&store), &args, &meta)
-        {
+        if let Err(e) = restore_from_cache(
+            config,
+            compiler,
+            &BlobSource::Store(&store),
+            args,
+            &meta,
+            extra_inputs,
+        ) {
             tracing::warn!(
                 "restoring cache hit for {} failed: {} — recompiling",
                 crate_name,
@@ -1827,7 +2018,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             );
             return passthrough_with_event(
                 config,
-                &args,
+                args,
                 crate_name,
                 &event_root,
                 start,
@@ -1855,7 +2046,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         // Replay the original compiler diagnostics, exactly as the other hit
         // sites do, so a coalesced compile does not swallow warnings or notes.
         replay_cached_diagnostics(&meta, std::io::stdout(), std::io::stderr());
-        clean_incremental_dir(config, &args);
+        clean_incremental_dir(config, args);
         reset_adaptive_unit(adaptive_unit.as_ref());
         return Ok(0);
     }
@@ -1864,7 +2055,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         tracing::warn!("wait for {} failed, compiling ourselves", crate_name);
         return passthrough_with_event(
             config,
-            &args,
+            args,
             crate_name,
             &event_root,
             start,
@@ -1879,7 +2070,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         &cache_key[..16]
     );
     let compile_start = std::time::Instant::now();
-    let mut result = match compiler.execute(&args) {
+    let mut result = match compiler.execute(args) {
         Ok(r) => r,
         // A spawn-level failure (missing binary, ENOMEM, fork pressure under
         // load) must not abort the build: fall back to passthrough so the
@@ -1888,7 +2079,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         Err(e) => {
             return passthrough_with_event(
                 config,
-                &args,
+                args,
                 crate_name,
                 &event_root,
                 start,
@@ -1934,7 +2125,9 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // racy versus what rustc actually read — refuse to store (the compile
     // already ran and is in place; we just don't cache it). Off by default;
     // the lookup above still ran, so a sound prior entry can still be served.
-    if config.modified_input_guard && key_too_new {
+    let extra_inputs_racy = args.is_primary
+        && extra_inputs_changed_during_compile(config, args, extra_inputs, invocation_start_ns);
+    if extra_inputs_racy || (config.modified_input_guard && key_too_new) {
         let elapsed = start.elapsed().as_millis() as u64;
         log_event_with_hash_stats(
             config,
@@ -1965,7 +2158,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // a later identical invocation hit it and find a requested `--emit=obj` /
     // `llvm-ir` missing. The compile already ran and is in place; we just decline
     // to cache it (mirrors the too-new guard above).
-    if let Some(missing) = missing_requested_emit(&args, &result.artifacts) {
+    if let Some(missing) = missing_requested_emit(args, &result.artifacts) {
         tracing::warn!(
             "not caching {}: discovered outputs do not cover requested --emit {} \
              (have {:?}) — refusing to store a partial entry",
@@ -2026,7 +2219,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
             0,
         );
         print_progress(crate_name, EventResult::Skipped, elapsed, 0);
-        clean_incremental_dir(config, &args);
+        clean_incremental_dir(config, args);
         drop(lock);
         return Ok(result.exit_code);
     }
@@ -2057,6 +2250,24 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         rewrite_depinfo_outputs(&result.artifacts, anchor, link::DepInfoMode::Relativize);
     }
 
+    // Validate the exact producer-neutral dep-info bytes before Store::put
+    // makes the entry observable. Restores complete the same bytes in memory;
+    // proving that transform now closes the publication window where another
+    // wrapper could otherwise observe an entry the producer later evicts.
+    if let Some(snapshot) = extra_inputs
+        && let Err(error) = validate_extra_inputs_dep_info_before_store(
+            args,
+            &result.artifacts,
+            depinfo_anchor.as_deref(),
+            snapshot,
+        )
+    {
+        if let Some(anchor) = depinfo_anchor.as_deref() {
+            rewrite_depinfo_outputs(&result.artifacts, anchor, link::DepInfoMode::Expand);
+        }
+        return Err(error).context("validating extra_inputs dep-info before cache commit");
+    }
+
     // Store-time debug bundle (kunobi-ninja/kache#319): a macOS `-g`
     // executable's `N_OSO` debug map points at per-build `.o` files that a
     // restoring build won't have — so while they still exist, bake a
@@ -2066,9 +2277,9 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // TempDir must outlive `store.put*` below, which hashes the tar at this
     // path — same lifetime pattern as `prepare_cc_store_files`.
     let mut _debug_bundle_staging: Option<tempfile::TempDir> = None;
-    if wants_debug_bundle(&args)
+    if wants_debug_bundle(args)
         && let Some((exec_path, exec_name)) =
-            find_executable_output(&compiler, &args, &result.artifacts)
+            find_executable_output(compiler, args, &result.artifacts)
     {
         match tempfile::tempdir() {
             Ok(staging) => {
@@ -2148,6 +2359,16 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         rewrite_depinfo_outputs(&result.artifacts, anchor, link::DepInfoMode::Expand);
     }
 
+    // Do not publish a cache entry until the consumer-facing dep-info is known
+    // to be completable. The stored blob remains the producer-neutral version
+    // captured above; on failure, evict it before any remote upload is queued.
+    if let Some(snapshot) = extra_inputs
+        && let Err(error) = complete_extra_inputs_dep_info(args, snapshot)
+    {
+        let _ = store.remove_entry(&cache_key);
+        return Err(error).context("validating extra_inputs dep-info before cache publication");
+    }
+
     // 6. Async upload to remote (if configured) — sends job to the daemon
     if config.remote.is_some() {
         let entry_dir = store.entry_dir(&cache_key);
@@ -2157,7 +2378,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     }
 
     // 7. Clean incremental dir, as with kache's caching, incremental compilation is redundant
-    clean_incremental_dir(config, &args);
+    clean_incremental_dir(config, args);
 
     let elapsed = start.elapsed().as_millis() as u64;
     let size = result.artifacts.total_size();
@@ -2272,6 +2493,44 @@ fn rewrite_depinfo_outputs(artifacts: &ArtifactSet, anchor: &Path, mode: link::D
     }
 }
 
+fn validate_extra_inputs_dep_info_before_store(
+    args: &RustcArgs,
+    artifacts: &ArtifactSet,
+    depinfo_anchor: Option<&Path>,
+    snapshot: &crate::extra_inputs::ExtraInputsSnapshot,
+) -> Result<()> {
+    let expected_name = args
+        .dep_info_path()
+        .and_then(|path| path.file_name().map(std::ffi::OsStr::to_os_string));
+    let mut saw_dep_info = false;
+    for artifact in artifacts.outputs() {
+        if artifact.kind != ArtifactKind::DepInfo {
+            continue;
+        }
+        if expected_name
+            .as_ref()
+            .is_some_and(|expected| artifact.path.file_name() != Some(expected.as_os_str()))
+        {
+            continue;
+        }
+        saw_dep_info = true;
+        let raw = std::fs::read_to_string(&artifact.path)
+            .with_context(|| format!("reading producer dep-info {}", artifact.path.display()))?;
+        let consumer = depinfo_anchor.map_or_else(
+            || raw.clone(),
+            |anchor| crate::link::rewrite_depinfo_content(&raw, anchor, link::DepInfoMode::Expand),
+        );
+        snapshot
+            .merge_dep_info_content(&consumer)
+            .with_context(|| format!("completing producer dep-info {}", artifact.path.display()))?;
+    }
+    anyhow::ensure!(
+        expected_name.is_none() || saw_dep_info,
+        "successful rustc invocation produced no expected dep-info artifact required by active extra_inputs"
+    );
+    Ok(())
+}
+
 /// How to materialize one restored artifact.
 ///
 /// `kind` comes from the compile context, which does not always identify an
@@ -2364,6 +2623,7 @@ fn materialize_cached_artifact(
     depinfo_anchor: &Path,
     platform: &dyn crate::compiler::Platform,
     context: &str,
+    extra_inputs: Option<&crate::extra_inputs::ExtraInputsSnapshot>,
 ) -> Result<()> {
     let store_path = blobs.blob_path(&cached_file.hash);
     if !store_path.exists() {
@@ -2386,7 +2646,8 @@ fn materialize_cached_artifact(
         .filter(|action| action.is_content_transform())
         .collect();
 
-    let transformed = if transforms.is_empty() {
+    let complete_extra_inputs = extra_inputs.filter(|_| kind == ArtifactKind::DepInfo);
+    let transformed = if transforms.is_empty() && complete_extra_inputs.is_none() {
         None
     } else {
         let original = std::fs::read(&store_path)
@@ -2394,6 +2655,14 @@ fn materialize_cached_artifact(
         let mut content = original.clone();
         for action in &transforms {
             content = action.transform(content, depinfo_anchor);
+        }
+        if let Some(snapshot) = complete_extra_inputs {
+            let text = String::from_utf8(content)
+                .with_context(|| format!("{context}: dep-info is not valid UTF-8"))?;
+            content = snapshot
+                .merge_dep_info_content(&text)
+                .with_context(|| format!("{context}: completing extra_inputs dep-info"))?
+                .into_bytes();
         }
         if content == original {
             None
@@ -2498,6 +2767,10 @@ fn compute_rustc_cache_key(
     workspace_root: Option<&Path>,
     invocation_start_ns: i64,
     store: Option<&Store>,
+    extra_inputs_digest: Option<&str>,
+    extra_inputs_hash_stats: FileHashStats,
+    extra_inputs_too_new: bool,
+    extra_inputs_key_ms: u64,
 ) -> Result<ComputedKey> {
     let key_start = std::time::Instant::now();
     let mut file_hasher = match store {
@@ -2532,13 +2805,19 @@ fn compute_rustc_cache_key(
         cache_dir: &config.cache_dir,
         key_salt: config.key_salt.as_deref(),
         key_env_vars: &config.key_env_vars,
+        extra_inputs_digest,
     };
     let cache_key = compiler.cache_key(args, &key_ctx)?;
+    let key_hash_stats = file_hasher.stats();
     Ok(ComputedKey {
         cache_key,
-        key_ms: key_start.elapsed().as_millis() as u64,
-        key_hash_stats: file_hasher.stats(),
-        key_too_new: file_hasher.too_new(),
+        key_ms: key_start.elapsed().as_millis() as u64 + extra_inputs_key_ms,
+        key_hash_stats: FileHashStats {
+            cache_hits: key_hash_stats.cache_hits + extra_inputs_hash_stats.cache_hits,
+            cache_misses: key_hash_stats.cache_misses + extra_inputs_hash_stats.cache_misses,
+            bytes_hashed: key_hash_stats.bytes_hashed + extra_inputs_hash_stats.bytes_hashed,
+        },
+        key_too_new: file_hasher.too_new() || extra_inputs_too_new,
     })
 }
 
@@ -2557,6 +2836,7 @@ fn try_daemon_local_hit(
     start: std::time::Instant,
     key_ms: u64,
     key_hash_stats: FileHashStats,
+    extra_inputs: Option<&crate::extra_inputs::ExtraInputsSnapshot>,
 ) -> Option<i32> {
     let lookup_start = std::time::Instant::now();
     let reply = crate::daemon::send_local_lookup(config, cache_key)?;
@@ -2571,7 +2851,7 @@ fn try_daemon_local_hit(
 
     let restore_start = std::time::Instant::now();
     let blobs = BlobSource::StoreDir(config.store_dir());
-    if let Err(e) = restore_from_cache(config, compiler, &blobs, args, &meta) {
+    if let Err(e) = restore_from_cache(config, compiler, &blobs, args, &meta, extra_inputs) {
         // Includes a blob evicted between the daemon's pin and our reflink —
         // the local path below recompiles; never serve a partial hit.
         tracing::warn!(
@@ -2666,12 +2946,20 @@ fn replay_cached_diagnostics(
 }
 
 fn restore_from_cache(
-    _config: &Config,
+    config: &Config,
     compiler: &RustcCompiler,
     blobs: &BlobSource<'_>,
     args: &RustcArgs,
     meta: &crate::store::EntryMeta,
+    extra_inputs: Option<&crate::extra_inputs::ExtraInputsSnapshot>,
 ) -> Result<()> {
+    let current = resolve_extra_inputs_for_passthrough(config, args)
+        .context("revalidating extra_inputs before cache-hit publication")?;
+    anyhow::ensure!(
+        current.as_ref() == extra_inputs,
+        "extra_inputs declaration changed during cache lookup; refusing the stale hit"
+    );
+
     // Emit-coverage gate (kunobi-ninja/kache#325): a stored entry must contain
     // outputs covering every `--emit` kind this invocation requested. An entry
     // that doesn't — a partial store from a pre-gate / directory-scan producer,
@@ -2686,6 +2974,31 @@ fn restore_from_cache(
             meta.crate_name,
             meta.emit_kinds,
             args.emit
+        );
+    }
+
+    // Legacy entries may predate emit-kind metadata and therefore bypass the
+    // coverage gate above. Active extra inputs still require a real `.d` blob:
+    // without one the outer success epilogue would fail after reporting a hit,
+    // leaving the same unusable entry to brick every retry.
+    let expected_dep_info_name = extra_inputs.and_then(|_| {
+        args.dep_info_path()
+            .and_then(|path| path.file_name().map(std::ffi::OsStr::to_os_string))
+    });
+    if let Some(expected) = &expected_dep_info_name
+        && !meta.files.iter().any(|file| {
+            matches!(
+                crate::compiler::classify_by_filename(&file.name),
+                crate::compiler::ArtifactKind::DepInfo
+            ) && Path::new(&file.name).file_name() == Some(expected.as_os_str())
+        })
+    {
+        blobs.remove_entry(&meta.cache_key);
+        anyhow::bail!(
+            "cached entry for {} has no dep-info artifact named {} required by active \
+             extra_inputs; evicting the legacy entry and recompiling",
+            meta.crate_name,
+            expected.to_string_lossy()
         );
     }
 
@@ -2735,15 +3048,67 @@ fn restore_from_cache(
         ) {
             continue;
         }
-        let blob = blobs.blob_path(&cached_file.hash);
-        let Ok(raw) = std::fs::read_to_string(&blob) else {
-            // Missing/unreadable blob is the materialize loop's concern;
-            // it reports a clean miss for it below.
+        if expected_dep_info_name.as_ref().is_some_and(|expected| {
+            Path::new(&cached_file.name).file_name() != Some(expected.as_os_str())
+        }) {
             continue;
+        }
+        let blob = blobs.blob_path(&cached_file.hash);
+        let raw = match std::fs::read_to_string(&blob) {
+            Ok(raw) => raw,
+            Err(error) if extra_inputs.is_some() => {
+                blobs.remove_entry(&meta.cache_key);
+                return Err(error).with_context(|| {
+                    format!(
+                        "cached dep-info for {} is unreadable or not UTF-8; evicting the entry",
+                        meta.crate_name
+                    )
+                });
+            }
+            Err(_) => {
+                // Missing/unreadable blobs without an active declaration are
+                // the materialize loop's existing clean-miss concern.
+                continue;
+            }
         };
         let expanded =
             crate::link::rewrite_depinfo_content(&raw, &depinfo_anchor, link::DepInfoMode::Expand);
-        for dep in crate::cache_key::parse_dep_info(&expanded) {
+        let expanded = if let Some(snapshot) = extra_inputs {
+            match snapshot.merge_dep_info_content(&expanded) {
+                Ok(completed) => completed,
+                Err(error) => {
+                    blobs.remove_entry(&meta.cache_key);
+                    return Err(error).with_context(|| {
+                        format!(
+                            "cached dep-info for {} cannot be completed safely; evicting the entry",
+                            meta.crate_name
+                        )
+                    });
+                }
+            }
+        } else {
+            expanded
+        };
+        let dependencies = match crate::extra_inputs::parse_dep_info_dependencies(&expanded) {
+            Ok(dependencies) if !dependencies.is_empty() => dependencies,
+            Ok(_) => {
+                blobs.remove_entry(&meta.cache_key);
+                anyhow::bail!(
+                    "cached dep-info for {} has no dependencies; evicting the entry and recompiling",
+                    meta.crate_name
+                );
+            }
+            Err(error) => {
+                blobs.remove_entry(&meta.cache_key);
+                return Err(error).with_context(|| {
+                    format!(
+                        "cached dep-info for {} is malformed; evicting the entry",
+                        meta.crate_name
+                    )
+                });
+            }
+        };
+        for dep in dependencies {
             if !dep.exists() {
                 blobs.remove_entry(&meta.cache_key);
                 anyhow::bail!(
@@ -2805,6 +3170,7 @@ fn restore_from_cache(
             &depinfo_anchor,
             &*platform,
             "rustc restore",
+            extra_inputs,
         )?;
     }
 
@@ -5376,6 +5742,7 @@ mod tests {
             dir.path(),
             &*platform,
             "test restore",
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -5414,6 +5781,7 @@ mod tests {
             &anchor,
             &*platform,
             "test restore",
+            None,
         )
         .unwrap();
 
@@ -5466,6 +5834,7 @@ mod tests {
             dir.path(),
             &*platform,
             "test restore",
+            None,
         )
         .unwrap();
 
@@ -5502,6 +5871,7 @@ mod tests {
             dir.path(),
             &*platform,
             "test restore",
+            None,
         )
         .unwrap();
 
@@ -5674,6 +6044,7 @@ mod tests {
             dir.path(),
             &*platform,
             "test restore",
+            None,
         )
         .unwrap();
 
@@ -5763,6 +6134,7 @@ mod tests {
             restore_dir.path(),
             &*platform,
             "test restore",
+            None,
         )
         .unwrap();
 
@@ -6684,6 +7056,7 @@ exit 0
             &BlobSource::Store(&store),
             &args,
             &meta,
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -6700,6 +7073,373 @@ exit 0
             !out_dir.join("foo.d").exists(),
             "nothing may be materialized before the gate"
         );
+    }
+
+    #[test]
+    fn restore_evicts_incomplete_extra_inputs_depinfo_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+        let store = Store::open(&config).unwrap();
+        let project = dir.path().join("project");
+        let source = project.join("src/lib.rs");
+        std::fs::create_dir_all(project.join("src")).unwrap();
+        std::fs::create_dir_all(project.join("data")).unwrap();
+        std::fs::write(
+            project.join("Cargo.toml"),
+            "[package]\nname='foo'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        std::fs::write(&source, "pub fn f() {}\n").unwrap();
+        std::fs::write(
+            project.join("kache.toml"),
+            "extra_inputs = [\"data/**/*.txt\"]\n",
+        )
+        .unwrap();
+        std::fs::write(project.join("data/value.txt"), "v1").unwrap();
+
+        let out_dir = dir.path().join("target/debug/deps");
+        let args = rustc_args(&[
+            "rustc",
+            source.to_str().unwrap(),
+            "--crate-name",
+            "foo",
+            "--emit",
+            "dep-info",
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+        ]);
+        let snapshot = crate::extra_inputs::ExtraInputsSnapshot::resolve(
+            args.source_file.as_deref(),
+            "foo",
+            args.is_primary,
+            &crate::cache_key::FileHasher::new(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let malformed = "not rustc dep-info\n";
+        let dep_hash = blake3::hash(malformed.as_bytes()).to_hex().to_string();
+        create_blob(&store, &dep_hash, malformed.as_bytes());
+        let mut dep_file = cached_file("foo.d", &dep_hash);
+        dep_file.size = malformed.len() as u64;
+        let meta = entry_meta("malformed-extra-key", vec![dep_file], &["dep-info"]);
+        let entry_dir = store.entry_dir(&meta.cache_key);
+        std::fs::create_dir_all(&entry_dir).unwrap();
+        std::fs::write(
+            entry_dir.join("meta.json"),
+            serde_json::to_string(&meta).unwrap(),
+        )
+        .unwrap();
+        store.insert_entry_row_for_test(&meta.cache_key);
+
+        let error = restore_from_cache(
+            &config,
+            &RustcCompiler::new(),
+            &BlobSource::Store(&store),
+            &args,
+            &meta,
+            Some(&snapshot),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("cannot be completed safely"),
+            "{error:#}"
+        );
+        assert!(
+            !entry_dir.join("meta.json").exists(),
+            "malformed cached dep-info must be evicted before hit publication"
+        );
+        assert!(!out_dir.join("foo.d").exists());
+
+        // A pre-emit-gate entry has no `emit_kinds`, so the generic coverage
+        // check intentionally accepts it. Active extra inputs must still
+        // require a concrete dep-info artifact before publishing a hit.
+        let rlib_bytes = b"legacy rlib";
+        let rlib_hash = blake3::hash(rlib_bytes).to_hex().to_string();
+        create_blob(&store, &rlib_hash, rlib_bytes);
+        let mut rlib_file = cached_file("libfoo.rlib", &rlib_hash);
+        rlib_file.size = rlib_bytes.len() as u64;
+        let legacy_meta = entry_meta("legacy-no-depinfo-key", vec![rlib_file], &[]);
+        let legacy_entry_dir = store.entry_dir(&legacy_meta.cache_key);
+        std::fs::create_dir_all(&legacy_entry_dir).unwrap();
+        std::fs::write(
+            legacy_entry_dir.join("meta.json"),
+            serde_json::to_string(&legacy_meta).unwrap(),
+        )
+        .unwrap();
+        store.insert_entry_row_for_test(&legacy_meta.cache_key);
+
+        let error = restore_from_cache(
+            &config,
+            &RustcCompiler::new(),
+            &BlobSource::Store(&store),
+            &args,
+            &legacy_meta,
+            Some(&snapshot),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("has no dep-info artifact"),
+            "{error:#}"
+        );
+        assert!(
+            !legacy_entry_dir.join("meta.json").exists(),
+            "legacy entry without dep-info must be evicted before hit publication"
+        );
+
+        // A differently named `.d` is not the output Cargo expects for this
+        // unit. Treat it exactly like a missing legacy dep-info artifact.
+        let wrong_dep = "other: src/lib.rs\n";
+        let wrong_hash = blake3::hash(wrong_dep.as_bytes()).to_hex().to_string();
+        create_blob(&store, &wrong_hash, wrong_dep.as_bytes());
+        let mut wrong_file = cached_file("other.d", &wrong_hash);
+        wrong_file.size = wrong_dep.len() as u64;
+        let wrong_meta = entry_meta("legacy-wrong-depinfo-key", vec![wrong_file], &[]);
+        let wrong_entry_dir = store.entry_dir(&wrong_meta.cache_key);
+        std::fs::create_dir_all(&wrong_entry_dir).unwrap();
+        std::fs::write(
+            wrong_entry_dir.join("meta.json"),
+            serde_json::to_string(&wrong_meta).unwrap(),
+        )
+        .unwrap();
+        store.insert_entry_row_for_test(&wrong_meta.cache_key);
+
+        let error = restore_from_cache(
+            &config,
+            &RustcCompiler::new(),
+            &BlobSource::Store(&store),
+            &args,
+            &wrong_meta,
+            Some(&snapshot),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("has no dep-info artifact named foo.d"),
+            "{error:#}"
+        );
+        assert!(!wrong_entry_dir.join("meta.json").exists());
+
+        // Cargo skips env-dep records even when their values contain `: `.
+        // Restore validation must inspect the following Make rule and evict a
+        // consumer-invalid path instead of accepting an empty dependency set.
+        let missing_dependency = project.join("does-not-exist.rs");
+        let env_prefixed = format!(
+            "# env-dep:CFG=foo: bar\nfoo: {}\n",
+            missing_dependency.display()
+        );
+        let env_hash = blake3::hash(env_prefixed.as_bytes()).to_hex().to_string();
+        create_blob(&store, &env_hash, env_prefixed.as_bytes());
+        let mut env_file = cached_file("foo.d", &env_hash);
+        env_file.size = env_prefixed.len() as u64;
+        let env_meta = entry_meta("env-prefixed-depinfo-key", vec![env_file], &["dep-info"]);
+        let env_entry_dir = store.entry_dir(&env_meta.cache_key);
+        std::fs::create_dir_all(&env_entry_dir).unwrap();
+        std::fs::write(
+            env_entry_dir.join("meta.json"),
+            serde_json::to_string(&env_meta).unwrap(),
+        )
+        .unwrap();
+        store.insert_entry_row_for_test(&env_meta.cache_key);
+
+        let error = restore_from_cache(
+            &config,
+            &RustcCompiler::new(),
+            &BlobSource::Store(&store),
+            &args,
+            &env_meta,
+            Some(&snapshot),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("does not resolve here"),
+            "{error:#}"
+        );
+        assert!(!env_entry_dir.join("meta.json").exists());
+    }
+
+    #[test]
+    fn compile_revalidation_rejects_nested_directory_aba() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+        let project = dir.path().join("project");
+        let source = project.join("src/lib.rs");
+        let nested = project.join("data/deep");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(
+            project.join("Cargo.toml"),
+            "[package]\nname='foo'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        std::fs::write(&source, "pub fn f() {}\n").unwrap();
+        std::fs::write(
+            project.join("kache.toml"),
+            "extra_inputs = [\"data/**/*.txt\"]\n",
+        )
+        .unwrap();
+        std::fs::write(project.join("data/stable.txt"), "v1").unwrap();
+
+        let args = rustc_args(&[
+            "rustc",
+            source.to_str().unwrap(),
+            "--crate-name",
+            "foo",
+            "--emit",
+            "dep-info",
+            "--out-dir",
+            dir.path().join("out").to_str().unwrap(),
+        ]);
+        let before = crate::extra_inputs::ExtraInputsSnapshot::resolve(
+            args.source_file.as_deref(),
+            "foo",
+            args.is_primary,
+            &crate::cache_key::FileHasher::new(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let transient = nested.join("transient.txt");
+        std::fs::write(&transient, "transient").unwrap();
+        std::fs::remove_file(&transient).unwrap();
+        filetime::set_file_mtime(
+            &nested,
+            filetime::FileTime::from_unix_time(2_000_000_000, 123),
+        )
+        .unwrap();
+        let after = crate::extra_inputs::ExtraInputsSnapshot::resolve(
+            args.source_file.as_deref(),
+            "foo",
+            args.is_primary,
+            &crate::cache_key::FileHasher::new(),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(before.digest(), after.digest());
+        assert_ne!(before, after);
+        assert!(extra_inputs_changed_during_compile(
+            &config,
+            &args,
+            Some(&before),
+            i64::MAX,
+        ));
+    }
+
+    #[test]
+    fn activation_from_none_is_rejected_on_miss_hit_and_success_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+        let store = Store::open(&config).unwrap();
+        let project = dir.path().join("project");
+        let source = project.join("src/lib.rs");
+        let out_dir = dir.path().join("target/debug/deps");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(project.join("data")).unwrap();
+        std::fs::write(
+            project.join("Cargo.toml"),
+            "[package]\nname='foo'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        std::fs::write(&source, "pub fn f() {}\n").unwrap();
+        std::fs::write(project.join("data/value.txt"), "v1").unwrap();
+
+        let args = rustc_args(&[
+            "rustc",
+            source.to_str().unwrap(),
+            "--crate-name",
+            "foo",
+            "--emit",
+            "dep-info",
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+        ]);
+        let initial = crate::extra_inputs::ExtraInputsSnapshot::resolve(
+            args.source_file.as_deref(),
+            "foo",
+            args.is_primary,
+            &crate::cache_key::FileHasher::new(),
+        )
+        .unwrap();
+        assert!(initial.is_none());
+
+        std::fs::write(
+            project.join("kache.toml"),
+            "extra_inputs = [\"data/**/*.txt\"]\n",
+        )
+        .unwrap();
+
+        // Miss/store and uncached passthrough lanes both use these two guards:
+        // publication is suppressed, then a successful compiler exit is turned
+        // into a retry instead of accepting dep-info that omitted the new config.
+        assert!(extra_inputs_changed_during_compile(
+            &config,
+            &args,
+            initial.as_ref(),
+            i64::MAX,
+        ));
+        let error = complete_current_extra_inputs_after_success(&config, &args, initial.as_ref())
+            .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("extra_inputs declaration changed"),
+            "{error:#}"
+        );
+
+        // A cache hit must reject the same None -> Some transition before any
+        // artifact is materialized.
+        let dep_info = format!("foo: {}\n", source.display());
+        let dep_hash = blake3::hash(dep_info.as_bytes()).to_hex().to_string();
+        create_blob(&store, &dep_hash, dep_info.as_bytes());
+        let mut dep_file = cached_file("foo.d", &dep_hash);
+        dep_file.size = dep_info.len() as u64;
+        let meta = entry_meta("pre-activation-key", vec![dep_file], &["dep-info"]);
+        let error = restore_from_cache(
+            &config,
+            &RustcCompiler::new(),
+            &BlobSource::Store(&store),
+            &args,
+            &meta,
+            initial.as_ref(),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("changed during cache lookup"),
+            "{error:#}"
+        );
+        assert!(!out_dir.join("foo.d").exists());
+    }
+
+    #[test]
+    fn active_extra_inputs_reject_checksum_freshness_with_actionable_fallback() {
+        let checksum_args = rustc_args(&[
+            "rustc",
+            "src/lib.rs",
+            "--crate-name",
+            "foo",
+            "--emit",
+            "dep-info,link",
+            "-Z",
+            "checksum-hash-algorithm=blake3",
+        ]);
+        let error = validate_extra_inputs_freshness_mode(&checksum_args, true).unwrap_err();
+        let rendered = format!("{error:#}");
+        for expected in [
+            "extra_inputs cannot safely complete Cargo checksum-freshness dep-info yet",
+            "disable -Z checksum-freshness",
+            "KACHE_DISABLED=1",
+            "cargo:rerun-if-changed",
+        ] {
+            assert!(rendered.contains(expected), "{rendered}");
+        }
+        assert!(validate_extra_inputs_freshness_mode(&checksum_args, false).is_ok());
+
+        let normal_args = rustc_args(&[
+            "rustc",
+            "src/lib.rs",
+            "--crate-name",
+            "foo",
+            "--emit",
+            "dep-info,link",
+        ]);
+        assert!(validate_extra_inputs_freshness_mode(&normal_args, true).is_ok());
     }
 
     #[test]
@@ -6754,6 +7494,7 @@ exit 0
             &BlobSource::Store(&store),
             &args,
             &meta,
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -6797,6 +7538,7 @@ exit 0
             &BlobSource::Store(&store),
             &args,
             &meta,
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -6823,6 +7565,7 @@ exit 0
             &BlobSource::Store(&store),
             &args,
             &meta,
+            None,
         )
         .unwrap_err()
         .to_string();

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -534,6 +534,30 @@ fn doctor_runs_readonly_diagnostics() {
     e.cmd().arg("doctor").assert().success();
 }
 
+#[test]
+fn doctor_does_not_prescribe_obsolete_build_script_for_extra_inputs() {
+    let e = env();
+    let project = TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname='doctor-extra-inputs'\nversion='0.1.0'\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project.path().join("kache.toml"),
+        "extra_inputs = [\"data/**/*.txt\"]\n",
+    )
+    .unwrap();
+
+    e.cmd()
+        .current_dir(project.path())
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("cargo:rerun-if-changed").not())
+        .stdout(predicates::str::contains("no build.rs").not());
+}
+
 /// kunobi-ninja/kache#176: `doctor --verify` is meant to gate CI, so a store
 /// with unrepairable corruption must exit NON-ZERO, and the same store must
 /// exit zero once `--repair` has cleared it. Drives the real binary because

--- a/tests/extra_inputs_warm_target_test.rs
+++ b/tests/extra_inputs_warm_target_test.rs
@@ -1,0 +1,1067 @@
+//! Real Cargo regression for #723: `extra_inputs` must participate in Cargo's
+//! warm-target freshness, not only in Kache's key after the wrapper is invoked.
+
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+mod common;
+use common::{build_kache, isolated_config_path, kache_binary};
+
+const INPUT_PATH_ENV: &str = "KACHE_TEST_DECLARED_INPUT";
+const ACTIVATE_CONFIG_ENV: &str = "KACHE_TEST_ACTIVATE_CONFIG";
+const CRATE_NAME: &str = "extra_input_warm_target";
+
+fn rustc_path() -> String {
+    std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string())
+}
+
+/// Build fixed proc-macro scaffolding outside Cargo and outside Kache. Its
+/// expansion reads the declared input without using `include_*`, so rustc does
+/// not discover the file on its own and the consumer's normal dep-info omits
+/// it. This is the minimal shape of an offline sqlx-style compile-time input.
+fn build_input_reader(root: &Path) -> PathBuf {
+    let source = root.join("input_reader.rs");
+    std::fs::write(
+        &source,
+        r#"
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn declared_value(_input: TokenStream) -> TokenStream {
+    let path = std::env::var("KACHE_TEST_DECLARED_INPUT").unwrap();
+    let value = std::fs::read_to_string(path).unwrap_or_else(|_| "missing".to_string());
+    format!("{value:?}").parse().unwrap()
+}
+"#,
+    )
+    .unwrap();
+
+    let out_dir = root.join("input-reader-out");
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let output = Command::new(rustc_path())
+        .args([
+            "--crate-name",
+            "input_reader",
+            "--crate-type",
+            "proc-macro",
+            "--edition",
+            "2021",
+            "--out-dir",
+        ])
+        .arg(&out_dir)
+        .arg(&source)
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .output()
+        .expect("build input-reader proc macro");
+    assert!(
+        output.status.success(),
+        "building input-reader proc macro failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let dylib_ext = if cfg!(windows) {
+        "dll"
+    } else if cfg!(target_os = "macos") {
+        "dylib"
+    } else {
+        "so"
+    };
+    std::fs::read_dir(&out_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.extension().is_some_and(|ext| ext == dylib_ext)
+                && path
+                    .file_stem()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.contains("input_reader"))
+        })
+        .unwrap_or_else(|| panic!("input-reader {dylib_ext} missing in {}", out_dir.display()))
+}
+
+/// Build a transparent Cargo workspace wrapper that creates `kache.toml` once
+/// immediately before rustc. This makes the absent -> active race deterministic
+/// without timing sleeps or platform-specific shell scripts.
+fn build_activating_workspace_wrapper(root: &Path) -> PathBuf {
+    let source = root.join("activate_config_wrapper.rs");
+    std::fs::write(
+        &source,
+        r#"
+use std::process::Command;
+
+fn main() {
+    let args: Vec<_> = std::env::args_os().skip(1).collect();
+    let is_fixture_compile = args.windows(2).any(|pair| {
+        pair[0] == "--crate-name" && pair[1] == "extra_input_warm_target"
+    });
+    if is_fixture_compile {
+        let config = std::env::var_os("KACHE_TEST_ACTIVATE_CONFIG").unwrap();
+        let config = std::path::PathBuf::from(config);
+        if !config.exists() {
+            std::fs::write(&config, "extra_inputs = [\"data/**/*.txt\"]\n").unwrap();
+        }
+    }
+
+    let compiler = &args[0];
+    let status = Command::new(compiler).args(&args[1..]).status().unwrap();
+    std::process::exit(status.code().unwrap_or(1));
+}
+"#,
+    )
+    .unwrap();
+    let mut output = root.join("activate-config-wrapper");
+    if cfg!(windows) {
+        output.set_extension("exe");
+    }
+    let compile = Command::new(rustc_path())
+        .args(["--edition", "2021", "-o"])
+        .arg(&output)
+        .arg(&source)
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .output()
+        .expect("build activating workspace wrapper");
+    assert!(
+        compile.status.success(),
+        "building activating workspace wrapper failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    output
+}
+
+fn cargo_build(
+    project: &Path,
+    target_dir: &Path,
+    cache_dir: &Path,
+    input: &Path,
+    input_reader: &Path,
+) -> Output {
+    cargo_build_with_env(project, target_dir, cache_dir, input, input_reader, &[])
+}
+
+fn cargo_build_with_env(
+    project: &Path,
+    target_dir: &Path,
+    cache_dir: &Path,
+    input: &Path,
+    input_reader: &Path,
+    extra_env: &[(&str, &str)],
+) -> Output {
+    let mut command = Command::new("cargo");
+    command
+        .args([
+            "build",
+            "--offline",
+            "--verbose",
+            "--bin",
+            "extra-input-warm-target",
+        ])
+        .current_dir(project)
+        .env("RUSTC_WRAPPER", kache_binary())
+        .env("CARGO_TARGET_DIR", target_dir)
+        .env("CARGO_INCREMENTAL", "0")
+        .env("CARGO_TERM_COLOR", "never")
+        .env("KACHE_CACHE_DIR", cache_dir)
+        .env("KACHE_CACHE_EXECUTABLES", "1")
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
+        .env("KACHE_LOG", "kache=debug")
+        .env(INPUT_PATH_ENV, input)
+        .env(
+            "RUSTFLAGS",
+            format!("--extern=input_reader={}", input_reader.display()),
+        )
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .env_remove("KACHE_DISABLED");
+    for (name, value) in extra_env {
+        command.env(name, value);
+    }
+    command.output().expect("run Cargo through Kache")
+}
+
+fn assert_build_succeeded(output: &Output) {
+    assert!(
+        output.status.success(),
+        "Cargo build failed.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn fixture_event_count(cache_dir: &Path) -> usize {
+    std::fs::read_to_string(cache_dir.join("events.jsonl"))
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|event| event["crate_name"] == CRATE_NAME)
+        .count()
+}
+
+fn last_fixture_event_result(cache_dir: &Path) -> Option<String> {
+    std::fs::read_to_string(cache_dir.join("events.jsonl"))
+        .ok()?
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|event| event["crate_name"] == CRATE_NAME)
+        .filter_map(|event| event["result"].as_str().map(str::to_owned))
+        .next_back()
+}
+
+fn last_fixture_passthrough_reason(cache_dir: &Path) -> Option<String> {
+    std::fs::read_to_string(cache_dir.join("events.jsonl"))
+        .ok()?
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|event| event["crate_name"] == CRATE_NAME)
+        .filter_map(|event| event["passthrough_reason"].as_str().map(str::to_owned))
+        .next_back()
+}
+
+fn run_fixture(target_dir: &Path) -> String {
+    let mut binary = target_dir.join("debug").join("extra-input-warm-target");
+    if cfg!(windows) {
+        binary.set_extension("exe");
+    }
+    let output = Command::new(&binary)
+        .output()
+        .unwrap_or_else(|error| panic!("run {}: {error}", binary.display()));
+    assert!(output.status.success(), "fixture binary failed");
+    String::from_utf8(output.stdout).unwrap()
+}
+
+fn copy_tree(source: &Path, destination: &Path) {
+    std::fs::create_dir_all(destination).unwrap();
+    for entry in std::fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        let target = destination.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_tree(&entry.path(), &target);
+        } else {
+            std::fs::copy(entry.path(), target).unwrap();
+        }
+    }
+}
+
+fn run_daemon_command(cache_dir: &Path, subcommand: &str) -> Output {
+    let stdout_path = cache_dir.join(format!("daemon-{subcommand}.stdout"));
+    let stderr_path = cache_dir.join(format!("daemon-{subcommand}.stderr"));
+    let stdout = std::fs::File::create(&stdout_path).unwrap();
+    let stderr = std::fs::File::create(&stderr_path).unwrap();
+    let mut child = Command::new(kache_binary())
+        .args(["daemon", subcommand])
+        .env("KACHE_CACHE_DIR", cache_dir)
+        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
+        .env("KACHE_LOCAL_HIT_DAEMON", "1")
+        .env("KACHE_DAEMON_IDLE_TIMEOUT", "60")
+        .env("KACHE_LOG", "off")
+        .env_remove("KACHE_SOCKET_PATH")
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .stdin(std::process::Stdio::null())
+        .stdout(stdout)
+        .stderr(stderr)
+        .spawn()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let status = loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("kache daemon {subcommand} timed out");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    Output {
+        status,
+        stdout: std::fs::read(stdout_path).unwrap_or_default(),
+        stderr: std::fs::read(stderr_path).unwrap_or_default(),
+    }
+}
+
+struct DaemonGuard {
+    cache_dir: PathBuf,
+}
+
+impl DaemonGuard {
+    fn start(cache_dir: &Path) -> Self {
+        let output = run_daemon_command(cache_dir, "start");
+        assert!(
+            output.status.success(),
+            "daemon start failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        Self {
+            cache_dir: cache_dir.to_path_buf(),
+        }
+    }
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = run_daemon_command(&self.cache_dir, "stop");
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn exercise_uncached_lane(
+    project: &Path,
+    input: &Path,
+    input_reader: &Path,
+    before: &str,
+    after: &str,
+    extra_env: &[(&str, &str)],
+    expected_result: &str,
+    expected_reason: Option<&str>,
+) {
+    let target = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    std::fs::write(input, before).unwrap();
+
+    let cold = cargo_build_with_env(
+        project,
+        target.path(),
+        cache.path(),
+        input,
+        input_reader,
+        extra_env,
+    );
+    assert_build_succeeded(&cold);
+    assert_eq!(run_fixture(target.path()), before);
+    let cold_events = fixture_event_count(cache.path());
+    assert!(cold_events > 0);
+    assert_eq!(
+        last_fixture_event_result(cache.path()).as_deref(),
+        Some(expected_result)
+    );
+    if let Some(reason) = expected_reason {
+        assert!(
+            last_fixture_passthrough_reason(cache.path())
+                .as_deref()
+                .is_some_and(|actual| actual.contains(reason)),
+            "expected passthrough reason containing {reason:?}, got {:?}",
+            last_fixture_passthrough_reason(cache.path())
+        );
+    }
+
+    let warm = cargo_build_with_env(
+        project,
+        target.path(),
+        cache.path(),
+        input,
+        input_reader,
+        extra_env,
+    );
+    assert_build_succeeded(&warm);
+    assert_eq!(
+        fixture_event_count(cache.path()),
+        cold_events,
+        "unchanged uncached lane must still become Cargo-fresh"
+    );
+
+    std::fs::write(input, after).unwrap();
+    let changed = cargo_build_with_env(
+        project,
+        target.path(),
+        cache.path(),
+        input,
+        input_reader,
+        extra_env,
+    );
+    assert_build_succeeded(&changed);
+    assert!(fixture_event_count(cache.path()) > cold_events);
+    assert_eq!(run_fixture(target.path()), after);
+}
+
+fn cargo_reported_fixture_fresh(output: &Output) -> bool {
+    String::from_utf8_lossy(&output.stderr)
+        .lines()
+        .any(|line| line.contains("Fresh extra-input-warm-target"))
+}
+
+fn exercise_workspace_wrapper_lane(
+    project: &Path,
+    input: &Path,
+    input_reader: &Path,
+    before: &str,
+    after: &str,
+) {
+    let target = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    let workspace_wrapper = kache_binary().to_string_lossy().into_owned();
+    let extra_env = [("RUSTC_WORKSPACE_WRAPPER", workspace_wrapper.as_str())];
+    std::fs::write(input, before).unwrap();
+
+    let cold = cargo_build_with_env(
+        project,
+        target.path(),
+        cache.path(),
+        input,
+        input_reader,
+        &extra_env,
+    );
+    assert_build_succeeded(&cold);
+    assert_eq!(run_fixture(target.path()), before);
+
+    let warm = cargo_build_with_env(
+        project,
+        target.path(),
+        cache.path(),
+        input,
+        input_reader,
+        &extra_env,
+    );
+    assert_build_succeeded(&warm);
+    assert!(
+        cargo_reported_fixture_fresh(&warm),
+        "unchanged double-wrapper build must be Cargo-fresh:\n{}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+
+    std::fs::write(input, after).unwrap();
+    let changed = cargo_build_with_env(
+        project,
+        target.path(),
+        cache.path(),
+        input,
+        input_reader,
+        &extra_env,
+    );
+    assert_build_succeeded(&changed);
+    assert!(
+        !cargo_reported_fixture_fresh(&changed),
+        "declared-input edit must make the double-wrapper crate dirty"
+    );
+    assert_eq!(run_fixture(target.path()), after);
+
+    let settled = cargo_build_with_env(
+        project,
+        target.path(),
+        cache.path(),
+        input,
+        input_reader,
+        &extra_env,
+    );
+    assert_build_succeeded(&settled);
+    assert!(
+        cargo_reported_fixture_fresh(&settled),
+        "double-wrapper build must settle back to Cargo-fresh"
+    );
+}
+
+#[test]
+fn declared_extra_input_invalidates_a_real_warm_cargo_target() {
+    build_kache();
+
+    // Exercise Cargo's actual dep-info grammar: `#`, drive colons, and
+    // backslashes are literal; only spaces use the trailing-backslash join.
+    let project = tempfile::Builder::new()
+        .prefix("kache #workspace")
+        .tempdir()
+        .unwrap();
+    let target_dir = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    let scaffolding = TempDir::new().unwrap();
+    let input_reader = build_input_reader(scaffolding.path());
+
+    let member = project.path().join("app");
+    std::fs::create_dir_all(member.join("src")).unwrap();
+    std::fs::write(
+        project.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"app\"]\nresolver = \"2\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        member.join("Cargo.toml"),
+        r#"[package]
+name = "extra-input-warm-target"
+version = "0.1.0"
+edition = "2021"
+"#,
+    )
+    .unwrap();
+    std::fs::write(member.join("kache.toml"), "extra_inputs = []\n").unwrap();
+    std::fs::write(
+        member.join("src/main.rs"),
+        "fn main() { print!(\"{}\", input_reader::declared_value!()); }\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(member.join("data")).unwrap();
+    let declared_input = member.join("data/declared.txt");
+    std::fs::write(&declared_input, "v1").unwrap();
+
+    let cold = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&cold);
+    assert_eq!(run_fixture(target_dir.path()), "v1");
+    let cold_events = fixture_event_count(cache_dir.path());
+    assert!(cold_events > 0, "cold build should invoke Kache");
+
+    // Establish a genuinely warm, Cargo-fresh target before changing the only
+    // out-of-band input. No Rust source or build configuration changes below.
+    let warm = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&warm);
+    assert_eq!(
+        fixture_event_count(cache_dir.path()),
+        cold_events,
+        "unchanged warm build should stay Cargo-fresh"
+    );
+
+    // Even an explicit empty declaration watches kache.toml without changing
+    // the cache key, so activating it in a warm target invokes Kache.
+    std::fs::write(
+        member.join("kache.toml"),
+        "extra_inputs = [\"data/**/*.txt\"]\n",
+    )
+    .unwrap();
+    let activated = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&activated);
+    let activated_events = fixture_event_count(cache_dir.path());
+    assert!(
+        activated_events > cold_events,
+        "editing an empty declaration to active must invoke Kache"
+    );
+
+    std::fs::write(&declared_input, "v2").unwrap();
+
+    let changed = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&changed);
+    let changed_events = fixture_event_count(cache_dir.path());
+    let changed_output = run_fixture(target_dir.path());
+    assert!(
+        changed_events > activated_events && changed_output == "v2",
+        "editing only the declared extra input must make Cargo invoke Kache and refresh the \
+         compiled output; Kache events {cold_events} -> {changed_events}, output after build \
+         was {changed_output:?}\nCargo stderr:\n{}",
+        String::from_utf8_lossy(&changed.stderr),
+    );
+    assert!(
+        String::from_utf8_lossy(&changed.stderr).contains("Compiling extra-input-warm-target"),
+        "changed input should make Cargo report a recompilation"
+    );
+
+    let unchanged_after_edit = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&unchanged_after_edit);
+    assert_eq!(
+        fixture_event_count(cache_dir.path()),
+        changed_events,
+        "unchanged follow-up after an edit must become Cargo-fresh again"
+    );
+
+    // A directory watch must catch a genuinely new glob member and its later
+    // removal, not only edits/deletion of a previously matched literal path.
+    let added_glob_member = member.join("data/added.txt");
+    std::fs::write(&added_glob_member, "additional").unwrap();
+    let glob_added = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&glob_added);
+    let glob_added_events = fixture_event_count(cache_dir.path());
+    assert!(
+        glob_added_events > changed_events,
+        "adding a new file to a declared glob must invoke Kache"
+    );
+
+    std::fs::remove_file(&added_glob_member).unwrap();
+    let glob_removed = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&glob_removed);
+    let glob_removed_events = fixture_event_count(cache_dir.path());
+    assert!(
+        glob_removed_events > glob_added_events,
+        "removing a file from a declared glob must invoke Kache"
+    );
+
+    // The config itself is part of Cargo freshness. Changing the declaration
+    // must invoke Kache even though no Rust source or compile-time value moved.
+    std::fs::write(
+        member.join("kache.toml"),
+        "extra_inputs = [\"data/**/*.txt\", \"data/future.txt\"]\n",
+    )
+    .unwrap();
+    let config_changed = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&config_changed);
+    let config_events = fixture_event_count(cache_dir.path());
+    assert!(
+        config_events > glob_removed_events,
+        "editing kache.toml must invoke Kache"
+    );
+    assert_eq!(run_fixture(target_dir.path()), "v2");
+
+    let unchanged_after_config = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&unchanged_after_config);
+    assert_eq!(
+        fixture_event_count(cache_dir.path()),
+        config_events,
+        "unchanged follow-up after a config edit must become Cargo-fresh"
+    );
+
+    // Deleting and then adding the compile-time input exercise both sides of
+    // a watch transition: the present file dependency catches deletion, and
+    // the bounded parent watch written by the deletion build catches re-add.
+    std::fs::remove_file(&declared_input).unwrap();
+    let deleted = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&deleted);
+    let deleted_events = fixture_event_count(cache_dir.path());
+    assert!(
+        deleted_events > config_events,
+        "deleting a declared input must invoke Kache"
+    );
+    assert_eq!(run_fixture(target_dir.path()), "missing");
+
+    let unchanged_after_delete = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&unchanged_after_delete);
+    assert_eq!(
+        fixture_event_count(cache_dir.path()),
+        deleted_events,
+        "a still-missing input must not make every Cargo build dirty"
+    );
+
+    std::fs::write(&declared_input, "v3").unwrap();
+    let added = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&added);
+    let added_events = fixture_event_count(cache_dir.path());
+    assert!(
+        added_events > deleted_events,
+        "adding a declared input must invoke Kache"
+    );
+    assert_eq!(run_fixture(target_dir.path()), "v3");
+
+    let unchanged_after_add = cargo_build(
+        project.path(),
+        target_dir.path(),
+        cache_dir.path(),
+        &declared_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&unchanged_after_add);
+    assert_eq!(
+        fixture_event_count(cache_dir.path()),
+        added_events,
+        "unchanged follow-up after an addition must become Cargo-fresh"
+    );
+
+    // Restore the same key into a relocated workspace and target. Cached
+    // dep-info is producer-neutral; the wrapper must augment the restored
+    // consumer copy before returning to Cargo, including for legacy entries.
+    let relocated_project = tempfile::Builder::new()
+        .prefix("relocated #workspace")
+        .tempdir()
+        .unwrap();
+    let relocated_member = relocated_project.path().join("app");
+    std::fs::create_dir_all(relocated_member.join("src")).unwrap();
+    std::fs::create_dir_all(relocated_member.join("data")).unwrap();
+    for relative in [
+        "Cargo.toml",
+        "Cargo.lock",
+        "app/Cargo.toml",
+        "app/kache.toml",
+        "app/src/main.rs",
+        "app/data/declared.txt",
+    ] {
+        std::fs::copy(
+            project.path().join(relative),
+            relocated_project.path().join(relative),
+        )
+        .unwrap_or_else(|error| panic!("copy relocated fixture {relative}: {error}"));
+    }
+    let relocated_input = relocated_member.join("data/declared.txt");
+    let restored_target = TempDir::new().unwrap();
+    let restored = cargo_build(
+        relocated_project.path(),
+        restored_target.path(),
+        cache_dir.path(),
+        &relocated_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&restored);
+    assert_eq!(
+        last_fixture_event_result(cache_dir.path()).as_deref(),
+        Some("local_hit"),
+        "fresh target should restore the already-cached v3 artifact"
+    );
+    assert_eq!(run_fixture(restored_target.path()), "v3");
+    let restored_events = fixture_event_count(cache_dir.path());
+
+    let restored_unchanged = cargo_build(
+        relocated_project.path(),
+        restored_target.path(),
+        cache_dir.path(),
+        &relocated_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&restored_unchanged);
+    assert_eq!(
+        fixture_event_count(cache_dir.path()),
+        restored_events,
+        "restored dep-info must leave the next unchanged build Cargo-fresh"
+    );
+
+    let restored_dep_info = std::fs::read_dir(restored_target.path().join("debug/deps"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.extension().is_some_and(|extension| extension == "d")
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("extra_input_warm_target-"))
+        })
+        .expect("restored consumer dep-info");
+    let restored_dep_info = std::fs::read_to_string(restored_dep_info).unwrap();
+    let producer = std::fs::canonicalize(project.path()).unwrap();
+    let consumer = std::fs::canonicalize(relocated_project.path()).unwrap();
+    let cargo_word = |path: &Path| path.to_string_lossy().replace(' ', "\\ ");
+    assert!(
+        !restored_dep_info.contains(&cargo_word(&producer)),
+        "restored dep-info retained the producer workspace: {restored_dep_info}"
+    );
+    assert!(
+        restored_dep_info.contains(&cargo_word(&consumer)),
+        "restored dep-info did not name the current consumer: {restored_dep_info}"
+    );
+
+    std::fs::write(&relocated_input, "v4").unwrap();
+    let changed_after_restore = cargo_build(
+        relocated_project.path(),
+        restored_target.path(),
+        cache_dir.path(),
+        &relocated_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&changed_after_restore);
+    assert!(
+        fixture_event_count(cache_dir.path()) > restored_events,
+        "declared input edit after a local hit must invoke Kache"
+    );
+    assert_eq!(run_fixture(restored_target.path()), "v4");
+
+    // The daemon-local lane reads metadata from cache A without opening cache
+    // B's SQLite. Copy only blobs so a successful fresh-target restore proves
+    // `BlobSource::StoreDir` completed the consumer dep-info.
+    let daemon_cache = TempDir::new().unwrap();
+    copy_tree(
+        &cache_dir.path().join("store/blobs"),
+        &daemon_cache.path().join("store/blobs"),
+    );
+    let daemon_target = TempDir::new().unwrap();
+    let _daemon = DaemonGuard::start(cache_dir.path());
+    let daemon_socket = cache_dir.path().join("daemon.sock");
+    let daemon_socket_text = daemon_socket.to_string_lossy().into_owned();
+    let daemon_env = [
+        ("KACHE_LOCAL_HIT_DAEMON", "1"),
+        ("KACHE_SOCKET_PATH", daemon_socket_text.as_str()),
+        ("KACHE_LOCAL_HIT_TIMEOUT_MS", "1000"),
+    ];
+    let daemon_hit = cargo_build_with_env(
+        relocated_project.path(),
+        daemon_target.path(),
+        daemon_cache.path(),
+        &relocated_input,
+        &input_reader,
+        &daemon_env,
+    );
+    assert_build_succeeded(&daemon_hit);
+    assert_eq!(run_fixture(daemon_target.path()), "v4");
+    assert_eq!(
+        last_fixture_event_result(daemon_cache.path()).as_deref(),
+        Some("local_hit")
+    );
+    assert!(
+        !daemon_cache.path().join("index.db").exists(),
+        "daemon hit must not fall back to opening the consumer store"
+    );
+    let daemon_events = fixture_event_count(daemon_cache.path());
+
+    let daemon_fresh = cargo_build_with_env(
+        relocated_project.path(),
+        daemon_target.path(),
+        daemon_cache.path(),
+        &relocated_input,
+        &input_reader,
+        &daemon_env,
+    );
+    assert_build_succeeded(&daemon_fresh);
+    assert_eq!(
+        fixture_event_count(daemon_cache.path()),
+        daemon_events,
+        "unchanged daemon-restored target must remain Cargo-fresh"
+    );
+
+    std::fs::write(&relocated_input, "daemon-v5").unwrap();
+    let daemon_miss = cargo_build_with_env(
+        relocated_project.path(),
+        daemon_target.path(),
+        daemon_cache.path(),
+        &relocated_input,
+        &input_reader,
+        &daemon_env,
+    );
+    assert_build_succeeded(&daemon_miss);
+    assert!(fixture_event_count(daemon_cache.path()) > daemon_events);
+    assert_eq!(run_fixture(daemon_target.path()), "daemon-v5");
+    assert!(
+        daemon_cache.path().join("index.db").exists(),
+        "new key must miss the donor daemon and compile through the consumer store"
+    );
+
+    exercise_uncached_lane(
+        relocated_project.path(),
+        &relocated_input,
+        &input_reader,
+        "v4",
+        "v5",
+        &[("KACHE_MIN_STORE_COMPILE_MS", "18446744073709551615")],
+        "skipped",
+        None,
+    );
+    exercise_uncached_lane(
+        relocated_project.path(),
+        &relocated_input,
+        &input_reader,
+        "v5",
+        "v6",
+        &[
+            ("KACHE_CACHE_EXECUTABLES", "0"),
+            ("KACHE_ADAPTIVE_INCREMENTAL", "0"),
+        ],
+        "passthrough",
+        Some("cache_executables=false"),
+    );
+    exercise_uncached_lane(
+        relocated_project.path(),
+        &relocated_input,
+        &input_reader,
+        "v6",
+        "v7",
+        &[
+            ("KACHE_CACHE_EXECUTABLES", "0"),
+            ("KACHE_PRESERVE_INCREMENTAL", "1"),
+            ("CARGO_INCREMENTAL", "1"),
+        ],
+        "passthrough",
+        Some("cache_executables=false"),
+    );
+    exercise_workspace_wrapper_lane(
+        relocated_project.path(),
+        &relocated_input,
+        &input_reader,
+        "v7",
+        "v8",
+    );
+
+    // If the wrapper is already running when kache.toml appears, Kache can and
+    // must reject that one invocation. This is separate from the documented
+    // already-Fresh bootstrap case below, where Cargo never invokes a wrapper.
+    let activation_project = tempfile::Builder::new()
+        .prefix("activation-race #workspace")
+        .tempdir()
+        .unwrap();
+    copy_tree(relocated_project.path(), activation_project.path());
+    let activation_member = activation_project.path().join("app");
+    let activation_config = activation_member.join("kache.toml");
+    let activation_input = activation_member.join("data/declared.txt");
+    std::fs::remove_file(&activation_config).unwrap();
+    std::fs::write(&activation_input, "v8").unwrap();
+    let activation_target = TempDir::new().unwrap();
+    let activation_cache = TempDir::new().unwrap();
+    let activating_wrapper = build_activating_workspace_wrapper(scaffolding.path());
+    let activating_wrapper_text = activating_wrapper.to_string_lossy().into_owned();
+    let activation_config_text = activation_config.to_string_lossy().into_owned();
+    let activation_env = [
+        ("RUSTC_WORKSPACE_WRAPPER", activating_wrapper_text.as_str()),
+        (ACTIVATE_CONFIG_ENV, activation_config_text.as_str()),
+    ];
+    let raced = cargo_build_with_env(
+        activation_project.path(),
+        activation_target.path(),
+        activation_cache.path(),
+        &activation_input,
+        &input_reader,
+        &activation_env,
+    );
+    assert!(
+        !raced.status.success()
+            && String::from_utf8_lossy(&raced.stderr).contains("extra_inputs declaration changed"),
+        "activation race must fail for a clean retry:\n{}",
+        String::from_utf8_lossy(&raced.stderr)
+    );
+    assert!(activation_config.is_file());
+
+    let retried = cargo_build_with_env(
+        activation_project.path(),
+        activation_target.path(),
+        activation_cache.path(),
+        &activation_input,
+        &input_reader,
+        &activation_env,
+    );
+    assert_build_succeeded(&retried);
+    assert_eq!(run_fixture(activation_target.path()), "v8");
+
+    // Kache cannot retrofit Cargo's fingerprint when a previously
+    // unconfigured target is already Fresh: Cargo never starts the wrapper.
+    // Prove the documented one-time bootstrap, then prove normal tracking.
+    let bootstrap_project = tempfile::Builder::new()
+        .prefix("bootstrap #workspace")
+        .tempdir()
+        .unwrap();
+    copy_tree(relocated_project.path(), bootstrap_project.path());
+    let bootstrap_member = bootstrap_project.path().join("app");
+    let bootstrap_input = bootstrap_member.join("data/declared.txt");
+    std::fs::remove_file(bootstrap_member.join("kache.toml")).unwrap();
+    std::fs::write(&bootstrap_input, "v8").unwrap();
+    let bootstrap_target = TempDir::new().unwrap();
+    let bootstrap_cache = TempDir::new().unwrap();
+
+    let pre_upgrade = cargo_build(
+        bootstrap_project.path(),
+        bootstrap_target.path(),
+        bootstrap_cache.path(),
+        &bootstrap_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&pre_upgrade);
+    assert_eq!(run_fixture(bootstrap_target.path()), "v8");
+    let pre_upgrade_events = fixture_event_count(bootstrap_cache.path());
+
+    std::fs::write(
+        bootstrap_member.join("kache.toml"),
+        "extra_inputs = [\"data/**/*.txt\"]\n",
+    )
+    .unwrap();
+    std::fs::write(&bootstrap_input, "v9").unwrap();
+    let still_fresh = cargo_build(
+        bootstrap_project.path(),
+        bootstrap_target.path(),
+        bootstrap_cache.path(),
+        &bootstrap_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&still_fresh);
+    assert!(cargo_reported_fixture_fresh(&still_fresh));
+    assert_eq!(run_fixture(bootstrap_target.path()), "v8");
+    assert_eq!(
+        fixture_event_count(bootstrap_cache.path()),
+        pre_upgrade_events,
+        "adding kache.toml cannot invoke a wrapper Cargo already considers Fresh"
+    );
+
+    let clean = Command::new("cargo")
+        .args(["clean", "--package", "extra-input-warm-target"])
+        .current_dir(bootstrap_project.path())
+        .env("CARGO_TARGET_DIR", bootstrap_target.path())
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .output()
+        .unwrap();
+    assert!(
+        clean.status.success(),
+        "bootstrap cargo clean failed:\n{}",
+        String::from_utf8_lossy(&clean.stderr)
+    );
+    let bootstrapped = cargo_build(
+        bootstrap_project.path(),
+        bootstrap_target.path(),
+        bootstrap_cache.path(),
+        &bootstrap_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&bootstrapped);
+    assert_eq!(run_fixture(bootstrap_target.path()), "v9");
+
+    let bootstrapped_events = fixture_event_count(bootstrap_cache.path());
+    std::fs::write(&bootstrap_input, "v10").unwrap();
+    let tracked_after_bootstrap = cargo_build(
+        bootstrap_project.path(),
+        bootstrap_target.path(),
+        bootstrap_cache.path(),
+        &bootstrap_input,
+        &input_reader,
+    );
+    assert_build_succeeded(&tracked_after_bootstrap);
+    assert!(fixture_event_count(bootstrap_cache.path()) > bootstrapped_events);
+    assert_eq!(run_fixture(bootstrap_target.path()), "v10");
+}

--- a/tests/extra_inputs_warm_target_test.rs
+++ b/tests/extra_inputs_warm_target_test.rs
@@ -781,24 +781,30 @@ edition = "2021"
         .unwrap()
         .filter_map(Result::ok)
         .map(|entry| entry.path())
-        .find(|path| {
-            path.extension().is_some_and(|extension| extension == "d")
-                && path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name.starts_with("extra_input_warm_target-"))
+        .filter(|path| path.extension().is_some_and(|extension| extension == "d"))
+        .find_map(|path| {
+            let content = std::fs::read_to_string(path).ok()?;
+            (content.contains("kache.toml") && content.contains("declared.txt")).then_some(content)
         })
         .expect("restored consumer dep-info");
-    let restored_dep_info = std::fs::read_to_string(restored_dep_info).unwrap();
     let producer = std::fs::canonicalize(project.path()).unwrap();
     let consumer = std::fs::canonicalize(relocated_project.path()).unwrap();
-    let cargo_word = |path: &Path| path.to_string_lossy().replace(' ', "\\ ");
+    let normalize_dep_info_spelling = |value: &str| {
+        value
+            .strip_prefix(r"\\?\")
+            .unwrap_or(value)
+            .replace("\\ ", " ")
+            .replace('\\', "/")
+    };
+    let restored_dep_info = normalize_dep_info_spelling(&restored_dep_info);
+    let producer = normalize_dep_info_spelling(&producer.to_string_lossy());
+    let consumer = normalize_dep_info_spelling(&consumer.to_string_lossy());
     assert!(
-        !restored_dep_info.contains(&cargo_word(&producer)),
+        !restored_dep_info.contains(&producer),
         "restored dep-info retained the producer workspace: {restored_dep_info}"
     );
     assert!(
-        restored_dep_info.contains(&cargo_word(&consumer)),
+        restored_dep_info.contains(&consumer),
         "restored dep-info did not name the current consumer: {restored_dep_info}"
     );
 

--- a/tests/extra_inputs_warm_target_test.rs
+++ b/tests/extra_inputs_warm_target_test.rs
@@ -847,12 +847,6 @@ edition = "2021"
     // The daemon-local lane reads metadata from cache A without opening cache
     // B's SQLite. Copy only blobs so a successful fresh-target restore proves
     // `BlobSource::StoreDir` completed the consumer dep-info.
-    let daemon_cache = TempDir::new().unwrap();
-    copy_tree(
-        &cache_dir.path().join("store/blobs"),
-        &daemon_cache.path().join("store/blobs"),
-    );
-    let daemon_target = TempDir::new().unwrap();
     let _daemon = DaemonGuard::start(cache_dir.path());
     let daemon_socket = cache_dir.path().join("daemon.sock");
     let daemon_socket_text = daemon_socket.to_string_lossy().into_owned();
@@ -861,24 +855,50 @@ edition = "2021"
         ("KACHE_SOCKET_PATH", daemon_socket_text.as_str()),
         ("KACHE_LOCAL_HIT_TIMEOUT_MS", "1000"),
     ];
-    let daemon_hit = cargo_build_with_env(
-        relocated_project.path(),
-        daemon_target.path(),
-        daemon_cache.path(),
-        &relocated_input,
-        &input_reader,
-        &daemon_env,
-    );
-    assert_build_succeeded(&daemon_hit);
-    assert_eq!(run_fixture(daemon_target.path()), "v4");
-    assert_eq!(
-        last_fixture_event_result(daemon_cache.path()).as_deref(),
-        Some("local_hit")
-    );
-    assert!(
-        !daemon_cache.path().join("index.db").exists(),
-        "daemon hit must not fall back to opening the consumer store"
-    );
+    // The daemon deliberately sheds lookup work after 50ms. A saturated CI
+    // runner may therefore take the sound local fallback even though the
+    // donor entry is present. Retry with a fresh consumer cache/target so the
+    // test still proves an actual daemon restore without weakening that
+    // production latency bound.
+    let mut fallback_results = Vec::new();
+    let (daemon_cache, daemon_target) = (0..8)
+        .find_map(|_| {
+            let daemon_cache = TempDir::new().unwrap();
+            copy_tree(
+                &cache_dir.path().join("store/blobs"),
+                &daemon_cache.path().join("store/blobs"),
+            );
+            let daemon_target = TempDir::new().unwrap();
+            let daemon_hit = cargo_build_with_env(
+                relocated_project.path(),
+                daemon_target.path(),
+                daemon_cache.path(),
+                &relocated_input,
+                &input_reader,
+                &daemon_env,
+            );
+            assert_build_succeeded(&daemon_hit);
+            assert_eq!(run_fixture(daemon_target.path()), "v4");
+            let result = last_fixture_event_result(daemon_cache.path());
+            if result.as_deref() == Some("local_hit")
+                && !daemon_cache.path().join("index.db").exists()
+            {
+                Some((daemon_cache, daemon_target))
+            } else {
+                fallback_results.push((
+                    result,
+                    String::from_utf8_lossy(&daemon_hit.stderr).into_owned(),
+                    std::fs::read_to_string(daemon_cache.path().join("events.jsonl"))
+                        .unwrap_or_default(),
+                ));
+                None
+            }
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "donor daemon never produced a local hit from 8 fresh consumers: {fallback_results:?}"
+            )
+        });
     let daemon_events = fixture_event_count(daemon_cache.path());
 
     let daemon_fresh = cargo_build_with_env(

--- a/tests/extra_inputs_warm_target_test.rs
+++ b/tests/extra_inputs_warm_target_test.rs
@@ -787,24 +787,45 @@ edition = "2021"
             (content.contains("kache.toml") && content.contains("declared.txt")).then_some(content)
         })
         .expect("restored consumer dep-info");
+    let dependencies = restored_dep_info
+        .lines()
+        .find_map(|line| {
+            (!line.starts_with("# env-dep:"))
+                .then(|| line.find(": ").map(|separator| &line[separator + 2..]))
+                .flatten()
+        })
+        .expect("Cargo dependency rule");
+    let mut parsed_dependencies = Vec::new();
+    let mut current = String::new();
+    for word in dependencies.split_whitespace() {
+        if let Some(continued) = word.strip_suffix('\\') {
+            current.push_str(continued);
+            current.push(' ');
+        } else {
+            current.push_str(word);
+            parsed_dependencies.push(PathBuf::from(std::mem::take(&mut current)));
+        }
+    }
+    assert!(current.is_empty(), "unterminated Cargo dependency path");
+    let canonical_dependencies: Vec<_> = parsed_dependencies
+        .iter()
+        .filter_map(|path| std::fs::canonicalize(path).ok())
+        .collect();
     let producer = std::fs::canonicalize(project.path()).unwrap();
     let consumer = std::fs::canonicalize(relocated_project.path()).unwrap();
-    let normalize_dep_info_spelling = |value: &str| {
-        value
-            .strip_prefix(r"\\?\")
-            .unwrap_or(value)
-            .replace("\\ ", " ")
-            .replace('\\', "/")
-    };
-    let restored_dep_info = normalize_dep_info_spelling(&restored_dep_info);
-    let producer = normalize_dep_info_spelling(&producer.to_string_lossy());
-    let consumer = normalize_dep_info_spelling(&consumer.to_string_lossy());
     assert!(
-        !restored_dep_info.contains(&producer),
+        canonical_dependencies
+            .iter()
+            .all(|dependency| !dependency.starts_with(&producer)),
         "restored dep-info retained the producer workspace: {restored_dep_info}"
     );
     assert!(
-        restored_dep_info.contains(&consumer),
+        canonical_dependencies.iter().any(|dependency| {
+            dependency.starts_with(&consumer)
+                && dependency
+                    .file_name()
+                    .is_some_and(|name| name == "kache.toml")
+        }),
         "restored dep-info did not name the current consumer: {restored_dep_info}"
     );
 


### PR DESCRIPTION
Parent: #722

Fixes #723
Closes #724

## Summary

- complete Cargo-facing rustc dep-info with each crate's `kache.toml`, matched extra inputs, and bounded directory watches
- apply the same snapshot across misses, every cache-hit lane, no-store/passthrough, and double-wrapper execution
- fail closed for unsafe declarations, races, stale cache entries, symlinks, unsupported dep-info layouts, and checksum freshness
- remove the now-obsolete recursive `doctor` build-script audit and its comma-joined duplicate output
- document the one-time warm-target bootstrap and supported checksum-freshness fallback

## Correctness coverage

The real-Cargo regression covers warm edit/add/delete/config changes, empty-to-active declarations, Cargo-fresh no-ops, relocated local hits, daemon hits, no-store, passthrough, preserved-incremental requests, double wrappers, and the pre-support bootstrap boundary.

## Validation

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`
