### PR TITLE
feat(cli): page kache list output through a pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
 | `kache doctor [--fix [--purge-sccache]] [--verify] [--checksums] [--repair]` | Diagnose setup; `--fix` migrates from sccache, `--verify` checks cache integrity, `--checksums` also hashes blobs, `--repair` deletes corrupted entries |
 | `kache monitor [--since <dur>]` | Live TUI dashboard showing build events, cache stats, and project breakdown |
 | `kache stats [--since <dur>]` | Non-interactive cache stats summary |
-| `kache list [<crate>] [--sort name\|size\|hits\|age]` | List cached entries, or show details for a specific crate |
+| `kache list [<crate>] [--sort name\|size\|hits\|age] [--no-pager]` | List cached entries, or show details for a specific crate (paged when interactive) |
 | `kache why-miss <crate>` | Explain why a specific crate missed the cache |
 | `kache report [--format text\|json\|markdown\|github\|perfetto\|chrome-trace] [--since <dur>] [--top <n>] [--output <path>]` | Generate a detailed hit/dup/miss build report or Perfetto/Chrome trace (`--top` defaults to 10) |
 | `kache sync [--manifest-path <path>] [--pull] [--push] [--all] [--workspace] [--dry-run]` | Synchronize the local cache with its configured remote (pull + push); `--manifest-path` controls the push-side workspace filter; `--workspace` scopes the pull to workspace members only (one LIST per member) |

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -15,7 +15,7 @@ When invoked without arguments, kache prints `--help` and exits — it does not 
 | `kache init [-y] [--no-service] [--check]` | Interactive setup: cargo wrapper + service install + daemon start |
 | `kache monitor [--since <dur>]` | Open the live TUI dashboard, optionally scoped to a time window |
 | `kache stats [--since <dur>]` | One-shot stats snapshot, no interactive UI |
-| `kache list [<crate>] [--sort <field>]` | List cache entries or show details for one crate |
+| `kache list [<crate>] [--sort <field>] [--no-pager]` | List cache entries or show details for one crate |
 | `kache why-miss <crate>` | Diagnose why a crate keeps missing the cache |
 | `kache report [--format <fmt>] [--since <dur>] [--root <path>] [--output <path>] [--top <n>]` | Build report in text / json / trace / markdown / github format |
 | `kache gc [--max-age <dur>]` | Evict entries by LRU or age |
@@ -91,7 +91,7 @@ kache stats --since 7d
 ## `kache list`
 
 ```sh
-kache list [<crate-name>] [--sort name|size|hits|age]
+kache list [<crate-name>] [--sort name|size|hits|age] [--no-pager]
 ```
 
 Without a crate name, lists all cached entries with sort control. With a crate name, shows all cached entries for that specific crate including cache keys, artifact sizes, features, and targets.
@@ -102,6 +102,14 @@ kache list --sort size        # largest first
 kache list --sort hits        # most frequently used first
 kache list serde              # all entries for serde
 ```
+
+### Paging
+
+When stdout is a terminal, the full listing is sent to a pager (`less -FRX` by
+default, so short output still prints normally). `--no-pager` prints directly.
+The pager is chosen from `KACHE_PAGER`, then `$PAGER`, then the platform
+default; setting either to `cat` disables paging. Piped or redirected output is
+never paged.
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1790,7 +1790,12 @@ pub(crate) fn compute_link_stats(store_dir: &std::path::Path) -> LinkStats {
 }
 
 /// List all cached entries, or show details for a specific crate.
-pub fn list(config: &Config, crate_name: Option<&str>, sort_by: &str) -> Result<()> {
+pub fn list(
+    config: &Config,
+    crate_name: Option<&str>,
+    sort_by: &str,
+    no_pager: bool,
+) -> Result<()> {
     let store = Store::open(config)?;
 
     if let Some(name) = crate_name {
@@ -1843,11 +1848,13 @@ pub fn list(config: &Config, crate_name: Option<&str>, sort_by: &str) -> Result<
             return Ok(());
         }
 
-        println!(
-            "{:<30} {:<10} {:<8} {:>10} {:>6} {:>12} {:>12}",
-            "Crate", "Type", "Profile", "Size", "Hits", "Created", "Accessed"
-        );
-        println!("{}", "-".repeat(92));
+        let mut lines = vec![
+            format!(
+                "{:<30} {:<10} {:<8} {:>10} {:>6} {:>12} {:>12}",
+                "Crate", "Type", "Profile", "Size", "Hits", "Created", "Accessed"
+            ),
+            "-".repeat(92),
+        ];
 
         for entry in &entries {
             let crate_type = if entry.crate_type.is_empty() {
@@ -1860,7 +1867,7 @@ pub fn list(config: &Config, crate_name: Option<&str>, sort_by: &str) -> Result<
             } else {
                 &entry.profile
             };
-            println!(
+            lines.push(format!(
                 "{:<30} {:<10} {:<8} {:>10} {:>6} {:>12} {:>12}",
                 entry.crate_name,
                 crate_type,
@@ -1869,13 +1876,72 @@ pub fn list(config: &Config, crate_name: Option<&str>, sort_by: &str) -> Result<
                 entry.hit_count,
                 &entry.created_at[..10],
                 &entry.last_accessed[..10],
-            );
+            ));
         }
 
-        println!("\n{} entries", entries.len());
+        lines.push(format!("\n{} entries", entries.len()));
+        write_paged(&lines, no_pager);
     }
 
     Ok(())
+}
+
+/// Write output lines to a pager when stdout is a terminal, else plain stdout.
+/// `KACHE_PAGER` > `$PAGER` > `less -FRX`; `cat` or empty disables. Pager spawn
+/// failures and early quits (EPIPE) fall back to / tolerate plain output.
+fn write_paged(lines: &[String], no_pager: bool) {
+    use std::io::{IsTerminal, Write};
+
+    let plain = || {
+        for line in lines {
+            println!("{line}");
+        }
+    };
+
+    if no_pager || !std::io::stdout().is_terminal() {
+        plain();
+        return;
+    }
+
+    let pager = std::env::var("KACHE_PAGER")
+        .or_else(|_| std::env::var("PAGER"))
+        .unwrap_or_else(|_| {
+            // `more.com` takes no flags and is the only pager guaranteed to
+            // exist on Windows; `less` is not installed there by default.
+            if cfg!(windows) {
+                "more.com".to_string()
+            } else {
+                "less -FRX".to_string()
+            }
+        });
+    if pager.trim().is_empty() || pager == "cat" {
+        plain();
+        return;
+    }
+
+    let mut words = pager.split_whitespace();
+    let program = words.next().unwrap();
+    let mut child = match std::process::Command::new(program)
+        .args(words)
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(_) => {
+            plain();
+            return;
+        }
+    };
+
+    if let Some(stdin) = child.stdin.as_mut() {
+        for line in lines {
+            if stdin.write_all(line.as_bytes()).is_err() || stdin.write_all(b"\n").is_err() {
+                break; // pager exited early (e.g. user pressed q)
+            }
+        }
+    }
+    drop(child.stdin.take());
+    let _ = child.wait();
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,10 @@ enum Commands {
         /// Sort by: name, size, hits, age
         #[arg(long, default_value = "name")]
         sort: String,
+
+        /// Print directly instead of using a pager
+        #[arg(long)]
+        no_pager: bool,
     },
 
     /// Run garbage collection (LRU eviction)
@@ -457,9 +461,11 @@ fn main() -> Result<()> {
     let (config, config_provenance) = config::Config::load_with_provenance()?;
 
     match cli.command {
-        Some(Commands::List { crate_name, sort }) => {
-            cli::list(&config, crate_name.as_deref(), &sort)
-        }
+        Some(Commands::List {
+            crate_name,
+            sort,
+            no_pager,
+        }) => cli::list(&config, crate_name.as_deref(), &sort, no_pager),
         Some(Commands::Gc { max_age }) => {
             let hours = max_age
                 .as_deref()

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -310,6 +310,23 @@ fn list_accepts_all_sort_modes() {
 }
 
 #[test]
+fn list_piped_stdout_bypasses_pager() {
+    let e = env();
+    e.cmd()
+        .arg("list")
+        .env("KACHE_PAGER", "definitely-not-a-real-pager")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("No cached entries"));
+}
+
+#[test]
+fn list_no_pager_flag_is_accepted() {
+    let e = env();
+    e.cmd().args(["list", "--no-pager"]).assert().success();
+}
+
+#[test]
 fn list_for_specific_missing_crate_succeeds() {
     let e = env();
     e.cmd().args(["list", "serde"]).assert().success();


### PR DESCRIPTION
## Summary

`kache list` with a large store dumps ~2000 lines straight to the terminal. When stdout is a TTY, the full listing is now sent through a pager; piped/redirected output is never paged, so scripts and tests are unaffected.

- `list()` summary view now builds a `Vec<String>` (matching `render_stats` / `render_clean_dry_run`) and prints via a new `write_paged()` helper
- Pager precedence: `KACHE_PAGER` > `$PAGER` > platform default (`less -FRX`; `more.com` on Windows). `cat` or empty disables. Spawn failure or early quit (EPIPE) falls back to plain output — the command never fails because of the pager
- New `--no-pager` flag forces direct printing
- Short output is unchanged: `less -F` exits immediately when the listing fits one screen

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --test cli_commands_test` — 57 passed, incl. 2 new: piped stdout bypasses a bogus `KACHE_PAGER`; `--no-pager` accepted
- [x] `cargo test --test integration_test list`
- [x] Manual: `kache list` in a terminal pages; `kache list | cat` does not

Note: `cargo clippy --workspace --all-targets -- -D warnings` currently fails on `main` itself with 3 errors (src/remote_backend.rs:190, src/tui.rs:614, src/wrapper.rs:4167 — new lints from a newer 1.95 point release; verified identical on a clean checkout). This PR introduces no new clippy warnings.

## Checklist

- [ ] `just check` passes locally (fmt + clippy + tests) — see clippy note above
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] User-visible changes (CLI, config, output) are reflected in the README or relevant docs