### PR TITLE
fix(store): serialize meta.json lifecycle with the registration lock

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -603,6 +603,14 @@ pub(crate) struct RemovalReclaim {
     pub(crate) blobs_unlinked: usize,
 }
 
+/// One pass of `remove_entry_guarded_with_hooks`: either a settled outcome,
+/// or the instruction to run again because a republication replaced the
+/// generation this pass was waiting on.
+enum RemovalAttempt {
+    Done(Option<RemovalReclaim>),
+    Republished,
+}
+
 /// A shadow policy's would-evict set for one size-driven sweep
 /// (kunobi-ninja/kache#594): the keys it would remove for the same byte
 /// budget the live policy is sweeping toward.
@@ -1715,7 +1723,6 @@ impl Store {
         allow_source_hardlinks: bool,
     ) -> Result<StorePutResult> {
         let entry_dir = self.entry_dir(cache_key);
-        fs::create_dir_all(&entry_dir).context("creating entry directory")?;
 
         // Phase 1: hash every output and durably materialize its blob on disk
         // *before* any committed entry can reference it. No DB writes happen
@@ -1791,13 +1798,19 @@ impl Store {
         let meta_json =
             serde_json::to_string_pretty(&meta).context("serializing entry metadata")?;
         let meta_path = entry_dir.join("meta.json");
-        fs::write(&meta_path, meta_json)?;
-        crate::atomic::fsync_file(&meta_path).context("flushing entry metadata")?;
 
         // Phase 2: register the entry and all of its blob references in a single
         // transaction, flipping `committed = 1` only once every blob is durable
         // on disk. Either the whole entry (with correct refcounts) becomes
         // visible, or none of it does — no refcount drift, no half-written row.
+        //
+        // `meta.json` is written INSIDE this transaction (#670), after the
+        // write lock is held, so its appearance on disk is serialized against
+        // `remove_entry_guarded`'s critical section. Written before the lock,
+        // a fresh meta could land between a racing removal's in-transaction
+        // re-read and its directory cleanup and be deleted with the old
+        // generation's directory — stranding this put's committed row with no
+        // artifacts and leaking its refcounts until doctor or an index rebuild.
         let crate_type_str = crate_types.join(",");
         let num_features = features.len() as i64;
         let tx = self.db.unchecked_transaction()?;
@@ -1820,6 +1833,16 @@ impl Store {
             materialize_blob(source, &self.blob_path(&file.hash), *use_source_hardlink)?;
         }
         record_entry_blobs(&tx, cache_key, &meta.files)?;
+        // The write lock is held from the statements above (record_entry_blobs
+        // always issues at least the DELETE). Materialize meta.json under it:
+        // a concurrent removal is either entirely before this transaction (its
+        // re-read guard then sees this meta and rolls back) or entirely after
+        // it (it removes this generation whole, row and meta together). The
+        // directory is re-created because a removal that won the previous
+        // generation deleted it.
+        fs::create_dir_all(&entry_dir).context("creating entry directory")?;
+        fs::write(&meta_path, meta_json)?;
+        crate::atomic::fsync_file(&meta_path).context("flushing entry metadata")?;
         tx.execute(
             "INSERT OR REPLACE INTO entries (cache_key, crate_name, crate_type, profile, num_features, size, content_hash, compile_time_ms, key_schema, committed) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1)",
             params![cache_key, crate_name, crate_type_str, profile, num_features, total_size as i64, content_hash, compile_time_ms as i64, crate::cache_key::CACHE_KEY_VERSION],
@@ -3140,6 +3163,52 @@ impl Store {
         skip_if_idle_lt: Option<Duration>,
         after_meta_read: impl FnOnce(),
     ) -> Result<Option<RemovalReclaim>> {
+        self.remove_entry_guarded_with_hooks(cache_key, skip_if_idle_lt, after_meta_read, || {})
+    }
+
+    /// [`Self::remove_entry_guarded_with_hook`] with a second seam:
+    /// `before_dir_cleanup` runs inside the write transaction, after the row
+    /// delete and refcount decrements, immediately before the entry directory
+    /// is removed — the residual #670 window where a publisher's fresh
+    /// `meta.json` used to be deleted out from under its registration.
+    fn remove_entry_guarded_with_hooks(
+        &self,
+        cache_key: &str,
+        skip_if_idle_lt: Option<Duration>,
+        after_meta_read: impl FnOnce(),
+        before_dir_cleanup: impl FnOnce(),
+    ) -> Result<Option<RemovalReclaim>> {
+        // Boxed so the republication-retry loop below stays non-generic; the
+        // production closures are zero-sized, so no allocation happens.
+        let mut after_meta_read: Option<Box<dyn FnOnce() + '_>> = Some(Box::new(after_meta_read));
+        let mut before_dir_cleanup: Option<Box<dyn FnOnce() + '_>> =
+            Some(Box::new(before_dir_cleanup));
+        loop {
+            match self.remove_entry_attempt(
+                cache_key,
+                skip_if_idle_lt,
+                after_meta_read.take(),
+                before_dir_cleanup.take(),
+            )? {
+                RemovalAttempt::Done(outcome) => return Ok(outcome),
+                // A republication landed while this attempt waited out a
+                // concurrent removal: the row belongs to a fresh generation
+                // whose meta is back. The caller asked to remove whatever is
+                // currently published, so run again against the new
+                // generation. Each pass requires another full republication
+                // inside the window, so this cannot spin on its own.
+                RemovalAttempt::Republished => {}
+            }
+        }
+    }
+
+    fn remove_entry_attempt(
+        &self,
+        cache_key: &str,
+        skip_if_idle_lt: Option<Duration>,
+        after_meta_read: Option<Box<dyn FnOnce() + '_>>,
+        before_dir_cleanup: Option<Box<dyn FnOnce() + '_>>,
+    ) -> Result<RemovalAttempt> {
         let entry_dir = self.entry_dir(cache_key);
         let meta_path = entry_dir.join("meta.json");
 
@@ -3163,22 +3232,42 @@ impl Store {
                 meta.files.iter().map(|f| f.hash.clone()).collect()
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // No meta.json. If a DB row still exists, its blob list is
-                // unknown and deleting the row would leak — refuse. If neither
-                // a row nor a dir exists, there is nothing to remove (idempotent
-                // for already-gone / never-existed keys).
-                let row_exists: i64 = self.db.query_row(
+                // No meta.json. A same-key removal may be mid-transaction: its
+                // directory cleanup runs under the write lock BEFORE its row
+                // delete commits (#670), so "meta missing, row present" is a
+                // transient of a healthy concurrent removal, not only the
+                // stranded-entry shape. Bounce off the write lock — the no-op
+                // write statement waits (busy_timeout) until any in-flight
+                // writer commits or rolls back — then judge the settled state.
+                let tx = self.db.unchecked_transaction()?;
+                tx.execute("UPDATE entries SET cache_key = cache_key WHERE 1 = 0", [])?;
+                let row_exists: i64 = tx.query_row(
                     "SELECT EXISTS(SELECT 1 FROM entries WHERE cache_key = ?1)",
                     params![cache_key],
                     |row| row.get(0),
                 )?;
-                if row_exists != 0 {
-                    anyhow::bail!(
-                        "entry {cache_key}: meta.json missing but DB row present — refusing \
-                         removal so blob refcounts are not leaked (#276)"
-                    );
+                drop(tx);
+                if row_exists == 0 {
+                    // The concurrent removal won (or the key never existed);
+                    // nothing left to remove.
+                    return Ok(RemovalAttempt::Done(None));
                 }
-                return Ok(None);
+                if meta_path.exists() {
+                    // A republication landed while we waited: the row belongs
+                    // to a fresh generation whose meta is back. The caller
+                    // asked to remove whatever is currently published, so
+                    // retry against the new generation. Each retry requires
+                    // another full republication in the window, so this
+                    // cannot spin on its own.
+                    return Ok(RemovalAttempt::Republished);
+                }
+                // Settled: a row with no meta.json. Its blob list is unknown
+                // and deleting the row would leak the refcounts — refuse, so
+                // a corrupt entry never silently leaks (#276).
+                anyhow::bail!(
+                    "entry {cache_key}: meta.json missing but DB row present — refusing \
+                     removal so blob refcounts are not leaked (#276)"
+                );
             }
             Err(e) => {
                 return Err(e).with_context(|| {
@@ -3190,109 +3279,113 @@ impl Store {
             }
         };
 
-        after_meta_read();
+        if let Some(hook) = after_meta_read {
+            hook();
+        }
 
-        let removed = {
-            let tx = self.db.unchecked_transaction()?;
+        let tx = self.db.unchecked_transaction()?;
 
-            // Active-pin guard (kunobi-ninja/kache#326, #182): bail out — under
-            // the write lock, before any decrement or unlink — if the entry was
-            // accessed within the grace window. Serializes against `get`'s
-            // `last_accessed` bump so an in-flight restore is never deleted out
-            // from under itself. Dropping `tx` here rolls back (nothing ran yet).
-            if let Some(grace) = skip_if_idle_lt {
-                let recently_accessed: i64 = tx.query_row(
-                    "SELECT EXISTS(SELECT 1 FROM entries \
+        // Active-pin guard (kunobi-ninja/kache#326, #182): bail out — under
+        // the write lock, before any decrement or unlink — if the entry was
+        // accessed within the grace window. Serializes against `get`'s
+        // `last_accessed` bump so an in-flight restore is never deleted out
+        // from under itself. Dropping `tx` here rolls back (nothing ran yet).
+        if let Some(grace) = skip_if_idle_lt {
+            let recently_accessed: i64 = tx.query_row(
+                "SELECT EXISTS(SELECT 1 FROM entries \
                      WHERE cache_key = ?1 AND last_accessed >= datetime('now', ?2))",
-                    params![cache_key, format!("-{} seconds", grace.as_secs())],
-                    |row| row.get(0),
-                )?;
-                if recently_accessed != 0 {
-                    return Ok(None);
-                }
-            }
-
-            // Delete the entry row first. If rows_affected is 0, another remover
-            // already released this entry's references; we skip the decrements so
-            // two removers can never double-decrement a shared blob's refcount
-            // and unlink a blob a live entry still points at (#510). This gate —
-            // not `gc.lock` — is what makes concurrent removal safe; the lock is
-            // defence in depth for bulk sweeps.
-            let rows_affected = tx.execute(
-                "DELETE FROM entries WHERE cache_key = ?1",
-                params![cache_key],
+                params![cache_key, format!("-{} seconds", grace.as_secs())],
+                |row| row.get(0),
             )?;
-
-            let mut reclaim = RemovalReclaim::default();
-            if rows_affected > 0 {
-                // Republication guard (#670): `put` writes meta.json BEFORE
-                // its registration transaction, so the row just deleted may
-                // belong to a NEWER publication than the meta.json this
-                // removal read its hash list from — decrementing the old
-                // hashes against the new row's refcounts corrupts the store.
-                // The write lock this transaction holds excludes the
-                // publisher's own transaction, so re-reading meta.json here
-                // pins the row↔meta pairing: any difference means a
-                // republication won, and the removal rolls back untouched.
-                // A meta.json that vanished or went corrupt in the window
-                // takes the same rollback; the NEXT removal attempt reports
-                // it properly through the #276 guards above.
-                let still_ours =
-                    matches!(fs::read_to_string(&meta_path), Ok(now) if now == meta_content);
-                if !still_ours {
-                    return Ok(None);
-                }
-                tx.execute(
-                    "DELETE FROM entry_blobs WHERE cache_key = ?1",
-                    params![cache_key],
-                )?;
-                for hash in &hashes {
-                    tx.execute(
-                        "UPDATE blobs SET refcount = refcount - 1 WHERE hash = ?1",
-                        params![hash],
-                    )?;
-                    let row: Option<(i64, i64)> = tx
-                        .query_row(
-                            "SELECT refcount, size FROM blobs WHERE hash = ?1",
-                            params![hash],
-                            |row| Ok((row.get(0)?, row.get(1)?)),
-                        )
-                        .ok();
-                    if let Some((rc, size)) = row
-                        && rc <= 0
-                    {
-                        tx.execute("DELETE FROM blobs WHERE hash = ?1", params![hash])?;
-                        // Unlink under the write lock so a concurrent adopter can't
-                        // commit a reference to a file we're deleting. Only bytes
-                        // whose last reference went away are physically freed —
-                        // that, not the entry's logical size, is what eviction
-                        // budgets on (#608).
-                        unlink_blob(&self.blob_path(hash));
-                        reclaim.freed_bytes += size.max(0) as u64;
-                        reclaim.blobs_unlinked += 1;
-                    }
-                }
+            if recently_accessed != 0 {
+                return Ok(RemovalAttempt::Done(None));
             }
-            tx.commit()?;
-            (rows_affected > 0).then_some(reclaim)
-        };
+        }
+
+        // Delete the entry row first. If rows_affected is 0, another remover
+        // already released this entry's references; we skip the decrements so
+        // two removers can never double-decrement a shared blob's refcount
+        // and unlink a blob a live entry still points at (#510). This gate —
+        // not `gc.lock` — is what makes concurrent removal safe; the lock is
+        // defence in depth for bulk sweeps.
+        let rows_affected = tx.execute(
+            "DELETE FROM entries WHERE cache_key = ?1",
+            params![cache_key],
+        )?;
+
+        // A remover that deleted no row releases nothing and must not touch
+        // the directory either (#670): a fresh `meta.json` there may belong
+        // to a publisher whose registration has not committed yet. Reporting
+        // `None` also keeps callers (eviction stats, tombstones) from
+        // double-counting one entry as two removals (#510).
+        if rows_affected == 0 {
+            return Ok(RemovalAttempt::Done(None));
+        }
+
+        // Republication guard (#670): the row just deleted may belong to a
+        // NEWER publication than the meta.json this removal read its hash
+        // list from — decrementing the old hashes against the new row's
+        // refcounts corrupts the store. `put` materializes meta.json inside
+        // its own registration transaction, so under the write lock this
+        // transaction holds the pairing cannot move: any difference means a
+        // republication won, and the removal rolls back untouched. A
+        // meta.json that vanished or went corrupt in the window takes the
+        // same rollback; the NEXT removal attempt reports it properly
+        // through the #276 guards above.
+        let still_ours = matches!(fs::read_to_string(&meta_path), Ok(now) if now == meta_content);
+        if !still_ours {
+            return Ok(RemovalAttempt::Done(None));
+        }
+        tx.execute(
+            "DELETE FROM entry_blobs WHERE cache_key = ?1",
+            params![cache_key],
+        )?;
+        // Decrement in the DB first, but defer every physical unlink until
+        // the directory cleanup below has succeeded: cleanup failure rolls
+        // this transaction back, and refcounts can only be restored if the
+        // blob files they count are still on disk.
+        let mut reclaim = RemovalReclaim::default();
+        let mut unlink = Vec::new();
+        for hash in &hashes {
+            tx.execute(
+                "UPDATE blobs SET refcount = refcount - 1 WHERE hash = ?1",
+                params![hash],
+            )?;
+            let row: Option<(i64, i64)> = tx
+                .query_row(
+                    "SELECT refcount, size FROM blobs WHERE hash = ?1",
+                    params![hash],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .ok();
+            if let Some((rc, size)) = row
+                && rc <= 0
+            {
+                tx.execute("DELETE FROM blobs WHERE hash = ?1", params![hash])?;
+                unlink.push((hash.clone(), size));
+            }
+        }
+
+        if let Some(hook) = before_dir_cleanup {
+            hook();
+        }
 
         // Remove the entry directory (just meta.json in new format, may have
-        // artifacts in legacy entries) — but only when THIS call deleted the
-        // row (#670): a remover that deleted nothing must not touch the
-        // directory, because a fresh `meta.json` there may belong to a
-        // publisher whose registration transaction has not committed yet, and
-        // deleting it strands the publisher's row with no artifacts. A
-        // winner-crashed-before-cleanup leftover (meta.json, no row) is
-        // recoverable by design: `rebuild_index_from_store` re-adopts it.
-        if removed.is_none() {
-            return Ok(None);
-        }
-        // Windows can still surface external interference as delete-pending
-        // errors (sharing violations from readers mid-hardlink), so on any
-        // error re-check whether the directory is actually gone, with a brief
-        // bounded retry. A directory that persists past the retries is a real
-        // failure (permissions, open handles) and propagates (#510).
+        // artifacts in legacy entries) INSIDE the transaction, while the
+        // write lock is still held (#670): after commit the lock is gone,
+        // and a same-key publisher could materialize its fresh meta.json in
+        // the gap before an unlocked cleanup — which would then delete it,
+        // stranding the publisher's committed row with no artifacts. Under
+        // the lock, a publisher is either entirely before this transaction
+        // (caught by the re-read guard above) or entirely after it (it
+        // re-creates the directory). Windows can still surface external
+        // interference as delete-pending errors (sharing violations from
+        // readers mid-hardlink), so on any error re-check whether the
+        // directory is actually gone, with a brief bounded retry (worst case
+        // 50ms of extra lock hold). A directory that persists past the
+        // retries is a real failure (permissions, open handles): it
+        // propagates (#510) and rolls the whole removal back, leaving row,
+        // refcounts, and blobs exactly as they were.
         if let Ok(entries) = fs::read_dir(&entry_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
@@ -3322,10 +3415,18 @@ impl Store {
         }
         result.with_context(|| format!("entry {cache_key}: removing entry directory"))?;
 
-        // Only the remover that deleted the row released the entry's blob
-        // references; a loser reports `None` so callers (eviction stats,
-        // tombstones) don't double-count one entry as two removals (#510).
-        Ok(removed)
+        // Point of no return: unlink dead blobs under the write lock so a
+        // concurrent adopter can't commit a reference to a file we're
+        // deleting. Only bytes whose last reference went away are physically
+        // freed — that, not the entry's logical size, is what eviction
+        // budgets on (#608).
+        for (hash, size) in unlink {
+            unlink_blob(&self.blob_path(&hash));
+            reclaim.freed_bytes += size.max(0) as u64;
+            reclaim.blobs_unlinked += 1;
+        }
+        tx.commit()?;
+        Ok(RemovalAttempt::Done(Some(reclaim)))
     }
 
     /// Test-only: insert a bare committed entry row, for tests that stage a
@@ -7730,6 +7831,115 @@ mod tests {
             refcount, 1,
             "B's refcounts must be untouched by the rollback"
         );
+    }
+
+    /// kunobi-ninja/kache#670, residual window: a same-key publisher whose
+    /// fresh `meta.json` lands while a removal is between its refcount
+    /// decrements and its directory cleanup must not have that meta deleted
+    /// out from under its registration — that strands the publisher's
+    /// committed row with no artifacts and leaks its refcounts until doctor
+    /// or an index rebuild.
+    ///
+    /// Cleanup now runs inside the removal's write transaction and `put`
+    /// materializes meta.json inside its registration transaction, so the
+    /// publisher is serialized to entirely-before (caught by the re-read
+    /// guard) or entirely-after (it re-creates the directory). The publisher
+    /// below is released exactly in the old danger window; on the old
+    /// structure (cleanup after commit) it finishes inside the window and
+    /// its meta.json is destroyed.
+    #[test]
+    fn republication_during_removal_cleanup_is_never_stranded() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let src_a = dir.path().join("a.rlib");
+        std::fs::write(&src_a, b"generation A").unwrap();
+        store
+            .put(
+                "key",
+                "c",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(src_a, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+
+        // The publisher runs on its own connection and is released inside
+        // the removal's cleanup window. With cleanup inside the transaction
+        // it blocks on the write lock, the bounded wait times out, and the
+        // removal finishes first; the publisher then lands cleanly after.
+        // With the old post-commit cleanup the lock is already free, the put
+        // completes inside the window, and the cleanup destroys its meta.
+        let (start_tx, start_rx) = std::sync::mpsc::channel::<()>();
+        let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+        let publisher = {
+            let config = config.clone();
+            let dir_path = dir.path().to_path_buf();
+            std::thread::spawn(move || {
+                let store = Store::open(&config).unwrap();
+                store.db.busy_timeout(Duration::from_secs(30)).unwrap();
+                let src_b = dir_path.join("b.rlib");
+                std::fs::write(&src_b, b"generation B, republished").unwrap();
+                start_rx.recv().unwrap();
+                store
+                    .put(
+                        "key",
+                        "c",
+                        &["lib".into()],
+                        &[],
+                        "",
+                        "dev",
+                        &[(src_b, "lib.rlib".into())],
+                        "",
+                        "",
+                    )
+                    .unwrap();
+                let _ = done_tx.send(());
+            })
+        };
+
+        let removed = store
+            .remove_entry_guarded_with_hooks(
+                "key",
+                None,
+                || {},
+                || {
+                    start_tx.send(()).unwrap();
+                    let _ = done_rx.recv_timeout(Duration::from_millis(1500));
+                },
+            )
+            .unwrap();
+        publisher.join().unwrap();
+
+        assert!(removed.is_some(), "the removal owned generation A's row");
+        assert!(
+            store.contains("key"),
+            "generation B's row must be committed"
+        );
+        assert!(
+            store.entry_dir("key").join("meta.json").is_file(),
+            "generation B's meta.json must survive the racing removal's cleanup"
+        );
+        let meta = store.get("key").unwrap().expect("B must be restorable");
+        let hash = meta.files[0].hash.clone();
+        assert!(
+            store.blob_path(&hash).is_file(),
+            "generation B's blob must be on disk"
+        );
+        let refcount: i64 = store
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(refcount, 1, "B's refcounts must be intact");
     }
 
     /// kunobi-ninja/kache#510: directory-cleanup tolerance is for the

--- a/src/store.rs
+++ b/src/store.rs
@@ -3261,14 +3261,16 @@ impl Store {
                 // the unreadable-meta arm below, not report already-absent.
                 let meta_is_back = match fs::metadata(&meta_path) {
                     Ok(_) => true,
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
                     Err(e) => {
-                        return Err(e).with_context(|| {
-                            format!(
-                                "entry {cache_key}: checking republished meta.json — refusing \
-                                 removal so blob refcounts are not leaked (#276)"
-                            )
-                        });
+                        if e.kind() != std::io::ErrorKind::NotFound {
+                            return Err(e).with_context(|| {
+                                format!(
+                                    "entry {cache_key}: checking republished meta.json — \
+                                     refusing removal so blob refcounts are not leaked (#276)"
+                                )
+                            });
+                        }
+                        false
                     }
                 };
                 drop(tx);
@@ -6213,7 +6215,15 @@ mod tests {
             )
             .unwrap();
         std::fs::remove_file(store.entry_dir("m1").join("meta.json")).unwrap();
-        assert!(store.remove_entry("m1").is_err());
+        let err = store.remove_entry("m1").unwrap_err();
+        // The message identifies WHICH state was diagnosed: the settled
+        // missing-meta shape, not the transient-recheck refusal — a removal
+        // that misclassifies the settled state would route corrupt entries
+        // through the wrong recovery advice.
+        assert!(
+            format!("{err:#}").contains("meta.json missing but DB row present"),
+            "wrong refusal shape: {err:#}"
+        );
         let still_there: i64 = store
             .db
             .query_row(
@@ -6223,6 +6233,51 @@ mod tests {
             )
             .unwrap();
         assert_eq!(still_there, 1, "entry row must survive a refused removal");
+    }
+
+    /// An unreadable meta.json (EACCES, not NotFound) must refuse through the
+    /// unreadable-meta arm — "reading meta.json" — not be misread as missing
+    /// and routed into the missing-meta bounce, whose diagnostics describe a
+    /// different state (#276, #670). The distinction is the arm's NotFound
+    /// guard; this pins it against being widened to every error.
+    #[cfg(unix)]
+    #[test]
+    fn remove_entry_refuses_unreadable_meta_as_a_read_error() {
+        use std::os::unix::fs::PermissionsExt;
+        if unsafe { libc::geteuid() } == 0 {
+            eprintln!("skipping: running as root, mode 000 does not deny access");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let output = dir.path().join("lib.rlib");
+        std::fs::write(&output, b"x").unwrap();
+        store
+            .put(
+                "locked",
+                "c1",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+        let entry_dir = store.entry_dir("locked");
+        std::fs::set_permissions(&entry_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let err = store.remove_entry("locked").unwrap_err();
+        std::fs::set_permissions(&entry_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(
+            format!("{err:#}").contains("reading meta.json"),
+            "an unreadable meta must refuse as a read error, got: {err:#}"
+        );
+        assert!(
+            store.contains("locked"),
+            "entry row must survive a refused removal"
+        );
     }
 
     /// #211: blob path construction must be panic-safe for a malformed (short)
@@ -8083,6 +8138,17 @@ mod tests {
         std::fs::write(inner.join("artifact"), b"x").unwrap();
         std::fs::set_permissions(&inner, std::fs::Permissions::from_mode(0o555)).unwrap();
 
+        // Stash the blob hash BEFORE the removal: remove_dir_all deletes
+        // children in unspecified order, so meta.json may or may not survive
+        // the failed cleanup.
+        let stashed_hash = {
+            let meta: EntryMeta = serde_json::from_str(
+                &std::fs::read_to_string(entry_dir.join("meta.json")).unwrap(),
+            )
+            .unwrap();
+            meta.files[0].hash.clone()
+        };
+
         let err = store.remove_entry("stuck");
         // Restore permissions so the tempdir can be dropped regardless.
         std::fs::set_permissions(&inner, std::fs::Permissions::from_mode(0o755)).unwrap();
@@ -8091,20 +8157,17 @@ mod tests {
             "a persistent cleanup failure must not be swallowed as a lost race"
         );
         // The failure direction matters (#670): the logical removal commits
-        // BEFORE cleanup, so a cleanup failure leaves a deleted row plus an
-        // unindexed directory — recoverable residue. Rolling the row back
-        // after files were already deleted would manufacture a committed row
-        // without artifacts, which is the phantom this function must never
-        // produce.
+        // BEFORE cleanup, so a cleanup failure leaves a deleted row plus
+        // partially deleted, unindexed residue — recoverable. Rolling the row
+        // back after files were already deleted would manufacture a committed
+        // row without artifacts, which is the phantom this function must
+        // never produce.
         assert!(
             !store.contains("stuck"),
             "the logical removal must stay committed across a cleanup failure"
         );
-        let meta: EntryMeta =
-            serde_json::from_str(&std::fs::read_to_string(entry_dir.join("meta.json")).unwrap())
-                .unwrap();
         assert!(
-            store.blob_path(&meta.files[0].hash).is_file(),
+            store.blob_path(&stashed_hash).is_file(),
             "blob unlinks run only after directory cleanup succeeds; a failed \
              cleanup leaves the file for the orphan sweep"
         );

--- a/src/store.rs
+++ b/src/store.rs
@@ -1806,11 +1806,12 @@ impl Store {
         //
         // `meta.json` is written INSIDE this transaction (#670), after the
         // write lock is held, so its appearance on disk is serialized against
-        // `remove_entry_guarded`'s critical section. Written before the lock,
-        // a fresh meta could land between a racing removal's in-transaction
-        // re-read and its directory cleanup and be deleted with the old
-        // generation's directory — stranding this put's committed row with no
-        // artifacts and leaking its refcounts until doctor or an index rebuild.
+        // `remove_entry_guarded`'s locked cleanup pass. Written before the
+        // lock, a fresh meta could land between a racing removal's committed
+        // row delete and its cleanup pass — whose republication check sees no
+        // row for this key yet and deletes the directory, fresh meta included
+        // — stranding this put's committed row with no artifacts and leaking
+        // its refcounts until doctor or an index rebuild.
         let crate_type_str = crate_types.join(",");
         let num_features = features.len() as i64;
         let tx = self.db.unchecked_transaction()?;
@@ -1835,14 +1836,17 @@ impl Store {
         record_entry_blobs(&tx, cache_key, &meta.files)?;
         // The write lock is held from the statements above (record_entry_blobs
         // always issues at least the DELETE). Materialize meta.json under it:
-        // a concurrent removal is either entirely before this transaction (its
-        // re-read guard then sees this meta and rolls back) or entirely after
-        // it (it removes this generation whole, row and meta together). The
-        // directory is re-created because a removal that won the previous
-        // generation deleted it.
+        // a concurrent removal's cleanup pass takes the same lock before it
+        // deletes anything, so it runs either entirely before this write (this
+        // put then re-creates the directory) or entirely after this
+        // transaction commits (its republication check then sees this row and
+        // leaves the directory alone). The staged write + atomic rename means
+        // no reader — locked or not — can ever observe a truncated or
+        // partially written meta.json, and the rename's parent-directory
+        // fsync makes the new name durable alongside the contents.
         fs::create_dir_all(&entry_dir).context("creating entry directory")?;
-        fs::write(&meta_path, meta_json)?;
-        crate::atomic::fsync_file(&meta_path).context("flushing entry metadata")?;
+        crate::atomic::atomic_replace(&meta_path, meta_json.as_bytes())
+            .context("writing entry metadata")?;
         tx.execute(
             "INSERT OR REPLACE INTO entries (cache_key, crate_name, crate_type, profile, num_features, size, content_hash, compile_time_ms, key_schema, committed) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1)",
             params![cache_key, crate_name, crate_type_str, profile, num_features, total_size as i64, content_hash, compile_time_ms as i64, crate::cache_key::CACHE_KEY_VERSION],
@@ -3167,10 +3171,11 @@ impl Store {
     }
 
     /// [`Self::remove_entry_guarded_with_hook`] with a second seam:
-    /// `before_dir_cleanup` runs inside the write transaction, after the row
-    /// delete and refcount decrements, immediately before the entry directory
-    /// is removed — the residual #670 window where a publisher's fresh
-    /// `meta.json` used to be deleted out from under its registration.
+    /// `before_dir_cleanup` runs inside the cleanup transaction — after the
+    /// logical removal has committed, holding the write lock, immediately
+    /// before the republication check and directory removal. That is the
+    /// residual #670 window where a publisher's fresh `meta.json` used to be
+    /// deleted out from under its registration.
     fn remove_entry_guarded_with_hooks(
         &self,
         cache_key: &str,
@@ -3232,13 +3237,18 @@ impl Store {
                 meta.files.iter().map(|f| f.hash.clone()).collect()
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // No meta.json. A same-key removal may be mid-transaction: its
-                // directory cleanup runs under the write lock BEFORE its row
-                // delete commits (#670), so "meta missing, row present" is a
-                // transient of a healthy concurrent removal, not only the
-                // stranded-entry shape. Bounce off the write lock — the no-op
-                // write statement waits (busy_timeout) until any in-flight
-                // writer commits or rolls back — then judge the settled state.
+                // No meta.json. A same-key operation may be mid-flight: a
+                // publisher materializes meta inside its registration
+                // transaction, and a removal's cleanup pass runs in its own
+                // locked transaction (#670) — so "meta missing, row present"
+                // can be a healthy transient, not only the stranded-entry
+                // shape. Bounce off the write lock — the no-op write statement
+                // waits (busy_timeout) until any in-flight writer commits or
+                // rolls back — then judge the settled state. Both the row and
+                // the meta are checked while the lock is still held: after
+                // dropping it another writer could move the pairing again and
+                // a healthy already-absent state would misreport as #276
+                // corruption.
                 let tx = self.db.unchecked_transaction()?;
                 tx.execute("UPDATE entries SET cache_key = cache_key WHERE 1 = 0", [])?;
                 let row_exists: i64 = tx.query_row(
@@ -3246,13 +3256,28 @@ impl Store {
                     params![cache_key],
                     |row| row.get(0),
                 )?;
+                // fs::metadata, not Path::exists: exists() swallows every
+                // error as false, and a permission failure must refuse like
+                // the unreadable-meta arm below, not report already-absent.
+                let meta_is_back = match fs::metadata(&meta_path) {
+                    Ok(_) => true,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+                    Err(e) => {
+                        return Err(e).with_context(|| {
+                            format!(
+                                "entry {cache_key}: checking republished meta.json — refusing \
+                                 removal so blob refcounts are not leaked (#276)"
+                            )
+                        });
+                    }
+                };
                 drop(tx);
                 if row_exists == 0 {
                     // The concurrent removal won (or the key never existed);
                     // nothing left to remove.
                     return Ok(RemovalAttempt::Done(None));
                 }
-                if meta_path.exists() {
+                if meta_is_back {
                     // A republication landed while we waited: the row belongs
                     // to a fresh generation whose meta is back. The caller
                     // asked to remove whatever is currently published, so
@@ -3340,10 +3365,9 @@ impl Store {
             "DELETE FROM entry_blobs WHERE cache_key = ?1",
             params![cache_key],
         )?;
-        // Decrement in the DB first, but defer every physical unlink until
-        // the directory cleanup below has succeeded: cleanup failure rolls
-        // this transaction back, and refcounts can only be restored if the
-        // blob files they count are still on disk.
+        // Decrement in the DB but defer every physical unlink to the cleanup
+        // pass after commit: while this transaction can still roll back, the
+        // blob files its refcounts describe must remain on disk.
         let mut reclaim = RemovalReclaim::default();
         let mut unlink = Vec::new();
         for hash in &hashes {
@@ -3366,66 +3390,102 @@ impl Store {
             }
         }
 
+        // Commit the LOGICAL removal before touching the filesystem (#670).
+        // SQLite can roll back SQL; it cannot restore a deleted meta.json or
+        // an unlinked blob — so any structure that deletes files inside this
+        // transaction turns a crash or commit failure after the deletions
+        // into a committed row whose artifacts are gone, the exact phantom
+        // this function exists to prevent. Committing first inverts every
+        // crash window into the recoverable direction: a crash from here on
+        // leaves at worst an unindexed directory (a later put or index
+        // rebuild reclaims it) or orphaned blob files (the orphan sweep
+        // reclaims those), never a live row without its files.
+        tx.commit()?;
+
+        // Cleanup pass: a second short transaction whose only purpose is the
+        // write lock. Serializing the filesystem deletions against same-key
+        // writers is what closes the original #670 window — an unlocked
+        // cleanup could delete a meta.json that a publisher materialized
+        // (inside its own registration transaction) between our commit above
+        // and this pass.
+        let cleanup_tx = self.db.unchecked_transaction()?;
+        cleanup_tx.execute("UPDATE entries SET cache_key = cache_key WHERE 1 = 0", [])?;
+
         if let Some(hook) = before_dir_cleanup {
             hook();
         }
 
-        // Remove the entry directory (just meta.json in new format, may have
-        // artifacts in legacy entries) INSIDE the transaction, while the
-        // write lock is still held (#670): after commit the lock is gone,
-        // and a same-key publisher could materialize its fresh meta.json in
-        // the gap before an unlocked cleanup — which would then delete it,
-        // stranding the publisher's committed row with no artifacts. Under
-        // the lock, a publisher is either entirely before this transaction
-        // (caught by the re-read guard above) or entirely after it (it
-        // re-creates the directory). Windows can still surface external
-        // interference as delete-pending errors (sharing violations from
-        // readers mid-hardlink), so on any error re-check whether the
-        // directory is actually gone, with a brief bounded retry (worst case
-        // 50ms of extra lock hold). A directory that persists past the
-        // retries is a real failure (permissions, open handles): it
-        // propagates (#510) and rolls the whole removal back, leaving row,
-        // refcounts, and blobs exactly as they were.
-        if let Ok(entries) = fs::read_dir(&entry_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if let Ok(meta) = fs::metadata(&path) {
-                    let mut perms = meta.permissions();
-                    perms.set_readonly(false);
-                    let _ = fs::set_permissions(&path, perms);
-                }
-            }
-        }
-        let mut result = Ok(());
-        for _ in 0..5 {
-            result = match fs::remove_dir_all(&entry_dir) {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    // Benign exactly when the directory is gone: NotFound is
-                    // the Unix shape of losing the race, and Windows surfaces
-                    // a competitor's in-flight delete as delete-pending
-                    // errors instead.
-                    if !entry_dir.exists() { Ok(()) } else { Err(e) }
-                }
-            };
-            if result.is_ok() {
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        result.with_context(|| format!("entry {cache_key}: removing entry directory"))?;
+        // A publisher may have republished this key between the commit above
+        // and this lock. The directory then belongs to the new generation:
+        // leave it untouched. Its blob adoption also re-inserted any of our
+        // zero-ref rows it needed, which the per-blob guard below observes.
+        let republished: i64 = cleanup_tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM entries WHERE cache_key = ?1)",
+            params![cache_key],
+            |row| row.get(0),
+        )?;
 
-        // Point of no return: unlink dead blobs under the write lock so a
-        // concurrent adopter can't commit a reference to a file we're
-        // deleting. Only bytes whose last reference went away are physically
-        // freed — that, not the entry's logical size, is what eviction
-        // budgets on (#608).
-        for (hash, size) in unlink {
-            unlink_blob(&self.blob_path(&hash));
-            reclaim.freed_bytes += size.max(0) as u64;
-            reclaim.blobs_unlinked += 1;
+        if republished == 0 {
+            // Remove the entry directory (just meta.json in new format, may
+            // have artifacts in legacy entries). Windows can surface external
+            // interference as delete-pending errors (sharing violations from
+            // readers mid-hardlink), so on any error re-check whether the
+            // directory is actually gone, with a brief bounded retry (worst
+            // case 50ms of extra lock hold). A directory that persists past
+            // the retries is a real failure (permissions, open handles): it
+            // propagates (#510). The logical removal is already committed, so
+            // the failure leaves only an unindexed directory — recoverable —
+            // never a live row whose files are gone.
+            if let Ok(entries) = fs::read_dir(&entry_dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if let Ok(meta) = fs::metadata(&path) {
+                        let mut perms = meta.permissions();
+                        perms.set_readonly(false);
+                        let _ = fs::set_permissions(&path, perms);
+                    }
+                }
+            }
+            let mut result = Ok(());
+            for _ in 0..5 {
+                result = match fs::remove_dir_all(&entry_dir) {
+                    Ok(()) => Ok(()),
+                    Err(e) => {
+                        // Benign exactly when the directory is gone: NotFound
+                        // is the Unix shape of losing the race, and Windows
+                        // surfaces a competitor's in-flight delete as
+                        // delete-pending errors instead.
+                        if !entry_dir.exists() { Ok(()) } else { Err(e) }
+                    }
+                };
+                if result.is_ok() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            result.with_context(|| format!("entry {cache_key}: removing entry directory"))?;
         }
-        tx.commit()?;
+
+        // Unlink dead blobs under the write lock so a concurrent adopter
+        // can't commit a reference to a file we're deleting — re-checked
+        // per blob, because a publisher that won the lock between our two
+        // transactions may have re-inserted some of the rows the first
+        // transaction deleted. Only bytes whose last reference went away are
+        // physically freed — that, not the entry's logical size, is what
+        // eviction budgets on (#608).
+        for (hash, size) in unlink {
+            let readopted: i64 = cleanup_tx.query_row(
+                "SELECT EXISTS(SELECT 1 FROM blobs WHERE hash = ?1)",
+                params![hash],
+                |row| row.get(0),
+            )?;
+            if readopted == 0 {
+                unlink_blob(&self.blob_path(&hash));
+                reclaim.freed_bytes += size.max(0) as u64;
+                reclaim.blobs_unlinked += 1;
+            }
+        }
+        cleanup_tx.commit()?;
         Ok(RemovalAttempt::Done(Some(reclaim)))
     }
 
@@ -7840,13 +7900,14 @@ mod tests {
     /// committed row with no artifacts and leaks its refcounts until doctor
     /// or an index rebuild.
     ///
-    /// Cleanup now runs inside the removal's write transaction and `put`
-    /// materializes meta.json inside its registration transaction, so the
-    /// publisher is serialized to entirely-before (caught by the re-read
-    /// guard) or entirely-after (it re-creates the directory). The publisher
-    /// below is released exactly in the old danger window; on the old
-    /// structure (cleanup after commit) it finishes inside the window and
-    /// its meta.json is destroyed.
+    /// Cleanup now runs in its own locked transaction after the logical
+    /// removal commits, guarded by a republication check, and `put`
+    /// materializes meta.json inside its registration transaction — so the
+    /// publisher is serialized to entirely-before the cleanup (the check then
+    /// sees its row and leaves the directory alone) or entirely-after (it
+    /// re-creates the directory). The publisher below is released exactly in
+    /// the old danger window; on the old structure (unlocked, unchecked
+    /// cleanup) it finishes inside the window and its meta.json is destroyed.
     #[test]
     fn republication_during_removal_cleanup_is_never_stranded() {
         let dir = tempfile::tempdir().unwrap();
@@ -7882,6 +7943,10 @@ mod tests {
         // is what lets the mutation lane kill mutants of the removal instead
         // of timing out on them.
         let released = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        // Proves the interleaving actually happened: without it the test can
+        // pass vacuously when the publisher thread is scheduled so late that
+        // its put simply runs after the whole removal.
+        let attempting = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let published = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let wait_for = |flag: &std::sync::atomic::AtomicBool, cap: Duration| {
             let deadline = std::time::Instant::now() + cap;
@@ -7895,6 +7960,7 @@ mod tests {
             let config = config.clone();
             let dir_path = dir.path().to_path_buf();
             let released = std::sync::Arc::clone(&released);
+            let attempting = std::sync::Arc::clone(&attempting);
             let published = std::sync::Arc::clone(&published);
             std::thread::spawn(move || {
                 let store = Store::open(&config).unwrap();
@@ -7910,6 +7976,7 @@ mod tests {
                 {
                     std::thread::sleep(Duration::from_millis(5));
                 }
+                attempting.store(true, std::sync::atomic::Ordering::Release);
                 store
                     .put(
                         "key",
@@ -7934,6 +8001,14 @@ mod tests {
                 || {},
                 || {
                     released.store(true, std::sync::atomic::Ordering::Release);
+                    // The publisher must have reached its put before cleanup
+                    // continues, or the "race" never happened and the test
+                    // proves nothing.
+                    wait_for(&attempting, Duration::from_secs(5));
+                    assert!(
+                        attempting.load(std::sync::atomic::Ordering::Acquire),
+                        "publisher never reached put; the interleaving was not exercised"
+                    );
                     // Give the publisher a real chance to race: on the fixed
                     // structure it blocks on the write lock and this expires;
                     // on the old structure it completes inside the window.
@@ -8014,6 +8089,24 @@ mod tests {
         assert!(
             err.is_err(),
             "a persistent cleanup failure must not be swallowed as a lost race"
+        );
+        // The failure direction matters (#670): the logical removal commits
+        // BEFORE cleanup, so a cleanup failure leaves a deleted row plus an
+        // unindexed directory — recoverable residue. Rolling the row back
+        // after files were already deleted would manufacture a committed row
+        // without artifacts, which is the phantom this function must never
+        // produce.
+        assert!(
+            !store.contains("stuck"),
+            "the logical removal must stay committed across a cleanup failure"
+        );
+        let meta: EntryMeta =
+            serde_json::from_str(&std::fs::read_to_string(entry_dir.join("meta.json")).unwrap())
+                .unwrap();
+        assert!(
+            store.blob_path(&meta.files[0].hash).is_file(),
+            "blob unlinks run only after directory cleanup succeeds; a failed \
+             cleanup leaves the file for the orphan sweep"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -7871,21 +7871,45 @@ mod tests {
 
         // The publisher runs on its own connection and is released inside
         // the removal's cleanup window. With cleanup inside the transaction
-        // it blocks on the write lock, the bounded wait times out, and the
-        // removal finishes first; the publisher then lands cleanly after.
+        // it blocks on the write lock, the seam's bounded wait expires, and
+        // the removal finishes first; the publisher then lands cleanly after.
         // With the old post-commit cleanup the lock is already free, the put
         // completes inside the window, and the cleanup destroys its meta.
-        let (start_tx, start_rx) = std::sync::mpsc::channel::<()>();
-        let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+        //
+        // Synchronization is deadline-bounded atomics, not channels: every
+        // wait has a hard cap, so a broken removal path that never reaches
+        // the seam degrades into assertion failures instead of a hang — which
+        // is what lets the mutation lane kill mutants of the removal instead
+        // of timing out on them.
+        let released = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let published = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let wait_for = |flag: &std::sync::atomic::AtomicBool, cap: Duration| {
+            let deadline = std::time::Instant::now() + cap;
+            while !flag.load(std::sync::atomic::Ordering::Acquire)
+                && std::time::Instant::now() < deadline
+            {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        };
         let publisher = {
             let config = config.clone();
             let dir_path = dir.path().to_path_buf();
+            let released = std::sync::Arc::clone(&released);
+            let published = std::sync::Arc::clone(&published);
             std::thread::spawn(move || {
                 let store = Store::open(&config).unwrap();
                 store.db.busy_timeout(Duration::from_secs(30)).unwrap();
                 let src_b = dir_path.join("b.rlib");
                 std::fs::write(&src_b, b"generation B, republished").unwrap();
-                start_rx.recv().unwrap();
+                // Bounded: if the removal never reaches the seam (a broken
+                // removal path), publish anyway so the join terminates and
+                // the assertions report the breakage.
+                let deadline = std::time::Instant::now() + Duration::from_secs(10);
+                while !released.load(std::sync::atomic::Ordering::Acquire)
+                    && std::time::Instant::now() < deadline
+                {
+                    std::thread::sleep(Duration::from_millis(5));
+                }
                 store
                     .put(
                         "key",
@@ -7899,7 +7923,7 @@ mod tests {
                         "",
                     )
                     .unwrap();
-                let _ = done_tx.send(());
+                published.store(true, std::sync::atomic::Ordering::Release);
             })
         };
 
@@ -7909,8 +7933,11 @@ mod tests {
                 None,
                 || {},
                 || {
-                    start_tx.send(()).unwrap();
-                    let _ = done_rx.recv_timeout(Duration::from_millis(1500));
+                    released.store(true, std::sync::atomic::Ordering::Release);
+                    // Give the publisher a real chance to race: on the fixed
+                    // structure it blocks on the write lock and this expires;
+                    // on the old structure it completes inside the window.
+                    wait_for(&published, Duration::from_millis(1500));
                 },
             )
             .unwrap();


### PR DESCRIPTION
Fixes #670.

## The race

#675 left a residual window. `put` wrote and fsynced `meta.json` before its registration transaction, and `remove_entry_guarded` deleted the entry directory after its commit. A publisher's fresh meta landing between the removal's in-transaction re-read and its post-commit cleanup was deleted along with the old generation's directory, leaving a committed row with no artifacts: reads as a miss and leaks refcounts until doctor or an index rebuild.

## The fix

Two invariants, both enforced by the SQLite write lock:

**put:** `meta.json` is materialized inside the registration transaction, through `atomic_replace` (staged temp, fsync, rename, parent-dir fsync). Its appearance on disk is serialized against removal cleanup, no reader can observe a truncated file, and the name is durable with the contents.

**removal:** two transactions. The first performs the entire logical removal (pin guard, row delete, re-read guard against republication, refcount decrements) and commits without touching the filesystem. The second takes the write lock purely for cleanup: it re-checks that no publisher republished the key (a republished directory is left alone), removes the directory, and unlinks each dead blob only after re-checking that its hash was not re-adopted.

The two-transaction shape is deliberate. An earlier iteration deleted the directory inside the removal transaction; review caught that this traded the race for a worse crash window, since SQLite rolls back SQL but cannot restore deleted files, so a crash after the deletions resurrected a committed row whose artifacts were gone. With the commit first, every crash window points in the recoverable direction: at worst an unindexed directory (a later put or rebuild reclaims it) or orphaned blob files (the orphan sweep reclaims them), never a live row without files.

Also fixed along the way: the missing-meta fallback classified the filesystem state after dropping the write lock, so a remover racing into that window could misreport a healthy already-absent entry as #276 corruption; the check now runs under the lock, via `fs::metadata` so permission errors refuse rather than read as absent.

## Known limitations, deliberately out of scope

- A crash between put's meta rename and its commit can pair a rolled-back row with newer meta bytes. This predates this PR (meta was previously written before the transaction entirely) and needs generation-addressed entries to fix properly.
- Two generations serializing byte-identical meta.json defeat the re-read guard, but identical meta means identical hash lists, so the refcount arithmetic is symmetric and no corruption results.
- `import` (remote ingestion) retains its own narrower version of this window; follow-up.
- The cleanup transaction holds the write lock across directory removal (bounded 50ms retry) and blob unlinks, as the previous code did for unlinks alone.

## Evidence

- Pre-fix reproducer (old ordering): fails with the phantom (row committed, `contains` false, meta destroyed). Post-fix: passes, and an `attempting` gate proves the interleaving actually happened rather than the publisher losing the schedule.
- The persistent-cleanup-failure test pins the failure direction: after a cleanup error the row stays deleted and the blob file remains for the orphan sweep.
- Store suite 12x consecutive green; full suite 2020/2020; clippy `-D warnings` and fmt clean; Cargo.lock untouched.
- Mutation pre-check over the removal functions: 25 mutants, 23 caught, 2 unviable, 0 missed, 0 timeouts.

