### PR TITLE
chore(release): 0.14.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more, with S3 and shared-filesystem remotes."
 license = "Apache-2.0"
@@ -36,7 +36,7 @@ reqsign-aws-v4 = { version = "=3.0.2", default-features = false }
 reqsign-core = { version = "=3.1.0", default-features = false }
 # Direct dep so OpenDAL/reqwest can use ring without reintroducing aws-lc.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.14.1", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.14.2", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/charts/kache-service/Chart.yaml
+++ b/charts/kache-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kache-service
 description: Advisory remote planner service for kache
 type: application
-version: 0.14.1
-appVersion: "0.14.1"
+version: 0.14.2
+appVersion: "0.14.2"
 keywords:
   - rust
   - cache

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
`v0.14.1` shipped images but **no usable chart**.

It published to `zondax/kache` — the same OCI repository and tag as the service image — and the image push overwrote it minutes later, leaving the tag holding a manifest list:

```console
$ helm show chart oci://registry-1.docker.io/zondax/kache --version 0.14.1
Error: could not load config with mediatype application/vnd.cncf.helm.config.v1+json
```

OCI tags are immutable, so that chart cannot be recovered. It needs a new version.

#751 fixed the collision on main: the chart is named `kache-service` and publishes to `zondax/kache-service`, which nothing else writes to. **This is the release that carries that fix**, so `v0.14.2` is the first kache tag to ship a chart anyone can actually pull.

## No code changes

Same binaries, same fixes as `v0.14.1` — only the chart identity moved. The two production fixes from that release (the planner schema crash, the PID guard) are already live and unaffected.

## Verified

```console
$ ./scripts/check-version-consistency.sh v0.14.2
version consistency OK: tag 0.14.2 == kache == kache-core == kache-core dep-pin

$ helm package charts/kache-service
Successfully packaged chart and saved it to: kache-service-0.14.2.tgz
```

Staged with explicit paths rather than `git add -A`, after that mistake committed two untracked local files in #749.

## After merge

```bash
git tag v0.14.2 && git push origin v0.14.2
```

This time I'll verify the chart **after both workflows finish**, not as soon as the chart job goes green — checking too early is exactly how `v0.14.1` looked successful.
