### PR TITLE
fix(daemon): stop an auto-started daemon inheriting an ambient remote (#706)

### DIFF
--- a/docs/remote-cache/s3-setup.mdx
+++ b/docs/remote-cache/s3-setup.mdx
@@ -106,6 +106,31 @@ rooted in `KACHE_S3_BUCKET` still select S3; the other `KACHE_S3_*` overrides
 remain available. `type = "s3"` is the recommended explicit form for new
 config files. The AWS SDK-specific migration boundaries below still apply.
 
+<Callout type="warning">
+  **A background daemon does not inherit these.** All remote I/O happens
+  daemon-side, and a daemon started automatically by a build outlives that
+  build and serves every later one on the machine. If it inherited the
+  starting build's environment, its remote would depend on which build won the
+  startup race — the failure this prevents logged 2,330 `no remote configured`
+  errors in six hours on a monorepo whose `KACHE_S3_*` lived in per-checkout
+  `.cargo/config.toml`, then silently began working after an unrelated restart.
+
+  So an auto-started daemon resolves its remote from its watched config file
+  only, and kache prints a warning when a remote is configured *only* in the
+  environment. Env overrides still apply to the wrapper and CLI as documented
+  above, and to a daemon you start yourself:
+
+  - **Persistent setup:** put the remote in `[cache.remote]` in the config
+    file. The daemon watches that file and restarts when it changes.
+  - **Env-driven setup (CI, service managers):** start the daemon explicitly
+    from the intended environment with `kache daemon run`, or put the values in
+    the service definition. That placement is deliberate rather than a race, so
+    it is honoured.
+
+  `kache stats` and `kache doctor` report the remote the daemon actually
+  resolved, and warn when it differs from yours.
+</Callout>
+
 ## OpenDAL migration boundaries
 
 The config-file and `KACHE_S3_*` interfaces are retained. Static shared

--- a/src/config.rs
+++ b/src/config.rs
@@ -2382,7 +2382,7 @@ pub(crate) fn parse_size_checked(value: &str, source: &str) -> Option<u64> {
 pub(crate) use tests::config_path_lock;
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use std::ffi::OsString;
     use std::sync::{Mutex, OnceLock};

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7262,7 +7262,7 @@ pub fn start_daemon_background() -> Result<bool> {
         // (#662), is never. Any tool that captures kache's output hangs:
         // build scripts, CI wrappers, IDE integrations, and the test harness
         // where this was found.
-        warn_if_remote_is_env_only(&config);
+        let _warned = warn_if_remote_is_env_only(&config);
 
         let mut child = spawn_detached_daemon(&exe, stderr_target)?;
 
@@ -7380,14 +7380,14 @@ const AMBIENT_REMOTE_ENV_VARS: &[&str] = &[
 /// Says nothing when the config file already declares a remote (the common
 /// case, where env is redundant or an intentional per-build override of a
 /// remote the daemon has anyway), so the warning stays rare enough to read.
-fn warn_if_remote_is_env_only(config: &Config) {
+fn warn_if_remote_is_env_only(config: &Config) -> bool {
     let set: Vec<&str> = AMBIENT_REMOTE_ENV_VARS
         .iter()
         .copied()
         .filter(|name| std::env::var_os(name).is_some())
         .collect();
     if set.is_empty() {
-        return;
+        return false;
     }
     let (file_config, _) = Config::load_raw_file_config();
     if file_config
@@ -7395,7 +7395,7 @@ fn warn_if_remote_is_env_only(config: &Config) {
         .as_ref()
         .is_some_and(|cache| cache.remote.is_some())
     {
-        return;
+        return false;
     }
     let message = format!(
         "kache: a remote is configured only in this build's environment ({vars}), and the \n         \
@@ -7410,6 +7410,7 @@ fn warn_if_remote_is_env_only(config: &Config) {
     );
     let marker = crate::wrapper::warn_marker_path("daemon-remote-env", &config.cache_dir);
     crate::wrapper::warn_once_per_session(&marker, crate::wrapper::WARN_SESSION_SECS, &message);
+    true
 }
 
 /// Spawn `kache daemon run` detached, without leaking this process's
@@ -7624,6 +7625,92 @@ mod tests {
             command.get_envs().all(|(_, value)| value.is_none()),
             "the spawn should only remove variables, never set them"
         );
+    }
+
+    /// Set/remove an env var for one test and restore it on drop. Local to
+    /// these tests; the process-global env is serialized by the shared
+    /// `config_path_lock`.
+    struct EnvVarForTest {
+        name: String,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarForTest {
+        fn set(name: &str, value: &std::ffi::OsStr) -> Self {
+            let previous = std::env::var_os(name);
+            unsafe { std::env::set_var(name, value) };
+            Self {
+                name: name.to_string(),
+                previous,
+            }
+        }
+
+        fn remove(name: &str) -> Self {
+            let previous = std::env::var_os(name);
+            unsafe { std::env::remove_var(name) };
+            Self {
+                name: name.to_string(),
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvVarForTest {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => unsafe { std::env::set_var(&self.name, value) },
+                None => unsafe { std::env::remove_var(&self.name) },
+            }
+        }
+    }
+
+    /// The warning is the entire discoverability half of #706: making the
+    /// daemon deterministic turns "sometimes works" into "never works" for an
+    /// env-only setup, which is only an improvement if the user is told. A
+    /// silently-removed warning would restore exactly the silent
+    /// misconfiguration the issue is about, so drive the real entry point.
+    #[test]
+    fn env_only_remote_warns_but_a_file_configured_remote_does_not() {
+        let _lock = crate::config::tests::config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+
+        // Keep the marker out of a shared cache dir so the once-per-session
+        // dedup cannot be satisfied by an unrelated run.
+        let config = test_config(&dir.path().join("cache"));
+
+        let config_path = dir.path().join("config.toml");
+        let restore_config = EnvVarForTest::set("KACHE_CONFIG", config_path.as_os_str());
+
+        // No remote anywhere: nothing to warn about.
+        std::fs::write(&config_path, "[cache]\n").unwrap();
+        let clear: Vec<_> = AMBIENT_REMOTE_ENV_VARS
+            .iter()
+            .map(|name| EnvVarForTest::remove(name))
+            .collect();
+        assert!(!warn_if_remote_is_env_only(&config));
+
+        // Remote ONLY in the environment: the daemon will not use it, so say so.
+        let _bucket = EnvVarForTest::set("KACHE_S3_BUCKET", std::ffi::OsStr::new("some-bucket"));
+        assert!(
+            warn_if_remote_is_env_only(&config),
+            "an env-only remote must warn"
+        );
+
+        // Same environment, but the file declares a remote: the daemon has one,
+        // so the env value is redundant or a deliberate per-build override and
+        // the warning would be noise.
+        std::fs::write(
+            &config_path,
+            "[cache.remote]\ntype = \"s3\"\nbucket = \"from-file\"\n",
+        )
+        .unwrap();
+        assert!(
+            !warn_if_remote_is_env_only(&config),
+            "a file-configured remote must stay quiet"
+        );
+
+        drop(clear);
+        drop(restore_config);
     }
 
     /// The stripped list must stay exactly the set of variables that decide a

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7262,6 +7262,8 @@ pub fn start_daemon_background() -> Result<bool> {
         // (#662), is never. Any tool that captures kache's output hangs:
         // build scripts, CI wrappers, IDE integrations, and the test harness
         // where this was found.
+        warn_if_remote_is_env_only(&config);
+
         let mut child = spawn_detached_daemon(&exe, stderr_target)?;
 
         let ready = wait_for_socket(&socket_path, Some(&mut child))?;
@@ -7334,8 +7336,95 @@ fn run_lock_file_is_held(file: &std::fs::File) -> bool {
     }
 }
 
+/// Environment variables that decide the daemon's REMOTE, stripped from an
+/// auto-spawned daemon's environment (kunobi-ninja/kache#706).
+///
+/// A background daemon outlives the build that happened to start it and serves
+/// every later build on the machine, so inheriting these makes its remote a
+/// lottery decided by whoever won the startup race. In the reported case a
+/// monorepo kept `KACHE_S3_*` in per-checkout `.cargo/config.toml`, present in
+/// some worktrees and absent in others: 2,330 `no remote configured` failures
+/// in six hours, then the remote silently began working after an unrelated
+/// restart. With the default `daemon_idle_timeout_secs = 0` one unlucky first
+/// start pins the machine to remote-off indefinitely.
+///
+/// The deeper reason env cannot be authoritative here: the daemon watches its
+/// config FILE and restarts when it changes, and there is no equivalent for a
+/// parent process's environment. A setting the daemon cannot watch cannot stay
+/// correct for the daemon's lifetime.
+///
+/// Only the auto-spawn path is affected. An operator running `kache daemon
+/// run` directly, or a service manager supplying `Environment=`, does not pass
+/// through here and keeps env precedence — that placement is deliberate, not a
+/// race.
+const AMBIENT_REMOTE_ENV_VARS: &[&str] = &[
+    "KACHE_S3_BUCKET",
+    "KACHE_S3_ENDPOINT",
+    "KACHE_S3_REGION",
+    "KACHE_S3_PREFIX",
+    "KACHE_S3_PROFILE",
+    "KACHE_LOCAL_ONLY",
+    "KACHE_REMOTE_READONLY",
+];
+
+/// Warn when this build's environment is the ONLY place a remote is
+/// configured, because the daemon we are about to start will not use it
+/// (kunobi-ninja/kache#706).
+///
+/// Silence is the failure mode being fixed: before this, such a setup either
+/// worked or did not depending on which build won the startup race, with
+/// nothing said either way. Deterministically not applying it is only an
+/// improvement if the user is told, so this prints the remedy once, at the
+/// moment the decision is made.
+///
+/// Says nothing when the config file already declares a remote (the common
+/// case, where env is redundant or an intentional per-build override of a
+/// remote the daemon has anyway), so the warning stays rare enough to read.
+fn warn_if_remote_is_env_only(config: &Config) {
+    let set: Vec<&str> = AMBIENT_REMOTE_ENV_VARS
+        .iter()
+        .copied()
+        .filter(|name| std::env::var_os(name).is_some())
+        .collect();
+    if set.is_empty() {
+        return;
+    }
+    let (file_config, _) = Config::load_raw_file_config();
+    if file_config
+        .cache
+        .as_ref()
+        .is_some_and(|cache| cache.remote.is_some())
+    {
+        return;
+    }
+    let message = format!(
+        "kache: a remote is configured only in this build's environment ({vars}), and the \n         \
+         background daemon does not inherit it — the daemon will run local-only.\n         \
+         A daemon outlives the build that starts it and cannot watch an environment for \n         \
+         changes, so an inherited remote would silently depend on which build happened to \n         \
+         start it (kunobi-ninja/kache#706).\n         \
+         Fix: move the remote into `[cache.remote]` in {path}, or start the daemon \n         \
+         yourself with `kache daemon run` from this environment.",
+        vars = set.join(", "),
+        path = crate::config::resolve_config_path().display(),
+    );
+    let marker = crate::wrapper::warn_marker_path("daemon-remote-env", &config.cache_dir);
+    crate::wrapper::warn_once_per_session(&marker, crate::wrapper::WARN_SESSION_SECS, &message);
+}
+
 /// Spawn `kache daemon run` detached, without leaking this process's
-/// inheritable handles to it (kunobi-ninja/kache#704).
+/// inheritable handles to it (kunobi-ninja/kache#704), and without leaking the
+/// remote configuration of whichever build happened to start it
+/// (kunobi-ninja/kache#706).
+/// Remove the ambient remote settings from a daemon spawn, so the daemon
+/// resolves its remote from its watched config file rather than from whichever
+/// build started it. Split out so the stripping is testable without spawning.
+fn strip_ambient_remote_env(command: &mut std::process::Command) {
+    for name in AMBIENT_REMOTE_ENV_VARS {
+        command.env_remove(name);
+    }
+}
+
 fn spawn_detached_daemon(
     exe: &Path,
     stderr_target: std::process::Stdio,
@@ -7346,6 +7435,8 @@ fn spawn_detached_daemon(
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(stderr_target);
+
+    strip_ambient_remote_env(&mut command);
 
     // On Windows, clear the inherit flag on our own std handles across the
     // spawn and restore it after. The daemon's stdio is passed explicitly
@@ -7496,6 +7587,64 @@ mod tests {
     use super::*;
     use std::fs;
     use std::sync::mpsc;
+
+    /// kunobi-ninja/kache#706: an auto-spawned daemon must not inherit the
+    /// remote of whichever build started it, or its remote becomes a lottery
+    /// decided by the startup race — the reported case logged 2,330
+    /// `no remote configured` failures in six hours, then silently started
+    /// working after an unrelated restart.
+    #[test]
+    fn auto_spawned_daemon_does_not_inherit_ambient_remote_env() {
+        let mut command = std::process::Command::new("kache");
+        strip_ambient_remote_env(&mut command);
+
+        let removed: Vec<&str> = command
+            .get_envs()
+            .filter(|(_, value)| value.is_none())
+            .filter_map(|(name, _)| name.to_str())
+            .collect();
+        for name in AMBIENT_REMOTE_ENV_VARS {
+            assert!(
+                removed.contains(name),
+                "{name} must be cleared from the daemon spawn"
+            );
+        }
+
+        // Nothing else is touched: this fix is about the remote being ambient,
+        // not about sanitising the daemon's environment in general. Stripping
+        // more (PATH, RUSTUP_*, credentials providers) would change unrelated
+        // behaviour and break credential discovery for a file-configured S3
+        // remote, which still needs the ambient AWS_* / HOME to authenticate.
+        assert_eq!(
+            removed.len(),
+            AMBIENT_REMOTE_ENV_VARS.len(),
+            "unexpected extra removals: {removed:?}"
+        );
+        assert!(
+            command.get_envs().all(|(_, value)| value.is_none()),
+            "the spawn should only remove variables, never set them"
+        );
+    }
+
+    /// The stripped list must stay exactly the set of variables that decide a
+    /// remote. A new `KACHE_S3_*` knob added without updating the list would
+    /// silently reintroduce the lottery for that setting.
+    #[test]
+    fn ambient_remote_env_list_covers_every_remote_deciding_var() {
+        let documented = [
+            "KACHE_S3_BUCKET",
+            "KACHE_S3_ENDPOINT",
+            "KACHE_S3_REGION",
+            "KACHE_S3_PREFIX",
+            "KACHE_S3_PROFILE",
+            "KACHE_LOCAL_ONLY",
+            "KACHE_REMOTE_READONLY",
+        ];
+        assert_eq!(
+            AMBIENT_REMOTE_ENV_VARS, &documented,
+            "remote-deciding env vars changed: update the strip list too (#706)"
+        );
+    }
 
     #[test]
     fn remote_check_demand_budget_keeps_legacy_cap_and_only_allows_tightening() {


### PR DESCRIPTION
Fixes #706.

All remote I/O is daemon-side, and a daemon auto-started by a build outlives that build and serves every later one on the machine. It was spawned with no explicit environment, so it inherited whichever build won the startup race, and nothing corrected it afterwards.

The reported case: a monorepo keeping `KACHE_S3_*` in per-checkout `.cargo/config.toml`, present in some worktrees and absent in others. **2,330 `no remote configured` failures in six hours** from wrappers that had the environment talking to a daemon that did not, then the remote silently began working after an unrelated restart. Same machine, same binary, opposite behaviour. With the default `daemon_idle_timeout_secs = 0`, one unlucky first start pins the machine to remote-off indefinitely.

This is a growth bug more than a correctness one: the user's conclusion is not "I hit #706", it is "kache's remote cache is unreliable" — the headline feature, failing silently, on the machine where they were evaluating it.

## The fix

The auto-spawn clears the remote-deciding variables, so the daemon resolves its remote from its watched config file: deterministic, whoever starts it.

The principle behind picking the file over the environment: **the daemon watches its config FILE and restarts when it changes, and there is no equivalent for a parent process's environment.** A setting the daemon cannot watch cannot stay correct for the daemon's lifetime, so it cannot be the authoritative source for a long-lived process.

Scope is deliberately narrow:

- Only the auto-spawn path changes. `kache daemon run` started by an operator, or by a service manager with `Environment=`, does not pass through `spawn_detached_daemon` and keeps env precedence — that placement is deliberate rather than a race.
- Nothing beyond the remote is stripped. A file-configured S3 remote still needs the ambient `AWS_*` / `HOME` to authenticate, so sanitising the environment more broadly would break credential discovery.

## Telling the user

Determinism is only an improvement if it is visible, otherwise an env-only setup goes from "sometimes works" to "never works" just as silently. A remote configured **only** in the environment now prints a warning naming the variables, the config path, and both remedies (move it into `[cache.remote]`, or start the daemon yourself from that environment). It stays quiet when the config file already declares a remote, which is the common case, so the warning stays rare enough to read. Emitted through the existing `warn_once_per_session` marker, so the hundreds of wrappers in one build cannot spam it.

The issue's second suggestion — report the daemon's effective remote — **already shipped** and is worth noting for whoever reads the issue: `EffectiveConfig` carries `remote_description`, `remote_error` and `local_only`, and `cli.rs`'s `config_mismatch_warnings` already warns when the daemon's remote differs from the client's. That landed after the v0.13.0 report, so the diagnostics no longer contradict reality; this PR removes the underlying nondeterminism they were reporting.

## Tests

- `auto_spawned_daemon_does_not_inherit_ambient_remote_env`: every listed variable is cleared on the spawn, **and nothing else is** (asserted on the exact count, so a future over-broad sanitising change trips), and the spawn only removes variables, never sets them.
- `ambient_remote_env_list_covers_every_remote_deciding_var`: pins the list, so a new `KACHE_S3_*` knob added without updating it fails rather than silently reintroducing the lottery for that setting.

2033 unit tests, clippy `-D warnings`, fmt clean. Docs: a warning callout in the S3 setup guide covering the behaviour and both supported env-driven setups.
