### PR TITLE
fix(lint): satisfy Rust 1.98's chunks_exact_to_as_chunks in the Mach-O parser

### DIFF
--- a/src/native_archive.rs
+++ b/src/native_archive.rs
@@ -680,7 +680,7 @@ fn parse_known_no_debug_macho_object(bytes: &[u8]) -> Option<()> {
                 }
                 let command: &[u8; 80] = command.try_into().ok()?;
                 let mut fields = [0_u32; 18];
-                for (field, raw) in fields.iter_mut().zip(command[8..].chunks_exact(4)) {
+                for (field, raw) in fields.iter_mut().zip(command[8..].as_chunks::<4>().0) {
                     *field = endian.u32(raw, 0)?;
                 }
                 dysymtab = Some(fields);


### PR DESCRIPTION
Unblocks every open PR, starting with #788, whose failures are unrelated to their diffs.

Rust 1.98.0 (released 2026-08-20) reached CI through mise.toml's floating `rust = "latest"`, and its new `clippy::chunks_exact_to_as_chunks` lint turns `-D warnings` red on one site in the Mach-O parser. Reproduced locally: clippy under 1.98 fails on untouched main, passes under 1.97.1. Same code was green in CI on Aug 21 and red on Aug 22, on both Linux and macOS lanes, while the Nix job (nixpkgs rustc) stayed green.

The rewrite is behavior-identical: the LC_DYSYMTAB load command is already a checked `&[u8; 80]`, so `command[8..]` is exactly 72 bytes and `chunks_exact(4)` versus `as_chunks::<4>().0` produce the same 18 chunks; the new spelling proves the exactness in the type. `as_chunks` stabilized in 1.88, comfortably inside the 1.95 MSRV.

Verified with clippy under both 1.97.1 and 1.98.0, full unit suite green, fmt clean.

Worth a separate decision: mise.toml pins every tool except rust itself, directly under the comment saying pins exist so a tool release cannot break CI on unchanged code. Today is that exact failure. Pinning rust (and bumping deliberately, as the mise CLI already is after #346) would prevent the next one; left out of this PR to keep the unblock minimal.
