### PR TITLE
fix(rust): isolate cache inputs across worktrees

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -125,6 +125,14 @@ gitignore = true
 # `run_cargo_non_unix` is the process-status half of the guarded Cargo
 # front-end. The Ubuntu mutation lane compiles only the Unix `exec` half;
 # hosted Windows tests still compile the status/exit-code path.
+#
+# `report_key_divergence` is a two-line stderr printer for the e2e convergence
+# diagnostic. Its only effect is bytes on the e2e driver's stderr, which an
+# in-process test cannot observe. Kept as narrow as the name allows: every
+# decision it delegates to stays in scope and is killed by direct unit tests —
+# `parse_keytrace` (which crate and field a trace line names),
+# `render_key_divergence` (which fields count as diverged), and
+# `key_divergence_report` (reading both phase logs off disk).
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -154,4 +162,5 @@ exclude_re = [
     "observe_storage_windows",
     "observe_storage_unsupported",
     "run_cargo_non_unix",
+    "replace report_key_divergence with \\(\\)",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -133,22 +133,6 @@ gitignore = true
 # `parse_keytrace` (which crate and field a trace line names),
 # `render_key_divergence` (which fields count as diverged), and
 # `key_divergence_report` (reading both phase logs off disk).
-#
-# `depinfo_next_char_boundary` is the step that advances `replace_depinfo_text`
-# past a match it rejected, so every mutant of it — the two return replacements
-# and the two arithmetic operators — leaves the search index where it was and
-# the scan loops forever. The lane cannot distinguish those from each other or
-# report them as caught: the run has no result until the 300s timeout expires,
-# and cargo-mutants scores a timeout as a failure rather than a kill, which is
-# the `touch_mtime_write_clock` O_NONBLOCK situation above. Confirmed by
-# measurement, not assumed: all four time out at 300s.
-#
-# The function exists to make that exclusion narrow. Folded back into the loop
-# the same mutants would force excluding arithmetic in `replace_depinfo_text`
-# by line number, which would also suppress the `+`, `!=` and boundary mutants
-# there that the lane does kill today. `depinfo_next_char_boundary_always_
-# advances_past_the_current_char` asserts the strict-advance property directly
-# and fails fast, so the behavior stays enforced by the test suite.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -179,5 +163,4 @@ exclude_re = [
     "observe_storage_unsupported",
     "run_cargo_non_unix",
     "replace report_key_divergence with \\(\\)",
-    "depinfo_next_char_boundary",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -133,6 +133,22 @@ gitignore = true
 # `parse_keytrace` (which crate and field a trace line names),
 # `render_key_divergence` (which fields count as diverged), and
 # `key_divergence_report` (reading both phase logs off disk).
+#
+# `depinfo_next_char_boundary` is the step that advances `replace_depinfo_text`
+# past a match it rejected, so every mutant of it — the two return replacements
+# and the two arithmetic operators — leaves the search index where it was and
+# the scan loops forever. The lane cannot distinguish those from each other or
+# report them as caught: the run has no result until the 300s timeout expires,
+# and cargo-mutants scores a timeout as a failure rather than a kill, which is
+# the `touch_mtime_write_clock` O_NONBLOCK situation above. Confirmed by
+# measurement, not assumed: all four time out at 300s.
+#
+# The function exists to make that exclusion narrow. Folded back into the loop
+# the same mutants would force excluding arithmetic in `replace_depinfo_text`
+# by line number, which would also suppress the `+`, `!=` and boundary mutants
+# there that the lane does kill today. `depinfo_next_char_boundary_always_
+# advances_past_the_current_char` asserts the strict-advance property directly
+# and fails fast, so the behavior stays enforced by the test suite.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -163,4 +179,5 @@ exclude_re = [
     "observe_storage_unsupported",
     "run_cargo_non_unix",
     "replace report_key_divergence with \\(\\)",
+    "depinfo_next_char_boundary",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,9 +2060,9 @@ checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -1631,18 +1631,6 @@ fn parse_key_line(line: &str) -> Option<(String, String)> {
 /// set-diffing reflects real key-input divergence — not chatty trace
 /// formatting.
 ///
-/// `cache_key.rs` emits `source:PATH=hash` for human readability, but
-/// the hasher only consumes the content hash. Two clones at different
-/// absolute paths that share identical source content emit different
-/// trace lines for the same key input. Without normalization the diff
-/// counts them as diverging when the cache key is actually stable —
-/// observed as 475 false positives in the first trace bench (the bug
-/// that made `final` appear as the top diverging field with only 77
-/// crates, despite the diff helper claiming 552 diverging crates).
-///
-/// Normalize to `source:hash` so the comparison reflects what the
-/// hasher actually consumes.
-///
 /// `link_lib_content:static=NAME=HASH (PATH)` has the same shape of noise:
 /// `cache_key.rs` hashes only `link_lib_content:` + the content hash, but the
 /// trace line appends the lib name and absolute `.a` path for readability. Two
@@ -1655,11 +1643,6 @@ fn parse_key_line(line: &str) -> Option<(String, String)> {
 /// association. Genuine content differences (e.g. `quickjs`, `jemalloc`, which
 /// bake the build path into the archive) keep distinct hashes and still diverge.
 fn normalize_payload(payload: &str) -> String {
-    if let Some(rest) = payload.strip_prefix("source:")
-        && let Some(eq) = rest.rfind('=')
-    {
-        return format!("source:{}", &rest[eq + 1..]);
-    }
     if let Some(rest) = payload.strip_prefix("link_lib_content:") {
         // The path is the trailing ` (PATH)` group. Split on the FIRST ` (`:
         // the lib name (a linker `-l` spec) has no ` (`, so the first one is the
@@ -3146,24 +3129,16 @@ mod tests {
     }
 
     #[test]
-    fn normalize_payload_strips_display_only_source_path() {
-        // `source:PATH=hash` is display-only path noise; the hasher
-        // consumes only the right-hand content hash. Normalizing to
-        // `source:hash` makes cross-clone set-diffing reflect what's
-        // actually in the cache key.
+    fn normalize_payload_preserves_keyed_source_identity() {
+        // Source path-to-content association is a real key input (#760), so
+        // diagnostics must not discard it as display-only noise.
         assert_eq!(
             normalize_payload("source:/Users/a/clone-a/foo.rs=254dfb8084fc2e3f"),
-            "source:254dfb8084fc2e3f"
+            "source:/Users/a/clone-a/foo.rs=254dfb8084fc2e3f"
         );
-        assert_eq!(
+        assert_ne!(
+            normalize_payload("source:/Users/a/clone-a/foo.rs=254dfb8084fc2e3f"),
             normalize_payload("source:/Users/b/clone-b/foo.rs=254dfb8084fc2e3f"),
-            "source:254dfb8084fc2e3f",
-        );
-        // Sanity: two clone paths with identical content collapse to
-        // the same normalized payload.
-        assert_eq!(
-            normalize_payload("source:/clone-a/x.rs=H"),
-            normalize_payload("source:/clone-b/x.rs=H"),
         );
         // Non-source payloads pass through untouched.
         assert_eq!(

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -303,19 +303,11 @@ fn report_key_divergence(cache_dir: &Path) {
                 continue;
             };
             let rest = &line[idx + "[key:".len()..];
-            let Some(end) = rest.find(']') else { continue };
-            let crate_name = rest[..end].to_string();
-            let mut field = rest[end + 1..].trim().to_string();
-            // `source:<path>=<hash>` keys ONLY the content hash (paths are
-            // hashed in content order, not by path), so a relocated build's
-            // differing display path is not a real divergence. Reduce it to
-            // the keyed hash so the diff reports only fields that move the key.
-            if let Some(hash) = field
-                .strip_prefix("source:")
-                .and_then(|s| s.rsplit('=').next())
-            {
-                field = format!("source:={hash}");
-            }
+            let Some((crate_name, field)) = rest.split_once(']') else {
+                continue;
+            };
+            let crate_name = crate_name.to_string();
+            let field = field.trim().to_string();
             if !field.is_empty() {
                 by_crate.entry(crate_name).or_default().push(field);
             }

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -280,71 +280,88 @@ fn keytrace_dir(cache_dir: &Path) -> PathBuf {
     std::env::temp_dir().join(format!("kache-keytrace-{tag}"))
 }
 
-/// Diff the per-crate cache-key fields between the cold and relocate phases and
-/// print, for every crate whose key changed, the fields that differ. Reads the
-/// `keytrace-<phase>.log` files `run_step` writes (see [`keytrace_dir`]) when
-/// `KACHE_E2E_KEYTRACE` is set. Pure diagnostics: a convergence miss already
-/// failed the fixture; this just makes the cause legible (which keyed field
-/// carried a build-location-dependent value) without a platform-specific local
-/// reproduction. Best-effort — silent if the trace files are absent (the
-/// common case: the opt-in env var was not set, or the cold phase itself
-/// failed).
-fn report_key_divergence(cache_dir: &Path) {
-    let kt_dir = keytrace_dir(cache_dir);
-    let parse = |phase: &str| -> std::collections::HashMap<String, Vec<String>> {
-        let mut by_crate: std::collections::HashMap<String, Vec<String>> =
-            std::collections::HashMap::new();
-        let Ok(text) = std::fs::read_to_string(kt_dir.join(format!("keytrace-{phase}.log"))) else {
-            return by_crate;
+/// The per-crate keyed fields recorded in one `keytrace-<phase>.log`.
+type KeytraceFields = std::collections::HashMap<String, Vec<String>>;
+
+/// Parse one keytrace log body into per-crate keyed-field lists.
+///
+/// Lines look like `... kache::cache_key: [key:<crate>] <field>`; anything
+/// without the `[key:` marker (ordinary log output) is ignored, as is a marker
+/// with no closing `]` or an empty field.
+fn parse_keytrace(text: &str) -> KeytraceFields {
+    let mut by_crate: KeytraceFields = std::collections::HashMap::new();
+    for line in text.lines() {
+        let Some(idx) = line.find("[key:") else {
+            continue;
         };
-        for line in text.lines() {
-            // Lines look like: `... kache::cache_key: [key:<crate>] <field>`.
-            let Some(idx) = line.find("[key:") else {
-                continue;
-            };
-            let rest = &line[idx + "[key:".len()..];
-            let Some((crate_name, field)) = rest.split_once(']') else {
-                continue;
-            };
-            let crate_name = crate_name.to_string();
-            let field = field.trim().to_string();
-            if !field.is_empty() {
-                by_crate.entry(crate_name).or_default().push(field);
-            }
+        let rest = &line[idx + "[key:".len()..];
+        let Some((crate_name, field)) = rest.split_once(']') else {
+            continue;
+        };
+        let crate_name = crate_name.to_string();
+        let field = field.trim().to_string();
+        if !field.is_empty() {
+            by_crate.entry(crate_name).or_default().push(field);
         }
-        by_crate
-    };
-
-    let cold = parse("cold");
-    let relocate = parse("relocate");
-    if cold.is_empty() || relocate.is_empty() {
-        return;
     }
+    by_crate
+}
 
-    let mut printed_header = false;
+/// Render the cold-vs-relocate field diff for every crate whose keyed fields
+/// moved. `None` when no crate diverged, which covers the common case of a
+/// phase that recorded nothing at all (the opt-in trace was never captured):
+/// a crate absent from either map can never contribute a difference.
+fn render_key_divergence(cold: &KeytraceFields, relocate: &KeytraceFields) -> Option<String> {
+    let mut out = String::new();
     let mut crates: Vec<&String> = cold.keys().collect();
     crates.sort();
     for crate_name in crates {
         let Some(reloc_fields) = relocate.get(crate_name) else {
             continue;
         };
-        let cold_fields = &cold[crate_name];
-        let cold_set: std::collections::BTreeSet<&String> = cold_fields.iter().collect();
+        let cold_set: std::collections::BTreeSet<&String> = cold[crate_name].iter().collect();
         let reloc_set: std::collections::BTreeSet<&String> = reloc_fields.iter().collect();
         if cold_set == reloc_set {
             continue;
         }
-        if !printed_header {
-            eprintln!("   key divergence (cold vs relocate):");
-            printed_header = true;
+        if out.is_empty() {
+            out.push_str("   key divergence (cold vs relocate):\n");
         }
-        eprintln!("   [{crate_name}]");
+        out.push_str(&format!("   [{crate_name}]\n"));
         for f in cold_set.difference(&reloc_set) {
-            eprintln!("     - cold-only:     {f}");
+            out.push_str(&format!("     - cold-only:     {f}\n"));
         }
         for f in reloc_set.difference(&cold_set) {
-            eprintln!("     + relocate-only: {f}");
+            out.push_str(&format!("     + relocate-only: {f}\n"));
         }
+    }
+    (!out.is_empty()).then_some(out)
+}
+
+/// Diff the per-crate cache-key fields between the cold and relocate phases so
+/// a convergence miss names the exact diverging field. Reads the
+/// `keytrace-<phase>.log` files `run_step` writes (see [`keytrace_dir`]) when
+/// `KACHE_E2E_KEYTRACE` is set. Pure diagnostics: a convergence miss already
+/// failed the fixture; this just makes the cause legible (which keyed field
+/// carried a build-location-dependent value) without a platform-specific local
+/// reproduction. Best-effort — `None` if the trace files are absent (the
+/// common case: the opt-in env var was not set, or the cold phase itself
+/// failed).
+fn key_divergence_report(cache_dir: &Path) -> Option<String> {
+    let kt_dir = keytrace_dir(cache_dir);
+    let read = |phase: &str| -> KeytraceFields {
+        std::fs::read_to_string(kt_dir.join(format!("keytrace-{phase}.log")))
+            .map(|text| parse_keytrace(&text))
+            .unwrap_or_default()
+    };
+    render_key_divergence(&read("cold"), &read("relocate"))
+}
+
+/// Print the divergence report, if there is one. Pure stderr I/O: everything
+/// it decides lives in [`key_divergence_report`] and is tested directly.
+fn report_key_divergence(cache_dir: &Path) {
+    if let Some(report) = key_divergence_report(cache_dir) {
+        eprint!("{report}");
     }
 }
 
@@ -1257,8 +1274,149 @@ fn inspect_restored_depinfo(root: &Path) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{artifact_candidates, inspect_restored_depinfo, resolve_artifact};
+    use super::{
+        KeytraceFields, artifact_candidates, inspect_restored_depinfo, key_divergence_report,
+        keytrace_dir, parse_keytrace, render_key_divergence, resolve_artifact,
+    };
     use std::path::{Path, PathBuf};
+
+    /// A realistic tracing line, so the `[key:` offset arithmetic is exercised
+    /// against the prefix the real logger emits rather than a bare marker.
+    fn keytrace_line(crate_name: &str, field: &str) -> String {
+        format!("  2026-08-18T09:00:00Z DEBUG kache::cache_key: [key:{crate_name}] {field}")
+    }
+
+    fn fields(entries: &[(&str, &[&str])]) -> KeytraceFields {
+        entries
+            .iter()
+            .map(|(name, fields)| {
+                (
+                    (*name).to_string(),
+                    fields.iter().map(|f| (*f).to_string()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn parse_keytrace_reads_the_crate_and_field_from_a_real_log_line() {
+        // The crate name must come from inside the `[key:...]` marker: an
+        // off-by-one in the marker offset silently attributes fields to a
+        // mangled crate name and the divergence report names the wrong crate.
+        let text = [
+            keytrace_line("serde_derive", "source:src/lib.rs=abc123"),
+            keytrace_line("serde_derive", "env:CARGO_PKG_VERSION=1.0.0"),
+            keytrace_line("syn", "source:src/lib.rs=def456"),
+            "  2026-08-18T09:00:00Z DEBUG kache::store: unrelated line".to_string(),
+        ]
+        .join("\n");
+
+        let parsed = parse_keytrace(&text);
+
+        assert_eq!(parsed.len(), 2, "only the two keyed crates are recorded");
+        assert_eq!(
+            parsed.get("serde_derive"),
+            Some(&vec![
+                "source:src/lib.rs=abc123".to_string(),
+                "env:CARGO_PKG_VERSION=1.0.0".to_string(),
+            ]),
+            "fields keep their emitted order under the exact crate name"
+        );
+        assert_eq!(
+            parsed.get("syn"),
+            Some(&vec!["source:src/lib.rs=def456".to_string()])
+        );
+    }
+
+    #[test]
+    fn parse_keytrace_skips_unusable_lines() {
+        let text = [
+            "no marker at all".to_string(),
+            "prefix [key:unterminated field".to_string(),
+            keytrace_line("empty_field", "   "),
+        ]
+        .join("\n");
+
+        assert!(parse_keytrace(&text).is_empty());
+    }
+
+    #[test]
+    fn render_key_divergence_reports_only_fields_that_moved() {
+        let cold = fields(&[
+            ("moved", &["source:a.rs=cold", "env:SHARED=1"]),
+            ("stable", &["source:b.rs=same"]),
+        ]);
+        let relocate = fields(&[
+            ("moved", &["source:a.rs=relocate", "env:SHARED=1"]),
+            ("stable", &["source:b.rs=same"]),
+        ]);
+
+        let report = render_key_divergence(&cold, &relocate).expect("a diverging crate reports");
+
+        assert!(report.contains("key divergence (cold vs relocate):"));
+        assert!(report.contains("[moved]"));
+        assert!(report.contains("- cold-only:     source:a.rs=cold"));
+        assert!(report.contains("+ relocate-only: source:a.rs=relocate"));
+        assert!(
+            !report.contains("env:SHARED=1"),
+            "a field present in both phases is not a divergence: {report}"
+        );
+        assert!(
+            !report.contains("[stable]"),
+            "a crate whose fields all match is omitted: {report}"
+        );
+    }
+
+    #[test]
+    fn render_key_divergence_is_silent_without_a_divergence() {
+        let same = fields(&[("crate_a", &["source:a.rs=hash"])]);
+        assert_eq!(render_key_divergence(&same, &same), None);
+
+        // A phase that recorded nothing means the opt-in trace was never
+        // captured, which must not be reported as "everything converged".
+        assert_eq!(
+            render_key_divergence(&same, &KeytraceFields::new()),
+            None,
+            "an empty relocate phase yields no report"
+        );
+        assert_eq!(
+            render_key_divergence(&KeytraceFields::new(), &same),
+            None,
+            "an empty cold phase yields no report"
+        );
+    }
+
+    #[test]
+    fn key_divergence_report_reads_both_phase_logs_from_disk() {
+        let cache_dir = tempfile::tempdir().unwrap();
+        // `keytrace_dir` is derived from the cache dir's basename and lives
+        // outside it, so the report has to look in that derived location.
+        let kt_dir = keytrace_dir(cache_dir.path());
+        std::fs::create_dir_all(&kt_dir).unwrap();
+        std::fs::write(
+            kt_dir.join("keytrace-cold.log"),
+            keytrace_line("relocatable", "source:src/lib.rs=cold-hash"),
+        )
+        .unwrap();
+        std::fs::write(
+            kt_dir.join("keytrace-relocate.log"),
+            keytrace_line("relocatable", "source:src/lib.rs=relocate-hash"),
+        )
+        .unwrap();
+
+        let report = key_divergence_report(cache_dir.path()).expect("both phase logs are present");
+        assert!(report.contains("[relocatable]"), "{report}");
+        assert!(report.contains("- cold-only:     source:src/lib.rs=cold-hash"));
+        assert!(report.contains("+ relocate-only: source:src/lib.rs=relocate-hash"));
+
+        std::fs::remove_file(kt_dir.join("keytrace-relocate.log")).unwrap();
+        assert_eq!(
+            key_divergence_report(cache_dir.path()),
+            None,
+            "a missing phase log is best-effort silence, not a panic"
+        );
+        std::fs::remove_dir_all(&kt_dir).ok();
+    }
 
     #[test]
     fn artifact_candidates_unix_is_single_unchanged() {

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -60,7 +60,16 @@ kache cargo -- build --workspace
 ```
 
 Runs Cargo's built-in `build` or `check` from the current directory with its
-arguments unchanged. If Cargo's
+arguments unchanged. It also keeps Cargo's intermediate build state under
+`{workspace-root}/target` while leaving final artifacts in the selected target
+directory. Cargo 1.91 introduced this `build-dir` split. It prevents a shared
+`CARGO_TARGET_DIR` from carrying fingerprints between worktrees and declaring
+the wrong unit `Fresh` before `RUSTC_WRAPPER` can run. Each worktree owns its
+freshness state, while Kache still shares compiled artifacts. Set
+`CARGO_BUILD_BUILD_DIR` explicitly, or configure `[build] build-dir`, to retain
+a different build-dir policy; Kache does not override either form.
+
+If Cargo's
 ancestor search finds a symlink to the selected Cargo-home config, Cargo would
 normally merge the same array-valued `build.rustflags` twice and re-key every
 unit. This front-end identifies that duplicate by canonical path, contributes
@@ -75,8 +84,9 @@ with a warning rather than risk reproducing Cargo's selection rules
 incorrectly. Cargo `-C`/`--config`, unstable flags, `install`, aliases, and
 external subcommands pass through unchanged. Config paths and contents are
 revalidated immediately before Cargo starts; concurrent config editing should
-still be avoided. Ordinary `cargo` remains supported; this command is needed
-only for the canonical-config alias case.
+still be avoided. Ordinary `cargo` remains supported. Use this front-end for
+the canonical-config alias case or when final artifacts intentionally share a
+target directory across worktrees.
 
 The command prevents Cargo's spurious rebuild in an existing target directory.
 It does not alias Kache entries across different rustflags transport sources;

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -328,7 +328,7 @@ AppImage mount, or a custom toolchain root:
 base_dirs = ["/snap", "/var/lib/flatpak", "/work"]
 ```
 
-Entries must be absolute and contain no `..`. They need not exist on every
+Entries must be absolute, narrower than a filesystem root, and contain no `..`. They need not exist on every
 machine, so a shared project config remains usable outside the container or
 sandbox. kache sorts the normalized entries independently of TOML order,
 assigns each one a distinct `<BASE_DIR_N>` key sentinel and

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -23,6 +23,15 @@ kache init --check
 
 After `kache init`, your next `cargo build` is already cached. The first run is a normal cold compile; the second run restores everything from kache's store with zero-copy reflinks (copy-on-write) where the filesystem supports it, and hardlink or copy otherwise.
 
+<Callout type="warning" title="Do not share one Cargo target directory across live worktrees">
+  With ordinary `cargo`, share Kache's cache but give each worktree its own
+  `CARGO_TARGET_DIR`. Cargo can declare an older worktree's unit `Fresh` from
+  shared fingerprint state without invoking `RUSTC_WRAPPER`, so no compiler
+  cache can validate that unit. If final artifacts must share one target, use
+  `kache cargo -- build` on Cargo 1.91+: it keeps intermediate fingerprints
+  worktree-local while Kache shares compiled artifacts.
+</Callout>
+
 ![kache: cold build populates the store, then `cargo clean && cargo build` restores every artifact with zero-copy reflinks](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/demo.gif)
 
 ## Verify the setup

--- a/src/args.rs
+++ b/src/args.rs
@@ -1863,6 +1863,36 @@ mod tests {
     }
 
     #[test]
+    fn path_normalization_root_exposes_the_frozen_root() {
+        // The key, the rustc invocation, and the dep-info rewrite all read this
+        // one accessor. If it stops reporting the frozen root they silently
+        // disagree about which anchor a source path is relative to, so a
+        // relocated hit rewrites dep-info against the wrong tree.
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().join("workspace");
+        let member = workspace.join("member");
+        std::fs::create_dir_all(&member).unwrap();
+        std::fs::write(workspace.join("Cargo.toml"), "[workspace]\n").unwrap();
+
+        let mut args = RustcArgs {
+            out_dir: Some(workspace.join("target/debug/deps")),
+            ..Default::default()
+        };
+        assert_eq!(
+            args.path_normalization_root(),
+            None,
+            "unset until the parse freezes it"
+        );
+
+        args.path_normalization_root = Some(args.select_path_normalization_root(&member));
+        assert_eq!(
+            args.path_normalization_root(),
+            Some(workspace.as_path()),
+            "the frozen workspace anchor must be readable back"
+        );
+    }
+
+    #[test]
     fn test_build_script_probe_detected_from_probe_out_dir() {
         let args: Vec<String> = vec![
             "rustc",

--- a/src/args.rs
+++ b/src/args.rs
@@ -278,6 +278,10 @@ pub struct RustcArgs {
     /// via [`RustcArgs::skip_path_remap`], so they can never observe different
     /// process-global env values and desync the key from the artifact.
     pub path_normalize_disabled: bool,
+    /// Path-normalization root selected once at parse time. Key construction,
+    /// rustc injection, and dep-info transport all reuse this frozen value so
+    /// filesystem drift cannot make them observe different remap rules.
+    path_normalization_root: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -366,6 +370,7 @@ impl RustcArgs {
             is_test: false,
             is_primary: false,
             path_normalize_disabled: !crate::path_normalizer::rustc_path_normalize_enabled(),
+            path_normalization_root: None,
         };
 
         let mut i = 0;
@@ -556,6 +561,9 @@ impl RustcArgs {
 
         parsed.features.sort();
         parsed.is_primary = parsed.crate_name.is_some() && parsed.source_file.is_some();
+        parsed.path_normalization_root = std::env::current_dir()
+            .ok()
+            .map(|cwd| parsed.select_path_normalization_root(&cwd));
 
         Ok(parsed)
     }
@@ -636,6 +644,42 @@ impl RustcArgs {
     pub fn workspace_root(&self) -> Option<PathBuf> {
         self.target_dir()
             .and_then(|t| t.parent().map(Path::to_path_buf))
+    }
+
+    /// Return the target-derived workspace root only when it is consistent
+    /// with Cargo's compiler working directory.
+    ///
+    /// An external `CARGO_TARGET_DIR` makes [`Self::workspace_root`] point at
+    /// the target's parent rather than the source workspace. Treating that as
+    /// a relocatable source root can alias unrelated files. Requiring a
+    /// manifest at the candidate and the compiler cwd beneath it fails closed
+    /// for external/shared targets while retaining normal workspace layouts.
+    pub fn verified_workspace_root(&self, cwd: &Path) -> Option<PathBuf> {
+        let candidate = self.workspace_root()?;
+        if !candidate.join("Cargo.toml").is_file() {
+            return None;
+        }
+        let canonical_candidate = candidate.canonicalize().ok()?;
+        let canonical_cwd = cwd.canonicalize().ok()?;
+        canonical_cwd
+            .starts_with(&canonical_candidate)
+            .then(|| std::path::absolute(&candidate).unwrap_or(candidate))
+    }
+
+    /// Workspace anchor shared by cache-key construction and rustc remapping.
+    ///
+    /// Cargo's output-derived candidate is valid for an in-workspace target,
+    /// but an external `CARGO_TARGET_DIR` makes it point at the target's parent.
+    /// Fall back to the compiler working directory in that case so key and
+    /// artifact remapping never treat an unrelated target parent as sources.
+    fn select_path_normalization_root(&self, cwd: &Path) -> PathBuf {
+        self.verified_workspace_root(cwd)
+            .unwrap_or_else(|| cwd.to_path_buf())
+    }
+
+    /// Frozen root shared by the key, rustc invocation, and dep-info rewrite.
+    pub fn path_normalization_root(&self) -> Option<&Path> {
+        self.path_normalization_root.as_deref()
     }
 
     /// Derive the cargo target directory (e.g. `<workspace>/target`) from
@@ -1790,6 +1834,32 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(args.workspace_root(), Some(PathBuf::from("/work/proj")));
+    }
+
+    #[test]
+    fn verified_workspace_root_rejects_external_target_parents() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().join("workspace");
+        let member = workspace.join("member");
+        std::fs::create_dir_all(&member).unwrap();
+        std::fs::write(workspace.join("Cargo.toml"), "[workspace]\n").unwrap();
+
+        let local = RustcArgs {
+            out_dir: Some(workspace.join("target/debug/deps")),
+            ..Default::default()
+        };
+        assert_eq!(
+            local.verified_workspace_root(&member),
+            Some(workspace.clone())
+        );
+        assert_eq!(local.select_path_normalization_root(&member), workspace);
+
+        let external = RustcArgs {
+            out_dir: Some(dir.path().join("external/shared-target/debug/deps")),
+            ..Default::default()
+        };
+        assert_eq!(external.verified_workspace_root(&member), None);
+        assert_eq!(external.select_path_normalization_root(&member), member);
     }
 
     #[test]

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -203,7 +203,14 @@ use std::path::{Path, PathBuf};
 // old unescaped `Expand` and re-corrupts it. Both directions share key v24, so
 // only a bump makes them unreachable. Cost is one cold rebuild, which v0.13.0
 // users (key v22) already pay crossing to this release regardless.
-pub(crate) const CACHE_KEY_VERSION: u32 = 25;
+//
+// v26 (kunobi-ninja/kache#760): source identity now folds each normalized path
+// together with its content hash. v25 retained only the sorted multiset of
+// contents, so swapping two module bodies (or renaming an include_dir asset)
+// could preserve the key while changing the compiled program. The same bump
+// also makes old dep-info blobs that retain donor-worktree absolute paths
+// unreachable; v26 stores separate target/cwd sentinels and re-roots both.
+pub(crate) const CACHE_KEY_VERSION: u32 = 26;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
 /// Collapse runs of ASCII whitespace into single spaces and trim
@@ -739,6 +746,27 @@ pub fn take_last_key_unit_id() -> Option<String> {
     LAST_KEY_UNIT_ID.lock().ok().and_then(|mut g| g.take())
 }
 
+/// Stable identity for one dep-info source path.
+///
+/// Cargo/worktree-local roots use the same rule rustc receives through
+/// `--remap-path-prefix`. Keep the dep-info spelling intact: canonicalizing a
+/// symlink would merge two spellings even though rustc may embed them
+/// differently through `file!()` or debug info. An unmodeled spelling stays
+/// deliberately path-local through an opaque, lossless-OS-byte digest.
+fn source_path_identity(file: &Path, path_normalizer: &PathNormalizer) -> Result<Vec<u8>> {
+    if let Some(identity) = path_normalizer.source_path_identity(file) {
+        return Ok(identity);
+    }
+
+    // Preserve the exact dep-info OS representation before hashing. Lossy
+    // UTF-8, NFC normalization, or canonicalization can merge distinct source
+    // spellings and recreate #760.
+    let mut opaque = blake3::Hasher::new();
+    opaque.update(b"kache-source-path-v1\0");
+    opaque.update(&env_os_key_bytes(file.as_os_str()));
+    Ok(format!("<OPAQUE_PATH>/{}", opaque.finalize().to_hex()).into_bytes())
+}
+
 /// Compute the blake3 cache key for a rustc invocation.
 ///
 /// The key captures everything that affects compilation output:
@@ -999,40 +1027,27 @@ pub fn compute_cache_key(
     // ── Group A: source files + env deps (from dep-info pre-pass) ──
     hasher.set_group("sources");
     if let Some(dep_info) = &dep_info {
-        // Hash source files in CONTENT-HASH order, not path order. Only
-        // the content hash enters the key (not the path), so the set of
-        // contents is what matters — and `dep_info.source_files` is
-        // sorted by absolute path, which is NOT path-independent: a
-        // build-script-generated file under `OUT_DIR` sorts among the
-        // registry sources differently once the build tree moves (e.g.
-        // `C:\Windows\...\tmp\...` vs `C:\actions-runner\...`), flipping
-        // the update order and changing the key — so a relocated build
-        // missed (kunobi-ninja/kache#201). Sorting by hash makes the
-        // order depend only on contents.
-        let mut hashed: Vec<(String, &std::path::Path)> =
-            Vec::with_capacity(dep_info.source_files.len());
+        // A source is identified by its stable normalized path and bytes.
+        // Hashing only a sorted content multiset lets swapping modules/assets
+        // preserve the key while changing semantics (#760). Matched paths use
+        // stable sentinels for relocation (#201); unmatched paths stay local
+        // rather than risk a false hit.
+        let mut hashed: Vec<(Vec<u8>, String)> = Vec::with_capacity(dep_info.source_files.len());
         for file in &dep_info.source_files {
-            match file_hasher.hash(file) {
-                Ok(file_hash) => hashed.push((file_hash, file.as_path())),
-                Err(e) => {
-                    tracing::warn!(
-                        "[key:{}] failed to hash source {}: {}",
-                        crate_name,
-                        file.display(),
-                        e
-                    );
-                }
-            }
+            let file_hash = file_hasher
+                .hash(file)
+                .with_context(|| format!("hashing source identity {}", file.display()))?;
+            let normalized_path = source_path_identity(file, path_normalizer)?;
+            hashed.push((normalized_path, file_hash));
         }
         hashed.sort();
-        for (file_hash, file) in &hashed {
-            hasher.update(b"source:");
-            hasher.update(file_hash.as_bytes());
-            hasher.update(b"\n");
+        for (normalized_path, file_hash) in &hashed {
+            fold_field(&mut hasher, b"source_path:", normalized_path);
+            fold_field(&mut hasher, b"source_hash:", file_hash.as_bytes());
             tracing::trace!(
                 "[key:{}] source:{}={}",
                 crate_name,
-                file.display(),
+                String::from_utf8_lossy(normalized_path),
                 &file_hash[..16]
             );
         }
@@ -1477,7 +1492,7 @@ pub fn compute_cache_key(
 /// working directory; `decl_file`s under the workspace / `$CARGO_TARGET_DIR` /
 /// `$CARGO_HOME` / `$RUSTUP_HOME` / `$HOME` / the tempdir / a build-script
 /// `OUT_DIR`). Without this fold the rest of `compute_cache_key` normalizes
-/// those path inputs to sentinels and hashes source by content, leaving the
+/// those path inputs to sentinels and hashes source by normalized path/content,
 /// `remap:none` key path-independent and letting a shared cache hand one
 /// checkout's real-path artifact to another (kunobi-ninja/kache#480 for the
 /// opt-out; the same hazard for coverage).
@@ -3483,6 +3498,89 @@ mod tests {
 
     const GNU_RUSTC_VERSION: &str =
         "rustc 1.90.0\nhost: x86_64-unknown-linux-gnu\nrelease: 1.90.0\n";
+
+    #[test]
+    fn source_identity_uses_a_stable_configured_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let checkout = dir.path().join("checkout");
+        let source = checkout.join("src/lib.rs");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(&source, "pub fn value() {}\n").unwrap();
+        let normalizer =
+            PathNormalizer::empty().with_base_dirs(&[checkout.to_string_lossy().into_owned()]);
+
+        let mut expected = b"<BASE_DIR_0>/".to_vec();
+        expected.extend_from_slice(
+            source
+                .strip_prefix(&checkout)
+                .unwrap()
+                .to_string_lossy()
+                .as_bytes(),
+        );
+        assert_eq!(
+            source_path_identity(&source, &normalizer).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn source_identity_uses_a_configured_external_root_losslessly() {
+        let dir = tempfile::tempdir().unwrap();
+        let external = dir.path().join("external");
+        let source = external.join("generated/value.rs");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(&source, "pub const VALUE: u8 = 1;\n").unwrap();
+        let normalizer =
+            PathNormalizer::empty().with_base_dirs(&[external.to_string_lossy().into_owned()]);
+
+        let mut expected = b"<BASE_DIR_0>/".to_vec();
+        expected.extend_from_slice(
+            source
+                .strip_prefix(&external)
+                .unwrap()
+                .to_string_lossy()
+                .as_bytes(),
+        );
+        assert_eq!(
+            source_path_identity(&source, &normalizer).unwrap(),
+            expected
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_identity_keeps_distinct_symlink_spellings_of_one_inode() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.rs");
+        let alias = dir.path().join("alias.rs");
+        std::fs::write(&real, "pub const VALUE: u8 = 1;\n").unwrap();
+        std::os::unix::fs::symlink(&real, &alias).unwrap();
+
+        let real_identity = source_path_identity(&real, &PathNormalizer::empty()).unwrap();
+        let alias_identity = source_path_identity(&alias, &PathNormalizer::empty()).unwrap();
+        assert_ne!(real_identity, alias_identity);
+        assert!(real_identity.starts_with(b"<OPAQUE_PATH>/"));
+        assert!(alias_identity.starts_with(b"<OPAQUE_PATH>/"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn source_identity_opaque_fallback_preserves_non_utf8_bytes() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let external = dir.path().join("external");
+        std::fs::create_dir_all(&external).unwrap();
+        let path_a = external.join(std::ffi::OsString::from_vec(vec![b'a', 0x80]));
+        let path_b = external.join(std::ffi::OsString::from_vec(vec![b'a', 0x81]));
+        std::fs::write(&path_a, b"same").unwrap();
+        std::fs::write(&path_b, b"same").unwrap();
+        let identity_a = source_path_identity(&path_a, &PathNormalizer::empty()).unwrap();
+        let identity_b = source_path_identity(&path_b, &PathNormalizer::empty()).unwrap();
+        assert_ne!(identity_a, identity_b);
+        assert!(identity_a.starts_with(b"<OPAQUE_PATH>/"));
+        assert!(identity_b.starts_with(b"<OPAQUE_PATH>/"));
+    }
 
     /// #131 load-bearing invariant: the grouped tee must produce EXACTLY the
     /// digest a plain blake3 hasher produces over the same update sequence —
@@ -7141,6 +7239,7 @@ exec {} \"$@\"\n",
         }
 
         let old_out_dir = std::env::var_os("OUT_DIR");
+        let old_manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR");
         let dir = tempfile::tempdir().unwrap();
         let workspace_a = dir.path().join("checkout-a");
         let workspace_b = dir.path().join("checkout-b");
@@ -7175,6 +7274,7 @@ pub fn value() -> u8 {
         let out_a = out_a.canonicalize().unwrap();
         unsafe {
             std::env::set_var("OUT_DIR", &out_a);
+            std::env::set_var("CARGO_MANIFEST_DIR", &workspace_a);
         }
         let parsed_a = RustcArgs::parse(&base_args(&source_a)).unwrap();
         let pn_a = PathNormalizer::from_env(Some(&workspace_a));
@@ -7183,12 +7283,14 @@ pub fn value() -> u8 {
         let out_b = out_b.canonicalize().unwrap();
         unsafe {
             std::env::set_var("OUT_DIR", &out_b);
+            std::env::set_var("CARGO_MANIFEST_DIR", &workspace_b);
         }
         let parsed_b = RustcArgs::parse(&base_args(&source_b)).unwrap();
         let pn_b = PathNormalizer::from_env(Some(&workspace_b));
         let key_b = compute_cache_key(&parsed_b, &fh, &pn_b).unwrap();
 
         restore_env_var("OUT_DIR", old_out_dir);
+        restore_env_var("CARGO_MANIFEST_DIR", old_manifest_dir);
 
         assert_eq!(
             key_a, key_b,

--- a/src/cargo_proxy.rs
+++ b/src/cargo_proxy.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const ENCODED_SEPARATOR: char = '\x1f';
+const WORKTREE_BUILD_DIR: &str = "{workspace-root}/target";
 
 #[derive(Debug, Clone)]
 struct ConfigSource {
@@ -33,6 +34,14 @@ struct NormalizationPlan {
 }
 
 #[derive(Debug)]
+struct BuildDirIsolationPlan {
+    snapshots: Vec<ConfigSource>,
+    cwd: PathBuf,
+    cargo_home: PathBuf,
+    candidate_paths: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
 enum PlanDecision {
     Apply(NormalizationPlan),
     Passthrough,
@@ -49,6 +58,27 @@ pub(crate) fn run(cargo_args: Vec<OsString>) -> Result<()> {
     let cargo = real_cargo_program()?;
     let mut command = Command::new(&cargo);
     command.args(&cargo_args).current_dir(&cwd);
+
+    // Cargo owns freshness before RUSTC_WRAPPER runs. Sharing its intermediate
+    // fingerprint directory across worktrees can therefore declare the wrong
+    // worktree Fresh without invoking Kache at all (#760). Cargo 1.91+'s
+    // build-dir split keeps intermediates local while leaving final artifacts
+    // in the caller's target-dir. Explicit environment or Cargo-config
+    // build-dir policies retain precedence.
+    let build_dir_plan = match worktree_build_dir_isolation_plan(
+        &cwd,
+        &cargo_args,
+        std::env::var_os("CARGO_BUILD_BUILD_DIR").as_deref(),
+    ) {
+        Ok(plan) => plan,
+        Err(reason) => {
+            eprintln!(
+                "kache: cannot safely isolate Cargo's build directory: {reason}; \
+                 retaining Cargo's configured layout"
+            );
+            None
+        }
+    };
 
     match normalization_plan(&cwd, &cargo_args) {
         PlanDecision::Apply(plan) => {
@@ -72,6 +102,20 @@ pub(crate) fn run(cargo_args: Vec<OsString>) -> Result<()> {
             );
         }
         PlanDecision::Passthrough => {}
+    }
+
+    // Revalidate immediately before launch. If a config file or candidate set
+    // changed after inspection, leave Cargo's layout untouched rather than
+    // override a newly configured build-dir policy with stale information.
+    if let Some(plan) = build_dir_plan {
+        if build_dir_plan_is_current(&plan) {
+            command.env("CARGO_BUILD_BUILD_DIR", WORKTREE_BUILD_DIR);
+        } else {
+            eprintln!(
+                "kache: Cargo config changed while build-dir isolation was being inspected; \
+                 retaining Cargo's configured layout"
+            );
+        }
     }
 
     #[cfg(unix)]
@@ -253,6 +297,47 @@ fn supported_cargo_command(args: &[OsString]) -> std::result::Result<(), String>
     Ok(())
 }
 
+fn worktree_build_dir_isolation_plan(
+    cwd: &Path,
+    args: &[OsString],
+    explicit: Option<&OsStr>,
+) -> std::result::Result<Option<BuildDirIsolationPlan>, String> {
+    if !worktree_build_dir_isolation_enabled(args, explicit, false) {
+        return Ok(None);
+    }
+    let cargo_home = cargo_home(cwd)?;
+    build_dir_isolation_plan_from_sources(cwd, cargo_home)
+}
+
+fn build_dir_isolation_plan_from_sources(
+    cwd: &Path,
+    cargo_home: PathBuf,
+) -> std::result::Result<Option<BuildDirIsolationPlan>, String> {
+    let candidates = cargo_config_candidates(cwd, &cargo_home);
+    let candidate_paths = candidates.iter().map(|(path, _)| path.clone()).collect();
+    let mut snapshots = Vec::with_capacity(candidates.len());
+    for (path, cargo_home_source) in candidates {
+        snapshots.push(read_source(path, cargo_home_source)?);
+    }
+    if configured_build_dir_in_sources(&snapshots)? {
+        return Ok(None);
+    }
+    Ok(Some(BuildDirIsolationPlan {
+        snapshots,
+        cwd: cwd.to_path_buf(),
+        cargo_home,
+        candidate_paths,
+    }))
+}
+
+fn worktree_build_dir_isolation_enabled(
+    args: &[OsString],
+    explicit: Option<&OsStr>,
+    configured: bool,
+) -> bool {
+    explicit.is_none() && !configured && supported_cargo_command(args).is_ok()
+}
+
 fn cargo_arg_may_change_config(arg: &str) -> bool {
     arg == "--config"
         || arg.starts_with("--config=")
@@ -277,6 +362,44 @@ fn cargo_config_candidates(cwd: &Path, cargo_home: &Path) -> Vec<(PathBuf, bool)
         }
     }
     candidates
+}
+
+fn configured_build_dir_in_sources(sources: &[ConfigSource]) -> std::result::Result<bool, String> {
+    for source in sources {
+        let table = source
+            .value
+            .as_table()
+            .ok_or_else(|| format!("{} is not a TOML table", source.logical_path.display()))?;
+        if table.contains_key("include") {
+            return Err(format!(
+                "{} uses Cargo config include",
+                source.logical_path.display()
+            ));
+        }
+        if let Some(build) = table.get("build") {
+            let build = build
+                .as_table()
+                .ok_or_else(|| format!("{}.build is not a table", source.logical_path.display()))?;
+            if build.contains_key("build-dir") {
+                return Ok(true);
+            }
+        }
+        if let Some(env) = table.get("env") {
+            let env = env
+                .as_table()
+                .ok_or_else(|| format!("{}.env is not a table", source.logical_path.display()))?;
+            if env.keys().any(|key| {
+                if cfg!(windows) {
+                    key.eq_ignore_ascii_case("CARGO_BUILD_BUILD_DIR")
+                } else {
+                    key == "CARGO_BUILD_BUILD_DIR"
+                }
+            }) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
 }
 
 fn cargo_home(cwd: &Path) -> std::result::Result<PathBuf, String> {
@@ -402,6 +525,14 @@ fn plan_is_current(plan: &NormalizationPlan) -> bool {
     revalidate_sources(&plan.snapshots).is_ok()
 }
 
+fn build_dir_plan_is_current(plan: &BuildDirIsolationPlan) -> bool {
+    let rescanned: Vec<PathBuf> = cargo_config_candidates(&plan.cwd, &plan.cargo_home)
+        .into_iter()
+        .map(|(path, _)| path)
+        .collect();
+    rescanned == plan.candidate_paths && revalidate_sources(&plan.snapshots).is_ok()
+}
+
 fn revalidate_sources(sources: &[ConfigSource]) -> std::result::Result<(), String> {
     for source in sources {
         let canonical = source.logical_path.canonicalize().map_err(|error| {
@@ -459,6 +590,101 @@ mod tests {
             let args = [OsString::from("check"), OsString::from_vec(vec![0x80])];
             assert!(supported_cargo_command(&args).is_err());
         }
+    }
+
+    #[test]
+    fn worktree_build_dir_is_scoped_and_respects_explicit_env() {
+        let build = [OsString::from("build")];
+        let check = [OsString::from("check"), OsString::from("--workspace")];
+        let install = [OsString::from("install"), OsString::from("demo")];
+
+        assert!(worktree_build_dir_isolation_enabled(&build, None, false));
+        assert!(worktree_build_dir_isolation_enabled(&check, None, false));
+        assert!(!worktree_build_dir_isolation_enabled(
+            &build,
+            Some(OsStr::new("/explicit/build-dir")),
+            false,
+        ));
+        assert!(!worktree_build_dir_isolation_enabled(&build, None, true,));
+        assert!(!worktree_build_dir_isolation_enabled(&install, None, false,));
+    }
+
+    #[test]
+    fn configured_build_dir_policy_is_never_overridden() {
+        let dir = tempfile::tempdir().unwrap();
+        let cargo_home = dir.path().join("cargo-home");
+        let cwd = dir.path().join("project");
+        let config_dir = cwd.join(".cargo");
+        std::fs::create_dir_all(&cargo_home).unwrap();
+        std::fs::create_dir_all(&config_dir).unwrap();
+
+        assert!(
+            build_dir_isolation_plan_from_sources(&cwd, cargo_home.clone())
+                .unwrap()
+                .is_some()
+        );
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[build]\nbuild-dir = \"custom-build\"\n",
+        )
+        .unwrap();
+        assert!(
+            build_dir_isolation_plan_from_sources(&cwd, cargo_home.clone())
+                .unwrap()
+                .is_none()
+        );
+
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[env]\nCARGO_BUILD_BUILD_DIR = \"custom-build\"\n",
+        )
+        .unwrap();
+        assert!(
+            build_dir_isolation_plan_from_sources(&cwd, cargo_home.clone())
+                .unwrap()
+                .is_none()
+        );
+
+        std::fs::write(config_dir.join("config.toml"), "include = \"other.toml\"\n").unwrap();
+        assert!(build_dir_isolation_plan_from_sources(&cwd, cargo_home).is_err());
+    }
+
+    #[test]
+    fn build_dir_plan_revalidation_detects_content_and_candidate_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let cargo_home = dir.path().join("cargo-home");
+        let root = dir.path().join("root");
+        let cwd = root.join("project");
+        let project_config_dir = cwd.join(".cargo");
+        std::fs::create_dir_all(&cargo_home).unwrap();
+        std::fs::create_dir_all(&project_config_dir).unwrap();
+        let project_config = project_config_dir.join("config.toml");
+        std::fs::write(&project_config, "[net]\noffline = true\n").unwrap();
+
+        let content_plan = build_dir_isolation_plan_from_sources(&cwd, cargo_home.clone())
+            .unwrap()
+            .unwrap();
+        assert!(build_dir_plan_is_current(&content_plan));
+        std::fs::write(&project_config, "[net]\noffline = false\n").unwrap();
+        assert!(
+            !build_dir_plan_is_current(&content_plan),
+            "changed content with the same candidate set must invalidate the plan"
+        );
+
+        let candidate_plan = build_dir_isolation_plan_from_sources(&cwd, cargo_home.clone())
+            .unwrap()
+            .unwrap();
+        let ancestor_config_dir = root.join(".cargo");
+        std::fs::create_dir_all(&ancestor_config_dir).unwrap();
+        std::fs::write(
+            ancestor_config_dir.join("config.toml"),
+            "[net]\ngit-fetch-with-cli = true\n",
+        )
+        .unwrap();
+        assert!(
+            !build_dir_plan_is_current(&candidate_plan),
+            "a new config candidate with unchanged snapshots must invalidate the plan"
+        );
     }
 
     #[test]

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -320,13 +320,6 @@ impl ArtifactSet {
         &self.outputs
     }
 
-    pub fn store_files(&self) -> Vec<(PathBuf, String)> {
-        self.outputs
-            .iter()
-            .map(|artifact| (artifact.path.clone(), artifact.store_name.clone()))
-            .collect()
-    }
-
     pub fn total_size(&self) -> u64 {
         self.outputs
             .iter()

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -137,6 +137,7 @@ impl RustcCompiler {
         // The invocation and key must use the same path-normalization rules.
         let workspace_root = parsed.path_normalization_root();
         let path_normalizer = crate::path_normalizer::PathNormalizer::from_env(workspace_root)
+            .with_target_dir(parsed.target_dir().as_deref())
             .with_base_dirs(&self.base_dirs)
             .with_rust_src_rule(
                 crate::cache_key::get_rustc_sysroot(parsed).as_deref(),

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -135,14 +135,13 @@ impl RustcCompiler {
         skip_remap_override: Option<bool>,
     ) -> Result<CompileResult> {
         // The invocation and key must use the same path-normalization rules.
-        let workspace_root = parsed.workspace_root();
-        let path_normalizer =
-            crate::path_normalizer::PathNormalizer::from_env(workspace_root.as_deref())
-                .with_base_dirs(&self.base_dirs)
-                .with_rust_src_rule(
-                    crate::cache_key::get_rustc_sysroot(parsed).as_deref(),
-                    crate::cache_key::get_rustc_commit_hash(&parsed.rustc).as_deref(),
-                );
+        let workspace_root = parsed.path_normalization_root();
+        let path_normalizer = crate::path_normalizer::PathNormalizer::from_env(workspace_root)
+            .with_base_dirs(&self.base_dirs)
+            .with_rust_src_rule(
+                crate::cache_key::get_rustc_sysroot(parsed).as_deref(),
+                crate::cache_key::get_rustc_commit_hash(&parsed.rustc).as_deref(),
+            );
         let skip_remap = skip_remap_override.unwrap_or_else(|| parsed.skip_path_remap());
         compile::run_rustc(
             &parsed.rustc,

--- a/src/config.rs
+++ b/src/config.rs
@@ -805,6 +805,12 @@ fn normalize_base_dirs(raw: impl IntoIterator<Item = String>) -> Result<Vec<Stri
         if value.is_empty() {
             anyhow::bail!("[paths].base_dirs[{index}] must not be empty");
         }
+        if value.starts_with(r"\\?\") || value.starts_with("//?/") {
+            anyhow::bail!(
+                "[paths].base_dirs[{index}] must not use a Windows verbatim prefix, got \
+                 {value:?}"
+            );
+        }
 
         let bytes = value.as_bytes();
         let windows_drive = bytes.len() >= 3
@@ -860,6 +866,12 @@ fn normalize_base_dirs(raw: impl IntoIterator<Item = String>) -> Result<Vec<Stri
         } else {
             format!("/{}", components.join("/"))
         };
+        if crate::path_normalizer::is_filesystem_root_prefix(&normalized) {
+            anyhow::bail!(
+                "[paths].base_dirs[{index}] must be narrower than a filesystem root, got \
+                 {value:?}"
+            );
+        }
         out.push(normalized);
     }
 
@@ -2752,6 +2764,27 @@ remote_key_cache_refresh_secs = 900
 
         let windows_parent = normalize_base_dirs([r"C:\work\..\other".to_string()]).unwrap_err();
         assert!(windows_parent.to_string().contains("must not contain `..`"));
+
+        for root in [
+            "/",
+            "C:/",
+            r"C:\",
+            "//server/share",
+            "//server/share/",
+            r"\\server\share",
+            r"\\server\share\",
+        ] {
+            let error = normalize_base_dirs([root.to_string()]).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("narrower than a filesystem root")
+            );
+        }
+        for verbatim in [r"\\?\C:\work", "//?/C:/work"] {
+            let error = normalize_base_dirs([verbatim.to_string()]).unwrap_err();
+            assert!(error.to_string().contains("Windows verbatim prefix"));
+        }
     }
 
     #[test]

--- a/src/link.rs
+++ b/src/link.rs
@@ -1594,10 +1594,7 @@ fn replace_depinfo_text(
         // across code-point boundaries. `str::find` guarantees this directly;
         // the ASCII-insensitive byte scan changes only ASCII case.
         if !depinfo_path_prefix_has_left_boundary(input, found, context) {
-            search = input[found..]
-                .char_indices()
-                .nth(1)
-                .map_or(input.len(), |(next, _)| found + next);
+            search = depinfo_next_char_boundary(input, found);
             continue;
         }
         output.push_str(&input[copied..found]);
@@ -1607,6 +1604,27 @@ fn replace_depinfo_text(
     }
     output.push_str(&input[copied..]);
     output
+}
+
+/// Byte index of the char boundary after the one starting at `start`, or the
+/// end of `input` when `start` holds the last char.
+///
+/// This is `replace_depinfo_text`'s progress guarantee: the loop calls it to
+/// step past a match it has rejected, so the result must be strictly greater
+/// than `start` or the search cannot terminate. Split out of the loop so that
+/// every mutant which breaks the guarantee lands in one narrowly-nameable
+/// function: each one hangs the suite instead of failing an assertion, and the
+/// mutation lane can only report a hang as a 300s timeout, never as a catch.
+/// Isolating them here keeps `replace_depinfo_text`'s other arithmetic — which
+/// the lane does kill — fully in scope. See `.cargo/mutants.toml`.
+///
+/// `depinfo_next_char_boundary_always_advances_past_the_current_char` is the
+/// real enforcement, and it is a normal fast-failing test.
+fn depinfo_next_char_boundary(input: &str, start: usize) -> usize {
+    input[start..]
+        .char_indices()
+        .nth(1)
+        .map_or(input.len(), |(next, _)| start + next)
 }
 
 fn depinfo_path_prefix_has_left_boundary(
@@ -2457,6 +2475,30 @@ __kache_target_rule__/debug/build/demo/out/generated.rs\n"
         );
     }
 
+    /// `replace_depinfo_text`'s search loop terminates only because this step
+    /// strictly advances. Asserted here rather than left to the loop, where a
+    /// slip shows up as a hang instead of a failure.
+    #[test]
+    fn depinfo_next_char_boundary_always_advances_past_the_current_char() {
+        // Single-byte, mid-string: the plain case the loop hits most.
+        assert_eq!(depinfo_next_char_boundary("abcd", 1), 2);
+        // Multi-byte: advancing lands on the next boundary, not the next byte.
+        assert_eq!(depinfo_next_char_boundary("aéb", 1), 3);
+        // Last char: clamps to the end rather than reporting no progress.
+        assert_eq!(depinfo_next_char_boundary("abc", 2), 3);
+        assert_eq!(depinfo_next_char_boundary("aé", 1), 3);
+
+        // The property the loop actually depends on, over every boundary of a
+        // mixed-width string.
+        let input = "a/é/b/日/c";
+        for (start, _) in input.char_indices() {
+            assert!(
+                depinfo_next_char_boundary(input, start) > start,
+                "must advance past byte {start} of {input:?}"
+            );
+        }
+    }
+
     #[test]
     fn windows_depinfo_prefixes_retain_drive_and_unc_verbatim_aliases() {
         let drive = depinfo_prefixes_for_display(r"\\?\C:\Work", true, true);
@@ -2472,6 +2514,23 @@ __kache_target_rule__/debug/build/demo/out/generated.rs\n"
         let expand = depinfo_prefixes_for_display(r"\\?\C:\Work", false, true);
         assert!(!expand.iter().any(|prefix| prefix.starts_with(r"\\?\")));
         assert!(expand.iter().all(|prefix| prefix.starts_with(r"C:\Work")));
+    }
+
+    /// The opposite-separator alias is contributed by the stripped display
+    /// only. A verbatim `\\?\` display is backslash-only to Windows, so
+    /// slash-expanding it would invent a spelling no dep-info ever carries.
+    #[test]
+    fn windows_depinfo_alternate_alias_is_expanded_only_for_non_verbatim_displays() {
+        let prefixes = depinfo_prefixes_for_display(r"\\?\C:\Work", true, true);
+
+        assert!(
+            prefixes.contains(&"C:/Work/".to_string()),
+            "stripped display contributes its slash alternate: {prefixes:?}"
+        );
+        assert!(
+            !prefixes.iter().any(|prefix| prefix.starts_with("//?/")),
+            "verbatim display must not be slash-expanded: {prefixes:?}"
+        );
     }
 
     #[test]

--- a/src/link.rs
+++ b/src/link.rs
@@ -1578,6 +1578,14 @@ fn replace_depinfo_text(
     let mut copied = 0;
     let mut search = 0;
     while search + needle_bytes.len() <= input_bytes.len() {
+        // Every path out of this iteration must leave `search` past where it
+        // started. Both do: a rejected match steps to the next char boundary,
+        // and an accepted one resumes after the replacement. Checked rather
+        // than assumed because the failure is not a wrong answer — the scan
+        // re-matches the same offset forever while `output` keeps growing, so
+        // an index slip here exhausts memory instead of returning. Debug-only,
+        // so the release scan is unchanged.
+        let scan_start = search;
         let offset = if ascii_case_insensitive {
             input_bytes[search..]
                 .windows(needle_bytes.len())
@@ -1595,12 +1603,14 @@ fn replace_depinfo_text(
         // the ASCII-insensitive byte scan changes only ASCII case.
         if !depinfo_path_prefix_has_left_boundary(input, found, context) {
             search = depinfo_next_char_boundary(input, found);
+            debug_assert!(scan_start < search, "rejected match must advance");
             continue;
         }
         output.push_str(&input[copied..found]);
         output.push_str(replacement);
         copied = end;
         search = copied;
+        debug_assert!(scan_start < search, "replaced match must advance");
     }
     output.push_str(&input[copied..]);
     output
@@ -1611,15 +1621,13 @@ fn replace_depinfo_text(
 ///
 /// This is `replace_depinfo_text`'s progress guarantee: the loop calls it to
 /// step past a match it has rejected, so the result must be strictly greater
-/// than `start` or the search cannot terminate. Split out of the loop so that
-/// every mutant which breaks the guarantee lands in one narrowly-nameable
-/// function: each one hangs the suite instead of failing an assertion, and the
-/// mutation lane can only report a hang as a 300s timeout, never as a catch.
-/// Isolating them here keeps `replace_depinfo_text`'s other arithmetic — which
-/// the lane does kill — fully in scope. See `.cargo/mutants.toml`.
+/// than `start` or the search cannot terminate. Named rather than inlined so
+/// the guarantee can be asserted directly, by
+/// `depinfo_next_char_boundary_always_advances_past_the_current_char`, instead
+/// of only showing up as the caller looping.
 ///
-/// `depinfo_next_char_boundary_always_advances_past_the_current_char` is the
-/// real enforcement, and it is a normal fast-failing test.
+/// The name is prefixed because `config_tui` has an unrelated
+/// `next_char_boundary`, and mutation excludes match on function name.
 fn depinfo_next_char_boundary(input: &str, start: usize) -> usize {
     input[start..]
         .char_indices()

--- a/src/link.rs
+++ b/src/link.rs
@@ -1136,18 +1136,22 @@ fn sample_write_clock(path: &Path) -> Result<filetime::FileTime> {
 }
 
 const DEPINFO_ROOT_SENTINEL: &str = "__kache_root__/";
+const DEPINFO_CWD_SENTINEL: &str = "__kache_cwd__/";
+const DEPINFO_WORKSPACE_SENTINEL: &str = "__kache_workspace__/";
 
 /// rustc's `# env-dep:NAME=value` records carry their own escape grammar:
 /// backslash is written `\\` (and newline/CR as `\n`/`\r`), and cargo's
 /// parser hard-rejects every other backslash sequence with
 /// "unknown escape character". A path prefix can only contribute the
 /// backslash case.
-#[cfg(any(windows, test))]
 const DEPINFO_ENV_DEP_PREFIX: &str = "# env-dep:";
 
-#[cfg(any(windows, test))]
 fn escape_depinfo_env_value(prefix: &str) -> String {
     prefix.replace('\\', "\\\\")
+}
+
+fn escape_depinfo_make_path(prefix: &str) -> String {
+    prefix.replace(' ', "\\ ")
 }
 
 /// Pure dep-info path rewrite: relativize absolute project paths to a
@@ -1158,34 +1162,226 @@ fn escape_depinfo_env_value(prefix: &str) -> String {
 /// it directly — it computes the final `.d` content from the store blob
 /// and materializes the result with [`write_restored`], so it never
 /// rewrites a restored, possibly read-only, possibly inode-shared file in
-/// place. The store side reaches it via [`rewrite_depinfo`].
+/// place. The Rust store side calls the two-root variant while creating a
+/// private store snapshot; C/C++ keeps using this one-root form.
 pub fn rewrite_depinfo_content(content: &str, project_dir: &Path, mode: DepInfoMode) -> String {
-    let project_prefix = format!("{}/", project_dir.display());
+    rewrite_depinfo_content_with_sentinel(content, project_dir, DEPINFO_ROOT_SENTINEL, mode)
+}
 
-    // Unix keeps the historical whole-content transform byte-for-byte. A
-    // backslash there is a legal FILENAME character, not a separator or an
-    // escape, so neither the dual-spelling prefix nor the env-dep escape
-    // treatment below may run — either could rewrite content the old code
-    // left alone (cross-model review finding).
-    #[cfg(not(windows))]
-    {
-        match mode {
-            DepInfoMode::Relativize => content.replace(&project_prefix, DEPINFO_ROOT_SENTINEL),
-            DepInfoMode::Expand => content.replace(DEPINFO_ROOT_SENTINEL, &project_prefix),
+/// Rust dep-info carries two independently relocatable path families: target
+/// outputs and sources below Cargo's invocation directory. Re-root both with
+/// distinct sentinels so a cached `.d` never leaves Cargo watching a live donor
+/// worktree after the artifact moves (#760).
+#[cfg(test)]
+pub fn rewrite_rustc_depinfo_content(
+    content: &str,
+    target_dir: &Path,
+    working_dir: &Path,
+    workspace_dir: Option<&Path>,
+    mode: DepInfoMode,
+) -> String {
+    rewrite_rustc_depinfo_content_with_configured_roots(
+        content,
+        target_dir,
+        working_dir,
+        workspace_dir,
+        &[],
+        mode,
+    )
+}
+
+pub fn rewrite_rustc_depinfo_content_with_configured_roots(
+    content: &str,
+    target_dir: &Path,
+    working_dir: &Path,
+    workspace_dir: Option<&Path>,
+    configured_roots: &[(PathBuf, String, u8)],
+    mode: DepInfoMode,
+) -> String {
+    let mut automatic_roots = vec![(
+        working_dir.to_path_buf(),
+        DEPINFO_CWD_SENTINEL.to_string(),
+        4_u8,
+        2_u8,
+    )];
+    if let Some(workspace_dir) = workspace_dir {
+        automatic_roots.push((
+            workspace_dir.to_path_buf(),
+            DEPINFO_WORKSPACE_SENTINEL.to_string(),
+            4_u8,
+            1_u8,
+        ));
+    }
+
+    if matches!(mode, DepInfoMode::Relativize) {
+        let mut roots = configured_roots
+            .iter()
+            .map(|(root, sentinel, priority)| {
+                (root.clone(), sentinel.clone(), *priority, 0_u8, true)
+            })
+            .chain(
+                automatic_roots
+                    .iter()
+                    .map(|(root, sentinel, priority, tie)| {
+                        (root.clone(), sentinel.clone(), *priority, *tie, false)
+                    }),
+            )
+            .collect::<Vec<_>>();
+        roots.sort_by_key(|(root, _, priority, tie, _)| {
+            std::cmp::Reverse((
+                *priority,
+                root.components().count(),
+                root.as_os_str().len(),
+                *tie,
+            ))
+        });
+        let target_rewritten = rewrite_rustc_depinfo_targets(content, target_dir, mode);
+        return roots.into_iter().fold(
+            target_rewritten,
+            |rewritten, (root, sentinel, _, _, exact)| {
+                if exact {
+                    rewrite_depinfo_content_with_exact_sentinel(&rewritten, &root, &sentinel, mode)
+                } else {
+                    rewrite_depinfo_content_with_sentinel(&rewritten, &root, &sentinel, mode)
+                }
+            },
+        );
+    }
+
+    // A portable owner may have multiple producer aliases, but the first entry
+    // for its sentinel is the designated lexical consumer root. Expand each
+    // sentinel exactly once so a longer canonical alias cannot steal restore.
+    let mut rewritten = content.to_string();
+    let mut expanded = std::collections::HashSet::new();
+    for (root, sentinel, _) in configured_roots {
+        if expanded.insert(sentinel) {
+            rewritten =
+                rewrite_depinfo_content_with_exact_sentinel(&rewritten, root, sentinel, mode);
         }
     }
+    let rewritten =
+        automatic_roots
+            .into_iter()
+            .fold(rewritten, |rewritten, (root, sentinel, _, _)| {
+                rewrite_depinfo_content_with_sentinel(&rewritten, &root, &sentinel, mode)
+            });
+    rewrite_rustc_depinfo_targets(&rewritten, target_dir, mode)
+}
 
-    // Windows dep-info paths use backslash separators — and often mix them
-    // (`...\out/generated.rs` from an env-var join). A prefix built with one
-    // separator silently fails to match the other, so the builder's absolute
-    // paths shipped verbatim in the cached entry and poisoned every other
-    // project sharing it (kunobi-ninja/kache#330). Relativize both spellings;
-    // the sentinel expands with `/`, which every Windows API accepts.
-    #[cfg(windows)]
-    {
-        let prefixes = [project_prefix, format!("{}\\", project_dir.display())];
-        rewrite_depinfo_content_with_prefixes(content, &prefixes, mode)
+/// Rebase only Makefile target tokens (left of rustc's `: ` delimiter).
+/// Dependencies on the right are source inputs and must follow PathNormalizer
+/// ownership instead; a generated source beneath `target/` can still belong to
+/// workspace/configured source identity.
+fn rewrite_rustc_depinfo_targets(content: &str, target_dir: &Path, mode: DepInfoMode) -> String {
+    content
+        .split_inclusive('\n')
+        .map(|line| {
+            if line.starts_with(DEPINFO_ENV_DEP_PREFIX) {
+                return line.to_string();
+            }
+            let Some(delimiter) = line.find(": ") else {
+                return line.to_string();
+            };
+            let (targets, dependencies) = line.split_at(delimiter);
+            let rewritten = rewrite_depinfo_content_with_sentinel(
+                targets,
+                target_dir,
+                DEPINFO_ROOT_SENTINEL,
+                mode,
+            );
+            format!("{rewritten}{dependencies}")
+        })
+        .collect()
+}
+
+/// Rewrite one exact configured-rule spelling. Configured roots already carry
+/// their explicitly constructed lexical/canonical/Windows aliases; adding a
+/// fresh canonical alias here could let one configured symlink steal another
+/// configured slot's sentinel.
+fn rewrite_depinfo_content_with_exact_sentinel(
+    content: &str,
+    project_dir: &Path,
+    sentinel: &str,
+    mode: DepInfoMode,
+) -> String {
+    rewrite_depinfo_content_with_exact_sentinel_for_platform(
+        content,
+        project_dir,
+        sentinel,
+        mode,
+        cfg!(windows),
+    )
+}
+
+fn rewrite_depinfo_content_with_exact_sentinel_for_platform(
+    content: &str,
+    project_dir: &Path,
+    sentinel: &str,
+    mode: DepInfoMode,
+    windows: bool,
+) -> String {
+    let prefixes = depinfo_prefixes_for_exact_display(&project_dir.to_string_lossy(), windows);
+    rewrite_depinfo_content_with_prefixes_and_sentinel(content, &prefixes, sentinel, mode)
+}
+
+fn depinfo_prefixes_for_exact_display(raw: &str, windows: bool) -> Vec<String> {
+    if windows {
+        // Expand uses the first spelling. Verbatim Windows paths (`\\?\...`)
+        // do not accept forward slashes, so the native separator must lead.
+        vec![format!("{raw}\\"), format!("{raw}/")]
+    } else {
+        vec![format!("{raw}/")]
     }
+}
+
+fn rewrite_depinfo_content_with_sentinel(
+    content: &str,
+    project_dir: &Path,
+    sentinel: &str,
+    mode: DepInfoMode,
+) -> String {
+    let mut roots = vec![project_dir.to_path_buf()];
+    if matches!(mode, DepInfoMode::Relativize)
+        && let Ok(canonical) = project_dir.canonicalize()
+        && canonical != project_dir
+    {
+        roots.push(canonical);
+    }
+    let mut prefixes = Vec::new();
+    for root in roots {
+        prefixes.extend(depinfo_prefixes_for_display(
+            &root.to_string_lossy(),
+            matches!(mode, DepInfoMode::Relativize),
+            cfg!(windows),
+        ));
+    }
+    prefixes.sort();
+    prefixes.dedup();
+    rewrite_depinfo_content_with_prefixes_and_sentinel(content, &prefixes, sentinel, mode)
+}
+
+fn depinfo_prefixes_for_display(
+    raw: &str,
+    retain_verbatim_alias: bool,
+    windows: bool,
+) -> Vec<String> {
+    let stripped = raw
+        .strip_prefix(r"\\?\UNC\")
+        .map(|path| format!(r"\\{path}"))
+        .or_else(|| raw.strip_prefix(r"\\?\").map(str::to_string))
+        .unwrap_or_else(|| raw.to_string());
+    let mut displays = vec![stripped.clone()];
+    if retain_verbatim_alias && raw != stripped {
+        displays.push(raw.to_string());
+    }
+    let mut prefixes = Vec::new();
+    for display in displays {
+        prefixes.push(format!("{display}/"));
+        if windows {
+            prefixes.push(format!("{display}\\"));
+        }
+    }
+    prefixes
 }
 
 /// Prefix-parameterized core of the Windows [`rewrite_depinfo_content`]
@@ -1199,10 +1395,24 @@ pub fn rewrite_depinfo_content(content: &str, project_dir: &Path, mode: DepInfoM
 /// cargo rejects, kunobi-ninja/kache#730). The record's key is an environment
 /// variable NAME, never a path — it is left untouched, as is a key-only
 /// record without `=`.
-#[cfg(any(windows, test))]
+#[cfg(test)]
 fn rewrite_depinfo_content_with_prefixes(
     content: &str,
     prefixes: &[String],
+    mode: DepInfoMode,
+) -> String {
+    rewrite_depinfo_content_with_prefixes_and_sentinel(
+        content,
+        prefixes,
+        DEPINFO_ROOT_SENTINEL,
+        mode,
+    )
+}
+
+fn rewrite_depinfo_content_with_prefixes_and_sentinel(
+    content: &str,
+    prefixes: &[String],
+    sentinel: &str,
     mode: DepInfoMode,
 ) -> String {
     content
@@ -1214,24 +1424,132 @@ fn rewrite_depinfo_content_with_prefixes(
                 };
                 let value = match mode {
                     DepInfoMode::Relativize => prefixes.iter().fold(value.to_string(), |acc, p| {
-                        acc.replace(&escape_depinfo_env_value(p), DEPINFO_ROOT_SENTINEL)
+                        replace_depinfo_text(
+                            &acc,
+                            &escape_depinfo_env_value(p),
+                            sentinel,
+                            cfg!(windows),
+                            DepInfoTextContext::EnvValue,
+                        )
                     }),
-                    DepInfoMode::Expand => value.replace(
-                        DEPINFO_ROOT_SENTINEL,
+                    DepInfoMode::Expand => replace_depinfo_text(
+                        value,
+                        sentinel,
                         &escape_depinfo_env_value(&prefixes[0]),
+                        false,
+                        DepInfoTextContext::EnvValue,
                     ),
                 };
                 format!("{DEPINFO_ENV_DEP_PREFIX}{key}={value}")
             } else {
                 match mode {
                     DepInfoMode::Relativize => prefixes.iter().fold(line.to_string(), |acc, p| {
-                        acc.replace(p.as_str(), DEPINFO_ROOT_SENTINEL)
+                        let escaped = escape_depinfo_make_path(p);
+                        let escaped = replace_depinfo_text(
+                            &acc,
+                            &escaped,
+                            sentinel,
+                            cfg!(windows),
+                            DepInfoTextContext::MakeLine,
+                        );
+                        replace_depinfo_text(
+                            &escaped,
+                            p,
+                            sentinel,
+                            cfg!(windows),
+                            DepInfoTextContext::MakeLine,
+                        )
                     }),
-                    DepInfoMode::Expand => line.replace(DEPINFO_ROOT_SENTINEL, &prefixes[0]),
+                    DepInfoMode::Expand => replace_depinfo_text(
+                        line,
+                        sentinel,
+                        &escape_depinfo_make_path(&prefixes[0]),
+                        false,
+                        DepInfoTextContext::MakeLine,
+                    ),
                 }
             }
         })
         .collect()
+}
+
+#[derive(Clone, Copy)]
+enum DepInfoTextContext {
+    MakeLine,
+    EnvValue,
+}
+
+fn replace_depinfo_text(
+    input: &str,
+    needle: &str,
+    replacement: &str,
+    ascii_case_insensitive: bool,
+    context: DepInfoTextContext,
+) -> String {
+    if needle.is_empty() {
+        return input.to_string();
+    }
+    let input_bytes = input.as_bytes();
+    let needle_bytes = needle.as_bytes();
+    let mut output = String::with_capacity(input.len());
+    let mut copied = 0;
+    let mut search = 0;
+    while search + needle_bytes.len() <= input_bytes.len() {
+        let offset = if ascii_case_insensitive {
+            input_bytes[search..]
+                .windows(needle_bytes.len())
+                .position(|window| window.eq_ignore_ascii_case(needle_bytes))
+        } else {
+            input[search..].find(needle)
+        };
+        let Some(offset) = offset else {
+            break;
+        };
+        let found = search + offset;
+        let end = found + needle_bytes.len();
+        // UTF-8 is self-synchronizing: a valid UTF-8 `needle` cannot match
+        // across code-point boundaries. `str::find` guarantees this directly;
+        // the ASCII-insensitive byte scan changes only ASCII case.
+        if !depinfo_path_prefix_has_left_boundary(input, found, context) {
+            search = input[found..]
+                .char_indices()
+                .nth(1)
+                .map_or(input.len(), |(next, _)| found + next);
+            continue;
+        }
+        output.push_str(&input[copied..found]);
+        output.push_str(replacement);
+        copied = end;
+        search = copied;
+    }
+    output.push_str(&input[copied..]);
+    output
+}
+
+fn depinfo_path_prefix_has_left_boundary(
+    input: &str,
+    start: usize,
+    context: DepInfoTextContext,
+) -> bool {
+    if start == 0 {
+        return true;
+    }
+    if matches!(context, DepInfoTextContext::EnvValue) {
+        return false;
+    }
+    let before = &input[..start];
+    let Some((delimiter_start, delimiter)) = before.char_indices().next_back() else {
+        return false;
+    };
+    if !delimiter.is_whitespace() && delimiter != ':' {
+        return false;
+    }
+    before[..delimiter_start]
+        .chars()
+        .rev()
+        .take_while(|ch| *ch == '\\')
+        .count()
+        .is_multiple_of(2)
 }
 
 /// Rewrite a `.d` (dep-info) file in place.
@@ -1239,15 +1557,20 @@ fn rewrite_depinfo_content_with_prefixes(
 /// Used on the **store** side, where the file is the build's own
 /// freshly-written, writable dep-info. The restore side does NOT use this
 /// — it computes the rewritten content in memory via
-/// [`rewrite_depinfo_content`] and materializes it with [`write_restored`],
-/// honoring "compute the final bytes, then materialize" rather than
-/// patching a restored file in place.
+/// [`rewrite_depinfo_content`] (or its Rust two-root variant), then materializes
+/// it with [`write_restored`]. This honors "compute the final bytes, then
+/// materialize" rather than patching a restored file in place.
+#[cfg(test)]
 pub fn rewrite_depinfo(depinfo_path: &Path, project_dir: &Path, mode: DepInfoMode) -> Result<()> {
     let content = fs::read_to_string(depinfo_path)
         .with_context(|| format!("reading dep-info file {}", depinfo_path.display()))?;
 
     let rewritten = rewrite_depinfo_content(&content, project_dir, mode);
+    write_rewritten_depinfo(depinfo_path, rewritten)
+}
 
+#[cfg(test)]
+fn write_rewritten_depinfo(depinfo_path: &Path, rewritten: String) -> Result<()> {
     // Defense-in-depth: if the file is hardlinked (nlink > 1), unlink
     // first so the in-place write can't mutate a shared inode. On the
     // store side `Store::put` never hardlinks `.d` blobs (DepInfo is
@@ -1753,6 +2076,474 @@ mod tests {
 
         let content = fs::read_to_string(&depfile).unwrap();
         assert!(content.contains("/home/user/project/"));
+    }
+
+    #[test]
+    fn rustc_depinfo_rewrite_rebases_target_and_worktree_separately() {
+        let producer_target = Path::new("/build/worktree-a/target");
+        let producer_cwd = Path::new("/build/worktree-a");
+        let input = "/build/worktree-a/target/debug/deps/libdemo.rlib: \
+/build/worktree-a/src/lib.rs /build/worktree-a/assets/value.txt\n";
+
+        let stored = rewrite_rustc_depinfo_content(
+            input,
+            producer_target,
+            producer_cwd,
+            None,
+            DepInfoMode::Relativize,
+        );
+        assert!(stored.contains("__kache_root__/debug/deps/libdemo.rlib"));
+        assert!(stored.contains("__kache_cwd__/src/lib.rs"));
+        assert!(stored.contains("__kache_cwd__/assets/value.txt"));
+        assert!(!stored.contains("worktree-a"));
+
+        let restored = rewrite_rustc_depinfo_content(
+            &stored,
+            Path::new("/build/worktree-b/target"),
+            Path::new("/build/worktree-b"),
+            None,
+            DepInfoMode::Expand,
+        );
+        assert!(restored.contains("/build/worktree-b/target/debug/deps/libdemo.rlib"));
+        assert!(restored.contains("/build/worktree-b/src/lib.rs"));
+        assert!(restored.contains("/build/worktree-b/assets/value.txt"));
+        assert!(!restored.contains("worktree-a"));
+    }
+
+    #[test]
+    fn rustc_depinfo_rewrite_handles_workspace_and_make_escaped_paths() {
+        let producer_workspace = Path::new("/build/work tree-a");
+        let producer_target = producer_workspace.join("target");
+        let producer_cwd = producer_workspace.join("crates/demo");
+        let input = "/build/work\\ tree-a/target/debug/deps/libdemo.rlib: \
+/build/work\\ tree-a/crates/demo/src/lib.rs \
+/build/work\\ tree-a/shared/schema.txt\n\
+# env-dep:SCHEMA_ROOT=/build/work tree-a/shared\n";
+
+        let stored = rewrite_rustc_depinfo_content(
+            input,
+            &producer_target,
+            &producer_cwd,
+            Some(producer_workspace),
+            DepInfoMode::Relativize,
+        );
+        assert!(stored.contains("__kache_root__/debug/deps/libdemo.rlib"));
+        assert!(stored.contains("__kache_cwd__/src/lib.rs"));
+        assert!(stored.contains("__kache_workspace__/shared/schema.txt"));
+        assert!(stored.contains("# env-dep:SCHEMA_ROOT=__kache_workspace__/shared"));
+        assert!(!stored.contains("work tree-a"));
+        assert!(!stored.contains("work\\ tree-a"));
+
+        let consumer_workspace = Path::new("/build/work tree-b");
+        let restored = rewrite_rustc_depinfo_content(
+            &stored,
+            &consumer_workspace.join("target"),
+            &consumer_workspace.join("crates/demo"),
+            Some(consumer_workspace),
+            DepInfoMode::Expand,
+        );
+        assert!(restored.contains("/build/work\\ tree-b/target/debug/deps/libdemo.rlib"));
+        assert!(restored.contains("/build/work\\ tree-b/crates/demo/src/lib.rs"));
+        assert!(restored.contains("/build/work\\ tree-b/shared/schema.txt"));
+        assert!(restored.contains("# env-dep:SCHEMA_ROOT=/build/work tree-b/shared"));
+        assert!(!restored.contains("work tree-a"));
+        assert!(!restored.contains("work\\ tree-a"));
+    }
+
+    #[test]
+    fn rustc_depinfo_rewrite_round_trips_configured_external_roots() {
+        let producer = PathBuf::from("/mount-a/generated");
+        let consumer = PathBuf::from("/mount-b/generated");
+        let sentinel = "__kache_base_dir_0__/".to_string();
+        let input = "/work-a/target/demo.d: /mount-a/generated/schema/data.json\n";
+
+        let stored = rewrite_rustc_depinfo_content_with_configured_roots(
+            input,
+            Path::new("/work-a/target"),
+            Path::new("/work-a/crate"),
+            Some(Path::new("/work-a")),
+            &[(producer, sentinel.clone(), 8)],
+            DepInfoMode::Relativize,
+        );
+        assert!(stored.contains("__kache_base_dir_0__/schema/data.json"));
+        assert!(!stored.contains("/mount-a/generated"));
+
+        let restored = rewrite_rustc_depinfo_content_with_configured_roots(
+            &stored,
+            Path::new("/work-b/target"),
+            Path::new("/work-b/crate"),
+            Some(Path::new("/work-b")),
+            &[(consumer, sentinel, 8)],
+            DepInfoMode::Expand,
+        );
+        assert!(restored.contains("/mount-b/generated/schema/data.json"));
+        assert!(!restored.contains("/mount-a/generated"));
+    }
+
+    #[test]
+    fn configured_root_wins_when_it_equals_the_working_directory() {
+        let root = PathBuf::from("/work/crate");
+        let stored = rewrite_rustc_depinfo_content_with_configured_roots(
+            "/work/target/demo.d: /work/crate/generated.rs\n",
+            Path::new("/work/target"),
+            &root,
+            Some(Path::new("/work")),
+            &[(root.clone(), "__kache_base_dir_0__/".to_string(), 8)],
+            DepInfoMode::Relativize,
+        );
+        assert!(stored.contains("__kache_base_dir_0__/generated.rs"));
+        assert!(!stored.contains(DEPINFO_CWD_SENTINEL));
+    }
+
+    #[test]
+    fn configured_ancestor_precedes_more_specific_automatic_roots() {
+        let configured = PathBuf::from("/sandbox");
+        let stored = rewrite_rustc_depinfo_content_with_configured_roots(
+            "/sandbox/worktree-a/target/demo.d: /sandbox/worktree-a/crate/generated.rs\n",
+            Path::new("/sandbox/worktree-a/target"),
+            Path::new("/sandbox/worktree-a/crate"),
+            Some(Path::new("/sandbox/worktree-a")),
+            &[(configured, "__kache_base_dir_0__/".to_string(), 8)],
+            DepInfoMode::Relativize,
+        );
+        assert!(stored.starts_with("__kache_root__/demo.d:"), "{stored}");
+        assert!(stored.contains("__kache_base_dir_0__/worktree-a/crate/generated.rs"));
+        assert!(!stored.contains(DEPINFO_CWD_SENTINEL));
+        assert!(!stored.contains(DEPINFO_WORKSPACE_SENTINEL));
+    }
+
+    #[test]
+    fn target_output_rebases_separately_from_generated_source_ownership() {
+        let stored = rewrite_rustc_depinfo_content_with_configured_roots(
+            "/work/target/demo.d: /work/target/generated.rs\n",
+            Path::new("/work/target"),
+            Path::new("/work"),
+            Some(Path::new("/work")),
+            &[],
+            DepInfoMode::Relativize,
+        );
+
+        assert_eq!(
+            stored,
+            "__kache_root__/demo.d: __kache_cwd__/target/generated.rs\n"
+        );
+    }
+
+    #[test]
+    fn external_target_generated_source_round_trips_independently_from_output() {
+        let producer_target = PathBuf::from("/external-a/target");
+        let consumer_target = PathBuf::from("/external-b/target");
+        let target_sentinel = "__kache_target_rule__/".to_string();
+        let input = "/external-a/target/debug/deps/demo.d: \
+/external-a/target/debug/build/demo/out/generated.rs\n";
+
+        let stored = rewrite_rustc_depinfo_content_with_configured_roots(
+            input,
+            &producer_target,
+            Path::new("/work-a/crate"),
+            Some(Path::new("/work-a")),
+            &[(producer_target.clone(), target_sentinel.clone(), 3)],
+            DepInfoMode::Relativize,
+        );
+        assert_eq!(
+            stored,
+            "__kache_root__/debug/deps/demo.d: \
+__kache_target_rule__/debug/build/demo/out/generated.rs\n"
+        );
+
+        let restored = rewrite_rustc_depinfo_content_with_configured_roots(
+            &stored,
+            &consumer_target,
+            Path::new("/work-b/crate"),
+            Some(Path::new("/work-b")),
+            &[(consumer_target.clone(), target_sentinel, 3)],
+            DepInfoMode::Expand,
+        );
+        assert_eq!(
+            restored,
+            "/external-b/target/debug/deps/demo.d: \
+/external-b/target/debug/build/demo/out/generated.rs\n"
+        );
+    }
+
+    #[test]
+    fn configured_root_does_not_match_an_interior_path_component() {
+        let stored = rewrite_rustc_depinfo_content_with_configured_roots(
+            "out: /mnt/sandbox/file.rs /mnt/@/sandbox/punctuation.rs \
+/mnt/foo\\ /sandbox/escaped-space.rs /sandbox/owned.rs\n\
+# env-dep:ASSET=/mnt/sandbox/asset.txt\n",
+            Path::new("/target"),
+            Path::new("/work"),
+            None,
+            &[(
+                PathBuf::from("/sandbox"),
+                "__kache_base_dir_0__/".to_string(),
+                8,
+            )],
+            DepInfoMode::Relativize,
+        );
+
+        assert!(stored.contains("/mnt/sandbox/file.rs"));
+        assert!(stored.contains("/mnt/@/sandbox/punctuation.rs"));
+        assert!(stored.contains("/mnt/foo\\ /sandbox/escaped-space.rs"));
+        assert!(stored.contains("# env-dep:ASSET=/mnt/sandbox/asset.txt"));
+        assert!(stored.contains("__kache_base_dir_0__/owned.rs"));
+    }
+
+    #[test]
+    fn portable_home_root_does_not_steal_nested_workspace_paths() {
+        let producer_roots = [(
+            PathBuf::from("/home/alice"),
+            "__kache_home__/".to_string(),
+            1,
+        )];
+        let stored = rewrite_rustc_depinfo_content_with_configured_roots(
+            "out: /home/alice/project/src/lib.rs /home/alice/shared/schema.json\n",
+            Path::new("/target"),
+            Path::new("/home/alice/project"),
+            Some(Path::new("/home/alice/project")),
+            &producer_roots,
+            DepInfoMode::Relativize,
+        );
+        assert!(stored.contains("__kache_cwd__/src/lib.rs"), "{stored}");
+        assert!(
+            stored.contains("__kache_home__/shared/schema.json"),
+            "{stored}"
+        );
+
+        let consumer_roots = [(
+            PathBuf::from("/Users/bob"),
+            "__kache_home__/".to_string(),
+            1,
+        )];
+        let restored = rewrite_rustc_depinfo_content_with_configured_roots(
+            &stored,
+            Path::new("/other-target"),
+            Path::new("/Users/bob/project"),
+            Some(Path::new("/Users/bob/project")),
+            &consumer_roots,
+            DepInfoMode::Expand,
+        );
+        assert!(restored.contains("/Users/bob/project/src/lib.rs"));
+        assert!(restored.contains("/Users/bob/shared/schema.json"));
+        assert!(!restored.contains("/home/alice"));
+    }
+
+    #[test]
+    fn depinfo_prefix_replacement_can_match_windows_ascii_case_aliases() {
+        assert_eq!(
+            replace_depinfo_text(
+                r"c:\\WORKTREE\\src\\lib.rs",
+                r"C:\\worktree\\",
+                DEPINFO_CWD_SENTINEL,
+                true,
+                DepInfoTextContext::MakeLine,
+            ),
+            r"__kache_cwd__/src\\lib.rs"
+        );
+        assert_eq!(
+            replace_depinfo_text(
+                "unrelated",
+                "C:\\worktree\\",
+                DEPINFO_CWD_SENTINEL,
+                true,
+                DepInfoTextContext::MakeLine,
+            ),
+            "unrelated"
+        );
+        assert_eq!(
+            replace_depinfo_text(
+                r"c:\WORKTREE\",
+                r"C:\worktree\",
+                DEPINFO_CWD_SENTINEL,
+                true,
+                DepInfoTextContext::MakeLine,
+            ),
+            DEPINFO_CWD_SENTINEL,
+            "a case-insensitive match ending exactly at EOF must be replaced"
+        );
+        assert_eq!(
+            replace_depinfo_text(
+                r"keep c:\WORKTREE\src\lib.rs and C:\worktree\asset.txt",
+                r"C:\worktree\",
+                DEPINFO_CWD_SENTINEL,
+                true,
+                DepInfoTextContext::MakeLine,
+            ),
+            r"keep __kache_cwd__/src\lib.rs and __kache_cwd__/asset.txt"
+        );
+    }
+
+    #[test]
+    fn windows_depinfo_prefixes_retain_drive_and_unc_verbatim_aliases() {
+        let drive = depinfo_prefixes_for_display(r"\\?\C:\Work", true, true);
+        assert!(drive.contains(&r"C:\Work\".to_string()));
+        assert!(drive.contains(&r"\\?\C:\Work\".to_string()));
+        assert!(drive.contains(&r"C:\Work/".to_string()));
+        assert!(drive.contains(&r"\\?\C:\Work/".to_string()));
+
+        let unc = depinfo_prefixes_for_display(r"\\?\UNC\server\share\root", true, true);
+        assert!(unc.contains(&r"\\server\share\root\".to_string()));
+        assert!(unc.contains(&r"\\?\UNC\server\share\root\".to_string()));
+
+        let expand = depinfo_prefixes_for_display(r"\\?\C:\Work", false, true);
+        assert!(!expand.iter().any(|prefix| prefix.starts_with(r"\\?\")));
+        assert!(expand.iter().all(|prefix| prefix.starts_with(r"C:\Work")));
+    }
+
+    #[test]
+    fn configured_windows_roots_keep_verbatim_and_plain_slots_distinct() {
+        let verbatim_drive = depinfo_prefixes_for_exact_display(r"\\?\C:\Work", true);
+        assert_eq!(verbatim_drive.len(), 2);
+        assert!(verbatim_drive.contains(&r"\\?\C:\Work/".to_string()));
+        assert!(verbatim_drive.contains(&r"\\?\C:\Work\".to_string()));
+        assert!(
+            verbatim_drive
+                .iter()
+                .all(|prefix| prefix.starts_with(r"\\?\"))
+        );
+        assert!(
+            !verbatim_drive
+                .iter()
+                .any(|prefix| prefix.starts_with(r"C:\Work"))
+        );
+
+        let verbatim_unc = depinfo_prefixes_for_exact_display(r"\\?\UNC\server\share", true);
+        assert_eq!(verbatim_unc.len(), 2);
+        assert!(verbatim_unc.contains(&r"\\?\UNC\server\share/".to_string()));
+        assert!(verbatim_unc.contains(&r"\\?\UNC\server\share\".to_string()));
+        assert!(
+            verbatim_unc
+                .iter()
+                .all(|prefix| prefix.starts_with(r"\\?\UNC\server\share"))
+        );
+        assert!(
+            !verbatim_unc
+                .iter()
+                .any(|prefix| prefix.starts_with(r"\\server\share"))
+        );
+
+        let input = r"out: \\?\C:\Work\src\verbatim.rs C:\Work\src\plain.rs \\?\UNC\server\share\src\verbatim_unc.rs \\server\share\src\plain_unc.rs";
+        let producer_roots = [
+            (
+                PathBuf::from(r"\\?\C:\Work"),
+                "__kache_base_dir_0__/".to_string(),
+            ),
+            (
+                PathBuf::from(r"C:\Work"),
+                "__kache_base_dir_1__/".to_string(),
+            ),
+            (
+                PathBuf::from(r"\\?\UNC\server\share"),
+                "__kache_base_dir_2__/".to_string(),
+            ),
+            (
+                PathBuf::from(r"\\server\share"),
+                "__kache_base_dir_3__/".to_string(),
+            ),
+        ];
+        let stored = producer_roots
+            .iter()
+            .fold(input.to_string(), |content, (root, sentinel)| {
+                rewrite_depinfo_content_with_exact_sentinel_for_platform(
+                    &content,
+                    root,
+                    sentinel,
+                    DepInfoMode::Relativize,
+                    true,
+                )
+            });
+        assert!(
+            stored.contains(r"__kache_base_dir_0__/src\verbatim.rs"),
+            "{stored}"
+        );
+        assert!(
+            stored.contains(r"__kache_base_dir_1__/src\plain.rs"),
+            "{stored}"
+        );
+        assert!(
+            stored.contains(r"__kache_base_dir_2__/src\verbatim_unc.rs"),
+            "{stored}"
+        );
+        assert!(
+            stored.contains(r"__kache_base_dir_3__/src\plain_unc.rs"),
+            "{stored}"
+        );
+
+        let consumer_roots = [
+            (
+                PathBuf::from(r"\\?\D:\Other"),
+                "__kache_base_dir_0__/".to_string(),
+            ),
+            (
+                PathBuf::from(r"D:\Other"),
+                "__kache_base_dir_1__/".to_string(),
+            ),
+            (
+                PathBuf::from(r"\\?\UNC\server2\share2"),
+                "__kache_base_dir_2__/".to_string(),
+            ),
+            (
+                PathBuf::from(r"\\server2\share2"),
+                "__kache_base_dir_3__/".to_string(),
+            ),
+        ];
+        let restored = consumer_roots
+            .iter()
+            .fold(stored, |content, (root, sentinel)| {
+                rewrite_depinfo_content_with_exact_sentinel_for_platform(
+                    &content,
+                    root,
+                    sentinel,
+                    DepInfoMode::Expand,
+                    true,
+                )
+            });
+        assert!(restored.contains(r"\\?\D:\Other\src\verbatim.rs"));
+        assert!(restored.contains(r"D:\Other\src\plain.rs"));
+        assert!(restored.contains(r"\\?\UNC\server2\share2\src\verbatim_unc.rs"));
+        assert!(restored.contains(r"\\server2\share2\src\plain_unc.rs"));
+        assert!(!restored.contains(r"C:\Work"));
+        assert!(!restored.contains(r"\\server\share"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn rustc_depinfo_rewrite_handles_native_windows_cwd_and_env_dep() {
+        let input = "D:\\WORK TREE\\target\\debug\\deps\\demo.d: \
+D:\\WORK TREE\\crate\\src\\lib.rs\n\
+# env-dep:ASSET=D:\\\\WORK TREE\\\\crate\\\\asset.txt\n";
+        let stored = rewrite_rustc_depinfo_content(
+            input,
+            Path::new(r"d:\work tree\target"),
+            Path::new(r"d:\work tree\crate"),
+            Some(Path::new(r"d:\work tree")),
+            DepInfoMode::Relativize,
+        );
+        assert!(stored.contains("__kache_root__/debug\\deps\\demo.d"));
+        assert!(stored.contains("__kache_cwd__/src\\lib.rs"));
+        assert!(stored.contains("# env-dep:ASSET=__kache_cwd__/asset.txt"));
+        assert!(!stored.to_ascii_lowercase().contains(r"d:\work tree"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn depinfo_relativize_matches_a_canonical_symlink_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real-target");
+        let alias = dir.path().join("target-alias");
+        std::fs::create_dir_all(&real).unwrap();
+        std::os::unix::fs::symlink(&real, &alias).unwrap();
+        let canonical = real.canonicalize().unwrap();
+        let input = format!(
+            "{}/debug/demo.d: {}/debug/input.rs\n",
+            canonical.display(),
+            canonical.display()
+        );
+
+        let stored = rewrite_depinfo_content(&input, &alias, DepInfoMode::Relativize);
+        assert_eq!(stored.matches(DEPINFO_ROOT_SENTINEL).count(), 2, "{stored}");
+        assert!(!stored.contains(canonical.to_str().unwrap()), "{stored}");
     }
 
     /// kunobi-ninja/kache#330: Windows dep-info uses backslash separators and

--- a/src/link.rs
+++ b/src/link.rs
@@ -2680,14 +2680,14 @@ S:\\proj\\target\\debug\\build\\demo-8a22\\out/generated.rs\n";
             "both references relativize: {rewritten}"
         );
 
-        // Expansion re-roots at the consumer with `/`, which Windows accepts.
+        // Expansion re-roots at the consumer using its native separator.
         let expanded = rewrite_depinfo_content(
             &rewritten,
             Path::new("T:\\other\\target"),
             DepInfoMode::Expand,
         );
         assert!(
-            expanded.contains("T:\\other\\target/debug\\build\\demo-8a22\\out/generated.rs"),
+            expanded.contains("T:\\other\\target\\debug\\build\\demo-8a22\\out/generated.rs"),
             "consumer-rooted mixed-separator path: {expanded}"
         );
         assert!(!expanded.contains(DEPINFO_ROOT_SENTINEL));

--- a/src/link.rs
+++ b/src/link.rs
@@ -1227,9 +1227,10 @@ pub fn rewrite_rustc_depinfo_content_with_configured_roots(
                     }),
             )
             .collect::<Vec<_>>();
-        roots.sort_by_key(|(root, _, priority, tie, _)| {
+        roots.sort_by_key(|(root, _, priority, tie, exact)| {
             std::cmp::Reverse((
                 *priority,
+                u8::from(*exact),
                 root.components().count(),
                 root.as_os_str().len(),
                 *tie,

--- a/src/link.rs
+++ b/src/link.rs
@@ -1327,11 +1327,20 @@ fn rewrite_depinfo_content_with_exact_sentinel_for_platform(
 
 fn depinfo_prefixes_for_exact_display(raw: &str, windows: bool) -> Vec<String> {
     if windows {
-        // Expand uses the first spelling. Verbatim Windows paths (`\\?\...`)
-        // do not accept forward slashes, so the native separator must lead.
-        vec![format!("{raw}\\"), format!("{raw}/")]
+        // Expand uses the first spelling. Preserve the configured spelling:
+        // verbatim/native Windows paths require `\`, while slash-form paths
+        // (including the platform-neutral paths used by pure tests) keep `/`.
+        let (first, second) = if windows_display_prefers_backslash(raw) {
+            ('\\', '/')
+        } else {
+            ('/', '\\')
+        };
+        vec![
+            with_trailing_separator(raw, first),
+            with_trailing_separator(raw, second),
+        ]
     } else {
-        vec![format!("{raw}/")]
+        vec![with_trailing_separator(raw, '/')]
     }
 }
 
@@ -1340,6 +1349,22 @@ fn rewrite_depinfo_content_with_sentinel(
     project_dir: &Path,
     sentinel: &str,
     mode: DepInfoMode,
+) -> String {
+    rewrite_depinfo_content_with_sentinel_for_platform(
+        content,
+        project_dir,
+        sentinel,
+        mode,
+        cfg!(windows),
+    )
+}
+
+fn rewrite_depinfo_content_with_sentinel_for_platform(
+    content: &str,
+    project_dir: &Path,
+    sentinel: &str,
+    mode: DepInfoMode,
+    windows: bool,
 ) -> String {
     let mut roots = vec![project_dir.to_path_buf()];
     if matches!(mode, DepInfoMode::Relativize)
@@ -1353,11 +1378,11 @@ fn rewrite_depinfo_content_with_sentinel(
         prefixes.extend(depinfo_prefixes_for_display(
             &root.to_string_lossy(),
             matches!(mode, DepInfoMode::Relativize),
-            cfg!(windows),
+            windows,
         ));
     }
-    prefixes.sort();
-    prefixes.dedup();
+    let mut seen = std::collections::HashSet::new();
+    prefixes.retain(|prefix| seen.insert(prefix.clone()));
     rewrite_depinfo_content_with_prefixes_and_sentinel(content, &prefixes, sentinel, mode)
 }
 
@@ -1377,12 +1402,54 @@ fn depinfo_prefixes_for_display(
     }
     let mut prefixes = Vec::new();
     for display in displays {
-        prefixes.push(format!("{display}/"));
         if windows {
-            prefixes.push(format!("{display}\\"));
+            let prefers_backslash = windows_display_prefers_backslash(&display);
+            let verbatim = display.starts_with(r"\\?\");
+            let preferred = if verbatim {
+                display.clone()
+            } else if prefers_backslash {
+                display.replace('/', "\\")
+            } else {
+                display.replace('\\', "/")
+            };
+            let alternate = if prefers_backslash {
+                display.replace('\\', "/")
+            } else {
+                display.replace('/', "\\")
+            };
+            let (first, second) = if prefers_backslash {
+                ('\\', '/')
+            } else {
+                ('/', '\\')
+            };
+            prefixes.push(with_trailing_separator(&preferred, first));
+            prefixes.push(with_trailing_separator(&display, first));
+            prefixes.push(with_trailing_separator(&display, second));
+            if retain_verbatim_alias && !verbatim {
+                prefixes.push(with_trailing_separator(&alternate, second));
+            }
+        } else {
+            prefixes.push(with_trailing_separator(&display, '/'));
         }
     }
     prefixes
+}
+
+fn windows_display_prefers_backslash(display: &str) -> bool {
+    let bytes = display.as_bytes();
+    display.starts_with('\\')
+        || (bytes.first().is_some_and(u8::is_ascii_alphabetic)
+            && bytes.get(1) == Some(&b':')
+            && bytes.get(2) == Some(&b'\\'))
+}
+
+fn with_trailing_separator(display: &str, separator: char) -> String {
+    let mut value = display.to_string();
+    if value.ends_with('/') || value.ends_with('\\') {
+        value.pop();
+    }
+    value.push(separator);
+    value
 }
 
 /// Prefix-parameterized core of the Windows [`rewrite_depinfo_content`]
@@ -2390,6 +2457,47 @@ __kache_target_rule__/debug/build/demo/out/generated.rs\n"
         let expand = depinfo_prefixes_for_display(r"\\?\C:\Work", false, true);
         assert!(!expand.iter().any(|prefix| prefix.starts_with(r"\\?\")));
         assert!(expand.iter().all(|prefix| prefix.starts_with(r"C:\Work")));
+    }
+
+    #[test]
+    fn windows_depinfo_expansion_preserves_native_and_slash_root_styles() {
+        assert!(windows_display_prefers_backslash(r"C:\work"));
+        assert!(windows_display_prefers_backslash(r"\\?\C:\work"));
+        assert!(windows_display_prefers_backslash(r"\\server\share"));
+        assert!(!windows_display_prefers_backslash("C:/work"));
+        assert!(!windows_display_prefers_backslash("/external/work"));
+
+        assert_eq!(with_trailing_separator("/", '/'), "/");
+        assert_eq!(with_trailing_separator("/work/", '/'), "/work/");
+        assert_eq!(with_trailing_separator(r"C:\", '\\'), r"C:\");
+        assert_eq!(with_trailing_separator(r"C:\work\", '/'), "C:\\work/");
+
+        let native = rewrite_depinfo_content_with_sentinel_for_platform(
+            "__kache_root__/debug/deps/demo.d\n",
+            Path::new(r"C:\work\target"),
+            DEPINFO_ROOT_SENTINEL,
+            DepInfoMode::Expand,
+            true,
+        );
+        assert_eq!(native, "C:\\work\\target\\debug/deps/demo.d\n");
+
+        let slash = rewrite_depinfo_content_with_sentinel_for_platform(
+            "__kache_root__/debug/deps/demo.d\n",
+            Path::new("/external/target"),
+            DEPINFO_ROOT_SENTINEL,
+            DepInfoMode::Expand,
+            true,
+        );
+        assert_eq!(slash, "/external/target/debug/deps/demo.d\n");
+
+        let mixed = rewrite_depinfo_content_with_sentinel_for_platform(
+            "/build/work/target/debug/deps/demo.d\n",
+            Path::new(r"/build/work\target"),
+            DEPINFO_ROOT_SENTINEL,
+            DepInfoMode::Relativize,
+            true,
+        );
+        assert_eq!(mixed, "__kache_root__/debug/deps/demo.d\n");
     }
 
     #[test]

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -3371,7 +3371,7 @@ mod tests {
             crate::link::DepInfoMode::Relativize,
         );
         assert!(
-            stored.contains("__kache_base_dir_0__/checkout/src/lib.rs"),
+            stored.contains(&format!("__kache_base_dir_0__/{relative}")),
             "{stored}"
         );
         assert!(!stored.contains("__kache_cwd__/"), "{stored}");

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -129,6 +129,10 @@ struct Rule {
     /// Key portability depends on this; unchanged from the original
     /// single-sentinel design.
     key_sentinel: String,
+    /// Source-key owner. Usually identical to `key_sentinel`, except the
+    /// process CWD and workspace root need distinct identities even though
+    /// rustc remaps both to the same debug-path target.
+    source_sentinel: String,
     /// Absolute, profiler-resolvable path injected into rustc
     /// `--remap-path-prefix` by [`PathNormalizer::remap_args`] so the spelling
     /// baked into debug info is resolvable by samply / the Firefox Profiler and
@@ -136,6 +140,24 @@ struct Rule {
     /// from `key_sentinel` so debug-info resolvability and cache-key portability
     /// evolve independently (kunobi-ninja/kache#480, #485).
     flag_target: String,
+}
+
+/// A user-configured source root that can be represented losslessly in source
+/// keys and round-tripped through rustc dep-info.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConfiguredSourceRoot {
+    pub root: PathBuf,
+    pub key_sentinel: String,
+    pub depinfo_sentinel: String,
+    pub priority: u8,
+}
+
+#[derive(Debug, Clone)]
+struct ConfiguredSourceRootGroup {
+    restore_root: PathBuf,
+    aliases: Vec<PathBuf>,
+    key_sentinel: String,
+    depinfo_sentinel: String,
 }
 
 /// Replaces machine-local path prefixes with stable sentinels so
@@ -153,6 +175,14 @@ pub struct PathNormalizer {
     /// from the expanded/deduplicated rules: two configured symlinks may
     /// resolve to the same prefix without ceasing to be two configured slots.
     configured_base_dir_count: usize,
+    /// Existing configured roots grouped by stable slot. The lexical root is
+    /// always emitted first for dep-info expansion; canonical/Windows aliases
+    /// are accepted only while relativizing producer paths.
+    configured_source_root_groups: Vec<ConfiguredSourceRootGroup>,
+    /// Lexical consumer root for automatic owners whose rule list also carries
+    /// canonical, Unicode, Windows, or 8.3 aliases. Key/remap matching may use
+    /// any alias; dep-info expansion must return to this designated spelling.
+    source_restore_roots: Vec<(String, PathBuf)>,
     /// Plain env vars and scoped `rustc_crate_name:VAR` assertions opted into
     /// path-only cache-key normalization. See
     /// [`crate::config::Config::path_only_env_vars`].
@@ -191,6 +221,7 @@ impl PathNormalizer {
     /// flow through tempdirs.
     pub fn from_env(workspace_root: Option<&Path>) -> Self {
         let mut rules = Vec::new();
+        let mut source_restore_roots = Vec::new();
 
         // User-declared base dir (`KACHE_BASE_DIR`, the analog of ccache's
         // `CCACHE_BASEDIR`). Highest priority — an explicit prefix the
@@ -198,33 +229,42 @@ impl PathNormalizer {
         // checkout location. Covers paths the auto-derived rules below
         // can't see (container mounts, generated-file env-deps that point
         // outside the workspace, etc.).
-        push_rule_with_variants(
+        let legacy_base_dir = std::env::var_os("KACHE_BASE_DIR");
+        push_legacy_base_dir_rules(
             &mut rules,
-            std::env::var_os("KACHE_BASE_DIR")
-                .filter(|v| !v.is_empty())
-                .and_then(|v| canonical_string(Path::new(&v))),
-            "<BASE_DIR>",
+            &mut source_restore_roots,
+            legacy_base_dir.as_deref(),
         );
 
-        push_rule_with_variants(
-            &mut rules,
-            std::env::current_dir()
-                .ok()
-                .and_then(|p| canonical_string(&p)),
-            "<WORKSPACE>",
-        );
+        if let Ok(current_dir) = std::env::current_dir() {
+            push_path_rule_aliases(
+                &mut rules,
+                &mut source_restore_roots,
+                &current_dir,
+                "<WORKSPACE>",
+                "<CWD>",
+            );
+        }
 
-        push_rule_with_variants(
-            &mut rules,
-            workspace_root.and_then(canonical_string),
-            "<WORKSPACE>",
-        );
+        if let Some(workspace_root) = workspace_root {
+            push_path_rule_aliases(
+                &mut rules,
+                &mut source_restore_roots,
+                workspace_root,
+                "<WORKSPACE>",
+                "<WORKSPACE>",
+            );
+        }
 
-        push_rule_with_variants(
-            &mut rules,
-            std::env::var_os("CARGO_TARGET_DIR").and_then(|p| canonical_string(Path::new(&p))),
-            "<TARGET>",
-        );
+        if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+            push_path_rule_aliases(
+                &mut rules,
+                &mut source_restore_roots,
+                Path::new(&target_dir),
+                "<TARGET>",
+                "<TARGET>",
+            );
+        }
 
         // CARGO_HOME defaults to $HOME/.cargo if not set; honor that
         // so users with the default layout still get the substitution.
@@ -298,6 +338,8 @@ impl PathNormalizer {
         Self {
             rules,
             configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots,
             path_only_env_vars: Vec::new(),
         }
     }
@@ -317,8 +359,8 @@ impl PathNormalizer {
     /// Within this explicit list, longer prefixes are placed first so an
     /// overlapping child root wins over its parent.
     pub fn with_base_dirs(mut self, base_dirs: &[String]) -> Self {
-        let (configured_count, mut extra_rules) = configured_base_dir_rules(base_dirs);
-        self.configured_base_dir_count = configured_count;
+        let (configured, mut extra_rules) = configured_base_dir_rules(base_dirs);
+        self.configured_base_dir_count = configured.len();
 
         let legacy_prefixes: std::collections::HashSet<String> = self
             .rules
@@ -343,6 +385,39 @@ impl PathNormalizer {
         let mut seen = std::collections::HashSet::new();
         extra_rules.retain(|rule| seen.insert(rule.prefix.clone()));
         self.rules = extra_rules;
+        self.configured_source_root_groups = configured
+            .iter()
+            .enumerate()
+            .filter_map(|(index, lexical)| {
+                let restore_root = PathBuf::from(lexical);
+                if !restore_root.exists() {
+                    return None;
+                }
+                let key_sentinel = configured_base_dir_sentinel(index);
+                if self
+                    .source_rule_for_path(&restore_root)
+                    .is_none_or(|winner| winner.key_sentinel != key_sentinel)
+                {
+                    return None;
+                }
+                let depinfo_sentinel = format!("__kache_base_dir_{index}__/");
+                let aliases = self
+                    .rules
+                    .iter()
+                    .filter(|rule| rule.key_sentinel == key_sentinel)
+                    .filter(|rule| is_native_configured_path(&rule.prefix))
+                    .filter(|rule| rule.prefix != *lexical)
+                    .map(|rule| PathBuf::from(&rule.prefix))
+                    .filter(|alias| alias.exists())
+                    .collect();
+                Some(ConfiguredSourceRootGroup {
+                    restore_root,
+                    aliases,
+                    key_sentinel,
+                    depinfo_sentinel,
+                })
+            })
+            .collect();
         self
     }
 
@@ -375,6 +450,145 @@ impl PathNormalizer {
             .iter()
             .map(|r| r.prefix.as_str())
             .filter(|p| !p.is_empty())
+    }
+
+    /// Existing configured roots with raw OS-path identity preserved.
+    ///
+    /// Non-existent cross-platform entries remain useful for flag remapping
+    /// but cannot contain a source in this invocation, so they are omitted.
+    /// Each returned spelling is an actual winning rustc remap rule. Do not
+    /// canonicalize or merge them: a configured symlink and its target may be
+    /// distinct configured slots, and dep-info must retain that ownership.
+    pub(crate) fn depinfo_source_roots(&self) -> Vec<ConfiguredSourceRoot> {
+        let mut groups = self.configured_source_root_groups.clone();
+        for source_sentinel in [
+            "<CWD>",
+            "<WORKSPACE>",
+            "<TARGET>",
+            "<CARGO_HOME>",
+            "<BASE_DIR>",
+            "<RUSTUP_HOME>",
+            "<HOME>",
+            "<APPDATA>",
+            "<LOCALAPPDATA>",
+            "<PROGRAMFILES>",
+            "<TMPDIR>",
+        ] {
+            let owned_rules = self
+                .rules
+                .iter()
+                .filter(|rule| rule.source_sentinel == source_sentinel)
+                .filter(|rule| is_native_configured_path(&rule.prefix))
+                .filter(|rule| Path::new(&rule.prefix).exists())
+                .collect::<Vec<_>>();
+            let designated = self
+                .source_restore_roots
+                .iter()
+                .find(|(sentinel, _)| sentinel == source_sentinel)
+                .map(|(_, root)| root.clone());
+            let restore_root = designated
+                .and_then(|root| {
+                    self.source_rule_for_path(&root)
+                        .is_some_and(|rule| rule.source_sentinel == source_sentinel)
+                        .then_some(root)
+                })
+                .or_else(|| {
+                    owned_rules.iter().find_map(|rule| {
+                        let root = PathBuf::from(&rule.prefix);
+                        self.source_rule_for_path(&root)
+                            .is_some_and(|winner| winner.source_sentinel == source_sentinel)
+                            .then_some(root)
+                    })
+                });
+            if let Some(restore_root) = restore_root {
+                let restore_spelling = restore_root.as_os_str();
+                let aliases = owned_rules
+                    .iter()
+                    .filter(|rule| {
+                        self.source_rule_for_path(Path::new(&rule.prefix))
+                            .is_some_and(|winner| winner.source_sentinel == source_sentinel)
+                    })
+                    .filter(|rule| std::ffi::OsStr::new(&rule.prefix) != restore_spelling)
+                    .map(|rule| PathBuf::from(&rule.prefix))
+                    .collect();
+                let Some(key_sentinel) = self
+                    .source_rule_for_path(&restore_root)
+                    .map(|rule| rule.key_sentinel.clone())
+                else {
+                    continue;
+                };
+                groups.push(ConfiguredSourceRootGroup {
+                    restore_root,
+                    aliases,
+                    key_sentinel,
+                    depinfo_sentinel: depinfo_sentinel_for_source(source_sentinel)
+                        .expect("listed source roots have dep-info sentinels"),
+                });
+            }
+        }
+        groups.sort_by_key(|group| {
+            let longest = std::iter::once(&group.restore_root)
+                .chain(group.aliases.iter())
+                .map(|root| root.as_os_str().len())
+                .max()
+                .unwrap_or_default();
+            std::cmp::Reverse((flag_emit_rank(&group.key_sentinel), longest))
+        });
+        groups
+            .into_iter()
+            .flat_map(|group| {
+                let key_sentinel = group.key_sentinel;
+                let depinfo_sentinel = group.depinfo_sentinel;
+                std::iter::once(group.restore_root)
+                    .chain(group.aliases)
+                    .map(move |root| ConfiguredSourceRoot {
+                        root,
+                        key_sentinel: key_sentinel.clone(),
+                        depinfo_sentinel: depinfo_sentinel.clone(),
+                        priority: flag_emit_rank(&key_sentinel),
+                    })
+            })
+            .collect()
+    }
+
+    /// Lossless source identity matching the rule rustc will actually apply.
+    ///
+    /// `remap_args` is last-match-wins by semantic rank, then prefix length.
+    /// Reusing that exact ordering prevents a key from collapsing paths that
+    /// rustc embeds differently (notably nested target/workspace roots).
+    /// Non-UTF-8 or unmatched paths return `None` so callers can bind an opaque
+    /// machine-local identity instead of guessing.
+    pub(crate) fn source_path_identity(&self, path: &Path) -> Option<Vec<u8>> {
+        let input = path.as_os_str().to_str()?;
+        let winner = self.source_rule_for_path(path)?;
+        depinfo_sentinel_for_source(&winner.source_sentinel)?;
+        let remainder = input.strip_prefix(&winner.prefix)?;
+        let remainder = remainder
+            .strip_prefix('/')
+            .or_else(|| remainder.strip_prefix('\\'))
+            .unwrap_or(remainder);
+        let mut identity = winner.source_sentinel.as_bytes().to_vec();
+        if !remainder.is_empty() {
+            identity.push(b'/');
+            identity.extend_from_slice(remainder.as_bytes());
+        }
+        Some(identity)
+    }
+
+    fn source_rule_for_path<'a>(&'a self, path: &Path) -> Option<&'a Rule> {
+        let input = path.as_os_str().to_str()?;
+        self.rules
+            .iter()
+            .filter(|rule| !rule.prefix.is_empty())
+            .filter_map(|rule| {
+                input.strip_prefix(&rule.prefix)?;
+                if !configured_prefix_boundaries_match(input, 0, rule.prefix.len(), &rule.prefix) {
+                    return None;
+                }
+                Some((flag_emit_rank(&rule.key_sentinel), rule.prefix.len(), rule))
+            })
+            .max_by_key(|(rank, prefix_len, _)| (*rank, *prefix_len))
+            .map(|(_, _, rule)| rule)
     }
 
     /// Add the toolchain-source rule that re-virtualizes rust std/core paths to
@@ -448,6 +662,8 @@ impl PathNormalizer {
         Self {
             rules: Vec::new(),
             configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots: Vec::new(),
             path_only_env_vars: Vec::new(),
         }
     }
@@ -675,11 +891,15 @@ fn flag_emit_rank(key_sentinel: &str) -> u8 {
 /// Otherwise `/a-link -> /z-real` could steal the exact `/z-real` spelling
 /// from a second configured entry and make sentinel assignment depend on
 /// whether the symlink exists on this host.
-fn configured_base_dir_rules(base_dirs: &[String]) -> (usize, Vec<Rule>) {
+fn configured_base_dir_rules(base_dirs: &[String]) -> (Vec<String>, Vec<Rule>) {
     let mut configured = base_dirs.to_vec();
     configured.sort();
     configured.dedup();
-    let configured_count = configured.len();
+    // Production configuration rejects filesystem roots. Keep this builder
+    // fail-safe for direct/test callers too: mapping `/` or `C:/` would erase
+    // every absolute-path distinction and cannot be safely represented in
+    // dep-info with whole-string replacement.
+    configured.retain(|path| !is_filesystem_root_prefix(path));
 
     let mut lexical_rules = Vec::new();
     for (index, path) in configured.iter().enumerate() {
@@ -700,16 +920,18 @@ fn configured_base_dir_rules(base_dirs: &[String]) -> (usize, Vec<Rule>) {
         if !is_native_configured_path(path) {
             continue;
         }
-        let Some(canonical) = canonical_string(Path::new(path)) else {
+        let Ok(canonical) = Path::new(path).canonicalize() else {
             continue;
         };
-        if canonical == lexical {
-            continue;
+        for canonical in os_path_spellings(&canonical) {
+            if canonical == lexical {
+                continue;
+            }
+            let mut candidates = Vec::new();
+            push_configured_base_dir_rule(&mut candidates, canonical, index);
+            candidates.retain(|rule| !reserved_lexical.contains(&rule.prefix));
+            alias_rules.extend(candidates);
         }
-        let mut candidates = Vec::new();
-        push_configured_base_dir_rule(&mut candidates, canonical, index);
-        candidates.retain(|rule| !reserved_lexical.contains(&rule.prefix));
-        alias_rules.extend(candidates);
     }
 
     lexical_rules.extend(alias_rules);
@@ -723,7 +945,7 @@ fn configured_base_dir_rules(base_dirs: &[String]) -> (usize, Vec<Rule>) {
     });
     let mut seen = std::collections::HashSet::new();
     lexical_rules.retain(|rule| seen.insert(rule.prefix.clone()));
-    (configured_count, lexical_rules)
+    (configured, lexical_rules)
 }
 
 fn push_configured_base_dir_rule(rules: &mut Vec<Rule>, prefix: String, index: usize) {
@@ -735,6 +957,7 @@ fn push_configured_base_dir_rule(rules: &mut Vec<Rule>, prefix: String, index: u
     rules.push(Rule {
         prefix: prefix.clone(),
         key_sentinel: sentinel.clone(),
+        source_sentinel: sentinel.clone(),
         flag_target: target.clone(),
     });
 
@@ -742,16 +965,17 @@ fn push_configured_base_dir_rule(rules: &mut Vec<Rule>, prefix: String, index: u
     // entry's syntax, not the OS running kache. In particular, `/snap` must not
     // gain a `\snap` alias merely because the client runs on Windows.
     if is_windows_absolute_path(&prefix) {
-        push_slash_and_case_variants(rules, &prefix, &sentinel, &target);
+        push_slash_and_case_variants(rules, &prefix, &sentinel, &sentinel, &target);
         if let Some(short) = short_path_name(&prefix)
             && short != prefix
         {
             rules.push(Rule {
                 prefix: short.clone(),
                 key_sentinel: sentinel.clone(),
+                source_sentinel: sentinel.clone(),
                 flag_target: target.clone(),
             });
-            push_slash_and_case_variants(rules, &short, &sentinel, &target);
+            push_slash_and_case_variants(rules, &short, &sentinel, &sentinel, &target);
         }
     }
 }
@@ -801,6 +1025,29 @@ fn configured_base_dir_index(sentinel: &str) -> Option<usize> {
         .strip_suffix('>')?
         .parse()
         .ok()
+}
+
+fn depinfo_sentinel_for_source(source_sentinel: &str) -> Option<String> {
+    if let Some(index) = configured_base_dir_index(source_sentinel) {
+        return Some(format!("__kache_base_dir_{index}__/"));
+    }
+    Some(
+        match source_sentinel {
+            "<CWD>" => "__kache_cwd__/",
+            "<WORKSPACE>" => "__kache_workspace__/",
+            "<TARGET>" => "__kache_target_rule__/",
+            "<CARGO_HOME>" => "__kache_cargo_home__/",
+            "<BASE_DIR>" => "__kache_base_dir__/",
+            "<RUSTUP_HOME>" => "__kache_rustup_home__/",
+            "<HOME>" => "__kache_home__/",
+            "<APPDATA>" => "__kache_appdata__/",
+            "<LOCALAPPDATA>" => "__kache_localappdata__/",
+            "<PROGRAMFILES>" => "__kache_programfiles__/",
+            "<TMPDIR>" => "__kache_tmpdir__/",
+            _ => return None,
+        }
+        .to_string(),
+    )
 }
 
 /// The resolvable `--remap-path-prefix` target for a given cache-key sentinel.
@@ -984,6 +1231,30 @@ fn strip_verbatim_prefix(s: &str) -> std::borrow::Cow<'_, str> {
     }
 }
 
+pub(crate) fn is_filesystem_root_prefix(value: &str) -> bool {
+    let value = strip_verbatim_prefix(value);
+    if value == "/" {
+        return true;
+    }
+    let bytes = value.as_bytes();
+    if bytes.len() == 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'/' | b'\\')
+    {
+        return true;
+    }
+
+    let normalized = value.replace('\\', "/");
+    let Some(unc) = normalized.strip_prefix("//") else {
+        return false;
+    };
+    let mut components = unc.trim_end_matches('/').split('/');
+    components.next().is_some_and(|part| !part.is_empty())
+        && components.next().is_some_and(|part| !part.is_empty())
+        && components.next().is_none()
+}
+
 /// Push a rule + its Windows-shape variants into the rule list.
 ///
 /// On unix, this is just `rules.push(Rule { prefix, sentinel })` —
@@ -1021,6 +1292,91 @@ fn push_rule_with_variants(rules: &mut Vec<Rule>, prefix: Option<String>, sentin
     push_rule_with_variants_target(rules, prefix, sentinel, &flag_target);
 }
 
+fn push_rule_with_variants_source(
+    rules: &mut Vec<Rule>,
+    prefix: Option<String>,
+    sentinel: &str,
+    source_sentinel: &str,
+) {
+    let flag_target = flag_target_for(sentinel);
+    push_rule_with_variants_target_and_source(
+        rules,
+        prefix,
+        sentinel,
+        source_sentinel,
+        &flag_target,
+    );
+}
+
+/// Add lexical and canonical spellings for one automatic source root.
+///
+/// Cargo can pass a lexical root while proc macros canonicalize included
+/// files (`/var` versus `/private/var` on macOS, plain versus `\\?\` on
+/// Windows). Every spelling maps to the same source identity/remap target and
+/// is exposed through [`PathNormalizer::depinfo_source_roots`].
+fn push_path_rule_aliases(
+    rules: &mut Vec<Rule>,
+    source_restore_roots: &mut Vec<(String, PathBuf)>,
+    path: &Path,
+    sentinel: &str,
+    source_sentinel: &str,
+) {
+    let lexical = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+    source_restore_roots.push((source_sentinel.to_string(), lexical.clone()));
+    let mut spellings = os_path_spellings(&lexical);
+    if let Ok(canonical) = path.canonicalize()
+        && canonical != lexical
+    {
+        spellings.extend(os_path_spellings(&canonical));
+    }
+    spellings.sort_by_key(|prefix| std::cmp::Reverse(prefix.len()));
+    spellings.dedup();
+    for prefix in spellings {
+        push_rule_with_variants_source(rules, Some(prefix), sentinel, source_sentinel);
+    }
+}
+
+/// Add the legacy explicit source root without letting an empty value or a
+/// filesystem root erase every absolute-path distinction.
+fn push_legacy_base_dir_rules(
+    rules: &mut Vec<Rule>,
+    source_restore_roots: &mut Vec<(String, PathBuf)>,
+    base_dir: Option<&std::ffi::OsStr>,
+) {
+    let Some(base_dir) = base_dir.filter(|value| !value.is_empty()) else {
+        return;
+    };
+    let path = Path::new(base_dir);
+    let absolute = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+    let Some(prefix) = absolute.as_os_str().to_str() else {
+        return;
+    };
+    if is_filesystem_root_prefix(prefix) {
+        return;
+    }
+    push_path_rule_aliases(
+        rules,
+        source_restore_roots,
+        path,
+        "<BASE_DIR>",
+        "<BASE_DIR>",
+    );
+}
+
+/// Preserve raw filesystem spelling while also adding the NFC/key form and
+/// the ordinary Windows spelling of a verbatim canonical path.
+fn os_path_spellings(path: &Path) -> Vec<String> {
+    let Some(raw) = path.as_os_str().to_str().filter(|value| !value.is_empty()) else {
+        return Vec::new();
+    };
+    let normalized: String = raw.nfc().collect();
+    let stripped = strip_verbatim_prefix(&normalized).into_owned();
+    let mut spellings = vec![raw.to_string(), normalized, stripped];
+    spellings.retain(|spelling| !is_filesystem_root_prefix(spelling));
+    spellings.dedup();
+    spellings
+}
+
 /// As [`push_rule_with_variants`] but with an explicit `flag_target`, for rules
 /// whose target isn't derivable from the sentinel alone (e.g. `<RUST_SRC>` →
 /// `/rustc/<commit-hash>`).
@@ -1028,6 +1384,16 @@ fn push_rule_with_variants_target(
     rules: &mut Vec<Rule>,
     prefix: Option<String>,
     sentinel: &str,
+    flag_target: &str,
+) {
+    push_rule_with_variants_target_and_source(rules, prefix, sentinel, sentinel, flag_target);
+}
+
+fn push_rule_with_variants_target_and_source(
+    rules: &mut Vec<Rule>,
+    prefix: Option<String>,
+    sentinel: &str,
+    source_sentinel: &str,
     flag_target: &str,
 ) {
     let Some(prefix) = prefix else { return };
@@ -1039,6 +1405,7 @@ fn push_rule_with_variants_target(
     rules.push(Rule {
         prefix: prefix.clone(),
         key_sentinel: sentinel.to_string(),
+        source_sentinel: source_sentinel.to_string(),
         flag_target: flag_target.to_string(),
     });
 
@@ -1049,7 +1416,7 @@ fn push_rule_with_variants_target(
         return;
     }
 
-    push_slash_and_case_variants(rules, &prefix, sentinel, flag_target);
+    push_slash_and_case_variants(rules, &prefix, sentinel, source_sentinel, flag_target);
 
     // 8.3 short-name form (issue #126). Resolved once at rule-build
     // time; `None` when the path doesn't exist, has no short name, or
@@ -1061,9 +1428,10 @@ fn push_rule_with_variants_target(
         rules.push(Rule {
             prefix: short.clone(),
             key_sentinel: sentinel.to_string(),
+            source_sentinel: source_sentinel.to_string(),
             flag_target: flag_target.to_string(),
         });
-        push_slash_and_case_variants(rules, &short, sentinel, flag_target);
+        push_slash_and_case_variants(rules, &short, sentinel, source_sentinel, flag_target);
     }
 }
 
@@ -1075,12 +1443,14 @@ fn push_slash_and_case_variants(
     rules: &mut Vec<Rule>,
     prefix: &str,
     sentinel: &str,
+    source_sentinel: &str,
     flag_target: &str,
 ) {
     let push = |rules: &mut Vec<Rule>, p: String| {
         rules.push(Rule {
             prefix: p,
             key_sentinel: sentinel.to_string(),
+            source_sentinel: source_sentinel.to_string(),
             flag_target: flag_target.to_string(),
         });
     };
@@ -1313,9 +1683,12 @@ mod tests {
             rules: vec![Rule {
                 prefix: String::new(),
                 key_sentinel: "<NEVER>".to_string(),
+                source_sentinel: "<NEVER>".to_string(),
                 flag_target: "<NEVER>".to_string(),
             }],
             configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots: Vec::new(),
             path_only_env_vars: Vec::new(),
         };
         assert_eq!(n.normalize("hello world"), "hello world");
@@ -1506,9 +1879,12 @@ mod tests {
             rules: vec![Rule {
                 prefix: String::new(),
                 key_sentinel: "<NEVER>".to_string(),
+                source_sentinel: "<NEVER>".to_string(),
                 flag_target: "<NEVER>".to_string(),
             }],
             configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots: Vec::new(),
             path_only_env_vars: Vec::new(),
         };
         assert!(n.remap_args().is_empty());
@@ -1629,6 +2005,8 @@ mod tests {
         let n = PathNormalizer {
             rules,
             configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots: Vec::new(),
             path_only_env_vars: Vec::new(),
         };
 
@@ -1637,6 +2015,16 @@ mod tests {
         assert!(
             out.contains("<BASE_DIR>"),
             "8.3 short-name input {input:?} should normalize via the short variant, got {out:?}"
+        );
+        assert_eq!(
+            n.source_path_identity(Path::new(&input)).unwrap(),
+            b"<BASE_DIR>/src\\main.rs"
+        );
+        assert!(
+            n.depinfo_source_roots()
+                .iter()
+                .any(|root| root.root == PathBuf::from(&short)),
+            "the same short spelling must be accepted while relativizing dep-info"
         );
     }
 
@@ -1667,6 +2055,8 @@ mod tests {
         let n = PathNormalizer {
             rules,
             configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots: Vec::new(),
             path_only_env_vars: Vec::new(),
         };
 
@@ -1730,6 +2120,8 @@ mod tests {
         let names: Vec<_> = rules_for(&PathNormalizer {
             rules,
             configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots: Vec::new(),
             path_only_env_vars: Vec::new(),
         })
         .into_iter()
@@ -1786,10 +2178,13 @@ mod tests {
                 .map(|(p, s)| Rule {
                     prefix: p.to_string(),
                     key_sentinel: s.to_string(),
+                    source_sentinel: s.to_string(),
                     flag_target: flag_target_for(s),
                 })
                 .collect(),
             configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots: Vec::new(),
             path_only_env_vars: Vec::new(),
         }
     }
@@ -2118,6 +2513,8 @@ mod tests {
         let n = PathNormalizer {
             rules,
             configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots: Vec::new(),
             path_only_env_vars: Vec::new(),
         };
         let args = n.remap_args();
@@ -2213,6 +2610,46 @@ mod tests {
         // Plain paths (and all Unix paths) pass through untouched.
         assert_eq!(strip_verbatim_prefix(r"C:\proj\out"), r"C:\proj\out");
         assert_eq!(strip_verbatim_prefix("/home/u/proj"), "/home/u/proj");
+    }
+
+    #[test]
+    fn filesystem_root_prefix_distinguishes_unc_share_roots() {
+        for root in [
+            "//server/share",
+            "//server/share/",
+            r"\\server\share",
+            r"\\server\share\",
+            r"\\?\UNC\server\share",
+        ] {
+            assert!(is_filesystem_root_prefix(root), "{root:?}");
+        }
+        for narrower_or_incomplete in [
+            "//server",
+            "//server/",
+            "///share",
+            "//server/share/app",
+            r"\\server\share\app",
+        ] {
+            assert!(
+                !is_filesystem_root_prefix(narrower_or_incomplete),
+                "{narrower_or_incomplete:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn os_path_spellings_keep_raw_and_plain_verbatim_windows_forms() {
+        assert_eq!(
+            os_path_spellings(Path::new(r"\\?\C:\Work\Root")),
+            vec![r"\\?\C:\Work\Root".to_string(), r"C:\Work\Root".to_string()]
+        );
+        assert_eq!(
+            os_path_spellings(Path::new(r"\\?\UNC\server\share\Root")),
+            vec![
+                r"\\?\UNC\server\share\Root".to_string(),
+                r"\\server\share\Root".to_string()
+            ]
+        );
     }
 
     #[test]
@@ -2355,6 +2792,74 @@ mod tests {
         assert!(is_native_configured_path_for(r"\\server\share", true));
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn configured_plain_root_owns_verbatim_canonical_sources_and_depinfo() {
+        let producer = TempDir::new().unwrap();
+        let consumer = TempDir::new().unwrap();
+        let producer_root = producer.path().join("Configured Root");
+        let consumer_root = consumer.path().join("Configured Root");
+        std::fs::create_dir_all(producer_root.join("src")).unwrap();
+        std::fs::create_dir_all(consumer_root.join("src")).unwrap();
+        std::fs::write(producer_root.join("src/value.rs"), "pub const V: u8 = 1;").unwrap();
+
+        let producer_cfg = producer_root.to_string_lossy().into_owned();
+        let consumer_cfg = consumer_root.to_string_lossy().into_owned();
+        let producer_normalizer =
+            PathNormalizer::empty().with_base_dirs(std::slice::from_ref(&producer_cfg));
+        let consumer_normalizer =
+            PathNormalizer::empty().with_base_dirs(std::slice::from_ref(&consumer_cfg));
+        let canonical_source = producer_root.join("src/value.rs").canonicalize().unwrap();
+
+        assert_eq!(
+            producer_normalizer
+                .source_path_identity(&canonical_source)
+                .unwrap(),
+            b"<BASE_DIR_0>/src\\value.rs"
+        );
+        assert_eq!(
+            apply_last_match(
+                &producer_normalizer.remap_args(),
+                canonical_source.to_str().unwrap()
+            ),
+            "/kache/base-dir-0\\src\\value.rs"
+        );
+
+        let producer_roots = producer_normalizer
+            .depinfo_source_roots()
+            .into_iter()
+            .map(|root| (root.root, root.depinfo_sentinel, root.priority))
+            .collect::<Vec<_>>();
+        let consumer_roots = consumer_normalizer
+            .depinfo_source_roots()
+            .into_iter()
+            .map(|root| (root.root, root.depinfo_sentinel, root.priority))
+            .collect::<Vec<_>>();
+        let raw = format!(r"C:\target\demo.d: {}", canonical_source.display());
+        let stored = crate::link::rewrite_rustc_depinfo_content_with_configured_roots(
+            &raw,
+            Path::new(r"C:\target"),
+            Path::new(r"C:\work"),
+            None,
+            &producer_roots,
+            crate::link::DepInfoMode::Relativize,
+        );
+        assert!(
+            stored.contains("__kache_base_dir_0__/src\\value.rs"),
+            "{stored}"
+        );
+        let restored = crate::link::rewrite_rustc_depinfo_content_with_configured_roots(
+            &stored,
+            Path::new(r"C:\target"),
+            Path::new(r"C:\work"),
+            None,
+            &consumer_roots,
+            crate::link::DepInfoMode::Expand,
+        );
+        assert!(restored.contains(&format!(r"{}\src\value.rs", consumer_root.display())));
+        assert!(!restored.contains(&producer_root.to_string_lossy().into_owned()));
+    }
+
     #[test]
     fn configured_root_wins_consistently_in_key_and_rustc_remap() {
         let cargo_home = "/sandbox/.cargo";
@@ -2370,19 +2875,448 @@ mod tests {
             apply_last_match(&normalizer.remap_args(), path),
             "/kache/base-dir-0/.cargo/registry/src/pkg/lib.rs"
         );
+        assert_eq!(
+            normalizer.source_path_identity(Path::new(path)).unwrap(),
+            b"<BASE_DIR_0>/.cargo/registry/src/pkg/lib.rs"
+        );
+    }
+
+    #[test]
+    fn legacy_base_dir_is_a_complete_owner_and_rejects_empty_or_root() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("legacy");
+        let source = base.join("src/lib.rs");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(&source, "pub const VALUE: u8 = 1;").unwrap();
+
+        let mut rules = Vec::new();
+        let mut source_restore_roots = Vec::new();
+        push_legacy_base_dir_rules(
+            &mut rules,
+            &mut source_restore_roots,
+            Some(base.as_os_str()),
+        );
+        let normalizer = PathNormalizer {
+            rules,
+            configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots,
+            path_only_env_vars: Vec::new(),
+        };
+        let relative = source.strip_prefix(&base).unwrap().to_string_lossy();
+        assert_eq!(
+            normalizer.source_path_identity(&source).unwrap(),
+            format!("<BASE_DIR>/{relative}").as_bytes()
+        );
+        assert_eq!(
+            apply_last_match(&normalizer.remap_args(), source.to_str().unwrap()),
+            format!("{}/{relative}", flag_target_for("<BASE_DIR>"))
+        );
+        assert!(normalizer.depinfo_source_roots().iter().any(|root| {
+            root.root == base
+                && root.key_sentinel == "<BASE_DIR>"
+                && root.depinfo_sentinel == "__kache_base_dir__/"
+        }));
+
+        let filesystem_root = if cfg!(windows) {
+            Path::new(r"C:\")
+        } else {
+            Path::new("/")
+        };
+        for invalid in [std::ffi::OsStr::new(""), filesystem_root.as_os_str()] {
+            let mut rules = Vec::new();
+            let mut restore_roots = Vec::new();
+            push_legacy_base_dir_rules(&mut rules, &mut restore_roots, Some(invalid));
+            assert!(rules.is_empty());
+            assert!(restore_roots.is_empty());
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn legacy_base_dir_owns_verbatim_canonical_sources() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("Legacy Root");
+        let source = base.join("src/value.rs");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(&source, "pub const VALUE: u8 = 1;").unwrap();
+
+        let mut rules = Vec::new();
+        let mut source_restore_roots = Vec::new();
+        push_legacy_base_dir_rules(
+            &mut rules,
+            &mut source_restore_roots,
+            Some(base.as_os_str()),
+        );
+        let normalizer = PathNormalizer {
+            rules,
+            configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots,
+            path_only_env_vars: Vec::new(),
+        };
+        let canonical_source = source.canonicalize().unwrap();
+        assert_eq!(
+            normalizer.source_path_identity(&canonical_source).unwrap(),
+            b"<BASE_DIR>/src\\value.rs"
+        );
+        assert_eq!(
+            apply_last_match(&normalizer.remap_args(), canonical_source.to_str().unwrap()),
+            "/kache/base-dir\\src\\value.rs"
+        );
+        let canonical_base = base.canonicalize().unwrap();
+        assert!(normalizer.depinfo_source_roots().iter().any(|root| {
+            root.root == canonical_base && root.depinfo_sentinel == "__kache_base_dir__/"
+        }));
+    }
+
+    #[test]
+    fn legacy_base_dir_exposes_a_depinfo_restore_descriptor() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().to_string_lossy().into_owned();
+        let normalizer = pn_with_rules(vec![(&root, "<BASE_DIR>")]);
+        let roots = normalizer.depinfo_source_roots();
+
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].root, dir.path());
+        assert_eq!(roots[0].key_sentinel, "<BASE_DIR>");
+        assert_eq!(roots[0].depinfo_sentinel, "__kache_base_dir__/");
+        assert_eq!(roots[0].priority, flag_emit_rank("<BASE_DIR>"));
+    }
+
+    #[test]
+    fn external_target_exposes_a_distinct_source_restore_descriptor() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().to_string_lossy().into_owned();
+        let normalizer = pn_with_rules(vec![(&root, "<TARGET>")]);
+        let roots = normalizer.depinfo_source_roots();
+
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].root, dir.path());
+        assert_eq!(roots[0].key_sentinel, "<TARGET>");
+        assert_eq!(roots[0].depinfo_sentinel, "__kache_target_rule__/");
+        assert_eq!(roots[0].priority, flag_emit_rank("<TARGET>"));
+    }
+
+    #[test]
+    fn configured_slot_does_not_duplicate_an_identical_legacy_owner() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().to_string_lossy().into_owned();
+        let normalizer =
+            pn_with_rules(vec![(&root, "<BASE_DIR>")]).with_base_dirs(std::slice::from_ref(&root));
+        let roots = normalizer.depinfo_source_roots();
+
+        assert_eq!(normalizer.configured_base_dir_count(), 1);
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].key_sentinel, "<BASE_DIR>");
+        assert_eq!(roots[0].depinfo_sentinel, "__kache_base_dir__/");
+        assert!(
+            !roots
+                .iter()
+                .any(|descriptor| descriptor.key_sentinel == "<BASE_DIR_0>")
+        );
+    }
+
+    #[test]
+    fn source_identity_matches_rustc_semantic_root_precedence() {
+        let normalizer = pn_with_rules(vec![
+            ("/workspace/target-a", "<TARGET>"),
+            ("/workspace", "<WORKSPACE>"),
+        ]);
+        let source = Path::new("/workspace/target-a/generated.rs");
+
+        assert_eq!(
+            normalizer.source_path_identity(source).unwrap(),
+            b"<WORKSPACE>/target-a/generated.rs"
+        );
+        assert_eq!(
+            apply_last_match(&normalizer.remap_args(), source.to_str().unwrap()),
+            format!("{}/target-a/generated.rs", workspace_flag_target())
+        );
+    }
+
+    #[test]
+    fn source_identity_distinguishes_member_cwd_from_workspace_root() {
+        let normalizer = PathNormalizer {
+            rules: vec![
+                Rule {
+                    prefix: "/repo/member".to_string(),
+                    key_sentinel: "<WORKSPACE>".to_string(),
+                    source_sentinel: "<CWD>".to_string(),
+                    flag_target: workspace_flag_target().to_string(),
+                },
+                Rule {
+                    prefix: "/repo".to_string(),
+                    key_sentinel: "<WORKSPACE>".to_string(),
+                    source_sentinel: "<WORKSPACE>".to_string(),
+                    flag_target: workspace_flag_target().to_string(),
+                },
+            ],
+            configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots: Vec::new(),
+            path_only_env_vars: Vec::new(),
+        };
+
+        assert_eq!(
+            normalizer
+                .source_path_identity(Path::new("/repo/member/value.rs"))
+                .unwrap(),
+            b"<CWD>/value.rs"
+        );
+        assert_eq!(
+            normalizer
+                .source_path_identity(Path::new("/repo/value.rs"))
+                .unwrap(),
+            b"<WORKSPACE>/value.rs"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn automatic_workspace_root_round_trips_lexical_and_canonical_spellings() {
+        let dir = TempDir::new().unwrap();
+        let real = dir.path().join("real/workspace");
+        let link = dir.path().join("workspace-link");
+        std::fs::create_dir_all(real.join("src")).unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let normalizer = PathNormalizer::from_env(Some(&link));
+        let lexical = link.join("src/lib.rs");
+        let canonical = real.canonicalize().unwrap().join("src/lib.rs");
+
+        for source in [&lexical, &canonical] {
+            assert_eq!(
+                normalizer.source_path_identity(source).unwrap(),
+                b"<WORKSPACE>/src/lib.rs"
+            );
+            assert_eq!(
+                apply_last_match(&normalizer.remap_args(), source.to_str().unwrap()),
+                format!("{}/src/lib.rs", workspace_flag_target())
+            );
+        }
+
+        let roots = normalizer.depinfo_source_roots();
+        let workspace_roots = roots
+            .iter()
+            .filter(|root| root.depinfo_sentinel == "__kache_workspace__/")
+            .map(|root| root.root.as_path())
+            .collect::<Vec<_>>();
+        assert_eq!(workspace_roots.first().copied(), Some(link.as_path()));
+        assert!(workspace_roots.contains(&real.canonicalize().unwrap().as_path()));
+
+        let depinfo_roots = roots
+            .into_iter()
+            .map(|root| (root.root, root.depinfo_sentinel, root.priority))
+            .collect::<Vec<_>>();
+        let target = dir.path().join("target");
+        let raw = format!("{}/demo.d: {}\n", target.display(), canonical.display());
+        let stored = crate::link::rewrite_rustc_depinfo_content_with_configured_roots(
+            &raw,
+            &target,
+            &link,
+            Some(&link),
+            &depinfo_roots,
+            crate::link::DepInfoMode::Relativize,
+        );
+        assert!(
+            stored.contains("__kache_workspace__/src/lib.rs"),
+            "{stored}"
+        );
+        let restored = crate::link::rewrite_rustc_depinfo_content_with_configured_roots(
+            &stored,
+            &target,
+            &link,
+            Some(&link),
+            &depinfo_roots,
+            crate::link::DepInfoMode::Expand,
+        );
+        assert!(restored.contains(&format!("{}/src/lib.rs", link.display())));
+        assert!(!restored.contains(&format!("{}/src/lib.rs", real.display())));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configured_ancestor_keeps_a_winning_workspace_canonical_alias() {
+        let dir = TempDir::new().unwrap();
+        let producer_configured = dir.path().join("producer/configured");
+        let consumer_configured = dir.path().join("consumer/configured");
+        let producer_link = producer_configured.join("workspace");
+        let consumer_link = consumer_configured.join("workspace");
+        let producer_real = dir.path().join("producer-real/workspace");
+        let consumer_real = dir.path().join("consumer-real/workspace");
+        std::fs::create_dir_all(producer_real.join("src")).unwrap();
+        std::fs::create_dir_all(consumer_real.join("src")).unwrap();
+        std::fs::create_dir_all(&producer_configured).unwrap();
+        std::fs::create_dir_all(&consumer_configured).unwrap();
+        std::os::unix::fs::symlink(&producer_real, &producer_link).unwrap();
+        std::os::unix::fs::symlink(&consumer_real, &consumer_link).unwrap();
+
+        let producer = PathNormalizer::from_env(Some(&producer_link))
+            .with_base_dirs(&[producer_configured.to_string_lossy().into_owned()]);
+        let consumer = PathNormalizer::from_env(Some(&consumer_link))
+            .with_base_dirs(&[consumer_configured.to_string_lossy().into_owned()]);
+        let producer_canonical = producer_real.canonicalize().unwrap();
+        let consumer_canonical = consumer_real.canonicalize().unwrap();
+        let producer_source = producer_canonical.join("src/lib.rs");
+        assert_eq!(
+            producer.source_path_identity(&producer_source).unwrap(),
+            b"<WORKSPACE>/src/lib.rs"
+        );
+
+        let producer_roots = producer
+            .depinfo_source_roots()
+            .into_iter()
+            .map(|root| (root.root, root.depinfo_sentinel, root.priority))
+            .collect::<Vec<_>>();
+        assert!(producer_roots.iter().any(|(root, sentinel, _)| {
+            root == &producer_canonical && sentinel == "__kache_workspace__/"
+        }));
+        let target = producer_link.join("target");
+        let raw = format!(
+            "{}/demo.d: {}\n",
+            target.display(),
+            producer_source.display()
+        );
+        let stored = crate::link::rewrite_rustc_depinfo_content_with_configured_roots(
+            &raw,
+            &target,
+            &producer_link,
+            Some(&producer_link),
+            &producer_roots,
+            crate::link::DepInfoMode::Relativize,
+        );
+        assert!(
+            stored.contains("__kache_workspace__/src/lib.rs"),
+            "{stored}"
+        );
+
+        let consumer_roots = consumer
+            .depinfo_source_roots()
+            .into_iter()
+            .map(|root| (root.root, root.depinfo_sentinel, root.priority))
+            .collect::<Vec<_>>();
+        let restored = crate::link::rewrite_rustc_depinfo_content_with_configured_roots(
+            &stored,
+            &consumer_link.join("target"),
+            &consumer_link,
+            Some(&consumer_link),
+            &consumer_roots,
+            crate::link::DepInfoMode::Expand,
+        );
+        assert!(restored.contains(&format!("{}/src/lib.rs", consumer_canonical.display())));
+        assert!(!restored.contains(&producer_canonical.to_string_lossy().into_owned()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_filesystem_root_is_never_added_as_an_alias() {
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("root-link");
+        std::os::unix::fs::symlink("/", &link).unwrap();
+
+        let mut legacy_rules = Vec::new();
+        let mut restore_roots = Vec::new();
+        push_legacy_base_dir_rules(
+            &mut legacy_rules,
+            &mut restore_roots,
+            Some(link.as_os_str()),
+        );
+        assert!(legacy_rules.iter().all(|rule| rule.prefix != "/"));
+
+        let configured =
+            PathNormalizer::empty().with_base_dirs(&[link.to_string_lossy().into_owned()]);
+        assert!(configured.rules.iter().all(|rule| rule.prefix != "/"));
+        assert!(
+            configured
+                .source_path_identity(Path::new("/etc/passwd"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn source_identity_stays_local_for_roots_without_depinfo_restore_ownership() {
+        let normalizer = pn_with_rules(vec![("/toolchain/rust", "<RUST_SRC>")]);
+        assert!(
+            normalizer
+                .source_path_identity(Path::new("/toolchain/rust/library/core/src/lib.rs"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn configured_ancestor_wins_over_nested_workspace_for_source_identity() {
+        let normalizer = pn_with_rules(vec![("/sandbox/checkout", "<WORKSPACE>")])
+            .with_base_dirs(&["/sandbox".to_string()]);
+        let source = Path::new("/sandbox/checkout/src/lib.rs");
+
+        assert_eq!(
+            normalizer.source_path_identity(source).unwrap(),
+            b"<BASE_DIR_0>/checkout/src/lib.rs"
+        );
+        assert_eq!(
+            apply_last_match(&normalizer.remap_args(), source.to_str().unwrap()),
+            "/kache/base-dir-0/checkout/src/lib.rs"
+        );
+    }
+
+    #[test]
+    fn configured_ancestor_also_wins_depinfo_ownership() {
+        let dir = TempDir::new().unwrap();
+        let configured = dir.path().join("configured");
+        let workspace = configured.join("checkout");
+        let source = workspace.join("src/lib.rs");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(&source, "pub const VALUE: u8 = 1;").unwrap();
+
+        let normalizer = PathNormalizer::from_env(Some(&workspace))
+            .with_base_dirs(&[configured.to_string_lossy().into_owned()]);
+        assert_eq!(
+            normalizer.source_path_identity(&source).unwrap(),
+            b"<BASE_DIR_0>/checkout/src/lib.rs"
+        );
+
+        let roots = normalizer.depinfo_source_roots();
+        assert!(!roots.iter().any(|root| {
+            root.root == workspace
+                && matches!(
+                    root.depinfo_sentinel.as_str(),
+                    "__kache_cwd__/" | "__kache_workspace__/"
+                )
+        }));
+        let roots = roots
+            .into_iter()
+            .map(|root| (root.root, root.depinfo_sentinel, root.priority))
+            .collect::<Vec<_>>();
+        let target = workspace.join("target");
+        let raw = format!("{}/demo.d: {}\n", target.display(), source.display());
+        let stored = crate::link::rewrite_rustc_depinfo_content_with_configured_roots(
+            &raw,
+            &target,
+            &workspace,
+            Some(&workspace),
+            &roots,
+            crate::link::DepInfoMode::Relativize,
+        );
+        assert!(
+            stored.contains("__kache_base_dir_0__/checkout/src/lib.rs"),
+            "{stored}"
+        );
+        assert!(!stored.contains("__kache_cwd__/"), "{stored}");
+        assert!(!stored.contains("__kache_workspace__/"), "{stored}");
     }
 
     #[cfg(unix)]
     #[test]
     fn configured_lexical_root_is_not_stolen_by_another_roots_alias() {
         let dir = TempDir::new().unwrap();
-        let real = dir.path().join("z-real");
-        let link = dir.path().join("a-link");
-        std::fs::create_dir_all(&real).unwrap();
-        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let real_path = dir.path().join("z-real");
+        let link_path = dir.path().join("a-link");
+        std::fs::create_dir_all(real_path.join("src")).unwrap();
+        std::os::unix::fs::symlink(&real_path, &link_path).unwrap();
 
-        let link = link.to_string_lossy().into_owned();
-        let real = real.to_string_lossy().into_owned();
+        let link = link_path.to_string_lossy().into_owned();
+        let real = real_path.to_string_lossy().into_owned();
         let normalizer = PathNormalizer::empty().with_base_dirs(&[link.clone(), real.clone()]);
 
         assert_eq!(normalizer.configured_base_dir_count(), 2);
@@ -2394,6 +3328,90 @@ mod tests {
             normalizer.normalize(format!("{real}/src")),
             "<BASE_DIR_1>/src"
         );
+        assert_eq!(
+            normalizer
+                .source_path_identity(&link_path.join("src/lib.rs"))
+                .unwrap(),
+            b"<BASE_DIR_0>/src/lib.rs"
+        );
+        assert_eq!(
+            normalizer
+                .source_path_identity(&real_path.join("src/lib.rs"))
+                .unwrap(),
+            b"<BASE_DIR_1>/src/lib.rs"
+        );
+
+        let roots = normalizer.depinfo_source_roots();
+        assert!(roots.iter().any(|root| {
+            root.root == link_path
+                && root.key_sentinel == "<BASE_DIR_0>"
+                && root.depinfo_sentinel == "__kache_base_dir_0__/"
+                && root.priority == flag_emit_rank("<BASE_DIR_0>")
+        }));
+        assert!(roots.iter().any(|root| {
+            root.root == real_path
+                && root.key_sentinel == "<BASE_DIR_1>"
+                && root.depinfo_sentinel == "__kache_base_dir_1__/"
+                && root.priority == flag_emit_rank("<BASE_DIR_1>")
+        }));
+        assert!(!roots.iter().any(|root| {
+            root.root == real_path
+                && (root.key_sentinel != "<BASE_DIR_1>"
+                    || root.depinfo_sentinel != "__kache_base_dir_1__/")
+        }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configured_symlink_alias_restores_through_lexical_root_after_retarget() {
+        let dir = TempDir::new().unwrap();
+        let old_real = dir.path().join("a-very-long-old-real-target");
+        let new_real = dir.path().join("new-real-target");
+        let link = dir.path().join("x");
+        std::fs::create_dir_all(old_real.join("src")).unwrap();
+        std::fs::create_dir_all(new_real.join("src")).unwrap();
+        std::os::unix::fs::symlink(&old_real, &link).unwrap();
+        let configured = link.to_string_lossy().into_owned();
+
+        let producer = PathNormalizer::empty().with_base_dirs(std::slice::from_ref(&configured));
+        let producer_roots = producer
+            .depinfo_source_roots()
+            .into_iter()
+            .map(|root| (root.root, root.depinfo_sentinel, root.priority))
+            .collect::<Vec<_>>();
+        let old_canonical = old_real.canonicalize().unwrap();
+        let input = format!("out: {}/src/value.rs\n", old_canonical.display());
+        let stored = crate::link::rewrite_rustc_depinfo_content_with_configured_roots(
+            &input,
+            Path::new("/unrelated-target"),
+            Path::new("/unrelated-cwd"),
+            None,
+            &producer_roots,
+            crate::link::DepInfoMode::Relativize,
+        );
+        assert!(
+            stored.contains("__kache_base_dir_0__/src/value.rs"),
+            "{stored}"
+        );
+
+        std::fs::remove_file(&link).unwrap();
+        std::os::unix::fs::symlink(&new_real, &link).unwrap();
+        let consumer = PathNormalizer::empty().with_base_dirs(&[configured]);
+        let consumer_roots = consumer
+            .depinfo_source_roots()
+            .into_iter()
+            .map(|root| (root.root, root.depinfo_sentinel, root.priority))
+            .collect::<Vec<_>>();
+        let restored = crate::link::rewrite_rustc_depinfo_content_with_configured_roots(
+            &stored,
+            Path::new("/other-target"),
+            Path::new("/other-cwd"),
+            None,
+            &consumer_roots,
+            crate::link::DepInfoMode::Expand,
+        );
+        assert!(restored.contains(&format!("{}/src/value.rs", link.display())));
+        assert!(!restored.contains(old_canonical.to_str().unwrap()));
     }
 
     #[test]

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -2061,7 +2061,7 @@ mod tests {
         assert!(
             n.depinfo_source_roots()
                 .iter()
-                .any(|root| root.root == PathBuf::from(&short)),
+                .any(|root| root.root.as_path() == Path::new(short.as_str())),
             "the same short spelling must be accepted while relativizing dep-info"
         );
     }
@@ -3043,6 +3043,177 @@ mod tests {
         assert_eq!(roots[0].key_sentinel, "<TARGET>");
         assert_eq!(roots[0].depinfo_sentinel, "__kache_target_rule__/");
         assert_eq!(roots[0].priority, flag_emit_rank("<TARGET>"));
+    }
+
+    #[test]
+    fn every_source_sentinel_has_a_distinct_depinfo_sentinel() {
+        // `depinfo_source_roots` walks exactly this sentinel list. A source
+        // sentinel missing its dep-info mapping silently drops that root from
+        // the portable rewrite, so the stored `.d` keeps a live local path and
+        // a relocated hit validates against the donor's tree.
+        let mapped = [
+            ("<CWD>", "__kache_cwd__/"),
+            ("<WORKSPACE>", "__kache_workspace__/"),
+            ("<TARGET>", "__kache_target_rule__/"),
+            ("<CARGO_HOME>", "__kache_cargo_home__/"),
+            ("<BASE_DIR>", "__kache_base_dir__/"),
+            ("<RUSTUP_HOME>", "__kache_rustup_home__/"),
+            ("<HOME>", "__kache_home__/"),
+            ("<APPDATA>", "__kache_appdata__/"),
+            ("<LOCALAPPDATA>", "__kache_localappdata__/"),
+            ("<PROGRAMFILES>", "__kache_programfiles__/"),
+            ("<TMPDIR>", "__kache_tmpdir__/"),
+        ];
+        for (source_sentinel, expected) in mapped {
+            assert_eq!(
+                depinfo_sentinel_for_source(source_sentinel).as_deref(),
+                Some(expected),
+                "{source_sentinel} must map to a portable dep-info sentinel"
+            );
+        }
+
+        let distinct: std::collections::HashSet<&str> =
+            mapped.iter().map(|(_, sentinel)| *sentinel).collect();
+        assert_eq!(
+            distinct.len(),
+            mapped.len(),
+            "two source roots sharing a dep-info sentinel would expand to the wrong tree"
+        );
+
+        // `<RUST_SRC>` is remapped for debug info but is never a restorable
+        // source root, and an unknown sentinel must not invent one.
+        assert_eq!(depinfo_sentinel_for_source("<RUST_SRC>"), None);
+        assert_eq!(depinfo_sentinel_for_source("<NOT_A_SENTINEL>"), None);
+
+        // Configured slots are numbered rather than named.
+        assert_eq!(
+            depinfo_sentinel_for_source("<BASE_DIR_2>").as_deref(),
+            Some("__kache_base_dir_2__/")
+        );
+    }
+
+    #[test]
+    fn a_second_target_root_lands_between_its_higher_and_lower_ranked_peers() {
+        // `with_target_dir` splices the new rules at the one position that
+        // preserves rustc's precedence: after every rule that outranks
+        // `<TARGET>` and after an equal-ranked peer (`from_env` already
+        // installed one when `CARGO_TARGET_DIR` is set), but before anything
+        // that ranks below it. `normalize` applies rules in list order, so
+        // landing on either side of that slot silently changes which root owns
+        // a generated source — and with it the cache key.
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().canonicalize().unwrap();
+        let outer_target = base.join("target");
+        let nested = outer_target.join("wasm32-unknown-unknown");
+        fs::create_dir_all(&nested).unwrap();
+        let workspace_prefix = base.join("workspace").to_string_lossy().into_owned();
+        let outer_prefix = outer_target.to_string_lossy().into_owned();
+        let tmpdir_prefix = base.join("tmp").to_string_lossy().into_owned();
+
+        // Ranks: <WORKSPACE> 4 > <TARGET> 3 > <TMPDIR> 0.
+        let normalizer = pn_with_rules(vec![
+            (&workspace_prefix, "<WORKSPACE>"),
+            (&outer_prefix, "<TARGET>"),
+            (&tmpdir_prefix, "<TMPDIR>"),
+        ])
+        .with_target_dir(Some(&nested));
+
+        let spellings = || {
+            normalizer
+                .rules
+                .iter()
+                .map(|rule| rule.prefix.clone())
+                .collect::<Vec<_>>()
+        };
+        let at = |prefix: &str| {
+            normalizer
+                .rules
+                .iter()
+                .position(|rule| rule.prefix == prefix)
+                .unwrap_or_else(|| panic!("{prefix} survives, got {:?}", spellings()))
+        };
+        let nested_at = normalizer
+            .rules
+            .iter()
+            .position(|rule| {
+                rule.prefix.starts_with(&outer_prefix) && rule.prefix.len() > outer_prefix.len()
+            })
+            .expect("the nested target rule is added");
+
+        assert!(
+            at(&workspace_prefix) < nested_at,
+            "a higher-ranked root must stay ahead of a new <TARGET>, got {:?}",
+            spellings()
+        );
+        assert!(
+            at(&outer_prefix) < nested_at,
+            "the established <TARGET> peer must keep normalizing first, got {:?}",
+            spellings()
+        );
+        assert!(
+            nested_at < at(&tmpdir_prefix),
+            "a lower-ranked root must not consume the target first, got {:?}",
+            spellings()
+        );
+
+        let generated = nested.join("generated.rs").to_string_lossy().into_owned();
+        let suffix = generated
+            .strip_prefix(&outer_prefix)
+            .expect("the nested target is under the outer target");
+        assert_eq!(
+            normalizer.normalize(&generated),
+            format!("<TARGET>{suffix}"),
+            "the outer target owns the prefix, so the nested segment stays in the key"
+        );
+    }
+
+    #[test]
+    fn depinfo_restore_root_prefers_the_designated_spelling_over_the_first_alias() {
+        // `from_env` records one restore root per source sentinel in push order
+        // (`<CWD>`, `<WORKSPACE>`, then `<TARGET>`), so a sentinel's designated
+        // entry is routinely preceded by a different sentinel's. Selecting the
+        // wrong entry falls back to whichever alias rule happens to come first,
+        // which rewrites dep-info against a spelling the build never used.
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().canonicalize().unwrap();
+        let alias = base.join("alias-target");
+        let designated = base.join("designated-target");
+        let workspace = base.join("workspace");
+        for path in [&alias, &designated, &workspace] {
+            fs::create_dir(path).unwrap();
+        }
+        let rule = |path: &Path, sentinel: &str| Rule {
+            prefix: path.to_string_lossy().into_owned(),
+            key_sentinel: sentinel.to_string(),
+            source_sentinel: sentinel.to_string(),
+            flag_target: flag_target_for(sentinel),
+        };
+
+        let normalizer = PathNormalizer {
+            // The alias rule comes first, so the fallback scan would pick it.
+            rules: vec![
+                rule(&alias, "<TARGET>"),
+                rule(&designated, "<TARGET>"),
+                rule(&workspace, "<WORKSPACE>"),
+            ],
+            configured_base_dir_count: 0,
+            configured_source_root_groups: Vec::new(),
+            source_restore_roots: vec![
+                ("<WORKSPACE>".to_string(), workspace.clone()),
+                ("<TARGET>".to_string(), designated.clone()),
+            ],
+            path_only_env_vars: Vec::new(),
+        };
+
+        let target_root = normalizer
+            .depinfo_source_roots()
+            .into_iter()
+            .find(|root| root.key_sentinel == "<TARGET>")
+            .expect("the target sentinel has an existing native root");
+        assert_eq!(
+            target_root.root, designated,
+            "the designated <TARGET> spelling must win over the earlier alias rule"
+        );
     }
 
     #[test]

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -351,6 +351,44 @@ impl PathNormalizer {
         self
     }
 
+    /// Add Cargo's effective target directory derived from the rustc argv.
+    ///
+    /// `CARGO_TARGET_DIR` is often unset, especially for Cargo's default
+    /// `<workspace>/target`. Dependency crates are compiled with their own
+    /// package directory as cwd, so the workspace root cannot always be
+    /// verified from cwd either. The rustc output layout still identifies the
+    /// target directory exactly; adding it here keeps build-script generated
+    /// sources portable without trusting an inferred workspace root.
+    pub(crate) fn with_target_dir(mut self, target_dir: Option<&Path>) -> Self {
+        let Some(target_dir) = target_dir else {
+            return self;
+        };
+
+        let mut target_rules = Vec::new();
+        push_path_rule_aliases(
+            &mut target_rules,
+            &mut self.source_restore_roots,
+            target_dir,
+            "<TARGET>",
+            "<TARGET>",
+        );
+
+        // Keep the same semantic order as rustc's last-match-wins remap set:
+        // workspace/configured/Cargo-home owners outrank TARGET, while user
+        // dirs and TMPDIR must not consume an external target first.
+        let target_rank = flag_emit_rank("<TARGET>");
+        let insert_at = self
+            .rules
+            .iter()
+            .position(|rule| flag_emit_rank(&rule.key_sentinel) < target_rank)
+            .unwrap_or(self.rules.len());
+        self.rules.splice(insert_at..insert_at, target_rules);
+
+        let mut seen = std::collections::HashSet::new();
+        self.rules.retain(|rule| seen.insert(rule.prefix.clone()));
+        self
+    }
+
     /// Add the validated `[paths].base_dirs` rule set.
     ///
     /// Entries are sorted by their lexical spelling before sentinel assignment,
@@ -3206,6 +3244,30 @@ mod tests {
         );
         assert!(restored.contains(&format!("{}/src/lib.rs", consumer_canonical.display())));
         assert!(!restored.contains(&producer_canonical.to_string_lossy().into_owned()));
+    }
+
+    #[test]
+    fn argv_target_dir_owns_generated_sources_without_a_workspace_root() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("target");
+        let generated = target.join("release/build/serde-core/out/private.rs");
+        std::fs::create_dir_all(generated.parent().unwrap()).unwrap();
+        std::fs::write(&generated, "pub const PRIVATE: bool = true;\n").unwrap();
+
+        let normalizer = PathNormalizer::empty().with_target_dir(Some(&target));
+        assert_eq!(
+            normalizer.source_path_identity(&generated).unwrap(),
+            b"<TARGET>/release/build/serde-core/out/private.rs"
+        );
+        assert!(normalizer.depinfo_source_roots().iter().any(|root| {
+            root.root == target && root.depinfo_sentinel == "__kache_target_rule__/"
+        }));
+        assert!(
+            normalizer
+                .remap_args()
+                .iter()
+                .any(|arg| arg.contains("=/kache/target"))
+        );
     }
 
     #[cfg(unix)]

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -2894,7 +2894,8 @@ mod tests {
             &consumer_roots,
             crate::link::DepInfoMode::Expand,
         );
-        assert!(restored.contains(&format!(r"{}\src\value.rs", consumer_root.display())));
+        let expected = format!(r"{}\src\value.rs", consumer_root.display()).replace(' ', "\\ ");
+        assert!(restored.contains(&expected), "{restored}");
         assert!(!restored.contains(&producer_root.to_string_lossy().into_owned()));
     }
 
@@ -2948,7 +2949,15 @@ mod tests {
         );
         assert_eq!(
             apply_last_match(&normalizer.remap_args(), source.to_str().unwrap()),
-            format!("{}/{relative}", flag_target_for("<BASE_DIR>"))
+            format!(
+                "{}{}",
+                flag_target_for("<BASE_DIR>"),
+                source
+                    .to_str()
+                    .unwrap()
+                    .strip_prefix(base.to_str().unwrap())
+                    .unwrap()
+            )
         );
         assert!(normalizer.depinfo_source_roots().iter().any(|root| {
             root.root == base
@@ -3333,9 +3342,10 @@ mod tests {
 
         let normalizer = PathNormalizer::from_env(Some(&workspace))
             .with_base_dirs(&[configured.to_string_lossy().into_owned()]);
+        let relative = source.strip_prefix(&configured).unwrap().to_string_lossy();
         assert_eq!(
             normalizer.source_path_identity(&source).unwrap(),
-            b"<BASE_DIR_0>/checkout/src/lib.rs"
+            format!("<BASE_DIR_0>/{relative}").as_bytes()
         );
 
         let roots = normalizer.depinfo_source_roots();

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1537,7 +1537,7 @@ fn run_parsed_rustc(
     // must take effect immediately even when this unit was already active.
     let refuse = compiler.refuse_reasons(args);
     let current_dir = std::env::current_dir().ok();
-    let workspace_root = args.workspace_root().or_else(|| current_dir.clone());
+    let workspace_root = args.path_normalization_root().map(Path::to_path_buf);
     let exclude_roots: Vec<_> = workspace_root
         .iter()
         .chain(current_dir.iter())
@@ -2226,35 +2226,20 @@ fn run_parsed_rustc(
         _ => "release",
     };
 
-    // Relativize dep-info (`.d`) files before they are cached so the
-    // stored blob is worktree-independent. cargo records each crate's
-    // inputs in its `.d` by *absolute* path; without this, a cached
-    // `.d` carries the producing build's paths, and a build that
-    // restores it at a different location finds those paths missing on
-    // its freshness `stat()` and recompiles — a cache hit that saved
-    // nothing. `store.put*` hashes the file at its on-disk source path,
-    // so we rewrite in place; the matching expand below restores the
-    // absolute paths the *current* build's cargo still needs to see.
+    // Rust dep-info is normalized into a private staging file before Store::put
+    // reads it. Cargo's compiler-owned `.d` stays untouched, while the cached
+    // blob gets target/package/workspace sentinels instead of donor paths.
     let depinfo_anchor = args.target_dir();
-    if let Some(anchor) = depinfo_anchor.as_deref() {
-        rewrite_depinfo_outputs(&result.artifacts, anchor, link::DepInfoMode::Relativize);
-    }
+    let depinfo_working_dir = current_dir.as_deref().unwrap_or_else(|| Path::new("."));
+    let depinfo_workspace_dir = args.path_normalization_root();
+    let depinfo_configured_roots = configured_rustc_depinfo_roots(config, depinfo_workspace_dir);
 
-    // Validate the exact producer-neutral dep-info bytes before Store::put
-    // makes the entry observable. Restores complete the same bytes in memory;
-    // proving that transform now closes the publication window where another
-    // wrapper could otherwise observe an entry the producer later evicts.
+    // Validate the compiler's consumer-facing dep-info before Store::put makes
+    // an entry observable. The staging transform below cannot alter its input.
     if let Some(snapshot) = extra_inputs
-        && let Err(error) = validate_extra_inputs_dep_info_before_store(
-            args,
-            &result.artifacts,
-            depinfo_anchor.as_deref(),
-            snapshot,
-        )
+        && let Err(error) =
+            validate_extra_inputs_dep_info_before_store(args, &result.artifacts, snapshot)
     {
-        if let Some(anchor) = depinfo_anchor.as_deref() {
-            rewrite_depinfo_outputs(&result.artifacts, anchor, link::DepInfoMode::Expand);
-        }
         return Err(error).context("validating extra_inputs dep-info before cache commit");
     }
 
@@ -2304,8 +2289,51 @@ fn run_parsed_rustc(
         }
     }
 
+    let prepared_store = match prepare_rustc_store_files(
+        &result.artifacts,
+        depinfo_anchor.as_deref(),
+        depinfo_working_dir,
+        depinfo_workspace_dir,
+        &depinfo_configured_roots,
+    ) {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            tracing::warn!(
+                "not caching {}: dep-info could not be staged safely: {error:#}",
+                crate_name
+            );
+            let elapsed = start.elapsed().as_millis() as u64;
+            log_event_with_hash_stats(
+                config,
+                &event_root,
+                crate_name,
+                EventResult::Skipped,
+                elapsed,
+                compile_time_ms,
+                0,
+                &cache_key,
+                key_ms,
+                key_hash_stats,
+                lookup_ms,
+                0,
+                0,
+            );
+            print_progress(crate_name, EventResult::Skipped, elapsed, 0);
+            clean_incremental_dir(config, args);
+            drop(lock);
+            return Ok(result.exit_code);
+        }
+    };
+
+    // Finish Cargo's consumer-facing dep-info before Store::put makes the
+    // neutral staged blob observable. The store reads only the private staged
+    // `.d`, so completing Cargo's compiler-owned file cannot change it.
+    if let Some(snapshot) = extra_inputs {
+        complete_extra_inputs_dep_info(args, snapshot)
+            .context("completing extra_inputs dep-info before cache publication")?;
+    }
+
     let store_start = std::time::Instant::now();
-    let store_files = result.artifacts.store_files();
     let mut store_put = StorePutResult::default();
     let mut store_error = String::new();
     match store.put_with_compile_time(
@@ -2315,7 +2343,7 @@ fn run_parsed_rustc(
         &args.features,
         target,
         profile,
-        &store_files,
+        &prepared_store.files,
         &result.stdout,
         &result.stderr,
         compile_time_ms,
@@ -2341,23 +2369,6 @@ fn run_parsed_rustc(
         }
     }
     let store_ms = store_start.elapsed().as_millis() as u64;
-
-    // Expand the on-disk `.d` files back to absolute paths. The store
-    // already captured the relativized form above; this leaves the
-    // current build's `.d` valid for cargo's own freshness checks.
-    if let Some(anchor) = depinfo_anchor.as_deref() {
-        rewrite_depinfo_outputs(&result.artifacts, anchor, link::DepInfoMode::Expand);
-    }
-
-    // Do not publish a cache entry until the consumer-facing dep-info is known
-    // to be completable. The stored blob remains the producer-neutral version
-    // captured above; on failure, evict it before any remote upload is queued.
-    if let Some(snapshot) = extra_inputs
-        && let Err(error) = complete_extra_inputs_dep_info(args, snapshot)
-    {
-        let _ = store.remove_entry(&cache_key);
-        return Err(error).context("validating extra_inputs dep-info before cache publication");
-    }
 
     // 6. Async upload to remote (if configured) — sends job to the daemon
     if config.remote.is_some() {
@@ -2458,35 +2469,88 @@ fn prepare_cc_store_files(
     })
 }
 
-/// Rewrite every dep-info (`.d`) file in a compiler artifact set, in place,
-/// against `anchor`.
+#[derive(Debug)]
+struct PreparedRustcStoreFiles {
+    files: Vec<(PathBuf, String)>,
+    _temporary_files: Vec<tempfile::TempPath>,
+}
+
+/// Freeze rustc store inputs without modifying compiler-owned outputs.
 ///
-/// Dep-info files are identified by the adapter-provided artifact kind,
-/// so the store and restore sides stay in lock-step on what counts as a
-/// `.d`.
-///
-/// Rewrite failures are logged and skipped, not propagated: a malformed
-/// `.d` must not abort an otherwise-successful cache store.
-fn rewrite_depinfo_outputs(artifacts: &ArtifactSet, anchor: &Path, mode: link::DepInfoMode) {
+/// Dep-info is normalized while copying it into a private staging file. The
+/// store therefore observes one immutable snapshot and a failed rewrite can
+/// only skip caching; it can never leave Cargo's output partially rewritten.
+fn prepare_rustc_store_files(
+    artifacts: &ArtifactSet,
+    target_dir: Option<&Path>,
+    working_dir: &Path,
+    workspace_dir: Option<&Path>,
+    configured_roots: &[(PathBuf, String, u8)],
+) -> Result<PreparedRustcStoreFiles> {
+    use std::io::{Read, Write};
+
+    let mut files = Vec::with_capacity(artifacts.outputs().len());
+    let mut temporary_files = Vec::with_capacity(artifacts.outputs().len());
     for artifact in artifacts.outputs() {
         if artifact.kind != ArtifactKind::DepInfo {
+            // Preserve the compiler-owned path (and therefore executable mode)
+            // for ordinary artifacts. Only dep-info needs transformed bytes.
+            files.push((artifact.path.clone(), artifact.store_name.clone()));
             continue;
         }
-        if let Err(e) = link::rewrite_depinfo(&artifact.path, anchor, mode) {
-            tracing::warn!(
-                "failed to rewrite dep-info {} ({:?}): {}",
-                artifact.path.display(),
-                mode,
-                e
-            );
-        }
+
+        let mut staged = tempfile::Builder::new()
+            .prefix("kache-rustc-artifact-")
+            .tempfile()
+            .context("rustc store: creating private artifact staging file")?;
+        let anchor = target_dir.context("rustc store: missing dep-info rewrite anchor")?;
+        let mut content = String::new();
+        std::fs::File::open(&artifact.path)
+            .with_context(|| format!("rustc store: opening dep-info {}", artifact.path.display()))?
+            .read_to_string(&mut content)
+            .with_context(|| {
+                format!("rustc store: reading dep-info {}", artifact.path.display())
+            })?;
+        let normalized = link::rewrite_rustc_depinfo_content_with_configured_roots(
+            &content,
+            anchor,
+            working_dir,
+            workspace_dir,
+            configured_roots,
+            link::DepInfoMode::Relativize,
+        );
+        staged
+            .write_all(normalized.as_bytes())
+            .context("rustc store: writing normalized dep-info staging file")?;
+        staged
+            .flush()
+            .context("rustc store: flushing private artifact staging file")?;
+        let staged = staged.into_temp_path();
+        files.push((staged.to_path_buf(), artifact.store_name.clone()));
+        temporary_files.push(staged);
     }
+
+    Ok(PreparedRustcStoreFiles {
+        files,
+        _temporary_files: temporary_files,
+    })
+}
+
+fn configured_rustc_depinfo_roots(
+    config: &Config,
+    workspace_root: Option<&Path>,
+) -> Vec<(PathBuf, String, u8)> {
+    crate::path_normalizer::PathNormalizer::from_env(workspace_root)
+        .with_base_dirs(&config.base_dirs)
+        .depinfo_source_roots()
+        .into_iter()
+        .map(|root| (root.root, root.depinfo_sentinel, root.priority))
+        .collect()
 }
 
 fn validate_extra_inputs_dep_info_before_store(
     args: &RustcArgs,
     artifacts: &ArtifactSet,
-    depinfo_anchor: Option<&Path>,
     snapshot: &crate::extra_inputs::ExtraInputsSnapshot,
 ) -> Result<()> {
     let expected_name = args
@@ -2506,12 +2570,8 @@ fn validate_extra_inputs_dep_info_before_store(
         saw_dep_info = true;
         let raw = std::fs::read_to_string(&artifact.path)
             .with_context(|| format!("reading producer dep-info {}", artifact.path.display()))?;
-        let consumer = depinfo_anchor.map_or_else(
-            || raw.clone(),
-            |anchor| crate::link::rewrite_depinfo_content(&raw, anchor, link::DepInfoMode::Expand),
-        );
         snapshot
-            .merge_dep_info_content(&consumer)
+            .merge_dep_info_content(&raw)
             .with_context(|| format!("completing producer dep-info {}", artifact.path.display()))?;
     }
     anyhow::ensure!(
@@ -2611,6 +2671,9 @@ fn materialize_cached_artifact(
     target_path: &Path,
     kind: ArtifactKind,
     depinfo_anchor: &Path,
+    depinfo_working_dir: &Path,
+    depinfo_workspace_dir: Option<&Path>,
+    depinfo_configured_roots: &[(PathBuf, String, u8)],
     platform: &dyn crate::compiler::Platform,
     context: &str,
     extra_inputs: Option<&crate::extra_inputs::ExtraInputsSnapshot>,
@@ -2645,6 +2708,20 @@ fn materialize_cached_artifact(
         let mut content = original.clone();
         for action in &transforms {
             content = action.transform(content, depinfo_anchor);
+        }
+        if kind == ArtifactKind::DepInfo {
+            content = match String::from_utf8(content) {
+                Ok(text) => crate::link::rewrite_rustc_depinfo_content_with_configured_roots(
+                    &text,
+                    depinfo_anchor,
+                    depinfo_working_dir,
+                    depinfo_workspace_dir,
+                    depinfo_configured_roots,
+                    link::DepInfoMode::Expand,
+                )
+                .into_bytes(),
+                Err(error) => error.into_bytes(),
+            };
         }
         if let Some(snapshot) = complete_extra_inputs {
             let text = String::from_utf8(content)
@@ -2800,11 +2877,10 @@ fn compute_rustc_cache_key(
         // up but refuse to store (kunobi-ninja/kache#324).
         file_hasher.arm_too_new_guard(invocation_start_ns, 0);
     }
-    // Workspace root for normalization: derive from `--out-dir`
-    // (see `RustcArgs::workspace_root` for the rationale — cargo
-    // cd's into each transitive dep's source dir, so CWD is the
-    // wrong anchor). Falls back to CWD if --out-dir isn't set
-    // (defensive — cargo always sets it for cacheable invocations).
+    // Workspace root for normalization: use the output-derived candidate only
+    // when it is verified against Cargo's cwd. An external target directory
+    // otherwise points at an unrelated parent; keying and rustc injection must
+    // both fall back to cwd through `RustcArgs::path_normalization_root`.
     // Re-virtualize rust std sources to `/rustc/<hash>` so profilers resolve
     // them (kunobi-ninja/kache#485). MUST match the injection-side normalizer in
     // `RustcCompiler::execute`, or the key would represent one remap rule set
@@ -3038,19 +3114,20 @@ fn restore_from_cache(
     std::fs::create_dir_all(&output_dir)
         .with_context(|| format!("creating output directory {}", output_dir.display()))?;
 
-    // Anchor for dep-info (`.d`) path expansion. Cached `.d` blobs hold
-    // paths relativized against the *producing* build's target dir
-    // (`<target>/...` → kache's dep-info sentinel); on restore they must
-    // be re-rooted at *this* invocation's target dir so cargo's freshness
-    // `stat()`s find them. `args.target_dir()` derives that from
-    // `--out-dir` / `-o` — cargo's cwd is the package source dir, so it
-    // cannot be used.
+    // Anchors for dep-info (`.d`) expansion. Cached blobs independently
+    // relativize the producer's target directory and package working
+    // directory; restore re-roots both for this invocation so Cargo watches
+    // the consumer worktree rather than a live donor (#760).
     // Falls back to cwd only for ad-hoc invocations outside cargo's
     // layout, where there is no cached `.d` to rewrite anyway.
     let depinfo_anchor = args
         .target_dir()
         .or_else(|| std::env::current_dir().ok())
         .unwrap_or_else(|| Path::new(".").to_path_buf());
+    let depinfo_working_dir =
+        std::env::current_dir().unwrap_or_else(|_| Path::new(".").to_path_buf());
+    let depinfo_workspace_dir = args.path_normalization_root();
+    let depinfo_configured_roots = configured_rustc_depinfo_roots(config, depinfo_workspace_dir);
 
     // Dep-info validation gate (kunobi-ninja/kache#330): a restored `.d`
     // whose paths do not resolve for THIS consumer poisons cargo's
@@ -3088,8 +3165,14 @@ fn restore_from_cache(
                 });
             }
         };
-        let expanded =
-            crate::link::rewrite_depinfo_content(&raw, &depinfo_anchor, link::DepInfoMode::Expand);
+        let expanded = crate::link::rewrite_rustc_depinfo_content_with_configured_roots(
+            &raw,
+            &depinfo_anchor,
+            &depinfo_working_dir,
+            depinfo_workspace_dir,
+            &depinfo_configured_roots,
+            link::DepInfoMode::Expand,
+        );
         let expanded = if let Some(snapshot) = extra_inputs {
             match snapshot.merge_dep_info_content(&expanded) {
                 Ok(completed) => completed,
@@ -3185,6 +3268,9 @@ fn restore_from_cache(
             &target_path,
             kind,
             &depinfo_anchor,
+            &depinfo_working_dir,
+            depinfo_workspace_dir,
+            &depinfo_configured_roots,
             &*platform,
             "rustc restore",
             extra_inputs,
@@ -5291,7 +5377,7 @@ mod tests {
         .unwrap()
         .unwrap();
         let artifacts = ArtifactSet::new(Vec::new());
-        let error = validate_extra_inputs_dep_info_before_store(&args, &artifacts, None, &snapshot)
+        let error = validate_extra_inputs_dep_info_before_store(&args, &artifacts, &snapshot)
             .expect_err("active extra_inputs requires the dep-info Cargo requested");
         assert!(
             format!("{error:#}").contains("no expected dep-info artifact"),
@@ -5352,7 +5438,7 @@ mod tests {
             },
         ]);
 
-        validate_extra_inputs_dep_info_before_store(&args, &artifacts, None, &snapshot)
+        validate_extra_inputs_dep_info_before_store(&args, &artifacts, &snapshot)
             .expect("the expected producer dep-info artifact is valid");
     }
 
@@ -5504,123 +5590,126 @@ mod tests {
         );
     }
 
-    /// `rewrite_depinfo_outputs` rewrites dep-info files in place and the
-    /// relativize→expand round trip re-roots the cached blob's paths at
-    /// the restoring build's target dir — the property that lets dep-info
-    /// produced at one location be restored valid at another.
+    /// Rust store staging leaves compiler outputs untouched while the cached
+    /// dep-info round trip re-roots target, package, and workspace paths.
     #[test]
-    fn rewrite_depinfo_outputs_round_trips_depinfo_files_across_target_dirs() {
+    fn rustc_store_staging_round_trips_depinfo_without_mutating_outputs() {
         let dir = tempfile::tempdir().unwrap();
-        let depfile = dir.path().join("foo-abc.d");
-        let mozilla_depfile = dir.path().join("host_pathsub.o.pp");
-        let producing_target = std::path::Path::new("/build/worktree-a/target");
-        std::fs::write(
-            &depfile,
-            format!(
-                "{}/release/deps/libfoo-abc.rlib: src/lib.rs",
-                producing_target.display()
-            ),
+        let producing_workspace = dir.path().join("worktree-a");
+        let producing_working_dir = producing_workspace.join("member");
+        let producing_target = producing_workspace.join("target");
+        let depfile = producing_target.join("release/deps/foo-abc.d");
+        let rlib = producing_target.join("release/deps/libfoo-abc.rlib");
+        std::fs::create_dir_all(depfile.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&producing_working_dir).unwrap();
+        let original = format!(
+            "{}: {} {}\n",
+            rlib.display(),
+            producing_working_dir.join("src/lib.rs").display(),
+            producing_workspace.join("shared/asset.txt").display(),
+        );
+        std::fs::write(&depfile, &original).unwrap();
+        std::fs::write(&rlib, b"rlib bytes").unwrap();
+        let outputs = ArtifactSet::new(vec![
+            crate::compiler::Artifact {
+                path: depfile.clone(),
+                store_name: "foo-abc.d".to_string(),
+                kind: ArtifactKind::DepInfo,
+                required: true,
+            },
+            crate::compiler::Artifact {
+                path: rlib.clone(),
+                store_name: "libfoo-abc.rlib".to_string(),
+                kind: ArtifactKind::Library,
+                required: true,
+            },
+        ]);
+
+        let prepared = prepare_rustc_store_files(
+            &outputs,
+            Some(&producing_target),
+            &producing_working_dir,
+            Some(&producing_workspace),
+            &[],
         )
         .unwrap();
-        std::fs::write(
-            &mozilla_depfile,
-            format!(
-                "{}/config/host_pathsub.o: {}/config/pathsub.c",
-                producing_target.display(),
-                producing_target.display()
-            ),
-        )
-        .unwrap();
+        assert_eq!(std::fs::read_to_string(&depfile).unwrap(), original);
+        assert_eq!(std::fs::read(&rlib).unwrap(), b"rlib bytes");
+        assert_ne!(prepared.files[0].0, depfile);
+        assert_eq!(prepared.files[1].0, rlib);
+        assert_eq!(std::fs::read(&prepared.files[1].0).unwrap(), b"rlib bytes");
 
-        let outputs = ArtifactSet::from_output_files(
-            vec![
-                (depfile.clone(), "foo-abc.d".to_string()),
-                (mozilla_depfile.clone(), "host_pathsub.o.pp".to_string()),
-            ],
-            classify_by_filename,
-        );
+        let stored = std::fs::read_to_string(&prepared.files[0].0).unwrap();
+        assert!(stored.contains("__kache_root__/release/deps/libfoo-abc.rlib"));
+        assert!(stored.contains("__kache_cwd__/src/lib.rs"));
+        assert!(stored.contains("__kache_workspace__/shared/asset.txt"));
+        assert!(!stored.contains(producing_workspace.to_str().unwrap()));
 
-        // Store side: relativize against the producing build's target dir.
-        rewrite_depinfo_outputs(&outputs, producing_target, link::DepInfoMode::Relativize);
-        let stored = std::fs::read_to_string(&depfile).unwrap();
-        assert!(
-            stored.starts_with("__kache_root__/release/deps/libfoo-abc.rlib:"),
-            "stored `.d` must be relativized, got: {stored}"
+        let restoring_workspace = dir.path().join("worktree-b");
+        let restoring_working_dir = restoring_workspace.join("member");
+        let restoring_target = restoring_workspace.join("target");
+        let restored = link::rewrite_rustc_depinfo_content(
+            &stored,
+            &restoring_target,
+            &restoring_working_dir,
+            Some(&restoring_workspace),
+            link::DepInfoMode::Expand,
         );
         assert!(
-            !stored.contains("/build/worktree-a/"),
-            "no producing-worktree path may survive relativization: {stored}"
+            restored.contains(
+                restoring_target
+                    .join("release/deps/libfoo-abc.rlib")
+                    .to_str()
+                    .unwrap()
+            )
         );
-        let stored_mozilla = std::fs::read_to_string(&mozilla_depfile).unwrap();
+        assert!(restored.contains(restoring_working_dir.join("src/lib.rs").to_str().unwrap()));
         assert!(
-            stored_mozilla.starts_with(
-                "__kache_root__/config/host_pathsub.o: __kache_root__/config/pathsub.c"
-            ),
-            "stored `.pp` must be relativized, got: {stored_mozilla}"
-        );
-
-        // Restore side: expand against a *different* target dir.
-        let restoring_target = std::path::Path::new("/build/worktree-b/target");
-        rewrite_depinfo_outputs(&outputs, restoring_target, link::DepInfoMode::Expand);
-        let restored = std::fs::read_to_string(&depfile).unwrap();
-        assert!(
-            restored.starts_with("/build/worktree-b/target/release/deps/libfoo-abc.rlib:"),
-            "restored `.d` must be re-rooted at the restoring target dir, got: {restored}"
-        );
-        // Source paths that were already package-relative are untouched.
-        assert!(restored.contains("src/lib.rs"), "got: {restored}");
-        let restored_mozilla = std::fs::read_to_string(&mozilla_depfile).unwrap();
-        assert!(
-            restored_mozilla.starts_with(
-                "/build/worktree-b/target/config/host_pathsub.o: /build/worktree-b/target/config/pathsub.c"
-            ),
-            "restored `.pp` must be re-rooted at the restoring target dir, got: {restored_mozilla}"
+            restored.contains(
+                restoring_workspace
+                    .join("shared/asset.txt")
+                    .to_str()
+                    .unwrap()
+            )
         );
     }
 
-    /// Only dep-info files are touched — the helper identifies them via
-    /// `ArtifactKind::DepInfo`, so an `.rlib` (or any non-dep-info artifact)
-    /// in the same output set is left byte-for-byte intact.
+    /// Any staging failure skips cache publication without changing an output
+    /// that was already read successfully.
     #[test]
-    fn rewrite_depinfo_outputs_ignores_non_dep_info_artifacts() {
+    fn rustc_store_staging_refuses_missing_depinfo_without_mutating_outputs() {
         let dir = tempfile::tempdir().unwrap();
-        let rlib = dir.path().join("libfoo-abc.rlib");
-        // Content that *looks* rewritable but must not be: an `.rlib` is
-        // not dep-info, so the helper must skip it entirely.
-        let original = "/build/worktree-a/target/release/deps/x";
-        std::fs::write(&rlib, original).unwrap();
-
-        let outputs = ArtifactSet::from_output_files(
-            vec![(rlib.clone(), "libfoo-abc.rlib".to_string())],
-            classify_by_filename,
+        let valid = dir.path().join("valid.d");
+        let original = format!(
+            "{}/valid: {}/input.rs\n",
+            dir.path().display(),
+            dir.path().display()
         );
-        rewrite_depinfo_outputs(
+        std::fs::write(&valid, &original).unwrap();
+        let outputs = ArtifactSet::new(vec![
+            crate::compiler::Artifact {
+                path: valid.clone(),
+                store_name: "valid.d".to_string(),
+                kind: ArtifactKind::DepInfo,
+                required: true,
+            },
+            crate::compiler::Artifact {
+                path: dir.path().join("missing.d"),
+                store_name: "missing.d".to_string(),
+                kind: ArtifactKind::DepInfo,
+                required: true,
+            },
+        ]);
+        let error = prepare_rustc_store_files(
             &outputs,
-            std::path::Path::new("/build/worktree-a/target"),
-            link::DepInfoMode::Relativize,
-        );
-
-        assert_eq!(
-            std::fs::read_to_string(&rlib).unwrap(),
-            original,
-            "non-`.d` artifacts must be left untouched"
-        );
-    }
-
-    /// A missing `.d` file is logged and skipped, not propagated — a
-    /// malformed output set must never abort an otherwise-good store.
-    #[test]
-    fn rewrite_depinfo_outputs_is_silent_on_missing_file() {
-        let outputs = ArtifactSet::from_output_files(
-            vec![(PathBuf::from("/nonexistent/foo.d"), "foo.d".to_string())],
-            classify_by_filename,
-        );
-        // Must not panic.
-        rewrite_depinfo_outputs(
-            &outputs,
-            std::path::Path::new("/some/target"),
-            link::DepInfoMode::Relativize,
-        );
+            Some(dir.path()),
+            dir.path(),
+            Some(dir.path()),
+            &[],
+        )
+        .expect_err("a missing dep-info must prevent cache publication");
+        assert!(format!("{error:#}").contains("opening dep-info"));
+        assert_eq!(std::fs::read_to_string(valid).unwrap(), original);
     }
 
     #[test]
@@ -5980,6 +6069,9 @@ mod tests {
             &target,
             ArtifactKind::Library,
             dir.path(),
+            dir.path(),
+            None,
+            &[],
             &*platform,
             "test restore",
             None,
@@ -6001,7 +6093,7 @@ mod tests {
         let config = test_config(dir.path().join("cache"));
         let store = Store::open(&config).unwrap();
         let hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        let stored = "__kache_root__/debug/deps/libfoo.rlib: src/lib.rs\n";
+        let stored = "__kache_root__/debug/deps/libfoo.rlib: __kache_cwd__/src/lib.rs\n";
         create_blob(&store, hash, stored.as_bytes());
         let cached = cached_file("foo.d", hash);
         let target = dir
@@ -6019,6 +6111,9 @@ mod tests {
             &target,
             ArtifactKind::DepInfo,
             &anchor,
+            dir.path(),
+            None,
+            &[],
             &*platform,
             "test restore",
             None,
@@ -6029,6 +6124,10 @@ mod tests {
         assert!(
             restored.starts_with(&format!("{}/debug/deps/libfoo.rlib:", anchor.display())),
             "dep-info should be expanded at restore anchor, got: {restored}"
+        );
+        assert!(
+            restored.contains(&format!("{}/src/lib.rs", dir.path().display())),
+            "dep-info source should be expanded at the consumer cwd: {restored}"
         );
         assert_eq!(
             std::fs::read_to_string(store.blob_path(hash)).unwrap(),
@@ -6072,6 +6171,9 @@ mod tests {
             &target,
             ArtifactKind::Other("rustc:unknown"),
             dir.path(),
+            dir.path(),
+            None,
+            &[],
             &*platform,
             "test restore",
             None,
@@ -6109,6 +6211,9 @@ mod tests {
             &target,
             ArtifactKind::Library,
             dir.path(),
+            dir.path(),
+            None,
+            &[],
             &*platform,
             "test restore",
             None,
@@ -6282,6 +6387,9 @@ mod tests {
             &target,
             ArtifactKind::DebugBundle,
             dir.path(),
+            dir.path(),
+            None,
+            &[],
             &*platform,
             "test restore",
             None,
@@ -6372,6 +6480,9 @@ mod tests {
             &target,
             ArtifactKind::DebugBundle,
             restore_dir.path(),
+            restore_dir.path(),
+            None,
+            &[],
             &*platform,
             "test restore",
             None,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -6128,11 +6128,19 @@ mod tests {
 
         let restored = std::fs::read_to_string(&target).unwrap();
         assert!(
-            restored.starts_with(&format!("{}/debug/deps/libfoo.rlib:", anchor.display())),
+            restored.starts_with(&format!(
+                "{}{}debug/deps/libfoo.rlib:",
+                anchor.display(),
+                std::path::MAIN_SEPARATOR
+            )),
             "dep-info should be expanded at restore anchor, got: {restored}"
         );
         assert!(
-            restored.contains(&format!("{}/src/lib.rs", dir.path().display())),
+            restored.contains(&format!(
+                "{}{}src/lib.rs",
+                dir.path().display(),
+                std::path::MAIN_SEPARATOR
+            )),
             "dep-info source should be expanded at the consumer cwd: {restored}"
         );
         assert_eq!(

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2232,7 +2232,8 @@ fn run_parsed_rustc(
     let depinfo_anchor = args.target_dir();
     let depinfo_working_dir = current_dir.as_deref().unwrap_or_else(|| Path::new("."));
     let depinfo_workspace_dir = args.path_normalization_root();
-    let depinfo_configured_roots = configured_rustc_depinfo_roots(config, depinfo_workspace_dir);
+    let depinfo_configured_roots =
+        configured_rustc_depinfo_roots(config, depinfo_workspace_dir, depinfo_anchor.as_deref());
 
     // Validate the compiler's consumer-facing dep-info before Store::put makes
     // an entry observable. The staging transform below cannot alter its input.
@@ -2539,8 +2540,10 @@ fn prepare_rustc_store_files(
 fn configured_rustc_depinfo_roots(
     config: &Config,
     workspace_root: Option<&Path>,
+    target_dir: Option<&Path>,
 ) -> Vec<(PathBuf, String, u8)> {
     crate::path_normalizer::PathNormalizer::from_env(workspace_root)
+        .with_target_dir(target_dir)
         .with_base_dirs(&config.base_dirs)
         .depinfo_source_roots()
         .into_iter()
@@ -2886,6 +2889,7 @@ fn compute_rustc_cache_key(
     // `RustcCompiler::execute`, or the key would represent one remap rule set
     // and the binary another.
     let path_normalizer = crate::path_normalizer::PathNormalizer::from_env(workspace_root)
+        .with_target_dir(args.target_dir().as_deref())
         .with_base_dirs(&config.base_dirs)
         .with_path_only_env_vars(config.path_only_env_vars.clone())
         .with_rust_src_rule(
@@ -3120,14 +3124,16 @@ fn restore_from_cache(
     // the consumer worktree rather than a live donor (#760).
     // Falls back to cwd only for ad-hoc invocations outside cargo's
     // layout, where there is no cached `.d` to rewrite anyway.
-    let depinfo_anchor = args
-        .target_dir()
+    let cargo_target_dir = args.target_dir();
+    let depinfo_anchor = cargo_target_dir
+        .clone()
         .or_else(|| std::env::current_dir().ok())
         .unwrap_or_else(|| Path::new(".").to_path_buf());
     let depinfo_working_dir =
         std::env::current_dir().unwrap_or_else(|_| Path::new(".").to_path_buf());
     let depinfo_workspace_dir = args.path_normalization_root();
-    let depinfo_configured_roots = configured_rustc_depinfo_roots(config, depinfo_workspace_dir);
+    let depinfo_configured_roots =
+        configured_rustc_depinfo_roots(config, depinfo_workspace_dir, cargo_target_dir.as_deref());
 
     // Dep-info validation gate (kunobi-ninja/kache#330): a restored `.d`
     // whose paths do not resolve for THIS consumer poisons cargo's

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -5008,6 +5008,63 @@ mod tests {
     }
 
     #[test]
+    fn configured_rustc_depinfo_roots_cover_every_restorable_anchor() {
+        // This is the set the store side relativizes dep-info against. Losing a
+        // root leaves a live producer path in the stored `.d`, so a relocated
+        // hit lets cargo validate freshness against the donor's worktree
+        // instead of the consumer's (#760).
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().canonicalize().unwrap();
+        let workspace = base.join("workspace");
+        let target = base.join("shared-target");
+        let vendored = base.join("vendored-sources");
+        for path in [&workspace, &target, &vendored] {
+            std::fs::create_dir_all(path).unwrap();
+        }
+
+        let config = Config {
+            base_dirs: vec![vendored.to_string_lossy().into_owned()],
+            ..test_config(base.join("cache"))
+        };
+        let roots = configured_rustc_depinfo_roots(&config, Some(&workspace), Some(&target));
+
+        let found = |root: &Path, sentinel: &str| {
+            roots
+                .iter()
+                .any(|(path, depinfo_sentinel, _)| path == root && depinfo_sentinel == sentinel)
+        };
+        assert!(
+            found(&workspace, "__kache_workspace__/"),
+            "workspace root missing from {roots:?}"
+        );
+        assert!(
+            found(&target, "__kache_target_rule__/"),
+            "external target root missing from {roots:?}"
+        );
+        assert!(
+            found(&vendored, "__kache_base_dir_0__/"),
+            "configured base dir missing from {roots:?}"
+        );
+
+        // Priorities are what break ties when roots nest, so they must be the
+        // real ranks rather than a uniform placeholder.
+        let workspace_priority = roots
+            .iter()
+            .find(|(path, _, _)| path == &workspace)
+            .map(|(_, _, priority)| *priority)
+            .unwrap();
+        let target_priority = roots
+            .iter()
+            .find(|(path, _, _)| path == &target)
+            .map(|(_, _, priority)| *priority)
+            .unwrap();
+        assert!(
+            workspace_priority > target_priority,
+            "the workspace must outrank an external target ({workspace_priority} vs {target_priority})"
+        );
+    }
+
+    #[test]
     fn input_race_store_suppression_truth_table() {
         for (extra_inputs_racy, guard_enabled, key_too_new, expected) in [
             (false, false, false, false),

--- a/tests/cache_key_underkeying_test.rs
+++ b/tests/cache_key_underkeying_test.rs
@@ -51,6 +51,16 @@ fn rustc_sysroot() -> String {
 /// Compile a trivial rlib through kache-as-RUSTC_WRAPPER with `extra` flags
 /// appended to the rustc argv. Asserts the compile succeeds.
 fn run_kache_rustc(cache_dir: &Path, out_dir: &Path, src: &Path, extra: &[&str]) {
+    run_kache_rustc_from(cache_dir, out_dir, src, extra, None);
+}
+
+fn run_kache_rustc_from(
+    cache_dir: &Path,
+    out_dir: &Path,
+    src: &Path,
+    extra: &[&str],
+    cwd: Option<&Path>,
+) {
     let mut args: Vec<String> = vec![
         rustc_path(),
         "--crate-name".into(),
@@ -66,15 +76,18 @@ fn run_kache_rustc(cache_dir: &Path, out_dir: &Path, src: &Path, extra: &[&str])
     ];
     args.extend(extra.iter().map(|s| s.to_string()));
 
-    let output = std::process::Command::new(kache_binary())
+    let mut command = std::process::Command::new(kache_binary());
+    command
         .args(&args)
         .env("KACHE_CACHE_DIR", cache_dir)
         .env("KACHE_CONFIG", isolated_config_path(cache_dir))
         .env("KACHE_LOG", "kache=info")
         .env_remove("RUSTC_WRAPPER")
-        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
-        .output()
-        .expect("failed to run kache rustc");
+        .env_remove("CARGO_BUILD_RUSTC_WRAPPER");
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let output = command.output().expect("failed to run kache rustc");
 
     assert!(
         output.status.success(),
@@ -207,16 +220,41 @@ fn direct_remap_path_prefix_changes_cache_key() {
     let portable_b = format!("--remap-path-prefix={}=/virtual/a", root_b.display());
     let different_target_b = format!("--remap-path-prefix={}=/virtual/b", root_b.display());
 
-    run_kache_rustc(
+    run_kache_rustc_from(
         cache_dir.path(),
         &out_a,
         &src_a,
         &["--remap-path-prefix", &map_a],
+        Some(&root_a),
     ); // miss
-    run_kache_rustc(cache_dir.path(), &out_a, &src_a, &[&attached_a]); // hit
-    run_kache_rustc(cache_dir.path(), &out_a, &src_a, &[&nonmatching_a]); // miss
-    run_kache_rustc(cache_dir.path(), &out_b, &src_b, &[&portable_b]); // hit
-    run_kache_rustc(cache_dir.path(), &out_b, &src_b, &[&different_target_b]); // miss
+    run_kache_rustc_from(
+        cache_dir.path(),
+        &out_a,
+        &src_a,
+        &[&attached_a],
+        Some(&root_a),
+    ); // hit
+    run_kache_rustc_from(
+        cache_dir.path(),
+        &out_a,
+        &src_a,
+        &[&nonmatching_a],
+        Some(&root_a),
+    ); // miss
+    run_kache_rustc_from(
+        cache_dir.path(),
+        &out_b,
+        &src_b,
+        &[&portable_b],
+        Some(&root_b),
+    ); // hit
+    run_kache_rustc_from(
+        cache_dir.path(),
+        &out_b,
+        &src_b,
+        &[&different_target_b],
+        Some(&root_b),
+    ); // miss
 
     assert_eq!(
         compiled_hit_counts(cache_dir.path()),
@@ -338,5 +376,102 @@ fn colocated_extra_input_changes_cache_key() {
         (2, 1),
         "editing a declared extra input must diverge the key; the pre-feature \
          behavior (ignoring it) would falsely hit and show compiled=1, hits=2"
+    );
+}
+
+/// #760: source identity is the path-to-content mapping, not merely the
+/// unordered multiset of source bytes. Swapping two module bodies keeps the
+/// byte multiset unchanged but changes which module owns each definition, so
+/// the third invocation must compile instead of restoring the first artifact.
+#[test]
+fn swapping_module_contents_changes_cache_key() {
+    build_kache();
+    let cache_dir = TempDir::new().unwrap();
+    let out = TempDir::new().unwrap();
+    let crate_dir = TempDir::new().unwrap();
+    let src = crate_dir.path().join("lib.rs");
+    let module_a = crate_dir.path().join("a.rs");
+    let module_b = crate_dir.path().join("b.rs");
+    let body_a = b"pub const VALUE: u8 = 1;\n";
+    let body_b = b"pub const VALUE: u8 = 2;\n";
+
+    std::fs::write(
+        &src,
+        b"mod a;\nmod b;\npub fn values() -> (u8, u8) { (a::VALUE, b::VALUE) }\n",
+    )
+    .unwrap();
+    std::fs::write(&module_a, body_a).unwrap();
+    std::fs::write(&module_b, body_b).unwrap();
+
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &[]); // miss
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &[]); // hit
+
+    std::fs::write(&module_a, body_b).unwrap();
+    std::fs::write(&module_b, body_a).unwrap();
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &[]); // must miss
+
+    assert_eq!(
+        compiled_hit_counts(cache_dir.path()),
+        (2, 1),
+        "swapping equal-multiset module contents must not restore the artifact for the old path mapping"
+    );
+}
+
+/// Linux filesystems can distinguish canonically equivalent Unicode names.
+/// Normalizing path identity to NFC would merge those names, so swapping their
+/// contents would preserve the sorted source records and recreate #760.
+#[test]
+#[cfg(target_os = "linux")]
+fn unicode_distinct_source_names_remain_distinct() {
+    build_kache();
+    let cache_dir = TempDir::new().unwrap();
+    let out = TempDir::new().unwrap();
+    let crate_dir = TempDir::new().unwrap();
+    let src = crate_dir.path().join("lib.rs");
+    let nfc = "\u{e9}.txt";
+    let nfd = "e\u{301}.txt";
+    let body_a = b"alpha";
+    let body_b = b"bravo";
+
+    std::fs::write(
+        &src,
+        format!(
+            "pub static A: &[u8] = include_bytes!({nfc:?});\n\
+             pub static B: &[u8] = include_bytes!({nfd:?});\n"
+        ),
+    )
+    .unwrap();
+    std::fs::write(crate_dir.path().join(nfc), body_a).unwrap();
+    std::fs::write(crate_dir.path().join(nfd), body_b).unwrap();
+
+    run_kache_rustc_from(
+        cache_dir.path(),
+        out.path(),
+        &src,
+        &[],
+        Some(crate_dir.path()),
+    );
+    run_kache_rustc_from(
+        cache_dir.path(),
+        out.path(),
+        &src,
+        &[],
+        Some(crate_dir.path()),
+    );
+
+    std::fs::write(crate_dir.path().join(nfc), body_b).unwrap();
+    std::fs::write(crate_dir.path().join(nfd), body_a).unwrap();
+    run_kache_rustc_from(
+        cache_dir.path(),
+        out.path(),
+        &src,
+        &[],
+        Some(crate_dir.path()),
+    );
+
+    assert_eq!(
+        compiled_hit_counts(cache_dir.path()),
+        (2, 1),
+        "filesystem-distinct Unicode source names must remain distinct key identities"
     );
 }

--- a/tests/cargo_proxy_test.rs
+++ b/tests/cargo_proxy_test.rs
@@ -7,7 +7,7 @@ use std::ffi::OsString;
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output};
 
 const KACHE_BIN: &str = env!("CARGO_BIN_EXE_kache");
 
@@ -49,8 +49,10 @@ fn canonical_cargo_home_alias_keeps_existing_cargo_unit_fresh() {
     )
     .unwrap();
 
-    let mut cold = Command::new(env!("CARGO"));
-    cold.args(["check", "--quiet"]).current_dir(&project);
+    let mut cold = Command::new(KACHE_BIN);
+    cold.args(["cargo", "--", "check", "--quiet"])
+        .current_dir(&project)
+        .env("KACHE_REAL_CARGO", env!("CARGO"));
     cargo_env(&mut cold, &home, &cache, &cold_target);
     let cold = cold.output().unwrap();
     assert!(
@@ -184,4 +186,161 @@ fn non_utf8_wrapper_argument_fails_closed_before_compiler_execution() {
         "unexpected error: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+#[test]
+fn configured_build_dir_reaches_cargo_without_proxy_override() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    let project = dir.path().join("project");
+    let config_dir = project.join(".cargo");
+    let fake_cargo = dir.path().join("cargo");
+    let capture = dir.path().join("captured-build-dir");
+    std::fs::create_dir_all(home.join(".cargo")).unwrap();
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.toml"),
+        "[build]\nbuild-dir = \"configured-build\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &fake_cargo,
+        "#!/bin/sh\nprintf '%s' \"${CARGO_BUILD_BUILD_DIR-unset}\" > \"$KACHE_TEST_CAPTURE\"\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&fake_cargo, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = Command::new(KACHE_BIN)
+        .args(["cargo", "--", "build"])
+        .current_dir(&project)
+        .env("HOME", &home)
+        .env("CARGO_HOME", home.join(".cargo"))
+        .env("KACHE_REAL_CARGO", &fake_cargo)
+        .env("KACHE_TEST_CAPTURE", &capture)
+        .env_remove("CARGO_BUILD_BUILD_DIR")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "proxy failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        std::fs::read_to_string(capture).unwrap(),
+        "unset",
+        "a config-defined build-dir must retain Cargo precedence"
+    );
+}
+
+fn write_shared_target_project(root: &Path, value: &str) {
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    let manifest = root.join("Cargo.toml");
+    let source = root.join("src/main.rs");
+    std::fs::write(
+        &manifest,
+        "[package]\nname = \"proxy_shared_target\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .unwrap();
+    std::fs::write(&source, format!("fn main() {{ print!({value:?}); }}\n")).unwrap();
+
+    // Make both worktrees older than the first produced artifact. This pins
+    // Cargo's shared-fingerprint failure deterministically: without a private
+    // build-dir, the second worktree is incorrectly declared Fresh.
+    let old = filetime::FileTime::from_unix_time(1_600_000_000, 0);
+    filetime::set_file_mtime(&manifest, old).unwrap();
+    filetime::set_file_mtime(&source, old).unwrap();
+}
+
+fn proxied_shared_target_build(project: &Path, home: &Path, cache: &Path, target: &Path) -> Output {
+    let mut command = Command::new(KACHE_BIN);
+    command
+        .args(["cargo", "--", "build", "--quiet"])
+        .current_dir(project)
+        .env("KACHE_REAL_CARGO", env!("CARGO"))
+        .env("KACHE_CACHE_EXECUTABLES", "1");
+    cargo_env(&mut command, home, cache, target);
+    command.output().unwrap()
+}
+
+fn run_shared_target_binary(target: &Path) -> String {
+    let mut binary = target.join("debug/proxy_shared_target");
+    if cfg!(windows) {
+        binary.set_extension("exe");
+    }
+    let output = Command::new(&binary).output().unwrap();
+    assert!(output.status.success(), "{} failed", binary.display());
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn cargo_proxy_isolates_fingerprints_while_sharing_final_target_and_kache() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    let cache = dir.path().join("cache");
+    let shared_target = dir.path().join("shared-target");
+    let worktree_a = dir.path().join("worktree-a");
+    let worktree_b = dir.path().join("worktree-b");
+    let worktree_c = dir.path().join("worktree-c");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&cache).unwrap();
+    write_shared_target_project(&worktree_a, "alpha");
+    write_shared_target_project(&worktree_b, "bravo");
+    write_shared_target_project(&worktree_c, "alpha");
+
+    let first = proxied_shared_target_build(&worktree_a, &home, &cache, &shared_target);
+    assert!(
+        first.status.success(),
+        "worktree A failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    assert_eq!(run_shared_target_binary(&shared_target), "alpha");
+
+    let second = proxied_shared_target_build(&worktree_b, &home, &cache, &shared_target);
+    assert!(
+        second.status.success(),
+        "worktree B failed: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    assert_eq!(
+        run_shared_target_binary(&shared_target),
+        "bravo",
+        "Cargo reused worktree A's shared fingerprint without invoking Kache"
+    );
+
+    let back_to_a = proxied_shared_target_build(&worktree_a, &home, &cache, &shared_target);
+    assert!(back_to_a.status.success());
+    assert_eq!(
+        run_shared_target_binary(&shared_target),
+        "alpha",
+        "a Fresh worktree-local unit did not refresh the shared final artifact"
+    );
+
+    let relocated = proxied_shared_target_build(&worktree_c, &home, &cache, &shared_target);
+    assert!(relocated.status.success());
+    assert_eq!(run_shared_target_binary(&shared_target), "alpha");
+
+    for worktree in [&worktree_a, &worktree_b, &worktree_c] {
+        assert!(
+            worktree.join("target/debug/.fingerprint").is_dir(),
+            "intermediate fingerprints must be private to {}",
+            worktree.display()
+        );
+    }
+    assert!(
+        !shared_target.join("debug/.fingerprint").exists(),
+        "the shared final target must not contain Cargo fingerprint state"
+    );
+
+    let events: Vec<Value> = std::fs::read_to_string(cache.join("events.jsonl"))
+        .unwrap()
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .filter(|event: &Value| event["crate_name"] == "proxy_shared_target")
+        .collect();
+    assert_eq!(events.len(), 3, "events: {events:#?}");
+    assert_eq!(events[0]["result"], "miss");
+    assert_ne!(events[1]["result"], "local_hit");
+    assert_eq!(events[2]["result"], "local_hit");
+    assert_eq!(events[0]["cache_key"], events[2]["cache_key"]);
 }

--- a/tests/worktree_depinfo_test.rs
+++ b/tests/worktree_depinfo_test.rs
@@ -1,0 +1,201 @@
+//! Cross-worktree regression for #760.
+//!
+//! A proc macro can expand to an absolute `include_bytes!` path elsewhere in
+//! the workspace. Rustc reports that path in dep-info, so a relocated Kache hit
+//! must rebase it to the consuming worktree. Otherwise Cargo watches the donor
+//! and can keep a stale rlib `Fresh` after the consumer's asset changes.
+
+use serde_json::Value;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::time::Duration;
+use tempfile::TempDir;
+
+mod common;
+use common::{build_kache, isolated_config_path, kache_binary};
+
+fn write_package(root: &Path, package: &str, manifest: &str, source: &str, name: &str) {
+    let package = root.join(package);
+    std::fs::create_dir_all(package.join("src")).unwrap();
+    std::fs::write(package.join("Cargo.toml"), manifest).unwrap();
+    std::fs::write(package.join("src").join(name), source).unwrap();
+}
+
+fn write_workspace(root: &Path) {
+    std::fs::write(
+        root.join("Cargo.toml"),
+        r#"[workspace]
+members = ["embed-macro", "embedded", "app"]
+resolver = "2"
+"#,
+    )
+    .unwrap();
+
+    write_package(
+        root,
+        "embed-macro",
+        r#"[package]
+name = "embed-macro"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+"#,
+        r#"use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn embed(_input: TokenStream) -> TokenStream {
+    let root = std::env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir");
+    let path = std::path::PathBuf::from(root)
+        .parent()
+        .expect("workspace root")
+        .join("shared/asset.txt")
+        .canonicalize()
+        .expect("workspace asset");
+    format!("include_bytes!({:?})", path.to_string_lossy())
+        .parse()
+        .expect("include_bytes expansion")
+}
+"#,
+        "lib.rs",
+    );
+
+    write_package(
+        root,
+        "embedded",
+        r#"[package]
+name = "embedded"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+embed-macro = { path = "../embed-macro" }
+"#,
+        r#"pub fn value() -> &'static str {
+    std::str::from_utf8(embed_macro::embed!()).expect("UTF-8 fixture")
+}
+"#,
+        "lib.rs",
+    );
+    std::fs::create_dir_all(root.join("shared")).unwrap();
+    std::fs::write(root.join("shared/asset.txt"), "alpha").unwrap();
+
+    write_package(
+        root,
+        "app",
+        r#"[package]
+name = "app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+embedded = { path = "../embedded" }
+"#,
+        "fn main() { print!(\"{}\", embedded::value()); }\n",
+        "main.rs",
+    );
+}
+
+fn cargo_build(workspace: &Path, target: &Path, cache: &Path) -> Output {
+    Command::new("cargo")
+        .args(["build", "--offline", "--workspace", "--verbose"])
+        .current_dir(workspace)
+        .env("RUSTC_WRAPPER", kache_binary())
+        .env("CARGO_TARGET_DIR", target)
+        .env("CARGO_INCREMENTAL", "0")
+        .env("CARGO_TERM_COLOR", "never")
+        .env("KACHE_CACHE_DIR", cache)
+        .env("KACHE_BASE_DIR", workspace)
+        .env("KACHE_CONFIG", isolated_config_path(cache))
+        .env("KACHE_LOG", "off")
+        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .env_remove("KACHE_DISABLED")
+        .output()
+        .expect("run Cargo through Kache")
+}
+
+fn assert_build_succeeded(output: &Output) {
+    assert!(
+        output.status.success(),
+        "Cargo build failed.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn run_app(target: &Path) -> String {
+    let mut binary = target.join("debug/app");
+    if cfg!(windows) {
+        binary.set_extension("exe");
+    }
+    let output = Command::new(&binary).output().unwrap();
+    assert!(output.status.success(), "{} failed", binary.display());
+    String::from_utf8(output.stdout).unwrap()
+}
+
+fn crate_events(cache: &Path, crate_name: &str) -> Vec<Value> {
+    std::fs::read_to_string(cache.join("events.jsonl"))
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|event| event["crate_name"] == crate_name)
+        .collect()
+}
+
+#[test]
+fn restored_depinfo_tracks_the_consuming_worktree() {
+    build_kache();
+    let root = TempDir::new().unwrap();
+    let workspace_a = root.path().join("worktree-a");
+    let workspace_b = root.path().join("worktree-b");
+    let target_a = workspace_a.join("target");
+    let target_b = workspace_b.join("target");
+    let cache = root.path().join("cache");
+    std::fs::create_dir_all(&workspace_a).unwrap();
+    std::fs::create_dir_all(&workspace_b).unwrap();
+    write_workspace(&workspace_a);
+    write_workspace(&workspace_b);
+
+    let donor = cargo_build(&workspace_b, &target_b, &cache);
+    assert_build_succeeded(&donor);
+    assert_eq!(run_app(&target_b), "alpha");
+
+    let relocated = cargo_build(&workspace_a, &target_a, &cache);
+    assert_build_succeeded(&relocated);
+    assert_eq!(run_app(&target_a), "alpha");
+    let relocated_events = crate_events(&cache, "embedded");
+    assert_eq!(relocated_events.len(), 2, "events: {relocated_events:#?}");
+    assert_eq!(relocated_events[1]["result"], "local_hit");
+
+    let unchanged = cargo_build(&workspace_a, &target_a, &cache);
+    assert_build_succeeded(&unchanged);
+    assert_eq!(run_app(&target_a), "alpha");
+    assert_eq!(
+        crate_events(&cache, "embedded").len(),
+        2,
+        "consumer-rooted dep-info should let Cargo keep an unchanged unit Fresh"
+    );
+
+    // Ensure Cargo's mtime freshness check can observe the edit even on
+    // filesystems with coarse timestamp granularity.
+    std::thread::sleep(Duration::from_millis(1100));
+    std::fs::write(workspace_a.join("shared/asset.txt"), "bravo").unwrap();
+
+    let changed = cargo_build(&workspace_a, &target_a, &cache);
+    assert_build_succeeded(&changed);
+    assert_eq!(
+        run_app(&target_a),
+        "bravo",
+        "Cargo watched the donor worktree and retained a stale embedded rlib"
+    );
+
+    let changed_events = crate_events(&cache, "embedded");
+    assert_eq!(changed_events.len(), 3, "events: {changed_events:#?}");
+    assert_ne!(changed_events[2]["result"], "local_hit");
+    assert_ne!(
+        changed_events[2]["cache_key"], relocated_events[1]["cache_key"],
+        "changing the included asset must re-key the consumer"
+    );
+}


### PR DESCRIPTION
Fixes #760.

## What changed

- Bind every rustc source's stable path identity together with its content hash (cache-key schema v26), so swapping equal content between paths cannot collide.
- Store Rust dep-info with portable source-root sentinels and expand it for the consuming worktree. Publication now fails closed if dep-info cannot be made portable.
- Make `kache cargo build/check` isolate Cargo fingerprints in a workspace-local build directory while retaining the configured shared artifact target (Cargo 1.91+).
- Cover configured roots, symlink/canonical aliases, Unicode/non-UTF-8 paths, Windows drive/UNC/verbatim paths, and source-root precedence.

## Root cause

The reported n00n history did not have byte-identical Rust sources: the relevant change added both a literal builtin entry and an `include_dir!` invocation. In the exact shared-target reproduction, Cargo marked the old unit `Fresh`, so it never invoked `RUSTC_WRAPPER`; Kache could not validate or reject it.

The investigation also found two independent Kache correctness holes:

- source keys folded a sorted multiset of content hashes without source-path association;
- cached `.d` files could retain a live donor-worktree path, allowing Cargo to validate the wrong tree after a relocated hit.

The new `kache cargo` isolation closes the pre-wrapper Cargo fingerprint boundary, while the key and dep-info changes close the Kache-owned boundaries. Arbitrary undeclared `std::fs` reads inside proc macros remain outside rustc's observable inputs and still require declared `extra_inputs`.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --tests`
- `just lint`
- `cargo test --workspace --test '*'` (all integration tests green)
- focused cache-key, Cargo proxy, path-normalizer, dep-info, and relocated-worktree tests green
- full unit run: 1,985/1,988 green; the three unrelated process-inspection tests fail under the shared macOS runner and pass individually

