### PR TITLE
chore(release): 0.15.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more, with S3 and shared-filesystem remotes."
 license = "Apache-2.0"
@@ -36,7 +36,7 @@ reqsign-aws-v4 = { version = "=3.0.2", default-features = false }
 reqsign-core = { version = "=3.1.0", default-features = false }
 # Direct dep so OpenDAL/reqwest can use ring without reintroducing aws-lc.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.15.0-rc.2", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.15.0-rc.3", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/charts/kache-service/Chart.yaml
+++ b/charts/kache-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kache-service
 description: Advisory remote planner service for kache
 type: application
-version: 0.15.0-rc.2
-appVersion: "0.15.0-rc.2"
+version: 0.15.0-rc.3
+appVersion: "0.15.0-rc.3"
 keywords:
   - rust
   - cache

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps the workspace, the e2e/service crates and the Helm chart to `0.15.0-rc.3`, and refreshes `Cargo.lock`.

Since `v0.15.0-rc.2`:

- feat(cc): compiler-name shims for transparent, config-free interception (#310, #796)
- feat(config): declarative bypass rules for argv, env and crate name (#222, #793)
- fix: isolate concurrent hardlink restores (#797)
- fix(daemon): stop an auto-started daemon inheriting an ambient remote (#706, #795)
- fix(nix): drop unneeded apple-sdk_15 dependency (#610, #788)
- fix(lint): satisfy Rust 1.98's chunks_exact_to_as_chunks in the Mach-O parser (#789)
- test(e2e): gate in-flight coalescing across simultaneous cargo invocations (#791)

Version-only change. Verified locally: `cargo fmt --check`, `cargo check --workspace --locked --all-targets`, `helm lint charts/kache-service`.

After merge, tag `v0.15.0-rc.3` on main so CI builds the release.