### PR TITLE
fix(release): keep prereleases off the floating image tags

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -31,14 +31,34 @@ variable "PLATFORM" {
   default = "linux/amd64"
 }
 
+# A prerelease version carries a `-` (0.15.0-rc.1); a stable one never does.
+# Compared against itself with the suffix stripped rather than pattern-matched,
+# so it holds for -rc.N, -alpha.N, -beta.N and anything else added later.
+function "is_prerelease" {
+  params = [version]
+  result = notequal(version, split("-", version)[0])
+}
+
+# `latest`, `vX` and `vX.Y` are FLOATING: whoever tracks them gets whatever was
+# pushed last, without asking. A release candidate must never move them —
+# otherwise tagging v0.15.0-rc.1 hands the experiment to everyone on
+# zondax/kache:latest, which includes clusters running pullPolicy: Always, and
+# the rc silently becomes everyone's kache on the next restart. That is the
+# opposite of what a prerelease is for.
+#
+# The exact tags (0.15.0-rc.1, v0.15.0-rc.1) are always pushed: an rc has to be
+# installable, just never by accident.
+#
+# Non-tag main builds keep moving `latest` as before — VERSION is 0.0.0 there,
+# which is not a prerelease. This narrows prereleases only.
 function "tags" {
   params = [name]
   result = compact([
-    "${REGISTRY}/${name}:latest",
+    is_prerelease(VERSION) ? "" : "${REGISTRY}/${name}:latest",
     "${REGISTRY}/${name}:${IMAGE_TAG}",
     notequal(VERSION, "0.0.0") ? "${REGISTRY}/${name}:v${VERSION}" : "",
-    notequal(VERSION, "0.0.0") ? "${REGISTRY}/${name}:v${split(".", VERSION)[0]}.${split(".", VERSION)[1]}" : "",
-    notequal(VERSION, "0.0.0") ? "${REGISTRY}/${name}:v${split(".", VERSION)[0]}" : "",
+    notequal(VERSION, "0.0.0") && !is_prerelease(VERSION) ? "${REGISTRY}/${name}:v${split(".", VERSION)[0]}.${split(".", VERSION)[1]}" : "",
+    notequal(VERSION, "0.0.0") && !is_prerelease(VERSION) ? "${REGISTRY}/${name}:v${split(".", VERSION)[0]}" : "",
   ])
 }
 


### PR DESCRIPTION
**Tagging `v0.15.0-rc.1` today would hand the release candidate to everyone.**

`docker-bake.hcl` pushes `:latest` unconditionally, and derives `vX` / `vX.Y` from the version string. For `VERSION=0.15.0-rc.1`:

| Tag | |
| --- | --- |
| `0.15.0-rc.1`, `v0.15.0-rc.1` | correct — explicit, opt-in |
| `latest` | ⚠️ unconditional |
| `v0.15` | ⚠️ `split(".", "0.15.0-rc.1")` → `["0","15",…]` |
| `v0` | ⚠️ same |

Those three are **floating**: whoever tracks them gets whatever was pushed last, without asking. That includes the int-pro cluster, which runs `image.tag: latest` with `pullPolicy: Always` — so the rc would become production's kache on the next container start.

That is the opposite of what a prerelease is for. The point of tagging an rc is to publish something users are *not* handed by accident.

## Fix

Push the floating tags only for a stable version. The exact tags are still published — an rc has to be installable, just deliberately.

Prerelease is detected by comparing the version against itself with any suffix stripped, rather than matching `rc`, so it covers `-alpha.N`, `-beta.N` and anything added later without another edit here.

**Non-tag main builds are untouched.** `VERSION` is `0.0.0` there, which is not a prerelease, so `latest` keeps following main exactly as it does today. This narrows prereleases only — it does not change what `latest` means for normal development.

## Verified against the actual bake plan

```console
$ VERSION=0.15.0 IMAGE_TAG=0.15.0 docker buildx bake --print service
    zondax/kache:latest
    zondax/kache:0.15.0
    zondax/kache:v0.15.0
    zondax/kache:v0.15
    zondax/kache:v0

$ VERSION=0.15.0-rc.1 IMAGE_TAG=0.15.0-rc.1 docker buildx bake --print service
    zondax/kache:0.15.0-rc.1
    zondax/kache:v0.15.0-rc.1

$ VERSION=0.0.0 IMAGE_TAG=edge docker buildx bake --print service
    zondax/kache:latest
    zondax/kache:edge
```

## Sequencing

This wants to land **before** `v0.15.0-rc.1` is tagged (#754) — the fix only takes effect for tags cut after it is on main.
