### PR TITLE
perf(hash): stream file digests

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -2254,9 +2254,13 @@ fn is_ident_continue(byte: u8) -> bool {
 
 /// Hash a file using blake3.
 pub fn hash_file(path: &Path) -> Result<String> {
-    let data = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
-    let hash = blake3::hash(&data);
-    Ok(hash.to_hex().to_string())
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("opening {} for hashing", path.display()))?;
+    let mut hasher = blake3::Hasher::new();
+    hasher
+        .update_reader(file)
+        .with_context(|| format!("reading {} for hashing", path.display()))?;
+    Ok(hasher.finalize().to_hex().to_string())
 }
 
 /// Compute a linked `static=` archive's cache-key digest. A proven GNU/BSD
@@ -4460,6 +4464,18 @@ mod tests {
         std::fs::write(&file3, b"fn main() { println!(\"hello\"); }").unwrap();
         let hash3 = hash_file(&file3).unwrap();
         assert_ne!(hash, hash3);
+
+        // Larger than blake3's streaming read buffer so the digest spans
+        // multiple reads instead of relying on a single in-memory buffer.
+        let large = dir.path().join("large.rlib");
+        let large_bytes: Vec<u8> = (0..256 * 1024 + 17)
+            .map(|index| (index % 251) as u8)
+            .collect();
+        std::fs::write(&large, &large_bytes).unwrap();
+        assert_eq!(
+            hash_file(&large).unwrap(),
+            blake3::hash(&large_bytes).to_hex().to_string()
+        );
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10640,7 +10640,7 @@ mod tests {
     }
 
     #[test]
-    fn handle_hash_files_reports_hash_read_error() {
+    fn handle_hash_files_reports_hash_io_error() {
         // Branch: hash_file failure becomes a per-file error result.
         let dir = tempfile::tempdir().unwrap();
         let config = test_config(dir.path());
@@ -10668,7 +10668,7 @@ mod tests {
                 .error
                 .as_deref()
                 .unwrap_or_default()
-                .contains("reading"),
+                .contains("hashing"),
             "got {:?}",
             result.error
         );


### PR DESCRIPTION
Closes #556

Epic: #552

## Summary

- stream ordinary file digests through BLAKE3's bounded 64 KiB reader buffer
- preserve the exact existing BLAKE3 digest format and all callers
- cover a multi-read artifact against the canonical single-shot digest

## Why this is atomic

`hash_file` was the shared whole-file allocation point used by source/artifact hashing, restore verification, and store checks. Replacing that one primitive removes file-sized allocations everywhere without changing cache keys or archive-specific hashing.

## Regression proof

- a 256 KiB + 17 byte fixture exercises multiple streaming reads and must equal `blake3::hash` byte-for-byte
- a 256 MiB local diagnostic measured maximum RSS at 270,401,536 bytes before and 1,916,928 bytes after; wall time was 2.54 s vs 2.50 s on this macOS arm64 host

## Validation

- `cargo test test_hash_file`
- `just check` — 2,075 main-binary tests plus workspace integration, E2E-harness, service, and doc tests green

## Risk and non-goals

- mmap and Rayon hashing remain out of scope until representative throughput measurements justify their platform and oversubscription complexity
- structural static-archive hashing still needs its bytes for archive parsing and is unchanged
