### PR TITLE
fix(chart): force Recreate when the planner DB is on a PVC

### DIFF
--- a/charts/kache-service/templates/deployment.yaml
+++ b/charts/kache-service/templates/deployment.yaml
@@ -6,7 +6,39 @@ metadata:
   labels:
     {{- include "kache-service.labels" . | nindent 4 }}
 spec:
+{{- if eq .Values.planner.persistence.type "pvc" }}
+{{- if gt (int .Values.replicaCount) 1 }}
+{{- fail "planner.persistence.type=pvc is single-writer: replicaCount must be 1. Two Pods cannot open the planner DB at once — the second fails on its LOCK file." }}
+{{- end }}
+{{- end }}
   replicas: {{ .Values.replicaCount }}
+{{- if eq .Values.planner.persistence.type "pvc" }}
+  # Recreate, NOT the RollingUpdate default.
+  #
+  # The planner DB takes an exclusive LOCK when opened, so exactly one Pod can
+  # hold it. RollingUpdate starts the replacement before terminating the old
+  # Pod, which deadlocks permanently: the new Pod cannot open the DB while the
+  # old one holds the LOCK, so it never becomes Ready — and the old Pod is
+  # never terminated precisely because the new one never becomes Ready. The
+  # rollout then sits there forever while the old Pod keeps serving, so the
+  # release looks healthy while the new version silently never ships.
+  #
+  # Observed on int-pro: stuck 3d18h across 1061 CrashLoopBackOff restarts,
+  # each logging "planner.db/LOCK is already locked by another process".
+  #
+  # Enabling `ha` does not substitute for this. Leader election would make the
+  # new Pod wait for the lease instead of crashing, but it would still never
+  # become Ready while the old Pod holds it — the same deadlock, just quieter.
+  #
+  # Not overridable by design: any value reintroducing surge here recreates the
+  # deadlock. `ephemeral` gives each Pod its own emptyDir and keeps the
+  # RollingUpdate default.
+  strategy:
+    type: Recreate
+{{- else if .Values.updateStrategy }}
+  strategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+{{- end }}
   selector:
     matchLabels:
       {{- include "kache-service.selectorLabels" . | nindent 6 }}

--- a/charts/kache-service/values.yaml
+++ b/charts/kache-service/values.yaml
@@ -8,6 +8,14 @@ fullnameOverride: ""
 
 replicaCount: 1
 
+# Deployment update strategy, honoured only when
+# `planner.persistence.type` is `ephemeral`.
+#
+# With `pvc` the chart forces `Recreate` and ignores this: the planner DB is
+# single-writer, so any surge deadlocks the rollout permanently (see the
+# comment in templates/deployment.yaml). Empty means the Kubernetes default.
+updateStrategy: {}
+
 image:
   repository: zondax/kache
   tag: ""


### PR DESCRIPTION
## The failure

A kache rollout on int-pro was deadlocked for **3d18h**, across **1061** CrashLoopBackOff
restarts, each logging:

```
Database at /var/lib/kache/planner.db/LOCK is already locked by another process
```

`replicaCount: 1`, yet two Pods existed: the old ReplicaSet's (Running, serving) and the
new one (CrashLoopBackOff), both mounting the same `planner-data` PVC.

## Why

The chart set no `strategy`, so it inherited **RollingUpdate**. That is right for
`persistence.type: ephemeral` — every Pod gets its own emptyDir — and unsurvivable for
`pvc`, where the planner DB takes an exclusive LOCK that exactly one Pod can hold.

RollingUpdate starts the replacement before terminating the old Pod, and the two
deadlock:

- the new Pod cannot open the DB while the old one holds the LOCK → never Ready
- the old Pod is never terminated **because** the new one never becomes Ready

Nothing breaks the cycle.

**The failure mode is worse than a crash.** The old Pod keeps serving, so the service
stays up and the Deployment looks healthy — while the new version silently never ships.
That is why it ran unnoticed for four days.

## The fix

| `persistence.type` | behaviour |
|---|---|
| `ephemeral` (default) | unchanged; new `updateStrategy` value for callers that want to set one |
| `pvc` | **forced `Recreate`**, not overridable |
| `pvc` + `replicaCount > 1` | **template-time `fail`** |

The `replicaCount` guard uses the chart's existing `fail` idiom (as
`persistence.type` validation already does). Several Pods sharing one RWO claim can never
work, so failing at render time beats discovering it through a crashloop.

Recreate is deliberately **not** overridable under `pvc` — any value reintroducing surge
recreates this exact deadlock.

## Why not just enable `ha`

Worth stating explicitly, because it looks like the obvious alternative and isn't. Leader
election would make the new Pod *wait* for the lease instead of crashing — but it would
still never become Ready while the old Pod holds it, so the old Pod is still never
terminated. Same deadlock, quieter logs. HA is for multi-replica failover, which an RWO
volume cannot do anyway.

(On int-pro `ha.enabled` was false, so the new Pod took the non-HA branch in `serve()` and
opened the DB unconditionally — `kunobi-ha` never even ran.)

## Verified

All four shapes rendered:

- `ephemeral` → no `strategy` emitted
- `ephemeral` + `updateStrategy.type=RollingUpdate` → override honoured
- `pvc` → `strategy.type: Recreate`
- `pvc` + `replicaCount=2` → fails with the explanation

## Deploying this

The stuck rollout on int-pro will not clear itself. Once this lands, the existing
CrashLoopBackOff Pod needs deleting (or the old ReplicaSet scaled to 0) so the new
Recreate-strategy rollout can take the LOCK cleanly.