### PR TITLE
feat(cli): page kache list output through a pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
 | `kache doctor [--fix [--purge-sccache]] [--verify] [--checksums] [--repair]` | Diagnose setup; `--fix` migrates from sccache, `--verify` checks cache integrity, `--checksums` also hashes blobs, `--repair` deletes corrupted entries |
 | `kache monitor [--since <dur>]` | Live TUI dashboard showing build events, cache stats, and project breakdown |
 | `kache stats [--since <dur>]` | Non-interactive cache stats summary |
-| `kache list [<crate>] [--sort name\|size\|hits\|age]` | List cached entries, or show details for a specific crate |
+| `kache list [<crate>] [--sort name\|size\|hits\|age] [--no-pager]` | List cached entries, or show details for a specific crate (paged when interactive) |
 | `kache why-miss <crate>` | Explain why a specific crate missed the cache |
 | `kache report [--format text\|json\|markdown\|github\|perfetto\|chrome-trace] [--since <dur>] [--top <n>] [--output <path>]` | Generate a detailed hit/dup/miss build report or Perfetto/Chrome trace (`--top` defaults to 10) |
 | `kache sync [--manifest-path <path>] [--pull] [--push] [--all] [--workspace] [--dry-run]` | Synchronize the local cache with its configured remote (pull + push); `--manifest-path` controls the push-side workspace filter; `--workspace` scopes the pull to workspace members only (one LIST per member) |

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -105,11 +105,18 @@ kache list serde              # all entries for serde
 
 ### Paging
 
-When stdout is a terminal, the full listing is sent to a pager (`less -FRX` by
-default, so short output still prints normally). `--no-pager` prints directly.
-The pager is chosen from `KACHE_PAGER`, then `$PAGER`, then the platform
-default; setting either to `cat` disables paging. Piped or redirected output is
-never paged.
+When stdout is a terminal, populated summary and crate-detail listings are sent
+to a pager. The platform default is `less -FRX` on Unix and `more.com` on
+Windows. `--no-pager` prints directly. The pager is chosen from `KACHE_PAGER`,
+then `$PAGER`, then that platform default; an empty value or the single command
+`cat` disables paging. Piped or redirected output is never paged.
+
+Pager values are parsed directly into a program and arguments, without a shell.
+Single or double quotes may group whitespace (for example,
+`KACHE_PAGER='"/opt/My Pager/less" -FRX'`), but shell expansion and operators are
+not interpreted. An invalid value or a program that cannot be started falls
+back to direct output. Quitting a running pager stops delivery without
+reprinting the listing.
 
 ---
 

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -15,7 +15,7 @@ When invoked without arguments, kache prints `--help` and exits — it does not 
 | `kache init [-y] [--no-service] [--check]` | Interactive setup: cargo wrapper + service install + daemon start |
 | `kache monitor [--since <dur>]` | Open the live TUI dashboard, optionally scoped to a time window |
 | `kache stats [--since <dur>]` | One-shot stats snapshot, no interactive UI |
-| `kache list [<crate>] [--sort <field>]` | List cache entries or show details for one crate |
+| `kache list [<crate>] [--sort <field>] [--no-pager]` | List cache entries or show details for one crate |
 | `kache why-miss <crate>` | Diagnose why a crate keeps missing the cache |
 | `kache report [--format <fmt>] [--since <dur>] [--root <path>] [--output <path>] [--top <n>]` | Build report in text / json / trace / markdown / github format |
 | `kache gc [--max-age <dur>]` | Evict entries by LRU or age |
@@ -91,7 +91,7 @@ kache stats --since 7d
 ## `kache list`
 
 ```sh
-kache list [<crate-name>] [--sort name|size|hits|age]
+kache list [<crate-name>] [--sort name|size|hits|age] [--no-pager]
 ```
 
 Without a crate name, lists all cached entries with sort control. With a crate name, shows all cached entries for that specific crate including cache keys, artifact sizes, features, and targets.
@@ -102,6 +102,14 @@ kache list --sort size        # largest first
 kache list --sort hits        # most frequently used first
 kache list serde              # all entries for serde
 ```
+
+### Paging
+
+When stdout is a terminal, the full listing is sent to a pager (`less -FRX` by
+default, so short output still prints normally). `--no-pager` prints directly.
+The pager is chosen from `KACHE_PAGER`, then `$PAGER`, then the platform
+default; setting either to `cat` disables paging. Piped or redirected output is
+never paged.
 
 ---
 

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -122,6 +122,7 @@ for AWS SDK-specific cases that need attention.
 | `KACHE_LOG` | — | `kache=warn` * | Log level for stderr output |
 | `KACHE_LOG_FILE` | — | `kache=info` * | Log level for the file log |
 | `KACHE_PROGRESS` | — | (off) | Per-crate progress lines to stderr: `1`/`hits` prints cache hits only; `verbose`/`all` also prints dups, misses, and in-flight heartbeats; unset or anything else stays silent |
+| `KACHE_PAGER` | — | `$PAGER`, then `less -FRX` on Unix / `more.com` on Windows | Pager program and arguments for populated interactive `kache list` output. Empty or the single command `cat` disables paging; see the [command reference](/docs/commands/reference#paging) for the safe argv format |
 
 \* In wrapper mode (`RUSTC_WRAPPER`, the common path) stderr logging defaults to **off** and the file log is **disabled** unless `KACHE_LOG_FILE` is set explicitly. The `kache=warn` / `kache=info` defaults apply to CLI and daemon invocations.
 
@@ -171,9 +172,14 @@ key_salt = "v3-toolchain-abc"
 
 With this, kache ignores the `KACHE_*` overrides for **file-backed settings** (cache dir, max size, key salt, fallback, remote/planner settings, the toggles, etc.) and takes the file value (or built-in default) instead. When an ignored override is actually set, kache logs a warning naming it, so the suppression is never silent.
 
-`ignore_env` is **file-only** by design — an env var can't re-enable env overrides, or the lockdown would be trivially undone by the same stray export it defends against. It deliberately does **not** cover bootstrap/operational vars that have no file representation (`KACHE_CONFIG`, `KACHE_DISABLED`, `KACHE_SOCKET_PATH`, `KACHE_LOG` / `KACHE_LOG_FILE` / `KACHE_PROGRESS`, `KACHE_NAMESPACE`, `KACHE_BASE_DIR`) or S3 credentials (`KACHE_S3_ACCESS_KEY` / `KACHE_S3_SECRET_KEY`), which are secrets rather than config.
+`ignore_env` is **file-only** by design — an env var can't re-enable env overrides, or the lockdown would be trivially undone by the same stray export it defends against. It deliberately does **not** cover bootstrap/operational vars that have no file representation (`KACHE_CONFIG`, `KACHE_DISABLED`, `KACHE_SOCKET_PATH`, `KACHE_LOG` / `KACHE_LOG_FILE` / `KACHE_PROGRESS`, `KACHE_PAGER`, `KACHE_NAMESPACE`, `KACHE_BASE_DIR`) or S3 credentials (`KACHE_S3_ACCESS_KEY` / `KACHE_S3_SECRET_KEY`), which are secrets rather than config.
 
-`KACHE_SOCKET_PATH` is the one to watch in that list. The others log or locate; this one moves the IPC endpoint, so a stray machine-global export redirects every client to a different daemon even under a pinned config. Treat it as a trust boundary rather than a setting `ignore_env` protects you from, and see [Daemon socket placement](/docs/daemon/overview#communication) for where to put it.
+`KACHE_SOCKET_PATH` is the one to watch in that list. Most others log or locate;
+`KACHE_PAGER` only selects a display program when a user explicitly runs a
+populated, interactive `kache list`. The socket variable moves the IPC endpoint,
+so a stray machine-global export redirects every client to a different daemon
+even under a pinned config. Treat it as a trust boundary rather than a setting
+`ignore_env` protects you from, and see [Daemon socket placement](/docs/daemon/overview#communication) for where to put it.
 
 ## Cache-key salt
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1790,7 +1790,12 @@ pub(crate) fn compute_link_stats(store_dir: &std::path::Path) -> LinkStats {
 }
 
 /// List all cached entries, or show details for a specific crate.
-pub fn list(config: &Config, crate_name: Option<&str>, sort_by: &str) -> Result<()> {
+pub fn list(
+    config: &Config,
+    crate_name: Option<&str>,
+    sort_by: &str,
+    no_pager: bool,
+) -> Result<()> {
     let store = Store::open(config)?;
 
     if let Some(name) = crate_name {
@@ -1843,11 +1848,13 @@ pub fn list(config: &Config, crate_name: Option<&str>, sort_by: &str) -> Result<
             return Ok(());
         }
 
-        println!(
-            "{:<30} {:<10} {:<8} {:>10} {:>6} {:>12} {:>12}",
-            "Crate", "Type", "Profile", "Size", "Hits", "Created", "Accessed"
-        );
-        println!("{}", "-".repeat(92));
+        let mut lines = vec![
+            format!(
+                "{:<30} {:<10} {:<8} {:>10} {:>6} {:>12} {:>12}",
+                "Crate", "Type", "Profile", "Size", "Hits", "Created", "Accessed"
+            ),
+            "-".repeat(92),
+        ];
 
         for entry in &entries {
             let crate_type = if entry.crate_type.is_empty() {
@@ -1860,7 +1867,7 @@ pub fn list(config: &Config, crate_name: Option<&str>, sort_by: &str) -> Result<
             } else {
                 &entry.profile
             };
-            println!(
+            lines.push(format!(
                 "{:<30} {:<10} {:<8} {:>10} {:>6} {:>12} {:>12}",
                 entry.crate_name,
                 crate_type,
@@ -1869,13 +1876,72 @@ pub fn list(config: &Config, crate_name: Option<&str>, sort_by: &str) -> Result<
                 entry.hit_count,
                 &entry.created_at[..10],
                 &entry.last_accessed[..10],
-            );
+            ));
         }
 
-        println!("\n{} entries", entries.len());
+        lines.push(format!("\n{} entries", entries.len()));
+        write_paged(&lines, no_pager);
     }
 
     Ok(())
+}
+
+/// Write output lines to a pager when stdout is a terminal, else plain stdout.
+/// `KACHE_PAGER` > `$PAGER` > `less -FRX`; `cat` or empty disables. Pager spawn
+/// failures and early quits (EPIPE) fall back to / tolerate plain output.
+fn write_paged(lines: &[String], no_pager: bool) {
+    use std::io::{IsTerminal, Write};
+
+    let plain = || {
+        for line in lines {
+            println!("{line}");
+        }
+    };
+
+    if no_pager || !std::io::stdout().is_terminal() {
+        plain();
+        return;
+    }
+
+    let pager = std::env::var("KACHE_PAGER")
+        .or_else(|_| std::env::var("PAGER"))
+        .unwrap_or_else(|_| {
+            // `more.com` takes no flags and is the only pager guaranteed to
+            // exist on Windows; `less` is not installed there by default.
+            if cfg!(windows) {
+                "more.com".to_string()
+            } else {
+                "less -FRX".to_string()
+            }
+        });
+    if pager.trim().is_empty() || pager == "cat" {
+        plain();
+        return;
+    }
+
+    let mut words = pager.split_whitespace();
+    let program = words.next().unwrap();
+    let mut child = match std::process::Command::new(program)
+        .args(words)
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(_) => {
+            plain();
+            return;
+        }
+    };
+
+    if let Some(stdin) = child.stdin.as_mut() {
+        for line in lines {
+            if stdin.write_all(line.as_bytes()).is_err() || stdin.write_all(b"\n").is_err() {
+                break; // pager exited early (e.g. user pressed q)
+            }
+        }
+    }
+    drop(child.stdin.take());
+    let _ = child.wait();
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1812,12 +1812,8 @@ pub fn list(
         for entry in &matching {
             lines.push(format!("Cache key: {}", &entry.cache_key[..16]));
             lines.push(format!("  Crate:    {}", entry.crate_name));
-            if !entry.crate_type.is_empty() {
-                lines.push(format!("  Type:     {}", entry.crate_type));
-            }
-            if !entry.profile.is_empty() {
-                lines.push(format!("  Profile:  {}", entry.profile));
-            }
+            push_nonempty_detail(&mut lines, "  Type:     ", &entry.crate_type);
+            push_nonempty_detail(&mut lines, "  Profile:  ", &entry.profile);
             lines.push(format!("  Size:     {}", ByteSize(entry.size)));
             lines.push(format!("  Hits:     {}", entry.hit_count));
             lines.push(format!("  Created:  {}", entry.created_at));
@@ -1827,12 +1823,8 @@ pub fn list(
             if let Ok(content) = std::fs::read_to_string(&meta_path)
                 && let Ok(meta) = serde_json::from_str::<crate::store::EntryMeta>(&content)
             {
-                if !meta.features.is_empty() {
-                    lines.push(format!("  Features: {}", meta.features.join(", ")));
-                }
-                if !meta.target.is_empty() {
-                    lines.push(format!("  Target:   {}", meta.target));
-                }
+                push_nonempty_detail(&mut lines, "  Features: ", &meta.features.join(", "));
+                push_nonempty_detail(&mut lines, "  Target:   ", &meta.target);
                 lines.push("  Files:".to_string());
                 for file in &meta.files {
                     lines.push(format!("    {} ({})", file.name, ByteSize(file.size)));
@@ -1886,6 +1878,12 @@ pub fn list(
     }
 
     Ok(())
+}
+
+fn push_nonempty_detail(lines: &mut Vec<String>, prefix: &str, value: &str) {
+    if !value.is_empty() {
+        lines.push(format!("{prefix}{value}"));
+    }
 }
 
 /// Resolve the pager to a direct process argv. Quotes group whitespace but are
@@ -1961,12 +1959,24 @@ fn parse_pager_argv(command: &str) -> Option<Vec<String>> {
     Some(argv)
 }
 
+fn write_pager_lines<W: std::io::Write>(writer: &mut W, lines: &[String]) -> bool {
+    for line in lines {
+        if writer.write_all(line.as_bytes()).is_err() {
+            return false;
+        }
+        if writer.write_all(b"\n").is_err() {
+            return false;
+        }
+    }
+    true
+}
+
 /// Write output lines to a pager when stdout is a terminal, else plain stdout.
 /// `KACHE_PAGER` > `$PAGER` > platform default; `cat` or empty disables. Invalid
 /// commands and spawn failures fall back to plain output. An early pager exit
 /// stops further delivery without failing the command or reprinting the listing.
 fn write_paged(lines: &[String], no_pager: bool) {
-    use std::io::{IsTerminal, Write};
+    use std::io::IsTerminal;
 
     let plain = || {
         for line in lines {
@@ -2007,11 +2017,7 @@ fn write_paged(lines: &[String], no_pager: bool) {
     };
 
     if let Some(stdin) = child.stdin.as_mut() {
-        for line in lines {
-            if stdin.write_all(line.as_bytes()).is_err() || stdin.write_all(b"\n").is_err() {
-                break; // pager exited early (e.g. user pressed q)
-            }
-        }
+        let _ = write_pager_lines(stdin, lines);
     }
     drop(child.stdin.take());
     let _ = child.wait();
@@ -4821,6 +4827,68 @@ mod tests {
     use std::fs;
 
     // ── List pager resolution ───────────────────────────────────────────────
+
+    #[test]
+    fn detail_fields_render_only_nonempty_values() {
+        let mut lines = Vec::new();
+        push_nonempty_detail(&mut lines, "  Type:     ", "");
+        assert!(lines.is_empty());
+
+        push_nonempty_detail(&mut lines, "  Type:     ", "lib");
+        push_nonempty_detail(&mut lines, "  Features: ", "serde, std");
+        assert_eq!(
+            lines,
+            vec![
+                "  Type:     lib".to_string(),
+                "  Features: serde, std".to_string(),
+            ]
+        );
+    }
+
+    struct FailOnWrite {
+        fail_on_call: usize,
+        calls: usize,
+    }
+
+    impl std::io::Write for FailOnWrite {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            self.calls += 1;
+            if self.calls == self.fail_on_call {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "pager exited",
+                ))
+            } else {
+                Ok(buffer.len())
+            }
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn pager_line_writer_stops_on_content_or_newline_errors() {
+        let lines = vec!["first".to_string(), "second".to_string()];
+        let mut output = Vec::new();
+        assert!(write_pager_lines(&mut output, &lines));
+        assert_eq!(output, b"first\nsecond\n");
+
+        let mut content_error = FailOnWrite {
+            fail_on_call: 1,
+            calls: 0,
+        };
+        assert!(!write_pager_lines(&mut content_error, &lines));
+        assert_eq!(content_error.calls, 1);
+
+        let mut newline_error = FailOnWrite {
+            fail_on_call: 2,
+            calls: 0,
+        };
+        assert!(!write_pager_lines(&mut newline_error, &lines));
+        assert_eq!(newline_error.calls, 2);
+    }
 
     #[test]
     fn pager_resolution_obeys_tty_disable_and_environment_precedence() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1808,37 +1808,39 @@ pub fn list(
             return Ok(());
         }
 
+        let mut lines = Vec::new();
         for entry in &matching {
-            println!("Cache key: {}", &entry.cache_key[..16]);
-            println!("  Crate:    {}", entry.crate_name);
+            lines.push(format!("Cache key: {}", &entry.cache_key[..16]));
+            lines.push(format!("  Crate:    {}", entry.crate_name));
             if !entry.crate_type.is_empty() {
-                println!("  Type:     {}", entry.crate_type);
+                lines.push(format!("  Type:     {}", entry.crate_type));
             }
             if !entry.profile.is_empty() {
-                println!("  Profile:  {}", entry.profile);
+                lines.push(format!("  Profile:  {}", entry.profile));
             }
-            println!("  Size:     {}", ByteSize(entry.size));
-            println!("  Hits:     {}", entry.hit_count);
-            println!("  Created:  {}", entry.created_at);
-            println!("  Accessed: {}", entry.last_accessed);
+            lines.push(format!("  Size:     {}", ByteSize(entry.size)));
+            lines.push(format!("  Hits:     {}", entry.hit_count));
+            lines.push(format!("  Created:  {}", entry.created_at));
+            lines.push(format!("  Accessed: {}", entry.last_accessed));
 
             let meta_path = store.entry_dir(&entry.cache_key).join("meta.json");
             if let Ok(content) = std::fs::read_to_string(&meta_path)
                 && let Ok(meta) = serde_json::from_str::<crate::store::EntryMeta>(&content)
             {
                 if !meta.features.is_empty() {
-                    println!("  Features: {}", meta.features.join(", "));
+                    lines.push(format!("  Features: {}", meta.features.join(", ")));
                 }
                 if !meta.target.is_empty() {
-                    println!("  Target:   {}", meta.target);
+                    lines.push(format!("  Target:   {}", meta.target));
                 }
-                println!("  Files:");
+                lines.push("  Files:".to_string());
                 for file in &meta.files {
-                    println!("    {} ({})", file.name, ByteSize(file.size));
+                    lines.push(format!("    {} ({})", file.name, ByteSize(file.size)));
                 }
             }
-            println!();
+            lines.push(String::new());
         }
+        write_paged(&lines, no_pager);
     } else {
         // Summary view of all entries
         let entries = store.list_entries(sort_by)?;
@@ -1886,9 +1888,83 @@ pub fn list(
     Ok(())
 }
 
+/// Resolve the pager to a direct process argv. Quotes group whitespace but are
+/// not shell syntax: there is no expansion, operator handling, or interpolation.
+fn resolve_pager_argv(
+    no_pager: bool,
+    stdout_is_terminal: bool,
+    kache_pager: Option<&str>,
+    pager: Option<&str>,
+    is_windows: bool,
+) -> Option<Vec<String>> {
+    if no_pager || !stdout_is_terminal {
+        return None;
+    }
+
+    let command = match kache_pager {
+        Some(command) => command,
+        None => pager.unwrap_or(if is_windows { "more.com" } else { "less -FRX" }),
+    };
+    let argv = parse_pager_argv(command)?;
+    if argv.first().is_none_or(|program| program.is_empty())
+        || (argv.len() == 1 && argv[0] == "cat")
+    {
+        None
+    } else {
+        Some(argv)
+    }
+}
+
+/// Split a pager command into argv without invoking a shell. Single and double
+/// quotes may group whitespace and are removed; every other character remains
+/// literal. An unmatched quote makes the command invalid.
+fn parse_pager_argv(command: &str) -> Option<Vec<String>> {
+    let mut argv = Vec::new();
+    let mut word = String::new();
+    let mut quote = None;
+    let mut word_started = false;
+
+    for character in command.chars() {
+        if let Some(delimiter) = quote {
+            if character == delimiter {
+                quote = None;
+            } else {
+                word.push(character);
+            }
+            continue;
+        }
+
+        match character {
+            '\'' | '"' => {
+                quote = Some(character);
+                word_started = true;
+            }
+            character if character.is_whitespace() => {
+                if word_started {
+                    argv.push(std::mem::take(&mut word));
+                    word_started = false;
+                }
+            }
+            character => {
+                word.push(character);
+                word_started = true;
+            }
+        }
+    }
+
+    if quote.is_some() {
+        return None;
+    }
+    if word_started {
+        argv.push(word);
+    }
+    Some(argv)
+}
+
 /// Write output lines to a pager when stdout is a terminal, else plain stdout.
-/// `KACHE_PAGER` > `$PAGER` > `less -FRX`; `cat` or empty disables. Pager spawn
-/// failures and early quits (EPIPE) fall back to / tolerate plain output.
+/// `KACHE_PAGER` > `$PAGER` > platform default; `cat` or empty disables. Invalid
+/// commands and spawn failures fall back to plain output. An early pager exit
+/// stops further delivery without failing the command or reprinting the listing.
 fn write_paged(lines: &[String], no_pager: bool) {
     use std::io::{IsTerminal, Write};
 
@@ -1898,31 +1974,28 @@ fn write_paged(lines: &[String], no_pager: bool) {
         }
     };
 
-    if no_pager || !std::io::stdout().is_terminal() {
+    let kache_pager = std::env::var_os("KACHE_PAGER");
+    let pager = std::env::var_os("PAGER");
+    let Some(argv) = resolve_pager_argv(
+        no_pager,
+        std::io::stdout().is_terminal(),
+        kache_pager
+            .as_deref()
+            .map(|value| value.to_str().unwrap_or("")),
+        pager.as_deref().map(|value| value.to_str().unwrap_or("")),
+        cfg!(windows),
+    ) else {
         plain();
         return;
-    }
+    };
 
-    let pager = std::env::var("KACHE_PAGER")
-        .or_else(|_| std::env::var("PAGER"))
-        .unwrap_or_else(|_| {
-            // `more.com` takes no flags and is the only pager guaranteed to
-            // exist on Windows; `less` is not installed there by default.
-            if cfg!(windows) {
-                "more.com".to_string()
-            } else {
-                "less -FRX".to_string()
-            }
-        });
-    if pager.trim().is_empty() || pager == "cat" {
+    let mut argv = argv.into_iter();
+    let Some(program) = argv.next() else {
         plain();
         return;
-    }
-
-    let mut words = pager.split_whitespace();
-    let program = words.next().unwrap();
+    };
     let mut child = match std::process::Command::new(program)
-        .args(words)
+        .args(argv)
         .stdin(std::process::Stdio::piped())
         .spawn()
     {
@@ -4746,6 +4819,88 @@ pub fn verify(config: &Config, checksums: bool, repair: bool) -> Result<VerifyOu
 mod tests {
     use super::*;
     use std::fs;
+
+    // ── List pager resolution ───────────────────────────────────────────────
+
+    #[test]
+    fn pager_resolution_obeys_tty_disable_and_environment_precedence() {
+        assert_eq!(
+            resolve_pager_argv(false, true, Some("most -R"), Some("less -S"), false),
+            Some(vec!["most".to_string(), "-R".to_string()])
+        );
+        assert_eq!(
+            resolve_pager_argv(false, true, None, Some("less -S"), false),
+            Some(vec!["less".to_string(), "-S".to_string()])
+        );
+        assert_eq!(
+            resolve_pager_argv(true, true, Some("less"), None, false),
+            None
+        );
+        assert_eq!(
+            resolve_pager_argv(false, false, Some("less"), None, false),
+            None
+        );
+
+        // A present but empty KACHE_PAGER wins over PAGER and disables paging.
+        assert_eq!(
+            resolve_pager_argv(false, true, Some(""), Some("less"), false),
+            None
+        );
+        assert_eq!(
+            resolve_pager_argv(false, true, Some("cat"), Some("less"), false),
+            None
+        );
+        assert_eq!(
+            resolve_pager_argv(false, true, None, Some("cat"), false),
+            None
+        );
+    }
+
+    #[test]
+    fn pager_resolution_uses_platform_defaults() {
+        assert_eq!(
+            resolve_pager_argv(false, true, None, None, false),
+            Some(vec!["less".to_string(), "-FRX".to_string()])
+        );
+        assert_eq!(
+            resolve_pager_argv(false, true, None, None, true),
+            Some(vec!["more.com".to_string()])
+        );
+    }
+
+    #[test]
+    fn pager_resolution_groups_quotes_without_shell_evaluation() {
+        assert_eq!(
+            resolve_pager_argv(
+                false,
+                true,
+                Some(r#""C:\Program Files\Git\usr\bin\less.exe" -FRX"#),
+                None,
+                true
+            ),
+            Some(vec![
+                r"C:\Program Files\Git\usr\bin\less.exe".to_string(),
+                "-FRX".to_string()
+            ])
+        );
+        assert_eq!(
+            resolve_pager_argv(
+                false,
+                true,
+                Some("less --prompt='literal ; $HOME | text'"),
+                None,
+                false
+            ),
+            Some(vec![
+                "less".to_string(),
+                "--prompt=literal ; $HOME | text".to_string()
+            ])
+        );
+        assert_eq!(
+            resolve_pager_argv(false, true, Some("less 'unterminated"), None, false),
+            None
+        );
+    }
 
     // ── Doctor check dispositions (kunobi-ninja/kache#443, #626) ──────────
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,10 @@ enum Commands {
         /// Sort by: name, size, hits, age
         #[arg(long, default_value = "name")]
         sort: String,
+
+        /// Print directly instead of using a pager
+        #[arg(long)]
+        no_pager: bool,
     },
 
     /// Run garbage collection (LRU eviction)
@@ -457,9 +461,11 @@ fn main() -> Result<()> {
     let (config, config_provenance) = config::Config::load_with_provenance()?;
 
     match cli.command {
-        Some(Commands::List { crate_name, sort }) => {
-            cli::list(&config, crate_name.as_deref(), &sort)
-        }
+        Some(Commands::List {
+            crate_name,
+            sort,
+            no_pager,
+        }) => cli::list(&config, crate_name.as_deref(), &sort, no_pager),
         Some(Commands::Gc { max_age }) => {
             let hours = max_age
                 .as_deref()

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -310,6 +310,23 @@ fn list_accepts_all_sort_modes() {
 }
 
 #[test]
+fn list_piped_stdout_bypasses_pager() {
+    let e = env();
+    e.cmd()
+        .arg("list")
+        .env("KACHE_PAGER", "definitely-not-a-real-pager")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("No cached entries"));
+}
+
+#[test]
+fn list_no_pager_flag_is_accepted() {
+    let e = env();
+    e.cmd().args(["list", "--no-pager"]).assert().success();
+}
+
+#[test]
 fn list_for_specific_missing_crate_succeeds() {
     let e = env();
     e.cmd().args(["list", "serde"]).assert().success();

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -310,17 +310,6 @@ fn list_accepts_all_sort_modes() {
 }
 
 #[test]
-fn list_piped_stdout_bypasses_pager() {
-    let e = env();
-    e.cmd()
-        .arg("list")
-        .env("KACHE_PAGER", "definitely-not-a-real-pager")
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("No cached entries"));
-}
-
-#[test]
 fn list_no_pager_flag_is_accepted() {
     let e = env();
     e.cmd().args(["list", "--no-pager"]).assert().success();
@@ -923,9 +912,11 @@ fn commands_operate_on_a_populated_cache() {
         String::from_utf8_lossy(&warm.stderr)
     );
 
-    // `list` now shows the crate we built.
+    // `list` now shows the crate we built. assert_cmd captures stdout through a
+    // pipe, so this reaches populated non-TTY rendering with a pager configured.
     e.cmd()
         .arg("list")
+        .env("KACHE_PAGER", "definitely-not-a-real-pager")
         .assert()
         .success()
         .stdout(predicates::str::contains("kachetestlib"));
@@ -981,8 +972,14 @@ fn commands_operate_on_a_populated_cache() {
             "Diagnosis: first build with these inputs -- entry is now cached",
         ));
 
-    // Listing the specific crate shows its entry detail.
-    e.cmd().args(["list", "kachetestlib"]).assert().success();
+    // Listing the specific crate reaches the same populated non-TTY renderer.
+    e.cmd()
+        .args(["list", "kachetestlib"])
+        .env("KACHE_PAGER", "definitely-not-a-real-pager")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Cache key:"))
+        .stdout(predicates::str::contains("kachetestlib"));
 
     // Purging that crate empties the cache for it; a subsequent list is clean.
     e.cmd()


### PR DESCRIPTION
## Provenance

This is a maintainer-owned replacement for [#759](https://github.com/kunobi-ninja/kache/pull/759), adopting Abdullah Alaqeel’s (@aqeelat) contribution from pinned fork head `3f8c37f471dbf0eae87f3980134acfeaead5f37c`.

The imported contribution remains the first distinct commit with its original Author metadata unchanged.

## Maintainer hardening

A separate maintainer-authored commit:

- pages populated summary and crate-detail listings;
- parses quoted pager arguments without invoking a shell;
- handles environment precedence and Unix/Windows defaults;
- falls back safely for invalid or unavailable pagers;
- documents that an early pager exit stops delivery without reprinting;
- adds populated non-TTY, resolver, parser, and configuration coverage.

Candidate tree: `60941cfc99425656110e4d10598fb4eb85cba884`.

## Validation

- Static safety and combined-diff review: clear.
- `cargo fmt --all -- --check`: pass.
- `git diff --check`: pass.
- No workflow, dependency, lockfile, or build-script changes.
- Contributor code and tests were not executed on a maintainer machine.
- Full GitHub-hosted CI: pass ([run 31958318017](https://github.com/kunobi-ninja/kache/actions/runs/31958318017)); all 24 changed-line mutants passed in one shard.
- Real-TTY validation and required review remain pending.

The original PR remains open while this replacement is validated.
