### PR TITLE
feat(cc): compiler-name shims for transparent, config-free interception (#310)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -133,6 +133,14 @@ gitignore = true
 # `parse_keytrace` (which crate and field a trace line names),
 # `render_key_divergence` (which fields count as diverged), and
 # `key_divergence_report` (reading both phase logs off disk).
+#
+# `install_shims`'s two `!x.is_empty()` guards decide only which summary line
+# prints ("Created N shim(s)" plus the optional created/skipped name lists).
+# Nothing an in-process test can observe changes: the shim set it creates, the
+# entries it preserves, and the errors it reports are all asserted directly by
+# the tests around it. Same shape as the `run_gc_local` progress strings above.
+# The function's behaviour, its `--force` semantics, and its error
+# classification all stay in scope and are killed by those tests.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -163,4 +171,5 @@ exclude_re = [
     "observe_storage_unsupported",
     "run_cargo_non_unix",
     "replace report_key_divergence with \\(\\)",
+    "delete ! in install_shims",
 ]

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -153,6 +153,38 @@ kache is also published to Homebrew, APT, winget, Scoop, Chocolatey, and the AUR
   </Tab>
 </Tabs>
 
+## Compiler shims (transparent interception)
+
+Setting `CC`/`CXX` per project does not scale when you support many
+differently structured builds. A shim directory routes every compiler call on
+the machine through kache with one `PATH` change and no per-project edits:
+
+```sh
+kache install-shims ~/.kache/shims
+export PATH="$HOME/.kache/shims:$PATH"
+```
+
+That creates symlinks named `cc`, `c++`, `gcc`, `g++`, `clang` and `clang++`,
+all pointing at the kache binary. When a build invokes one, kache recognizes
+that it was called under a compiler name, finds the real compiler behind the
+shim, and wraps it.
+
+Two rules make or break it:
+
+- The shim directory must come **before** your real toolchain on `PATH`.
+  Appended, it is never consulted and nothing happens.
+- The real compilers must still be reachable on `PATH` behind it, because
+  kache runs them. If every `cc` on `PATH` is a shim, kache says so and exits
+  rather than recursing.
+
+The real compiler is found by skipping any `PATH` entry that resolves to the
+kache binary, so several shim directories, relative entries, and symlinked
+entries all behave.
+
+Unix only for now: it relies on symlinks, and the Windows `.exe` shim story
+differs. Use `CC`/`CXX` there. C/C++ caching is still experimental, so treat
+machine-wide interception as opt-in.
+
 ## Nix
 
 The repo is a flake. Unlike the methods above it builds kache from source, with the Rust toolchain pinned in `rust-toolchain.toml` rather than whatever rustc your nixpkgs happens to ship. Use the `stable` branch: it advances only after a non-prerelease GitHub release has passed the gated release build. The default `main` branch contains unreleased development work.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10010,3 +10010,79 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
         Ok(())
     }
 }
+
+/// Populate `dir` with compiler-name symlinks pointing at this kache binary
+/// (kunobi-ninja/kache#310).
+///
+/// Prepending the result to `PATH` routes every build's compiler calls through
+/// kache with no `CC`/`CXX` edits and no per-project build-system changes.
+pub(crate) fn install_shims(dir: &std::path::Path, force: bool) -> anyhow::Result<()> {
+    #[cfg(not(unix))]
+    {
+        let _ = (dir, force);
+        anyhow::bail!(
+            "shim installation is Unix-only for now: it relies on symlinks, and the Windows \
+             `.exe` shim story differs (kunobi-ninja/kache#310). Use `CC`/`CXX` there."
+        );
+    }
+
+    #[cfg(unix)]
+    {
+        let exe = std::env::current_exe().context("locating the kache binary")?;
+        // Resolve so the shims survive kache being invoked through its own
+        // symlink, and so `resolve_real_compiler`'s identity check (which
+        // canonicalizes) reliably recognizes them as kache.
+        let exe = std::fs::canonicalize(&exe).unwrap_or(exe);
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("creating shim directory {}", dir.display()))?;
+
+        let mut created = Vec::new();
+        let mut skipped = Vec::new();
+        for name in crate::compiler::shim::SHIM_NAMES {
+            let link = dir.join(name);
+            match std::fs::symlink_metadata(&link) {
+                Ok(_) if !force => {
+                    skipped.push((*name).to_string());
+                    continue;
+                }
+                Ok(_) => std::fs::remove_file(&link)
+                    .with_context(|| format!("replacing existing {}", link.display()))?,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    return Err(e).with_context(|| format!("inspecting {}", link.display()));
+                }
+            }
+            std::os::unix::fs::symlink(&exe, &link)
+                .with_context(|| format!("creating shim {}", link.display()))?;
+            created.push((*name).to_string());
+        }
+
+        println!(
+            "Created {} shim(s) in {} -> {}",
+            created.len(),
+            dir.display(),
+            exe.display()
+        );
+        if !created.is_empty() {
+            println!("  {}", created.join(", "));
+        }
+        if !skipped.is_empty() {
+            println!(
+                "Skipped {} existing entr(ies): {} (use --force to replace)",
+                skipped.len(),
+                skipped.join(", ")
+            );
+        }
+        println!();
+        println!("Add it to PATH ahead of your toolchain:");
+        println!("  export PATH=\"{}:$PATH\"", dir.display());
+        println!();
+        // The ordering caveat is the one way this silently does nothing: a
+        // shim dir appended rather than prepended is never consulted.
+        println!(
+            "The directory must come BEFORE the real toolchain on PATH, and the real \
+             compilers must remain on PATH behind it — kache runs them."
+        );
+        Ok(())
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10017,17 +10017,11 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
 /// Prepending the result to `PATH` routes every build's compiler calls through
 /// kache with no `CC`/`CXX` edits and no per-project build-system changes.
 ///
-/// Two cfg'd definitions rather than one function with cfg'd blocks: the
-/// non-unix body must still produce the function's return value, and a single
-/// body whose only remaining statement diverges does not type-check there.
-#[cfg(not(unix))]
-pub(crate) fn install_shims(_dir: &std::path::Path, _force: bool) -> anyhow::Result<()> {
-    anyhow::bail!(
-        "shim installation is Unix-only for now: it relies on symlinks, and the Windows \
-         `.exe` shim story differs (kunobi-ninja/kache#310). Use `CC`/`CXX` there."
-    )
-}
-
+///
+/// Unix-only: it creates symlinks, and the Windows `.exe` shim story differs
+/// (kunobi-ninja/kache#310). The unsupported message lives in the command
+/// dispatch so this stays a single, fully testable definition rather than two
+/// same-named ones the mutation lane cannot tell apart.
 #[cfg(unix)]
 pub(crate) fn install_shims(dir: &std::path::Path, force: bool) -> anyhow::Result<()> {
     let exe = std::env::current_exe().context("locating the kache binary")?;
@@ -10086,4 +10080,119 @@ pub(crate) fn install_shims(dir: &std::path::Path, force: bool) -> anyhow::Resul
          compilers must remain on PATH behind it — kache runs them."
     );
     Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod shim_install_tests {
+    use super::install_shims;
+    use crate::compiler::shim::SHIM_NAMES;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn is_symlink(path: &std::path::Path) -> bool {
+        std::fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink())
+    }
+
+    #[test]
+    fn installs_a_symlink_for_every_shim_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let shims = dir.path().join("shims");
+        install_shims(&shims, false).unwrap();
+
+        let exe = std::fs::canonicalize(std::env::current_exe().unwrap()).unwrap();
+        for name in SHIM_NAMES {
+            let link = shims.join(name);
+            assert!(is_symlink(&link), "{name} must be a symlink");
+            assert_eq!(
+                std::fs::read_link(&link).unwrap(),
+                exe,
+                "{name} must point at this binary"
+            );
+        }
+    }
+
+    /// Without `--force` an existing entry is left exactly as it was. Silently
+    /// overwriting whatever sits in the target directory would be a
+    /// destructive default for a command users may point at `~/.local/bin`.
+    #[test]
+    fn existing_entries_are_preserved_unless_forced() {
+        let dir = tempfile::tempdir().unwrap();
+        let shims = dir.path().join("shims");
+        std::fs::create_dir_all(&shims).unwrap();
+        let occupied = shims.join(SHIM_NAMES[0]);
+        std::fs::write(&occupied, b"a real compiler wrapper").unwrap();
+
+        install_shims(&shims, false).unwrap();
+
+        assert!(
+            !is_symlink(&occupied),
+            "existing entry must not be replaced"
+        );
+        assert_eq!(
+            std::fs::read(&occupied).unwrap(),
+            b"a real compiler wrapper",
+            "existing content must be untouched"
+        );
+        // The rest are still installed: one collision must not abort the run.
+        for name in &SHIM_NAMES[1..] {
+            assert!(is_symlink(&shims.join(name)), "{name} should be installed");
+        }
+    }
+
+    #[test]
+    fn force_replaces_an_existing_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let shims = dir.path().join("shims");
+        std::fs::create_dir_all(&shims).unwrap();
+        let occupied = shims.join(SHIM_NAMES[0]);
+        std::fs::write(&occupied, b"stale").unwrap();
+
+        install_shims(&shims, true).unwrap();
+
+        assert!(is_symlink(&occupied), "--force must replace the entry");
+    }
+
+    /// Re-running with `--force` is the "I moved the kache binary" refresh, so
+    /// it must not fail on its own previous output or accumulate entries.
+    #[test]
+    fn forced_reinstall_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let shims = dir.path().join("shims");
+        install_shims(&shims, false).unwrap();
+        install_shims(&shims, true).unwrap();
+
+        for name in SHIM_NAMES {
+            assert!(is_symlink(&shims.join(name)));
+        }
+        assert_eq!(
+            std::fs::read_dir(&shims).unwrap().count(),
+            SHIM_NAMES.len(),
+            "reinstall must not accumulate entries"
+        );
+    }
+
+    /// An inspection failure that is NOT "missing" must surface rather than be
+    /// treated as an empty slot.
+    #[test]
+    fn unreadable_target_directory_is_an_error() {
+        if unsafe { libc::geteuid() } == 0 {
+            eprintln!("skipping: running as root, mode 000 does not deny access");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let shims = dir.path().join("shims");
+        std::fs::create_dir_all(&shims).unwrap();
+        std::fs::set_permissions(&shims, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = install_shims(&shims, false);
+        std::fs::set_permissions(&shims, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // The MESSAGE matters, not just the failure: treating a
+        // permission error as "nothing there" would fall through to the
+        // symlink call and report the wrong stage.
+        let err = format!("{:#}", result.unwrap_err());
+        assert!(
+            err.contains("inspecting"),
+            "an inspection failure must be reported as such, got: {err}"
+        );
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10016,73 +10016,74 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
 ///
 /// Prepending the result to `PATH` routes every build's compiler calls through
 /// kache with no `CC`/`CXX` edits and no per-project build-system changes.
+///
+/// Two cfg'd definitions rather than one function with cfg'd blocks: the
+/// non-unix body must still produce the function's return value, and a single
+/// body whose only remaining statement diverges does not type-check there.
+#[cfg(not(unix))]
+pub(crate) fn install_shims(_dir: &std::path::Path, _force: bool) -> anyhow::Result<()> {
+    anyhow::bail!(
+        "shim installation is Unix-only for now: it relies on symlinks, and the Windows \
+         `.exe` shim story differs (kunobi-ninja/kache#310). Use `CC`/`CXX` there."
+    )
+}
+
+#[cfg(unix)]
 pub(crate) fn install_shims(dir: &std::path::Path, force: bool) -> anyhow::Result<()> {
-    #[cfg(not(unix))]
-    {
-        let _ = (dir, force);
-        anyhow::bail!(
-            "shim installation is Unix-only for now: it relies on symlinks, and the Windows \
-             `.exe` shim story differs (kunobi-ninja/kache#310). Use `CC`/`CXX` there."
-        );
-    }
+    let exe = std::env::current_exe().context("locating the kache binary")?;
+    // Resolve so the shims survive kache being invoked through its own
+    // symlink, and so `resolve_real_compiler`'s identity check (which
+    // canonicalizes) reliably recognizes them as kache.
+    let exe = std::fs::canonicalize(&exe).unwrap_or(exe);
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("creating shim directory {}", dir.display()))?;
 
-    #[cfg(unix)]
-    {
-        let exe = std::env::current_exe().context("locating the kache binary")?;
-        // Resolve so the shims survive kache being invoked through its own
-        // symlink, and so `resolve_real_compiler`'s identity check (which
-        // canonicalizes) reliably recognizes them as kache.
-        let exe = std::fs::canonicalize(&exe).unwrap_or(exe);
-        std::fs::create_dir_all(dir)
-            .with_context(|| format!("creating shim directory {}", dir.display()))?;
-
-        let mut created = Vec::new();
-        let mut skipped = Vec::new();
-        for name in crate::compiler::shim::SHIM_NAMES {
-            let link = dir.join(name);
-            match std::fs::symlink_metadata(&link) {
-                Ok(_) if !force => {
-                    skipped.push((*name).to_string());
-                    continue;
-                }
-                Ok(_) => std::fs::remove_file(&link)
-                    .with_context(|| format!("replacing existing {}", link.display()))?,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => {
-                    return Err(e).with_context(|| format!("inspecting {}", link.display()));
-                }
+    let mut created = Vec::new();
+    let mut skipped = Vec::new();
+    for name in crate::compiler::shim::SHIM_NAMES {
+        let link = dir.join(name);
+        match std::fs::symlink_metadata(&link) {
+            Ok(_) if !force => {
+                skipped.push((*name).to_string());
+                continue;
             }
-            std::os::unix::fs::symlink(&exe, &link)
-                .with_context(|| format!("creating shim {}", link.display()))?;
-            created.push((*name).to_string());
+            Ok(_) => std::fs::remove_file(&link)
+                .with_context(|| format!("replacing existing {}", link.display()))?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(e).with_context(|| format!("inspecting {}", link.display()));
+            }
         }
-
-        println!(
-            "Created {} shim(s) in {} -> {}",
-            created.len(),
-            dir.display(),
-            exe.display()
-        );
-        if !created.is_empty() {
-            println!("  {}", created.join(", "));
-        }
-        if !skipped.is_empty() {
-            println!(
-                "Skipped {} existing entr(ies): {} (use --force to replace)",
-                skipped.len(),
-                skipped.join(", ")
-            );
-        }
-        println!();
-        println!("Add it to PATH ahead of your toolchain:");
-        println!("  export PATH=\"{}:$PATH\"", dir.display());
-        println!();
-        // The ordering caveat is the one way this silently does nothing: a
-        // shim dir appended rather than prepended is never consulted.
-        println!(
-            "The directory must come BEFORE the real toolchain on PATH, and the real \
-             compilers must remain on PATH behind it — kache runs them."
-        );
-        Ok(())
+        std::os::unix::fs::symlink(&exe, &link)
+            .with_context(|| format!("creating shim {}", link.display()))?;
+        created.push((*name).to_string());
     }
+
+    println!(
+        "Created {} shim(s) in {} -> {}",
+        created.len(),
+        dir.display(),
+        exe.display()
+    );
+    if !created.is_empty() {
+        println!("  {}", created.join(", "));
+    }
+    if !skipped.is_empty() {
+        println!(
+            "Skipped {} existing entr(ies): {} (use --force to replace)",
+            skipped.len(),
+            skipped.join(", ")
+        );
+    }
+    println!();
+    println!("Add it to PATH ahead of your toolchain:");
+    println!("  export PATH=\"{}:$PATH\"", dir.display());
+    println!();
+    // The ordering caveat is the one way this silently does nothing: a shim
+    // dir appended rather than prepended is never consulted.
+    println!(
+        "The directory must come BEFORE the real toolchain on PATH, and the real \
+         compilers must remain on PATH behind it — kache runs them."
+    );
+    Ok(())
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -2088,6 +2088,101 @@ mod shim_tests {
         assert_eq!(found, Some(PathBuf::from("/usr/bin/cc")));
     }
 
+    /// Guard that restores PATH even if the test panics; process env is
+    /// global and a leaked PATH would corrupt every later test.
+    #[cfg(unix)]
+    struct PathForTest(Option<std::ffi::OsString>);
+
+    #[cfg(unix)]
+    impl Drop for PathForTest {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(previous) => unsafe { std::env::set_var("PATH", previous) },
+                None => unsafe { std::env::remove_var("PATH") },
+            }
+        }
+    }
+
+    /// Drives the LIVE wiring against a real PATH, not the injected core.
+    ///
+    /// The tests above inject their own PATH list and resolver, so they leave
+    /// the half that reads the process's actual PATH and `current_exe`
+    /// unproven: a `wrapper_args` that always returned `None` would silently
+    /// stop treating anything as a shim — the whole feature off — and still
+    /// pass them.
+    #[cfg(unix)]
+    #[test]
+    fn live_resolution_finds_the_real_compiler_behind_a_real_shim() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _lock = crate::config::tests::config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let shim_dir = dir.path().join("shims");
+        let real_dir = dir.path().join("real");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+        std::fs::create_dir_all(&real_dir).unwrap();
+
+        // A real `cc` that is a genuine executable...
+        let real_cc = real_dir.join("cc");
+        std::fs::write(&real_cc, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&real_cc, std::fs::Permissions::from_mode(0o755)).unwrap();
+        // ...shadowed on PATH by a `cc` symlink to this binary, exactly as
+        // `kache install-shims` creates.
+        let exe = std::env::current_exe().unwrap();
+        std::os::unix::fs::symlink(&exe, shim_dir.join("cc")).unwrap();
+
+        let _path = PathForTest(std::env::var_os("PATH"));
+        unsafe {
+            std::env::set_var(
+                "PATH",
+                format!("{}:{}", shim_dir.display(), real_dir.display()),
+            )
+        };
+
+        let found = resolve_real_compiler_from_env("cc").expect("the real cc must be found");
+        assert_eq!(
+            std::fs::canonicalize(&found).unwrap(),
+            std::fs::canonicalize(&real_cc).unwrap(),
+            "must skip the shim and select the real compiler"
+        );
+
+        let rewritten = wrapper_args(&["cc".to_string(), "foo.c".to_string()])
+            .expect("a compiler-shaped argv0 is a shim invocation")
+            .expect("resolution succeeds");
+        assert_eq!(
+            std::fs::canonicalize(&rewritten[0]).unwrap(),
+            std::fs::canonicalize(&real_cc).unwrap(),
+            "the rewritten argv must run the real compiler"
+        );
+        assert_eq!(
+            &rewritten[1..],
+            &["foo.c".to_string()],
+            "the original arguments must be preserved verbatim"
+        );
+    }
+
+    /// With only the shim on PATH there is nothing to run, so this must report
+    /// the condition rather than resolve back to itself and recurse.
+    #[cfg(unix)]
+    #[test]
+    fn live_resolution_reports_when_only_the_shim_is_on_path() {
+        let _lock = crate::config::tests::config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let shim_dir = dir.path().join("shims");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+        let exe = std::env::current_exe().unwrap();
+        std::os::unix::fs::symlink(&exe, shim_dir.join("cc")).unwrap();
+
+        let _path = PathForTest(std::env::var_os("PATH"));
+        unsafe { std::env::set_var("PATH", format!("{}", shim_dir.display())) };
+
+        assert_eq!(resolve_real_compiler_from_env("cc"), None);
+        let err = wrapper_args(&["cc".to_string(), "foo.c".to_string()])
+            .expect("still a shim invocation")
+            .expect_err("but with no compiler to run");
+        assert!(err.contains("no real `cc`"), "unexpected message: {err}");
+    }
+
     #[test]
     fn non_shim_argv_is_left_alone() {
         // Normal `kache <compiler> …` and plain CLI use must not be rewritten.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1916,6 +1916,10 @@ pub(crate) mod shim {
     /// recognize. Versioned and target-prefixed spellings are still handled
     /// when a user creates them by hand, because detection reuses
     /// `CcCompiler::recognizes`.
+    // Only the generator consumes this, and generation is Unix-only (it
+    // creates symlinks). Detection below stays cross-platform, so a hand-made
+    // `gcc.exe` copy of kache still works on Windows.
+    #[cfg_attr(not(unix), allow(dead_code))]
     pub(crate) const SHIM_NAMES: &[&str] = &["cc", "c++", "gcc", "g++", "clang", "clang++"];
 
     /// Whether `argv[0]` names a compiler, meaning kache is being invoked

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1892,3 +1892,203 @@ mod tests {
         }
     }
 }
+
+/// Compiler-name shim support (kunobi-ninja/kache#310).
+///
+/// A directory of symlinks named after the compilers, each pointing at the
+/// `kache` binary, prepended to `PATH`, routes every build's compiler calls
+/// through kache with no `CC`/`CXX` edits and no per-project build-system
+/// changes. That is the lowest-friction way to put kache in front of arbitrary
+/// builds, which matters most for people supporting many differently
+/// structured projects where editing each build's compiler config is not
+/// practical.
+///
+/// kache otherwise decides it is wrapping a compiler purely from `argv[1..]`,
+/// so under a shim (`argv[0] = gcc`, `argv[1] = foo.c`) it would find no
+/// compiler at `argv[1]`, fall through to CLI mode, and fail parsing `foo.c`
+/// as a subcommand.
+pub(crate) mod shim {
+    use std::path::{Path, PathBuf};
+
+    /// The compiler names a generated shim directory populates. Deliberately
+    /// the canonical drivers only: a shim is a `PATH` ambush, so it should
+    /// cover what builds actually invoke rather than every name kache can
+    /// recognize. Versioned and target-prefixed spellings are still handled
+    /// when a user creates them by hand, because detection reuses
+    /// `CcCompiler::recognizes`.
+    pub(crate) const SHIM_NAMES: &[&str] = &["cc", "c++", "gcc", "g++", "clang", "clang++"];
+
+    /// Whether `argv[0]` names a compiler, meaning kache is being invoked
+    /// through a shim rather than as itself.
+    pub(crate) fn invoked_as_compiler(arg0: &str) -> bool {
+        // Reuses the full name set (exact, versioned, target-prefixed, MinGW
+        // alternatives), so a hand-made `x86_64-linux-gnu-gcc` shim works
+        // without a second list to keep in sync.
+        super::cc::CcCompiler::recognizes(std::slice::from_ref(&arg0.to_string()))
+    }
+
+    /// The real compiler behind a shim: the first `name` on `PATH` that is not
+    /// kache itself.
+    ///
+    /// Skipping by *resolved identity* rather than by directory is what makes
+    /// this safe. It finds every shim wherever the user put them, tolerates
+    /// several shim directories, and cannot be defeated by a relative or
+    /// symlinked `PATH` entry — all of which would otherwise re-select the
+    /// shim and recurse.
+    pub(crate) fn resolve_real_compiler(
+        name: &str,
+        path_dirs: &[PathBuf],
+        self_exe: Option<&Path>,
+        is_candidate: &dyn Fn(&Path) -> bool,
+        resolve: &dyn Fn(&Path) -> Option<PathBuf>,
+    ) -> Option<PathBuf> {
+        let self_real = self_exe.and_then(resolve);
+        for dir in path_dirs {
+            let candidate = dir.join(name);
+            if !is_candidate(&candidate) {
+                continue;
+            }
+            // A candidate that resolves to our own binary IS the shim.
+            if let (Some(real), Some(mine)) = (resolve(&candidate), self_real.as_deref())
+                && real == mine
+            {
+                continue;
+            }
+            return Some(candidate);
+        }
+        None
+    }
+
+    /// Live wiring for [`resolve_real_compiler`].
+    pub(crate) fn resolve_real_compiler_from_env(name: &str) -> Option<PathBuf> {
+        let path = std::env::var_os("PATH")?;
+        let dirs: Vec<PathBuf> = std::env::split_paths(&path).collect();
+        let self_exe = std::env::current_exe().ok();
+        resolve_real_compiler(
+            name,
+            &dirs,
+            self_exe.as_deref(),
+            &|candidate| super::is_executable(candidate),
+            &|path| std::fs::canonicalize(path).ok(),
+        )
+    }
+
+    /// Rewrite a shim invocation into the wrapper-mode argv kache already
+    /// understands: the resolved real compiler followed by the original
+    /// arguments. `None` when this is not a shim invocation.
+    pub(crate) fn wrapper_args(argv: &[String]) -> Option<Result<Vec<String>, String>> {
+        let arg0 = argv.first()?;
+        if !invoked_as_compiler(arg0) {
+            return None;
+        }
+        let name = super::command_basename(arg0)?;
+        let Some(real) = resolve_real_compiler_from_env(name) else {
+            return Some(Err(format!(
+                "kache was invoked through a compiler shim named `{name}`, but no real `{name}` \
+                 was found on PATH behind it. Every `{name}` on PATH resolves to kache itself, \
+                 so there is nothing to run. Check that the real toolchain is still on PATH \
+                 after the shim directory."
+            )));
+        };
+        let Some(real) = real.to_str() else {
+            return Some(Err(format!(
+                "the real `{name}` behind the shim has a non-UTF-8 path and cannot be wrapped \
+                 safely"
+            )));
+        };
+        let mut rewritten = Vec::with_capacity(argv.len());
+        rewritten.push(real.to_string());
+        rewritten.extend_from_slice(&argv[1..]);
+        Some(Ok(rewritten))
+    }
+}
+
+#[cfg(test)]
+mod shim_tests {
+    use super::shim::*;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn compiler_shaped_argv0_is_recognized_but_kache_itself_is_not() {
+        for name in ["cc", "gcc", "g++", "clang++", "/usr/local/bin/gcc"] {
+            assert!(invoked_as_compiler(name), "{name} should look like a shim");
+        }
+        // Versioned and target-prefixed shims work without a second list.
+        assert!(invoked_as_compiler("x86_64-linux-gnu-gcc"));
+        assert!(invoked_as_compiler("gcc-13"));
+        // kache invoked normally, and companion tools, must NOT be shims:
+        // treating `kache` as a compiler would recurse, and `gcc-ar` is not a
+        // compiler at all.
+        assert!(!invoked_as_compiler("kache"));
+        assert!(!invoked_as_compiler("/usr/local/bin/kache"));
+        assert!(!invoked_as_compiler("gcc-ar"));
+    }
+
+    /// The shim must be skipped by RESOLVED IDENTITY, not by directory: that
+    /// is what survives several shim dirs, relative PATH entries, and a
+    /// symlinked PATH entry, each of which would otherwise re-select the shim
+    /// and recurse forever.
+    #[test]
+    fn resolve_skips_every_path_entry_that_is_kache_itself() {
+        let kache = PathBuf::from("/opt/kache/bin/kache");
+        let shim_a = PathBuf::from("/shims-a");
+        let shim_b = PathBuf::from("/shims-b");
+        let real = PathBuf::from("/usr/bin");
+
+        // Both shim dirs hold a `cc` that resolves to the kache binary.
+        let resolve = |path: &Path| -> Option<PathBuf> {
+            if path.starts_with("/shims-a") || path.starts_with("/shims-b") {
+                Some(kache.clone())
+            } else {
+                Some(path.to_path_buf())
+            }
+        };
+        let exists = |_: &Path| true;
+
+        let found = resolve_real_compiler(
+            "cc",
+            &[shim_a, shim_b, real],
+            Some(&kache),
+            &exists,
+            &resolve,
+        );
+        assert_eq!(found, Some(PathBuf::from("/usr/bin/cc")));
+    }
+
+    #[test]
+    fn resolve_returns_none_when_only_shims_are_on_path() {
+        let kache = PathBuf::from("/opt/kache/bin/kache");
+        let found = resolve_real_compiler(
+            "cc",
+            &[PathBuf::from("/shims")],
+            Some(&kache),
+            &|_| true,
+            &|_| Some(kache.clone()),
+        );
+        assert_eq!(found, None, "must report no real compiler, not recurse");
+    }
+
+    /// A non-executable file with the right name must not be selected as the
+    /// compiler; PATH lookup semantics, and picking one would fail the build
+    /// with a confusing exec error.
+    #[test]
+    fn resolve_skips_non_executable_candidates() {
+        let kache = PathBuf::from("/opt/kache/bin/kache");
+        let found = resolve_real_compiler(
+            "cc",
+            &[PathBuf::from("/not-exec"), PathBuf::from("/usr/bin")],
+            Some(&kache),
+            &|path: &Path| path.starts_with("/usr/bin"),
+            &|path: &Path| Some(path.to_path_buf()),
+        );
+        assert_eq!(found, Some(PathBuf::from("/usr/bin/cc")));
+    }
+
+    #[test]
+    fn non_shim_argv_is_left_alone() {
+        // Normal `kache <compiler> …` and plain CLI use must not be rewritten.
+        assert!(wrapper_args(&["kache".into(), "gcc".into(), "a.c".into()]).is_none());
+        assert!(wrapper_args(&["kache".into(), "stats".into()]).is_none());
+        assert!(wrapper_args(&[]).is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,6 +273,17 @@ enum Commands {
     /// Open the configuration editor
     Config,
 
+    /// Create compiler-name symlinks pointing at kache, for transparent
+    /// interception by prepending the directory to PATH
+    InstallShims {
+        /// Directory to populate (created if missing)
+        dir: PathBuf,
+
+        /// Replace existing entries instead of refusing
+        #[arg(long)]
+        force: bool,
+    },
+
     /// Generate shell completion scripts
     Completions {
         /// Shell to generate completions for
@@ -464,6 +475,23 @@ fn main() -> Result<()> {
             .collect::<Vec<_>>();
         &lossy_args
     };
+    // Compiler-name shim (#310): invoked as `gcc`/`cc`/… through a PATH
+    // symlink, so the compiler is our own argv[0] rather than argv[1]. Checked
+    // BEFORE `detect_log_mode`, which only ever inspects argv[1..] and would
+    // classify `gcc foo.c` as CLI mode and fail parsing `foo.c` as a
+    // subcommand.
+    let shim_args = compiler::shim::wrapper_args(detection_args);
+    if let Some(shim_args) = shim_args {
+        init_logging(LogMode::Wrapper);
+        let shim_args = shim_args.map_err(anyhow::Error::msg)?;
+        if env_args.is_none() {
+            anyhow::bail!(
+                "compiler wrapper arguments contain non-UTF-8 bytes and cannot be cached safely"
+            );
+        }
+        return run_wrapper_mode(&shim_args);
+    }
+
     let log_mode = detect_log_mode(detection_args);
 
     // Detect RUSTC_WRAPPER mode: cargo passes the rustc path as arg[1]
@@ -624,6 +652,7 @@ fn main() -> Result<()> {
             let hours = since.as_deref().and_then(parse_duration_hours);
             tui::run_monitor(&config, hours)
         }
+        Some(Commands::InstallShims { dir, force }) => cli::install_shims(&dir, force),
         Some(Commands::Cargo { .. }) => unreachable!(),
         Some(Commands::Config) => unreachable!(),
         Some(Commands::Completions { .. }) => unreachable!(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -652,7 +652,14 @@ fn main() -> Result<()> {
             let hours = since.as_deref().and_then(parse_duration_hours);
             tui::run_monitor(&config, hours)
         }
+        #[cfg(unix)]
         Some(Commands::InstallShims { dir, force }) => cli::install_shims(&dir, force),
+        // Unix-only (symlinks); the Windows `.exe` shim story differs (#310).
+        #[cfg(not(unix))]
+        Some(Commands::InstallShims { .. }) => Err(anyhow::anyhow!(
+            "shim installation is Unix-only for now: it relies on symlinks, and the Windows \
+             `.exe` shim story differs (kunobi-ninja/kache#310). Use `CC`/`CXX` there."
+        )),
         Some(Commands::Cargo { .. }) => unreachable!(),
         Some(Commands::Config) => unreachable!(),
         Some(Commands::Completions { .. }) => unreachable!(),


### PR DESCRIPTION
Closes #310.

kache decided it was wrapping a compiler purely from `argv[1..]`, so the only supported convention was `kache <compiler> <args…>`. Under a shim symlink (`gcc -> kache` on `PATH`) the invocation is `argv[0] = gcc`, `argv[1] = foo.c`: no compiler at argv[1], so it fell through to CLI mode and failed parsing `foo.c` as a subcommand.

Now an `argv[0]` whose basename names a compiler enters wrapper mode with argv[0] as the implied compiler:

```sh
kache install-shims ~/.kache/shims
export PATH="$HOME/.kache/shims:$PATH"
```

One `PATH` change then covers every build tree on the machine regardless of how each project is configured. That is the point of the issue: editing `CC`/`CXX` per project does not scale for people supporting many differently structured builds (CMake and friends).

## Design notes

**Detection reuses `CcCompiler::recognizes`**, so versioned and target-prefixed shims a user creates by hand (`gcc-13`, `x86_64-linux-gnu-gcc`) work without a second name list to drift out of sync. `kache` itself and companion tools like `gcc-ar` are correctly not shims.

**Real-compiler resolution skips by resolved identity, not by directory.** The real compiler is the first same-named executable on `PATH` that does not canonicalize to the kache binary. This is the load-bearing choice: it finds shims wherever they live, tolerates several shim directories, and cannot be defeated by a relative or symlinked `PATH` entry — each of which would otherwise re-select the shim and recurse forever. When every candidate on `PATH` is a shim, kache reports that and exits rather than recursing.

**`install-shims` prints the two rules that decide whether this works at all**, because both fail silently otherwise: the directory must come *before* the real toolchain on `PATH` (appended, it is never consulted and nothing happens), and the real compilers must remain reachable behind it, because kache runs them.

**Unix only for now**, per the issue's own scoping: it relies on symlinks and the Windows `.exe` shim story differs. That path errors with the reason instead of half-working.

## Verification

Tested against a real toolchain rather than only in unit tests:

- `cc -c hello.c -o hello.o` through a shim on `PATH`: intercepted, cold miss, 1 entry stored.
- Same command again: **local hit**, hit rate 50% (1 hit / 1 miss).
- `cc hello.c -o hello` through the shim links, and the binary runs.
- `PATH` containing *only* the shim directory: clean error naming the cause, exit 1, no recursion.

Unit tests cover the pure core: argv[0] recognition (including the negatives that would recurse), identity-based skipping across multiple shim dirs, the all-shims case, non-executable candidates, and that normal `kache <compiler> …` / CLI argv is left alone.

2035 unit tests, clippy `-D warnings`, fmt clean. Docs: an "Compiler shims" section in the installation guide.

## Caveat worth stating

C/C++ caching is still experimental and local-only, and this makes it machine-wide with one export. The docs say so and call it opt-in. The shim entry point is orthogonal to that maturity and, as the issue notes, could land independently.
