### PR TITLE
chore: bump kache to v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more, with S3 and shared-filesystem remotes."
 license = "Apache-2.0"
@@ -36,7 +36,7 @@ reqsign-aws-v4 = { version = "=3.0.2", default-features = false }
 reqsign-core = { version = "=3.1.0", default-features = false }
 # Direct dep so OpenDAL/reqwest can use ring without reintroducing aws-lc.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.13.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.14.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bumps the kache workspace version to v0.14.0 (all 4 member manifests, the `kache-core` dep-pin, and `Cargo.lock`) via `just bump 0.14.0`. No dependency churn.

## Release readiness
- `CACHE_KEY_VERSION` is already at **24** on main (was 22 at v0.13.0), bumped by `c504a8c` (cross-clone key convergence) and `af3e19c` (portable archive identity). Nothing key-affecting landed after that last bump: `433f898`'s `cache_key.rs` change is a too-new guard, `extra_inputs` is opt-in and keys byte-identically when unconfigured, and `55a3903` changes stored dep-info content rather than key derivation. **This release invalidates all existing cache entries.**
- `PROBE_SCHEMA_VERSION` unchanged at 4.
- No hand-maintained version strings need editing: the flake derives `version` from `Cargo.toml`, `docker-bake.hcl` takes `VERSION` as a variable, the binary reads `KACHE_VERSION` from the tag, and `aur/*/PKGBUILD` `pkgver` is rewritten by the `aur` CI job at publish time (never committed back).

## Release plan
- Squash this PR after CI is green.
- From synced main, run `just release`.
- Monitor CI, Service Image, Publish crates, Package Publish, Homebrew, Winget, Scoop, and Chocolatey.