### PR TITLE
fix(nix): drop unneeded apple-sdk_15 dependency (#610)

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -2,7 +2,6 @@
   lib,
   rustPlatform,
   fetchurl,
-  apple-sdk_15,
   cacert,
   stdenv,
 }:
@@ -56,10 +55,6 @@ buildRustPackage {
   cargoTestFlags = [
     "-p"
     "kache"
-  ];
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    apple-sdk_15
   ];
 
   # The tmutil xattr test shells out to /usr/bin/tmutil which isn't in the sandbox.

--- a/src/native_archive.rs
+++ b/src/native_archive.rs
@@ -680,7 +680,8 @@ fn parse_known_no_debug_macho_object(bytes: &[u8]) -> Option<()> {
                 }
                 let command: &[u8; 80] = command.try_into().ok()?;
                 let mut fields = [0_u32; 18];
-                for (field, raw) in fields.iter_mut().zip(command[8..].chunks_exact(4)) {
+                let (chunks, _) = command[8..].as_chunks::<4>();
+                for (field, raw) in fields.iter_mut().zip(chunks) {
                     *field = endian.u32(raw, 0)?;
                 }
                 dysymtab = Some(fields);


### PR DESCRIPTION
## Summary
Drops `apple-sdk_15` from `nix/package.nix`.

nixpkgs' Darwin `stdenv` provides SDK 14.4 by default. `kache` only uses standard filesystem, process, networking, and xattr APIs and builds cleanly without macOS 15 SDK features. Dropping `apple-sdk_15` removes the extra dependency and avoids pinning to a newer SDK than needed.

Ref: #610 (Item 1)
