### PR TITLE
ci(release): publish the Helm chart, versioned on the release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1166,3 +1166,35 @@ jobs:
     permissions:
       contents: write
       id-token: write
+
+  # Publish the Helm chart to the OCI registry, tag-only.
+  #
+  # Until now the chart was never published at all: Flux read
+  # ./charts/kache-service straight from the git revision, so there was no
+  # versioned artifact and no way to say which chart a cluster ran. That is the
+  # same shape as tracking a mutable `:latest` image — which is how a build the
+  # planner could not start from reached production and sat there for 13 days.
+  #
+  # Tag-only for a concrete reason: chart versions are IMMUTABLE in the
+  # registry, so a push from main would eventually try to overwrite a released
+  # version and fail. `needs: version-consistency` proves Chart.yaml agrees with
+  # the tag before anything immutable is pushed.
+  publish-chart:
+    name: Publish Helm chart (OCI)
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [version-consistency]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: azure/setup-helm@v4
+
+      - name: Package & push Helm chart
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          helm registry login registry-1.docker.io -u "$DOCKERHUB_USER" -p "$DOCKERHUB_TOKEN"
+          helm package charts/kache-service
+          helm push kache-*.tgz oci://registry-1.docker.io/zondax

--- a/Justfile
+++ b/Justfile
@@ -341,10 +341,18 @@ bump VERSION:
     fi
   fi
   cargo set-version --workspace {{VERSION}}
+  # Mirror into the chart. Both fields track the release tag: `appVersion` names
+  # the app the chart deploys, `version` is the chart's own identity in the OCI
+  # registry, and publish-chart ships it from the same `v*` tag. A chart-only
+  # fix is therefore a patch release of the whole thing.
+  perl -i -pe 's/^version:.*$/version: {{VERSION}}/' charts/kache-service/Chart.yaml
+  perl -i -pe 's/^appVersion:.*$/appVersion: "{{VERSION}}"/' charts/kache-service/Chart.yaml
   # NO --locked: set-version rewrites the lock's version entries, so --locked
   # would error "lock file needs updating". Plain check settles the lock for the
   # local crates only (it does not advance kunobi-* / registry deps).
   cargo check --workspace
+  # Fail here rather than at the release floor if anything did not line up.
+  ./scripts/check-version-consistency.sh
   ./scripts/check-version-consistency.sh
   echo "Bumped to {{VERSION}}. Commit + open a PR; after merge, cut the tag with 'just release'."
 

--- a/charts/kache-service/Chart.yaml
+++ b/charts/kache-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kache
 description: Advisory remote planner service for kache
 type: application
-version: 0.0.0
-appVersion: "0.0.0"
+version: 0.14.0
+appVersion: "0.14.0"
 keywords:
   - rust
   - cache

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -109,6 +109,32 @@ if kache_version != core_version:
         "(the workspace is bumped in lockstep)"
     )
 
+# (1b) Chart.yaml — both fields, because the chart ships from the same `v*` tag
+# (see the publish-chart job). `appVersion` names the app the chart deploys and
+# `version` is the chart's own identity in the registry; kobe learned to keep
+# both on the release tag rather than a separate track, so a chart-only fix is a
+# patch release of the whole thing. Chart versions are immutable once pushed, so
+# a mismatch has to fail here — before the push, not after.
+#
+# Plain line reads rather than a yaml dependency: this gate stays hermetic.
+chart_path = root / "charts" / "kache-service" / "Chart.yaml"
+chart = chart_path.read_text()
+
+
+def chart_field(name):
+    mm = re.search(rf'(?m)^{name}:\s*"?([^"\s]+)"?\s*$', chart)
+    return mm.group(1) if mm else None
+
+
+for field in ("version", "appVersion"):
+    value = chart_field(field)
+    if value is None:
+        errors.append(f"charts/kache-service/Chart.yaml has no `{field}:`")
+    elif value != kache_version:
+        errors.append(
+            f"Chart.yaml {field} {value!r} != workspace version {kache_version!r}"
+        )
+
 # (2) Tag agreement — only when a tag is supplied (tag pushes / publish). The
 # full version must match, prerelease suffix included.
 if tag_version:


### PR DESCRIPTION
kache never released a Helm chart. `Chart.yaml` sat at `0.0.0`/`0.0.0` permanently, nothing packaged or pushed it, and Flux read `./charts/kache-service` straight from a git revision:

```json
chart: {"chart": "./charts/kache-service", "sourceRef": {"kind": "GitRepository", "name": "kache"}}
values: {"image": {"tag": "latest", "pullPolicy": "Always"}}
```

No versioned artifact, and no way to say which chart a cluster runs beyond a commit sha in a label.

## Why this matters now

That's the same shape as tracking a mutable `:latest` image, and #747 showed what it costs. A pod restart on 30 July pulled a then-current `:latest` whose schema init couldn't survive a populated volume; the planner sat in `CrashLoopBackOff` for **13 days, ~3700 restarts, never once ready** — and nothing recorded which build it had been handed.

## What kobe settled on

kobe's chart *used* to run on its own track (chart 0.21.x while appVersion was 0.31.x). As of **0.36.0** both fields track the release tag and ship from it, with the reasoning in its own gate:

> the chart's own `version:` used to be on its own track… As of 0.36.0 the chart is published from the same `v*` tag. A chart-only fix is therefore a patch release of the whole thing.

This adopts that.

## Changes

- **`Chart.yaml`** — `version` and `appVersion` both move to the workspace version (`0.14.0`).
- **`check-version-consistency.sh`** — gates *both* fields against the workspace version. Chart versions are immutable once pushed, so a mismatch has to fail **before** the push. Plain line reads keep the gate hermetic (no yaml dependency), matching kobe's approach.
- **`just bump`** — mirrors the version into the chart, then re-runs the gate, so a half-applied bump fails locally rather than at the release floor.
- **`publish-chart`** — tag-only job packaging and pushing to `oci://registry-1.docker.io/zondax`.

Tag-only is load-bearing: a push from main would eventually try to overwrite an already-released immutable version and fail.

## Verified locally

```console
$ ./scripts/check-version-consistency.sh v0.14.0
version consistency OK: tag 0.14.0 == kache == kache-core == kache-core dep-pin

$ helm template kache charts/kache-service   # renders
$ helm package charts/kache-service
Successfully packaged chart and saved it to: kache-0.14.0.tgz
```

And the gate fails closed on drift:

```console
$ # Chart.yaml version -> 0.13.0
$ ./scripts/check-version-consistency.sh
version consistency FAILED for the workspace manifests:
  - Chart.yaml version '0.13.0' != workspace version '0.14.0'
exit=1
```

## One deliberate deviation from kobe

kobe gates `publish-chart` on `needs: [version-consistency, publish]`, so the chart can only ship once the operator image for that version was pushed **in the same run**. kache builds its image in a separate workflow (`service-image.yml`), which a job in `ci.yml` cannot depend on, so this gates on `version-consistency` alone.

Closing that gap means either moving the image build into `ci.yml` or having `publish-chart` probe the registry for the tag first. Happy to do either — it seemed worth raising rather than silently shipping a weaker gate than kobe's.

## Follow-up, not in this PR

Once a versioned chart exists, the Flux `HelmRelease` can move off the git source onto the OCI chart. That's what actually retires the mutable `:latest` in production — it lives in `Zondax/flux-apps`, not here.
