### PR TITLE
feat(report): version and regression-test the JSON output contract (#699)

### DIFF
--- a/crates/kache-e2e/src/report.rs
+++ b/crates/kache-e2e/src/report.rs
@@ -10,11 +10,15 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Command;
 
+/// Expected report schema version supported by this E2E reader.
+pub const SUPPORTED_REPORT_SCHEMA_VERSION: u32 = 1;
+
 /// Raw `kache report --format json` document, deserialized with the
 /// summary surface lifted out for assertions and the full body kept as
 /// `serde_json::Value` for verbatim forwarding.
 #[derive(Debug, Clone, Deserialize)]
 pub struct KacheReport {
+    pub schema_version: u32,
     pub summary: ReportSummary,
     /// Time-ordered event list — every cache lookup the wrapper has
     /// recorded inside the report's window. Used for per-crate
@@ -175,6 +179,22 @@ pub fn fetch_since(
     fetch_since_with_root(kache_path, cache_dir, since, None)
 }
 
+/// Parse and validate report JSON bytes against the supported schema version.
+pub fn parse_report_json(bytes: &[u8]) -> Result<(KacheReport, serde_json::Value)> {
+    let raw: serde_json::Value =
+        serde_json::from_slice(bytes).context("parsing kache report JSON")?;
+    let typed: KacheReport =
+        serde_json::from_value(raw.clone()).context("extracting summary from kache report")?;
+    if typed.schema_version != SUPPORTED_REPORT_SCHEMA_VERSION {
+        anyhow::bail!(
+            "unsupported report schema_version {} (expected {})",
+            typed.schema_version,
+            SUPPORTED_REPORT_SCHEMA_VERSION
+        );
+    }
+    Ok((typed, raw))
+}
+
 pub fn fetch_since_with_root(
     kache_path: &Path,
     cache_dir: &Path,
@@ -199,11 +219,7 @@ pub fn fetch_since_with_root(
         );
     }
 
-    let raw: serde_json::Value =
-        serde_json::from_slice(&output.stdout).context("parsing kache report JSON")?;
-    let typed: KacheReport =
-        serde_json::from_value(raw.clone()).context("extracting summary from kache report")?;
-    Ok((typed, raw))
+    parse_report_json(&output.stdout)
 }
 
 #[cfg(test)]
@@ -238,5 +254,98 @@ mod tests {
         assert_eq!(delta.misses, 0);
         assert_eq!(delta.total_crates, 4);
         assert_eq!(delta.hit_rate_pct, 75.0);
+    }
+
+    #[test]
+    fn kache_report_deserialization_accepts_supported_schema_version_and_additive_fields() {
+        let json = serde_json::json!({
+            "schema_version": 1,
+            "summary": {
+                "hit_rate_pct": 50.0,
+                "total_crates": 2,
+                "local_hits": 1,
+                "prefetch_hits": 0,
+                "remote_hits": 0,
+                "dups": 0,
+                "misses": 1
+            },
+            "all_events": [
+                {
+                    "crate_name": "foo",
+                    "result": "local_hit",
+                    "compiler_runs": 0,
+                    "preprocessor_runs": 0,
+                    "probe_runs": 0,
+                    "passthrough_reason": ""
+                }
+            ],
+            "future_unrecognized_metric": 42,
+            "future_nested_object": { "new_field": "value" }
+        });
+
+        let typed: KacheReport = serde_json::from_value(json).expect("should deserialize");
+        assert_eq!(typed.schema_version, 1);
+        assert_eq!(typed.summary.total_crates, 2);
+        assert_eq!(typed.all_events.len(), 1);
+        assert_eq!(typed.all_events[0].crate_name, "foo");
+    }
+
+    #[test]
+    fn kache_report_rejects_missing_or_incompatible_schema_version() {
+        // Missing schema_version fails typed deserialization
+        let no_version = serde_json::json!({
+            "summary": {
+                "hit_rate_pct": 0.0,
+                "total_crates": 0,
+                "local_hits": 0,
+                "prefetch_hits": 0,
+                "remote_hits": 0,
+                "dups": 0,
+                "misses": 0
+            }
+        });
+        assert!(serde_json::from_value::<KacheReport>(no_version).is_err());
+    }
+
+    #[test]
+    fn parse_report_json_accepts_supported_version() {
+        let json = serde_json::json!({
+            "schema_version": SUPPORTED_REPORT_SCHEMA_VERSION,
+            "summary": {
+                "hit_rate_pct": 100.0,
+                "total_crates": 1,
+                "local_hits": 1,
+                "prefetch_hits": 0,
+                "remote_hits": 0,
+                "dups": 0,
+                "misses": 0
+            }
+        });
+        let bytes = serde_json::to_vec(&json).unwrap();
+        let (typed, raw) = parse_report_json(&bytes).expect("valid supported report");
+        assert_eq!(typed.schema_version, SUPPORTED_REPORT_SCHEMA_VERSION);
+        assert_eq!(raw["schema_version"], SUPPORTED_REPORT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn parse_report_json_rejects_unsupported_version() {
+        let json = serde_json::json!({
+            "schema_version": SUPPORTED_REPORT_SCHEMA_VERSION + 1,
+            "summary": {
+                "hit_rate_pct": 100.0,
+                "total_crates": 1,
+                "local_hits": 1,
+                "prefetch_hits": 0,
+                "remote_hits": 0,
+                "dups": 0,
+                "misses": 0
+            }
+        });
+        let bytes = serde_json::to_vec(&json).unwrap();
+        let err = parse_report_json(&bytes).expect_err("should reject unsupported version");
+        assert!(
+            err.to_string()
+                .contains("unsupported report schema_version")
+        );
     }
 }

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -185,6 +185,21 @@ For timeline analysis, JSON reports include a `timeline` window plus a top-level
 
 The `github` format is friendly for posting as a PR comment via `gh pr comment --body-file`.
 
+### JSON report schema and compatibility
+
+`kache report --format json` emits structured, machine-readable telemetry adhering to a versioned output contract:
+
+- **`schema_version`**: A top-level integer (currently `1`) defining the contract version. A formal JSON Schema definition is maintained at [`docs/commands/report.schema.json`](./report.schema.json).
+- **Machine codes vs. descriptive text**:
+  - Stable result, route, and bypass codes are separated from freeform human diagnostics.
+  - **`result`**: Stable outcome codes (`"local_hit"`, `"prefetch_hit"`, `"remote_hit"`, `"dup"`, `"miss"`, `"error"`, `"passthrough"`, `"skipped"`).
+  - **`route`**: Stable dispatch routes (`"direct"`, `"fallback"`, `"skipped"`, `"n/a"`).
+  - **`reason` categories**: Structured prefix categories (`"not-a-compile"`, `"unsupported"`, etc.) that separate query/probe invocations from real compile refusals.
+  - Freeform strings (`passthrough_reason`, `store_error`, `lookup_rejection`, `suggestions`) provide diagnostics and should not be relied upon for exact string matching across releases.
+- **Compatibility contract**:
+  - **Additive extensions**: Adding new fields or non-breaking metrics to objects does not increment `schema_version`. Machine readers MUST ignore unrecognized fields.
+  - **Breaking changes**: Removing fields, renaming fields, changing field data types, or altering code semantics increments `schema_version`.
+
 ---
 
 ## `kache save-manifest`

--- a/docs/commands/report.schema.json
+++ b/docs/commands/report.schema.json
@@ -1,0 +1,518 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/kunobi-ninja/kache/blob/main/docs/commands/report.schema.json",
+  "title": "KacheBuildReport",
+  "description": "Schema for kache report --format json machine-readable build reports.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "meta",
+    "summary",
+    "timeline",
+    "timing",
+    "storage",
+    "prefetch",
+    "top_misses",
+    "top_hits",
+    "all_events",
+    "traceEvents",
+    "displayTimeUnit",
+    "bypass",
+    "errors_detail",
+    "suggestions"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "enum": [1],
+      "description": "Report schema version (currently 1). Incremented on breaking changes."
+    },
+    "meta": {
+      "type": "object",
+      "required": ["kache_version", "generated_at", "since_hours"],
+      "properties": {
+        "kache_version": {
+          "type": "string",
+          "description": "Version of kache that generated this report."
+        },
+        "generated_at": {
+          "type": "string",
+          "description": "UTC timestamp when this report was generated."
+        },
+        "since_hours": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Lookback window duration in hours."
+        },
+        "root_filter": {
+          "type": ["string", "null"],
+          "description": "Root path filter if --root was specified."
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "hit_rate_pct",
+        "time_saved_ms",
+        "total_crates",
+        "local_hits",
+        "prefetch_hits",
+        "remote_hits",
+        "dups",
+        "misses",
+        "errors",
+        "passthroughs",
+        "probes",
+        "skipped",
+        "store_failures",
+        "fallbacks",
+        "total_duration_ms",
+        "cache_efficiency_pct"
+      ],
+      "properties": {
+        "hit_rate_pct": { "type": "number", "minimum": 0.0, "maximum": 100.0 },
+        "weighted_hit_rate_pct": { "type": ["number", "null"] },
+        "time_saved_ms": { "type": "integer", "minimum": 0 },
+        "total_crates": { "type": "integer", "minimum": 0 },
+        "local_hits": { "type": "integer", "minimum": 0 },
+        "prefetch_hits": { "type": "integer", "minimum": 0 },
+        "remote_hits": { "type": "integer", "minimum": 0 },
+        "dups": { "type": "integer", "minimum": 0 },
+        "misses": { "type": "integer", "minimum": 0 },
+        "errors": { "type": "integer", "minimum": 0 },
+        "passthroughs": { "type": "integer", "minimum": 0 },
+        "probes": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "store_failures": { "type": "integer", "minimum": 0 },
+        "fallbacks": { "type": "integer", "minimum": 0 },
+        "total_duration_ms": { "type": "integer", "minimum": 0 },
+        "cache_efficiency_pct": { "type": "number", "minimum": 0.0, "maximum": 100.0 }
+      }
+    },
+    "timeline": {
+      "type": "object",
+      "required": [
+        "duration_ms",
+        "event_count",
+        "cacheable_count",
+        "hit_count",
+        "compiled_count",
+        "passthrough_count",
+        "probe_count",
+        "skipped_count",
+        "error_count"
+      ],
+      "properties": {
+        "start_time": { "type": ["string", "null"] },
+        "end_time": { "type": ["string", "null"] },
+        "start_unix_ms": { "type": ["integer", "null"] },
+        "end_unix_ms": { "type": ["integer", "null"] },
+        "duration_ms": { "type": "integer", "minimum": 0 },
+        "event_count": { "type": "integer", "minimum": 0 },
+        "cacheable_count": { "type": "integer", "minimum": 0 },
+        "hit_count": { "type": "integer", "minimum": 0 },
+        "compiled_count": { "type": "integer", "minimum": 0 },
+        "passthrough_count": { "type": "integer", "minimum": 0 },
+        "probe_count": { "type": "integer", "minimum": 0 },
+        "skipped_count": { "type": "integer", "minimum": 0 },
+        "error_count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "timing": {
+      "type": "object",
+      "required": [
+        "hit_time_ms",
+        "miss_time_ms",
+        "avg_hit_ms",
+        "avg_miss_ms",
+        "avg_hit_overhead_ms",
+        "miss_compile_time_ms",
+        "avg_key_ms",
+        "avg_lookup_ms",
+        "avg_restore_ms",
+        "avg_store_ms",
+        "total_key_ms",
+        "total_lookup_ms",
+        "total_restore_ms",
+        "total_store_ms"
+      ],
+      "properties": {
+        "hit_time_ms": { "type": "integer", "minimum": 0 },
+        "miss_time_ms": { "type": "integer", "minimum": 0 },
+        "avg_hit_ms": { "type": "number", "minimum": 0.0 },
+        "avg_miss_ms": { "type": "number", "minimum": 0.0 },
+        "avg_hit_overhead_ms": { "type": "number", "minimum": 0.0 },
+        "miss_compile_time_ms": { "type": "integer", "minimum": 0 },
+        "avg_key_ms": { "type": "number", "minimum": 0.0 },
+        "avg_lookup_ms": { "type": "number", "minimum": 0.0 },
+        "avg_restore_ms": { "type": "number", "minimum": 0.0 },
+        "avg_store_ms": { "type": "number", "minimum": 0.0 },
+        "total_key_ms": { "type": "integer", "minimum": 0 },
+        "total_lookup_ms": { "type": "integer", "minimum": 0 },
+        "total_restore_ms": { "type": "integer", "minimum": 0 },
+        "total_store_ms": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "required": [
+        "reflinked_bytes",
+        "hardlinked_bytes",
+        "copied_bytes",
+        "restored_bytes",
+        "zero_copy_pct",
+        "store_reflinked_bytes",
+        "store_hardlinked_bytes",
+        "store_copied_bytes",
+        "store_blobs",
+        "logical_bytes",
+        "blob_bytes",
+        "dedup_saved_bytes"
+      ],
+      "properties": {
+        "reflinked_bytes": { "type": "integer", "minimum": 0 },
+        "hardlinked_bytes": { "type": "integer", "minimum": 0 },
+        "copied_bytes": { "type": "integer", "minimum": 0 },
+        "restored_bytes": { "type": "integer", "minimum": 0 },
+        "zero_copy_pct": { "type": "number", "minimum": 0.0, "maximum": 100.0 },
+        "store_reflinked_bytes": { "type": "integer", "minimum": 0 },
+        "store_hardlinked_bytes": { "type": "integer", "minimum": 0 },
+        "store_copied_bytes": { "type": "integer", "minimum": 0 },
+        "store_blobs": { "type": "integer", "minimum": 0 },
+        "logical_bytes": { "type": "integer", "minimum": 0 },
+        "blob_bytes": { "type": "integer", "minimum": 0 },
+        "dedup_saved_bytes": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "network": {
+      "type": ["object", "null"],
+      "properties": {
+        "bytes_up": { "type": "integer", "minimum": 0 },
+        "bytes_down": { "type": "integer", "minimum": 0 },
+        "uploads_ok": { "type": "integer", "minimum": 0 },
+        "uploads_failed": { "type": "integer", "minimum": 0 },
+        "downloads_ok": { "type": "integer", "minimum": 0 },
+        "downloads_failed": { "type": "integer", "minimum": 0 },
+        "avg_download_ms": { "type": "number", "minimum": 0.0 },
+        "p95_download_ms": { "type": "integer", "minimum": 0 },
+        "max_download_ms": { "type": "integer", "minimum": 0 },
+        "throughput_mbps": { "type": "number", "minimum": 0.0 },
+        "configured_backend": { "type": "string" },
+        "network_throughput_mbps": { "type": "number", "minimum": 0.0 },
+        "body_throughput_mbps": { "type": "number", "minimum": 0.0 },
+        "dominant_download_phase": { "type": "string" },
+        "dominant_download_phase_ms": { "type": "integer", "minimum": 0 },
+        "dominant_download_phase_pct": { "type": "number", "minimum": 0.0, "maximum": 100.0 },
+        "total_request_ms": { "type": "integer", "minimum": 0 },
+        "total_body_ms": { "type": "integer", "minimum": 0 },
+        "total_semaphore_wait_ms": { "type": "integer", "minimum": 0 },
+        "total_head_ms": { "type": "integer", "minimum": 0 },
+        "total_get_requests": { "type": "integer", "minimum": 0 },
+        "compression_ratio": { "type": "number", "minimum": 0.0 },
+        "original_bytes_down": { "type": "integer", "minimum": 0 },
+        "total_decompress_ms": { "type": "integer", "minimum": 0 },
+        "total_extract_ms": { "type": "integer", "minimum": 0 },
+        "total_disk_io_ms": { "type": "integer", "minimum": 0 },
+        "total_import_ms": { "type": "integer", "minimum": 0 },
+        "total_compression_ms": { "type": "integer", "minimum": 0 },
+        "total_head_checks_ms": { "type": "integer", "minimum": 0 },
+        "blobs_skipped": { "type": "integer", "minimum": 0 },
+        "blobs_total": { "type": "integer", "minimum": 0 },
+        "v1_downloads": { "type": "integer", "minimum": 0 },
+        "v2_downloads": { "type": "integer", "minimum": 0 },
+        "v3_downloads": { "type": "integer", "minimum": 0 },
+        "unknown_format_downloads": { "type": "integer", "minimum": 0 },
+        "slowest_downloads": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/TransferDetail" }
+        }
+      }
+    },
+    "prefetch": {
+      "type": "object",
+      "required": ["prefetch_hits", "total_hits", "contribution_pct"],
+      "properties": {
+        "prefetch_hits": { "type": "integer", "minimum": 0 },
+        "total_hits": { "type": "integer", "minimum": 0 },
+        "contribution_pct": { "type": "number", "minimum": 0.0, "maximum": 100.0 }
+      }
+    },
+    "top_misses": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/CrateDetail" }
+    },
+    "top_hits": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/CrateDetail" }
+    },
+    "all_events": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/CrateDetail" }
+    },
+    "traceEvents": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/TraceEvent" }
+    },
+    "displayTimeUnit": {
+      "type": "string",
+      "enum": ["ms", "ns"]
+    },
+    "bypass": {
+      "type": "object",
+      "required": [
+        "passthroughs",
+        "probes",
+        "skipped",
+        "fallbacks",
+        "direct_passthroughs",
+        "reasons",
+        "slowest"
+      ],
+      "properties": {
+        "passthroughs": { "type": "integer", "minimum": 0 },
+        "probes": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "fallbacks": { "type": "integer", "minimum": 0 },
+        "direct_passthroughs": { "type": "integer", "minimum": 0 },
+        "reasons": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/BypassReason" }
+        },
+        "slowest": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/BypassDetail" }
+        }
+      }
+    },
+    "errors_detail": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/ErrorDetail" }
+    },
+    "suggestions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "gc": {
+      "type": ["object", "null"],
+      "properties": {
+        "last_run": { "type": "string" },
+        "entries_evicted": { "type": "integer", "minimum": 0 },
+        "bytes_freed": { "type": "integer", "minimum": 0 },
+        "blobs_removed": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["last_run", "entries_evicted", "bytes_freed", "blobs_removed"]
+    }
+  },
+  "definitions": {
+    "CrateDetail": {
+      "type": "object",
+      "required": [
+        "crate_name",
+        "result",
+        "start_time",
+        "end_time",
+        "start_unix_ms",
+        "end_unix_ms",
+        "elapsed_ms",
+        "compile_time_ms",
+        "overhead_ms",
+        "size",
+        "cache_key",
+        "store_output_blobs",
+        "store_duplicate_blobs",
+        "store_new_blobs",
+        "compiler_runs",
+        "preprocessor_runs",
+        "probe_runs"
+      ],
+      "properties": {
+        "crate_name": { "type": "string" },
+        "root": { "type": "string" },
+        "result": {
+          "type": "string",
+          "enum": [
+            "local_hit",
+            "prefetch_hit",
+            "remote_hit",
+            "dup",
+            "miss",
+            "error",
+            "passthrough",
+            "skipped"
+          ],
+          "description": "Stable machine result code."
+        },
+        "start_time": { "type": "string" },
+        "end_time": { "type": "string" },
+        "start_unix_ms": { "type": "integer" },
+        "end_unix_ms": { "type": "integer" },
+        "elapsed_ms": { "type": "integer", "minimum": 0 },
+        "compile_time_ms": { "type": "integer", "minimum": 0 },
+        "overhead_ms": { "type": "integer", "minimum": 0 },
+        "size": { "type": "integer", "minimum": 0 },
+        "cache_key": { "type": "string" },
+        "store_output_blobs": { "type": "integer", "minimum": 0 },
+        "store_duplicate_blobs": { "type": "integer", "minimum": 0 },
+        "store_new_blobs": { "type": "integer", "minimum": 0 },
+        "compiler_runs": { "type": "integer", "minimum": 0 },
+        "preprocessor_runs": { "type": "integer", "minimum": 0 },
+        "probe_runs": { "type": "integer", "minimum": 0 },
+        "store_error": { "type": "string" }
+      }
+    },
+    "BypassReason": {
+      "type": "object",
+      "required": ["result", "route", "reason", "count", "failures", "max_elapsed_ms"],
+      "properties": {
+        "result": {
+          "type": "string",
+          "enum": [
+            "local_hit",
+            "prefetch_hit",
+            "remote_hit",
+            "dup",
+            "miss",
+            "error",
+            "passthrough",
+            "skipped"
+          ]
+        },
+        "route": {
+          "type": "string",
+          "enum": ["direct", "fallback", "skipped", "n/a"]
+        },
+        "reason": { "type": "string" },
+        "count": { "type": "integer", "minimum": 0 },
+        "failures": { "type": "integer", "minimum": 0 },
+        "max_elapsed_ms": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "BypassDetail": {
+      "type": "object",
+      "required": [
+        "crate_name",
+        "result",
+        "route",
+        "reason",
+        "start_time",
+        "end_time",
+        "start_unix_ms",
+        "end_unix_ms",
+        "elapsed_ms",
+        "timestamp"
+      ],
+      "properties": {
+        "crate_name": { "type": "string" },
+        "root": { "type": "string" },
+        "result": {
+          "type": "string",
+          "enum": [
+            "local_hit",
+            "prefetch_hit",
+            "remote_hit",
+            "dup",
+            "miss",
+            "error",
+            "passthrough",
+            "skipped"
+          ]
+        },
+        "route": {
+          "type": "string",
+          "enum": ["direct", "fallback", "skipped", "n/a"]
+        },
+        "reason": { "type": "string" },
+        "start_time": { "type": "string" },
+        "end_time": { "type": "string" },
+        "start_unix_ms": { "type": "integer" },
+        "end_unix_ms": { "type": "integer" },
+        "elapsed_ms": { "type": "integer", "minimum": 0 },
+        "exit_code": { "type": ["integer", "null"] },
+        "timestamp": { "type": "string" }
+      }
+    },
+    "TraceEvent": {
+      "type": "object",
+      "required": ["name", "cat", "ph", "ts", "dur", "pid", "tid", "args"],
+      "properties": {
+        "name": { "type": "string" },
+        "cat": { "type": "string" },
+        "ph": { "type": "string" },
+        "ts": { "type": "integer" },
+        "dur": { "type": "integer", "minimum": 0 },
+        "pid": { "type": "integer", "minimum": 0 },
+        "tid": { "type": "integer", "minimum": 0 },
+        "cname": { "type": "string" },
+        "args": { "$ref": "#/definitions/TraceArgs" }
+      }
+    },
+    "TraceArgs": {
+      "type": "object",
+      "required": [
+        "crate_name",
+        "root",
+        "result",
+        "route",
+        "reason",
+        "cache_key",
+        "elapsed_ms",
+        "compile_time_ms",
+        "overhead_ms",
+        "size",
+        "compiler_runs",
+        "preprocessor_runs",
+        "probe_runs",
+        "store_output_blobs",
+        "store_duplicate_blobs",
+        "store_new_blobs"
+      ],
+      "properties": {
+        "crate_name": { "type": "string" },
+        "root": { "type": "string" },
+        "result": { "type": "string" },
+        "route": { "type": "string" },
+        "reason": { "type": "string" },
+        "cache_key": { "type": "string" },
+        "elapsed_ms": { "type": "integer", "minimum": 0 },
+        "compile_time_ms": { "type": "integer", "minimum": 0 },
+        "overhead_ms": { "type": "integer", "minimum": 0 },
+        "size": { "type": "integer", "minimum": 0 },
+        "compiler_runs": { "type": "integer", "minimum": 0 },
+        "preprocessor_runs": { "type": "integer", "minimum": 0 },
+        "probe_runs": { "type": "integer", "minimum": 0 },
+        "store_output_blobs": { "type": "integer", "minimum": 0 },
+        "store_duplicate_blobs": { "type": "integer", "minimum": 0 },
+        "store_new_blobs": { "type": "integer", "minimum": 0 },
+        "exit_code": { "type": ["integer", "null"] }
+      }
+    },
+    "ErrorDetail": {
+      "type": "object",
+      "required": ["crate_name", "cache_key", "timestamp"],
+      "properties": {
+        "crate_name": { "type": "string" },
+        "cache_key": { "type": "string" },
+        "timestamp": { "type": "string" }
+      }
+    },
+    "TransferDetail": {
+      "type": "object",
+      "required": ["crate_name", "direction", "compressed_bytes", "elapsed_ms"],
+      "properties": {
+        "crate_name": { "type": "string" },
+        "direction": { "type": "string" },
+        "format": { "type": "string" },
+        "cache_key": { "type": "string" },
+        "object_key": { "type": "string" },
+        "compressed_bytes": { "type": "integer", "minimum": 0 },
+        "elapsed_ms": { "type": "integer", "minimum": 0 },
+        "network_ms": { "type": "integer", "minimum": 0 },
+        "semaphore_wait_ms": { "type": "integer", "minimum": 0 },
+        "head_ms": { "type": "integer", "minimum": 0 },
+        "request_ms": { "type": "integer", "minimum": 0 },
+        "body_ms": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -29,8 +29,16 @@ pub struct GcSummary {
     pub blobs_removed: usize,
 }
 
+/// Schema version of the machine-readable JSON build report.
+///
+/// Incremented when a breaking change is made to the report's JSON structure
+/// or code semantics. Additive fields (such as new optional/default fields or
+/// non-breaking telemetry metrics) do not increment this version.
+pub const REPORT_SCHEMA_VERSION: u32 = 1;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BuildReport {
+    pub schema_version: u32,
     pub meta: ReportMeta,
     pub summary: ReportSummary,
     #[serde(default)]
@@ -645,6 +653,7 @@ pub fn generate_report_with_filter(
     };
 
     Ok(BuildReport {
+        schema_version: REPORT_SCHEMA_VERSION,
         meta: ReportMeta {
             kache_version: crate::VERSION.to_string(),
             generated_at: Utc::now().to_rfc3339(),
@@ -3313,6 +3322,234 @@ mod tests {
         assert!(summary.contains("1 passthrough"), "got: {summary}");
     }
 
+    const REPORT_SCHEMA_JSON: &str = include_str!("report.schema.json");
+
+    fn check_numeric_bounds(val: &serde_json::Value, schema: &serde_json::Value, path: &str) {
+        if let Some(num) = val.as_f64() {
+            if let Some(min) = schema.get("minimum").and_then(|m| m.as_f64()) {
+                assert!(num >= min, "expected >= {min} at {path}, got {num}");
+            }
+            if let Some(max) = schema.get("maximum").and_then(|m| m.as_f64()) {
+                assert!(num <= max, "expected <= {max} at {path}, got {num}");
+            }
+            if let Some(ex_min) = schema.get("exclusiveMinimum").and_then(|m| m.as_f64()) {
+                assert!(num > ex_min, "expected > {ex_min} at {path}, got {num}");
+            }
+            if let Some(ex_max) = schema.get("exclusiveMaximum").and_then(|m| m.as_f64()) {
+                assert!(num < ex_max, "expected < {ex_max} at {path}, got {num}");
+            }
+        }
+    }
+
+    fn validate_json_value(
+        val: &serde_json::Value,
+        schema: &serde_json::Value,
+        root_schema: &serde_json::Value,
+        path: &str,
+    ) {
+        if let Some(ref_path) = schema.get("$ref").and_then(|r| r.as_str())
+            && let Some(def_name) = ref_path.strip_prefix("#/definitions/")
+        {
+            let target_schema = &root_schema["definitions"][def_name];
+            assert!(
+                !target_schema.is_null(),
+                "schema definition not found for {ref_path} at {path}"
+            );
+            return validate_json_value(val, target_schema, root_schema, path);
+        }
+
+        if let Some(expected_type) = schema.get("type") {
+            if let Some(type_str) = expected_type.as_str() {
+                match type_str {
+                    "object" => {
+                        assert!(val.is_object(), "expected object at {path}, got {val:?}");
+                        let obj = val.as_object().unwrap();
+                        if let Some(required) = schema.get("required").and_then(|r| r.as_array()) {
+                            for req_key in required {
+                                let key_str = req_key.as_str().unwrap();
+                                assert!(
+                                    obj.contains_key(key_str),
+                                    "missing required key '{key_str}' at {path}"
+                                );
+                            }
+                        }
+                        if let Some(props) = schema.get("properties").and_then(|p| p.as_object()) {
+                            for (prop_name, prop_val) in obj {
+                                if let Some(prop_schema) = props.get(prop_name) {
+                                    validate_json_value(
+                                        prop_val,
+                                        prop_schema,
+                                        root_schema,
+                                        &format!("{path}.{prop_name}"),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    "array" => {
+                        assert!(val.is_array(), "expected array at {path}, got {val:?}");
+                        if let Some(item_schema) = schema.get("items") {
+                            for (i, elem) in val.as_array().unwrap().iter().enumerate() {
+                                validate_json_value(
+                                    elem,
+                                    item_schema,
+                                    root_schema,
+                                    &format!("{path}[{i}]"),
+                                );
+                            }
+                        }
+                    }
+                    "string" => {
+                        assert!(val.is_string(), "expected string at {path}, got {val:?}");
+                    }
+                    "integer" => {
+                        assert!(
+                            val.is_i64() || val.is_u64(),
+                            "expected integer at {path}, got {val:?}"
+                        );
+                        check_numeric_bounds(val, schema, path);
+                    }
+                    "number" => {
+                        assert!(val.is_number(), "expected number at {path}, got {val:?}");
+                        check_numeric_bounds(val, schema, path);
+                    }
+                    "boolean" => {
+                        assert!(val.is_boolean(), "expected boolean at {path}, got {val:?}");
+                    }
+                    "null" => {
+                        assert!(val.is_null(), "expected null at {path}, got {val:?}");
+                    }
+                    other => panic!("unhandled schema type '{other}' at {path}"),
+                }
+            } else if let Some(type_arr) = expected_type.as_array() {
+                let allowed_types: Vec<&str> = type_arr.iter().filter_map(|t| t.as_str()).collect();
+                let matches_any = allowed_types.iter().any(|&t| match t {
+                    "object" => val.is_object(),
+                    "array" => val.is_array(),
+                    "string" => val.is_string(),
+                    "integer" => val.is_i64() || val.is_u64(),
+                    "number" => val.is_number(),
+                    "boolean" => val.is_boolean(),
+                    "null" => val.is_null(),
+                    _ => false,
+                });
+                assert!(
+                    matches_any,
+                    "value at {path} ({val:?}) does not match any allowed type in {allowed_types:?}"
+                );
+                if val.is_number() {
+                    check_numeric_bounds(val, schema, path);
+                }
+                if val.is_object() && allowed_types.contains(&"object") {
+                    if let Some(required) = schema.get("required").and_then(|r| r.as_array()) {
+                        let obj = val.as_object().unwrap();
+                        for req_key in required {
+                            let key_str = req_key.as_str().unwrap();
+                            assert!(
+                                obj.contains_key(key_str),
+                                "missing required key '{key_str}' at {path}"
+                            );
+                        }
+                    }
+                    if let Some(props) = schema.get("properties").and_then(|p| p.as_object()) {
+                        let obj = val.as_object().unwrap();
+                        for (prop_name, prop_val) in obj {
+                            if let Some(prop_schema) = props.get(prop_name) {
+                                validate_json_value(
+                                    prop_val,
+                                    prop_schema,
+                                    root_schema,
+                                    &format!("{path}.{prop_name}"),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(enums) = schema.get("enum").and_then(|e| e.as_array()) {
+            let is_allowed = enums.contains(val);
+            assert!(
+                is_allowed,
+                "value at {path} ({val:?}) not in enum set {enums:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_format_json_conforms_to_schema_contract() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = write_test_events(dir.path());
+        let report = generate_report(&config, 24, 10).unwrap();
+
+        let json = format_json(&report).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let schema: serde_json::Value = serde_json::from_str(REPORT_SCHEMA_JSON).unwrap();
+
+        validate_json_value(&val, &schema, &schema, "report");
+    }
+
+    #[test]
+    #[should_panic(expected = "expected <= 100 at report.summary.hit_rate_pct, got 500")]
+    fn test_validator_rejects_out_of_bounds_number_maximum() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = write_test_events(dir.path());
+        let report = generate_report(&config, 24, 10).unwrap();
+
+        let json = format_json(&report).unwrap();
+        let mut val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        val["summary"]["hit_rate_pct"] = serde_json::json!(500.0);
+        let schema: serde_json::Value = serde_json::from_str(REPORT_SCHEMA_JSON).unwrap();
+
+        validate_json_value(&val, &schema, &schema, "report");
+    }
+
+    #[test]
+    #[should_panic(expected = "expected >= 0 at report.summary.time_saved_ms, got -10")]
+    fn test_validator_rejects_out_of_bounds_integer_minimum() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = write_test_events(dir.path());
+        let report = generate_report(&config, 24, 10).unwrap();
+
+        let json = format_json(&report).unwrap();
+        let mut val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        val["summary"]["time_saved_ms"] = serde_json::json!(-10);
+        let schema: serde_json::Value = serde_json::from_str(REPORT_SCHEMA_JSON).unwrap();
+
+        validate_json_value(&val, &schema, &schema, "report");
+    }
+
+    #[test]
+    #[should_panic(expected = "not in enum set")]
+    fn test_validator_rejects_invalid_schema_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = write_test_events(dir.path());
+        let report = generate_report(&config, 24, 10).unwrap();
+
+        let json = format_json(&report).unwrap();
+        let mut val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        val["schema_version"] = serde_json::json!(2);
+        let schema: serde_json::Value = serde_json::from_str(REPORT_SCHEMA_JSON).unwrap();
+
+        validate_json_value(&val, &schema, &schema, "report");
+    }
+
+    #[test]
+    #[should_panic(expected = "missing required key 'schema_version' at report")]
+    fn test_validator_rejects_missing_required_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = write_test_events(dir.path());
+        let report = generate_report(&config, 24, 10).unwrap();
+
+        let json = format_json(&report).unwrap();
+        let mut val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        val.as_object_mut().unwrap().remove("schema_version");
+        let schema: serde_json::Value = serde_json::from_str(REPORT_SCHEMA_JSON).unwrap();
+
+        validate_json_value(&val, &schema, &schema, "report");
+    }
+
     #[test]
     fn test_json_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
@@ -3321,11 +3558,13 @@ mod tests {
 
         let json = format_json(&report).unwrap();
         let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(raw["schema_version"], 1);
         assert!(raw.get("traceEvents").is_some());
         assert!(raw.get("trace_events").is_none());
         assert_eq!(raw["displayTimeUnit"], "ms");
 
         let parsed: BuildReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.schema_version, REPORT_SCHEMA_VERSION);
 
         assert_eq!(parsed.summary.total_crates, report.summary.total_crates);
         assert_eq!(parsed.summary.misses, report.summary.misses);

--- a/src/report.schema.json
+++ b/src/report.schema.json
@@ -1,0 +1,518 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/kunobi-ninja/kache/blob/main/docs/commands/report.schema.json",
+  "title": "KacheBuildReport",
+  "description": "Schema for kache report --format json machine-readable build reports.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "meta",
+    "summary",
+    "timeline",
+    "timing",
+    "storage",
+    "prefetch",
+    "top_misses",
+    "top_hits",
+    "all_events",
+    "traceEvents",
+    "displayTimeUnit",
+    "bypass",
+    "errors_detail",
+    "suggestions"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "enum": [1],
+      "description": "Report schema version (currently 1). Incremented on breaking changes."
+    },
+    "meta": {
+      "type": "object",
+      "required": ["kache_version", "generated_at", "since_hours"],
+      "properties": {
+        "kache_version": {
+          "type": "string",
+          "description": "Version of kache that generated this report."
+        },
+        "generated_at": {
+          "type": "string",
+          "description": "UTC timestamp when this report was generated."
+        },
+        "since_hours": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Lookback window duration in hours."
+        },
+        "root_filter": {
+          "type": ["string", "null"],
+          "description": "Root path filter if --root was specified."
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "hit_rate_pct",
+        "time_saved_ms",
+        "total_crates",
+        "local_hits",
+        "prefetch_hits",
+        "remote_hits",
+        "dups",
+        "misses",
+        "errors",
+        "passthroughs",
+        "probes",
+        "skipped",
+        "store_failures",
+        "fallbacks",
+        "total_duration_ms",
+        "cache_efficiency_pct"
+      ],
+      "properties": {
+        "hit_rate_pct": { "type": "number", "minimum": 0.0, "maximum": 100.0 },
+        "weighted_hit_rate_pct": { "type": ["number", "null"] },
+        "time_saved_ms": { "type": "integer", "minimum": 0 },
+        "total_crates": { "type": "integer", "minimum": 0 },
+        "local_hits": { "type": "integer", "minimum": 0 },
+        "prefetch_hits": { "type": "integer", "minimum": 0 },
+        "remote_hits": { "type": "integer", "minimum": 0 },
+        "dups": { "type": "integer", "minimum": 0 },
+        "misses": { "type": "integer", "minimum": 0 },
+        "errors": { "type": "integer", "minimum": 0 },
+        "passthroughs": { "type": "integer", "minimum": 0 },
+        "probes": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "store_failures": { "type": "integer", "minimum": 0 },
+        "fallbacks": { "type": "integer", "minimum": 0 },
+        "total_duration_ms": { "type": "integer", "minimum": 0 },
+        "cache_efficiency_pct": { "type": "number", "minimum": 0.0, "maximum": 100.0 }
+      }
+    },
+    "timeline": {
+      "type": "object",
+      "required": [
+        "duration_ms",
+        "event_count",
+        "cacheable_count",
+        "hit_count",
+        "compiled_count",
+        "passthrough_count",
+        "probe_count",
+        "skipped_count",
+        "error_count"
+      ],
+      "properties": {
+        "start_time": { "type": ["string", "null"] },
+        "end_time": { "type": ["string", "null"] },
+        "start_unix_ms": { "type": ["integer", "null"] },
+        "end_unix_ms": { "type": ["integer", "null"] },
+        "duration_ms": { "type": "integer", "minimum": 0 },
+        "event_count": { "type": "integer", "minimum": 0 },
+        "cacheable_count": { "type": "integer", "minimum": 0 },
+        "hit_count": { "type": "integer", "minimum": 0 },
+        "compiled_count": { "type": "integer", "minimum": 0 },
+        "passthrough_count": { "type": "integer", "minimum": 0 },
+        "probe_count": { "type": "integer", "minimum": 0 },
+        "skipped_count": { "type": "integer", "minimum": 0 },
+        "error_count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "timing": {
+      "type": "object",
+      "required": [
+        "hit_time_ms",
+        "miss_time_ms",
+        "avg_hit_ms",
+        "avg_miss_ms",
+        "avg_hit_overhead_ms",
+        "miss_compile_time_ms",
+        "avg_key_ms",
+        "avg_lookup_ms",
+        "avg_restore_ms",
+        "avg_store_ms",
+        "total_key_ms",
+        "total_lookup_ms",
+        "total_restore_ms",
+        "total_store_ms"
+      ],
+      "properties": {
+        "hit_time_ms": { "type": "integer", "minimum": 0 },
+        "miss_time_ms": { "type": "integer", "minimum": 0 },
+        "avg_hit_ms": { "type": "number", "minimum": 0.0 },
+        "avg_miss_ms": { "type": "number", "minimum": 0.0 },
+        "avg_hit_overhead_ms": { "type": "number", "minimum": 0.0 },
+        "miss_compile_time_ms": { "type": "integer", "minimum": 0 },
+        "avg_key_ms": { "type": "number", "minimum": 0.0 },
+        "avg_lookup_ms": { "type": "number", "minimum": 0.0 },
+        "avg_restore_ms": { "type": "number", "minimum": 0.0 },
+        "avg_store_ms": { "type": "number", "minimum": 0.0 },
+        "total_key_ms": { "type": "integer", "minimum": 0 },
+        "total_lookup_ms": { "type": "integer", "minimum": 0 },
+        "total_restore_ms": { "type": "integer", "minimum": 0 },
+        "total_store_ms": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "required": [
+        "reflinked_bytes",
+        "hardlinked_bytes",
+        "copied_bytes",
+        "restored_bytes",
+        "zero_copy_pct",
+        "store_reflinked_bytes",
+        "store_hardlinked_bytes",
+        "store_copied_bytes",
+        "store_blobs",
+        "logical_bytes",
+        "blob_bytes",
+        "dedup_saved_bytes"
+      ],
+      "properties": {
+        "reflinked_bytes": { "type": "integer", "minimum": 0 },
+        "hardlinked_bytes": { "type": "integer", "minimum": 0 },
+        "copied_bytes": { "type": "integer", "minimum": 0 },
+        "restored_bytes": { "type": "integer", "minimum": 0 },
+        "zero_copy_pct": { "type": "number", "minimum": 0.0, "maximum": 100.0 },
+        "store_reflinked_bytes": { "type": "integer", "minimum": 0 },
+        "store_hardlinked_bytes": { "type": "integer", "minimum": 0 },
+        "store_copied_bytes": { "type": "integer", "minimum": 0 },
+        "store_blobs": { "type": "integer", "minimum": 0 },
+        "logical_bytes": { "type": "integer", "minimum": 0 },
+        "blob_bytes": { "type": "integer", "minimum": 0 },
+        "dedup_saved_bytes": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "network": {
+      "type": ["object", "null"],
+      "properties": {
+        "bytes_up": { "type": "integer", "minimum": 0 },
+        "bytes_down": { "type": "integer", "minimum": 0 },
+        "uploads_ok": { "type": "integer", "minimum": 0 },
+        "uploads_failed": { "type": "integer", "minimum": 0 },
+        "downloads_ok": { "type": "integer", "minimum": 0 },
+        "downloads_failed": { "type": "integer", "minimum": 0 },
+        "avg_download_ms": { "type": "number", "minimum": 0.0 },
+        "p95_download_ms": { "type": "integer", "minimum": 0 },
+        "max_download_ms": { "type": "integer", "minimum": 0 },
+        "throughput_mbps": { "type": "number", "minimum": 0.0 },
+        "configured_backend": { "type": "string" },
+        "network_throughput_mbps": { "type": "number", "minimum": 0.0 },
+        "body_throughput_mbps": { "type": "number", "minimum": 0.0 },
+        "dominant_download_phase": { "type": "string" },
+        "dominant_download_phase_ms": { "type": "integer", "minimum": 0 },
+        "dominant_download_phase_pct": { "type": "number", "minimum": 0.0, "maximum": 100.0 },
+        "total_request_ms": { "type": "integer", "minimum": 0 },
+        "total_body_ms": { "type": "integer", "minimum": 0 },
+        "total_semaphore_wait_ms": { "type": "integer", "minimum": 0 },
+        "total_head_ms": { "type": "integer", "minimum": 0 },
+        "total_get_requests": { "type": "integer", "minimum": 0 },
+        "compression_ratio": { "type": "number", "minimum": 0.0 },
+        "original_bytes_down": { "type": "integer", "minimum": 0 },
+        "total_decompress_ms": { "type": "integer", "minimum": 0 },
+        "total_extract_ms": { "type": "integer", "minimum": 0 },
+        "total_disk_io_ms": { "type": "integer", "minimum": 0 },
+        "total_import_ms": { "type": "integer", "minimum": 0 },
+        "total_compression_ms": { "type": "integer", "minimum": 0 },
+        "total_head_checks_ms": { "type": "integer", "minimum": 0 },
+        "blobs_skipped": { "type": "integer", "minimum": 0 },
+        "blobs_total": { "type": "integer", "minimum": 0 },
+        "v1_downloads": { "type": "integer", "minimum": 0 },
+        "v2_downloads": { "type": "integer", "minimum": 0 },
+        "v3_downloads": { "type": "integer", "minimum": 0 },
+        "unknown_format_downloads": { "type": "integer", "minimum": 0 },
+        "slowest_downloads": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/TransferDetail" }
+        }
+      }
+    },
+    "prefetch": {
+      "type": "object",
+      "required": ["prefetch_hits", "total_hits", "contribution_pct"],
+      "properties": {
+        "prefetch_hits": { "type": "integer", "minimum": 0 },
+        "total_hits": { "type": "integer", "minimum": 0 },
+        "contribution_pct": { "type": "number", "minimum": 0.0, "maximum": 100.0 }
+      }
+    },
+    "top_misses": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/CrateDetail" }
+    },
+    "top_hits": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/CrateDetail" }
+    },
+    "all_events": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/CrateDetail" }
+    },
+    "traceEvents": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/TraceEvent" }
+    },
+    "displayTimeUnit": {
+      "type": "string",
+      "enum": ["ms", "ns"]
+    },
+    "bypass": {
+      "type": "object",
+      "required": [
+        "passthroughs",
+        "probes",
+        "skipped",
+        "fallbacks",
+        "direct_passthroughs",
+        "reasons",
+        "slowest"
+      ],
+      "properties": {
+        "passthroughs": { "type": "integer", "minimum": 0 },
+        "probes": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "fallbacks": { "type": "integer", "minimum": 0 },
+        "direct_passthroughs": { "type": "integer", "minimum": 0 },
+        "reasons": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/BypassReason" }
+        },
+        "slowest": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/BypassDetail" }
+        }
+      }
+    },
+    "errors_detail": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/ErrorDetail" }
+    },
+    "suggestions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "gc": {
+      "type": ["object", "null"],
+      "properties": {
+        "last_run": { "type": "string" },
+        "entries_evicted": { "type": "integer", "minimum": 0 },
+        "bytes_freed": { "type": "integer", "minimum": 0 },
+        "blobs_removed": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["last_run", "entries_evicted", "bytes_freed", "blobs_removed"]
+    }
+  },
+  "definitions": {
+    "CrateDetail": {
+      "type": "object",
+      "required": [
+        "crate_name",
+        "result",
+        "start_time",
+        "end_time",
+        "start_unix_ms",
+        "end_unix_ms",
+        "elapsed_ms",
+        "compile_time_ms",
+        "overhead_ms",
+        "size",
+        "cache_key",
+        "store_output_blobs",
+        "store_duplicate_blobs",
+        "store_new_blobs",
+        "compiler_runs",
+        "preprocessor_runs",
+        "probe_runs"
+      ],
+      "properties": {
+        "crate_name": { "type": "string" },
+        "root": { "type": "string" },
+        "result": {
+          "type": "string",
+          "enum": [
+            "local_hit",
+            "prefetch_hit",
+            "remote_hit",
+            "dup",
+            "miss",
+            "error",
+            "passthrough",
+            "skipped"
+          ],
+          "description": "Stable machine result code."
+        },
+        "start_time": { "type": "string" },
+        "end_time": { "type": "string" },
+        "start_unix_ms": { "type": "integer" },
+        "end_unix_ms": { "type": "integer" },
+        "elapsed_ms": { "type": "integer", "minimum": 0 },
+        "compile_time_ms": { "type": "integer", "minimum": 0 },
+        "overhead_ms": { "type": "integer", "minimum": 0 },
+        "size": { "type": "integer", "minimum": 0 },
+        "cache_key": { "type": "string" },
+        "store_output_blobs": { "type": "integer", "minimum": 0 },
+        "store_duplicate_blobs": { "type": "integer", "minimum": 0 },
+        "store_new_blobs": { "type": "integer", "minimum": 0 },
+        "compiler_runs": { "type": "integer", "minimum": 0 },
+        "preprocessor_runs": { "type": "integer", "minimum": 0 },
+        "probe_runs": { "type": "integer", "minimum": 0 },
+        "store_error": { "type": "string" }
+      }
+    },
+    "BypassReason": {
+      "type": "object",
+      "required": ["result", "route", "reason", "count", "failures", "max_elapsed_ms"],
+      "properties": {
+        "result": {
+          "type": "string",
+          "enum": [
+            "local_hit",
+            "prefetch_hit",
+            "remote_hit",
+            "dup",
+            "miss",
+            "error",
+            "passthrough",
+            "skipped"
+          ]
+        },
+        "route": {
+          "type": "string",
+          "enum": ["direct", "fallback", "skipped", "n/a"]
+        },
+        "reason": { "type": "string" },
+        "count": { "type": "integer", "minimum": 0 },
+        "failures": { "type": "integer", "minimum": 0 },
+        "max_elapsed_ms": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "BypassDetail": {
+      "type": "object",
+      "required": [
+        "crate_name",
+        "result",
+        "route",
+        "reason",
+        "start_time",
+        "end_time",
+        "start_unix_ms",
+        "end_unix_ms",
+        "elapsed_ms",
+        "timestamp"
+      ],
+      "properties": {
+        "crate_name": { "type": "string" },
+        "root": { "type": "string" },
+        "result": {
+          "type": "string",
+          "enum": [
+            "local_hit",
+            "prefetch_hit",
+            "remote_hit",
+            "dup",
+            "miss",
+            "error",
+            "passthrough",
+            "skipped"
+          ]
+        },
+        "route": {
+          "type": "string",
+          "enum": ["direct", "fallback", "skipped", "n/a"]
+        },
+        "reason": { "type": "string" },
+        "start_time": { "type": "string" },
+        "end_time": { "type": "string" },
+        "start_unix_ms": { "type": "integer" },
+        "end_unix_ms": { "type": "integer" },
+        "elapsed_ms": { "type": "integer", "minimum": 0 },
+        "exit_code": { "type": ["integer", "null"] },
+        "timestamp": { "type": "string" }
+      }
+    },
+    "TraceEvent": {
+      "type": "object",
+      "required": ["name", "cat", "ph", "ts", "dur", "pid", "tid", "args"],
+      "properties": {
+        "name": { "type": "string" },
+        "cat": { "type": "string" },
+        "ph": { "type": "string" },
+        "ts": { "type": "integer" },
+        "dur": { "type": "integer", "minimum": 0 },
+        "pid": { "type": "integer", "minimum": 0 },
+        "tid": { "type": "integer", "minimum": 0 },
+        "cname": { "type": "string" },
+        "args": { "$ref": "#/definitions/TraceArgs" }
+      }
+    },
+    "TraceArgs": {
+      "type": "object",
+      "required": [
+        "crate_name",
+        "root",
+        "result",
+        "route",
+        "reason",
+        "cache_key",
+        "elapsed_ms",
+        "compile_time_ms",
+        "overhead_ms",
+        "size",
+        "compiler_runs",
+        "preprocessor_runs",
+        "probe_runs",
+        "store_output_blobs",
+        "store_duplicate_blobs",
+        "store_new_blobs"
+      ],
+      "properties": {
+        "crate_name": { "type": "string" },
+        "root": { "type": "string" },
+        "result": { "type": "string" },
+        "route": { "type": "string" },
+        "reason": { "type": "string" },
+        "cache_key": { "type": "string" },
+        "elapsed_ms": { "type": "integer", "minimum": 0 },
+        "compile_time_ms": { "type": "integer", "minimum": 0 },
+        "overhead_ms": { "type": "integer", "minimum": 0 },
+        "size": { "type": "integer", "minimum": 0 },
+        "compiler_runs": { "type": "integer", "minimum": 0 },
+        "preprocessor_runs": { "type": "integer", "minimum": 0 },
+        "probe_runs": { "type": "integer", "minimum": 0 },
+        "store_output_blobs": { "type": "integer", "minimum": 0 },
+        "store_duplicate_blobs": { "type": "integer", "minimum": 0 },
+        "store_new_blobs": { "type": "integer", "minimum": 0 },
+        "exit_code": { "type": ["integer", "null"] }
+      }
+    },
+    "ErrorDetail": {
+      "type": "object",
+      "required": ["crate_name", "cache_key", "timestamp"],
+      "properties": {
+        "crate_name": { "type": "string" },
+        "cache_key": { "type": "string" },
+        "timestamp": { "type": "string" }
+      }
+    },
+    "TransferDetail": {
+      "type": "object",
+      "required": ["crate_name", "direction", "compressed_bytes", "elapsed_ms"],
+      "properties": {
+        "crate_name": { "type": "string" },
+        "direction": { "type": "string" },
+        "format": { "type": "string" },
+        "cache_key": { "type": "string" },
+        "object_key": { "type": "string" },
+        "compressed_bytes": { "type": "integer", "minimum": 0 },
+        "elapsed_ms": { "type": "integer", "minimum": 0 },
+        "network_ms": { "type": "integer", "minimum": 0 },
+        "semaphore_wait_ms": { "type": "integer", "minimum": 0 },
+        "head_ms": { "type": "integer", "minimum": 0 },
+        "request_ms": { "type": "integer", "minimum": 0 },
+        "body_ms": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -447,8 +447,16 @@ fn report_json_on_empty_cache_is_valid_json() {
         .stdout
         .clone();
     let v: serde_json::Value = serde_json::from_slice(&out).expect("valid json");
+    assert_eq!(v["schema_version"].as_u64(), Some(1));
     assert_eq!(v["summary"]["misses"].as_u64(), Some(0));
     assert_eq!(v["summary"]["local_hits"].as_u64(), Some(0));
+
+    let schema_text = include_str!("../docs/commands/report.schema.json");
+    let schema: serde_json::Value = serde_json::from_str(schema_text).expect("valid schema json");
+    assert_eq!(
+        schema["properties"]["schema_version"]["enum"],
+        serde_json::json!([1])
+    );
 }
 
 #[test]
@@ -979,6 +987,7 @@ fn commands_operate_on_a_populated_cache() {
         .stdout
         .clone();
     let v: serde_json::Value = serde_json::from_slice(&out).expect("valid json");
+    assert_eq!(v["schema_version"].as_u64(), Some(1));
     // The clean+rebuild produced exactly one cache miss (cold) and one local
     // hit (warm) for our crate, with the artifact blobs stored.
     assert_eq!(v["summary"]["local_hits"].as_u64(), Some(1), "report: {v}");


### PR DESCRIPTION
## Description
Fixes #699

Defines, versions, and regression-tests a stable JSON report contract for `kache report --format json`.

### Summary of Changes
1. **Schema Versioning (`src/report.rs`)**:
   - Added `pub const REPORT_SCHEMA_VERSION: u32 = 1;`.
   - Added `pub schema_version: u32` as the top-level identifier in `BuildReport`.
   - Stamped `schema_version: REPORT_SCHEMA_VERSION` in `generate_report`.
2. **E2E Typed Reader (`crates/kache-e2e/src/report.rs`)**:
   - Added `schema_version: u32` to `KacheReport`.
   - Added `SUPPORTED_REPORT_SCHEMA_VERSION: u32 = 1` validation in `fetch_since_with_root`, failing cleanly when an unsupported schema version is encountered while remaining tolerant of additive fields.
   - Added unit tests for supported schema version parsing and tolerance of unknown/additive fields.
3. **JSON Schema Contract Fixture (`docs/commands/report.schema.json`)**:
   - Checked in a Draft-07 JSON Schema definition covering the full `BuildReport` object structure and stable machine codes.
4. **CI Regression Tests**:
   - Added `test_format_json_conforms_to_schema_contract` in `src/report.rs` validating report output against the checked-in JSON Schema.
   - Added schema assertions in `tests/cli_commands_test.rs`.
5. **Documentation (`docs/commands/reference.mdx`)**:
   - Added a `JSON report schema and compatibility` section documenting `schema_version`, stable machine codes vs descriptive text, additive vs breaking compatibility rules, and version-bump guidelines.

## Verification
- `just fmt-check` passed with 0 diffs.
- `cargo test report` passed (83/83 tests).
- `cargo test -p kache-e2e` passed (92/92 tests).
- `cargo test --test cli_commands_test` passed.
