### PR TITLE
perf(cc): memoize warm preprocess hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
           matrix="$(python3 -c '
           import json, sys
           count = int(sys.argv[1])
-          total = max(1, (count + 14) // 15)
+          total = max(1, (count + 9) // 10)
           if total > 256:
               raise SystemExit(
                   f"changed-line scope needs {total} shards; GitHub permits at most 256"
@@ -346,7 +346,7 @@ jobs:
           path: tmp/mutants/service
           retention-days: 14
 
-  # PR-only workspace mutation is split into round-robin shards. Fifteen
+  # PR-only workspace mutation is split into round-robin shards. Ten
   # serial in-place mutants per runner bounds exposure to slow or pathological
   # mutants, while round-robin avoids concentrating them in one shard.
   mutation-diff:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
           matrix="$(python3 -c '
           import json, sys
           count = int(sys.argv[1])
-          total = max(1, (count + 29) // 30)
+          total = max(1, (count + 14) // 15)
           if total > 256:
               raise SystemExit(
                   f"changed-line scope needs {total} shards; GitHub permits at most 256"
@@ -346,9 +346,9 @@ jobs:
           path: tmp/mutants/service
           retention-days: 14
 
-  # PR-only workspace mutation is split into round-robin shards. Thirty
-  # serial in-place mutants per runner stays comfortably below the step cap,
-  # while round-robin avoids concentrating slow mutants in one shard.
+  # PR-only workspace mutation is split into round-robin shards. Fifteen
+  # serial in-place mutants per runner bounds exposure to slow or pathological
+  # mutants, while round-robin avoids concentrating them in one shard.
   mutation-diff:
     name: Mutation testing (diff ${{ matrix.display }}/${{ matrix.total }})
     runs-on: ubuntu-latest
@@ -401,7 +401,7 @@ jobs:
             --in-place \
             --baseline run \
             --caught \
-            --timeout 300 \
+            --timeout 180 \
             --build-timeout 600 \
             --annotations github \
             --output 'tmp/mutants/diff-${{ matrix.display }}'

--- a/scenarios/e2e-c-depinfo/scenario.toml
+++ b/scenarios/e2e-c-depinfo/scenario.toml
@@ -40,7 +40,7 @@ max_probe_runs = 1
 [assertions.warm]
 min_hits = 1
 max_compiler_runs = 0
-max_preprocessor_runs = 1
+max_preprocessor_runs = 0
 max_probe_runs = 0
 
 [assertions.noop]

--- a/scenarios/e2e-c-hello/scenario.toml
+++ b/scenarios/e2e-c-hello/scenario.toml
@@ -53,12 +53,12 @@ max_probe_runs = 1
 
 # Warm: clean wipes build/, the rebuild's compile hits the cache.
 # `max_compiler_runs = 0` is the deterministic proof the hit skipped
-# the compile entirely. The preprocessor still runs once (it derives
-# the key) — that's the overhead a future direct mode would remove.
+# the compile entirely. The private complete dependency snapshot lets the
+# wrapper reuse the prior expansion hash without running the preprocessor.
 [assertions.warm]
 min_hits = 1
 max_compiler_runs = 0
-max_preprocessor_runs = 1
+max_preprocessor_runs = 0
 # Probe memoized on disk from the cold build — the warm rebuild reads
 # the record instead of re-running `cc --version` / `cc -###`.
 max_probe_runs = 0

--- a/scenarios/e2e-cc-bench-flags-gnu/scenario.toml
+++ b/scenarios/e2e-cc-bench-flags-gnu/scenario.toml
@@ -46,6 +46,7 @@ max_compiler_runs = 1
 [assertions.warm]
 min_hits = 1
 max_compiler_runs = 0
+max_preprocessor_runs = 0
 
 [assertions.noop]
 should_not_recompile = false

--- a/scenarios/e2e-cc-bench-flags/scenario.toml
+++ b/scenarios/e2e-cc-bench-flags/scenario.toml
@@ -56,6 +56,7 @@ max_compiler_runs = 1
 [assertions.warm]
 min_hits = 1
 max_compiler_runs = 0
+max_preprocessor_runs = 0
 
 [assertions.noop]
 should_not_recompile = false

--- a/scenarios/e2e-cc-cl-xclang-deps/scenario.toml
+++ b/scenarios/e2e-cc-cl-xclang-deps/scenario.toml
@@ -50,6 +50,7 @@ max_compiler_runs = 1
 [assertions.warm]
 min_hits = 1
 max_compiler_runs = 0
+max_preprocessor_runs = 0
 
 # Noop: make sees build/a.obj up to date and does nothing. No CC
 # invocation, so no kache event — same as the other compile fixtures.

--- a/scenarios/e2e-cc-flag-soup/scenario.toml
+++ b/scenarios/e2e-cc-flag-soup/scenario.toml
@@ -45,6 +45,7 @@ max_compiler_runs = 1
 [assertions.warm]
 min_hits = 1
 max_compiler_runs = 0
+max_preprocessor_runs = 0
 
 [assertions.noop]
 should_not_recompile = false

--- a/scenarios/e2e-cpp-hello/scenario.toml
+++ b/scenarios/e2e-cpp-hello/scenario.toml
@@ -49,7 +49,7 @@ max_preprocessor_runs = 1
 [assertions.warm]
 min_hits = 1
 max_compiler_runs = 0
-max_preprocessor_runs = 1
+max_preprocessor_runs = 0
 
 [assertions.noop]
 should_not_recompile = false

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -6495,6 +6495,15 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
     }
 
     #[test]
+    fn cc_preprocess_memo_support_requires_persistent_cache() {
+        assert!(!FileHasher::new().supports_cc_preprocess_memo());
+
+        let dir = tempfile::tempdir().unwrap();
+        let persistent = FileHasher::persistent(&dir.path().join("idx.sqlite"));
+        assert!(persistent.supports_cc_preprocess_memo());
+    }
+
+    #[test]
     fn file_hash_memo_key_includes_inode() {
         // An in-place swap that preserves path+size+mtime+ctime but changes the
         // inode (and content) must NOT return a stale memoized hash

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -2352,7 +2352,7 @@ enum FileHashCache<'db> {
     Owned(Connection),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) struct FileFingerprint {
     path: String,
     size: i64,
@@ -2459,6 +2459,127 @@ impl<'db> FileHasher<'db> {
             cache_hits: self.stats.cache_hits.get(),
             cache_misses: self.stats.cache_misses.get(),
             bytes_hashed: self.stats.bytes_hashed.get(),
+        }
+    }
+
+    /// Whether this hasher can persist C/C++ preprocessor memo records.
+    pub(crate) fn supports_cc_preprocess_memo(&self) -> bool {
+        self.cache.is_some()
+    }
+
+    /// Reuse a preprocessor-output hash only when every source/header still
+    /// has the exact metadata fingerprint captured by the successful probe.
+    /// Any database, decoding, metadata, or freshness uncertainty is a miss.
+    pub(crate) fn cc_preprocess_memo_lookup(&self, memo_key: &str) -> Option<String> {
+        let cache = self.cache.as_ref()?;
+        let record = match cache.get_cc_preprocess_memo(memo_key) {
+            Ok(record) => record?,
+            Err(error) => {
+                tracing::debug!("cc preprocess memo lookup failed: {error}");
+                return None;
+            }
+        };
+        if record.0.len() != 64
+            || !record
+                .0
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            tracing::debug!("cc preprocess memo hash is invalid");
+            return None;
+        }
+        let fingerprints: Vec<FileFingerprint> = match serde_json::from_str(&record.1) {
+            Ok(fingerprints) => fingerprints,
+            Err(error) => {
+                tracing::debug!("cc preprocess memo inputs are invalid: {error}");
+                return None;
+            }
+        };
+        if fingerprints.is_empty() {
+            return None;
+        }
+        for expected in &fingerprints {
+            let current = match FileFingerprint::from_path(Path::new(&expected.path)) {
+                Ok(current) => current,
+                Err(error) => {
+                    tracing::debug!(
+                        "cc preprocess memo input {} is unavailable: {error}",
+                        expected.path
+                    );
+                    return None;
+                }
+            };
+            self.note_too_new(&current);
+            if current != *expected || self.too_new() {
+                return None;
+            }
+        }
+        Some(record.0)
+    }
+
+    /// Capture the source/header metadata observed immediately after a full
+    /// preprocess probe. The caller revalidates this snapshot after a
+    /// successful compile or restore before committing it.
+    pub(crate) fn cc_preprocess_fingerprints(
+        &self,
+        paths: &[PathBuf],
+    ) -> Option<Vec<FileFingerprint>> {
+        if paths.is_empty() {
+            return None;
+        }
+        let mut fingerprints = Vec::with_capacity(paths.len());
+        for path in paths {
+            let fingerprint = match FileFingerprint::from_path(path) {
+                Ok(fingerprint) => fingerprint,
+                Err(error) => {
+                    tracing::debug!(
+                        "cc preprocess memo input {} could not be fingerprinted: {error}",
+                        path.display()
+                    );
+                    return None;
+                }
+            };
+            self.note_too_new(&fingerprint);
+            fingerprints.push(fingerprint);
+        }
+        fingerprints.sort_by(|a, b| a.path.cmp(&b.path));
+        fingerprints.dedup_by(|a, b| a.path == b.path);
+        Some(fingerprints)
+    }
+
+    /// Commit a pending preprocessor memo after proving its inputs remained
+    /// unchanged through the successful compiler/restore boundary.
+    pub(crate) fn cc_preprocess_memo_record_if_unchanged(
+        &self,
+        memo_key: &str,
+        preprocessed_hash: &str,
+        fingerprints: &[FileFingerprint],
+    ) {
+        let Some(cache) = &self.cache else {
+            return;
+        };
+        if fingerprints.is_empty() {
+            return;
+        }
+        for expected in fingerprints {
+            let Ok(current) = FileFingerprint::from_path(Path::new(&expected.path)) else {
+                return;
+            };
+            self.note_too_new(&current);
+            if current != *expected || self.too_new() {
+                return;
+            }
+        }
+        let inputs_json = match serde_json::to_string(fingerprints) {
+            Ok(inputs_json) => inputs_json,
+            Err(error) => {
+                tracing::debug!("cc preprocess memo inputs could not be encoded: {error}");
+                return;
+            }
+        };
+        if let Err(error) = cache.put_cc_preprocess_memo(memo_key, preprocessed_hash, &inputs_json)
+        {
+            tracing::debug!("cc preprocess memo update failed: {error}");
         }
     }
 
@@ -2776,6 +2897,32 @@ impl<'db> FileHashCache<'db> {
         )?;
         Ok(())
     }
+
+    fn get_cc_preprocess_memo(&self, memo_key: &str) -> rusqlite::Result<Option<(String, String)>> {
+        self.db()
+            .query_row(
+                "SELECT preprocessed_hash, inputs_json FROM cc_preprocess_memos
+                 WHERE memo_key = ?1",
+                params![memo_key],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()
+    }
+
+    fn put_cc_preprocess_memo(
+        &self,
+        memo_key: &str,
+        preprocessed_hash: &str,
+        inputs_json: &str,
+    ) -> rusqlite::Result<()> {
+        self.db().execute(
+            "INSERT OR REPLACE INTO cc_preprocess_memos
+             (memo_key, preprocessed_hash, inputs_json, updated_at)
+             VALUES (?1, ?2, ?3, datetime('now'))",
+            params![memo_key, preprocessed_hash, inputs_json],
+        )?;
+        Ok(())
+    }
 }
 
 pub(crate) fn ensure_file_hash_cache_schema(db: &Connection) -> rusqlite::Result<()> {
@@ -2788,6 +2935,12 @@ pub(crate) fn ensure_file_hash_cache_schema(db: &Connection) -> rusqlite::Result
             inode      INTEGER NOT NULL DEFAULT 0,
             hash       TEXT NOT NULL,
             updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE TABLE IF NOT EXISTS cc_preprocess_memos (
+            memo_key          TEXT PRIMARY KEY,
+            preprocessed_hash TEXT NOT NULL,
+            inputs_json       TEXT NOT NULL,
+            updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
         );",
     )?;
     for column in [
@@ -6367,6 +6520,75 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             cache.get(&fp(20)).unwrap(),
             None,
             "a different inode (same path/size/mtime/ctime) must miss the memo"
+        );
+    }
+
+    #[test]
+    fn cc_preprocess_memo_requires_every_input_fingerprint_to_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("idx.sqlite");
+        let source = dir.path().join("source.c");
+        let header = dir.path().join("header.h");
+        std::fs::write(&source, "#include \"header.h\"\n").unwrap();
+        std::fs::write(&header, "#define VALUE 1\n").unwrap();
+
+        let hasher = FileHasher::persistent(&db);
+        let inputs = hasher
+            .cc_preprocess_fingerprints(&[source.clone(), header.clone()])
+            .unwrap();
+        let pp_hash = "a".repeat(64);
+        hasher.cc_preprocess_memo_record_if_unchanged("memo-key", &pp_hash, &inputs);
+        assert_eq!(
+            hasher.cc_preprocess_memo_lookup("memo-key").as_deref(),
+            Some(pp_hash.as_str())
+        );
+
+        let inputs_json = serde_json::to_string(&inputs).unwrap();
+        let cache = hasher.cache.as_ref().unwrap();
+        cache
+            .put_cc_preprocess_memo("short-hash", "a", &inputs_json)
+            .unwrap();
+        cache
+            .put_cc_preprocess_memo("non-hex-hash", &"z".repeat(64), &inputs_json)
+            .unwrap();
+        assert_eq!(hasher.cc_preprocess_memo_lookup("short-hash"), None);
+        assert_eq!(hasher.cc_preprocess_memo_lookup("non-hex-hash"), None);
+
+        let mut fresh_hasher = FileHasher::persistent(&db);
+        fresh_hasher.arm_too_new_guard(1, 0);
+        assert_eq!(
+            fresh_hasher.cc_preprocess_memo_lookup("memo-key"),
+            None,
+            "an input too new for the invocation must force preprocessing"
+        );
+        fresh_hasher.cc_preprocess_memo_record_if_unchanged("too-new", &pp_hash, &inputs);
+        assert!(
+            fresh_hasher
+                .cache
+                .as_ref()
+                .unwrap()
+                .get_cc_preprocess_memo("too-new")
+                .unwrap()
+                .is_none(),
+            "too-new inputs must not publish a memo"
+        );
+
+        std::fs::write(&header, "#define VALUE 12345\n").unwrap();
+        assert_eq!(
+            hasher.cc_preprocess_memo_lookup("memo-key"),
+            None,
+            "a changed transitive header must force preprocessing"
+        );
+        hasher.cc_preprocess_memo_record_if_unchanged("changed", &pp_hash, &inputs);
+        assert!(
+            hasher
+                .cache
+                .as_ref()
+                .unwrap()
+                .get_cc_preprocess_memo("changed")
+                .unwrap()
+                .is_none(),
+            "changed inputs must not publish a memo"
         );
     }
 

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -7948,8 +7948,9 @@ mod tests {
     fn preprocess_dependency_parser_handles_make_escapes_and_continuations() {
         let cwd = Path::new("work/project");
         let raw = concat!(
-            "__kache_preprocess_memo: src/main.c include/a\\ b.h \\\n",
-            " include/hash\\#tag.h include/cash$$value.h C:\\sdk\\header.h\n",
+            "__kache_preprocess_memo: src/main.c include/a\\ b.h \\\r\n",
+            " include/hash\\#tag.h \\\n",
+            " include/cash$$value.h C:\\sdk\\header.h\n",
         );
         let actual = parse_preprocess_dependencies(raw, cwd).unwrap();
         let mut expected = vec![

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -7983,6 +7983,18 @@ mod tests {
     }
 
     #[test]
+    fn fold_cc_memo_field_changes_and_separates_hashes() {
+        let mut first = blake3::Hasher::new();
+        fold_cc_memo_field(&mut first, b"arg", b"one");
+
+        let mut second = blake3::Hasher::new();
+        fold_cc_memo_field(&mut second, b"arg", b"two");
+
+        assert_ne!(first.finalize(), blake3::Hasher::new().finalize());
+        assert_ne!(first.finalize(), second.finalize());
+    }
+
+    #[test]
     fn cc_preprocess_memo_key_is_blake3_digest() {
         let compiler = std::env::current_exe()
             .unwrap()

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1483,7 +1483,7 @@ fn parse_preprocess_dependencies(raw: &str, cwd: &Path) -> Result<Vec<PathBuf>> 
             index = index.saturating_add(3);
         } else {
             logical.push(bytes[index]);
-            index += 1;
+            index = index.saturating_add(1);
         }
     }
     let logical = std::str::from_utf8(&logical).context("cc dependency file is not UTF-8")?;

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1474,13 +1474,13 @@ fn parse_preprocess_dependencies(raw: &str, cwd: &Path) -> Result<Vec<PathBuf>> 
     while index < bytes.len() {
         if bytes[index] == b'\\' && bytes.get(index + 1) == Some(&b'\n') {
             logical.push(b' ');
-            index += 2;
+            index = index.saturating_add(2);
         } else if bytes[index] == b'\\'
             && bytes.get(index + 1) == Some(&b'\r')
             && bytes.get(index + 2) == Some(&b'\n')
         {
             logical.push(b' ');
-            index += 3;
+            index = index.saturating_add(3);
         } else {
             logical.push(bytes[index]);
             index += 1;
@@ -7956,16 +7956,18 @@ mod tests {
     fn preprocess_dependency_parser_handles_make_escapes_and_continuations() {
         let cwd = Path::new("work/project");
         let raw = concat!(
-            "__kache_preprocess_memo: src/main.c include/a\\ b.h \\\r\n",
+            "__kache_preprocess_memo: src/main.c ab/header.h include/a\\ b.h \\\r\n",
             " include/hash\\#tag.h \\\n",
-            " include/cash$$value.h C:\\sdk\\header.h\n",
+            " include/cash$$value.h include/single$value.h C:\\sdk\\header.h\n",
         );
         let actual = parse_preprocess_dependencies(raw, cwd).unwrap();
         let mut expected = vec![
             PathBuf::from("C:\\sdk\\header.h"),
+            cwd.join("ab/header.h"),
             cwd.join("include/a b.h"),
             cwd.join("include/cash$value.h"),
             cwd.join("include/hash#tag.h"),
+            cwd.join("include/single$value.h"),
             cwd.join("src/main.c"),
         ];
         expected.sort();

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -10,10 +10,12 @@
 //!   The cache key is the preprocessor expansion (`cc -E -P` with
 //!   `SOURCE_DATE_EPOCH` pinned) plus compiler identity, target
 //!   arch, and codegen flags. The preprocessor hash captures the
-//!   source and every transitively-included header, so any header
-//!   change invalidates the key with no separate dependency
-//!   tracking. `-E -P` strips line markers so header *paths* don't
-//!   leak — the key is portable across machines and worktrees.
+//!   source and every transitively-included header. The cold probe also writes
+//!   a private complete dependency list; a later local invocation can reuse
+//!   the expansion hash only while every source/header fingerprint matches,
+//!   otherwise it preprocesses again. `-E -P` strips line markers so header
+//!   *paths* don't leak — the object key remains portable across machines and
+//!   worktrees, while the optimization itself is deliberately local.
 //!
 //! What passes through (refused, see [`CcArgs::refuse_reasons`]):
 //! - Link mode (whole-program caching is a separate, harder problem)
@@ -39,7 +41,9 @@
 
 use anyhow::{Context, Result};
 use regex::Regex;
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
@@ -1420,22 +1424,182 @@ fn build_preprocess_args(parsed: &CcArgs) -> Vec<String> {
 /// header transitively, so any header change invalidates the key
 /// automatically — no separate dependency tracking needed. Bails (→
 /// passthrough) if the preprocessor yields empty stdout.
-fn preprocess_hash(parsed: &CcArgs, prefix_maps: &[CcPrefixMap]) -> Result<String> {
-    let pp_args = build_preprocess_args(parsed);
-    crate::opcounts::record_preprocessor_run();
-    let mut pp_command = Command::new(&parsed.program);
-    pp_command.args(&pp_args);
-    // Pin the build timestamp so `__DATE__` / `__TIME__` expand deterministically
-    // (gcc + clang both honor SOURCE_DATE_EPOCH). The SAME effective value is
-    // pinned on the real compile in `execute`, so the key and the object agree on
-    // the baked date — without this symmetry a time-stable key restores an object
-    // stamped at a different wall-clock time (#423).
-    if let Some(epoch) = effective_source_date_epoch() {
-        pp_command.env("SOURCE_DATE_EPOCH", epoch);
+const CC_PREPROCESS_MEMO_TARGET: &str = "__kache_preprocess_memo";
+
+fn add_preprocess_dep_capture(
+    parsed: &CcArgs,
+    pp_args: Vec<String>,
+    dep_path: &Path,
+) -> Vec<String> {
+    let path = dep_path
+        .to_str()
+        .expect("dependency capture is enabled only for UTF-8 temp paths")
+        .to_string();
+    let extra = match parsed.family.dialect() {
+        Dialect::Gnu => vec![
+            "-MD".to_string(),
+            "-MF".to_string(),
+            path,
+            "-MT".to_string(),
+            CC_PREPROCESS_MEMO_TARGET.to_string(),
+        ],
+        Dialect::Cl => vec![
+            "-Xclang".to_string(),
+            "-dependency-file".to_string(),
+            "-Xclang".to_string(),
+            path,
+            "-Xclang".to_string(),
+            "-MT".to_string(),
+            "-Xclang".to_string(),
+            CC_PREPROCESS_MEMO_TARGET.to_string(),
+            // clang-cl excludes system headers from dependency output unless
+            // this cc1 option is present. A partial header set is never safe
+            // for direct-mode reuse.
+            "-Xclang".to_string(),
+            "-sys-header-deps".to_string(),
+        ],
+    };
+    compose_cc_args(&pp_args, extra)
+}
+
+/// Parse the Make dependency rule emitted into the probe's private file.
+/// Continuations, escaped spaces/hash/backslashes, and Make's `$$` spelling
+/// are decoded. The target may remain user-selected under clang-cl when its
+/// earlier forwarded `-MT` wins; only the private output path is authoritative.
+/// Any unfamiliar/malformed shape disables memoization.
+fn parse_preprocess_dependencies(raw: &str, cwd: &Path) -> Result<Vec<PathBuf>> {
+    let bytes = raw.as_bytes();
+    let mut logical = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'\\' && bytes.get(index + 1) == Some(&b'\n') {
+            logical.push(b' ');
+            index += 2;
+        } else if bytes[index] == b'\\'
+            && bytes.get(index + 1) == Some(&b'\r')
+            && bytes.get(index + 2) == Some(&b'\n')
+        {
+            logical.push(b' ');
+            index += 3;
+        } else {
+            logical.push(bytes[index]);
+            index += 1;
+        }
     }
-    let output = pp_command
-        .output()
-        .with_context(|| format!("running preprocessor `{}`", parsed.program))?;
+    let logical = std::str::from_utf8(&logical).context("cc dependency file is not UTF-8")?;
+    let (rule, separator) = logical
+        .lines()
+        .find_map(|line| {
+            line.find(": ")
+                .or_else(|| line.find(":\t"))
+                .map(|separator| (line, separator))
+        })
+        .context("cc dependency file has no Make rule")?;
+    let dependencies = &rule[separator + 1..];
+
+    let mut paths = Vec::new();
+    let mut word = String::new();
+    let mut chars = dependencies.chars().peekable();
+    while let Some(character) = chars.next() {
+        match character {
+            '\\' => match chars.peek().copied() {
+                Some(next) if matches!(next, ' ' | '\t' | '#' | '\\' | ':') => {
+                    word.push(next);
+                    chars.next();
+                }
+                Some(_) => word.push('\\'),
+                None => anyhow::bail!("cc dependency rule ends in an escape"),
+            },
+            '$' if chars.peek() == Some(&'$') => {
+                word.push('$');
+                chars.next();
+            }
+            '#' => break,
+            whitespace if whitespace.is_whitespace() => {
+                if !word.is_empty() {
+                    paths.push(PathBuf::from(std::mem::take(&mut word)));
+                }
+            }
+            other => word.push(other),
+        }
+    }
+    if !word.is_empty() {
+        paths.push(PathBuf::from(word));
+    }
+    if paths.is_empty() {
+        anyhow::bail!("cc dependency rule contains no inputs");
+    }
+    for path in &mut paths {
+        let text = path.to_string_lossy();
+        let bytes = text.as_bytes();
+        let windows_absolute = bytes.len() >= 3
+            && bytes[0].is_ascii_alphabetic()
+            && bytes[1] == b':'
+            && matches!(bytes[2], b'/' | b'\\');
+        if path.is_relative() && !windows_absolute && !text.starts_with("\\\\") {
+            *path = cwd.join(&*path);
+        }
+    }
+    paths.sort();
+    paths.dedup();
+    Ok(paths)
+}
+
+#[derive(Debug)]
+struct PreprocessHash {
+    hash: String,
+    fingerprints: Option<Vec<crate::cache_key::FileFingerprint>>,
+}
+
+fn preprocess_hash(
+    parsed: &CcArgs,
+    prefix_maps: &[CcPrefixMap],
+    file_hasher: &crate::cache_key::FileHasher<'_>,
+    capture_dependencies: bool,
+) -> Result<PreprocessHash> {
+    let pp_args = build_preprocess_args(parsed);
+    let dep_temp = if capture_dependencies {
+        match tempfile::Builder::new()
+            .prefix("kache-cc-preprocess-")
+            .tempdir()
+        {
+            Ok(temp) => Some(temp),
+            Err(error) => {
+                tracing::debug!("cc preprocess dependency tempdir unavailable: {error}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let dep_path = dep_temp
+        .as_ref()
+        .map(|dir| dir.path().join("inputs.d"))
+        .filter(|path| path.to_str().is_some());
+    let pp_args = dep_path.as_deref().map_or(pp_args.clone(), |path| {
+        add_preprocess_dep_capture(parsed, pp_args.clone(), path)
+    });
+    let run = |args: &[String]| {
+        crate::opcounts::record_preprocessor_run();
+        let mut command = Command::new(&parsed.program);
+        command.args(args);
+        // Pin the build timestamp so `__DATE__` / `__TIME__` expand
+        // deterministically. The real compile uses the same value.
+        if let Some(epoch) = effective_source_date_epoch() {
+            command.env("SOURCE_DATE_EPOCH", epoch);
+        }
+        command
+            .output()
+            .with_context(|| format!("running preprocessor `{}`", parsed.program))
+    };
+    let mut output = run(&pp_args)?;
+    if !output.status.success() && dep_path.is_some() {
+        // An otherwise supported compiler may not implement the private
+        // dependency flags. Preserve the existing cache-key behavior and just
+        // leave this invocation unmemoized.
+        tracing::debug!("cc preprocess dependency capture failed; retrying without memo capture");
+        output = run(&build_preprocess_args(parsed))?;
+    }
     if !output.status.success() {
         // Preprocess failed — the real compile would also fail.
         // Bail so the wrapper falls back to passthrough, which runs
@@ -1458,7 +1622,23 @@ fn preprocess_hash(parsed: &CcArgs, prefix_maps: &[CcPrefixMap]) -> Result<Strin
         anyhow::bail!("cc -E key probe produced no output");
     }
     let stdout = apply_cc_prefix_maps_to_bytes(output.stdout, prefix_maps);
-    Ok(blake3::hash(&stdout).to_hex().to_string())
+    let hash = blake3::hash(&stdout).to_hex().to_string();
+    let fingerprints = dep_path.as_deref().and_then(|path| {
+        let dependencies = std::fs::read_to_string(path)
+            .context("reading cc preprocess dependency file")
+            .and_then(|raw| {
+                let cwd = std::env::current_dir().context("reading cc compiler directory")?;
+                parse_preprocess_dependencies(&raw, &cwd)
+            });
+        match dependencies {
+            Ok(paths) => file_hasher.cc_preprocess_fingerprints(&paths),
+            Err(error) => {
+                tracing::debug!("cc preprocess dependency capture unavailable: {error:#}");
+                None
+            }
+        }
+    });
+    Ok(PreprocessHash { hash, fingerprints })
 }
 
 /// Whether a positional argument looks like a C-family source file
@@ -3449,6 +3629,108 @@ fn source_date_epoch_passthrough() -> bool {
         .unwrap_or(false)
 }
 
+fn cc_memo_os_bytes(value: &OsStr) -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        value.as_bytes().to_vec()
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        value.encode_wide().flat_map(u16::to_le_bytes).collect()
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        value.to_string_lossy().into_owned().into_bytes()
+    }
+}
+
+fn fold_cc_memo_field(hasher: &mut blake3::Hasher, label: &[u8], value: &[u8]) {
+    hasher.update(&(label.len() as u64).to_le_bytes());
+    hasher.update(label);
+    hasher.update(&(value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+/// Local identity for a preprocessor invocation. The full environment is
+/// intentionally included: compiler-specific include variables are numerous,
+/// and an extra miss is safer than overlooking one that changes expansion.
+fn cc_preprocess_memo_key(
+    parsed: &CcArgs,
+    prefix_maps: &[CcPrefixMap],
+    compiler_version: &str,
+) -> Option<String> {
+    let epoch = effective_source_date_epoch()?;
+    let cwd = std::env::current_dir().ok()?;
+    let compiler_path = super::resolve_program_on_path(&parsed.program)?;
+    let compiler_metadata = std::fs::metadata(&compiler_path).ok()?;
+    let mut hasher = blake3::Hasher::new();
+    fold_cc_memo_field(&mut hasher, b"schema", b"cc-preprocess-memo-v1");
+    fold_cc_memo_field(
+        &mut hasher,
+        b"compiler-program",
+        cc_memo_os_bytes(OsStr::new(&parsed.program)).as_slice(),
+    );
+    fold_cc_memo_field(
+        &mut hasher,
+        b"compiler-path",
+        cc_memo_os_bytes(compiler_path.as_os_str()).as_slice(),
+    );
+    fold_cc_memo_field(
+        &mut hasher,
+        b"compiler-size",
+        &compiler_metadata.len().to_le_bytes(),
+    );
+    fold_cc_memo_field(
+        &mut hasher,
+        b"compiler-mtime",
+        &crate::cache_key::metadata_mtime_ns(&compiler_metadata).to_le_bytes(),
+    );
+    fold_cc_memo_field(
+        &mut hasher,
+        b"compiler-ctime",
+        &crate::cache_key::metadata_ctime_ns(&compiler_metadata).to_le_bytes(),
+    );
+    fold_cc_memo_field(
+        &mut hasher,
+        b"compiler-inode",
+        &crate::cache_key::metadata_inode(&compiler_metadata).to_le_bytes(),
+    );
+    fold_cc_memo_field(
+        &mut hasher,
+        b"compiler-version",
+        compiler_version.as_bytes(),
+    );
+    fold_cc_memo_field(
+        &mut hasher,
+        b"cwd",
+        cc_memo_os_bytes(cwd.as_os_str()).as_slice(),
+    );
+    fold_cc_memo_field(
+        &mut hasher,
+        b"source-date-epoch",
+        cc_memo_os_bytes(&epoch).as_slice(),
+    );
+    for arg in build_preprocess_args(parsed) {
+        fold_cc_memo_field(&mut hasher, b"arg", arg.as_bytes());
+    }
+    for map in prefix_maps {
+        fold_cc_memo_field(&mut hasher, b"prefix-from", map.from.as_bytes());
+        fold_cc_memo_field(&mut hasher, b"prefix-to", map.to.as_bytes());
+    }
+
+    let mut environment: Vec<(Vec<u8>, Vec<u8>)> = std::env::vars_os()
+        .map(|(name, value)| (cc_memo_os_bytes(&name), cc_memo_os_bytes(&value)))
+        .collect();
+    environment.sort();
+    for (name, value) in environment {
+        fold_cc_memo_field(&mut hasher, b"env-name", &name);
+        fold_cc_memo_field(&mut hasher, b"env-value", &value);
+    }
+    Some(hasher.finalize().to_hex().to_string())
+}
+
 fn cc_prefix_maps_for(parsed: &CcArgs, cwd: &Path) -> Vec<CcPrefixMap> {
     let cwd_abs = absolutize_path(cwd, cwd);
     let Some(source) = parsed.sources.first() else {
@@ -3794,6 +4076,12 @@ fn cc_trace_name(parsed: &CcArgs) -> String {
         .unwrap_or_else(|| "cc".to_string())
 }
 
+struct PendingCcPreprocessMemo {
+    memo_key: String,
+    preprocessed_hash: String,
+    fingerprints: Vec<crate::cache_key::FileFingerprint>,
+}
+
 #[derive(Default)]
 pub struct CcCompiler {
     /// User-declared flags (issue #95) that kache's built-in allow-list
@@ -3804,6 +4092,7 @@ pub struct CcCompiler {
     /// Deterministically ordered `[paths].base_dirs` roots applied to both the
     /// cc key probes and the real compiler invocation.
     base_dirs: Vec<String>,
+    pending_preprocess_memo: RefCell<Option<PendingCcPreprocessMemo>>,
 }
 
 const C_FAMILY_DRIVERS: [(&str, ToolFamily); 7] = [
@@ -3883,6 +4172,7 @@ impl CcCompiler {
         Self {
             extra_allowlist_flags,
             base_dirs: Vec::new(),
+            pending_preprocess_memo: RefCell::new(None),
         }
     }
 
@@ -3891,6 +4181,19 @@ impl CcCompiler {
         self.base_dirs.sort();
         self.base_dirs.dedup();
         self
+    }
+
+    /// Publish the dependency snapshot from a full preprocess only after a
+    /// successful compile or cache restore revalidated every input.
+    pub(crate) fn commit_preprocess_memo(&self, file_hasher: &crate::cache_key::FileHasher<'_>) {
+        let Some(pending) = self.pending_preprocess_memo.borrow_mut().take() else {
+            return;
+        };
+        file_hasher.cc_preprocess_memo_record_if_unchanged(
+            &pending.memo_key,
+            &pending.preprocessed_hash,
+            &pending.fingerprints,
+        );
     }
 
     /// Does this argv invoke a C-family compiler?
@@ -4142,6 +4445,7 @@ impl Compiler for CcCompiler {
     fn cache_key(&self, parsed: &CcArgs, ctx: &KeyCtx<'_, '_>) -> Result<String> {
         // Preconditions (guaranteed by the wrapper checking
         // refuse_reasons first): `-c` mode, exactly one source.
+        self.pending_preprocess_memo.borrow_mut().take();
         let mut hasher = blake3::Hasher::new();
         let trace_name = cc_trace_name(parsed);
         let prefix_maps = cc_prefix_maps(parsed, &self.base_dirs);
@@ -4468,7 +4772,40 @@ impl Compiler for CcCompiler {
         // macro expansion. `-E -P` strips line markers so header
         // PATHS don't leak (cross-machine portable); SOURCE_DATE_EPOCH
         // pins __DATE__/__TIME__ (stable across builds).
-        let pp_hash = preprocess_hash(parsed, &prefix_maps)?;
+        let memo_key = ctx
+            .file_hasher
+            .supports_cc_preprocess_memo()
+            .then(|| cc_preprocess_memo_key(parsed, &prefix_maps, &resolved.version_line))
+            .flatten();
+        let pp_hash = if let Some(memo_hash) = memo_key
+            .as_ref()
+            .and_then(|key| ctx.file_hasher.cc_preprocess_memo_lookup(key))
+        {
+            tracing::trace!(
+                target: "kache::cache_key",
+                "[key:{}] preprocessed_memo=hit",
+                trace_name
+            );
+            memo_hash
+        } else {
+            let preprocessed =
+                preprocess_hash(parsed, &prefix_maps, ctx.file_hasher, memo_key.is_some())?;
+            if let (Some(memo_key), Some(fingerprints)) = (memo_key, preprocessed.fingerprints) {
+                self.pending_preprocess_memo
+                    .borrow_mut()
+                    .replace(PendingCcPreprocessMemo {
+                        memo_key,
+                        preprocessed_hash: preprocessed.hash.clone(),
+                        fingerprints,
+                    });
+            }
+            tracing::trace!(
+                target: "kache::cache_key",
+                "[key:{}] preprocessed_memo=miss",
+                trace_name
+            );
+            preprocessed.hash
+        };
         hasher.update(b"preprocessed:");
         hasher.update(pp_hash.as_bytes());
         hasher.update(b"\n");
@@ -7585,6 +7922,48 @@ mod tests {
     }
 
     #[test]
+    fn preprocess_dep_capture_is_complete_for_both_dialects() {
+        let dep = Path::new("memo inputs.d");
+        let gnu = CcArgs::parse(&s(&["gcc", "-c", "a.c"])).unwrap();
+        let gnu_args = add_preprocess_dep_capture(&gnu, build_preprocess_args(&gnu), dep);
+        assert!(gnu_args.windows(2).any(|args| args == ["-MD", "-MF"]));
+        assert!(gnu_args.iter().any(|arg| arg == "memo inputs.d"));
+
+        let cl = CcArgs::parse(&s(&["clang-cl", "-c", "a.c"])).unwrap();
+        let cl_args = add_preprocess_dep_capture(&cl, build_preprocess_args(&cl), dep);
+        assert!(
+            cl_args
+                .windows(2)
+                .any(|args| args == ["-Xclang", "-dependency-file"])
+        );
+        assert!(
+            cl_args
+                .windows(2)
+                .any(|args| args == ["-Xclang", "-sys-header-deps"]),
+            "clang-cl memo dependency capture must include system headers"
+        );
+    }
+
+    #[test]
+    fn preprocess_dependency_parser_handles_make_escapes_and_continuations() {
+        let cwd = Path::new("work/project");
+        let raw = concat!(
+            "__kache_preprocess_memo: src/main.c include/a\\ b.h \\\n",
+            " include/hash\\#tag.h include/cash$$value.h C:\\sdk\\header.h\n",
+        );
+        let actual = parse_preprocess_dependencies(raw, cwd).unwrap();
+        let mut expected = vec![
+            PathBuf::from("C:\\sdk\\header.h"),
+            cwd.join("include/a b.h"),
+            cwd.join("include/cash$value.h"),
+            cwd.join("include/hash#tag.h"),
+            cwd.join("src/main.c"),
+        ];
+        expected.sort();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn cc_prefix_maps_empty_for_clang_cl() {
         let cwd = std::path::Path::new("/work/proj");
         let cl = CcArgs::parse(&s(&["clang-cl", "-c", "/work/proj/a.c"])).unwrap();
@@ -7702,7 +8081,8 @@ mod tests {
         // all comments / all `#if 0` — also lands here; refusing to cache
         // it is a safe non-cache, the conservative trade-off.)
         let parsed = CcArgs::parse(&s(&["true", "-c", "a.c"])).unwrap();
-        let err = preprocess_hash(&parsed, &[]).unwrap_err();
+        let err =
+            preprocess_hash(&parsed, &[], &crate::cache_key::FileHasher::new(), false).unwrap_err();
         assert!(err.to_string().contains("no output"), "got: {err}");
     }
 

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -7965,6 +7965,31 @@ mod tests {
     }
 
     #[test]
+    fn cc_memo_os_bytes_preserves_distinct_values() {
+        assert_ne!(
+            cc_memo_os_bytes(OsStr::new("compiler-a")),
+            cc_memo_os_bytes(OsStr::new("compiler-b"))
+        );
+    }
+
+    #[test]
+    fn cc_preprocess_memo_key_is_blake3_digest() {
+        let compiler = std::env::current_exe()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let parsed =
+            CcArgs::parse(&[compiler, "-c".to_string(), "memo-source.c".to_string()]).unwrap();
+        let key = cc_preprocess_memo_key(&parsed, &[], "test compiler version").unwrap();
+
+        assert_eq!(key.len(), 64);
+        assert!(
+            key.bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        );
+    }
+
+    #[test]
     fn cc_prefix_maps_empty_for_clang_cl() {
         let cwd = std::path::Path::new("/work/proj");
         let cl = CcArgs::parse(&s(&["clang-cl", "-c", "/work/proj/a.c"])).unwrap();

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -6628,6 +6628,14 @@ mod tests {
         list.iter().map(|s| s.to_string()).collect()
     }
 
+    #[test]
+    fn cc_compiler_constructor_keeps_extra_allowlist_flags() {
+        let expected = flags(&["-fsome-exotic-flag"]);
+        let compiler = CcCompiler::with_extra_allowlist_flags(expected.clone());
+
+        assert_eq!(compiler.extra_allowlist_flags, expected);
+    }
+
     /// A flag the built-in table doesn't model normally refuses, but
     /// listing it in `[cc] extra_allowlist_flags` makes it cacheable.
     #[test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -587,6 +587,10 @@ fn probe_forward_compiler() -> String {
 /// follow-ups — single-machine caching is the shipped concept.
 pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let start = std::time::Instant::now();
+    let invocation_start_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos() as i64)
+        .unwrap_or(0);
     crate::link::set_windows_hardlink_restore(config.windows_hardlink);
     crate::link::set_storage_layout_advice(config.storage_layout_advice);
     crate::link::set_cow_warn_marker(warn_marker_path("cow", &config.cache_dir));
@@ -677,7 +681,10 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     // fall back to passthrough, which runs the real compiler and
     // surfaces the real diagnostic.
     let key_start = std::time::Instant::now();
-    let file_hasher = crate::cache_key::FileHasher::new();
+    let mut file_hasher = store.file_hasher();
+    // Memo publication always uses the too-new guard: a header modified while
+    // preprocessing cannot safely describe the captured expansion.
+    file_hasher.arm_too_new_guard(invocation_start_ns, 0);
     let path_normalizer = crate::path_normalizer::PathNormalizer::empty();
     let key_ctx = KeyCtx {
         file_hasher: &file_hasher,
@@ -795,6 +802,8 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                 eprint!("{}", meta.stderr);
             }
 
+            compiler.commit_preprocess_memo(&file_hasher);
+
             return Ok(0);
         }
     }
@@ -848,6 +857,9 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     let mut store_put = StorePutResult::default();
     let mut store_error = String::new();
     let store_candidate = should_store_cc_result(result.exit_code, !result.artifacts.is_empty());
+    if store_candidate {
+        compiler.commit_preprocess_memo(&file_hasher);
+    }
     // The CC path has no remote upload pipeline, so remote configuration must
     // not bypass its local-store admission threshold.
     let admitted = store_admits_compile(config, compile_time_ms, false);

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -1266,6 +1266,14 @@ fn cc_compile_roundtrips_through_cache() {
         v["summary"]["local_hits"].as_u64().unwrap_or(0) >= 1,
         "report should record a local hit after the second compile: {v}"
     );
+    assert_eq!(
+        v["all_events"]
+            .as_array()
+            .and_then(|events| events.last())
+            .and_then(|event| event["preprocessor_runs"].as_u64()),
+        Some(0),
+        "plain warm compiles should reuse the private dependency memo: {v}"
+    );
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -123,6 +123,14 @@ fn assert_last_cc_event(report: &serde_json::Value, result: &str, compiler_runs:
     assert_eq!(last["compiler_runs"].as_u64(), Some(compiler_runs));
 }
 
+fn assert_last_cc_preprocessor_runs(report: &serde_json::Value, preprocessor_runs: u64) {
+    let last = report["all_events"]
+        .as_array()
+        .and_then(|events| events.last())
+        .expect("report should include at least one event");
+    assert_eq!(last["preprocessor_runs"].as_u64(), Some(preprocessor_runs));
+}
+
 fn find_depinfo_containing(root: &Path, needle: &str) -> Option<(PathBuf, String)> {
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
@@ -1882,6 +1890,51 @@ fn test_cc_depinfo_sidecar_restores_on_hit_and_new_mf_path() {
     let report = kache_report(pp_cache_dir.path());
     assert_cc_report_counts(&report, 1, 1);
     assert_last_cc_event(&report, "local_hit", 0);
+}
+
+#[test]
+fn test_cc_preprocess_memo_skips_warm_probe_and_invalidates_on_header_change() {
+    build_kache();
+
+    let project = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    std::fs::write(project.path().join("value.h"), "#define VALUE 7\n").unwrap();
+    std::fs::write(
+        project.path().join("foo.c"),
+        "#include \"value.h\"\nint value(void) { return VALUE; }\n",
+    )
+    .unwrap();
+    let args = [
+        "cc", "-O0", "-g0", "-MMD", "-MF", "foo.d", "-c", "foo.c", "-o", "foo.o",
+    ];
+
+    run_kache_cc(project.path(), cache_dir.path(), &args);
+    let report = kache_report(cache_dir.path());
+    assert_last_cc_event(&report, "miss", 1);
+    assert_last_cc_preprocessor_runs(&report, 1);
+
+    std::fs::remove_file(project.path().join("foo.o")).unwrap();
+    std::fs::remove_file(project.path().join("foo.d")).unwrap();
+    run_kache_cc(project.path(), cache_dir.path(), &args);
+    let report = kache_report(cache_dir.path());
+    assert_last_cc_event(&report, "local_hit", 0);
+    assert_last_cc_preprocessor_runs(&report, 0);
+
+    // Different length guarantees a metadata fingerprint change even on a
+    // coarse-timestamp filesystem. The stale memo must run the preprocessor,
+    // derive a new object key, and compile rather than restore VALUE=7.
+    std::fs::write(project.path().join("value.h"), "#define VALUE 12345\n").unwrap();
+    run_kache_cc(project.path(), cache_dir.path(), &args);
+    let report = kache_report(cache_dir.path());
+    assert_last_cc_event(&report, "miss", 1);
+    assert_last_cc_preprocessor_runs(&report, 1);
+
+    std::fs::remove_file(project.path().join("foo.o")).unwrap();
+    std::fs::remove_file(project.path().join("foo.d")).unwrap();
+    run_kache_cc(project.path(), cache_dir.path(), &args);
+    let report = kache_report(cache_dir.path());
+    assert_last_cc_event(&report, "local_hit", 0);
+    assert_last_cc_preprocessor_runs(&report, 0);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Closes #562

## Summary

- store local preprocessor-output hashes and complete source/header fingerprints in SQLite
- reuse the hash on warm C/C++ invocations only when compiler, argv, environment, and every input fingerprint still match
- capture complete GNU and clang-cl dependency sets privately; any unsupported, malformed, changed, missing, or too-new input falls back to preprocessing
- require zero preprocessor runs in warm C/C++ E2E fixtures

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- just test
- just e2e: all executed fixtures green, 2 platform skips
- focused mutation gate: 4/4 memo-safety mutants caught