### PR TITLE
fix(chart): publish under kache-service so the image cannot overwrite it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1179,6 +1179,14 @@ jobs:
   # registry, so a push from main would eventually try to overwrite a released
   # version and fail. `needs: version-consistency` proves Chart.yaml agrees with
   # the tag before anything immutable is pushed.
+  #
+  # The chart is named `kache-service`, NOT `kache`, and that is load-bearing:
+  # `helm push` derives the OCI repository from the chart name, so a chart named
+  # `kache` lands on zondax/kache — the same repository and tag as the service
+  # IMAGE. v0.14.1 published the chart, then the image push overwrote the tag
+  # with a manifest list, and `helm show` started failing with "could not load
+  # config with mediatype ...helm.config.v1+json". kobe never hit this because
+  # its chart (kobe) and images (kobe-operator, kobe-sync) already differ.
   publish-chart:
     name: Publish Helm chart (OCI)
     if: startsWith(github.ref, 'refs/tags/v')
@@ -1197,4 +1205,6 @@ jobs:
         run: |
           helm registry login registry-1.docker.io -u "$DOCKERHUB_USER" -p "$DOCKERHUB_TOKEN"
           helm package charts/kache-service
-          helm push kache-*.tgz oci://registry-1.docker.io/zondax
+          # Explicit name, not kache-*.tgz: that glob would also match a stray
+          # kache-<version>.tgz and silently push to the image's repository.
+          helm push kache-service-*.tgz oci://registry-1.docker.io/zondax

--- a/charts/kache-service/Chart.yaml
+++ b/charts/kache-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: kache
+name: kache-service
 description: Advisory remote planner service for kache
 type: application
 version: 0.14.1

--- a/charts/kache-service/values.yaml
+++ b/charts/kache-service/values.yaml
@@ -1,4 +1,9 @@
-nameOverride: ""
+# Pins the rendered app name to `kache`, which is what every resource and —
+# critically — every selector label already uses in the clusters running this
+# chart. Selector labels are immutable on a Deployment, so letting the rendered
+# name follow the chart rename below would make the next upgrade fail rather
+# than roll.
+nameOverride: "kache"
 fullnameOverride: ""
 
 replicaCount: 1


### PR DESCRIPTION
**`v0.14.1` published a chart that no longer exists.**

```console
$ helm show chart oci://registry-1.docker.io/zondax/kache --version 0.14.1
Error: could not load config with mediatype application/vnd.cncf.helm.config.v1+json
```

The tag holds an `application/vnd.oci.image.index.v1+json` — the service image's manifest list, not a chart.

## What happened

`helm push` derives the OCI repository from the chart **name**. The chart was named `kache`, so it landed on `zondax/kache:0.14.1` — the exact repository and tag the service image publishes to. Both run off the same `v*` tag, the chart pushed first, and the image overwrote it minutes later.

The chart genuinely was there. Immediately after the chart job succeeded:

```console
$ helm show chart oci://registry-1.docker.io/zondax/kache --version 0.14.1
Pulled: registry-1.docker.io/zondax/kache:0.14.1
Digest: sha256:38d64a9817a8b1c32a32e52722d035e6d113a17961709570a7edf613c8dc2ef1
appVersion: 0.14.1
```

The same command failed once `Build Service Image` finished at 06:05:36.

**kobe never hit this** because its names already differ — chart `kobe` against images `kobe-operator` and `kobe-sync`. I ported its publish step in #748 without checking that kache's chart and image share a name.

## Fix

Rename the chart to `kache-service`: what its directory has always been called, and what it actually deploys (the planner service, not the CLI). It now publishes to `zondax/kache-service`, which nothing else writes to.

## Why the rename needed `nameOverride`

Renaming `.Chart.Name` alone would have been **worse than the bug**. It feeds:

- `kache-service.name` → `app.kubernetes.io/name`, a Deployment **selector label**, which Kubernetes treats as immutable
- `kache-service.fullname` → the name of every resource

The next Flux upgrade would have failed on an immutable-field error instead of rolling. `nameOverride: kache` pins the rendered name, so nothing user-visible moves.

Verified by diffing `helm template` before and after:

```console
$ diff <(grep -vE "helm.sh/chart:|^# Source:" before.yaml) \
       <(grep -vE "helm.sh/chart:|^# Source:" after.yaml)
  NO functional difference
```

Resource names and all three selector labels are unchanged; only the mutable `helm.sh/chart` label and source comments differ.

```console
$ helm package charts/kache-service
Successfully packaged chart and saved it to: kache-service-0.14.1.tgz
```

Also pins the push glob to `kache-service-*.tgz`. `kache-*.tgz` matches it today, but would equally match a stray `kache-<version>.tgz` and silently push to the image's repository again.

## Follow-up

`v0.14.1`'s chart is unrecoverable — that tag now points at the image, and OCI tags are immutable. A `v0.14.2` after this merges would be the first release to actually ship a usable chart. **No running system is affected**: the image tag holds the correct image, and Flux still reads the chart from git.
