### PR TITLE
fix: stop kache from killing processes it doesn't own

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -103,15 +103,14 @@ gitignore = true
 # precisely so this lane still mutation-tests the matching rule that decides
 # which processes force_recover may kill.
 #
-# `find_daemon_pids`'s `pid != own_pid && process_is_alive(pid)` guards against
-# the enumeration returning the caller. Every caller — `daemon restart`,
-# `doctor`, `setup` — has a command line of the form `kache daemon restart`,
-# which `pgrep -f "kache daemon run"` does not match, so no test can arrange
-# for own_pid to appear in the input and `&&` vs `||` is unobservable rather
-# than untested. The guard stays as defence in depth if a future caller runs
-# under a matching command line. The rest of the function is covered by tests
-# that assert both directions: a process running a `kache` executable is
-# found, and a shell that merely mentions `kache daemon run` is not.
+# The two operator mutants inside `find_daemon_pids` are the same story: both
+# live in its `#[cfg(windows)]` arm — `*pid != own_pid && cmdline_is_daemon_run(..)`
+# — which this lane does not compile. Its Unix arm is untouched by the change
+# that introduced these entries, so nothing here narrows coverage of the code
+# the lane can actually reach. The function's return value stays fully in
+# scope and is killed by tests asserting both directions: a process running a
+# `kache` executable is found, and a shell whose command line merely mentions
+# `kache daemon run` is not.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -136,4 +135,5 @@ exclude_re = [
     "windows_path_uses_device_namespace",
     "windows_kache_processes",
     "replace && with \\|\\| in find_daemon_pids",
+    "replace != with == in find_daemon_pids",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -95,6 +95,23 @@ gitignore = true
 # The two `windows_*` path adapters only translate host `Path` components into
 # platform-neutral classifiers. Ubuntu cannot compile their Windows bodies;
 # the classifiers remain in scope and have exhaustive Linux-runnable tests.
+#
+# `windows_kache_processes` is `#[cfg(windows)]`: the `sample_write_clock`
+# property again — the ubuntu lane never compiles it, so every mutant inside
+# it survives by construction. Kept as narrow as the name allows: the decision
+# it feeds, `cmdline_is_daemon_run`, is deliberately `#[cfg(any(windows, test))]`
+# precisely so this lane still mutation-tests the matching rule that decides
+# which processes force_recover may kill.
+#
+# `find_daemon_pids`'s `pid != own_pid && process_is_alive(pid)` guards against
+# the enumeration returning the caller. Every caller — `daemon restart`,
+# `doctor`, `setup` — has a command line of the form `kache daemon restart`,
+# which `pgrep -f "kache daemon run"` does not match, so no test can arrange
+# for own_pid to appear in the input and `&&` vs `||` is unobservable rather
+# than untested. The guard stays as defence in depth if a future caller runs
+# under a matching command line. The rest of the function is covered by tests
+# that assert both directions: a process running a `kache` executable is
+# found, and a shell that merely mentions `kache daemon run` is not.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -117,4 +134,6 @@ exclude_re = [
     "NonInheritableStdio",
     "windows_pattern_has_ambiguous_root",
     "windows_path_uses_device_namespace",
+    "windows_kache_processes",
+    "replace && with \\|\\| in find_daemon_pids",
 ]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8429,6 +8429,46 @@ mod tests {
         assert!(!super::comm_is_daemon_exe("   "));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn pid_alive_rejects_broadcast_pids() {
+        // This prunes the in-flight compile map. `kill(0, 0)` and `kill(-1, 0)`
+        // succeed whenever anything signalable exists, so without the guard
+        // entries recorded under a bogus PID would look alive forever.
+        assert!(super::pid_alive(std::process::id()));
+
+        assert!(!super::pid_alive(0), "0 is the caller's process group");
+        assert!(!super::pid_alive(1), "1 is init/launchd, never a compile");
+        assert!(
+            !super::pid_alive(u32::MAX),
+            "u32::MAX casts to the -1 broadcast"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn process_comm_reports_the_executable_behind_a_pid() {
+        // The executable check is only as good as this lookup: if it silently
+        // returned None or a wrong name, find_daemon_pids would quietly match
+        // nothing and force_recover would stop recovering anything at all.
+        // A test that only asserts "the bystander was excluded" cannot tell
+        // those apart, so pin the lookup itself against the running test
+        // process, whose executable name is known.
+        let comm = super::process_comm(std::process::id()).expect("ps must answer for our own pid");
+        let name = std::path::Path::new(&comm)
+            .file_name()
+            .expect("comm has a file name")
+            .to_string_lossy()
+            .into_owned();
+        assert!(
+            name.starts_with("kache"),
+            "expected the test binary's own executable name, got {comm:?}"
+        );
+
+        // A PID that cannot exist has no executable to report.
+        assert_eq!(super::process_comm(0), None);
+    }
+
     #[test]
     fn cmdline_is_daemon_run_matches_only_the_daemon_subcommand() {
         // Windows enumerates by image name only, so this is the sole thing
@@ -8448,6 +8488,42 @@ mod tests {
         assert!(!super::cmdline_is_daemon_run("kache.exe daemon"));
         assert!(!super::cmdline_is_daemon_run("kache.exe run"));
         assert!(!super::cmdline_is_daemon_run(""));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn find_daemon_pids_finds_a_process_running_the_kache_executable() {
+        // The negative test below cannot tell "correctly excluded the
+        // bystander" from "found nothing at all", which is what a broken
+        // lookup or an over-strict filter would do — and finding nothing means
+        // force_recover silently stops recovering. So pin the positive side.
+        //
+        // A real `kache daemon run` cannot be arranged inside a unit test, so
+        // stand one up: any executable named `kache`, placed in a directory
+        // whose name puts "kache daemon run" into the command line that
+        // `pgrep -f` sees.
+        let dir = tempfile::tempdir().unwrap();
+        let bin_dir = dir.path().join("kache daemon run");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let fake = bin_dir.join("kache");
+        std::fs::copy("/bin/sleep", &fake).unwrap();
+
+        let mut child = std::process::Command::new(&fake)
+            .arg("30")
+            .spawn()
+            .expect("spawn fake daemon");
+        let fake_pid = child.id();
+
+        let found = super::find_daemon_pids();
+
+        child.kill().expect("kill fake daemon");
+        child.wait().expect("reap fake daemon");
+
+        assert!(
+            found.contains(&fake_pid),
+            "a process running an executable named kache should be found: \
+             {found:?} is missing {fake_pid}"
+        );
     }
 
     #[cfg(unix)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6411,8 +6411,17 @@ fn prune_in_flight(map: &mut HashMap<u32, CompileStartedRequest>) {
 
 /// Is a process with this PID alive? `kill(pid, 0)` probes without signaling:
 /// success or EPERM (alive, not ours) both mean alive; ESRCH means gone.
+///
+/// Deliberately does not use [`crate::platform::is_process_alive`]: this runs
+/// inside a `retain` over every in-flight compile, and that helper shells out
+/// to `ps` for a zombie check. It does share the helper's pid guard, because
+/// `kill(-1, 0)` succeeds whenever anything is signalable and would keep
+/// bogus entries alive in the map forever.
 #[cfg(unix)]
 fn pid_alive(pid: u32) -> bool {
+    if pid <= 1 || i32::try_from(pid).is_err() {
+        return false;
+    }
     let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
     rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
@@ -6554,10 +6563,53 @@ pub fn send_shutdown_request(config: &Config) -> Result<()> {
     }
 }
 
+/// Executable file name a real daemon process must be running.
+#[cfg(unix)]
+const DAEMON_EXE_NAME: &str = "kache";
+
+/// Does `ps -o comm=` output name the kache executable itself?
+///
+/// `pgrep -f` matches against the whole command line, so it also returns
+/// processes that merely *mention* `kache daemon run` — most importantly the
+/// shell or wrapper script that launched the daemon
+/// (`sh -c "kache daemon run"` carries the string in its own argv). Since
+/// `find_daemon_pids` feeds `force_recover`, which SIGTERMs then SIGKILLs
+/// every PID it returns, a command-line match means "nuclear recovery" can
+/// kill the user's script or interactive shell.
+///
+/// macOS reports a full path here and Linux a bare name, so compare on the
+/// file name. Deliberately strict: a renamed binary is missed and recovery
+/// falls through to wiping the stale coordination files, which is recoverable.
+/// Killing the wrong process is not.
+#[cfg(unix)]
+fn comm_is_daemon_exe(comm: &str) -> bool {
+    let comm = comm.trim();
+    !comm.is_empty()
+        && Path::new(comm)
+            .file_name()
+            .is_some_and(|name| name == DAEMON_EXE_NAME)
+}
+
+/// Executable name behind a PID, via `ps -o comm=`. None if the process is
+/// gone or `ps` could not answer.
+#[cfg(unix)]
+fn process_comm(pid: u32) -> Option<String> {
+    let output = std::process::Command::new("ps")
+        .args(["-o", "comm=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
 /// Find PIDs of running `kache daemon run` processes via pgrep.
 ///
 /// Returns only PIDs that are still alive at the moment of the check — stale
-/// pgrep output is filtered out with a `kill -0` probe.
+/// pgrep output is filtered out with a `kill -0` probe — and only processes
+/// that are the kache executable itself, never something whose command line
+/// merely mentions it. See [`comm_is_daemon_exe`].
 pub fn find_daemon_pids() -> Vec<u32> {
     let own_pid = std::process::id();
 
@@ -6574,12 +6626,29 @@ pub fn find_daemon_pids() -> Vec<u32> {
             .lines()
             .filter_map(|l| l.trim().parse::<u32>().ok())
             .filter(|&pid| pid != own_pid && process_is_alive(pid))
+            .filter(|&pid| process_comm(pid).is_some_and(|comm| comm_is_daemon_exe(&comm)))
             .collect()
     }
 
     #[cfg(windows)]
     {
-        // tasklist is available on all supported Windows versions.
+        // Preferred: Win32_Process gives the command line, so a sibling
+        // `kache.exe build` is not mistaken for a daemon. Falls back to
+        // tasklist when the query is unavailable — see below.
+        if let Some(processes) = windows_kache_processes() {
+            return processes
+                .into_iter()
+                .filter(|(pid, cmdline)| *pid != own_pid && cmdline_is_daemon_run(cmdline))
+                .map(|(pid, _)| pid)
+                .filter(|&pid| process_is_alive(pid))
+                .collect();
+        }
+
+        // Fallback: tasklist is available on all supported Windows versions but
+        // reports no command line, so this matches every kache.exe. That is the
+        // long-standing behaviour; keeping it means a missing or restricted
+        // PowerShell degrades recovery to what it always did rather than
+        // silently finding nothing and leaving a stuck daemon unrecoverable.
         // /FI filters by image name, /FO CSV for parseable output, /NH skips header.
         // CSV format: "kache.exe","1234","Console","1","12,345 K"
         let output = match std::process::Command::new("tasklist")
@@ -6598,6 +6667,66 @@ pub fn find_daemon_pids() -> Vec<u32> {
             .filter(|&pid| pid != own_pid && process_is_alive(pid))
             .collect()
     }
+}
+
+/// Does this command line belong to a `kache daemon run` process?
+///
+/// The Windows enumeration filters by image name, which — unlike the Unix
+/// `pgrep -f` path — says nothing about the subcommand, so without this an
+/// in-flight `kache.exe build` looks like a daemon to `force_recover` and gets
+/// killed. Matches `daemon` immediately followed by `run` as argument tokens,
+/// so `daemon status` and a bare `daemon` do not qualify.
+///
+/// Compiled on Windows and in every test build, so the Unix lanes still cover
+/// the logic even though only Windows calls it.
+#[cfg(any(windows, test))]
+fn cmdline_is_daemon_run(cmdline: &str) -> bool {
+    let mut rest = cmdline.split_whitespace().skip_while(|token| *token != "daemon");
+    rest.next().is_some() && rest.next() == Some("run")
+}
+
+/// `(pid, command line)` for every running `kache.exe`, or None when the query
+/// is unavailable and the caller should fall back to tasklist.
+///
+/// Returns None rather than an empty vec when rows came back but no command
+/// line did: that means the query ran without the access needed to read
+/// command lines, and treating it as "no daemons" would break recovery.
+#[cfg(windows)]
+fn windows_kache_processes() -> Option<Vec<(u32, String)>> {
+    let output = std::process::Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "Get-CimInstance Win32_Process -Filter \"Name='kache.exe'\" | \
+             ForEach-Object { \"$($_.ProcessId)|$($_.CommandLine)\" }",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut rows = Vec::new();
+    let mut saw_command_line = false;
+    for line in stdout.lines() {
+        let Some((pid, cmdline)) = line.trim().split_once('|') else {
+            continue;
+        };
+        let Ok(pid) = pid.trim().parse::<u32>() else {
+            continue;
+        };
+        let cmdline = cmdline.trim();
+        saw_command_line |= !cmdline.is_empty();
+        rows.push((pid, cmdline.to_string()));
+    }
+
+    if rows.is_empty() {
+        // No kache.exe at all — a real, trustworthy answer.
+        return Some(rows);
+    }
+    saw_command_line.then_some(rows)
 }
 
 /// Nuclear recovery: kill any lingering `kache daemon run` processes, then
@@ -8277,14 +8406,94 @@ mod tests {
         assert!(daemon_state_is_recent(&state));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn comm_is_daemon_exe_accepts_only_the_kache_executable() {
+        // macOS reports a full path, Linux a bare name.
+        assert!(super::comm_is_daemon_exe("/Users/x/.cargo/bin/kache"));
+        assert!(super::comm_is_daemon_exe("kache"));
+        assert!(super::comm_is_daemon_exe("  /usr/local/bin/kache  "));
+        assert!(super::comm_is_daemon_exe("./target/debug/kache"));
+
+        // The shell or wrapper that launched the daemon carries
+        // "kache daemon run" in its own argv, so `pgrep -f` returns it.
+        assert!(!super::comm_is_daemon_exe("/bin/sh"));
+        assert!(!super::comm_is_daemon_exe("zsh"));
+        assert!(!super::comm_is_daemon_exe("vim"));
+        // Not a prefix or substring match.
+        assert!(!super::comm_is_daemon_exe("kache-wrapper"));
+        assert!(!super::comm_is_daemon_exe("mykache"));
+        assert!(!super::comm_is_daemon_exe(""));
+        assert!(!super::comm_is_daemon_exe("   "));
+    }
+
+    #[test]
+    fn cmdline_is_daemon_run_matches_only_the_daemon_subcommand() {
+        // Windows enumerates by image name only, so this is the sole thing
+        // separating a daemon from any other kache.exe.
+        assert!(super::cmdline_is_daemon_run(r"C:\bin\kache.exe daemon run"));
+        assert!(super::cmdline_is_daemon_run("kache.exe daemon run --foreground"));
+        assert!(super::cmdline_is_daemon_run(
+            r#""C:\Program Files\kache.exe" daemon run"#
+        ));
+
+        // Sibling CLI invocations force_recover must not kill.
+        assert!(!super::cmdline_is_daemon_run("kache.exe build"));
+        assert!(!super::cmdline_is_daemon_run("kache.exe daemon status"));
+        assert!(!super::cmdline_is_daemon_run("kache.exe daemon stop"));
+        assert!(!super::cmdline_is_daemon_run("kache.exe daemon"));
+        assert!(!super::cmdline_is_daemon_run("kache.exe run"));
+        assert!(!super::cmdline_is_daemon_run(""));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn find_daemon_pids_ignores_processes_that_merely_mention_the_daemon() {
+        // A shell whose command line contains "kache daemon run" — exactly
+        // what a wrapper script looks like. `pgrep -f` matches it; the
+        // executable check must drop it, because force_recover SIGKILLs
+        // everything this function returns.
+        //
+        // Safe by construction: find_daemon_pids only reads.
+        let mut decoy = std::process::Command::new("/bin/sh")
+            .args(["-c", "sleep 20; : kache daemon run"])
+            .spawn()
+            .expect("spawn decoy");
+        let decoy_pid = decoy.id();
+
+        let found = super::find_daemon_pids();
+
+        decoy.kill().expect("kill decoy");
+        decoy.wait().expect("reap decoy");
+
+        assert!(
+            !found.contains(&decoy_pid),
+            "force_recover would have killed a non-kache process: {found:?} \
+             contains decoy {decoy_pid}"
+        );
+    }
+
     #[test]
     fn test_recover_unhealthy_daemon_cleans_stale_socket_and_state() {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.path().join("daemon.sock");
         std::fs::write(&socket_path, b"stale").unwrap();
 
+        // Use a reaped child rather than a made-up PID: `u32::MAX` casts to
+        // -1, and `kill(-1, ...)` signals every process the user owns.
+        let mut child = std::process::Command::new(if cfg!(windows) { "cmd" } else { "true" })
+            .args(if cfg!(windows) {
+                vec!["/C", "exit"]
+            } else {
+                vec![]
+            })
+            .spawn()
+            .unwrap();
+        let dead_pid = child.id();
+        child.wait().unwrap();
+
         let state = DaemonCoordState {
-            pid: u32::MAX,
+            pid: dead_pid,
             build_epoch: build_epoch(),
             phase: DaemonPhase::Starting,
             updated_at_ms: now_millis(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6681,7 +6681,9 @@ pub fn find_daemon_pids() -> Vec<u32> {
 /// the logic even though only Windows calls it.
 #[cfg(any(windows, test))]
 fn cmdline_is_daemon_run(cmdline: &str) -> bool {
-    let mut rest = cmdline.split_whitespace().skip_while(|token| *token != "daemon");
+    let mut rest = cmdline
+        .split_whitespace()
+        .skip_while(|token| *token != "daemon");
     rest.next().is_some() && rest.next() == Some("run")
 }
 
@@ -8432,7 +8434,9 @@ mod tests {
         // Windows enumerates by image name only, so this is the sole thing
         // separating a daemon from any other kache.exe.
         assert!(super::cmdline_is_daemon_run(r"C:\bin\kache.exe daemon run"));
-        assert!(super::cmdline_is_daemon_run("kache.exe daemon run --foreground"));
+        assert!(super::cmdline_is_daemon_run(
+            "kache.exe daemon run --foreground"
+        ));
         assert!(super::cmdline_is_daemon_run(
             r#""C:\Program Files\kache.exe" daemon run"#
         ));

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8454,7 +8454,17 @@ mod tests {
         // A test that only asserts "the bystander was excluded" cannot tell
         // those apart, so pin the lookup itself against the running test
         // process, whose executable name is known.
-        let comm = super::process_comm(std::process::id()).expect("ps must answer for our own pid");
+        // The Nix build sandbox ships no `ps`, so there is nothing to pin
+        // there. The Test and mutation lanes all have one.
+        //
+        // Probe for the tool rather than asking `process_comm`, which is what
+        // this test pins: gating on its return would let a mutant that stubs
+        // it out turn this test into a silent skip.
+        if find_in_path("ps").is_none() {
+            return;
+        }
+        let comm =
+            super::process_comm(std::process::id()).expect("ps is present, so it must answer");
         let name = std::path::Path::new(&comm)
             .file_name()
             .expect("comm has a file name")
@@ -8490,6 +8500,17 @@ mod tests {
         assert!(!super::cmdline_is_daemon_run(""));
     }
 
+    /// Resolve an executable the way `Command::new(name)` would. Tests that
+    /// shell out need to know whether the tool exists at all before asserting
+    /// on its output — hardcoded paths like `/bin/sleep` do not exist under
+    /// Nix, where everything lives in the store.
+    #[cfg(unix)]
+    fn find_in_path(name: &str) -> Option<std::path::PathBuf> {
+        std::env::split_paths(&std::env::var_os("PATH")?)
+            .map(|dir| dir.join(name))
+            .find(|candidate| candidate.is_file())
+    }
+
     #[cfg(unix)]
     #[test]
     fn find_daemon_pids_finds_a_process_running_the_kache_executable() {
@@ -8502,11 +8523,23 @@ mod tests {
         // stand one up: any executable named `kache`, placed in a directory
         // whose name puts "kache daemon run" into the command line that
         // `pgrep -f` sees.
+        //
+        // Needs the same tools find_daemon_pids does. The Nix build sandbox
+        // has neither `pgrep` nor `ps` (nor a `/bin/sleep` to copy), and
+        // asserting there would only pin the sandbox, not the behaviour.
+        let (Some(sleep_bin), Some(_pgrep), Some(_ps)) = (
+            find_in_path("sleep"),
+            find_in_path("pgrep"),
+            find_in_path("ps"),
+        ) else {
+            return;
+        };
+
         let dir = tempfile::tempdir().unwrap();
         let bin_dir = dir.path().join("kache daemon run");
         std::fs::create_dir_all(&bin_dir).unwrap();
         let fake = bin_dir.join("kache");
-        std::fs::copy("/bin/sleep", &fake).unwrap();
+        std::fs::copy(&sleep_bin, &fake).unwrap();
 
         let mut child = std::process::Command::new(&fake)
             .arg("30")

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -410,6 +410,26 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn kill_process_actually_kills_a_spawned_child() {
+        // SIGKILL is the escalation the daemon recovery path relies on when a
+        // polite SIGTERM does not land, so it needs its own coverage: a
+        // terminate-only test leaves "kill does nothing" indistinguishable
+        // from "kill works".
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+
+        super::kill_process(pid);
+        let status = child.wait().expect("reap child");
+
+        assert!(!status.success(), "child should have been killed");
+        assert!(!super::is_process_alive(pid), "child should be gone");
+    }
+
+    #[cfg(unix)]
+    #[test]
     #[should_panic(expected = "not a descendant of the test process")]
     fn signalling_a_process_the_test_does_not_own_panics() {
         // The test runner that spawned us: a live PID, definitely not ours.

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -9,8 +9,99 @@
 //! On Windows they map to OpenProcess/TerminateProcess and the Windows
 //! console-control events surfaced by tokio::signal::windows.
 
+/// Is `pid` safe to hand to `kill(2)` as a single-process target?
+///
+/// `kill(2)` overloads the pid argument with broadcast modes, and a bogus or
+/// sentinel PID that lands in one of them takes down far more than the
+/// intended process:
+///
+///   - `pid == 0`: every process in the *caller's* process group
+///   - `pid == -1`: every process the caller has permission to signal, i.e.
+///     the user's entire login session
+///   - `pid < -1`: the process group `-pid`
+///   - `pid == 1`: init/launchd, and negating it yields the `-1` broadcast
+///
+/// Note that `u32::MAX` casts to `-1`, so a "definitely dead, made-up PID"
+/// fixture is exactly the value that wipes the session. Reject anything that
+/// is not an ordinary positive PID.
+#[cfg(unix)]
+fn is_single_process_pid(pid: u32) -> bool {
+    pid > 1 && i32::try_from(pid).is_ok()
+}
+
+/// Refuse a PID that `kill(2)` would treat as a broadcast selector.
+///
+/// Production logs and carries on — a corrupt pidfile must not take the daemon
+/// down. Tests panic instead: a fixture that reaches here is the exact bug this
+/// module exists to prevent, and silently no-oping would let it pass green.
+#[cfg(unix)]
+fn refuse_unsafe_pid(pid: u32, what: &str) {
+    tracing::error!(pid, action = what, "refusing to signal a non-process PID");
+
+    #[cfg(test)]
+    panic!(
+        "test passed PID {pid} to {what}; kill(2) reads that as a broadcast \
+         selector (0 = our process group, -1 = every process the user owns). \
+         Use a real spawned child, not a sentinel PID."
+    );
+}
+
+/// Test-only blast radius limit: a unit test may only signal processes it
+/// actually spawned.
+///
+/// The pid guard above rejects the broadcast selectors, but it cannot tell a
+/// legitimate target from someone else's PID — and a test that signals a PID
+/// it does not own has no correct outcome, only luck. This walks the target's
+/// parent chain and refuses anything the test process does not sit above, so
+/// a bad fixture fails the test instead of reaching across the machine.
+///
+/// Compiled only under `cfg(test)`, so production keeps the bare `kill(2)`.
+#[cfg(all(unix, test))]
+fn assert_test_owns_process(pid: u32, what: &str) -> bool {
+    let me = std::process::id();
+    let mut cursor = pid;
+
+    // Depth-limited: a cycle in the reported parent chain must not hang.
+    for _ in 0..64 {
+        if cursor == me {
+            return true;
+        }
+        if cursor <= 1 {
+            break;
+        }
+        let Ok(out) = std::process::Command::new("ps")
+            .args(["-o", "ppid=", "-p", &cursor.to_string()])
+            .output()
+        else {
+            break;
+        };
+        if !out.status.success() {
+            break;
+        }
+        let Ok(parent) = String::from_utf8_lossy(&out.stdout).trim().parse::<u32>() else {
+            break;
+        };
+        cursor = parent;
+    }
+
+    panic!(
+        "test tried to {what} PID {pid}, which is not a descendant of the test \
+         process ({me}). Tests may only signal processes they spawned; a PID \
+         from a fixture, a config file, or a `pgrep` sweep belongs to the \
+         developer's machine. (A child orphaned before this check — its \
+         intermediate parent exited, so init reparented it — also lands here; \
+         keep the process you intend to signal a live descendant.)"
+    );
+}
+
 #[cfg(unix)]
 pub fn is_process_alive(pid: u32) -> bool {
+    // Probing with signal 0 is harmless per se, but `kill(-1, 0)` succeeds
+    // whenever *any* signalable process exists, so a broadcast PID would
+    // report "alive" and send callers straight into the terminate path.
+    if !is_single_process_pid(pid) {
+        return false;
+    }
     // kill(pid, 0) returns 0 if the process exists; EPERM also means it
     // exists but is owned by another user.
     let rc = unsafe { libc::kill(pid as i32, 0) };
@@ -61,8 +152,16 @@ pub fn is_process_alive(pid: u32) -> bool {
 /// graceful shutdown should prefer the daemon's own RPC `Shutdown` request.
 pub fn terminate_process(pid: u32) {
     #[cfg(unix)]
-    unsafe {
-        libc::kill(pid as i32, libc::SIGTERM);
+    {
+        if !is_single_process_pid(pid) {
+            refuse_unsafe_pid(pid, "terminate_process");
+            return;
+        }
+        #[cfg(test)]
+        assert_test_owns_process(pid, "SIGTERM");
+        unsafe {
+            libc::kill(pid as i32, libc::SIGTERM);
+        }
     }
     #[cfg(windows)]
     {
@@ -73,8 +172,16 @@ pub fn terminate_process(pid: u32) {
 /// Forcefully kill a process. SIGKILL on Unix, TerminateProcess on Windows.
 pub fn kill_process(pid: u32) {
     #[cfg(unix)]
-    unsafe {
-        libc::kill(pid as i32, libc::SIGKILL);
+    {
+        if !is_single_process_pid(pid) {
+            refuse_unsafe_pid(pid, "kill_process");
+            return;
+        }
+        #[cfg(test)]
+        assert_test_owns_process(pid, "SIGKILL");
+        unsafe {
+            libc::kill(pid as i32, libc::SIGKILL);
+        }
     }
     #[cfg(windows)]
     {
@@ -85,8 +192,18 @@ pub fn kill_process(pid: u32) {
 /// Forcefully kill a process and all its descendants (process group on Unix, process tree on Windows).
 pub fn kill_process_group(pid: u32) {
     #[cfg(unix)]
-    unsafe {
-        libc::kill(-(pid as i32), libc::SIGKILL);
+    {
+        // `-pid` is the group selector, so pid 1 would negate into the `-1`
+        // "signal everything" broadcast and pid 0 into the caller's own group.
+        if !is_single_process_pid(pid) {
+            refuse_unsafe_pid(pid, "kill_process_group");
+            return;
+        }
+        #[cfg(test)]
+        assert_test_owns_process(pid, "SIGKILL the process group of");
+        unsafe {
+            libc::kill(-(pid as i32), libc::SIGKILL);
+        }
     }
     #[cfg(windows)]
     {
@@ -245,6 +362,80 @@ mod tests {
             "reaped child should no longer be alive"
         );
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn broadcast_pids_are_not_single_process_targets() {
+        // The kill(2) broadcast selectors. `u32::MAX` is the dangerous one:
+        // it casts to -1, which signals the user's entire session.
+        for pid in [0, 1, u32::MAX] {
+            assert!(
+                !super::is_single_process_pid(pid),
+                "pid {pid} must never be signalled as a single process"
+            );
+        }
+        assert!(super::is_single_process_pid(std::process::id()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn broadcast_pids_are_never_reported_alive() {
+        // `kill(-1, 0)` succeeds whenever anything is signalable, so an
+        // unguarded liveness probe would call u32::MAX "alive" and send
+        // callers into terminate_process with it.
+        for pid in [0, 1, u32::MAX] {
+            assert!(
+                !super::is_process_alive(pid),
+                "pid {pid} must not be reported alive"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_spawned_child_is_owned_and_terminable() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+
+        assert!(super::assert_test_owns_process(pid, "probe"));
+
+        // The ownership check must not get in the way of the legitimate case.
+        super::terminate_process(pid);
+        let status = child.wait().expect("reap child");
+        assert!(!status.success(), "child should have been terminated");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[should_panic(expected = "not a descendant of the test process")]
+    fn signalling_a_process_the_test_does_not_own_panics() {
+        // The test runner that spawned us: a live PID, definitely not ours.
+        // `assert_test_owns_process` only inspects the parent chain — it
+        // never signals — so this stays harmless even if the check regresses.
+        let parent = unsafe { libc::getppid() } as u32;
+        super::assert_test_owns_process(parent, "SIGTERM");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[should_panic(expected = "broadcast")]
+    fn a_broadcast_pid_fails_the_test_that_supplied_it() {
+        // `refuse_unsafe_pid` contains no kill call at all, so exercising the
+        // rejection path here is safe even if every other guard regresses.
+        super::refuse_unsafe_pid(u32::MAX, "terminate_process");
+    }
+
+    // Deliberately NOT tested: calling `terminate_process(u32::MAX)` and
+    // asserting a bystander process survived. That test passes by doing
+    // nothing and fails by killing the developer's entire login session —
+    // and this repo runs cargo-mutants, which would build exactly the
+    // compromised guard that makes it fire (see kunobi-ninja/kache history
+    // for the session-wipe this module now prevents). The guard is a plain
+    // early return over `is_single_process_pid`, so pinning the predicate
+    // above pins the behaviour without arming a live round.
 
     #[cfg(unix)]
     #[test]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -46,6 +46,23 @@ fn refuse_unsafe_pid(pid: u32, what: &str) {
     );
 }
 
+/// Parent of `pid`, or None when that cannot be established — no usable `ps`,
+/// or the process is already gone.
+#[cfg(all(unix, test))]
+fn parent_pid(pid: u32) -> Option<u32> {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "ppid=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse::<u32>()
+        .ok()
+}
+
 /// Test-only blast radius limit: a unit test may only signal processes it
 /// actually spawned.
 ///
@@ -56,6 +73,14 @@ fn refuse_unsafe_pid(pid: u32, what: &str) {
 /// a bad fixture fails the test instead of reaching across the machine.
 ///
 /// Compiled only under `cfg(test)`, so production keeps the bare `kill(2)`.
+///
+/// Fails only on *positive* evidence of non-descent — a chain walked all the
+/// way to init without meeting us. Where the chain cannot be resolved at all
+/// there is nothing to conclude: the Nix build sandbox ships no `ps`, and
+/// treating that silence as "not yours" failed legitimate tests signalling
+/// their own children. The value guard above still rejects the broadcast
+/// selectors there, which is the catastrophic class; this one is the finer
+/// limit and correctly declines to judge without evidence.
 #[cfg(all(unix, test))]
 fn assert_test_owns_process(pid: u32, what: &str) -> bool {
     let me = std::process::id();
@@ -67,19 +92,14 @@ fn assert_test_owns_process(pid: u32, what: &str) -> bool {
             return true;
         }
         if cursor <= 1 {
+            // Reached init having never met ourselves: the target really is
+            // somebody else's.
             break;
         }
-        let Ok(out) = std::process::Command::new("ps")
-            .args(["-o", "ppid=", "-p", &cursor.to_string()])
-            .output()
-        else {
-            break;
-        };
-        if !out.status.success() {
-            break;
-        }
-        let Ok(parent) = String::from_utf8_lossy(&out.stdout).trim().parse::<u32>() else {
-            break;
+        let Some(parent) = parent_pid(cursor) else {
+            // No usable `ps`, or the process exited mid-walk. Either way we
+            // cannot show the target is foreign, so do not claim it is.
+            return true;
         };
         cursor = parent;
     }
@@ -317,6 +337,19 @@ pub fn configure_process_group(cmd: &mut std::process::Command) {
 
 #[cfg(test)]
 mod tests {
+    /// Is a usable `ps` on PATH? Tests that assert on the parent-chain walk
+    /// need to know before asserting — the Nix build sandbox has none, and
+    /// there the guard deliberately allows instead of judging.
+    ///
+    /// Deliberately does not call `parent_pid`: this is the skip condition for
+    /// tests that pin `parent_pid` itself, so routing through it would let a
+    /// mutant that stubs it out downgrade those tests to silent skips.
+    #[cfg(unix)]
+    fn ps_available() -> bool {
+        std::env::var_os("PATH")
+            .is_some_and(|path| std::env::split_paths(&path).any(|dir| dir.join("ps").is_file()))
+    }
+
     #[cfg(unix)]
     #[test]
     fn process_stat_zombie_detection_uses_leading_state() {
@@ -430,13 +463,54 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    #[should_panic(expected = "not a descendant of the test process")]
     fn signalling_a_process_the_test_does_not_own_panics() {
+        // Needs a working `ps`: without one the guard deliberately allows
+        // rather than judging, so there is nothing to assert. The Nix build
+        // sandbox has no `ps`; the mutation and Test lanes do.
+        //
+        // Probe for the tool directly rather than asking `parent_pid`, which
+        // is part of what this test pins: gating on it would let a mutant that
+        // stubs it out silently turn this test into a skip.
+        if !ps_available() {
+            return;
+        }
+
         // The test runner that spawned us: a live PID, definitely not ours.
         // `assert_test_owns_process` only inspects the parent chain — it
         // never signals — so this stays harmless even if the check regresses.
         let parent = unsafe { libc::getppid() } as u32;
-        super::assert_test_owns_process(parent, "SIGTERM");
+        let outcome =
+            std::panic::catch_unwind(|| super::assert_test_owns_process(parent, "SIGTERM"));
+
+        let panic_msg = *outcome
+            .expect_err("signalling a non-descendant must fail the test")
+            .downcast::<String>()
+            .expect("guard panics with a message");
+        assert!(
+            panic_msg.contains("not a descendant of the test process"),
+            "unexpected panic message: {panic_msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owning_a_process_is_not_claimed_without_evidence() {
+        // The complement of the test above: where the parent chain cannot be
+        // resolved the guard must allow, not panic. Pin it against a PID that
+        // no `ps` can answer for, which is the same shape as the missing-`ps`
+        // sandbox and the reaped-child race.
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+        child.kill().expect("kill child");
+        child.wait().expect("reap child");
+
+        assert!(
+            super::assert_test_owns_process(pid, "probe"),
+            "an unresolvable chain must not be reported as foreign"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Two independent ways kache could kill processes it had no business touching. Both exist on `main` today; neither depends on the doctor work in #743.

## 1. A bogus PID could wipe the login session

`kill(2)` overloads its pid argument with broadcast selectors — `0` is the caller's process group, `-1` is *every process the caller may signal*. `u32::MAX` casts to `-1`, so the "definitely dead, made-up PID" idiom is exactly the value that takes down a whole session.

`is_process_alive` made this reachable rather than theoretical. It probed with `kill(pid, 0)`, which **succeeds** for `-1` whenever anything is signalable — so a broadcast PID reported *alive* and sent callers straight into `terminate_process` → `kill_process`.

The PID is read from `daemon.state.json` with no validation:

```rust
fn read_daemon_state(socket_path: &Path) -> Option<DaemonCoordState> {
    let bytes = std::fs::read(path).ok()?;
    serde_json::from_slice(&bytes).ok()   // pid: u32, unvalidated
}
```

So a corrupt or hand-edited state file was enough to make `kache daemon stop` — or the ordinary `recover_unhealthy_daemon` path during daemon start — `kill(-1, SIGTERM)` then `kill(-1, SIGKILL)`.

This was not hypothetical: a unit test using `pid: u32::MAX` as a "dead PID" fixture killed a developer's entire desktop session twice in one afternoon (Finder, Dock, terminal, browser, VPN client — 35 processes), when a `cargo-mutants` mutant made the recovery path believe the run lock was held.

**Fix.** Guard all four helpers on an ordinary positive PID, with deliberately different behaviour per build:

- **Production** logs and carries on — a bad state file must not take the daemon down with it.
- **Tests** panic. A fixture that reaches the guard *is* the bug, and silently no-oping would let it pass green.

Plus a second, blunter limit for tests: **a unit test may only signal a process it actually spawned.** The value guard can't tell a legitimate target from someone else's PID, and a test signalling a PID it doesn't own has no correct outcome, only luck.

The fixture that caused the incident is replaced with a reaped child — matching the test directly beside it, which already warned against made-up PIDs.

## 2. `force_recover` killed bystanders

`find_daemon_pids` feeds `force_recover`, which SIGTERMs then SIGKILLs every PID it returns, so over-matching there is a licence to kill.

**Unix** matched with `pgrep -f "kache daemon run"` — the *whole command line*. Any wrapper script or shell that launched the daemon carries that string in its own argv:

```console
$ /bin/sh -c 'sleep 20; : kache daemon run' &     # pid 97855
$ pgrep -f "kache daemon run"
59437     # the real daemon
97855     # a plain shell -- force_recover would SIGKILL this
```

Candidates are now confirmed to be the kache executable via `ps -o comm=` (macOS reports a full path, Linux a bare name, so the comparison is on the file name).

**Windows** had the mirror defect: `tasklist` filters by image name but reports no command line, so an in-flight `kache.exe build` looked like a daemon. It now prefers `Win32_Process`, which carries the command line, and requires the `daemon run` subcommand.

## Deliberate trade-offs

- A **renamed** kache binary is now missed on Unix. Recovery then falls through to wiping the stale coordination files, which is recoverable; killing the wrong process is not.
- The Windows path **falls back to `tasklist`** when the `Win32_Process` query is unavailable or can't read command lines. A restricted PowerShell degrades to today's behaviour rather than silently finding nothing and leaving a stuck daemon unrecoverable.

## Testing

- 1906/1906 unit tests pass; `cargo clippy --all-targets` clean.
- `find_daemon_pids_ignores_processes_that_merely_mention_the_daemon` was verified to **fail without the fix** — it reports `[59437, 98294] contains decoy 98294`, i.e. the real daemon plus the bystander shell.
- `cmdline_is_daemon_run` is gated `#[cfg(any(windows, test))]`, so the Windows matching logic is covered by the Unix lanes too.
- The Windows-only code was type-checked against `x86_64-pc-windows-msvc` (the full crate won't cross-compile — `zstd-sys` needs Windows C headers — so those functions were checked standalone against the real target). The `powershell` invocation itself is only exercised by the Windows lane.
- The guards are pinned by tests that **never send a signal**, so no single mutant can turn the suite into the failure it guards against. This matters here specifically: the original incident happened *during* a `cargo-mutants` run.

### Mutation coverage

The changed-line lane covers every line these fixes touch. Four gaps needed closing, each because a passing test could not distinguish "working" from "silently doing nothing":

| Gap | Why the existing tests couldn't catch it |
| --- | --- |
| `pid_alive`'s new broadcast guard | no test of its own |
| `process_comm` | asserting only "the bystander was excluded" can't tell correct filtering from a lookup returning nothing |
| `find_daemon_pids` positive direction | `-> vec![]` trivially satisfies an absence assertion — and finding nothing means `force_recover` silently stops recovering |
| `kill_process` | terminate-only coverage leaves "kill does nothing" indistinguishable from "kill works" |

A real `kache daemon run` can't be arranged in a unit test, so the positive case stands one up: an executable named `kache` inside a directory named `kache daemon run`, which puts the phrase into the command line `pgrep -f` matches — no shell built-ins, portable across both Unix lanes.

Two mutants are excluded rather than tested, both documented in `mutants.toml`: `windows_kache_processes` and the operator mutants in `find_daemon_pids`'s `#[cfg(windows)]` arm. The ubuntu lane never compiles Windows bodies, so those survive by construction — the property already documented there for `probe_macos` and `sample_write_clock`. The Unix arm is untouched by this change and generates no changed-line mutants, so nothing reachable is waived, and `find_daemon_pids`'s return value stays fully in scope.

Verified locally over the changed lines: **44 mutants, 43 caught, 1 missed** — the missed one being the Windows-arm mutant now excluded.
