### PR TITLE
fix(probe): guard the .exe strip on a UTF-8 char boundary (adopts #739)

### DIFF
--- a/src/probe/resolve.rs
+++ b/src/probe/resolve.rs
@@ -867,8 +867,8 @@ mod tests {
         let stderr = "使用内建 specs。\n\
                       COLLECT_GCC=gcc\n\
                        /usr/lib/gcc/cc1plus -quiet -O2 a.c -o /tmp/ccXYZ.s\n";
-        let line = extract_gnu_cc1_line(stderr)
-            .expect("cc1plus line resolves past the localized banner");
+        let line =
+            extract_gnu_cc1_line(stderr).expect("cc1plus line resolves past the localized banner");
         assert!(line.contains("cc1plus"));
         assert!(line.contains("-O2"));
     }

--- a/src/probe/resolve.rs
+++ b/src/probe/resolve.rs
@@ -242,7 +242,9 @@ pub fn extract_gnu_cc1_line(stderr: &str) -> Option<&str> {
         let base = base
             .len()
             .checked_sub(4)
-            .filter(|_| base[base.len() - 4..].eq_ignore_ascii_case(".exe"))
+            // `is_char_boundary` so non-ASCII basenames (e.g. `使用内建`
+            // from a localized gcc banner) don't panic the slice.
+            .filter(|&n| base.is_char_boundary(n) && base[n..].eq_ignore_ascii_case(".exe"))
             .map_or(base, |cut| &base[..cut]);
         base.eq_ignore_ascii_case("cc1") || base.eq_ignore_ascii_case("cc1plus")
     })
@@ -849,6 +851,26 @@ mod tests {
         assert!(line.contains("-O2"));
         // The reverse: gnu extractor must not match a clang `-cc1` line.
         assert!(extract_gnu_cc1_line(O2).is_none());
+    }
+
+    /// `gcc -###` prints a localized first line in non-English locales
+    /// (`LANG=zh_CN.UTF-8` → `使用内建 specs。`); its first whitespace token
+    /// is multi-byte non-ASCII, so the `.exe`-suffix strip must guard on a
+    /// UTF-8 char boundary.
+    #[test]
+    fn extract_gnu_cc1_line_handles_non_ascii_chars() {
+        // Banner only — must not panic and must not match anything.
+        assert!(extract_gnu_cc1_line("使用内建 specs。\n").is_none());
+
+        // Banner with a cc1plus subprocess below it — must resolve to the
+        // subprocess line, silently skipping the localized banner header.
+        let stderr = "使用内建 specs。\n\
+                      COLLECT_GCC=gcc\n\
+                       /usr/lib/gcc/cc1plus -quiet -O2 a.c -o /tmp/ccXYZ.s\n";
+        let line = extract_gnu_cc1_line(stderr)
+            .expect("cc1plus line resolves past the localized banner");
+        assert!(line.contains("cc1plus"));
+        assert!(line.contains("-O2"));
     }
 
     #[test]


### PR DESCRIPTION
This is a maintainer-opened replacement for #739 by @AzureZee, adopted so the fix can land without sending the contributor back for a formatting nit. The original PR stays open until this merges.

## What it fixes

`kache doctor` panics on any system with a non-English `LANG`. `gcc -###` prints a localized first line (`使用内建 specs。` under `zh_CN.UTF-8` rather than `Using built-in specs.`), and `extract_gnu_cc1_line` strips a possible `.exe` suffix by slicing at `len() - 4`. For that banner the first token's basename is `使用内建`: 12 bytes with char boundaries at 0, 3, 6, 9 and 12, so byte 8 lands inside `内` and the slice panics.

```
thread 'main' panicked at src/probe/resolve.rs:245:29:
start byte index 8 is not a char boundary; it is inside '内' (bytes 6..9) of `使用内建`
```

The fix guards the cut with `is_char_boundary` before slicing.

## Commits

- `a912ea9` by @AzureZee: the fix and its regression test. Imported unchanged. The commit object is identical to the head reviewed on #739, with no rebase and no cherry-pick.
- `115cd5d` maintainer commit: `cargo fmt` on the new test. Formatting only.

Reviewed contributor head: `a912ea9ba7bc49c8e218a1a976430caa2bbf1d93`.

## Validation

- The regression test is genuinely red before the fix. Reverting the two-line guard while keeping the test reproduces the reported panic at the same line and the same byte index. Green with the fix.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test --workspace` pass locally on macOS at `115cd5d`.
- No `CACHE_KEY_VERSION` bump. For every input that returned without panicking before, the result is unchanged: basenames shorter than 4 bytes are untouched either way, and where `len() - 4` is already a valid boundary the comparison is identical. The only newly reachable inputs are the ones that used to panic, which produced no cache key at all.
- Only one instance of this pattern existed. The similar strip at `src/compiler/mod.rs:973` operates on `&[u8]` behind a length guard and is unaffected.

## Not in scope

None of the probe spawn sites pin `LC_ALL=C` (`src/probe/mod.rs:378`, `:469`, `:526`, `:797`), while other subprocess spawns in the repo do. That is the root reason the banner was localized at all. Normalizing the probe locale is worth a separate change and is not required here, since the `cc1` line itself is not localized.
