### PR TITLE
chore(release): 0.15.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.14.2"
+version = "0.15.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.14.2"
+version = "0.15.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.14.2"
+version = "0.15.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.14.2"
+version = "0.15.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.14.2"
+version = "0.15.0-rc.1"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more, with S3 and shared-filesystem remotes."
 license = "Apache-2.0"
@@ -36,7 +36,7 @@ reqsign-aws-v4 = { version = "=3.0.2", default-features = false }
 reqsign-core = { version = "=3.1.0", default-features = false }
 # Direct dep so OpenDAL/reqwest can use ring without reintroducing aws-lc.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.14.2", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.15.0-rc.1", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/charts/kache-service/Chart.yaml
+++ b/charts/kache-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kache-service
 description: Advisory remote planner service for kache
 type: application
-version: 0.14.2
-appVersion: "0.14.2"
+version: 0.15.0-rc.1
+appVersion: "0.15.0-rc.1"
 keywords:
   - rust
   - cache

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.14.2"
+version = "0.15.0-rc.1"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.14.2"
+version = "0.15.0-rc.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.14.2"
+version = "0.15.0-rc.1"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps to **0.15.0-rc.1** ahead of tagging `v0.15.0-rc.1`.

## Why a release candidate

`#753` adds an HTTP endpoint and four metric series that have never run anywhere but CI and a local test suite. An rc publishes the same artifacts under a version that says so, so the planner metrics can be exercised against a real cluster — and the `signoz.io/scrape` annotations proven to actually deliver series into SigNoz — before `0.15.0` is cut.

That matters here specifically: the whole point of these metrics is to make a silently-degraded planner visible. Shipping them without confirming they arrive would repeat the pattern in a smaller way.

## Version mechanics

The prerelease lives in the manifest, not only the tag (Policy B): `Cargo.toml` says `0.15.0-rc.1` and the tag is `v0.15.0-rc.1`, full suffix included. Cargo serves prereleases only on an explicit `--version` request, so a normal `cargo install kache` is unaffected.

**Dotted form on purpose.** `-rc1` sorts lexically on crates.io — `rc.2` would order after `rc.10` — and crates.io is permanent. The gate rejects it, which I confirmed:

```console
$ # with 0.15.0-rc1 in the manifest
version consistency FAILED for the workspace manifests:
  - version '0.15.0-rc1' uses a no-dot prerelease (rc1…); use the dotted form
    (e.g. -rc.4) — the no-dot form sorts lexically on crates.io
```

## Verified

```console
$ ./scripts/check-version-consistency.sh v0.15.0-rc.1
version consistency OK: tag 0.15.0-rc.1 == kache == kache-core == kache-core dep-pin

$ helm package charts/kache-service
Successfully packaged chart and saved it to: kache-service-0.15.0-rc.1.tgz
```

Staged with explicit paths, not `git add -A`.

## After merge

```bash
git tag v0.15.0-rc.1 && git push origin v0.15.0-rc.1
```

Publishes the versioned images and `kache-service-0.15.0-rc.1` to the OCI registry.

The running pod won't report metrics until it restarts — it tracks `:latest` with `pullPolicy: Always`, which only pulls on container start, and it's currently stable with 0 restarts. Validating the rc means pointing something at the rc image deliberately, or a `rollout restart` once `:latest` carries it.
