### PR TITLE
chore(release): 0.15.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.15.0-rc.1"
+version = "0.15.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.15.0-rc.1"
+version = "0.15.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.15.0-rc.1"
+version = "0.15.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.15.0-rc.1"
+version = "0.15.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.15.0-rc.1"
+version = "0.15.0-rc.2"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more, with S3 and shared-filesystem remotes."
 license = "Apache-2.0"
@@ -36,7 +36,7 @@ reqsign-aws-v4 = { version = "=3.0.2", default-features = false }
 reqsign-core = { version = "=3.1.0", default-features = false }
 # Direct dep so OpenDAL/reqwest can use ring without reintroducing aws-lc.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.15.0-rc.1", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.15.0-rc.2", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/charts/kache-service/Chart.yaml
+++ b/charts/kache-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kache-service
 description: Advisory remote planner service for kache
 type: application
-version: 0.15.0-rc.1
-appVersion: "0.15.0-rc.1"
+version: 0.15.0-rc.2
+appVersion: "0.15.0-rc.2"
 keywords:
   - rust
   - cache

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.15.0-rc.1"
+version = "0.15.0-rc.2"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.15.0-rc.1"
+version = "0.15.0-rc.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.15.0-rc.1"
+version = "0.15.0-rc.2"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump to 0.15.0-rc.2 across the workspace (kache, kache-core, kache-e2e, kache-service, Helm chart), same file set as the rc.1 bump (#754).

Note: `v0.15.0-rc.1` was never tagged or released; the rc.1 manifest has only ever shipped as source builds (flakes tracking main, AUR -git). Skipping straight to rc.2 keeps the released artifact distinguishable from those wild builds — several of the bugs fixed below were reported against them.

Since the rc.1 bump this carries, highlights:

- correctness: worktree cache-input isolation (#769), store put/remove race with crash-safe removal ordering (#785), cc ordinary existing outputs (#772), canonical cargo config aliases (#768), locale-independent compiler probes (#775)
- robustness: incremental-policy state survives transient read failures (#783), session ids distinct under coarse clocks (#781), thread-local key stashes (#778), probe env-race fix (#776), ZFS/tmpfs FIEMAP tolerance (#771)
- sync now exits non-zero when a transfer or import fails (#697)
- gc: stale cache-key schema reclamation (#773), clean reports reclaimable bytes (#765)
- report JSON contract is versioned and regression-tested (#779)
- monitor TUI: Esc no longer quits, per-tab filters, Shift+Tab (#780)
- nix: `stable` release branch + docs (#756), sandbox fd-limit fix in the check phase
- chart: Recreate strategy for PVC-backed planner DB (#767)

`scripts/check-version-consistency.sh` passes both bare and against `v0.15.0-rc.2`.

After merge: tag the squash commit `v0.15.0-rc.2` to trigger the gated release. Prerelease tags do not advance the `stable` branch and stay off the floating image tags (#755). Per Policy B the rc publishes to crates.io.
