### PR TITLE
fix(macos): allow LaunchAgent local-network remotes

### DIFF
--- a/assets/macos/Info.plist
+++ b/assets/macos/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>ninja.kunobi.kache</string>
+    <key>CFBundleName</key>
+    <string>kache</string>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Kache connects to build-cache servers configured on your local network.</string>
+</dict>
+</plist>

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -386,6 +386,10 @@ kache doctor [--fix [--purge-sccache]] [--verify] [--checksums] [--repair]
 
 Diagnoses common setup issues: missing `RUSTC_WRAPPER`, conflicting wrappers, config file problems, and daemon connectivity. Without `--fix`, it only reports issues.
 
+An installed daemon service is recommended but not mandatory. If a healthy
+on-demand daemon is already reachable, `doctor` reports the missing service as
+a passing runtime configuration instead of directing you to replace it.
+
 The verify family checks cache integrity:
 
 - `--verify` checks entry, blob, and metadata integrity (orphaned/missing blobs).

--- a/docs/daemon/lifecycle.mdx
+++ b/docs/daemon/lifecycle.mdx
@@ -31,6 +31,17 @@ For the daemon to survive reboots and start automatically, install it as a syste
 
     This creates a launchd plist at `~/Library/LaunchAgents/ninja.kunobi.kache.plist` and loads it. The daemon will start on login and restart if it crashes.
 
+    On macOS 15 and newer, the first connection to a cache server on the local
+    network may show a **Local Network** permission prompt for kache. Allow it;
+    you can review the decision later under **System Settings > Privacy &
+    Security > Local Network**. Kache embeds the usage description in its binary
+    and associates the LaunchAgent with that identity.
+
+    If an older installation instead logs `No route to host (os error 65)` for
+    a LAN endpoint, reinstall the service with the current binary. As a safe
+    fallback, `kache daemon uninstall` lets the next terminal build start an
+    on-demand daemon under the terminal's Local Network permission.
+
     To remove it:
 
     ```sh

--- a/docs/remote-cache/s3-setup.mdx
+++ b/docs/remote-cache/s3-setup.mdx
@@ -67,6 +67,26 @@ With just a bucket name and no endpoint, kache uses AWS S3 with the default cred
   </Tab>
 </Tabs>
 
+### macOS and self-hosted LAN endpoints
+
+macOS 15 and newer protects connections to servers reached directly through a
+local Wi-Fi or Ethernet interface. When kache runs as an installed LaunchAgent,
+allow its **Local Network** prompt; the setting is available later under
+**System Settings > Privacy & Security > Local Network**.
+
+If only the installed daemon fails with `No route to host (os error 65)` while
+the same endpoint works from `kache daemon run` in a terminal, Local Network
+privacy is the likely cause rather than DNS or S3 credentials. Reinstall the
+service with the current kache binary so its responsible-code metadata is up to
+date. If permission still cannot be granted, use:
+
+```sh
+kache daemon uninstall
+```
+
+The next terminal build starts the daemon on demand and inherits the terminal's
+Local Network permission. Kache logs a specific hint for this failure shape.
+
 ## Credential resolution order
 
 When kache needs S3 credentials, it checks these sources in order:

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -35,6 +35,7 @@ buildRustPackage {
     fileset = lib.fileset.unions [
       ../Cargo.toml
       ../Cargo.lock
+      ../assets
       ../crates
       ../src
     ];

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3209,6 +3209,14 @@ fn daemon_needed(remote_configured: bool, planner_configured: bool) -> bool {
     remote_configured || planner_configured
 }
 
+fn daemon_service_check(
+    installed: bool,
+    healthy_daemon_reachable: bool,
+) -> (bool, Option<&'static str>) {
+    let pass = installed || healthy_daemon_reachable;
+    (pass, (!pass).then_some("kache daemon install"))
+}
+
 /// Whether a `doctor` check counts toward the "N issue(s) found" total. Checks
 /// downgraded to informational (`optional`) never count, even when they fail.
 fn is_doctor_issue(pass: bool, optional: bool) -> bool {
@@ -3692,6 +3700,7 @@ pub fn doctor(
     // replacement takes to bind its socket (kunobi-ninja/kache#720). `--fix` opts
     // into that wait below.
     let my_version = crate::VERSION;
+    let mut healthy_daemon_reachable = false;
     if let Some(ref cfg) = config {
         let my_epoch = crate::daemon::build_epoch();
         let mut stats = crate::daemon::send_stats_request_without_restart(cfg, false).ok();
@@ -3715,6 +3724,8 @@ pub fn doctor(
             stats = crate::daemon::send_stats_request_without_restart(cfg, false).ok();
         }
 
+        healthy_daemon_reachable = stats.is_some();
+
         let (pass, detail, fix_hint) = daemon_version_check(
             stats.as_ref().map(|s| (s.version.as_str(), s.build_epoch)),
             crate::daemon::starting_daemon_epoch(cfg),
@@ -3732,19 +3743,18 @@ pub fn doctor(
     // 9. Daemon service installed
     if let Some(service_path) = crate::service::service_file_path() {
         let installed = service_path.exists();
+        let (pass, fix) = daemon_service_check(installed, healthy_daemon_reachable);
         checks.push(Check {
             label: "Daemon service",
-            pass: installed,
+            pass,
             detail: if installed {
                 service_path.display().to_string()
+            } else if healthy_daemon_reachable {
+                "not installed; healthy on-demand daemon is reachable".into()
             } else {
                 "not installed".into()
             },
-            fix: if installed {
-                None
-            } else {
-                Some("kache daemon install".into())
-            },
+            fix: fix.map(str::to_string),
         });
     }
 
@@ -5452,6 +5462,16 @@ mod tests {
         assert!(!doctor_check_is_optional("Compiler probe", true, false));
         // Non-daemon, non-probe labels are never optional.
         assert!(!doctor_check_is_optional("Remote", true, true));
+    }
+
+    #[test]
+    fn daemon_service_is_satisfied_by_install_or_healthy_on_demand_daemon() {
+        assert_eq!(daemon_service_check(true, false), (true, None));
+        assert_eq!(daemon_service_check(false, true), (true, None));
+        assert_eq!(
+            daemon_service_check(false, false),
+            (false, Some("kache daemon install"))
+        );
     }
 
     /// The daemon footnote prints only for a FAILING daemon check under an

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,17 @@ mod tui;
 mod wrapper;
 mod wrapper_config;
 
+// macOS local-network privacy attributes a LaunchAgent's network access to
+// responsible code. Kache is a standalone executable rather than an app
+// bundle, so embed the identity and usage description directly in its Mach-O
+// image. The generated LaunchAgent associates itself with the same bundle id
+// in `service::launchd_plist_content` (kunobi-ninja/kache#798).
+#[cfg(target_os = "macos")]
+#[used]
+#[unsafe(link_section = "__TEXT,__info_plist")]
+static MACOS_INFO_PLIST: [u8; include_bytes!("../assets/macos/Info.plist").len()] =
+    *include_bytes!("../assets/macos/Info.plist");
+
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;

--- a/src/remote_resilience.rs
+++ b/src/remote_resilience.rs
@@ -25,6 +25,8 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+const MACOS_LOCAL_NETWORK_PRIVACY_HINT: &str = "macOS Local Network privacy may be blocking the installed LaunchAgent; allow kache in System Settings > Privacy & Security > Local Network, or run `kache daemon uninstall` so terminal builds start the daemon on demand";
+
 // ── Error classification ────────────────────────────────────────────────────
 
 /// What a failed remote operation means for the caller.
@@ -255,6 +257,30 @@ pub(crate) fn classify_remote_error(error: &anyhow::Error) -> RemoteErrorClass {
         // arbitrary local error is a remote outage would suppress healthy
         // reads and writes.
         RemoteErrorClass::Local
+    }
+}
+
+fn macos_local_network_privacy_hint(
+    platform: &str,
+    launch_agent_installed: bool,
+    detail: &str,
+) -> Option<&'static str> {
+    let detail = detail.to_ascii_lowercase();
+    (platform == "macos"
+        && launch_agent_installed
+        && (detail.contains("no route to host") || detail.contains("os error 65")))
+    .then_some(MACOS_LOCAL_NETWORK_PRIVACY_HINT)
+}
+
+fn diagnose_remote_failure(detail: &str) -> std::borrow::Cow<'_, str> {
+    #[cfg(target_os = "macos")]
+    let launch_agent_installed =
+        crate::service::service_file_path().is_some_and(|path| path.exists());
+    #[cfg(not(target_os = "macos"))]
+    let launch_agent_installed = false;
+    match macos_local_network_privacy_hint(std::env::consts::OS, launch_agent_installed, detail) {
+        Some(hint) => std::borrow::Cow::Owned(format!("{detail}; hint: {hint}")),
+        None => std::borrow::Cow::Borrowed(detail),
     }
 }
 
@@ -568,6 +594,7 @@ impl BreakerPermit {
         }
 
         let class = class.expect("poisoning class checked above");
+        let detail = diagnose_remote_failure(detail);
         state.failures = state.failures.saturating_add(1);
         if self.probe || state.failures >= self.breaker.threshold {
             state.epoch = state.epoch.wrapping_add(1);
@@ -578,7 +605,7 @@ impl BreakerPermit {
                 direction = ?self.breaker.direction,
                 operation = self.operation.label(),
                 ?class,
-                error = detail,
+                error = detail.as_ref(),
                 cooldown_secs = self.breaker.cooldown.as_secs(),
                 "remote direction degraded"
             );
@@ -589,7 +616,7 @@ impl BreakerPermit {
                 ?class,
                 failures = state.failures,
                 threshold = self.breaker.threshold,
-                error = detail,
+                error = detail.as_ref(),
                 "remote operation failed"
             );
         }
@@ -1082,6 +1109,47 @@ mod tests {
             }
             .to_string(),
             "remote deadline elapsed during request queue"
+        );
+    }
+
+    #[test]
+    fn macos_launch_agent_no_route_failure_gets_local_network_privacy_hint() {
+        let hint =
+            macos_local_network_privacy_hint("macos", true, "tcp connect error: No route to host")
+                .expect("service-managed macOS EHOSTUNREACH should be diagnosed");
+        assert!(hint.contains("Local Network privacy"));
+        assert!(hint.contains("kache daemon uninstall"));
+    }
+
+    #[test]
+    fn macos_launch_agent_errno_65_gets_local_network_privacy_hint() {
+        assert!(
+            macos_local_network_privacy_hint("macos", true, "tcp connect error (os error 65)",)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn local_network_privacy_hint_is_narrow_and_qualified() {
+        assert_eq!(
+            macos_local_network_privacy_hint(
+                "linux",
+                true,
+                "tcp connect error: No route to host (os error 65)"
+            ),
+            None
+        );
+        assert_eq!(
+            macos_local_network_privacy_hint(
+                "macos",
+                false,
+                "tcp connect error: No route to host (os error 65)"
+            ),
+            None
+        );
+        assert_eq!(
+            macos_local_network_privacy_hint("macos", true, "connection refused"),
+            None
         );
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
 const LABEL: &str = "ninja.kunobi.kache";
+const MACOS_BUNDLE_IDENTIFIER: &str = LABEL;
 const PLIST_NAME: &str = "ninja.kunobi.kache.plist";
 const LEGACY_LABEL: &str = "com.zondax.kache";
 const LEGACY_PLIST_NAME: &str = "com.zondax.kache.plist";
@@ -141,6 +142,10 @@ fn launchd_plist_content(
         <string>{exe_str}</string>
         <string>daemon</string>
         <string>run</string>
+    </array>
+    <key>AssociatedBundleIdentifiers</key>
+    <array>
+        <string>{MACOS_BUNDLE_IDENTIFIER}</string>
     </array>
     <key>RunAtLoad</key>
     <true/>
@@ -1073,9 +1078,19 @@ WantedBy=default.target
         assert!(content.contains("/opt/kache/bin/kache"));
         assert!(content.contains("<string>daemon</string>"));
         assert!(content.contains("<string>run</string>"));
+        assert!(content.contains("AssociatedBundleIdentifiers"));
+        assert!(content.contains(&format!("<string>{MACOS_BUNDLE_IDENTIFIER}</string>")));
         assert!(content.contains("/var/log/kache/out.log"));
         assert!(content.contains("/var/log/kache/err.log"));
         assert!(content.contains("RunAtLoad"));
+    }
+
+    #[test]
+    fn test_embedded_macos_info_plist_matches_launchd_identity() {
+        let info = include_str!("../assets/macos/Info.plist");
+        assert!(info.contains(&format!("<string>{MACOS_BUNDLE_IDENTIFIER}</string>")));
+        assert!(info.contains("NSLocalNetworkUsageDescription"));
+        assert!(info.contains("build-cache servers configured on your local network"));
     }
 
     #[test]

--- a/tests/macos_local_network_metadata_test.rs
+++ b/tests/macos_local_network_metadata_test.rs
@@ -1,0 +1,35 @@
+#![cfg(target_os = "macos")]
+
+use std::process::Command;
+
+#[test]
+fn kache_binary_embeds_local_network_privacy_metadata() {
+    let output = Command::new("otool")
+        .args(["-s", "__TEXT", "__info_plist", env!("CARGO_BIN_EXE_kache")])
+        .output()
+        .expect("run otool against the built kache binary");
+    assert!(
+        output.status.success(),
+        "otool could not read __TEXT,__info_plist: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("otool output is UTF-8");
+    let mut bytes = Vec::new();
+    for line in stdout.lines().skip(2) {
+        for word in line.split_whitespace().skip(1) {
+            let pairs: Vec<_> = word.as_bytes().chunks_exact(2).collect();
+            // `otool -s` prints each little-endian 32-bit word as a host-order
+            // hex integer, so restore its byte order before parsing the plist.
+            for pair in pairs.into_iter().rev() {
+                let pair = std::str::from_utf8(pair).expect("otool hex is ASCII");
+                bytes.push(u8::from_str_radix(pair, 16).expect("otool emitted valid hex"));
+            }
+        }
+    }
+    let plist = String::from_utf8(bytes).expect("embedded Info.plist is UTF-8");
+
+    assert!(plist.contains("<string>ninja.kunobi.kache</string>"));
+    assert!(plist.contains("NSLocalNetworkUsageDescription"));
+    assert!(plist.contains("build-cache servers configured on your local network"));
+}

--- a/tests/macos_local_network_metadata_test.rs
+++ b/tests/macos_local_network_metadata_test.rs
@@ -18,7 +18,7 @@ fn kache_binary_embeds_local_network_privacy_metadata() {
     let mut bytes = Vec::new();
     for line in stdout.lines().skip(2) {
         for word in line.split_whitespace().skip(1) {
-            let pairs: Vec<_> = word.as_bytes().chunks_exact(2).collect();
+            let pairs: Vec<_> = word.as_bytes().as_chunks::<2>().0.iter().collect();
             // `otool -s` prints each little-endian 32-bit word as a host-order
             // hex integer, so restore its byte order before parsing the plist.
             for pair in pairs.into_iter().rev() {


### PR DESCRIPTION
## Summary

- embed a macOS `Info.plist` in the standalone `kache` Mach-O with a stable bundle identity and `NSLocalNetworkUsageDescription`
- associate the generated LaunchAgent with that identity so macOS can attribute Local Network access
- add a qualified hint for LaunchAgent `No route to host` / `os error 65` failures
- let `kache doctor` accept a healthy on-demand daemon when no service is installed
- document the permission prompt, reinstall path, and on-demand fallback

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked -- --test-threads=1`
- focused tests rerun after rebasing onto `0.15.0-rc.3`
- release build inspected with `otool`: `__TEXT,__info_plist` contains the expected bundle ID and Local Network usage description
- changed-line mutation testing: 20 caught, 4 unviable, 0 missed after recheck

Live first-prompt behavior still needs a clean macOS privacy database and a real LAN endpoint; the PR validates the responsible-code metadata structurally on macOS.

Closes #798
