### PR TITLE
fix(cargo): keep canonical config aliases transparent

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -121,6 +121,10 @@ gitignore = true
 # Linux. Hosted Windows tests still exercise the real identity syscall, stable
 # identity, link count, and failure behavior. Only the cfg-only adapters below
 # are excluded.
+#
+# `run_cargo_non_unix` is the process-status half of the guarded Cargo
+# front-end. The Ubuntu mutation lane compiles only the Unix `exec` half;
+# hosted Windows tests still compile the status/exit-code path.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -149,4 +153,5 @@ exclude_re = [
     "query_windows_file_identity",
     "observe_storage_windows",
     "observe_storage_unsupported",
+    "run_cargo_non_unix",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,6 +2285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +2942,7 @@ dependencies = [
  "futures",
  "glob",
  "guppy",
+ "home",
  "interprocess",
  "kache-core",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ zstd = "0.13"
 bytesize = "2"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
+home = "0.5.12"
 tar = "0.4"
 futures = "0.3"
 glob = "0.3"

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
 |---|---|
 | `kache` | Print help (bare invocation) |
 | `kache init [-y] [--no-service] [--check]` | Interactive setup: cargo wrapper + service install + daemon start |
+| `kache cargo -- <build\|check> [args...]` | Keep an existing Cargo unit fresh when an ancestor symlinks Cargo home's array-valued `build.rustflags` |
 | `kache doctor [--fix [--purge-sccache]] [--verify] [--checksums] [--repair]` | Diagnose setup; `--fix` migrates from sccache, `--verify` checks cache integrity, `--checksums` also hashes blobs, `--repair` deletes corrupted entries |
 | `kache monitor [--since <dur>]` | Live TUI dashboard showing build events, cache stats, and project breakdown |
 | `kache stats [--since <dur>]` | Non-interactive cache stats summary |

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -13,6 +13,7 @@ When invoked without arguments, kache prints `--help` and exits — it does not 
 |---|---|
 | `kache` | Print `--help` and exit (use `kache monitor` for the live TUI) |
 | `kache init [-y] [--no-service] [--check]` | Interactive setup: cargo wrapper + service install + daemon start |
+| `kache cargo -- <build\|check> [args...]` | Keep existing Cargo units fresh when Cargo discovers a canonical duplicate of Cargo-home `build.rustflags` |
 | `kache monitor [--since <dur>]` | Open the live TUI dashboard, optionally scoped to a time window |
 | `kache stats [--since <dur>]` | One-shot stats snapshot, no interactive UI |
 | `kache list [<crate>] [--sort <field>] [--no-pager]` | List cache entries or show details for one crate |
@@ -48,6 +49,38 @@ kache init --check        # report what init would do, change nothing
 ```
 
 If you'd rather wire things up manually, see [Quick start](/docs/getting-started/quick-start#manual-setup-without-kache-init).
+
+---
+
+## `kache cargo`
+
+```sh
+kache cargo -- check
+kache cargo -- build --workspace
+```
+
+Runs Cargo's built-in `build` or `check` from the current directory with its
+arguments unchanged. If Cargo's
+ancestor search finds a symlink to the selected Cargo-home config, Cargo would
+normally merge the same array-valued `build.rustflags` twice and re-key every
+unit. This front-end identifies that duplicate by canonical path, contributes
+the Cargo-home array once, and passes the corrected argument sequence to Cargo.
+User-authored repeated flags inside one config and contributions from distinct
+config files remain repeated and ordered.
+
+Normalization is deliberately conservative. Existing `RUSTFLAGS` or encoded
+flags take precedence unchanged. Config includes, target-specific rustflags,
+string-form rustflags, and rustflags supplied through `[env]` run unchanged
+with a warning rather than risk reproducing Cargo's selection rules
+incorrectly. Cargo `-C`/`--config`, unstable flags, `install`, aliases, and
+external subcommands pass through unchanged. Config paths and contents are
+revalidated immediately before Cargo starts; concurrent config editing should
+still be avoided. Ordinary `cargo` remains supported; this command is needed
+only for the canonical-config alias case.
+
+The command prevents Cargo's spurious rebuild in an existing target directory.
+It does not alias Kache entries across different rustflags transport sources;
+an empty target still uses Kache's normal exact-key safety.
 
 ---
 

--- a/src/cargo_proxy.rs
+++ b/src/cargo_proxy.rs
@@ -166,7 +166,7 @@ fn normalization_plan(cwd: &Path, cargo_args: &[OsString]) -> PlanDecision {
     let home_canonical = home_source.canonical_path.clone();
     let duplicate_paths: Vec<PathBuf> = sources
         .iter()
-        .filter(|source| !source.cargo_home && source.canonical_path == home_canonical)
+        .filter(|source| is_cargo_home_alias(source, &home_canonical))
         .map(|source| source.logical_path.clone())
         .collect();
     if duplicate_paths.is_empty() {
@@ -175,7 +175,7 @@ fn normalization_plan(cwd: &Path, cargo_args: &[OsString]) -> PlanDecision {
 
     let mut rustflags = Vec::new();
     for source in &sources {
-        if !source.cargo_home && source.canonical_path == home_canonical {
+        if is_cargo_home_alias(source, &home_canonical) {
             continue;
         }
         match source_rustflags(&source.value, &source.logical_path) {
@@ -200,6 +200,10 @@ fn normalization_plan(cwd: &Path, cargo_args: &[OsString]) -> PlanDecision {
     })
 }
 
+fn is_cargo_home_alias(source: &ConfigSource, home_canonical: &Path) -> bool {
+    !source.cargo_home && source.canonical_path == home_canonical
+}
+
 fn rustflags_environment_is_explicit() -> bool {
     std::env::vars_os().any(|(key, _)| {
         let Some(key) = key.to_str() else {
@@ -221,20 +225,27 @@ fn rustflags_env_name(key: &str, case_insensitive: bool) -> bool {
 }
 
 fn supported_cargo_command(args: &[OsString]) -> std::result::Result<(), String> {
-    let command_index = usize::from(
-        args.first()
-            .and_then(|arg| arg.to_str())
-            .is_some_and(|arg| arg.starts_with('+')),
-    );
-    let Some(command) = args.get(command_index).and_then(|arg| arg.to_str()) else {
+    let Some((first, remaining)) = args.split_first() else {
         return Err("no Cargo build/check command was provided".into());
+    };
+    let (command, trailing) = if first
+        .to_str()
+        .is_some_and(|argument| argument.starts_with('+'))
+    {
+        remaining
+            .split_first()
+            .ok_or_else(|| "no Cargo build/check command was provided".to_string())?
+    } else {
+        (first, remaining)
+    };
+    let Some(command) = command.to_str() else {
+        return Err("the Cargo command is not UTF-8".into());
     };
     if !matches!(command, "build" | "check") {
         return Err("only Cargo's built-in build/check commands are normalized".into());
     }
-    if args
+    if trailing
         .iter()
-        .skip(command_index + 1)
         .any(|arg| arg.to_str().is_none_or(cargo_arg_may_change_config))
     {
         return Err("Cargo -C/-Z/--config arguments are not normalized".into());
@@ -489,6 +500,25 @@ mod tests {
             source_rustflags(&value, Path::new("config.toml")).unwrap(),
             Some(vec!["-Clink-arg=-lfoo".into(), "-Clink-arg=-lfoo".into()])
         );
+    }
+
+    #[test]
+    fn only_non_home_sources_with_the_same_identity_are_aliases() {
+        let canonical = PathBuf::from("/physical/config.toml");
+        let mut source = ConfigSource {
+            logical_path: PathBuf::from("/cargo-home/config.toml"),
+            canonical_path: canonical.clone(),
+            content_hash: blake3::hash(b""),
+            value: toml::Value::Table(Default::default()),
+            cargo_home: true,
+        };
+        assert!(!is_cargo_home_alias(&source, &canonical));
+
+        source.cargo_home = false;
+        assert!(is_cargo_home_alias(&source, &canonical));
+
+        source.canonical_path = PathBuf::from("/different/config.toml");
+        assert!(!is_cargo_home_alias(&source, &canonical));
     }
 
     #[test]

--- a/src/cargo_proxy.rs
+++ b/src/cargo_proxy.rs
@@ -1,0 +1,597 @@
+//! Guarded Cargo front-end for canonical duplicate config files (#766).
+//!
+//! Cargo merges array-valued configuration every time a config path is
+//! discovered.  An ancestor `.cargo` symlink to `$CARGO_HOME` therefore reads
+//! one physical `build.rustflags` array twice.  `RUSTC_WRAPPER` runs too late to
+//! repair Cargo's unit identities, so `kache cargo -- ...` removes only that
+//! duplicate source before Cargo computes them.
+
+use anyhow::{Context, Result, bail};
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const ENCODED_SEPARATOR: char = '\x1f';
+
+#[derive(Debug, Clone)]
+struct ConfigSource {
+    logical_path: PathBuf,
+    canonical_path: PathBuf,
+    content_hash: blake3::Hash,
+    value: toml::Value,
+    cargo_home: bool,
+}
+
+#[derive(Debug)]
+struct NormalizationPlan {
+    encoded_rustflags: String,
+    snapshots: Vec<ConfigSource>,
+    cwd: PathBuf,
+    cargo_home: PathBuf,
+    candidate_paths: Vec<PathBuf>,
+    duplicate_paths: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+enum PlanDecision {
+    Apply(NormalizationPlan),
+    Passthrough,
+    Refused(String),
+}
+
+/// Run Cargo with canonical duplicate `$CARGO_HOME` rustflags collapsed once.
+///
+/// Every ambiguous case fails closed by launching Cargo unchanged. That keeps
+/// this command a conservative convenience rather than a second, incomplete
+/// Cargo config implementation.
+pub(crate) fn run(cargo_args: Vec<OsString>) -> Result<()> {
+    let cwd = std::env::current_dir().context("resolving the Cargo working directory")?;
+    let cargo = real_cargo_program()?;
+    let mut command = Command::new(&cargo);
+    command.args(&cargo_args).current_dir(&cwd);
+
+    match normalization_plan(&cwd, &cargo_args) {
+        PlanDecision::Apply(plan) => {
+            if !plan_is_current(&plan) {
+                eprintln!(
+                    "kache: Cargo config changed while it was being inspected; \
+                     running Cargo unchanged"
+                );
+            } else {
+                tracing::info!(
+                    aliases = ?plan.duplicate_paths,
+                    "collapsing canonical duplicate Cargo rustflags source"
+                );
+                command.env("CARGO_ENCODED_RUSTFLAGS", &plan.encoded_rustflags);
+            }
+        }
+        PlanDecision::Refused(reason) => {
+            eprintln!(
+                "kache: safe Cargo config normalization is unavailable: \
+                 {reason}; running Cargo unchanged"
+            );
+        }
+        PlanDecision::Passthrough => {}
+    }
+
+    #[cfg(unix)]
+    {
+        exec_cargo_unix(command, &cargo)
+    }
+    #[cfg(not(unix))]
+    {
+        run_cargo_non_unix(command, &cargo)
+    }
+}
+
+fn real_cargo_program() -> Result<PathBuf> {
+    let program = std::env::var_os("KACHE_REAL_CARGO")
+        .or_else(|| std::env::var_os("CARGO"))
+        .unwrap_or_else(|| OsString::from("cargo"));
+    let cwd = std::env::current_dir().context("resolving the Cargo working directory")?;
+    resolve_cargo_program(&program, &cwd)
+}
+
+fn resolve_cargo_program(program: &OsStr, cwd: &Path) -> Result<PathBuf> {
+    let path = Path::new(program);
+    let executable = match program.to_str() {
+        Some(program) => crate::compiler::resolve_program_on_path(program),
+        None => Some(path.to_path_buf()),
+    }
+    .with_context(|| format!("resolving Cargo program {program:?}"))?;
+    let executable = if executable.is_absolute() {
+        executable
+    } else {
+        cwd.join(executable)
+    };
+    let resolved_identity = executable
+        .canonicalize()
+        .with_context(|| format!("resolving Cargo program {program:?}"))?;
+    let current = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.canonicalize().ok());
+    if Some(&resolved_identity) == current.as_ref() {
+        bail!(
+            "resolved Cargo program {:?} points back to kache; set KACHE_REAL_CARGO to the real Cargo binary",
+            program
+        );
+    }
+    // Preserve the launcher path. In a rustup installation `cargo` is a symlink
+    // to the shared rustup binary, whose behavior depends on argv[0]. Executing
+    // its canonical target would launch `rustup`, not the Cargo proxy.
+    Ok(executable)
+}
+
+#[cfg(unix)]
+fn exec_cargo_unix(mut command: Command, cargo: &Path) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+
+    let error = command.exec();
+    Err(error).with_context(|| format!("executing Cargo program {cargo:?}"))
+}
+
+#[cfg(not(unix))]
+fn run_cargo_non_unix(mut command: Command, cargo: &Path) -> Result<()> {
+    let status = command
+        .status()
+        .with_context(|| format!("running Cargo program {cargo:?}"))?;
+    std::process::exit(status.code().unwrap_or(1));
+}
+
+fn normalization_plan(cwd: &Path, cargo_args: &[OsString]) -> PlanDecision {
+    if rustflags_environment_is_explicit() {
+        return PlanDecision::Passthrough;
+    }
+    if supported_cargo_command(cargo_args).is_err() {
+        return PlanDecision::Passthrough;
+    }
+
+    let cargo_home = match cargo_home(cwd) {
+        Ok(cargo_home) => cargo_home,
+        Err(reason) => return PlanDecision::Refused(reason),
+    };
+    let candidates = cargo_config_candidates(cwd, &cargo_home);
+    let mut sources = Vec::with_capacity(candidates.len());
+    let candidate_paths = candidates.iter().map(|(path, _)| path.clone()).collect();
+    for (logical_path, cargo_home) in candidates {
+        match read_source(logical_path, cargo_home) {
+            Ok(source) => sources.push(source),
+            Err(reason) => return PlanDecision::Refused(reason),
+        }
+    }
+
+    let Some(home_source) = sources.iter().find(|source| source.cargo_home) else {
+        return PlanDecision::Passthrough;
+    };
+    let home_canonical = home_source.canonical_path.clone();
+    let duplicate_paths: Vec<PathBuf> = sources
+        .iter()
+        .filter(|source| !source.cargo_home && source.canonical_path == home_canonical)
+        .map(|source| source.logical_path.clone())
+        .collect();
+    if duplicate_paths.is_empty() {
+        return PlanDecision::Passthrough;
+    }
+
+    let mut rustflags = Vec::new();
+    for source in &sources {
+        if !source.cargo_home && source.canonical_path == home_canonical {
+            continue;
+        }
+        match source_rustflags(&source.value, &source.logical_path) {
+            Ok(Some(flags)) => rustflags.extend(flags),
+            Ok(None) => {}
+            Err(reason) => return PlanDecision::Refused(reason),
+        }
+    }
+    if rustflags.is_empty() {
+        return PlanDecision::Refused(
+            "the canonical duplicate has no array-valued build.rustflags".into(),
+        );
+    }
+    let encoded_rustflags = rustflags.join("\x1f");
+    PlanDecision::Apply(NormalizationPlan {
+        encoded_rustflags,
+        snapshots: sources,
+        cwd: cwd.to_path_buf(),
+        cargo_home,
+        candidate_paths,
+        duplicate_paths,
+    })
+}
+
+fn rustflags_environment_is_explicit() -> bool {
+    std::env::vars_os().any(|(key, _)| {
+        let Some(key) = key.to_str() else {
+            return false;
+        };
+        rustflags_env_name(key, cfg!(windows))
+    })
+}
+
+fn rustflags_env_name(key: &str, case_insensitive: bool) -> bool {
+    let key = if case_insensitive {
+        key.to_ascii_uppercase()
+    } else {
+        key.to_string()
+    };
+    key == "RUSTFLAGS"
+        || key == "CARGO_ENCODED_RUSTFLAGS"
+        || (key.starts_with("CARGO_") && key.ends_with("RUSTFLAGS"))
+}
+
+fn supported_cargo_command(args: &[OsString]) -> std::result::Result<(), String> {
+    let command_index = usize::from(
+        args.first()
+            .and_then(|arg| arg.to_str())
+            .is_some_and(|arg| arg.starts_with('+')),
+    );
+    let Some(command) = args.get(command_index).and_then(|arg| arg.to_str()) else {
+        return Err("no Cargo build/check command was provided".into());
+    };
+    if !matches!(command, "build" | "check") {
+        return Err("only Cargo's built-in build/check commands are normalized".into());
+    }
+    if args
+        .iter()
+        .skip(command_index + 1)
+        .any(|arg| arg.to_str().is_none_or(cargo_arg_may_change_config))
+    {
+        return Err("Cargo -C/-Z/--config arguments are not normalized".into());
+    }
+    Ok(())
+}
+
+fn cargo_arg_may_change_config(arg: &str) -> bool {
+    arg == "--config"
+        || arg.starts_with("--config=")
+        || arg.starts_with("-C")
+        || arg.starts_with("-Z")
+}
+
+fn cargo_config_candidates(cwd: &Path, cargo_home: &Path) -> Vec<(PathBuf, bool)> {
+    let mut candidates = Vec::new();
+    if let Some(path) = selected_config(cargo_home) {
+        candidates.push((path, true));
+    }
+
+    let mut ancestors: Vec<&Path> = cwd.ancestors().collect();
+    ancestors.reverse();
+    for ancestor in ancestors {
+        let Some(path) = selected_config(&ancestor.join(".cargo")) else {
+            continue;
+        };
+        if !candidates.iter().any(|(candidate, _)| candidate == &path) {
+            candidates.push((path, false));
+        }
+    }
+    candidates
+}
+
+fn cargo_home(cwd: &Path) -> std::result::Result<PathBuf, String> {
+    home::cargo_home_with_cwd(cwd)
+        .map_err(|error| format!("cannot resolve Cargo's home directory: {error}"))
+}
+
+/// Cargo retains the extensionless file for backwards compatibility when both
+/// names exist (and emits its own warning).
+fn selected_config(config_dir: &Path) -> Option<PathBuf> {
+    let legacy = config_dir.join("config");
+    if legacy.is_file() {
+        return Some(legacy);
+    }
+    let modern = config_dir.join("config.toml");
+    modern.is_file().then_some(modern)
+}
+
+fn read_source(path: PathBuf, cargo_home: bool) -> std::result::Result<ConfigSource, String> {
+    let canonical_path = path
+        .canonicalize()
+        .map_err(|error| format!("cannot canonicalize {}: {error}", path.display()))?;
+    let bytes =
+        std::fs::read(&path).map_err(|error| format!("cannot read {}: {error}", path.display()))?;
+    let text = std::str::from_utf8(&bytes)
+        .map_err(|error| format!("{} is not UTF-8: {error}", path.display()))?;
+    let value = toml::from_str(text)
+        .map_err(|error| format!("cannot parse {}: {error}", path.display()))?;
+    Ok(ConfigSource {
+        logical_path: path,
+        canonical_path,
+        content_hash: blake3::hash(&bytes),
+        value,
+        cargo_home,
+    })
+}
+
+fn source_rustflags(
+    value: &toml::Value,
+    path: &Path,
+) -> std::result::Result<Option<Vec<String>>, String> {
+    let table = value
+        .as_table()
+        .ok_or_else(|| format!("{} is not a TOML table", path.display()))?;
+    if table.contains_key("include") {
+        return Err(format!("{} uses Cargo config include", path.display()));
+    }
+    if target_rustflags_present(table) {
+        return Err(format!(
+            "{} defines target-specific rustflags",
+            path.display()
+        ));
+    }
+    if config_env_rustflags_present(table) {
+        return Err(format!(
+            "{} defines rustflags through [env]",
+            path.display()
+        ));
+    }
+
+    let Some(build) = table.get("build") else {
+        return Ok(None);
+    };
+    let build = build
+        .as_table()
+        .ok_or_else(|| format!("{}.build is not a table", path.display()))?;
+    let Some(rustflags) = build.get("rustflags") else {
+        return Ok(None);
+    };
+    let array = rustflags.as_array().ok_or_else(|| {
+        format!(
+            "{}.build.rustflags uses string form instead of an argument array",
+            path.display()
+        )
+    })?;
+    let mut flags = Vec::with_capacity(array.len());
+    for flag in array {
+        let Some(flag) = flag.as_str() else {
+            return Err(format!(
+                "{}.build.rustflags contains a non-string value",
+                path.display()
+            ));
+        };
+        if flag.is_empty() || flag.contains(ENCODED_SEPARATOR) {
+            return Err(format!(
+                "{}.build.rustflags contains an empty argument or Cargo's encoded-argument separator",
+                path.display()
+            ));
+        }
+        flags.push(flag.to_string());
+    }
+    Ok(Some(flags))
+}
+
+fn target_rustflags_present(table: &toml::map::Map<String, toml::Value>) -> bool {
+    table
+        .get("target")
+        .and_then(toml::Value::as_table)
+        .is_some_and(|targets| {
+            targets.values().any(|target| {
+                target
+                    .as_table()
+                    .is_some_and(|target| target.contains_key("rustflags"))
+            })
+        })
+}
+
+fn config_env_rustflags_present(table: &toml::map::Map<String, toml::Value>) -> bool {
+    table
+        .get("env")
+        .and_then(toml::Value::as_table)
+        .is_some_and(|env| env.keys().any(|key| rustflags_env_name(key, cfg!(windows))))
+}
+
+fn plan_is_current(plan: &NormalizationPlan) -> bool {
+    let rescanned: Vec<PathBuf> = cargo_config_candidates(&plan.cwd, &plan.cargo_home)
+        .into_iter()
+        .map(|(path, _)| path)
+        .collect();
+    if rescanned != plan.candidate_paths {
+        return false;
+    }
+    revalidate_sources(&plan.snapshots).is_ok()
+}
+
+fn revalidate_sources(sources: &[ConfigSource]) -> std::result::Result<(), String> {
+    for source in sources {
+        let canonical = source.logical_path.canonicalize().map_err(|error| {
+            format!(
+                "cannot re-canonicalize {}: {error}",
+                source.logical_path.display()
+            )
+        })?;
+        let bytes = std::fs::read(&source.logical_path).map_err(|error| {
+            format!("cannot re-read {}: {error}", source.logical_path.display())
+        })?;
+        if canonical != source.canonical_path || blake3::hash(&bytes) != source.content_hash {
+            return Err(format!("{} changed", source.logical_path.display()));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_gate_accepts_only_unambiguous_builtin_build_and_check() {
+        for args in [
+            vec!["build"],
+            vec!["build", "--workspace"],
+            vec!["+nightly", "check", "--locked"],
+            vec!["check", "--color=always"],
+        ] {
+            let args: Vec<OsString> = args.into_iter().map(OsString::from).collect();
+            assert!(supported_cargo_command(&args).is_ok(), "args: {args:?}");
+        }
+
+        for args in [
+            vec!["install", "demo"],
+            vec!["xtask", "check"],
+            vec!["b"],
+            vec!["--locked", "check"],
+            vec!["-C", "elsewhere", "check"],
+            vec!["check", "--config", "build.rustflags=[]"],
+            vec!["check", "--config=build.rustflags=[]"],
+            vec!["check", "-Celsewhere"],
+            vec!["-Zunstable-options", "check"],
+            vec!["check", "-Zunstable-options"],
+        ] {
+            let args: Vec<OsString> = args.into_iter().map(OsString::from).collect();
+            assert!(supported_cargo_command(&args).is_err(), "args: {args:?}");
+        }
+        assert!(supported_cargo_command(&[]).is_err());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStringExt;
+            let args = [OsString::from("check"), OsString::from_vec(vec![0x80])];
+            assert!(supported_cargo_command(&args).is_err());
+        }
+    }
+
+    #[test]
+    fn only_config_affecting_cargo_arguments_are_ambiguous() {
+        for arg in [
+            "--config",
+            "--config=build.rustflags=[]",
+            "-C",
+            "-Celsewhere",
+            "-Zunstable-options",
+        ] {
+            assert!(cargo_arg_may_change_config(arg), "arg: {arg}");
+        }
+        for arg in ["--color=always", "--target", "--locked"] {
+            assert!(!cargo_arg_may_change_config(arg), "arg: {arg}");
+        }
+    }
+
+    #[test]
+    fn windows_rustflags_environment_names_are_case_insensitive() {
+        assert!(rustflags_env_name("RUSTFLAGS", false));
+        assert!(!rustflags_env_name("rustflags", false));
+        assert!(rustflags_env_name("rustflags", true));
+        assert!(rustflags_env_name(
+            "cargo_target_x86_64_unknown_linux_gnu_rustflags",
+            true
+        ));
+        assert!(!rustflags_env_name("CARGO_BUILD_TARGET", false));
+        assert!(!rustflags_env_name("MY_RUSTFLAGS", false));
+        assert!(!rustflags_env_name("CARGO_RUSTFLAGS_EXTRA", false));
+    }
+
+    #[test]
+    fn source_flags_preserve_repeated_additive_arguments() {
+        let value: toml::Value =
+            toml::from_str("[build]\nrustflags = [\"-Clink-arg=-lfoo\", \"-Clink-arg=-lfoo\"]\n")
+                .unwrap();
+        assert_eq!(
+            source_rustflags(&value, Path::new("config.toml")).unwrap(),
+            Some(vec!["-Clink-arg=-lfoo".into(), "-Clink-arg=-lfoo".into()])
+        );
+    }
+
+    #[test]
+    fn target_include_string_empty_and_env_forms_fail_closed() {
+        for source in [
+            "include = \"other.toml\"\n[build]\nrustflags = [\"-Copt-level=2\"]\n",
+            "[build]\nrustflags = \"-Copt-level=2\"\n",
+            "[build]\nrustflags = [\"\"]\n",
+            "[build]\nrustflags = [\"\\u001f\"]\n",
+            "[target.x86_64-unknown-linux-gnu]\nrustflags = [\"-Copt-level=2\"]\n",
+            "[env]\nRUSTFLAGS = \"-Copt-level=2\"\n",
+        ] {
+            let value: toml::Value = toml::from_str(source).unwrap();
+            assert!(source_rustflags(&value, Path::new("config.toml")).is_err());
+        }
+    }
+
+    #[test]
+    fn extensionless_config_has_cargo_compatibility_precedence() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.toml"), "[build]\n").unwrap();
+        std::fs::write(dir.path().join("config"), "[build]\n").unwrap();
+        assert_eq!(selected_config(dir.path()), Some(dir.path().join("config")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cargo_resolution_preserves_a_launcher_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("rustup");
+        let launcher = dir.path().join("cargo");
+        std::fs::write(&target, "#!/bin/sh\nexit 0\n").unwrap();
+        std::os::unix::fs::symlink(&target, &launcher).unwrap();
+
+        assert_eq!(
+            resolve_cargo_program(launcher.as_os_str(), dir.path()).unwrap(),
+            launcher
+        );
+    }
+
+    #[test]
+    fn bare_cargo_program_resolves_through_path() {
+        let resolved = resolve_cargo_program(OsStr::new("cargo"), Path::new(".")).unwrap();
+        assert!(resolved.is_absolute(), "resolved Cargo path: {resolved:?}");
+        assert!(resolved.is_file(), "resolved Cargo path: {resolved:?}");
+    }
+
+    #[test]
+    fn revalidation_rejects_changed_config_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        std::fs::write(&config, "[build]\nrustflags = [\"--cfg=a\"]\n").unwrap();
+        let source = read_source(config.clone(), true).unwrap();
+        std::fs::write(&config, "[build]\nrustflags = [\"--cfg=b\"]\n").unwrap();
+        assert!(revalidate_sources(&[source]).is_err());
+    }
+
+    #[test]
+    fn revalidation_rejects_a_changed_candidate_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let cargo_home = dir.path().join("home/.cargo");
+        let cwd = dir.path().join("work/project");
+        std::fs::create_dir_all(&cargo_home).unwrap();
+        std::fs::create_dir_all(&cwd).unwrap();
+        let home_config = cargo_home.join("config.toml");
+        std::fs::write(&home_config, "[build]\nrustflags = [\"--cfg=home\"]\n").unwrap();
+        let candidate_paths = cargo_config_candidates(&cwd, &cargo_home)
+            .into_iter()
+            .map(|(path, _)| path)
+            .collect();
+        let plan = NormalizationPlan {
+            encoded_rustflags: "--cfg=home".into(),
+            snapshots: vec![read_source(home_config, true).unwrap()],
+            cwd: cwd.clone(),
+            cargo_home,
+            candidate_paths,
+            duplicate_paths: Vec::new(),
+        };
+        assert!(plan_is_current(&plan));
+
+        std::fs::create_dir_all(dir.path().join("work/.cargo")).unwrap();
+        std::fs::write(
+            dir.path().join("work/.cargo/config.toml"),
+            "[build]\nrustflags = [\"--cfg=project\"]\n",
+        )
+        .unwrap();
+        assert!(!plan_is_current(&plan));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn revalidation_rejects_retargeted_symlink_even_with_same_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first.toml");
+        let second = dir.path().join("second.toml");
+        let alias = dir.path().join("config.toml");
+        let content = "[build]\nrustflags = [\"--cfg=same\"]\n";
+        std::fs::write(&first, content).unwrap();
+        std::fs::write(&second, content).unwrap();
+        std::os::unix::fs::symlink(&first, &alias).unwrap();
+        let source = read_source(alias.clone(), false).unwrap();
+        std::fs::remove_file(&alias).unwrap();
+        std::os::unix::fs::symlink(&second, &alias).unwrap();
+        assert!(revalidate_sources(&[source]).is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -441,17 +441,23 @@ fn main() -> Result<()> {
     // adapters still parse UTF-8 option syntax; a wrapper invocation with a
     // non-UTF-8 path is detected here and fails closed below.
     let raw_args: Vec<std::ffi::OsString> = std::env::args_os().collect();
-    let detection_args: Vec<String> = raw_args
-        .iter()
-        .map(|arg| arg.to_string_lossy().into_owned())
-        .collect();
     let env_args: Option<Vec<String>> = raw_args
         .iter()
         .cloned()
         .map(|arg| arg.into_string())
         .collect::<Result<_, _>>()
         .ok();
-    let log_mode = detect_log_mode(&detection_args);
+    let lossy_args;
+    let detection_args = if let Some(args) = env_args.as_deref() {
+        args
+    } else {
+        lossy_args = raw_args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        &lossy_args
+    };
+    let log_mode = detect_log_mode(detection_args);
 
     // Detect RUSTC_WRAPPER mode: cargo passes the rustc path as arg[1]
     // In this mode: argv[0]=kache, argv[1]=rustc, argv[2..]=rustc args

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod atomic;
 mod build_intent;
 mod cache_fs;
 mod cache_key;
+mod cargo_proxy;
 mod cli;
 mod compile;
 mod compiler;
@@ -80,6 +81,13 @@ pub(crate) struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Run Cargo with canonical duplicate Cargo-home rustflags collapsed once
+    Cargo {
+        /// Built-in build/check arguments passed verbatim to Cargo (use `--` first)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<std::ffi::OsString>,
+    },
+
     /// List cache entries, or show details for one crate
     List {
         /// Crate name to show details for (omit to list all)
@@ -429,8 +437,21 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let env_args: Vec<String> = std::env::args().collect();
-    let log_mode = detect_log_mode(&env_args);
+    // Keep the original argv byte-preserving for `kache cargo`. Compiler
+    // adapters still parse UTF-8 option syntax; a wrapper invocation with a
+    // non-UTF-8 path is detected here and fails closed below.
+    let raw_args: Vec<std::ffi::OsString> = std::env::args_os().collect();
+    let detection_args: Vec<String> = raw_args
+        .iter()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect();
+    let env_args: Option<Vec<String>> = raw_args
+        .iter()
+        .cloned()
+        .map(|arg| arg.into_string())
+        .collect::<Result<_, _>>()
+        .ok();
+    let log_mode = detect_log_mode(&detection_args);
 
     // Detect RUSTC_WRAPPER mode: cargo passes the rustc path as arg[1]
     // In this mode: argv[0]=kache, argv[1]=rustc, argv[2..]=rustc args
@@ -438,7 +459,12 @@ fn main() -> Result<()> {
     init_logging(log_mode);
 
     if is_wrapper {
-        return run_wrapper_mode(&env_args[1..]);
+        if let Some(env_args) = env_args {
+            return run_wrapper_mode(&env_args[1..]);
+        }
+        anyhow::bail!(
+            "compiler wrapper arguments contain non-UTF-8 bytes and cannot be cached safely"
+        );
     }
 
     // CLI mode: parse subcommands
@@ -447,6 +473,7 @@ fn main() -> Result<()> {
     // Config and Completions run before Config::load() (broken/missing config).
     match &cli.command {
         Some(Commands::Config) => return config_tui::run_config_editor(),
+        Some(Commands::Cargo { args }) => return cargo_proxy::run(args.clone()),
         Some(Commands::Completions { shell }) => {
             use clap::CommandFactory;
             use clap_complete::generate;
@@ -579,6 +606,7 @@ fn main() -> Result<()> {
             let hours = since.as_deref().and_then(parse_duration_hours);
             tui::run_monitor(&config, hours)
         }
+        Some(Commands::Cargo { .. }) => unreachable!(),
         Some(Commands::Config) => unreachable!(),
         Some(Commands::Completions { .. }) => unreachable!(),
         None => {

--- a/tests/cargo_proxy_test.rs
+++ b/tests/cargo_proxy_test.rs
@@ -62,9 +62,10 @@ fn canonical_cargo_home_alias_keeps_existing_cargo_unit_fresh() {
     std::os::unix::fs::symlink(&cargo_home, home.join("work/.cargo")).unwrap();
 
     let mut warm = Command::new(KACHE_BIN);
-    warm.args(["cargo", "--", "check", "--verbose"])
+    warm.args(["cargo", "--", "check", "--verbose", "--color=never"])
         .current_dir(&project)
-        .env("KACHE_REAL_CARGO", env!("CARGO"));
+        .env("KACHE_REAL_CARGO", env!("CARGO"))
+        .env("CARGO_TERM_COLOR", "always");
     cargo_env(&mut warm, &home, &cache, &cold_target);
     let warm = warm.output().unwrap();
     assert!(

--- a/tests/cargo_proxy_test.rs
+++ b/tests/cargo_proxy_test.rs
@@ -1,0 +1,186 @@
+//! End-to-end regression for canonical duplicate Cargo config discovery (#766).
+
+#![cfg(unix)]
+
+use serde_json::Value;
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+const KACHE_BIN: &str = env!("CARGO_BIN_EXE_kache");
+
+fn cargo_env(command: &mut Command, home: &Path, cache: &Path, target: &Path) {
+    command
+        .env("HOME", home)
+        .env("CARGO_HOME", home.join(".cargo"))
+        .env("CARGO_TARGET_DIR", target)
+        .env("CARGO_INCREMENTAL", "0")
+        .env("RUSTC_WRAPPER", KACHE_BIN)
+        .env("KACHE_CACHE_DIR", cache)
+        .env("KACHE_CONFIG", cache.join("config.toml"))
+        .env("KACHE_LOG", "off")
+        .env_remove("RUSTFLAGS")
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .env_remove("CARGO_BUILD_RUSTFLAGS");
+}
+
+#[test]
+fn canonical_cargo_home_alias_keeps_existing_cargo_unit_fresh() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    let project = home.join("work/project");
+    let cargo_home = home.join(".cargo");
+    let cache = dir.path().join("cache");
+    let cold_target = dir.path().join("target-cold");
+    std::fs::create_dir_all(project.join("src")).unwrap();
+    std::fs::create_dir_all(&cargo_home).unwrap();
+    std::fs::create_dir_all(&cache).unwrap();
+    std::fs::write(
+        project.join("Cargo.toml"),
+        "[package]\nname = \"proxy_fixture\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .unwrap();
+    std::fs::write(project.join("src/lib.rs"), "pub fn answer() -> u8 { 42 }\n").unwrap();
+    std::fs::write(
+        cargo_home.join("config.toml"),
+        "[build]\nrustflags = [\"--cfg\", \"kache_proxy_fixture\"]\n",
+    )
+    .unwrap();
+
+    let mut cold = Command::new(env!("CARGO"));
+    cold.args(["check", "--quiet"]).current_dir(&project);
+    cargo_env(&mut cold, &home, &cache, &cold_target);
+    let cold = cold.output().unwrap();
+    assert!(
+        cold.status.success(),
+        "cold cargo failed: {}",
+        String::from_utf8_lossy(&cold.stderr)
+    );
+
+    std::os::unix::fs::symlink(&cargo_home, home.join("work/.cargo")).unwrap();
+
+    let mut warm = Command::new(KACHE_BIN);
+    warm.args(["cargo", "--", "check", "--verbose"])
+        .current_dir(&project)
+        .env("KACHE_REAL_CARGO", env!("CARGO"));
+    cargo_env(&mut warm, &home, &cache, &cold_target);
+    let warm = warm.output().unwrap();
+    assert!(
+        warm.status.success(),
+        "proxied cargo failed: {}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&warm.stderr).contains("Fresh proxy_fixture"),
+        "Cargo should keep the existing unit fresh: {}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+
+    let events: Vec<Value> = std::fs::read_to_string(cache.join("events.jsonl"))
+        .unwrap()
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .filter(|event: &Value| event["crate_name"] == "proxy_fixture")
+        .collect();
+    assert_eq!(
+        events.len(),
+        1,
+        "a fresh Cargo unit must not invoke the wrapper again: {events:#?}"
+    );
+    assert_eq!(events[0]["result"], "miss", "events: {events:#?}");
+    assert_eq!(events[0]["compiler_runs"], 1, "events: {events:#?}");
+}
+
+#[test]
+fn explicit_rustflags_keep_their_cargo_precedence() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    let project = home.join("work/project");
+    let cargo_home = home.join(".cargo");
+    let cache = dir.path().join("cache");
+    let target = dir.path().join("target");
+    std::fs::create_dir_all(project.join("src")).unwrap();
+    std::fs::create_dir_all(&cargo_home).unwrap();
+    std::fs::create_dir_all(&cache).unwrap();
+    std::fs::write(
+        project.join("Cargo.toml"),
+        "[package]\nname = \"proxy_env_fixture\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project.join("src/lib.rs"),
+        "#[cfg(not(from_env))]\ncompile_error!(\"explicit RUSTFLAGS was replaced\");\n",
+    )
+    .unwrap();
+    std::fs::write(
+        cargo_home.join("config.toml"),
+        "[build]\nrustflags = [\"--cfg\", \"from_config\"]\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(&cargo_home, home.join("work/.cargo")).unwrap();
+
+    let mut command = Command::new(KACHE_BIN);
+    command
+        .args(["cargo", "--", "check", "--quiet"])
+        .current_dir(&project)
+        .env("KACHE_REAL_CARGO", env!("CARGO"));
+    cargo_env(&mut command, &home, &cache, &target);
+    command.env("RUSTFLAGS", "--cfg from_env");
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "explicit RUSTFLAGS lost precedence: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn non_utf8_cargo_argument_passes_through_without_cli_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    let fake_cargo = dir.path().join("cargo");
+    std::fs::write(&fake_cargo, "#!/bin/sh\nexit 0\n").unwrap();
+    std::fs::set_permissions(&fake_cargo, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = Command::new(KACHE_BIN)
+        .args(["cargo", "--", "build"])
+        .arg(OsString::from_vec(vec![b'f', b'o', 0x80]))
+        .env("KACHE_REAL_CARGO", &fake_cargo)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "non-UTF-8 passthrough failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn non_utf8_wrapper_argument_fails_closed_before_compiler_execution() {
+    let dir = tempfile::tempdir().unwrap();
+    let fake_rustc = dir.path().join("rustc");
+    let sentinel = dir.path().join("compiler-ran");
+    std::fs::write(
+        &fake_rustc,
+        format!("#!/bin/sh\ntouch '{}'\n", sentinel.display()),
+    )
+    .unwrap();
+    std::fs::set_permissions(&fake_rustc, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = Command::new(KACHE_BIN)
+        .arg(&fake_rustc)
+        .arg(OsString::from_vec(vec![b's', b'r', b'c', b'/', 0x80]))
+        .env("RUSTC", &fake_rustc)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(!sentinel.exists(), "unsafe compiler fallback was executed");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("cannot be cached safely"),
+        "unexpected error: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## What

- add `kache cargo -- build|check` for the canonical Cargo-home alias case
- collapse only duplicate discoveries of the same physical Cargo-home config
- preserve distinct config sources, repeated additive flags, and explicit rustflag precedence
- fail closed or pass through unchanged whenever Cargo's config rules are ambiguous

## Why

Cargo array-merges configuration by discovery path before `RUSTC_WRAPPER` runs. An ancestor `.cargo` symlink to `$CARGO_HOME` therefore contributes the same `build.rustflags` twice and changes Cargo's unit identity even though the effective physical config is unchanged.

This fixes the problem before Cargo computes the unit. It does not alias Kache keys or rewrite cached artifacts.

## Validation

- exact E2E: cold Cargo build, add ancestor `.cargo -> $CARGO_HOME`, proxied rebuild remains `Fresh` with no second wrapper invocation
- explicit `RUSTFLAGS` precedence E2E
- non-UTF-8 CLI pass-through and wrapper fail-closed coverage
- `cargo test --bin kache cargo_proxy::tests`
- `cargo test --test cargo_proxy_test`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- two independent static reviews: no blockers

Closes #766
