### PR TITLE
fix(policy): stop transient read failures destroying learned state (#756)

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -67,6 +67,15 @@ buildRustPackage {
     "--skip=store::tests::test_exclude_from_indexing_sets_tmutil_xattr"
   ];
 
+  # The suite runs ~2000 tests at full parallelism; nix-daemon's default soft
+  # descriptor limit (often 1024) is low enough for the parallel run to hit
+  # EMFILE, which surfaced as spurious single-test failures in flake builds
+  # (#756). Raise the soft limit toward the hard limit; best-effort so a
+  # builder with a lower hard cap still runs.
+  preCheck = ''
+    ulimit -n 4096 2>/dev/null || true
+  '';
+
   # Avoid bootstrapping loop: don't let kache wrap itself during build
   env.RUSTC_WRAPPER = "";
 

--- a/src/incremental_policy.rs
+++ b/src/incremental_policy.rs
@@ -1042,9 +1042,25 @@ mod tests {
         fs::set_permissions(&unit.state_path, fs::Permissions::from_mode(0o000)).unwrap();
 
         assert!(matches!(unit.load_state(), LoadedState::Unavailable));
+        // Every load_state caller must decline without resetting, not just
+        // the active path: a deleted Unavailable arm in any of them falls
+        // through to the Corrupt arm and destroys the state file.
         assert!(
             unit.try_active_at(103).is_none(),
-            "decline while the state cannot be read"
+            "active: decline while the state cannot be read"
+        );
+        assert!(
+            unit.try_seed_at(
+                &cache_key("third"),
+                &fields("stable", "source-c", "extern-a"),
+                103,
+            )
+            .is_none(),
+            "seed: decline while the state cannot be read"
+        );
+        assert!(
+            unit.try_immediate_at(103).is_none(),
+            "immediate: decline while the state cannot be read"
         );
         assert!(
             path_exists(&unit.state_path),

--- a/src/incremental_policy.rs
+++ b/src/incremental_policy.rs
@@ -107,7 +107,17 @@ struct DiskState {
 enum LoadedState {
     Missing,
     Valid(DiskState),
+    /// The file is present and readable but its contents are wrong: not a
+    /// regular file, oversized, unparsable, or failing validation. Callers
+    /// reset the unit — the state is evidence of corruption and relearning is
+    /// the only safe response.
     Corrupt,
+    /// The environment refused the read: descriptor exhaustion, permissions,
+    /// I/O errors. Says nothing about the state's contents, so callers must
+    /// decline the current compile WITHOUT resetting — under transient
+    /// pressure (a parallel build hitting EMFILE, #756) destroying learned
+    /// state would turn a momentary refusal into a permanent relearn.
+    Unavailable,
 }
 
 impl AdaptiveUnit {
@@ -220,7 +230,7 @@ impl AdaptiveUnit {
         let lock = self.lock()?;
         let state = match self.load_state() {
             LoadedState::Valid(state) if !state.in_flight => state,
-            LoadedState::Missing => return None,
+            LoadedState::Missing | LoadedState::Unavailable => return None,
             LoadedState::Valid(_) | LoadedState::Corrupt => {
                 reset_locked(self);
                 return None;
@@ -252,6 +262,8 @@ impl AdaptiveUnit {
         let restore = match self.load_state() {
             LoadedState::Missing => None,
             LoadedState::Valid(state) if !state.in_flight => Some(state),
+            // Decline rather than start fresh over a file that may be intact.
+            LoadedState::Unavailable => return None,
             LoadedState::Valid(_) | LoadedState::Corrupt => {
                 reset_locked(self);
                 return None;
@@ -293,7 +305,7 @@ impl AdaptiveUnit {
         let lock = self.lock()?;
         let previous = match self.load_state() {
             LoadedState::Valid(state) if !state.in_flight => state,
-            LoadedState::Missing => return None,
+            LoadedState::Missing | LoadedState::Unavailable => return None,
             LoadedState::Valid(_) | LoadedState::Corrupt => {
                 reset_locked(self);
                 return None;
@@ -418,17 +430,23 @@ impl AdaptiveUnit {
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 return LoadedState::Missing;
             }
-            Err(_) => return LoadedState::Corrupt,
+            // A metadata error other than NotFound (EMFILE, EACCES, EIO) is
+            // the environment failing, not the file being wrong.
+            Err(_) => return LoadedState::Unavailable,
         };
         if !meta.is_file() || meta.len() > MAX_STATE_BYTES {
             return LoadedState::Corrupt;
         }
-        let state: DiskState = match fs::read(&self.state_path)
-            .ok()
-            .and_then(|bytes| serde_json::from_slice(&bytes).ok())
-        {
-            Some(state) => state,
-            None => return LoadedState::Corrupt,
+        // Read and parse failures are distinct: a failed read is the
+        // environment (folding it into Corrupt is what let a transient EMFILE
+        // under a parallel test suite destroy learned state, #756); bytes that
+        // do not parse are the file itself being wrong.
+        let Ok(bytes) = fs::read(&self.state_path) else {
+            return LoadedState::Unavailable;
+        };
+        let state: DiskState = match serde_json::from_slice(&bytes) {
+            Ok(state) => state,
+            Err(_) => return LoadedState::Corrupt,
         };
         if !valid_state(&state, &self.unit_key) {
             return LoadedState::Corrupt;
@@ -997,10 +1015,49 @@ mod tests {
     }
 
     #[test]
-    fn state_io_errors_are_corrupt_not_missing() {
+    fn state_io_errors_are_unavailable_not_missing_or_corrupt() {
         let (_temp, _args, mut unit) = fixture();
         unit.state_path = unit.unit_dir.join("invalid\0state");
-        assert!(matches!(unit.load_state(), LoadedState::Corrupt));
+        assert!(matches!(unit.load_state(), LoadedState::Unavailable));
+    }
+
+    /// A state file the environment refuses to read (EMFILE under a parallel
+    /// suite, EACCES) is not corruption evidence: the policy must decline the
+    /// compile and leave the learned state alone. Folding the two together is
+    /// how transient descriptor exhaustion inside the Nix build sandbox reset
+    /// a freshly seeded unit and failed the suite (#756).
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_state_declines_without_destroying_learned_state() {
+        use std::os::unix::fs::PermissionsExt;
+        // Root reads through mode 000, which would void the simulation.
+        if unsafe { libc::geteuid() } == 0 {
+            eprintln!("skipping: running as root, chmod 000 does not deny reads");
+            return;
+        }
+        let (_temp, _args, unit) = fixture();
+        activate(&unit, 100);
+
+        let readable = fs::metadata(&unit.state_path).unwrap().permissions();
+        fs::set_permissions(&unit.state_path, fs::Permissions::from_mode(0o000)).unwrap();
+
+        assert!(matches!(unit.load_state(), LoadedState::Unavailable));
+        assert!(
+            unit.try_active_at(103).is_none(),
+            "decline while the state cannot be read"
+        );
+        assert!(
+            path_exists(&unit.state_path),
+            "a refused read must not reset the unit"
+        );
+
+        // Pressure gone: the learned state is intact and still activates.
+        fs::set_permissions(&unit.state_path, readable).unwrap();
+        let lease = unit
+            .try_active_at(104)
+            .expect("learned state survived the transient refusal");
+        assert_eq!(lease.kind(), LeaseKind::Active);
+        assert!(lease.finish_at(true, 105));
     }
 
     #[test]


### PR DESCRIPTION
Second of the two test failures reported in #756. The stable-ref half of that issue is separate work; this PR does not close it.

## Diagnosis

`incremental_policy::tests::second_distinct_dynamic_miss_seeds_then_activates` panics on `try_active_at(122).unwrap()` in Nix flake builds, passes in isolation, and passes 1933/1933 under `RUST_TEST_THREADS=1`. Static analysis goes nowhere: every branch of that path is logically clocked and TempDir-scoped, so nothing in the test's own thread can differ between environments.

It reproduces with the full parallel suite under `ulimit -n 256`: same panic, same line. The mechanism is descriptor exhaustion from neighbouring tests. nix-daemon commonly runs builds with a soft fd limit of 1024 while GitHub runners get 65536, which is why the reporter hit it and CI never did, and why serializing the suite makes it vanish.

Under EMFILE, `load_state` folded the failed read into `Corrupt`, and the `Corrupt` arm calls `reset_locked`. `try_active_at` then returned `None` and the unwrap fired.

## The real defect

The flaky test is the small half. A refused read says nothing about the state's contents, but the reset destroyed the unit's learned incremental state anyway. In production that turns momentary fd pressure into a silent full relearn.

`load_state` now distinguishes:

- `Unavailable`: the environment refused the read (metadata or read errors other than NotFound). Callers decline the current compile and leave the state alone.
- `Corrupt`: the file is provably wrong (not a regular file, oversized, unparsable, failing validation). Still resets; relearning is the only safe response.

`observe_normal_miss_at` keeps its unconditional reset: that one is semantic, not error-driven.

`nix/package.nix` also raises the check phase's soft fd limit (best-effort), so flake builds stop running ~2000 parallel tests under a limit no CI lane uses.

## Verification

- Before the fix: `ulimit -n 256` + full suite fails on the reported assertion.
- After: 4/4 full-suite runs green at `ulimit -n 256`; 2014/2014 at normal limits.
- New regression test: make the state file unreadable, assert the policy declines without deleting it, restore permissions, assert the learned state still activates. Root-guarded, since root reads through mode 000.
- `state_io_errors_are_corrupt_not_missing` asserted the old taxonomy and is renamed/retargeted to `Unavailable`.
- Also ran 3 full + 400 module iterations on ubuntu-latest with tmpfs TMPDIR and no HOME (scratch workflow, since deleted): clean, which is what ruled the filesystem and HOME theories out.
- Clippy `-D warnings`, fmt, and `nix-instantiate --parse nix/package.nix` clean.

