### PR TITLE
ci(release): call the in-org mirror of _release-rust.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1083,7 +1083,19 @@ jobs:
     # disagrees with the manifest BEFORE any binary builds; `e2e` includes the
     # (blocking) Windows arm, so a tag won't release unless Windows e2e is green.
     needs: [check, nix-package, e2e, test-macos, test-windows, version-consistency]
-    uses: zondax/_workflows/.github/workflows/_release-rust.yml@7f61511b59d2b86454e65a6bbf48f14469692324 # v11
+    # IN-ORG MIRROR of zondax/_workflows@7f61511 (v11) — a byte-identical import.
+    # The macOS legs run on the self-hosted signing runners, whose runner group
+    # restricts which workflows may use it. GitHub matches that allowlist against
+    # the workflow a job is DEFINED in (not the caller), and an org-owned group
+    # cannot name a workflow from another org — so while this pointed at
+    # `zondax/`, no allowlist entry could authorize the Darwin jobs. They queued
+    # forever against online, idle runners with no error anywhere; v0.14.0 lost
+    # ~2h to exactly that. See kunobi-ninja/_workflows for the full rationale.
+    #
+    # The signing-runners allowlist pins THIS SHA. Bumping the pin without
+    # updating that group's selected_workflows breaks releases SILENTLY — move
+    # both in one change; the mirror's README has the one-liner.
+    uses: kunobi-ninja/_workflows/.github/workflows/_release-rust.yml@ee8dc66895f75bf79c8fa4c87e06aaeb752e7db5 # v1
     with:
       binary_name: kache
       # Build .deb assets (kache_<version>_{amd64,arm64}.deb) for the apt repo,


### PR DESCRIPTION
## Why

The macOS release legs run on the self-hosted signing Mac minis. Their runner group (`signing-runners`) restricts which workflows may use it, and two GitHub rules combine badly here:

> Only jobs **directly defined within the selected workflows** will have access to the runner group.

> Organization-owned runner groups **cannot access workflows from a different organization** in the enterprise; instead, you must create an enterprise-owned runner group.

The Darwin build jobs are defined in `_release-rust.yml`, which lived in the **`Zondax`** org. So the allowlist had to name a workflow it is structurally forbidden from naming — **no entry could ever authorize these jobs.** Listing the caller (`kache/ci.yml`, even at the exact tag ref) does nothing, because the caller is not what's matched. The enterprise-owned-group escape hatch is unavailable: both orgs are on the `team` plan.

**The failure mode is silent.** During v0.14.0 both `Build *-apple-darwin` jobs sat `queued` for **2h10m** with all four Mac runners `online`/`busy=false` and `runner_group_name: ""`. GitHub only ever reports "waiting for a runner" — there is no "blocked by workflow filter" signal in the UI or the API. Shipping required disabling the restriction entirely.

## What

Repoint the release job at [`kunobi-ninja/_workflows`](https://github.com/kunobi-ninja/_workflows), a **byte-identical** mirror of `zondax/_workflows@7f61511` (v11), pinned to SHA `ee8dc66`.

This makes the jobs in-org so the allowlist can name them, which is what allows `restricted_to_workflows` to be turned back on.

## Evidence this actually fixes it

An identically-shaped allowlist entry, tested against the live group:

| Entry | Result |
| --- | --- |
| `Zondax/_workflows/.github/workflows/_release-rust.yml@7f61511` | **400** — "does not resolve to a file in any repository you can access" (the file provably exists and is public) |
| `kunobi-ninja/_workflows/.github/workflows/_release-rust.yml@ee8dc66` | **accepted and stored** |

Same shape, same ref form — rejected cross-org, accepted in-org. That isolates policy from permissions and confirms the mirror is the fix.

## Risk

**No behaviour change.** The mirror is a verbatim copy of the exact SHA this already pinned (696 lines, `diff` clean). kobe pinned tag `v11`, which resolves to the same content, so [its companion PR](https://github.com/kunobi-ninja/kobe/pulls) moves to the same mirror with no change either.

## Ongoing cost, stated plainly

This forks kache off the shared Zondax workflow — upstream fixes now need deliberate porting. And the allowlist pins this SHA, so **bumping the pin without updating `signing-runners` breaks releases silently.** Both must move in one change; the mirror's README carries the command and the reasoning.

## Sequencing

Merge this first. `restricted_to_workflows` stays **off** until a throwaway `-rc` tag proves the path end to end — branch CI cannot exercise it, because no job on `main` requests the `mac-mini` label.