### PR TITLE
feat(s3): support custom user-agent header

### DIFF
--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -81,6 +81,7 @@ for AWS SDK-specific cases that need attention.
 | `KACHE_S3_REGION` | `cache.remote.region` | `us-east-1` | AWS region |
 | `KACHE_S3_PREFIX` | `cache.remote.prefix` | `artifacts` | Object or path prefix. The environment override is retained for S3; filesystem remotes configure it in the file |
 | `KACHE_S3_PROFILE` | `cache.remote.profile` | — | AWS credentials profile |
+| `KACHE_S3_USER_AGENT` | `cache.remote.user_agent` | — | Custom User-Agent header for S3 HTTP requests |
 | `KACHE_S3_ACCESS_KEY` | — | — | Explicit S3 access key |
 | `KACHE_S3_SECRET_KEY` | — | — | Explicit S3 secret key |
 | `KACHE_CACHE_EXECUTABLES` | `cache.cache_executables` | `true` on Linux/macOS, `false` on Windows | Also cache user-facing executables (`bin` crates and `--test` binaries). dylib/cdylib/proc-macro are always cached and are unaffected by this flag. On Linux, DWARF is embedded in the binary so a restored executable debugs like a fresh one; on macOS, kache bakes a `.dSYM` at store time and restores it next to the binary so `lldb` keeps source-level symbols ([#319](https://github.com/kunobi-ninja/kache/issues/319)); Windows (`.pdb` path) still references debug info outside the binary, so it stays off pending the equivalent work |

--- a/docs/remote-cache/s3-setup.mdx
+++ b/docs/remote-cache/s3-setup.mdx
@@ -118,6 +118,7 @@ Every remote config field has a matching `KACHE_S3_*` env var, which takes prece
 | `KACHE_S3_REGION` | `region` |
 | `KACHE_S3_PREFIX` | `prefix` |
 | `KACHE_S3_PROFILE` | `profile` |
+| `KACHE_S3_USER_AGENT` | `user_agent` |
 | `KACHE_S3_ACCESS_KEY` / `KACHE_S3_SECRET_KEY` | (explicit credentials) |
 
 Existing Kache S3 config keys and defaults remain accepted. A legacy

--- a/src/config.rs
+++ b/src/config.rs
@@ -355,6 +355,8 @@ pub struct S3RemoteConfig {
     pub region: String,
     /// AWS profile name for credential lookup (e.g. "ceph").
     pub profile: Option<String>,
+    /// Custom User-Agent header for S3 HTTP requests.
+    pub user_agent: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -422,6 +424,7 @@ impl RemoteConfig {
                 endpoint: None,
                 region: "us-east-1".to_string(),
                 profile: None,
+                user_agent: None,
             }),
         }
     }
@@ -646,6 +649,8 @@ pub(crate) struct RemoteFileConfig {
     pub(crate) prefix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) profile: Option<String>,
+    #[serde(alias = "user-agent", skip_serializing_if = "Option::is_none")]
+    pub(crate) user_agent: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -677,6 +682,7 @@ pub(crate) struct EnvOverrides {
     pub(crate) s3_region: bool,
     pub(crate) s3_prefix: bool,
     pub(crate) s3_profile: bool,
+    pub(crate) s3_user_agent: bool,
     pub(crate) fallback: bool,
     pub(crate) key_salt: bool,
     pub(crate) cc_extra_allowlist_flags: bool,
@@ -706,6 +712,7 @@ impl EnvOverrides {
             s3_region: env_or_ignored("KACHE_S3_REGION", ignore_env).is_ok(),
             s3_prefix: env_or_ignored("KACHE_S3_PREFIX", ignore_env).is_ok(),
             s3_profile: env_or_ignored("KACHE_S3_PROFILE", ignore_env).is_ok(),
+            s3_user_agent: env_or_ignored("KACHE_S3_USER_AGENT", ignore_env).is_ok(),
             fallback: env_or_ignored("KACHE_FALLBACK", ignore_env).is_ok(),
             key_salt: env_or_ignored("KACHE_KEY_SALT", ignore_env).is_ok(),
             cc_extra_allowlist_flags: env_or_ignored("KACHE_CC_EXTRA_ALLOWLIST_FLAGS", ignore_env)
@@ -928,6 +935,7 @@ const IGNORE_ENV_GATED_VARS: &[&str] = &[
     "KACHE_S3_REGION",
     "KACHE_S3_PREFIX",
     "KACHE_S3_PROFILE",
+    "KACHE_S3_USER_AGENT",
     "KACHE_LOCAL_ONLY",
     "KACHE_REMOTE_READONLY",
     "KACHE_MODIFIED_INPUT_GUARD",
@@ -1553,7 +1561,7 @@ impl Config {
             .map(str::to_ascii_lowercase);
 
         let file_has_s3_fields = file_remote.is_some_and(|r| {
-            [&r.bucket, &r.endpoint, &r.region, &r.profile]
+            [&r.bucket, &r.endpoint, &r.region, &r.profile, &r.user_agent]
                 .into_iter()
                 .any(|v| v.as_deref().is_some_and(|v| !v.trim().is_empty()))
         });
@@ -1567,7 +1575,7 @@ impl Config {
             Some("filesystem" | "fs") => {
                 if file_has_s3_fields {
                     anyhow::bail!(
-                        "[cache.remote] type = \"filesystem\" cannot include S3 bucket, endpoint, region, or profile"
+                        "[cache.remote] type = \"filesystem\" cannot include S3 bucket, endpoint, region, profile, or user_agent"
                     );
                 }
                 true
@@ -1709,6 +1717,12 @@ impl Config {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
+        let user_agent = env_or_ignored("KACHE_S3_USER_AGENT", ignore_env)
+            .ok()
+            .or_else(|| file_remote.and_then(|r| r.user_agent.clone()))
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
         Ok(Some(RemoteConfig {
             prefix,
             backend: RemoteBackendConfig::S3(S3RemoteConfig {
@@ -1716,6 +1730,7 @@ impl Config {
                 endpoint,
                 region,
                 profile,
+                user_agent,
             }),
         }))
     }
@@ -3133,6 +3148,7 @@ remote_key_cache_refresh_secs = 900
                     region: Some("eu-west-1".to_string()),
                     prefix: Some("my-prefix".to_string()),
                     profile: None,
+                    user_agent: None,
                     path: None,
                     atomic_write_dir: None,
                 }),
@@ -4159,12 +4175,13 @@ exclude = ["src/generated/**", "vendor/problem/**"]
         GenericEnvGuard { key, previous }
     }
 
-    const S3_ENV_VARS: [&str; 5] = [
+    const S3_ENV_VARS: [&str; 6] = [
         "KACHE_S3_BUCKET",
         "KACHE_S3_ENDPOINT",
         "KACHE_S3_REGION",
         "KACHE_S3_PREFIX",
         "KACHE_S3_PROFILE",
+        "KACHE_S3_USER_AGENT",
     ];
 
     /// Clear every `KACHE_S3_*` override, restoring them on drop.
@@ -4530,6 +4547,7 @@ exclude = ["src/generated/**", "vendor/problem/**"]
             "KACHE_S3_REGION",
             "KACHE_S3_PREFIX",
             "KACHE_S3_PROFILE",
+            "KACHE_S3_USER_AGENT",
         ] {
             // SAFETY: serialized by config_path_lock; restored implicitly by
             // being absent (these are not set elsewhere in the test suite).
@@ -5029,5 +5047,102 @@ exclude = ["src/generated/**", "vendor/problem/**"]
             vec!["-O2".to_string(), "-fPIC".to_string()]
         );
         assert!(normalize_cc_flags(Vec::<String>::new()).is_empty());
+    }
+
+    #[test]
+    fn s3_user_agent_loaded_from_file_and_env() {
+        let _guard = config_path_lock();
+        let _env_guard = isolate_s3_env();
+
+        // 1. From TOML with `user_agent`
+        let toml_underscore = r#"
+            [cache.remote]
+            type = "s3"
+            bucket = "my-bucket"
+            user_agent = "custom-agent/1.0"
+        "#;
+        let file_cfg: Result<FileConfig> = toml::from_str(toml_underscore).map_err(Into::into);
+        let loaded = Config::load_remote_config(&file_cfg).unwrap().unwrap();
+        match loaded.backend {
+            RemoteBackendConfig::S3(s3) => {
+                assert_eq!(s3.user_agent.as_deref(), Some("custom-agent/1.0"));
+            }
+            _ => panic!("expected S3 backend"),
+        }
+
+        // 2. From TOML with `user-agent` (alias)
+        let toml_hyphen = r#"
+            [cache.remote]
+            type = "s3"
+            bucket = "my-bucket"
+            user-agent = "custom-agent/2.0"
+        "#;
+        let file_cfg: Result<FileConfig> = toml::from_str(toml_hyphen).map_err(Into::into);
+        let loaded = Config::load_remote_config(&file_cfg).unwrap().unwrap();
+        match loaded.backend {
+            RemoteBackendConfig::S3(s3) => {
+                assert_eq!(s3.user_agent.as_deref(), Some("custom-agent/2.0"));
+            }
+            _ => panic!("expected S3 backend"),
+        }
+
+        // 3. Environment variable KACHE_S3_USER_AGENT overrides file config (precedence)
+        unsafe { std::env::set_var("KACHE_S3_USER_AGENT", "env-agent/3.0") };
+        let toml_file_val = r#"
+            [cache.remote]
+            type = "s3"
+            bucket = "my-bucket"
+            user_agent = "file-agent/1.0"
+        "#;
+        let file_cfg: Result<FileConfig> = toml::from_str(toml_file_val).map_err(Into::into);
+        let loaded = Config::load_remote_config(&file_cfg).unwrap().unwrap();
+        match loaded.backend {
+            RemoteBackendConfig::S3(s3) => {
+                assert_eq!(
+                    s3.user_agent.as_deref(),
+                    Some("env-agent/3.0"),
+                    "environment variable override must take precedence over file config"
+                );
+            }
+            _ => panic!("expected S3 backend"),
+        }
+
+        // 4. [cache] ignore_env = true suppresses environment override in favor of file
+        let toml_ignore_env = r#"
+            [cache]
+            ignore_env = true
+
+            [cache.remote]
+            type = "s3"
+            bucket = "my-bucket"
+            user_agent = "file-agent/1.0"
+        "#;
+        let resolved_cfg =
+            Config::load_resolved(toml::from_str(toml_ignore_env).map_err(Into::into)).unwrap();
+        match resolved_cfg.remote.unwrap().backend {
+            RemoteBackendConfig::S3(s3) => {
+                assert_eq!(
+                    s3.user_agent.as_deref(),
+                    Some("file-agent/1.0"),
+                    "ignore_env = true must ignore KACHE_S3_USER_AGENT in favor of file config"
+                );
+            }
+            _ => panic!("expected S3 backend"),
+        }
+        unsafe { std::env::remove_var("KACHE_S3_USER_AGENT") };
+
+        // 5. Reject user_agent when type = "filesystem"
+        let toml_fs = r#"
+            [cache.remote]
+            type = "filesystem"
+            path = "/tmp/cache"
+            user_agent = "invalid-for-fs"
+        "#;
+        let file_cfg: Result<FileConfig> = toml::from_str(toml_fs).map_err(Into::into);
+        let err = Config::load_remote_config(&file_cfg).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot include S3 bucket, endpoint, region, profile, or user_agent")
+        );
     }
 }

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -436,6 +436,27 @@ fn build_fields(file_config: &FileConfig, env: &EnvOverrides) -> Vec<FormField> 
             env_locked: !filesystem_remote && env.s3_profile,
         },
         FormField {
+            key: "s3_user_agent",
+            label: "User-Agent",
+            kind: FieldKind::Text,
+            value: remote
+                .and_then(|r| r.user_agent.clone())
+                .unwrap_or_default(),
+            env_var: if env.s3_user_agent {
+                "KACHE_S3_USER_AGENT"
+            } else {
+                ""
+            },
+            env_value: if env.s3_user_agent {
+                env_val("KACHE_S3_USER_AGENT")
+            } else {
+                None
+            },
+            default_hint: "(none)",
+            validation_error: None,
+            env_locked: !filesystem_remote && env.s3_user_agent,
+        },
+        FormField {
             key: "fs_path",
             label: "Filesystem path",
             kind: FieldKind::Text,
@@ -517,11 +538,11 @@ fn build_sections() -> Vec<Section> {
         },
         Section {
             label: "Remote",
-            fields: 10..18,
+            fields: 10..19,
         },
         Section {
             label: "Advanced",
-            fields: 18..20,
+            fields: 19..21,
         },
     ]
 }
@@ -579,9 +600,15 @@ fn validate_cross_field(fields: &[FormField]) -> Vec<(usize, String)> {
     let is_configured = |key: &str| configured_value(key).is_some();
 
     let remote_type = value("remote_type").map(str::to_ascii_lowercase);
-    let has_s3_fields = ["s3_bucket", "s3_endpoint", "s3_region", "s3_profile"]
-        .iter()
-        .any(|key| is_set(key));
+    let has_s3_fields = [
+        "s3_bucket",
+        "s3_endpoint",
+        "s3_region",
+        "s3_profile",
+        "s3_user_agent",
+    ]
+    .iter()
+    .any(|key| is_set(key));
     let has_filesystem_fields = ["fs_path", "fs_atomic_write_dir"]
         .iter()
         .any(|key| is_set(key));
@@ -591,6 +618,7 @@ fn validate_cross_field(fields: &[FormField]) -> Vec<(usize, String)> {
         "s3_endpoint",
         "s3_region",
         "s3_profile",
+        "s3_user_agent",
         "fs_path",
         "fs_atomic_write_dir",
         "remote_prefix",
@@ -663,7 +691,13 @@ fn validate_cross_field(fields: &[FormField]) -> Vec<(usize, String)> {
                     ));
                 }
             }
-            for key in ["s3_bucket", "s3_endpoint", "s3_region", "s3_profile"] {
+            for key in [
+                "s3_bucket",
+                "s3_endpoint",
+                "s3_region",
+                "s3_profile",
+                "s3_user_agent",
+            ] {
                 // Legacy S3 environment variables do not apply to an explicitly
                 // selected filesystem backend. Only persisted form values conflict.
                 if is_configured(key)
@@ -704,7 +738,12 @@ fn refresh_remote_env_scope(fields: &mut [FormField]) {
     for field in fields.iter_mut().filter(|field| {
         matches!(
             field.key,
-            "s3_bucket" | "s3_endpoint" | "s3_region" | "s3_profile" | "remote_prefix"
+            "s3_bucket"
+                | "s3_endpoint"
+                | "s3_region"
+                | "s3_profile"
+                | "s3_user_agent"
+                | "remote_prefix"
         )
     }) {
         // An active KACHE_S3_* override is stored in env_var/env_value, but it
@@ -795,6 +834,7 @@ fn fields_to_file_config(
     let region = get("s3_region");
     let prefix = get("remote_prefix");
     let profile = get("s3_profile");
+    let user_agent = get("s3_user_agent");
     let path = get("fs_path");
     let atomic_write_dir = get("fs_atomic_write_dir");
     let remote_type = get("remote_type")
@@ -806,6 +846,7 @@ fn fields_to_file_config(
         || region.is_some()
         || prefix.is_some()
         || profile.is_some()
+        || user_agent.is_some()
         || path.is_some()
         || atomic_write_dir.is_some();
 
@@ -817,6 +858,7 @@ fn fields_to_file_config(
             region,
             prefix,
             profile,
+            user_agent,
             path,
             atomic_write_dir,
         })
@@ -1493,6 +1535,7 @@ mod tests {
             s3_region: false,
             s3_prefix: false,
             s3_profile: false,
+            s3_user_agent: false,
         }
     }
 
@@ -1500,13 +1543,13 @@ mod tests {
     fn test_build_fields_count() {
         let config = FileConfig::default();
         let fields = build_fields(&config, &empty_env());
-        assert_eq!(fields.len(), 20);
+        assert_eq!(fields.len(), 21);
 
         let sections = build_sections();
         assert_eq!(sections[0].fields, 0..3);
         assert_eq!(sections[1].fields, 3..10);
-        assert_eq!(sections[2].fields, 10..18);
-        assert_eq!(sections[3].fields, 18..20);
+        assert_eq!(sections[2].fields, 10..19);
+        assert_eq!(sections[3].fields, 19..21);
     }
 
     #[test]
@@ -1519,6 +1562,12 @@ mod tests {
                 local_store: Some("~/my/cache".to_string()),
                 local_max_size: Some("100GiB".to_string()),
                 adaptive_incremental: Some(false),
+                remote: Some(RemoteFileConfig {
+                    _type: Some("s3".to_string()),
+                    bucket: Some("my-bucket".to_string()),
+                    user_agent: Some("custom-agent/1.0".to_string()),
+                    ..Default::default()
+                }),
                 ..Default::default()
             }),
         };
@@ -1531,6 +1580,11 @@ mod tests {
             .unwrap();
         assert_eq!(adaptive.value, "false");
         assert_eq!(adaptive.default_hint, "true");
+        let user_agent = fields
+            .iter()
+            .find(|field| field.key == "s3_user_agent")
+            .unwrap();
+        assert_eq!(user_agent.value, "custom-agent/1.0");
     }
 
     #[test]
@@ -1797,6 +1851,7 @@ mod tests {
         env.s3_region = true;
         env.s3_prefix = true;
         env.s3_profile = true;
+        env.s3_user_agent = true;
 
         let fields = build_fields(&config, &env);
         for key in [
@@ -1804,6 +1859,7 @@ mod tests {
             "s3_endpoint",
             "s3_region",
             "s3_profile",
+            "s3_user_agent",
             "remote_prefix",
         ] {
             let field = fields.iter().find(|field| field.key == key).unwrap();
@@ -1831,7 +1887,13 @@ mod tests {
             .find(|field| field.key == "fs_path")
             .unwrap()
             .value = absolute_test_path();
-        for key in ["s3_bucket", "s3_endpoint", "s3_region", "s3_profile"] {
+        for key in [
+            "s3_bucket",
+            "s3_endpoint",
+            "s3_region",
+            "s3_profile",
+            "s3_user_agent",
+        ] {
             let field = fields.iter_mut().find(|field| field.key == key).unwrap();
             field.env_locked = true;
             field.env_value = Some("ambient".to_string());
@@ -2019,6 +2081,7 @@ mod tests {
                     region: Some("eu-west-1".to_string()),
                     prefix: Some("my-project".to_string()),
                     profile: Some("build-account".to_string()),
+                    user_agent: Some("custom-ua/1.0".to_string()),
                     path: None,
                     atomic_write_dir: None,
                 }),
@@ -2239,6 +2302,51 @@ mod tests {
         assert!(remote.endpoint.is_none());
         assert!(remote.region.is_none());
         assert!(remote.profile.is_none());
+    }
+
+    #[test]
+    fn test_fields_to_file_config_only_user_agent_persists_remote() {
+        let config = FileConfig::default();
+        let mut fields = build_fields(&config, &empty_env());
+        let ua_field = fields
+            .iter_mut()
+            .find(|field| field.key == "s3_user_agent")
+            .unwrap();
+        ua_field.value = "custom-agent/1.0".to_string();
+
+        let result = fields_to_file_config(
+            &fields,
+            None,
+            None,
+            None,
+            PreservedAdvancedConfig::default(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        let remote = result
+            .cache
+            .as_ref()
+            .and_then(|cache| cache.remote.as_ref())
+            .expect("remote section must be created when only s3_user_agent is populated");
+        assert_eq!(remote.user_agent.as_deref(), Some("custom-agent/1.0"));
+        assert!(remote._type.is_none());
+        assert!(remote.bucket.is_none());
+        assert!(remote.endpoint.is_none());
+        assert!(remote.region.is_none());
+        assert!(remote.profile.is_none());
+        assert!(remote.path.is_none());
+        assert!(remote.atomic_write_dir.is_none());
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7363,6 +7363,7 @@ const AMBIENT_REMOTE_ENV_VARS: &[&str] = &[
     "KACHE_S3_REGION",
     "KACHE_S3_PREFIX",
     "KACHE_S3_PROFILE",
+    "KACHE_S3_USER_AGENT",
     "KACHE_LOCAL_ONLY",
     "KACHE_REMOTE_READONLY",
 ];
@@ -7724,6 +7725,7 @@ mod tests {
             "KACHE_S3_REGION",
             "KACHE_S3_PREFIX",
             "KACHE_S3_PROFILE",
+            "KACHE_S3_USER_AGENT",
             "KACHE_LOCAL_ONLY",
             "KACHE_REMOTE_READONLY",
         ];

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -676,7 +676,7 @@ fn create_s3_operator(config: &S3RemoteConfig, pool_idle_secs: u64) -> Result<Op
     // direct library/test callers safe; the operation is idempotent when
     // another Kache HTTP client already installed it.
     ensure_rustls_provider();
-    let client = reqwest::Client::builder()
+    let mut client_builder = reqwest::Client::builder()
         .pool_idle_timeout(Duration::from_secs(pool_idle_secs))
         // `pool_idle_timeout` only reaps idle pooled connections; without these an
         // endpoint that accepts a connection and then goes silent hangs the
@@ -686,9 +686,17 @@ fn create_s3_operator(config: &S3RemoteConfig, pool_idle_secs: u64) -> Result<Op
         // read-inactivity deadline. Deliberately NOT a total-request timeout,
         // which would cap large artifact transfers on slow links.
         .connect_timeout(CONNECT_TIMEOUT)
-        .read_timeout(READ_INACTIVITY_TIMEOUT)
-        .build()
-        .context("building S3 HTTP client")?;
+        .read_timeout(READ_INACTIVITY_TIMEOUT);
+
+    if let Some(user_agent) = config
+        .user_agent
+        .as_deref()
+        .filter(|ua| !ua.trim().is_empty())
+    {
+        client_builder = client_builder.user_agent(user_agent);
+    }
+
+    let client = client_builder.build().context("building S3 HTTP client")?;
     let context = OperationContext::new()
         .with_http_transport(HttpTransporter::new(ReqwestTransport::new(client)));
 
@@ -1080,6 +1088,7 @@ mod tests {
             endpoint: Some("http://127.0.0.1:9000".to_string()),
             region: "us-east-1".to_string(),
             profile: Some("team".to_string()),
+            user_agent: Some("custom-ua/1.0".to_string()),
         };
         create_s3_operator(&config, 30).expect("S3 operator builds without network I/O");
     }
@@ -1470,5 +1479,52 @@ mod tests {
         assert_eq!(env.var("AWS_PROFILE").as_deref(), Some("selected"));
         assert_eq!(env.var("AWS_REGION").as_deref(), Some("eu-west-1"));
         assert_eq!(env.home_dir(), Some(PathBuf::from("/home/test")));
+    }
+
+    #[tokio::test]
+    async fn s3_wire_sends_custom_user_agent() {
+        let (endpoint, requests) = mock_http_server(vec![http_response("404 Not Found", "")]).await;
+
+        struct ScopedEnvVar(&'static str);
+        impl ScopedEnvVar {
+            fn set(key: &'static str, val: &str) -> Self {
+                unsafe { std::env::set_var(key, val) };
+                Self(key)
+            }
+        }
+        impl Drop for ScopedEnvVar {
+            fn drop(&mut self) {
+                unsafe { std::env::remove_var(self.0) };
+            }
+        }
+
+        let _access = ScopedEnvVar::set("KACHE_S3_ACCESS_KEY", "mock-access-key");
+        let _secret = ScopedEnvVar::set("KACHE_S3_SECRET_KEY", "mock-secret-key");
+
+        let config = S3RemoteConfig {
+            bucket: "bucket".to_string(),
+            endpoint: Some(endpoint),
+            region: "us-east-1".to_string(),
+            profile: None,
+            user_agent: Some("kache-custom-agent/9.9".to_string()),
+        };
+        let operator = create_s3_operator(&config, 30).unwrap();
+        let backend = OpenDalBackend::new(operator, "s3://bucket".to_string());
+
+        assert!(
+            backend
+                .get("nested/key", Some(1024))
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let requests = requests.await.unwrap();
+        let request_text = &requests[0];
+        assert!(
+            request_text.lines().any(|line| line
+                .to_ascii_lowercase()
+                .starts_with("user-agent: kache-custom-agent/9.9")),
+            "expected custom User-Agent header in request: {request_text}"
+        );
     }
 }

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -1297,6 +1297,7 @@ mod tests {
                 endpoint: None,
                 region: "us-east-1".to_string(),
                 profile: None,
+                user_agent: None,
             }),
         };
         let backend = memory_backend();


### PR DESCRIPTION
## Summary
Fixes #792.

Allows configuring a custom `User-Agent` HTTP header for S3 remote backend transfers. This is required by some S3-compatible object store providers and enterprise HTTP proxies that inspect or require a specific `User-Agent` header value.

### Details
- **Configuration file**: Supports `user_agent` (and `user-agent` alias) under `[cache.remote]`.
- **Environment variable**: Supports `KACHE_S3_USER_AGENT` override.
- **Client builder**: In `src/remote_backend.rs` (`create_s3_operator`), applies `.user_agent(...)` to `reqwest::Client::builder()`.
- **TUI & Daemon**: Added `s3_user_agent` field in config TUI editor and included `KACHE_S3_USER_AGENT` in daemon ambient remote check.
- **Documentation**: Updated `docs/getting-started/configuration.mdx` and `docs/remote-cache/s3-setup.mdx`.
- **Tests**:
  - `config::tests::s3_user_agent_loaded_from_file_and_env`: Tests TOML parsing (`user_agent` and `user-agent`), env var override, and filesystem backend rejection.
  - `remote_backend::tests::s3_wire_sends_custom_user_agent`: Verifies custom `User-Agent` header is transmitted over the wire during S3 HTTP requests.

## Test Plan
- `cargo test --workspace`
- `cargo fmt --all -- --check`
