### PR TITLE
chore(release): 0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more, with S3 and shared-filesystem remotes."
 license = "Apache-2.0"
@@ -36,7 +36,7 @@ reqsign-aws-v4 = { version = "=3.0.2", default-features = false }
 reqsign-core = { version = "=3.1.0", default-features = false }
 # Direct dep so OpenDAL/reqwest can use ring without reintroducing aws-lc.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.14.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.14.1", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/Justfile
+++ b/Justfile
@@ -353,7 +353,6 @@ bump VERSION:
   cargo check --workspace
   # Fail here rather than at the release floor if anything did not line up.
   ./scripts/check-version-consistency.sh
-  ./scripts/check-version-consistency.sh
   echo "Bumped to {{VERSION}}. Commit + open a PR; after merge, cut the tag with 'just release'."
 
 # Deliberately read-only: the value is only correct once HEAD is the tagged

--- a/charts/kache-service/Chart.yaml
+++ b/charts/kache-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kache
 description: Advisory remote planner service for kache
 type: application
-version: 0.14.0
-appVersion: "0.14.0"
+version: 0.14.1
+appVersion: "0.14.1"
 keywords:
   - rust
   - cache

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps the workspace and chart to **0.14.1** ahead of tagging `v0.14.1`.

## What ships

Seven commits since `v0.14.0`, two of them production fixes diagnosed against the live `int-pro/zur1-worker1` cluster:

| | |
|---|---|
| #747 | the planner could not start against a db it had already initialised — held it in `CrashLoopBackOff` for **13 days, ~3700 restarts**, never once ready |
| #746 | a bogus PID could make kache `kill(-1, …)` — signal every process the user owns |
| #743 | doctor reports the daemon upgrade window instead of stalling on it |
| #748 | the Helm chart is versioned on the release tag and published to OCI |
| #745, #740, #738 | CI mirror, `.exe` strip UTF-8 boundary guard, daemon test fix |

## Why patch, not minor

Every commit is a `fix` or a `ci` change and none adds public API, so `0.14.1` is the honest number. Flagging it explicitly because #743 and #748 do change observable behaviour (doctor's output, and the existence of a published chart) — if you read either as feature work, say so and I'll re-cut as `0.15.0` before the tag goes anywhere irreversible.

## First release with a chart

`v0.14.1` will be the first kache tag to publish a versioned Helm chart — `kache-0.14.1.tgz` to `oci://registry-1.docker.io/zondax`, alongside the images. Until now the chart sat at `0.0.0` and was never packaged; Flux read it straight from a git revision, so no cluster could name the chart it was running.

## Verified

```console
$ ./scripts/check-version-consistency.sh
version consistency OK: kache == kache-core == kache-core dep-pin == 0.14.1

$ ./scripts/check-version-consistency.sh v0.14.1
version consistency OK: tag 0.14.1 == kache == kache-core == kache-core dep-pin
```

Both modes pass, so the tag-time gate in `version-consistency` (which now covers `Chart.yaml` `version` *and* `appVersion`) will pass too.

## Drive-by

`just bump` had grown a duplicated `check-version-consistency.sh` call — mine, from #748, on top of one already there. It printed the gate twice. Now runs once.

## After merge

```bash
git tag v0.14.1 && git push origin v0.14.1
```

That triggers the versioned image build and `publish-chart`. Chart versions are immutable in the registry, so this is the point of no return for `0.14.1`.
