### PR TITLE
fix(key): bump CACHE_KEY_VERSION to 25 for the Windows dep-info rewrite (#730)

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -190,7 +190,20 @@ use std::path::{Path, PathBuf};
 // make the invocation uncacheable because their external bytes are absent from
 // the container. This intentionally gives up #471/#691 cross-clone reuse when
 // member names differ, preferring false misses over false hits.
-pub(crate) const CACHE_KEY_VERSION: u32 = 24;
+//
+// v25 (kunobi-ninja/kache#730): the Windows dep-info rewrite (#733) is escape-
+// aware per line, but the entries the OLD rewrite already stored under v24 stay
+// reachable, and they are not merely stale — they are build-breakers. The old
+// whole-content `Relativize` could split an escaped `\\` pair while anchoring,
+// so the CORRUPTION IS BAKED INTO THE STORED BYTES: the fixed `Expand` cannot
+// repair an orphan escape, and cargo hard-rejects the restored `.d` with
+// "unknown escape character", failing the compile on every hit (the nightly
+// Firefox/Windows bench reproduced exactly this). The mixed fleet is exposed
+// both ways too — a pre-#733 client restoring a correctly stored entry runs the
+// old unescaped `Expand` and re-corrupts it. Both directions share key v24, so
+// only a bump makes them unreachable. Cost is one cold rebuild, which v0.13.0
+// users (key v22) already pay crossing to this release regardless.
+pub(crate) const CACHE_KEY_VERSION: u32 = 25;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
 /// Collapse runs of ASCII whitespace into single spaces and trim


### PR DESCRIPTION
## Why

#733 made the Windows dep-info rewrite escape-aware per line, but it did **not** move the cache key. The entries the *old* rewrite already stored under **v24** stay reachable — and they are not merely stale, they are **build-breakers**.

The old whole-content `Relativize` (`src/link.rs`) could split an escaped `\\` pair while anchoring, so **the corruption is baked into the stored bytes**. The fixed `Expand` cannot repair an orphan escape, and cargo hard-rejects the restored `.d` with `unknown escape character` — failing the compile on *every* hit. That is exactly what the nightly Firefox/Windows pull bench kept reproducing.

The mixed fleet is exposed in both directions:
1. **Poison already stored.** A pre-#733 client stored a split-escape `.d` under v24; a fixed client restoring it still fails the compile.
2. **Re-poisoning.** A pre-#733 client restoring a *correctly* stored entry runs the old unescaped `Expand` and corrupts it again.

Both directions share key v24, so only a version bump makes them unreachable.

## What

One-line bump `CACHE_KEY_VERSION: 24 → 25`, plus the history entry the file's "one constant, one bump" discipline requires (v16–v24 all carry one, several for smaller reasons than a deterministic build failure).

## Cost

One cold rebuild — which v0.13.0 users (key **v22**) already pay crossing to the next release regardless, so the marginal cost to released users is zero. The bump lands before the v0.14.0 tag so the release ships a clean key space.

No test pins the literal (`compiler/cc.rs` derives from the constant), so this is the only change needed.

Refs #730, follows #733.