### PR TITLE
fix(doctor): report the daemon upgrade window instead of stalling on it

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2668,6 +2668,81 @@ fn daemon_footnote_needed(daemon_optional: bool, results: &[(&str, bool)]) -> bo
             .any(|(label, pass)| !pass && DAEMON_CHECK_LABELS.contains(label))
 }
 
+/// Wording for the "Daemon version" check, as `(pass, detail, fix hint)`.
+///
+/// Split out of [`doctor`] because the interesting part is the mid-upgrade
+/// states, and those are the ones a live run is least likely to catch. `daemon`
+/// is the version and build epoch of a daemon that answered; `starting_epoch` is
+/// the build epoch of one that holds the run lock but has not bound its socket
+/// yet. Both absent means nothing is running.
+///
+/// `doctor` reports these states rather than repairing them: restarting a stale
+/// daemon costs an 8s wait for the replacement to come up, which is `--fix`'s
+/// job, not a diagnostic's (kunobi-ninja/kache#740).
+fn daemon_version_check(
+    daemon: Option<(&str, u64)>,
+    starting_epoch: Option<u64>,
+    my_version: &str,
+    my_epoch: u64,
+) -> (bool, String, Option<String>) {
+    match (daemon, starting_epoch) {
+        (Some((version, epoch)), _) if version == my_version && epoch == my_epoch => {
+            (true, format!("v{version} (epoch {epoch})"), None)
+        }
+        // Left running across an upgrade: the common case, and the one worth
+        // naming outright so the version pair does not read as a corrupt install.
+        //
+        // Reading its stats is what tells the daemon it is stale — it schedules
+        // a graceful restart on any request from a newer binary — so by the time
+        // this prints, the handoff is already under way. It exits cleanly, which
+        // launchd's `SuccessfulExit=false` and systemd's `Restart=on-failure`
+        // both decline to act on, so something has to start the replacement.
+        (Some((version, epoch)), _) if crate::daemon::client_epoch_is_newer(my_epoch, epoch) => (
+            false,
+            format!(
+                "daemon v{version} (epoch {epoch}) predates binary v{my_version} \
+                 (epoch {my_epoch}) — it is shutting down to pick up the new build"
+            ),
+            Some(
+                "the next build starts the replacement; `kache doctor --fix` or \
+                 `kache daemon start` to do it now"
+                    .into(),
+            ),
+        ),
+        // The daemon is the newer build: an old binary is on PATH, and
+        // restarting the daemon would be the wrong advice.
+        (Some((version, epoch)), _) => (
+            false,
+            format!(
+                "daemon v{version} (epoch {epoch}) is newer than binary v{my_version} \
+                 (epoch {my_epoch})"
+            ),
+            Some("this binary is the stale one — reinstall kache or fix PATH".into()),
+        ),
+        // Nothing answered, but a daemon is on its way up. Reporting "not
+        // reachable → start the daemon" here is what made a routine upgrade look
+        // like a broken install.
+        (None, Some(epoch)) if epoch == my_epoch => (
+            false,
+            format!("v{my_version} (epoch {epoch}) is starting — not accepting connections yet"),
+            Some("re-run `kache doctor` in a moment".into()),
+        ),
+        (None, Some(epoch)) => (
+            false,
+            format!(
+                "a daemon (epoch {epoch}) is starting; this binary is v{my_version} \
+                 (epoch {my_epoch})"
+            ),
+            Some("re-run `kache doctor` in a moment".into()),
+        ),
+        (None, None) => (
+            false,
+            "daemon not reachable".into(),
+            Some("start daemon with `kache daemon start` or `kache daemon install`".into()),
+        ),
+    }
+}
+
 pub fn doctor(
     fix: bool,
     purge_sccache: bool,
@@ -2957,41 +3032,60 @@ pub fn doctor(
     }
 
     // 8. Daemon version match
+    //
+    // Read-only: `send_stats_request_read_only` skips the stale-daemon restart
+    // that `send_stats_request` performs, so an upgrade left half-applied is
+    // described in the report instead of stalling it for the 8s the replacement
+    // takes to bind its socket (kunobi-ninja/kache#740). `--fix` opts into that
+    // wait below.
     let my_version = crate::VERSION;
+    // Hoisted so the later daemon checks describe the same daemon this one saw.
+    // A stats request from a newer binary makes the daemon schedule its own
+    // graceful restart, so a second probe further down can legitimately find
+    // nothing running — and would then contradict this check within one report.
+    let mut daemon_was_reachable = false;
+    let mut daemon_upgrade_pending = false;
     if let Some(ref cfg) = config {
-        match crate::daemon::send_stats_request(cfg, false, None, None) {
-            Ok(stats) => {
-                let my_epoch = crate::daemon::build_epoch();
-                let version_match = stats.version == my_version && stats.build_epoch == my_epoch;
-                checks.push(Check {
-                    label: "Daemon version",
-                    pass: version_match,
-                    detail: if version_match {
-                        format!("v{} (epoch {})", stats.version, stats.build_epoch)
-                    } else {
-                        format!(
-                            "daemon v{} (epoch {}) vs binary v{} (epoch {})",
-                            stats.version, stats.build_epoch, my_version, my_epoch
-                        )
-                    },
-                    fix: if version_match {
-                        None
-                    } else {
-                        Some("kache daemon stop && kache daemon start (or just run a build — auto-restart will handle it)".into())
-                    },
-                });
+        let my_epoch = crate::daemon::build_epoch();
+        let mut stats = crate::daemon::send_stats_request_read_only(cfg, false).ok();
+
+        let is_stale = |stats: &Option<crate::daemon::StatsResponse>| {
+            stats
+                .as_ref()
+                .is_some_and(|s| crate::daemon::client_epoch_is_newer(my_epoch, s.build_epoch))
+        };
+        daemon_was_reachable = stats.is_some();
+        daemon_upgrade_pending = is_stale(&stats);
+
+        if fix && daemon_upgrade_pending {
+            // Attributed rather than silent: this is where doctor's runtime goes
+            // when it is slow, so say what it is waiting for.
+            println!("  Restarting daemon left over from before the upgrade...");
+            if !crate::daemon::restart_daemon_for_stale_client(cfg).unwrap_or(false) {
+                println!(
+                    "  \x1b[2mthe replacement has not bound its socket yet; it keeps \
+                     coming up in the background\x1b[0m"
+                );
             }
-            Err(_) => {
-                checks.push(Check {
-                    label: "Daemon version",
-                    pass: false,
-                    detail: "daemon not reachable".into(),
-                    fix: Some(
-                        "start daemon with `kache daemon start` or `kache daemon install`".into(),
-                    ),
-                });
-            }
+            // Re-read either way: the outgoing daemon is gone now, so the report
+            // should describe what is there, not what answered a moment ago.
+            stats = crate::daemon::send_stats_request_read_only(cfg, false).ok();
+            daemon_was_reachable = stats.is_some();
+            daemon_upgrade_pending = is_stale(&stats);
         }
+
+        let (pass, detail, fix_hint) = daemon_version_check(
+            stats.as_ref().map(|s| (s.version.as_str(), s.build_epoch)),
+            crate::daemon::starting_daemon_epoch(cfg),
+            my_version,
+            my_epoch,
+        );
+        checks.push(Check {
+            label: "Daemon version",
+            pass,
+            detail,
+            fix: fix_hint,
+        });
     }
 
     // 9. Daemon service installed
@@ -3060,6 +3154,11 @@ pub fn doctor(
     // 11. Stale lock files — when no daemon is running, leftover lock files
     //     are legacy cruft from an unclean shutdown. Harmless but worth
     //     surfacing so users know `daemon restart` will tidy them up.
+    //
+    //     Reuses the daemon snapshot from check 8 rather than re-probing: the
+    //     lock files of a daemon that is mid-handoff are in use, not cruft, and
+    //     re-probing here would report them the moment the outgoing daemon lets
+    //     go (kunobi-ninja/kache#740).
     if let Some(ref cfg) = config {
         let sock = cfg.socket_path();
         let mut stale_files = Vec::new();
@@ -3070,8 +3169,10 @@ pub fn doctor(
             }
         }
         if !stale_files.is_empty()
+            && !daemon_was_reachable
+            && !daemon_upgrade_pending
+            && crate::daemon::starting_daemon_epoch(cfg).is_none()
             && crate::daemon::find_daemon_pids().is_empty()
-            && crate::daemon::send_stats_request(cfg, false, None, None).is_err()
         {
             if fix {
                 for f in &stale_files {
@@ -4550,6 +4651,90 @@ mod tests {
             &[("Compiler probe", false), ("Binary", false)]
         ));
         assert!(!daemon_footnote_needed(true, &[]));
+    }
+
+    // ── Daemon version reporting (kunobi-ninja/kache#740) ──────────────────
+
+    /// The upgrade window: a daemon from before the upgrade is still answering.
+    /// It must read as an upgrade left to finish, not as a version conflict, and
+    /// the hint must point at the flag that actually restarts it.
+    #[test]
+    fn daemon_version_check_names_the_pending_upgrade() {
+        let (pass, detail, fix) = daemon_version_check(Some(("0.13.0", 100)), None, "0.14.0", 200);
+        assert!(!pass);
+        assert!(detail.contains("predates"), "{detail}");
+        assert!(
+            detail.contains("0.13.0") && detail.contains("0.14.0"),
+            "{detail}"
+        );
+        assert!(detail.contains("shutting down"), "{detail}");
+        assert!(fix.unwrap().contains("doctor --fix"));
+    }
+
+    /// The other direction — an old binary against a newer daemon — must not
+    /// advise restarting the daemon, which would downgrade it.
+    #[test]
+    fn daemon_version_check_blames_the_binary_when_the_daemon_is_newer() {
+        let (pass, detail, fix) = daemon_version_check(Some(("0.14.0", 200)), None, "0.13.0", 100);
+        assert!(!pass);
+        assert!(detail.contains("newer than binary"), "{detail}");
+        let fix = fix.unwrap();
+        assert!(fix.contains("this binary is the stale one"), "{fix}");
+        assert!(!fix.contains("daemon start"), "{fix}");
+    }
+
+    /// Matching build: the only passing state, and it stays terse.
+    #[test]
+    fn daemon_version_check_passes_on_identical_build() {
+        let (pass, detail, fix) = daemon_version_check(Some(("0.14.0", 200)), None, "0.14.0", 200);
+        assert!(pass);
+        assert_eq!(detail, "v0.14.0 (epoch 200)");
+        assert!(fix.is_none());
+    }
+
+    /// Same version string, different build — a locally rebuilt daemon is stale
+    /// even though the version reads identical.
+    #[test]
+    fn daemon_version_check_catches_same_version_different_build() {
+        let (pass, detail, _) = daemon_version_check(Some(("0.14.0", 100)), None, "0.14.0", 200);
+        assert!(!pass, "{detail}");
+        assert!(detail.contains("predates"), "{detail}");
+    }
+
+    /// The window that made a routine upgrade look like a broken install: no
+    /// daemon answers yet because the replacement is still binding its socket.
+    /// Reporting "not reachable → start the daemon" there is actively wrong.
+    #[test]
+    fn daemon_version_check_reports_a_daemon_that_is_still_starting() {
+        let (pass, detail, fix) = daemon_version_check(None, Some(200), "0.14.0", 200);
+        assert!(!pass);
+        assert!(detail.contains("starting"), "{detail}");
+        assert!(fix.unwrap().contains("re-run"));
+
+        // A starting daemon of some other build gets named as such rather than
+        // silently claimed to be this one.
+        let (_, detail, _) = daemon_version_check(None, Some(100), "0.14.0", 200);
+        assert!(detail.contains("epoch 100"), "{detail}");
+        assert!(detail.contains("0.14.0"), "{detail}");
+    }
+
+    /// Nothing answering and nothing coming up keeps the original wording.
+    #[test]
+    fn daemon_version_check_reports_an_absent_daemon() {
+        let (pass, detail, fix) = daemon_version_check(None, None, "0.14.0", 200);
+        assert!(!pass);
+        assert_eq!(detail, "daemon not reachable");
+        assert!(fix.unwrap().contains("kache daemon start"));
+    }
+
+    /// A daemon that answered wins over the coordinator file: a leftover
+    /// `Starting` record must not relabel a reachable daemon as starting.
+    #[test]
+    fn daemon_version_check_prefers_the_daemon_that_answered() {
+        let (pass, detail, _) =
+            daemon_version_check(Some(("0.14.0", 200)), Some(100), "0.14.0", 200);
+        assert!(pass, "{detail}");
+        assert_eq!(detail, "v0.14.0 (epoch 200)");
     }
 
     // ── Eviction reporting (kunobi-ninja/kache#509) ────────────────────────

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2678,7 +2678,7 @@ fn daemon_footnote_needed(daemon_optional: bool, results: &[(&str, bool)]) -> bo
 ///
 /// `doctor` reports these states rather than repairing them: restarting a stale
 /// daemon costs an 8s wait for the replacement to come up, which is `--fix`'s
-/// job, not a diagnostic's.
+/// job, not a diagnostic's (kunobi-ninja/kache#720).
 ///
 /// Build epochs are executable mtimes, and `0` means "could not be read". Two
 /// builds are therefore only ever *ordered* through
@@ -3099,7 +3099,7 @@ pub fn doctor(
     // `send_stats_request_without_restart` skips the client-side stale-daemon
     // restart that `send_stats_request` performs, so an upgrade left half-applied
     // is described in the report instead of stalling it for the 8s the
-    // replacement takes to bind its socket. `--fix` opts
+    // replacement takes to bind its socket (kunobi-ninja/kache#720). `--fix` opts
     // into that wait below.
     let my_version = crate::VERSION;
     if let Some(ref cfg) = config {
@@ -3166,7 +3166,7 @@ pub fn doctor(
     //     daemon anything is what makes an outgoing one shut down and what could
     //     spend the 8s restart wait a second time; connecting asks nothing, costs
     //     nothing, and — unlike reusing check 8's answer — is true *now*, so a
-    //     daemon that died in between is not covered for.
+    //     daemon that died in between is not covered for (kunobi-ninja/kache#720).
     if let Some(ref cfg) = config {
         let reachable = daemon_is_live_now(cfg);
         let pids = crate::daemon::find_daemon_pids();
@@ -4708,7 +4708,7 @@ mod tests {
         assert!(!daemon_footnote_needed(true, &[]));
     }
 
-    // ── Daemon version reporting ───────────────────────────────────────────
+    // ── Daemon version reporting (kunobi-ninja/kache#720) ──────────────────
 
     /// The upgrade window: a daemon from before the upgrade is still answering.
     /// It must read as an upgrade left to finish, not as a version conflict, and

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2692,13 +2692,25 @@ fn daemon_footnote_needed(daemon_optional: bool, results: &[(&str, bool)]) -> bo
 /// Split out because the mistake it guards against is a boolean one: any of the
 /// three conditions weakening turns "no daemon owns these" into a claim about a
 /// daemon that is running, and `doctor` then tells someone to restart a healthy
-/// one to clean up files it is still using.
+/// one to clean up files it is still using. Counts rather than booleans, so the
+/// call site hands over raw observations and keeps no logic of its own.
 fn stale_locks_are_abandoned(
-    lock_files_present: bool,
+    lock_files: usize,
     daemon_live: bool,
     daemon_processes: usize,
 ) -> bool {
-    lock_files_present && !daemon_live && daemon_processes == 0
+    lock_files > 0 && !daemon_live && daemon_processes == 0
+}
+
+/// Whether `doctor` should replace a daemon left over from before an upgrade.
+///
+/// The one-line answer to the bug this all started from: only under `--fix`.
+/// Restarting costs the 8s the replacement needs to bind its socket, and a
+/// diagnostic that silently spends it — then reports the state it just
+/// invalidated — is what made a routine upgrade look like a broken install
+/// (kunobi-ninja/kache#720).
+fn should_restart_stale_daemon(fix_requested: bool, daemon_is_stale: bool) -> bool {
+    fix_requested && daemon_is_stale
 }
 
 /// What `doctor --fix` prints after trying to replace a stale daemon, or `None`
@@ -3114,7 +3126,7 @@ pub fn doctor(
                 .is_some_and(|s| crate::daemon::client_epoch_is_newer(my_epoch, s.build_epoch))
         };
 
-        if fix && is_stale(&stats) {
+        if should_restart_stale_daemon(fix, is_stale(&stats)) {
             // Attributed rather than silent: this is where doctor's runtime goes
             // when it is slow, so say what it is waiting for.
             println!("  Restarting daemon left over from before the upgrade...");
@@ -3228,7 +3240,7 @@ pub fn doctor(
             }
         }
         if stale_locks_are_abandoned(
-            !stale_files.is_empty(),
+            stale_files.len(),
             crate::daemon::daemon_is_live(cfg),
             crate::daemon::find_daemon_pids().len(),
         ) {
@@ -4824,12 +4836,25 @@ mod tests {
     /// restart a healthy daemon to clean up files it is still using.
     #[test]
     fn stale_locks_are_abandoned_needs_every_condition() {
-        assert!(stale_locks_are_abandoned(true, false, 0));
+        assert!(stale_locks_are_abandoned(1, false, 0));
+        assert!(stale_locks_are_abandoned(2, false, 0));
 
-        assert!(!stale_locks_are_abandoned(false, false, 0), "no lock files");
-        assert!(!stale_locks_are_abandoned(true, true, 0), "daemon serving");
-        assert!(!stale_locks_are_abandoned(true, false, 1), "daemon process");
-        assert!(!stale_locks_are_abandoned(false, true, 2), "none of them");
+        assert!(!stale_locks_are_abandoned(0, false, 0), "no lock files");
+        assert!(!stale_locks_are_abandoned(1, true, 0), "daemon serving");
+        assert!(!stale_locks_are_abandoned(1, false, 1), "daemon process");
+        assert!(!stale_locks_are_abandoned(0, true, 2), "none of them");
+    }
+
+    /// The behaviour this whole change exists for: a plain `doctor` run reports
+    /// a stale daemon, it does not replace it and pay the startup wait. Only
+    /// `--fix` opts into that.
+    #[test]
+    fn only_fix_restarts_a_stale_daemon() {
+        assert!(should_restart_stale_daemon(true, true));
+
+        assert!(!should_restart_stale_daemon(false, true), "plain doctor");
+        assert!(!should_restart_stale_daemon(true, false), "nothing stale");
+        assert!(!should_restart_stale_daemon(false, false), "neither");
     }
 
     /// A restart that did not finish must never read as one that is still

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2687,16 +2687,18 @@ fn daemon_footnote_needed(daemon_optional: bool, results: &[(&str, bool)]) -> bo
 /// unknown, and gets said so rather than guessed: telling someone their binary is
 /// stale on the strength of an unreadable mtime sends them to reinstall a kache
 /// that was fine.
-/// Whether a daemon is serving or coming up right now, asking it nothing.
+/// Whether leftover lock files are abandoned rather than in use.
 ///
-/// `doctor`'s liveness checks need an answer that is current and free of side
-/// effects, which a stats request is neither: it makes an older daemon schedule
-/// its own shutdown, and its answer goes stale within the same report. A socket
-/// connect plus the coordinator state file covers both a daemon that is serving
-/// and one that has the run lock but has not bound its socket yet.
-fn daemon_is_live_now(config: &crate::config::Config) -> bool {
-    crate::transport::is_reachable(&config.socket_path())
-        || crate::daemon::starting_daemon_epoch(config).is_some()
+/// Split out because the mistake it guards against is a boolean one: any of the
+/// three conditions weakening turns "no daemon owns these" into a claim about a
+/// daemon that is running, and `doctor` then tells someone to restart a healthy
+/// one to clean up files it is still using.
+fn stale_locks_are_abandoned(
+    lock_files_present: bool,
+    daemon_live: bool,
+    daemon_processes: usize,
+) -> bool {
+    lock_files_present && !daemon_live && daemon_processes == 0
 }
 
 /// What `doctor --fix` prints after trying to replace a stale daemon, or `None`
@@ -3168,7 +3170,7 @@ pub fn doctor(
     //     nothing, and — unlike reusing check 8's answer — is true *now*, so a
     //     daemon that died in between is not covered for (kunobi-ninja/kache#720).
     if let Some(ref cfg) = config {
-        let reachable = daemon_is_live_now(cfg);
+        let reachable = crate::daemon::daemon_is_live(cfg);
         let pids = crate::daemon::find_daemon_pids();
         if !reachable && !pids.is_empty() {
             let pids_str = pids
@@ -3225,10 +3227,11 @@ pub fn doctor(
                 stale_files.push(p);
             }
         }
-        if !stale_files.is_empty()
-            && !daemon_is_live_now(cfg)
-            && crate::daemon::find_daemon_pids().is_empty()
-        {
+        if stale_locks_are_abandoned(
+            !stale_files.is_empty(),
+            crate::daemon::daemon_is_live(cfg),
+            crate::daemon::find_daemon_pids().len(),
+        ) {
             if fix {
                 for f in &stale_files {
                     let _ = std::fs::remove_file(f);
@@ -4814,6 +4817,19 @@ mod tests {
         // through the equality arm.
         let (pass, detail, _) = daemon_version_check(None, Some(0), "0.14.0", 0);
         assert!(!pass, "{detail}");
+    }
+
+    /// Lock files are only cruft when nothing owns them. Each condition is
+    /// load-bearing on its own: weaken any one and doctor tells someone to
+    /// restart a healthy daemon to clean up files it is still using.
+    #[test]
+    fn stale_locks_are_abandoned_needs_every_condition() {
+        assert!(stale_locks_are_abandoned(true, false, 0));
+
+        assert!(!stale_locks_are_abandoned(false, false, 0), "no lock files");
+        assert!(!stale_locks_are_abandoned(true, true, 0), "daemon serving");
+        assert!(!stale_locks_are_abandoned(true, false, 1), "daemon process");
+        assert!(!stale_locks_are_abandoned(false, true, 2), "none of them");
     }
 
     /// A restart that did not finish must never read as one that is still

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2679,6 +2679,14 @@ fn daemon_footnote_needed(daemon_optional: bool, results: &[(&str, bool)]) -> bo
 /// `doctor` reports these states rather than repairing them: restarting a stale
 /// daemon costs an 8s wait for the replacement to come up, which is `--fix`'s
 /// job, not a diagnostic's (kunobi-ninja/kache#740).
+///
+/// Build epochs are executable mtimes, and `0` means "could not be read". Two
+/// builds are therefore only ever *ordered* through
+/// [`crate::daemon::client_epoch_is_newer`], which rejects a zero on either side
+/// and rejects equal epochs. Everything it declines to order is genuinely
+/// unknown, and gets said so rather than guessed: telling someone their binary is
+/// stale on the strength of an unreadable mtime sends them to reinstall a kache
+/// that was fine.
 fn daemon_version_check(
     daemon: Option<(&str, u64)>,
     starting_epoch: Option<u64>,
@@ -2686,7 +2694,7 @@ fn daemon_version_check(
     my_epoch: u64,
 ) -> (bool, String, Option<String>) {
     match (daemon, starting_epoch) {
-        (Some((version, epoch)), _) if version == my_version && epoch == my_epoch => {
+        (Some((version, epoch)), _) if epoch > 0 && version == my_version && epoch == my_epoch => {
             (true, format!("v{version} (epoch {epoch})"), None)
         }
         // Left running across an upgrade: the common case, and the one worth
@@ -2701,7 +2709,7 @@ fn daemon_version_check(
             false,
             format!(
                 "daemon v{version} (epoch {epoch}) predates binary v{my_version} \
-                 (epoch {my_epoch}) — it is shutting down to pick up the new build"
+                 (epoch {my_epoch}) — it is shutting down now"
             ),
             Some(
                 "the next build starts the replacement; `kache doctor --fix` or \
@@ -2711,7 +2719,7 @@ fn daemon_version_check(
         ),
         // The daemon is the newer build: an old binary is on PATH, and
         // restarting the daemon would be the wrong advice.
-        (Some((version, epoch)), _) => (
+        (Some((version, epoch)), _) if crate::daemon::client_epoch_is_newer(epoch, my_epoch) => (
             false,
             format!(
                 "daemon v{version} (epoch {epoch}) is newer than binary v{my_version} \
@@ -2719,13 +2727,29 @@ fn daemon_version_check(
             ),
             Some("this binary is the stale one — reinstall kache or fix PATH".into()),
         ),
+        // Mismatched, but in no determinable order: an unreadable mtime on either
+        // side, or one build epoch carrying two version strings. Say that much and
+        // no more — the two arms above are the ones that name a culprit, and
+        // naming the wrong one sends someone to reinstall a working install.
+        (Some((version, epoch)), _) => (
+            false,
+            format!(
+                "daemon v{version} (epoch {epoch}) does not match binary v{my_version} \
+                 (epoch {my_epoch}), and their build order cannot be determined"
+            ),
+            Some("check which kache is on PATH, then `kache daemon restart`".into()),
+        ),
         // Nothing answered, but a daemon is on its way up. Reporting "not
         // reachable → start the daemon" here is what made a routine upgrade look
         // like a broken install.
-        (None, Some(epoch)) if epoch == my_epoch => (
-            false,
+        //
+        // Passing: the check asks whether the daemon matches this binary, and the
+        // coordinator file answers yes. Not yet accepting connections is what the
+        // detail says, not a fault to count against the install.
+        (None, Some(epoch)) if epoch > 0 && epoch == my_epoch => (
+            true,
             format!("v{my_version} (epoch {epoch}) is starting — not accepting connections yet"),
-            Some("re-run `kache doctor` in a moment".into()),
+            None,
         ),
         (None, Some(epoch)) => (
             false,
@@ -3033,21 +3057,24 @@ pub fn doctor(
 
     // 8. Daemon version match
     //
-    // Read-only: `send_stats_request_read_only` skips the stale-daemon restart
-    // that `send_stats_request` performs, so an upgrade left half-applied is
-    // described in the report instead of stalling it for the 8s the replacement
-    // takes to bind its socket (kunobi-ninja/kache#740). `--fix` opts into that
-    // wait below.
+    // `send_stats_request_without_restart` skips the client-side stale-daemon
+    // restart that `send_stats_request` performs, so an upgrade left half-applied
+    // is described in the report instead of stalling it for the 8s the
+    // replacement takes to bind its socket (kunobi-ninja/kache#740). `--fix` opts
+    // into that wait below.
     let my_version = crate::VERSION;
-    // Hoisted so the later daemon checks describe the same daemon this one saw.
-    // A stats request from a newer binary makes the daemon schedule its own
-    // graceful restart, so a second probe further down can legitimately find
-    // nothing running — and would then contradict this check within one report.
+    // One daemon observation, taken here and shared with checks 10 and 11 below.
+    // Re-probing per check made the report disagree with itself: this very
+    // request tells a daemon older than us to shut down (it schedules a graceful
+    // restart on any request from a newer binary), so a probe a few checks later
+    // legitimately sees a different world — one where the daemon just described
+    // as running is gone, its lock files look abandoned, and its process is still
+    // draining. All three checks now describe the same moment.
     let mut daemon_was_reachable = false;
-    let mut daemon_upgrade_pending = false;
+    let mut daemon_starting_epoch = None;
     if let Some(ref cfg) = config {
         let my_epoch = crate::daemon::build_epoch();
-        let mut stats = crate::daemon::send_stats_request_read_only(cfg, false).ok();
+        let mut stats = crate::daemon::send_stats_request_without_restart(cfg, false).ok();
 
         let is_stale = |stats: &Option<crate::daemon::StatsResponse>| {
             stats
@@ -3055,28 +3082,32 @@ pub fn doctor(
                 .is_some_and(|s| crate::daemon::client_epoch_is_newer(my_epoch, s.build_epoch))
         };
         daemon_was_reachable = stats.is_some();
-        daemon_upgrade_pending = is_stale(&stats);
 
-        if fix && daemon_upgrade_pending {
+        if fix && is_stale(&stats) {
             // Attributed rather than silent: this is where doctor's runtime goes
-            // when it is slow, so say what it is waiting for.
+            // when it is slow, so say what it is waiting for. And report what the
+            // restart actually did — "still coming up" is a claim, and an `Err`
+            // means no replacement was ever spawned to come up.
             println!("  Restarting daemon left over from before the upgrade...");
-            if !crate::daemon::restart_daemon_for_stale_client(cfg).unwrap_or(false) {
-                println!(
-                    "  \x1b[2mthe replacement has not bound its socket yet; it keeps \
-                     coming up in the background\x1b[0m"
-                );
+            match crate::daemon::restart_daemon_for_stale_client(cfg) {
+                Ok(true) => {}
+                Ok(false) => println!(
+                    "  \x1b[2mthe replacement did not bind its socket within \
+                     the startup timeout\x1b[0m"
+                ),
+                Err(error) => println!("  \x1b[31mrestart failed: {error:#}\x1b[0m"),
             }
             // Re-read either way: the outgoing daemon is gone now, so the report
             // should describe what is there, not what answered a moment ago.
-            stats = crate::daemon::send_stats_request_read_only(cfg, false).ok();
+            stats = crate::daemon::send_stats_request_without_restart(cfg, false).ok();
             daemon_was_reachable = stats.is_some();
-            daemon_upgrade_pending = is_stale(&stats);
         }
+
+        daemon_starting_epoch = crate::daemon::starting_daemon_epoch(cfg);
 
         let (pass, detail, fix_hint) = daemon_version_check(
             stats.as_ref().map(|s| (s.version.as_str(), s.build_epoch)),
-            crate::daemon::starting_daemon_epoch(cfg),
+            daemon_starting_epoch,
             my_version,
             my_epoch,
         );
@@ -3110,8 +3141,13 @@ pub fn doctor(
     // 10. Lingering live kache daemon processes — if the socket isn't reachable
     //     but `kache daemon run` processes exist, something got stuck.
     //     `kache daemon restart` now force-recovers this automatically.
-    if let Some(ref cfg) = config {
-        let reachable = crate::daemon::send_stats_request(cfg, false, None, None).is_ok();
+    //
+    //     Reuses check 8's observation. Probing again through
+    //     `send_stats_request` was the second place doctor could spend the 8s
+    //     restart wait — an outgoing daemon still draining in-flight work answers
+    //     here too, and answering is what triggers it (kunobi-ninja/kache#740).
+    if config.is_some() {
+        let reachable = daemon_was_reachable || daemon_starting_epoch.is_some();
         let pids = crate::daemon::find_daemon_pids();
         if !reachable && !pids.is_empty() {
             let pids_str = pids
@@ -3170,8 +3206,7 @@ pub fn doctor(
         }
         if !stale_files.is_empty()
             && !daemon_was_reachable
-            && !daemon_upgrade_pending
-            && crate::daemon::starting_daemon_epoch(cfg).is_none()
+            && daemon_starting_epoch.is_none()
             && crate::daemon::find_daemon_pids().is_empty()
         {
             if fix {
@@ -4671,6 +4706,39 @@ mod tests {
         assert!(fix.unwrap().contains("doctor --fix"));
     }
 
+    /// Epochs are executable mtimes and `0` means unreadable, so several
+    /// mismatches are genuinely unordered. Guessing a culprit there sends someone
+    /// to reinstall a working kache, so every one of them must decline to.
+    #[test]
+    fn daemon_version_check_does_not_invent_an_order_it_cannot_determine() {
+        for (daemon, my_version, my_epoch, case) in [
+            (("0.13.0", 0), "0.14.0", 200, "daemon epoch unreadable"),
+            (("0.13.0", 200), "0.14.0", 0, "binary epoch unreadable"),
+            (("0.13.0", 0), "0.14.0", 0, "neither epoch readable"),
+            (
+                ("0.13.0", 200),
+                "0.14.0",
+                200,
+                "one build, two version strings",
+            ),
+        ] {
+            let (pass, detail, fix) =
+                daemon_version_check(Some(daemon), None, my_version, my_epoch);
+            assert!(!pass, "{case}: {detail}");
+            assert!(detail.contains("cannot be determined"), "{case}: {detail}");
+            let fix = fix.unwrap();
+            assert!(
+                !fix.contains("this binary is the stale one"),
+                "{case}: {fix}"
+            );
+        }
+
+        // Equal version strings and unreadable epochs are not evidence of the
+        // same build either — that pair must not pass.
+        let (pass, detail, _) = daemon_version_check(Some(("0.14.0", 0)), None, "0.14.0", 0);
+        assert!(!pass, "{detail}");
+    }
+
     /// The other direction — an old binary against a newer daemon — must not
     /// advise restarting the daemon, which would downgrade it.
     #[test]
@@ -4703,19 +4771,27 @@ mod tests {
 
     /// The window that made a routine upgrade look like a broken install: no
     /// daemon answers yet because the replacement is still binding its socket.
-    /// Reporting "not reachable → start the daemon" there is actively wrong.
+    /// Reporting "not reachable → start the daemon" there is actively wrong, and
+    /// so is counting a healthy transient against the install — the coordinator
+    /// file says the right build is coming up, which is what this check asks.
     #[test]
     fn daemon_version_check_reports_a_daemon_that_is_still_starting() {
         let (pass, detail, fix) = daemon_version_check(None, Some(200), "0.14.0", 200);
-        assert!(!pass);
+        assert!(pass, "{detail}");
         assert!(detail.contains("starting"), "{detail}");
-        assert!(fix.unwrap().contains("re-run"));
+        assert!(fix.is_none());
 
         // A starting daemon of some other build gets named as such rather than
         // silently claimed to be this one.
-        let (_, detail, _) = daemon_version_check(None, Some(100), "0.14.0", 200);
+        let (pass, detail, _) = daemon_version_check(None, Some(100), "0.14.0", 200);
+        assert!(!pass, "{detail}");
         assert!(detail.contains("epoch 100"), "{detail}");
         assert!(detail.contains("0.14.0"), "{detail}");
+
+        // An unreadable epoch on both sides is not a match, so it must not pass
+        // through the equality arm.
+        let (pass, detail, _) = daemon_version_check(None, Some(0), "0.14.0", 0);
+        assert!(!pass, "{detail}");
     }
 
     /// Nothing answering and nothing coming up keeps the original wording.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2678,7 +2678,7 @@ fn daemon_footnote_needed(daemon_optional: bool, results: &[(&str, bool)]) -> bo
 ///
 /// `doctor` reports these states rather than repairing them: restarting a stale
 /// daemon costs an 8s wait for the replacement to come up, which is `--fix`'s
-/// job, not a diagnostic's (kunobi-ninja/kache#740).
+/// job, not a diagnostic's.
 ///
 /// Build epochs are executable mtimes, and `0` means "could not be read". Two
 /// builds are therefore only ever *ordered* through
@@ -3099,7 +3099,7 @@ pub fn doctor(
     // `send_stats_request_without_restart` skips the client-side stale-daemon
     // restart that `send_stats_request` performs, so an upgrade left half-applied
     // is described in the report instead of stalling it for the 8s the
-    // replacement takes to bind its socket (kunobi-ninja/kache#740). `--fix` opts
+    // replacement takes to bind its socket. `--fix` opts
     // into that wait below.
     let my_version = crate::VERSION;
     if let Some(ref cfg) = config {
@@ -3166,7 +3166,7 @@ pub fn doctor(
     //     daemon anything is what makes an outgoing one shut down and what could
     //     spend the 8s restart wait a second time; connecting asks nothing, costs
     //     nothing, and — unlike reusing check 8's answer — is true *now*, so a
-    //     daemon that died in between is not covered for (kunobi-ninja/kache#740).
+    //     daemon that died in between is not covered for.
     if let Some(ref cfg) = config {
         let reachable = daemon_is_live_now(cfg);
         let pids = crate::daemon::find_daemon_pids();
@@ -3215,7 +3215,7 @@ pub fn doctor(
     //     "In use" includes a daemon that holds the run lock but has not bound
     //     its socket yet, which a socket probe alone reads as absent — that is
     //     how a mid-upgrade handoff came to be reported as leftover cruft
-    //     (kunobi-ninja/kache#740).
+    //    .
     if let Some(ref cfg) = config {
         let sock = cfg.socket_path();
         let mut stale_files = Vec::new();
@@ -4708,7 +4708,7 @@ mod tests {
         assert!(!daemon_footnote_needed(true, &[]));
     }
 
-    // ── Daemon version reporting (kunobi-ninja/kache#740) ──────────────────
+    // ── Daemon version reporting ───────────────────────────────────────────
 
     /// The upgrade window: a daemon from before the upgrade is still answering.
     /// It must read as an upgrade left to finish, not as a version conflict, and

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2687,6 +2687,38 @@ fn daemon_footnote_needed(daemon_optional: bool, results: &[(&str, bool)]) -> bo
 /// unknown, and gets said so rather than guessed: telling someone their binary is
 /// stale on the strength of an unreadable mtime sends them to reinstall a kache
 /// that was fine.
+/// Whether a daemon is serving or coming up right now, asking it nothing.
+///
+/// `doctor`'s liveness checks need an answer that is current and free of side
+/// effects, which a stats request is neither: it makes an older daemon schedule
+/// its own shutdown, and its answer goes stale within the same report. A socket
+/// connect plus the coordinator state file covers both a daemon that is serving
+/// and one that has the run lock but has not bound its socket yet.
+fn daemon_is_live_now(config: &crate::config::Config) -> bool {
+    crate::transport::is_reachable(&config.socket_path())
+        || crate::daemon::starting_daemon_epoch(config).is_some()
+}
+
+/// What `doctor --fix` prints after trying to replace a stale daemon, or `None`
+/// when it came up and the check below will say so.
+///
+/// A restart that did not finish must not be reported as one that is still
+/// finishing: `Ok(false)` means the replacement was spawned but had not bound its
+/// socket in time, while `Err` means the handoff failed outright and there may be
+/// no replacement at all. Claiming "still coming up in the background" for both
+/// invites the reader to ignore a real failure.
+fn stale_restart_note(outcome: &anyhow::Result<bool>) -> Option<String> {
+    match outcome {
+        Ok(true) => None,
+        Ok(false) => Some(
+            "\x1b[2mthe replacement did not bind its socket within the startup \
+             timeout\x1b[0m"
+                .into(),
+        ),
+        Err(error) => Some(format!("\x1b[31mrestart failed: {error:#}\x1b[0m")),
+    }
+}
+
 fn daemon_version_check(
     daemon: Option<(&str, u64)>,
     starting_epoch: Option<u64>,
@@ -2737,7 +2769,10 @@ fn daemon_version_check(
                 "daemon v{version} (epoch {epoch}) does not match binary v{my_version} \
                  (epoch {my_epoch}), and their build order cannot be determined"
             ),
-            Some("check which kache is on PATH, then `kache daemon restart`".into()),
+            // Deliberately not "restart the daemon": in an unordered state the
+            // daemon may be the newer build, and restarting it through this
+            // binary would downgrade it.
+            Some("work out which kache build should be running, then restart from that one".into()),
         ),
         // Nothing answered, but a daemon is on its way up. Reporting "not
         // reachable → start the daemon" here is what made a routine upgrade look
@@ -2746,9 +2781,13 @@ fn daemon_version_check(
         // Passing: the check asks whether the daemon matches this binary, and the
         // coordinator file answers yes. Not yet accepting connections is what the
         // detail says, not a fault to count against the install.
+        //
+        // Phrased around the epoch, not the version: coordinator state carries no
+        // version string, and one mtime second can carry two of them, so the
+        // matching build is all this state actually establishes.
         (None, Some(epoch)) if epoch > 0 && epoch == my_epoch => (
             true,
-            format!("v{my_version} (epoch {epoch}) is starting — not accepting connections yet"),
+            format!("a daemon of this build (epoch {epoch}) is starting — not serving yet"),
             None,
         ),
         (None, Some(epoch)) => (
@@ -3063,15 +3102,6 @@ pub fn doctor(
     // replacement takes to bind its socket (kunobi-ninja/kache#740). `--fix` opts
     // into that wait below.
     let my_version = crate::VERSION;
-    // One daemon observation, taken here and shared with checks 10 and 11 below.
-    // Re-probing per check made the report disagree with itself: this very
-    // request tells a daemon older than us to shut down (it schedules a graceful
-    // restart on any request from a newer binary), so a probe a few checks later
-    // legitimately sees a different world — one where the daemon just described
-    // as running is gone, its lock files look abandoned, and its process is still
-    // draining. All three checks now describe the same moment.
-    let mut daemon_was_reachable = false;
-    let mut daemon_starting_epoch = None;
     if let Some(ref cfg) = config {
         let my_epoch = crate::daemon::build_epoch();
         let mut stats = crate::daemon::send_stats_request_without_restart(cfg, false).ok();
@@ -3081,33 +3111,23 @@ pub fn doctor(
                 .as_ref()
                 .is_some_and(|s| crate::daemon::client_epoch_is_newer(my_epoch, s.build_epoch))
         };
-        daemon_was_reachable = stats.is_some();
 
         if fix && is_stale(&stats) {
             // Attributed rather than silent: this is where doctor's runtime goes
-            // when it is slow, so say what it is waiting for. And report what the
-            // restart actually did — "still coming up" is a claim, and an `Err`
-            // means no replacement was ever spawned to come up.
+            // when it is slow, so say what it is waiting for.
             println!("  Restarting daemon left over from before the upgrade...");
-            match crate::daemon::restart_daemon_for_stale_client(cfg) {
-                Ok(true) => {}
-                Ok(false) => println!(
-                    "  \x1b[2mthe replacement did not bind its socket within \
-                     the startup timeout\x1b[0m"
-                ),
-                Err(error) => println!("  \x1b[31mrestart failed: {error:#}\x1b[0m"),
+            let outcome = crate::daemon::restart_daemon_for_stale_client(cfg);
+            if let Some(note) = stale_restart_note(&outcome) {
+                println!("  {note}");
             }
             // Re-read either way: the outgoing daemon is gone now, so the report
             // should describe what is there, not what answered a moment ago.
             stats = crate::daemon::send_stats_request_without_restart(cfg, false).ok();
-            daemon_was_reachable = stats.is_some();
         }
-
-        daemon_starting_epoch = crate::daemon::starting_daemon_epoch(cfg);
 
         let (pass, detail, fix_hint) = daemon_version_check(
             stats.as_ref().map(|s| (s.version.as_str(), s.build_epoch)),
-            daemon_starting_epoch,
+            crate::daemon::starting_daemon_epoch(cfg),
             my_version,
             my_epoch,
         );
@@ -3142,12 +3162,13 @@ pub fn doctor(
     //     but `kache daemon run` processes exist, something got stuck.
     //     `kache daemon restart` now force-recovers this automatically.
     //
-    //     Reuses check 8's observation. Probing again through
-    //     `send_stats_request` was the second place doctor could spend the 8s
-    //     restart wait — an outgoing daemon still draining in-flight work answers
-    //     here too, and answering is what triggers it (kunobi-ninja/kache#740).
-    if config.is_some() {
-        let reachable = daemon_was_reachable || daemon_starting_epoch.is_some();
+    //     Liveness here is a bare socket connect, not a stats request. Asking the
+    //     daemon anything is what makes an outgoing one shut down and what could
+    //     spend the 8s restart wait a second time; connecting asks nothing, costs
+    //     nothing, and — unlike reusing check 8's answer — is true *now*, so a
+    //     daemon that died in between is not covered for (kunobi-ninja/kache#740).
+    if let Some(ref cfg) = config {
+        let reachable = daemon_is_live_now(cfg);
         let pids = crate::daemon::find_daemon_pids();
         if !reachable && !pids.is_empty() {
             let pids_str = pids
@@ -3191,10 +3212,10 @@ pub fn doctor(
     //     are legacy cruft from an unclean shutdown. Harmless but worth
     //     surfacing so users know `daemon restart` will tidy them up.
     //
-    //     Reuses the daemon snapshot from check 8 rather than re-probing: the
-    //     lock files of a daemon that is mid-handoff are in use, not cruft, and
-    //     re-probing here would report them the moment the outgoing daemon lets
-    //     go (kunobi-ninja/kache#740).
+    //     "In use" includes a daemon that holds the run lock but has not bound
+    //     its socket yet, which a socket probe alone reads as absent — that is
+    //     how a mid-upgrade handoff came to be reported as leftover cruft
+    //     (kunobi-ninja/kache#740).
     if let Some(ref cfg) = config {
         let sock = cfg.socket_path();
         let mut stale_files = Vec::new();
@@ -3205,8 +3226,7 @@ pub fn doctor(
             }
         }
         if !stale_files.is_empty()
-            && !daemon_was_reachable
-            && daemon_starting_epoch.is_none()
+            && !daemon_is_live_now(cfg)
             && crate::daemon::find_daemon_pids().is_empty()
         {
             if fix {
@@ -4780,6 +4800,8 @@ mod tests {
         assert!(pass, "{detail}");
         assert!(detail.contains("starting"), "{detail}");
         assert!(fix.is_none());
+        // Coordinator state has no version string, so none may be asserted here.
+        assert!(!detail.contains("v0.14.0"), "{detail}");
 
         // A starting daemon of some other build gets named as such rather than
         // silently claimed to be this one.
@@ -4792,6 +4814,22 @@ mod tests {
         // through the equality arm.
         let (pass, detail, _) = daemon_version_check(None, Some(0), "0.14.0", 0);
         assert!(!pass, "{detail}");
+    }
+
+    /// A restart that did not finish must never read as one that is still
+    /// finishing — that is what turns a failed `--fix` into a silent no-op in the
+    /// reader's head.
+    #[test]
+    fn stale_restart_note_never_claims_a_replacement_that_may_not_exist() {
+        assert!(stale_restart_note(&Ok(true)).is_none());
+
+        let timed_out = stale_restart_note(&Ok(false)).unwrap();
+        assert!(timed_out.contains("did not bind"), "{timed_out}");
+        assert!(!timed_out.contains("background"), "{timed_out}");
+
+        let failed = stale_restart_note(&Err(anyhow::anyhow!("spawn refused"))).unwrap();
+        assert!(failed.contains("restart failed"), "{failed}");
+        assert!(failed.contains("spawn refused"), "{failed}");
     }
 
     /// Nothing answering and nothing coming up keeps the original wording.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -220,7 +220,7 @@ fn read_daemon_state(socket_path: &Path) -> Option<DaemonCoordState> {
 ///
 /// Read-only and instant: it inspects the coordinator state file rather than the
 /// socket, which is what makes it usable from `doctor` during the window where a
-/// stats request would only report "not reachable".
+/// stats request would only report "not reachable" (kunobi-ninja/kache#720).
 ///
 /// A coordinator file outlives an unclean exit, so its mere existence proves
 /// nothing, and neither does its PID: PIDs are recycled, and a fresh record whose
@@ -6527,7 +6527,7 @@ pub fn send_stats_request(
 /// [`DAEMON_START_TIMEOUT`] waiting for it to bind its socket.
 ///
 /// `doctor` reads through this variant because a pending upgrade is something to
-/// describe, not something to stall on.
+/// describe, not something to stall on (kunobi-ninja/kache#720).
 pub fn send_stats_request_without_restart(
     config: &Config,
     include_entries: bool,
@@ -8710,7 +8710,7 @@ mod tests {
     /// during the window where the socket is not yet bound. It must answer only
     /// for a live starter that holds the run lock: a coordinator file survives an
     /// unclean exit, and a recorded PID can be recycled by an unrelated process,
-    /// so neither the file nor a live PID proves anything on its own.
+    /// so neither the file nor a live PID proves anything on its own (#720).
     #[test]
     fn starting_daemon_epoch_reports_only_a_live_starting_daemon() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -220,20 +220,38 @@ fn read_daemon_state(socket_path: &Path) -> Option<DaemonCoordState> {
 ///
 /// Read-only and instant: it inspects the coordinator state file rather than the
 /// socket, which is what makes it usable from `doctor` during the window where a
-/// stats request would only report "not reachable" (kunobi-ninja/kache#740). A
-/// stale heartbeat or a dead PID reads as "nothing starting" — a coordinator file
-/// outlives an unclean exit, so its mere existence proves nothing.
+/// stats request would only report "not reachable" (kunobi-ninja/kache#740).
+///
+/// A coordinator file outlives an unclean exit, so its mere existence proves
+/// nothing, and neither does its PID: PIDs are recycled, and a fresh record whose
+/// PID has been reused by an unrelated process would otherwise read as a live
+/// starter. The run lock is what actually distinguishes them — a daemon takes it
+/// before writing `Starting` and holds it for its whole life, so only a real
+/// starter can be holding it. The lock is probed but never created here: `doctor`
+/// reports on lock files, and a diagnostic that manufactures one would then flag
+/// its own leftovers.
 pub fn starting_daemon_epoch(config: &Config) -> Option<u64> {
-    let state = read_daemon_state(&config.socket_path())?;
-    (state.phase == DaemonPhase::Starting
-        && daemon_state_is_recent(&state)
-        && process_is_alive(state.pid))
-    .then_some(state.build_epoch)
+    let socket_path = config.socket_path();
+    let state = read_daemon_state(&socket_path)?;
+    if state.phase != DaemonPhase::Starting
+        || !daemon_state_is_recent(&state)
+        || !process_is_alive(state.pid)
+        || !daemon_run_lock_path(&socket_path).exists()
+    {
+        return None;
+    }
+    daemon_run_lock_is_held(&socket_path)
+        .ok()?
+        .then_some(state.build_epoch)
 }
 
 fn daemon_state_is_recent(state: &DaemonCoordState) -> bool {
-    let age_ms = now_millis().saturating_sub(state.updated_at_ms);
-    age_ms <= DAEMON_COORD_STALE_AFTER.as_millis() as u64
+    // A timestamp in the future is not a fresh heartbeat, it is a clock that
+    // moved: saturating to an age of zero would read a long-dead record as live
+    // until the wall clock caught back up.
+    now_millis()
+        .checked_sub(state.updated_at_ms)
+        .is_some_and(|age_ms| age_ms <= DAEMON_COORD_STALE_AFTER.as_millis() as u64)
 }
 
 /// Whether `client_epoch` is a strictly newer build than `daemon_epoch`. A zero
@@ -6500,14 +6518,18 @@ pub fn send_stats_request(
     send_stats_request_options(config, include_entries, false, sort_by, event_hours)
 }
 
-/// Read the daemon's stats without the stale-daemon restart side effect.
+/// Read the daemon's stats without starting or waiting for a replacement.
 ///
-/// [`send_stats_request`] upgrades a daemon older than the calling binary and
-/// blocks up to [`DAEMON_START_TIMEOUT`] waiting for the replacement to bind its
-/// socket. `doctor` reports state rather than changing it, so it reads through
-/// this variant: a pending upgrade is something to describe, not something to
-/// stall on (kunobi-ninja/kache#740).
-pub fn send_stats_request_read_only(
+/// Not the same as side-effect-free, and deliberately not named that way: the
+/// request still carries this binary's build epoch, so an older daemon schedules
+/// its own graceful shutdown after answering, exactly as it does for any other
+/// client. What this variant drops is the *client* side of that handoff —
+/// [`send_stats_request`] spawns the replacement and blocks up to
+/// [`DAEMON_START_TIMEOUT`] waiting for it to bind its socket.
+///
+/// `doctor` reads through this variant because a pending upgrade is something to
+/// describe, not something to stall on (kunobi-ninja/kache#740).
+pub fn send_stats_request_without_restart(
     config: &Config,
     include_entries: bool,
 ) -> Result<StatsResponse> {
@@ -7259,8 +7281,12 @@ pub fn start_daemon_background() -> Result<bool> {
     Ok(false)
 }
 
+fn daemon_run_lock_path(socket_path: &Path) -> PathBuf {
+    socket_path.with_extension("run.lock")
+}
+
 fn daemon_run_lock_is_held(socket_path: &Path) -> Result<bool> {
-    let run_lock_path = socket_path.with_extension("run.lock");
+    let run_lock_path = daemon_run_lock_path(socket_path);
     let run_lock_file = std::fs::OpenOptions::new()
         .create(true)
         .write(true)
@@ -8458,6 +8484,15 @@ mod tests {
                 .saturating_sub(DAEMON_COORD_STALE_AFTER.as_millis() as u64 * 2),
         };
         assert!(!daemon_state_is_recent(&stale));
+
+        // Clock moved backwards: a record stamped in the future is not fresh.
+        let future = DaemonCoordState {
+            pid: 1,
+            build_epoch: build_epoch(),
+            phase: DaemonPhase::Ready,
+            updated_at_ms: now_millis() + DAEMON_COORD_STALE_AFTER.as_millis() as u64 * 2,
+        };
+        assert!(!daemon_state_is_recent(&future));
     }
 
     #[test]
@@ -8654,8 +8689,9 @@ mod tests {
 
     /// `starting_daemon_epoch` is what lets `doctor` say "a daemon is coming up"
     /// during the window where the socket is not yet bound. It must answer only
-    /// for a live, freshly-heartbeating starter: a coordinator file survives an
-    /// unclean exit, so its presence alone proves nothing (#740).
+    /// for a live starter that holds the run lock: a coordinator file survives an
+    /// unclean exit, and a recorded PID can be recycled by an unrelated process,
+    /// so neither the file nor a live PID proves anything on its own (#740).
     #[test]
     fn starting_daemon_epoch_reports_only_a_live_starting_daemon() {
         let dir = tempfile::tempdir().unwrap();
@@ -8674,6 +8710,21 @@ mod tests {
             updated_at_ms: now_millis(),
         };
         write_json_atomically(&state_path, &state).unwrap();
+
+        // A fresh record naming a live process is exactly what PID reuse looks
+        // like. Without the run lock it must not read as a starting daemon — and
+        // probing must not create the lock file, which `doctor` would then report
+        // as leftover cruft.
+        assert_eq!(starting_daemon_epoch(&config), None);
+        assert!(!daemon_run_lock_path(&socket_path).exists());
+
+        let run_lock = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(daemon_run_lock_path(&socket_path))
+            .unwrap();
+        run_lock.try_lock().unwrap();
         assert_eq!(starting_daemon_epoch(&config), Some(4242));
 
         // Already serving: the socket answers, so this is not the starting window.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -73,6 +73,14 @@ fn key_cache_periodic_refresh_disabled(refresh_secs: u64) -> bool {
 }
 const DAEMON_START_TIMEOUT: Duration = Duration::from_secs(8);
 const DAEMON_START_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Read timeout for a stats round trip. Generous: a busy daemon may be holding
+/// the index lock when the request lands.
+const STATS_READ_TIMEOUT: Duration = Duration::from_secs(5);
+/// Read timeout for the stats refetch after a stale daemon was replaced. The
+/// replacement has just bound its socket and has nothing queued, so a slow
+/// answer here means something is wrong rather than busy.
+const STATS_REFETCH_TIMEOUT: Duration = Duration::from_secs(3);
 const DAEMON_COORD_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 
 /// How often the daemon re-checks its config file for changes. On a change it
@@ -207,12 +215,30 @@ fn read_daemon_state(socket_path: &Path) -> Option<DaemonCoordState> {
     serde_json::from_slice(&bytes).ok()
 }
 
+/// Build epoch of a daemon that holds the run lock but has not bound its socket
+/// yet, if one is coming up right now.
+///
+/// Read-only and instant: it inspects the coordinator state file rather than the
+/// socket, which is what makes it usable from `doctor` during the window where a
+/// stats request would only report "not reachable" (kunobi-ninja/kache#740). A
+/// stale heartbeat or a dead PID reads as "nothing starting" — a coordinator file
+/// outlives an unclean exit, so its mere existence proves nothing.
+pub fn starting_daemon_epoch(config: &Config) -> Option<u64> {
+    let state = read_daemon_state(&config.socket_path())?;
+    (state.phase == DaemonPhase::Starting
+        && daemon_state_is_recent(&state)
+        && process_is_alive(state.pid))
+    .then_some(state.build_epoch)
+}
+
 fn daemon_state_is_recent(state: &DaemonCoordState) -> bool {
     let age_ms = now_millis().saturating_sub(state.updated_at_ms);
     age_ms <= DAEMON_COORD_STALE_AFTER.as_millis() as u64
 }
 
-fn client_epoch_is_newer(client_epoch: u64, daemon_epoch: u64) -> bool {
+/// Whether `client_epoch` is a strictly newer build than `daemon_epoch`. A zero
+/// on either side means "unknown", never "older".
+pub(crate) fn client_epoch_is_newer(client_epoch: u64, daemon_epoch: u64) -> bool {
     client_epoch > 0 && daemon_epoch > 0 && client_epoch > daemon_epoch
 }
 
@@ -6474,6 +6500,27 @@ pub fn send_stats_request(
     send_stats_request_options(config, include_entries, false, sort_by, event_hours)
 }
 
+/// Read the daemon's stats without the stale-daemon restart side effect.
+///
+/// [`send_stats_request`] upgrades a daemon older than the calling binary and
+/// blocks up to [`DAEMON_START_TIMEOUT`] waiting for the replacement to bind its
+/// socket. `doctor` reports state rather than changing it, so it reads through
+/// this variant: a pending upgrade is something to describe, not something to
+/// stall on (kunobi-ninja/kache#740).
+pub fn send_stats_request_read_only(
+    config: &Config,
+    include_entries: bool,
+) -> Result<StatsResponse> {
+    fetch_stats(
+        config,
+        include_entries,
+        false,
+        None,
+        None,
+        STATS_READ_TIMEOUT,
+    )
+}
+
 pub(crate) fn send_stats_request_options(
     config: &Config,
     include_entries: bool,
@@ -6481,27 +6528,15 @@ pub(crate) fn send_stats_request_options(
     sort_by: Option<&str>,
     event_hours: Option<u64>,
 ) -> Result<StatsResponse> {
-    let socket_path = config.socket_path();
     let client_epoch = build_epoch();
-
-    let req = Request::Stats(StatsRequest {
+    let stats = fetch_stats(
+        config,
         include_entries,
         include_summaries,
-        sort_by: sort_by.map(String::from),
+        sort_by,
         event_hours,
-        client_epoch,
-    });
-
-    let resp_str =
-        send_request_with_timeout(&socket_path, &req, std::time::Duration::from_secs(5))?;
-    let resp: Response = serde_json::from_str(&resp_str)?;
-
-    let stats = if resp.ok {
-        resp.stats
-            .ok_or_else(|| anyhow::anyhow!("stats response missing payload"))?
-    } else {
-        anyhow::bail!("daemon stats error: {}", resp.error.unwrap_or_default())
-    };
+        STATS_READ_TIMEOUT,
+    )?;
 
     if client_epoch_is_newer(client_epoch, stats.build_epoch) {
         tracing::info!(
@@ -6510,17 +6545,48 @@ pub(crate) fn send_stats_request_options(
             "stale daemon detected via stats request, restarting"
         );
         if restart_daemon_for_stale_client(config)?
-            && let Ok(fresh_resp_str) =
-                send_request_with_timeout(&socket_path, &req, std::time::Duration::from_secs(3))
-            && let Ok(fresh_resp) = serde_json::from_str::<Response>(&fresh_resp_str)
-            && fresh_resp.ok
-            && let Some(fresh_stats) = fresh_resp.stats
+            && let Ok(fresh_stats) = fetch_stats(
+                config,
+                include_entries,
+                include_summaries,
+                sort_by,
+                event_hours,
+                STATS_REFETCH_TIMEOUT,
+            )
         {
             return Ok(fresh_stats);
         }
     }
 
     Ok(stats)
+}
+
+/// One stats round trip: no auto-start, no restart, no retry.
+fn fetch_stats(
+    config: &Config,
+    include_entries: bool,
+    include_summaries: bool,
+    sort_by: Option<&str>,
+    event_hours: Option<u64>,
+    read_timeout: Duration,
+) -> Result<StatsResponse> {
+    let req = Request::Stats(StatsRequest {
+        include_entries,
+        include_summaries,
+        sort_by: sort_by.map(String::from),
+        event_hours,
+        client_epoch: build_epoch(),
+    });
+
+    let resp_str = send_request_with_timeout(&config.socket_path(), &req, read_timeout)?;
+    let resp: Response = serde_json::from_str(&resp_str)?;
+
+    if resp.ok {
+        resp.stats
+            .ok_or_else(|| anyhow::anyhow!("stats response missing payload"))
+    } else {
+        anyhow::bail!("daemon stats error: {}", resp.error.unwrap_or_default())
+    }
 }
 
 /// Send a shutdown request to the running daemon.
@@ -6838,7 +6904,7 @@ pub fn restart(config: &Config) -> Result<bool> {
 /// Best-effort restart for stale-daemon detection from stats polling.
 /// This path is intentionally outside build hot paths, so a short bounded wait
 /// is acceptable to keep monitor/status output current.
-fn restart_daemon_for_stale_client(config: &Config) -> Result<bool> {
+pub(crate) fn restart_daemon_for_stale_client(config: &Config) -> Result<bool> {
     let socket_path = config.socket_path();
 
     let _ = send_request_with_timeout(&socket_path, &Request::Shutdown, Duration::from_secs(2));
@@ -8584,6 +8650,62 @@ mod tests {
             "force_recover would have killed a non-kache process: {found:?} \
              contains decoy {decoy_pid}"
         );
+    }
+
+    /// `starting_daemon_epoch` is what lets `doctor` say "a daemon is coming up"
+    /// during the window where the socket is not yet bound. It must answer only
+    /// for a live, freshly-heartbeating starter: a coordinator file survives an
+    /// unclean exit, so its presence alone proves nothing (#740).
+    #[test]
+    fn starting_daemon_epoch_reports_only_a_live_starting_daemon() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let socket_path = config.socket_path();
+        std::fs::create_dir_all(socket_path.parent().unwrap()).unwrap();
+        let state_path = daemon_state_path(&socket_path);
+
+        // No coordinator file at all.
+        assert_eq!(starting_daemon_epoch(&config), None);
+
+        let mut state = DaemonCoordState {
+            pid: std::process::id(),
+            build_epoch: 4242,
+            phase: DaemonPhase::Starting,
+            updated_at_ms: now_millis(),
+        };
+        write_json_atomically(&state_path, &state).unwrap();
+        assert_eq!(starting_daemon_epoch(&config), Some(4242));
+
+        // Already serving: the socket answers, so this is not the starting window.
+        state.phase = DaemonPhase::Ready;
+        write_json_atomically(&state_path, &state).unwrap();
+        assert_eq!(starting_daemon_epoch(&config), None);
+
+        // Starting, but the heartbeat went cold — a crashed starter, not a live one.
+        state.phase = DaemonPhase::Starting;
+        state.updated_at_ms =
+            now_millis().saturating_sub(DAEMON_COORD_STALE_AFTER.as_millis() as u64 * 2);
+        write_json_atomically(&state_path, &state).unwrap();
+        assert_eq!(starting_daemon_epoch(&config), None);
+
+        // Fresh record, dead PID: the starter died between writing the file and
+        // binding the socket. Use a reaped child rather than a made-up PID so
+        // the process really is gone.
+        let mut child = std::process::Command::new(if cfg!(windows) { "cmd" } else { "true" })
+            .args(if cfg!(windows) {
+                vec!["/C", "exit"]
+            } else {
+                vec![]
+            })
+            .spawn()
+            .unwrap();
+        let dead_pid = child.id();
+        child.wait().unwrap();
+
+        state.updated_at_ms = now_millis();
+        state.pid = dead_pid;
+        write_json_atomically(&state_path, &state).unwrap();
+        assert_eq!(starting_daemon_epoch(&config), None);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -215,6 +215,17 @@ fn read_daemon_state(socket_path: &Path) -> Option<DaemonCoordState> {
     serde_json::from_slice(&bytes).ok()
 }
 
+/// Whether a daemon is serving or coming up right now, asking it nothing.
+///
+/// `doctor`'s liveness checks need an answer that is current and free of side
+/// effects, which a stats request is neither: it makes an older daemon schedule
+/// its own shutdown, and its answer goes stale within the same report. A socket
+/// connect plus the coordinator state file covers both a daemon that is serving
+/// and one that holds the run lock but has not bound its socket yet.
+pub fn daemon_is_live(config: &Config) -> bool {
+    crate::transport::is_reachable(&config.socket_path()) || starting_daemon_epoch(config).is_some()
+}
+
 /// Build epoch of a daemon that holds the run lock but has not bound its socket
 /// yet, if one is coming up right now.
 ///
@@ -8704,6 +8715,68 @@ mod tests {
             "force_recover would have killed a non-kache process: {found:?} \
              contains decoy {decoy_pid}"
         );
+    }
+
+    /// A missing run lock file means "nobody holds it", which is a different
+    /// answer from "the probe failed": callers treat an error as unknown and
+    /// stop, so collapsing the two would make a host that never ran a daemon
+    /// indistinguishable from one whose lock could not be read.
+    #[test]
+    fn existing_run_lock_probe_separates_missing_from_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("daemon.sock");
+
+        assert!(!existing_daemon_run_lock_is_held(&socket_path).unwrap());
+        // Answering must not have created the file it was asked about.
+        assert!(!daemon_run_lock_path(&socket_path).exists());
+
+        let lock = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(daemon_run_lock_path(&socket_path))
+            .unwrap();
+
+        // Present but free.
+        assert!(!existing_daemon_run_lock_is_held(&socket_path).unwrap());
+
+        lock.try_lock().unwrap();
+        assert!(existing_daemon_run_lock_is_held(&socket_path).unwrap());
+    }
+
+    /// The liveness signal behind doctor's process and stale-lock checks: true
+    /// for a daemon that is serving *or* still binding its socket, and false when
+    /// nothing is there. A signal stuck on either answer silently disables both
+    /// checks, so both directions are pinned here.
+    #[test]
+    fn daemon_is_live_covers_serving_and_starting_daemons() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let socket_path = config.socket_path();
+        std::fs::create_dir_all(socket_path.parent().unwrap()).unwrap();
+
+        assert!(!daemon_is_live(&config), "nothing running");
+
+        // No socket yet, but the run lock is held and the coordinator says a
+        // daemon is on its way up.
+        let lock = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(daemon_run_lock_path(&socket_path))
+            .unwrap();
+        lock.try_lock().unwrap();
+        write_json_atomically(
+            &daemon_state_path(&socket_path),
+            &DaemonCoordState {
+                pid: std::process::id(),
+                build_epoch: 4242,
+                phase: DaemonPhase::Starting,
+                updated_at_ms: now_millis(),
+            },
+        )
+        .unwrap();
+        assert!(daemon_is_live(&config), "starting daemon");
     }
 
     /// `starting_daemon_epoch` is what lets `doctor` say "a daemon is coming up"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -220,7 +220,7 @@ fn read_daemon_state(socket_path: &Path) -> Option<DaemonCoordState> {
 ///
 /// Read-only and instant: it inspects the coordinator state file rather than the
 /// socket, which is what makes it usable from `doctor` during the window where a
-/// stats request would only report "not reachable" (kunobi-ninja/kache#740).
+/// stats request would only report "not reachable".
 ///
 /// A coordinator file outlives an unclean exit, so its mere existence proves
 /// nothing, and neither does its PID: PIDs are recycled, and a fresh record whose
@@ -6527,7 +6527,7 @@ pub fn send_stats_request(
 /// [`DAEMON_START_TIMEOUT`] waiting for it to bind its socket.
 ///
 /// `doctor` reads through this variant because a pending upgrade is something to
-/// describe, not something to stall on (kunobi-ninja/kache#740).
+/// describe, not something to stall on.
 pub fn send_stats_request_without_restart(
     config: &Config,
     include_entries: bool,
@@ -8710,7 +8710,7 @@ mod tests {
     /// during the window where the socket is not yet bound. It must answer only
     /// for a live starter that holds the run lock: a coordinator file survives an
     /// unclean exit, and a recorded PID can be recycled by an unrelated process,
-    /// so neither the file nor a live PID proves anything on its own (#740).
+    /// so neither the file nor a live PID proves anything on its own.
     #[test]
     fn starting_daemon_epoch_reports_only_a_live_starting_daemon() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -236,11 +236,10 @@ pub fn starting_daemon_epoch(config: &Config) -> Option<u64> {
     if state.phase != DaemonPhase::Starting
         || !daemon_state_is_recent(&state)
         || !process_is_alive(state.pid)
-        || !daemon_run_lock_path(&socket_path).exists()
     {
         return None;
     }
-    daemon_run_lock_is_held(&socket_path)
+    existing_daemon_run_lock_is_held(&socket_path)
         .ok()?
         .then_some(state.build_epoch)
 }
@@ -7286,21 +7285,41 @@ fn daemon_run_lock_path(socket_path: &Path) -> PathBuf {
 }
 
 fn daemon_run_lock_is_held(socket_path: &Path) -> Result<bool> {
-    let run_lock_path = daemon_run_lock_path(socket_path);
     let run_lock_file = std::fs::OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(false)
-        .open(&run_lock_path)
+        .open(daemon_run_lock_path(socket_path))
         .context("opening daemon run lock probe file")?;
 
-    // Probe: if we can acquire the lock, no daemon is running. Releases
-    // immediately on drop (or via explicit unlock below).
-    if run_lock_file.try_lock().is_ok() {
-        let _ = run_lock_file.unlock();
-        Ok(false)
+    Ok(run_lock_file_is_held(&run_lock_file))
+}
+
+/// Like [`daemon_run_lock_is_held`], but never creates the lock file: a missing
+/// file reads as "not held".
+///
+/// For callers that only observe. `doctor` reports leftover lock files, so a
+/// probe that creates one on a host that has never run a daemon would hand it a
+/// finding it manufactured itself — and testing for the file first only narrows
+/// that race rather than closing it.
+fn existing_daemon_run_lock_is_held(socket_path: &Path) -> Result<bool> {
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .open(daemon_run_lock_path(socket_path))
+    {
+        Ok(file) => Ok(run_lock_file_is_held(&file)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error).context("opening daemon run lock probe file"),
+    }
+}
+
+/// Probe: if we can acquire the lock, no daemon holds it. Releases immediately.
+fn run_lock_file_is_held(file: &std::fs::File) -> bool {
+    if file.try_lock().is_ok() {
+        let _ = file.unlock();
+        false
     } else {
-        Ok(true)
+        true
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8744,6 +8744,32 @@ mod tests {
         assert!(existing_daemon_run_lock_is_held(&socket_path).unwrap());
     }
 
+    /// A lock file that cannot be opened must surface as an error, not as
+    /// "nobody holds it".
+    ///
+    /// The probe special-cases exactly one failure — `NotFound`, meaning the
+    /// file was never created — and propagates everything else. The test above
+    /// covers missing, present-and-free, and held, but never an unreadable
+    /// lock, so the `NotFound` guard could be widened to match every error and
+    /// nothing would notice: an unreadable lock would then read as free, and
+    /// doctor would report a host as clean precisely when it could not tell.
+    ///
+    /// A directory where the file belongs is the portable way to fail an open
+    /// with something that is not `NotFound` (EISDIR on unix, access-denied on
+    /// Windows) without depending on running as an unprivileged user, which
+    /// chmod-based variants do.
+    #[test]
+    fn existing_run_lock_probe_propagates_an_unreadable_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("daemon.sock");
+        std::fs::create_dir_all(daemon_run_lock_path(&socket_path)).unwrap();
+
+        assert!(
+            existing_daemon_run_lock_is_held(&socket_path).is_err(),
+            "an unopenable lock file must not be reported as unheld"
+        );
+    }
+
     /// The liveness signal behind doctor's process and stale-lock checks: true
     /// for a daemon that is serving *or* still binding its socket, and false when
     /// nothing is there. A signal stuck on either answer silently disables both


### PR DESCRIPTION
Relates to #720 (the same "daemon did not start within timeout" WARN reaching users, from the doctor side rather than init).

## What happened

Running `kache doctor` right after upgrading the binary took about ten seconds, printed a raw WARN above its own report, and then reported the daemon version it had already read and knew was stale, with a fix hint for the restart it had just tried and failed to complete. A routine upgrade looked like a broken install.

The daemon version check went through `send_stats_request`, which restarts a daemon older than the calling binary and blocks up to `DAEMON_START_TIMEOUT` (8s) waiting for the replacement to bind its socket. The daemon already handles this itself: any request carrying a newer client epoch makes it schedule a graceful restart. The client side blocking wait was not load bearing, only slow.

Check 10 ("Daemon processes") probed through the same restarting call, so a daemon still draining in flight work could answer there and spend the 8s a second time.

## What changed

`doctor` reports rather than repairs. `--fix` keeps the restart and the wait, and says what it is waiting for.

* the version check reads through `send_stats_request_without_restart`
* liveness for the process and stale lock checks is a bare socket connect plus the coordinator state file. It sends no request, so it cannot trigger the shutdown or the wait, and it is true at the moment it is asked
* a daemon that holds the run lock but has not bound its socket is reported as starting, instead of "not reachable, start the daemon"

Reporting was also wrong in ways the stall hid. Build epochs are executable mtimes where 0 means unreadable, and `client_epoch_is_newer` refuses to order a zero or a tie, but the catch all arm treated everything it declined to order as "the daemon is newer" and told people to reinstall a kache that was fine. `starting_daemon_epoch` accepted a fresh coordinator record naming any live PID, which is what PID reuse after an unclean exit looks like; it now also requires the run lock, and probes without creating the lock file, since doctor reports on lock files and should not manufacture its own findings.

## Behaviour

| state | before | after |
|---|---|---|
| daemon older than binary | WARN, 8s wait, then the stale version | `daemon v0.13.0 (epoch ...) predates binary v0.14.0 (epoch ...) - it is shutting down now`, plus where the replacement comes from |
| replacement still binding | `daemon not reachable -> start daemon` | `a daemon of this build (epoch ...) is starting - not serving yet`, passing |
| binary older than daemon | restart the daemon, which downgrades it | blamed on the binary |
| unorderable epochs | claimed the daemon was newer | says the order cannot be determined |

About 10s to about 0.15s in the upgrade case.

## Testing

1908 unit tests pass, clippy and fmt clean. All four states above verified live against real daemons in an isolated cache dir, including that a host that has never run a daemon gets no lock file created by the probe.

`doctor --fix` was not run live because it also rewrites `~/.cargo/config.toml` and stops a running sccache. Its restart outcome logic is unit tested through `stale_restart_note`, and the state it produces was verified by hand.

## Known, not addressed here

* `find_daemon_pids()` is a machine wide pgrep while sockets are per cache dir, so with two cache dirs one daemon is counted against the other
* coordinator state carries no version or generation token, so a starting daemon's identity is only its mtime second
* check 10 can still fire transiently mid handoff. Suppressing it needs a cached answer, which hides true findings
* plain `doctor` still nudges an older daemon into shutting down, since its stats request carries this binary's epoch. Kept deliberately: the report now says so and says where the replacement comes from