### PR TITLE
test(daemon): hold the socket in the clean-child-exit test too

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8116,18 +8116,28 @@ mod tests {
         let socket_path = dir.path().join("daemon.sock");
         let socket_path_bg = socket_path.clone();
 
+        // Same race #734 fixed in the sibling test above, which this one kept:
+        // the socket existed only during [150ms, 350ms] while the waiter polls
+        // every DAEMON_START_POLL_INTERVAL (100ms) against a 1s deadline. On a
+        // loaded runner the background thread may not even bind before that
+        // deadline expires. This is the test that actually failed on macOS CI.
+        // recv_timeout is a hard failure bound, never a silent early drop.
+        let (done_tx, done_rx) = mpsc::channel::<()>();
         let handle = std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(150));
             let listener = bind_sync_listener(&socket_path_bg);
-            std::thread::sleep(Duration::from_millis(200));
+            done_rx
+                .recv_timeout(Duration::from_secs(60))
+                .expect("main thread should signal before the bound");
             drop(listener);
         });
 
         let mut child = spawn_quick_exit_child();
 
         let ready =
-            wait_for_socket_until(&socket_path, Some(&mut child), Duration::from_secs(1)).unwrap();
+            wait_for_socket_until(&socket_path, Some(&mut child), Duration::from_secs(30)).unwrap();
 
+        done_tx.send(()).ok();
         handle.join().unwrap();
         assert!(ready);
     }


### PR DESCRIPTION
Follow-up to #734, which fixed this race in one of the two tests that had it.

## The gap

#734 fixed `test_wait_for_socket_until_observes_late_socket`. The identical pattern survives in `test_wait_for_socket_until_ignores_clean_child_exit_if_socket_appears` — and that is the test that actually failed on the macOS leg of #731:

```
daemon::tests::test_wait_for_socket_until_ignores_clean_child_exit_if_socket_appears
panicked at src/daemon.rs:8084: assertion failed: ready
```

On current `main` it still reads:

```rust
std::thread::sleep(Duration::from_millis(150));
let listener = bind_sync_listener(&socket_path_bg);
std::thread::sleep(Duration::from_millis(200));
drop(listener);
...
wait_for_socket_until(&socket_path, Some(&mut child), Duration::from_secs(1))
```

So the socket exists only during `[150ms, 350ms]` while `wait_for_socket_until` polls every `DAEMON_START_POLL_INTERVAL` (100 ms) against a **1 second** deadline.

Two ways that loses:
- a ~200 ms scheduling stall drops both in-window polls; or
- more likely on a loaded runner, the background thread does not bind *at all* before the 1 s deadline expires.

## Fix

Applies #734's own remedy verbatim rather than inventing a second idiom: hold the listener until the waiter signals, with `recv_timeout` as a hard failure bound rather than a silent early drop, and a 30 s outer deadline.

Neither test is about the timeout — `test_wait_for_socket_until_times_out_cleanly` covers that directly, so the tight 1 s bound bought only sensitivity to runner scheduling.

## Honest limit

I could not reproduce the original failure locally; the unmodified test passed 25/25 under full CPU load on my machine. This is justified by construction — the window and the deadline provably exist — not by a local repro. The CI failure on #731 and its clean re-run are the evidence the flake is real.