### PR TITLE
fix(service): let the planner start against a db it already initialised

### DIFF
--- a/crates/kache-service/src/state.rs
+++ b/crates/kache-service/src/state.rs
@@ -95,23 +95,34 @@ impl SurrealPlannerRepository {
         Ok(())
     }
 
+    /// Define the planner tables, tolerating a database that already has them.
+    ///
+    /// This runs on every `open`, so it runs on every process start — and the
+    /// planner db lives on a persistent volume in production. Plain
+    /// `DEFINE TABLE` errors with "The table 'x' already exists" the second
+    /// time, which is not a startup the service can recover from: it exits 1
+    /// and CrashLoopBackOffs forever while the volume keeps the tables that
+    /// caused it. `IF NOT EXISTS` makes each definition a no-op when present.
+    ///
+    /// Deliberately not `OVERWRITE`: on a SCHEMAFULL table that redefines
+    /// rather than skips, which would churn the schema on every start.
     async fn init_schema(&self) -> Result<()> {
         self.db
             .query(
                 r#"
-DEFINE TABLE namespace_artifact SCHEMAFULL;
-DEFINE FIELD namespace ON namespace_artifact TYPE string;
-DEFINE FIELD dep_key ON namespace_artifact TYPE string;
-DEFINE FIELD cache_key ON namespace_artifact TYPE string;
-DEFINE FIELD crate_name ON namespace_artifact TYPE string;
-DEFINE FIELD last_seen_at ON namespace_artifact TYPE datetime;
-DEFINE INDEX namespace_dep_cache ON namespace_artifact FIELDS namespace, dep_key, cache_key UNIQUE;
+DEFINE TABLE IF NOT EXISTS namespace_artifact SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS namespace ON namespace_artifact TYPE string;
+DEFINE FIELD IF NOT EXISTS dep_key ON namespace_artifact TYPE string;
+DEFINE FIELD IF NOT EXISTS cache_key ON namespace_artifact TYPE string;
+DEFINE FIELD IF NOT EXISTS crate_name ON namespace_artifact TYPE string;
+DEFINE FIELD IF NOT EXISTS last_seen_at ON namespace_artifact TYPE datetime;
+DEFINE INDEX IF NOT EXISTS namespace_dep_cache ON namespace_artifact FIELDS namespace, dep_key, cache_key UNIQUE;
 
-DEFINE TABLE crate_artifact SCHEMAFULL;
-DEFINE FIELD crate_name ON crate_artifact TYPE string;
-DEFINE FIELD cache_key ON crate_artifact TYPE string;
-DEFINE FIELD last_seen_at ON crate_artifact TYPE datetime;
-DEFINE INDEX crate_cache ON crate_artifact FIELDS crate_name, cache_key UNIQUE;
+DEFINE TABLE IF NOT EXISTS crate_artifact SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS crate_name ON crate_artifact TYPE string;
+DEFINE FIELD IF NOT EXISTS cache_key ON crate_artifact TYPE string;
+DEFINE FIELD IF NOT EXISTS last_seen_at ON crate_artifact TYPE datetime;
+DEFINE INDEX IF NOT EXISTS crate_cache ON crate_artifact FIELDS crate_name, cache_key UNIQUE;
 "#,
             )
             .await
@@ -318,6 +329,34 @@ fn composite_id(parts: &[&str]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Defining the schema against a db that already has it must succeed.
+    ///
+    /// Every other test here starts from an empty tempdir, so the suite only
+    /// ever exercised the first-ever start. Production does not: the planner db
+    /// sits on a persistent volume, so the *second* start is the normal case
+    /// and the only one that can hit "table already exists". That gap let a
+    /// non-idempotent `DEFINE TABLE` reach production, where the planner exited
+    /// 1 on boot and CrashLoopBackOffed ~3700 times over 13 days without ever
+    /// becoming ready.
+    ///
+    /// Re-runs `init_schema` rather than reopening the file: surrealkv holds an
+    /// exclusive LOCK that a dropped handle does not release synchronously, so
+    /// a genuine reopen would need a sleep-and-retry and would be flaky in CI.
+    /// A restarting pod runs exactly this statement against exactly this state.
+    #[tokio::test]
+    async fn init_schema_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // `open` defines the schema once.
+        let repo = SurrealPlannerRepository::open(&dir.path().join("planner.db"))
+            .await
+            .unwrap();
+
+        repo.init_schema()
+            .await
+            .expect("defining the schema against an existing schema must succeed");
+    }
 
     #[test]
     fn dep_key_joins_name_and_version() {


### PR DESCRIPTION
The planner has been `CrashLoopBackOff` in **int-pro / zur1-worker1** for 13 days — ~3700 restarts, and `Ready=False` since `2026-07-30T13:35:08Z`. It has never once become ready.

```
Error: validating planner db schema

Caused by:
    The table 'namespace_artifact' already exists
```

## Why

`init_schema` runs on every `open`, so on every process start, and its `DEFINE TABLE` used surrealdb's default kind. surrealdb-core is explicit about what that means once the table exists:

```rust
DefineKind::Default     => bail!(Error::TbAlreadyExists { name }),
DefineKind::Overwrite   => {}                     // redefines
DefineKind::IfNotExists => return Ok(Value::None) // no-op
```

So the service could only ever start against an **empty** database. In production it isn't: the planner db lives on a 10Gi PVC mounted at `/var/lib/kache` (`KACHE_PLANNER_DB_PATH=/var/lib/kache/planner.db`), which outlives the pod. The first start defined the tables; every start after that hit the tables the volume had kept, and exited 1.

That makes it a loop nothing can break out of on its own — the state causing the failure is the state that survives the restart. The container dies one second after starting, so backoff pins at the 5m cap: **~280 failures/day, flat for the whole 13 days.**

Note this is a latent bug, not a regression from any deploy — the deployment spec hasn't changed in 116 days. It simply needed a restart to surface, and got one on 30 July.

## Fix

`IF NOT EXISTS` on every `DEFINE`. Not `OVERWRITE`: on a `SCHEMAFULL` table that redefines rather than skips, churning the schema on every start.

The rest of the codebase already gets this right — `src/store.rs` and `src/cache_key.rs` use `CREATE TABLE IF NOT EXISTS` throughout. The SurrealDB path was the lone outlier.

## Why the tests didn't catch it

Every existing test opens a fresh `tempdir`, so the entire suite only ever exercised the **first-ever** start. Production is the opposite: the db is persistent, so the *second* start is the normal case — and the only one that can fail.

The new test closes exactly that gap and fails without this change with the same error the pod prints:

```
test state::tests::init_schema_is_idempotent ... FAILED
    The table 'namespace_artifact' already exists
```

It re-runs `init_schema` rather than reopening the file: surrealkv holds an exclusive `LOCK` that a dropped handle doesn't release synchronously, so a genuine reopen would need sleep-and-retry and be flaky in CI. A restarting pod runs this statement against this state.

## Verifying it worked

There's a clean before/after signal already in SigNoz — no new instrumentation needed:

```
k8s.namespace.name = 'kache-system' AND body CONTAINS 'already exists'
```

Currently ~280/day, flat. After deploy it should be **0**, `k8s.container.restart_count` should stop advancing, and the pod should reach `Ready`.

## Deploying

Code alone won't clear it — `zondax/kache:latest` needs rebuilding and the deployment restarting. The existing `planner.db` does **not** need wiping: `IF NOT EXISTS` skips the definitions that are already there and keeps the accumulated planner state.
