### PR TITLE
test(daemon): remove the timing window in the socket-wait tests

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8077,15 +8077,22 @@ mod tests {
         let socket_path = dir.path().join("daemon.sock");
         let socket_path_bg = socket_path.clone();
 
+        // Same race as the clean-child-exit test below: a fixed 200ms hold left
+        // the socket present only between t=150ms and t=350ms, so a poll
+        // landing either side of that window on a loaded runner saw nothing.
+        // Hold it until the waiter is done instead.
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+
         let handle = std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(150));
             let listener = bind_sync_listener(&socket_path_bg);
-            std::thread::sleep(Duration::from_millis(200));
+            let _ = release_rx.recv();
             drop(listener);
         });
 
-        let ready = wait_for_socket_until(&socket_path, None, Duration::from_secs(1)).unwrap();
+        let ready = wait_for_socket_until(&socket_path, None, Duration::from_secs(10)).unwrap();
 
+        let _ = release_tx.send(());
         handle.join().unwrap();
         assert!(ready);
     }
@@ -8106,20 +8113,43 @@ mod tests {
         let socket_path = dir.path().join("daemon.sock");
         let socket_path_bg = socket_path.clone();
 
+        // The listener is held until the waiter has finished, rather than for a
+        // fixed 200ms. Previously the socket existed only between t=150ms and
+        // t=350ms, so on a loaded runner a poll landing either side of that
+        // window saw nothing and `assert!(ready)` failed. The macOS leg flaked
+        // on exactly this.
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let (bound_tx, bound_rx) = std::sync::mpsc::channel::<()>();
+
         let handle = std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(150));
             let listener = bind_sync_listener(&socket_path_bg);
-            std::thread::sleep(Duration::from_millis(200));
+            let _ = bound_tx.send(());
+            // Stay bound until the main thread says it is done.
+            let _ = release_rx.recv();
             drop(listener);
         });
 
         let mut child = spawn_quick_exit_child();
 
+        // Deliberately generous: this test is about a clean child exit not
+        // aborting the wait, not about the timeout. A tight bound only
+        // reintroduces sensitivity to how fast the runner schedules the thread
+        // above — `test_wait_for_socket_until_times_out_cleanly` covers the
+        // timeout itself.
         let ready =
-            wait_for_socket_until(&socket_path, Some(&mut child), Duration::from_secs(1)).unwrap();
+            wait_for_socket_until(&socket_path, Some(&mut child), Duration::from_secs(10)).unwrap();
 
+        let _ = release_tx.send(());
         handle.join().unwrap();
+
         assert!(ready);
+        // Guard against passing for the wrong reason: the socket must actually
+        // have been bound, not merely reported reachable.
+        assert!(
+            bound_rx.try_recv().is_ok(),
+            "the background listener never bound"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

`Test (macOS)` failed on #731 with:

```
daemon::tests::test_wait_for_socket_until_ignores_clean_child_exit_if_socket_appears
panicked at src/daemon.rs:8084: assertion failed: ready
```

That PR changes **no Rust at all** — only workflows, the Justfile and two shell scripts — so it cannot have caused this. A re-run of the same commit passed, which is what a flake looks like.

## The race

Both socket-wait tests did this:

```rust
std::thread::sleep(Duration::from_millis(150));
let listener = bind_sync_listener(&socket_path_bg);
std::thread::sleep(Duration::from_millis(200));
drop(listener);
```

So the socket exists only during `[150ms, 350ms]`, while `wait_for_socket_until` polls every `DAEMON_START_POLL_INTERVAL` (100 ms) against a **1 second** deadline.

Two ways that loses:

- a scheduling stall of ~200 ms drops both in-window polls; or
- **more likely** — the background thread is starved enough that it does not bind before the 1 s deadline expires at all. A 150 ms sleep plus thread scheduling has to fit inside 1 s on a runner already running several test binaries in parallel.

## The fix

Hold the listener until the waiter has finished, rather than on a timer, and raise the deadline to 10 s.

Neither test is *about* the timeout — `test_wait_for_socket_until_times_out_cleanly` covers that directly — so the tight 1 s bound bought nothing except sensitivity to how quickly the runner schedules a thread.

The clean-child-exit test now also asserts the listener actually bound, so it cannot pass for the wrong reason (previously `ready == true` was the only signal, and a test that returns early for an unrelated reason would look identical).

## What I did and did not verify

- ✅ Both tests pass 25/25 under full CPU load with the fix.
- ❌ **I could not reproduce the original failure locally.** The unmodified tests also passed 25/25 under the same load — my machine does not starve a thread for the ~850 ms it would take.

So this is justified *by construction* — it removes a window and a deadline that demonstrably exist in the code — not by a local repro. The CI failure plus its clean re-run is the evidence the flake is real. Stating that plainly rather than implying I proved the fix end to end.

## Note

`cargo clippy -D warnings` reports one pre-existing error in `src/remote_backend.rs:190` (`this boolean expression can be simplified`). It is present on pristine `origin/main` and is untouched here.