### PR TITLE
test(daemon): hold the late socket until the waiter observes it

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8077,15 +8077,25 @@ mod tests {
         let socket_path = dir.path().join("daemon.sock");
         let socket_path_bg = socket_path.clone();
 
+        // The property under test is that the waiter survives the socket's
+        // absence and then observes it. The listener appears late, and stays
+        // up until the waiter has its answer: dropping it after a fixed
+        // window instead let a loaded runner miss the whole window between
+        // reachability probes (seen as flakes on the macOS runner). The
+        // recv_timeout is a hard failure bound, never a silent early drop.
+        let (done_tx, done_rx) = mpsc::channel::<()>();
         let handle = std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(150));
             let listener = bind_sync_listener(&socket_path_bg);
-            std::thread::sleep(Duration::from_millis(200));
+            done_rx
+                .recv_timeout(Duration::from_secs(60))
+                .expect("test did not report a wait result");
             drop(listener);
         });
 
-        let ready = wait_for_socket_until(&socket_path, None, Duration::from_secs(1)).unwrap();
+        let ready = wait_for_socket_until(&socket_path, None, Duration::from_secs(30)).unwrap();
 
+        done_tx.send(()).unwrap();
         handle.join().unwrap();
         assert!(ready);
     }


### PR DESCRIPTION
`Test (macOS)` failed twice in a row today (post-merge main for #729 and PR #732, both on `test_wait_for_socket_until_observes_late_socket`, `assertion failed: ready`). Same disease #729 just fixed in the recovery tests: a fixed-duration timing window.

The test bound the listener 150ms in and dropped it 200ms later. `wait_for_socket_until` probes reachability in a loop, so on a loaded runner the probes can miss the whole 200ms live window, or the bind itself can slip past the 1s deadline. Either way `ready` comes back false with nothing actually broken.

The fix keeps the delayed bind, since late arrival is the property under test, but holds the listener until the waiter has reported its result. The release channel's timeout is a hard test failure rather than a silent early drop, and the wait deadline is generous because it only bounds how long a genuine failure takes.

Validation: 5 consecutive clean runs of the `wait_for_socket` tests locally (macOS); fmt clean.