### PR TITLE
feat(service): serve planner metrics and let SigNoz scrape them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,6 +3002,7 @@ dependencies = [
  "kube",
  "kunobi-auth",
  "kunobi-ha",
+ "prometheus",
  "serde",
  "serde_json",
  "surrealdb",
@@ -4334,6 +4335,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "proptest"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4378,6 +4394,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/charts/kache-service/templates/deployment.yaml
+++ b/charts/kache-service/templates/deployment.yaml
@@ -14,6 +14,19 @@ spec:
     metadata:
       labels:
         {{- include "kache-service.selectorLabels" . | nindent 8 }}
+      {{- if or .Values.signoz.scrape .Values.podAnnotations }}
+      annotations:
+        {{- if .Values.signoz.scrape }}
+        # The cluster SigNoz OTel collector discovers pods by these
+        # annotations and scrapes their Prometheus /metrics into SigNoz.
+        signoz.io/scrape: "true"
+        signoz.io/port: {{ .Values.signoz.port | default .Values.service.port | quote }}
+        signoz.io/path: {{ .Values.signoz.path | quote }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/kache-service/values.yaml
+++ b/charts/kache-service/values.yaml
@@ -79,3 +79,16 @@ extraEnv: []
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# SigNoz metrics scraping (how the planner's Prometheus metrics reach SigNoz).
+#
+# The cluster's SigNoz OTel collector discovers scrape targets by pod
+# annotations (signoz.io/scrape|port|path) — NOT by Prometheus ServiceMonitors,
+# because these clusters run no Prometheus to consume them. The planner always
+# serves /metrics on the http port (auth-exempt, like the health probes), so
+# this is ON by default; the annotations are inert on any cluster without a
+# SigNoz collector watching for them.
+signoz:
+  scrape: true
+  path: /metrics
+  # port: defaults to service.port (the http port serving /metrics)

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4", features = ["derive", "env"] }
 kache-core = { path = "../kache-core", default-features = false, features = ["planning"] }
 k8s-openapi = { version = "0.27", features = ["v1_34"] }
 kube = { version = "3", features = ["client"] }
+prometheus = "0.14"
 kunobi-auth = { git = "https://github.com/kunobi-ninja/kunobi-auth.git", tag = "v0.3.0", default-features = false, features = ["server"] }
 kunobi-ha = { git = "https://github.com/kunobi-ninja/kunobi-ha.git", branch = "main" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/kache-service/src/lib.rs
+++ b/crates/kache-service/src/lib.rs
@@ -26,6 +26,8 @@ use std::{
 };
 use tokio::sync::{RwLock, watch};
 
+mod metrics;
+
 mod state;
 
 pub use state::{DEFAULT_DB_PATH, NamespaceState, PlannerStateFile, SurrealPlannerRepository};
@@ -117,6 +119,7 @@ fn app_with_repository(
 fn router(state: AppState) -> Router {
     Router::new()
         .route("/healthz", get(healthz))
+        .route("/metrics", get(metrics_endpoint))
         .route("/readyz", get(readyz))
         .route("/v1/prefetch-plan", post(prefetch_plan))
         .route("/v2/prefetch-plan", post(prefetch_plan))
@@ -156,6 +159,7 @@ pub async fn serve(config: PlannerConfig) -> Result<()> {
         let repository = load_repository(&config).await?;
         *state.repository.write().await = repository;
         state.ready.store(true, Ordering::Release);
+        metrics::metrics().set_ready(true);
     }
 
     let listener = tokio::net::TcpListener::bind(bind)
@@ -222,9 +226,11 @@ where
     let repository = load_repository(&config).await?;
     *state.repository.write().await = repository;
     state.ready.store(true, Ordering::Release);
+    metrics::metrics().set_ready(true);
 
     leadership_lost.await;
     state.ready.store(false, Ordering::Release);
+    metrics::metrics().set_ready(false);
     *state.repository.write().await = None;
     tracing::warn!(namespace = %namespace, lease = %lease_name, "lost kache planner leadership");
     Ok(())
@@ -276,6 +282,21 @@ fn normalize_name(value: String) -> String {
     }
 }
 
+/// Prometheus scrape endpoint.
+///
+/// Deliberately unauthenticated, like /healthz and /readyz: the cluster's
+/// SigNoz collector scrapes by pod annotation and carries no bearer token, and
+/// the series here describe the planner's own behaviour, not cache contents.
+async fn metrics_endpoint() -> ([(axum::http::header::HeaderName, &'static str); 1], String) {
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; version=0.0.4",
+        )],
+        metrics::metrics().render(),
+    )
+}
+
 async fn healthz(State(state): State<AppState>) -> Json<HealthResponse> {
     Json(HealthResponse {
         status: "ok".to_string(),
@@ -321,11 +342,21 @@ async fn prefetch_plan(
     OptionalAuth(identity): OptionalAuth,
     Json(intent): Json<BuildIntent>,
 ) -> Result<Json<PrefetchPlan>, StatusCode> {
+    let started = std::time::Instant::now();
+    // Every exit below records exactly one outcome. Keeping the helper local
+    // means a new early return that forgets to call it shows up as a request
+    // that vanished, rather than as silence.
+    let record = |outcome: metrics::Outcome| {
+        metrics::metrics().record_request(outcome, started.elapsed().as_secs_f64());
+    };
+
     if state.token.is_some() && identity.is_none() {
+        record(metrics::Outcome::Unauthorized);
         return Err(StatusCode::UNAUTHORIZED);
     }
 
     if !state.ready.load(Ordering::Acquire) {
+        record(metrics::Outcome::NotReady);
         return Err(StatusCode::SERVICE_UNAVAILABLE);
     }
 
@@ -338,6 +369,7 @@ async fn prefetch_plan(
             has_namespace = intent.namespace.is_some(),
             "planner request: no service-side state configured, requesting fallback"
         );
+        record(metrics::Outcome::FallbackNoState);
         return Ok(Json(fallback_plan(&state.planner_name)));
     };
 
@@ -350,6 +382,7 @@ async fn prefetch_plan(
                     %error,
                     "planner request: planning failed, requesting fallback"
                 );
+                record(metrics::Outcome::FallbackPlanningError);
                 return Ok(Json(fallback_plan(&state.planner_name)));
             }
         };
@@ -362,6 +395,7 @@ async fn prefetch_plan(
             has_namespace = intent.namespace.is_some(),
             "planner request: no candidates resolved from service state, requesting fallback"
         );
+        record(metrics::Outcome::FallbackNoCandidates);
         return Ok(Json(fallback_plan(&state.planner_name)));
     }
 
@@ -373,6 +407,9 @@ async fn prefetch_plan(
         candidate_count = plan.candidates.len(),
         "planner request: returning execute plan from service state"
     );
+
+    metrics::metrics().record_plan_candidates(plan.candidates.len());
+    record(metrics::Outcome::Execute);
 
     plan.plan_id.get_or_insert_with(next_plan_id);
     Ok(Json(plan))
@@ -672,6 +709,49 @@ mod tests {
                 planner: "planner".to_string(),
                 version: VERSION.to_string(),
             }
+        );
+    }
+
+    /// The scrape endpoint has to be reachable without a token.
+    ///
+    /// The metrics module's own tests prove the registry renders; they say
+    /// nothing about whether the route is wired, so a missing `.route()` or a
+    /// token check creeping onto /metrics would leave the series correct and
+    /// the scrape silently 404/401 — metrics that exist but nobody collects.
+    #[tokio::test]
+    async fn metrics_endpoint_serves_prometheus_text_without_auth() {
+        let response = test_app(Some("secret-token"), None)
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("GET")
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "a configured bearer token must not gate the scrape endpoint"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("text/plain; version=0.0.4"),
+            "the collector needs the Prometheus text content type"
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            body.contains("kache_planner_requests_total"),
+            "scrape body carried no planner series: {body}"
         );
     }
 

--- a/crates/kache-service/src/metrics.rs
+++ b/crates/kache-service/src/metrics.rs
@@ -1,0 +1,251 @@
+//! Prometheus metrics for the planner, scraped into SigNoz.
+//!
+//! The planner's operational question is not "is the process up" — Kubernetes
+//! already answers that, and a readiness probe is what finally surfaced the
+//! 13-day CrashLoopBackOff in kunobi-ninja/kache#747. It is "of the requests
+//! that arrive, how many produce a usable plan, and when they do not, why".
+//!
+//! A planner that answers every request with `use_fallback` is indistinguishable
+//! from a healthy one at the Kubernetes level: it is ready, it serves 200s, it
+//! burns no CPU. Every client silently falls back to building from scratch and
+//! the cache quietly stops paying for itself. `planner_requests_total` split by
+//! outcome is the signal that separates those two worlds, which is why the
+//! fallback reasons are kept distinct rather than collapsed into one counter —
+//! "no state configured" is a deployment mistake, "planning error" is a bug, and
+//! "no candidates" is a cold or mismatched cache. They need different responses.
+
+use prometheus::{
+    Encoder, HistogramVec, IntCounterVec, IntGauge, Registry, TextEncoder, histogram_opts, opts,
+};
+use std::sync::OnceLock;
+
+/// Why a planner request ended the way it did.
+///
+/// Carried as the `outcome` label. Deliberately an enum rather than free
+/// strings: the label set is bounded by construction, so no handler can grow
+/// the cardinality of this metric by accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Outcome {
+    /// A plan with at least one candidate — the case the planner exists for.
+    Execute,
+    /// No service-side state is configured. A deployment problem, not a cache
+    /// state: the planner cannot answer anything useful until it is fixed.
+    FallbackNoState,
+    /// Planning itself failed. A bug or a broken database; the request still
+    /// gets a usable answer, so nothing else surfaces it.
+    FallbackPlanningError,
+    /// State exists but resolved nothing. A cold or mismatched cache — expected
+    /// early on, worth alerting on if it stays high.
+    FallbackNoCandidates,
+    /// Rejected: missing or wrong bearer token.
+    Unauthorized,
+    /// Rejected: the planner has not finished coming up.
+    NotReady,
+}
+
+impl Outcome {
+    fn as_label(self) -> &'static str {
+        match self {
+            Outcome::Execute => "execute",
+            Outcome::FallbackNoState => "fallback_no_state",
+            Outcome::FallbackPlanningError => "fallback_planning_error",
+            Outcome::FallbackNoCandidates => "fallback_no_candidates",
+            Outcome::Unauthorized => "unauthorized",
+            Outcome::NotReady => "not_ready",
+        }
+    }
+
+    /// Every variant, so each series is registered at startup.
+    ///
+    /// A counter that has never been incremented is absent from `/metrics`
+    /// entirely, and absent reads as zero on some panels and as "no data" on
+    /// others. Initialising all of them makes "no fallbacks yet" and "this
+    /// planner is not reporting" distinguishable from the first scrape.
+    const ALL: [Outcome; 6] = [
+        Outcome::Execute,
+        Outcome::FallbackNoState,
+        Outcome::FallbackPlanningError,
+        Outcome::FallbackNoCandidates,
+        Outcome::Unauthorized,
+        Outcome::NotReady,
+    ];
+}
+
+pub(crate) struct Metrics {
+    registry: Registry,
+    requests: IntCounterVec,
+    duration: HistogramVec,
+    candidates: HistogramVec,
+    ready: IntGauge,
+}
+
+impl Metrics {
+    fn new() -> Self {
+        let registry = Registry::new();
+
+        let requests = IntCounterVec::new(
+            opts!(
+                "kache_planner_requests_total",
+                "Planner requests by outcome. `execute` means a usable plan was returned; \
+                 every other value means the client fell back to building without help."
+            ),
+            &["outcome"],
+        )
+        .expect("planner request counter is statically valid");
+
+        let duration = HistogramVec::new(
+            histogram_opts!(
+                "kache_planner_request_duration_seconds",
+                "Time to answer a planner request. Buckets are tight at the low end: the \
+                 planner sits in front of a build, so its own latency is pure overhead.",
+                vec![0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5]
+            ),
+            &["outcome"],
+        )
+        .expect("planner duration histogram is statically valid");
+
+        let candidates = HistogramVec::new(
+            histogram_opts!(
+                "kache_planner_plan_candidates",
+                "Candidates per returned plan. Separates a planner that answers with one \
+                 lucky artefact from one resolving a whole dependency set.",
+                vec![1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0]
+            ),
+            &[] as &[&str],
+        )
+        .expect("planner candidate histogram is statically valid");
+
+        let ready = IntGauge::with_opts(opts!(
+            "kache_planner_ready",
+            "1 when the planner is serving, 0 while it is still coming up. Mirrors /readyz \
+             so the same fact is available to a scrape without an HTTP probe."
+        ))
+        .expect("planner ready gauge is statically valid");
+
+        registry
+            .register(Box::new(requests.clone()))
+            .expect("request counter registers once");
+        registry
+            .register(Box::new(duration.clone()))
+            .expect("duration histogram registers once");
+        registry
+            .register(Box::new(candidates.clone()))
+            .expect("candidate histogram registers once");
+        registry
+            .register(Box::new(ready.clone()))
+            .expect("ready gauge registers once");
+
+        for outcome in Outcome::ALL {
+            requests.with_label_values(&[outcome.as_label()]);
+            duration.with_label_values(&[outcome.as_label()]);
+        }
+
+        Self {
+            registry,
+            requests,
+            duration,
+            candidates,
+            ready,
+        }
+    }
+
+    /// Record a finished planner request.
+    pub(crate) fn record_request(&self, outcome: Outcome, seconds: f64) {
+        let label = outcome.as_label();
+        self.requests.with_label_values(&[label]).inc();
+        self.duration.with_label_values(&[label]).observe(seconds);
+    }
+
+    /// Record the size of a plan that was actually returned for execution.
+    pub(crate) fn record_plan_candidates(&self, count: usize) {
+        self.candidates
+            .with_label_values(&[] as &[&str])
+            .observe(count as f64);
+    }
+
+    pub(crate) fn set_ready(&self, ready: bool) {
+        self.ready.set(i64::from(ready));
+    }
+
+    /// Render the registry in the Prometheus text format.
+    pub(crate) fn render(&self) -> String {
+        let mut buffer = Vec::new();
+        let encoder = TextEncoder::new();
+        if let Err(error) = encoder.encode(&self.registry.gather(), &mut buffer) {
+            // Losing a scrape must never take the planner down with it.
+            tracing::warn!(%error, "encoding metrics failed");
+            return String::new();
+        }
+        String::from_utf8(buffer).unwrap_or_default()
+    }
+}
+
+/// Process-wide metrics.
+///
+/// A single registry for the process, because a scrape has one endpoint to read
+/// and Prometheus counters are meaningless if they reset per request.
+pub(crate) fn metrics() -> &'static Metrics {
+    static METRICS: OnceLock<Metrics> = OnceLock::new();
+    METRICS.get_or_init(Metrics::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_outcome_has_a_distinct_label() {
+        let labels: Vec<&str> = Outcome::ALL.iter().map(|o| o.as_label()).collect();
+        let mut unique = labels.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            labels.len(),
+            unique.len(),
+            "two outcomes share a label, so they would be summed into one series: {labels:?}"
+        );
+    }
+
+    /// Counters must exist at zero before anything happens.
+    ///
+    /// Prometheus omits a labelled series that was never touched, and an absent
+    /// series is not the same as zero: a dashboard cannot tell "no fallbacks"
+    /// from "this planner is not reporting". Pinning this because it is silent
+    /// when it regresses — the endpoint still returns 200, just with fewer
+    /// series than the panels expect.
+    #[test]
+    fn all_outcome_series_exist_before_any_request() {
+        let rendered = metrics().render();
+        for outcome in Outcome::ALL {
+            let series = format!(
+                "kache_planner_requests_total{{outcome=\"{}\"}}",
+                outcome.as_label()
+            );
+            assert!(
+                rendered.contains(&series),
+                "{series} missing from a fresh registry; absent reads as no-data, not zero"
+            );
+        }
+    }
+
+    #[test]
+    fn recording_a_request_increments_its_outcome_only() {
+        let m = metrics();
+        m.record_request(Outcome::Execute, 0.01);
+        let rendered = m.render();
+        assert!(rendered.contains("kache_planner_requests_total{outcome=\"execute\"} 1"));
+        assert!(
+            rendered.contains("kache_planner_requests_total{outcome=\"unauthorized\"} 0"),
+            "an unrelated outcome moved, so the label is not selecting one series"
+        );
+    }
+
+    #[test]
+    fn ready_gauge_tracks_both_directions() {
+        let m = metrics();
+        m.set_ready(false);
+        assert!(m.render().contains("kache_planner_ready 0"));
+        m.set_ready(true);
+        assert!(m.render().contains("kache_planner_ready 1"));
+    }
+}

--- a/crates/kache-service/src/metrics.rs
+++ b/crates/kache-service/src/metrics.rs
@@ -240,12 +240,66 @@ mod tests {
         );
     }
 
+    /// Value of a sample line, ignoring `# HELP` / `# TYPE`.
+    ///
+    /// Substring matching on the whole render is not safe here: `# HELP
+    /// kache_planner_ready 1 when the planner is serving…` contains the exact
+    /// text `kache_planner_ready 1`, so a `contains` assertion passes whatever
+    /// the gauge holds. That is not hypothetical — it let a mutant that stubbed
+    /// out `set_ready` survive the changed-line lane. Match the sample line.
+    fn sample(rendered: &str, name: &str) -> Option<f64> {
+        rendered
+            .lines()
+            .filter(|line| !line.starts_with('#'))
+            .find_map(|line| {
+                let (key, value) = line.rsplit_once(' ')?;
+                (key == name).then(|| value.parse().ok())?
+            })
+    }
+
     #[test]
     fn ready_gauge_tracks_both_directions() {
         let m = metrics();
+
         m.set_ready(false);
-        assert!(m.render().contains("kache_planner_ready 0"));
+        assert_eq!(
+            sample(&m.render(), "kache_planner_ready"),
+            Some(0.0),
+            "gauge did not follow set_ready(false)"
+        );
+
         m.set_ready(true);
-        assert!(m.render().contains("kache_planner_ready 1"));
+        assert_eq!(
+            sample(&m.render(), "kache_planner_ready"),
+            Some(1.0),
+            "gauge did not follow set_ready(true)"
+        );
+    }
+
+    /// Plan size has to actually reach the histogram.
+    ///
+    /// Nothing else observes this one: the request counter moves whether or not
+    /// the candidate count is recorded, so a `record_plan_candidates` that did
+    /// nothing would leave every other assertion here green while the only
+    /// signal describing how much work a plan saves silently stayed empty.
+    #[test]
+    fn recording_plan_candidates_observes_the_histogram() {
+        let m = metrics();
+        let before = sample(&m.render(), "kache_planner_plan_candidates_count").unwrap_or(0.0);
+        let sum_before = sample(&m.render(), "kache_planner_plan_candidates_sum").unwrap_or(0.0);
+
+        m.record_plan_candidates(7);
+
+        let rendered = m.render();
+        assert_eq!(
+            sample(&rendered, "kache_planner_plan_candidates_count"),
+            Some(before + 1.0),
+            "observation was not counted"
+        );
+        assert_eq!(
+            sample(&rendered, "kache_planner_plan_candidates_sum"),
+            Some(sum_before + 7.0),
+            "observation was counted but its value was lost"
+        );
     }
 }


### PR DESCRIPTION
kache emits **no application metrics**. SigNoz has k8s infra metrics for it — cpu, memory, restarts, readiness — but nothing from the app:

```console
$ signoz_list_metrics searchText="kache"
{"metrics": []}
```

The workspace has no `prometheus`/`opentelemetry` dependency, and the service exposes only `/healthz` and `/readyz`.

## Why this matters for a planner specifically

A planner answering **every** request with `use_fallback` is indistinguishable from a healthy one at the Kubernetes level: it's ready, it serves 200s, it burns near-zero CPU. Clients quietly build without help and the cache stops paying for itself, with nothing anywhere to show it.

That's the same shape as the failure that started this whole thread — invisible because nothing was looking, not because nothing was wrong.

## What it adds

| Metric | Question it answers |
| --- | --- |
| `kache_planner_requests_total{outcome}` | of the requests arriving, how many produce a usable plan |
| `kache_planner_request_duration_seconds` | planner latency, which is pure overhead in front of a build — buckets tight at the low end |
| `kache_planner_plan_candidates` | plan size: one lucky artefact vs a resolved dependency set |
| `kache_planner_ready` | mirrors `/readyz` so a scrape sees it without an HTTP probe |

**Fallback reasons stay distinct** rather than collapsing into one counter:

- `fallback_no_state` — a deployment mistake
- `fallback_planning_error` — a bug
- `fallback_no_candidates` — a cold or mismatched cache

They need different responses, so they can't share a series.

Two deliberate choices:

- `outcome` is an **enum, not a free string**, so no handler can grow this metric's cardinality by accident.
- **Every variant is initialised at startup.** Prometheus omits a labelled series that was never touched, and absent is not zero — a panel cannot distinguish "no fallbacks yet" from "this planner isn't reporting".

## Chart

Follows kobe: pod annotations (`signoz.io/scrape|port|path`), **not** a ServiceMonitor. These clusters run no Prometheus to consume one — the SigNoz collector discovers by annotation, as kobe's own values.yaml documents. On by default, inert anywhere without a collector.

`helm template` is otherwise unchanged — resource names and selector labels don't move — and `--set signoz.scrape=false` removes the annotations cleanly.

## Testing

33 tests pass, clippy and fmt clean.

The route is tested **separately from the registry**, because they fail differently. The module tests prove the series render; only a router-level test catches a missing `.route()` or a token check creeping onto the scrape path — which would leave the metrics perfectly correct and never collected. Verified it has teeth:

```console
$ # with .route("/metrics", …) removed
test tests::metrics_endpoint_serves_prometheus_text_without_auth ... FAILED
```

## Scope

Metrics only. No OTLP tracing — that's a larger change and lower value here.

Worth flagging: this does **not** fix log severity. kobe already emits perfect JSON logs and they still land in SigNoz with `severity_text: ""`, because the collector's filelog receiver has only a `container` operator — no `json_parser`, no `severity_parser`. That fix lives in `Zondax/flux-apps` and would unblock severity alerting for every service at once.
