### PR TITLE
fix(rustc): classify source-bearing print queries

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -372,6 +372,11 @@ impl RustcArgs {
             path_normalize_disabled: !crate::path_normalizer::rustc_path_normalize_enabled(),
             path_normalization_root: None,
         };
+        // Some rustc queries accept a crate name and source path but only print
+        // information to stdout; they deliberately emit no cacheable artifacts.
+        // Keep this separate from ignored-key flags so source-bearing queries
+        // cannot be mistaken for primary compilations.
+        let mut is_query = false;
 
         let mut i = 0;
         while i < rustc_args.len() {
@@ -533,6 +538,16 @@ impl RustcArgs {
                         .remap_path_prefixes
                         .push(arg["--remap-path-prefix=".len()..].to_string());
                 }
+                "--print" | "--explain" => {
+                    is_query = true;
+                    i += 1; // skip the value argument
+                }
+                _ if arg.starts_with("--print=") || arg.starts_with("--explain=") => {
+                    is_query = true;
+                }
+                "-V" | "--version" | "-h" | "--help" | "-vV" => {
+                    is_query = true;
+                }
                 // Diagnostics / lint / query flags: never change the artifact,
                 // so drop them (and their separated value) before the residual
                 // catch-all (kunobi-ninja/kache#324).
@@ -560,7 +575,8 @@ impl RustcArgs {
         }
 
         parsed.features.sort();
-        parsed.is_primary = parsed.crate_name.is_some() && parsed.source_file.is_some();
+        parsed.is_primary =
+            !is_query && parsed.crate_name.is_some() && parsed.source_file.is_some();
         parsed.path_normalization_root = std::env::current_dir()
             .ok()
             .map(|cwd| parsed.select_path_normalization_root(&cwd));

--- a/src/args.rs
+++ b/src/args.rs
@@ -540,7 +540,7 @@ impl RustcArgs {
                 }
                 "--print" | "--explain" => {
                     is_query = true;
-                    i += 1; // skip the value argument
+                    i = i.saturating_add(1); // skip the value argument
                 }
                 _ if arg.starts_with("--print=") || arg.starts_with("--explain=") => {
                     is_query = true;

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -380,10 +380,35 @@ mod tests {
             ]);
             argv.extend(print.iter().map(|arg| (*arg).to_string()));
             let parsed = RustcCompiler::new().parse(&argv).unwrap();
+            assert!(
+                parsed.residual_args.is_empty(),
+                "query value leaked into residual args: {print:?} -> {:?}",
+                parsed.residual_args
+            );
             let reasons = RustcCompiler::new().refuse_reasons(&parsed);
             assert!(
                 matches!(reasons.as_slice(), [RefuseReason::NotPrimary]),
                 "source-bearing print query was treated as a compile: {print:?} -> {reasons:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn refuse_reasons_returns_not_primary_for_source_bearing_info_query() {
+        for query in ["-V", "--version", "-h", "--help", "-vV"] {
+            let parsed = RustcCompiler::new()
+                .parse(&s(&[
+                    "rustc",
+                    "src/lib.rs",
+                    "--crate-name",
+                    "dummy_crate",
+                    query,
+                ]))
+                .unwrap();
+            let reasons = RustcCompiler::new().refuse_reasons(&parsed);
+            assert!(
+                matches!(reasons.as_slice(), [RefuseReason::NotPrimary]),
+                "source-bearing info query was treated as a compile: {query} -> {reasons:?}"
             );
         }
     }

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -362,6 +362,33 @@ mod tests {
     }
 
     #[test]
+    fn refuse_reasons_returns_not_primary_for_source_bearing_print_query() {
+        // substrate-wasm-builder probes the wasm artifact name with a real
+        // crate/source pair plus `--print=file-names`. It is still a query: rustc
+        // prints the name and deliberately emits no dep-info or compile output.
+        for print in [
+            ["--print", "file-names"].as_slice(),
+            ["--print=file-names"].as_slice(),
+        ] {
+            let mut argv = s(&[
+                "rustc",
+                "src/lib.rs",
+                "--crate-name",
+                "dummy_crate",
+                "--crate-type",
+                "rlib",
+            ]);
+            argv.extend(print.iter().map(|arg| (*arg).to_string()));
+            let parsed = RustcCompiler::new().parse(&argv).unwrap();
+            let reasons = RustcCompiler::new().refuse_reasons(&parsed);
+            assert!(
+                matches!(reasons.as_slice(), [RefuseReason::NotPrimary]),
+                "source-bearing print query was treated as a compile: {print:?} -> {reasons:?}"
+            );
+        }
+    }
+
+    #[test]
     fn refuse_reasons_empty_for_primary_compilation() {
         let parsed = RustcCompiler::new()
             .parse(&s(&[


### PR DESCRIPTION
## Summary

- classify source-bearing rustc queries as non-primary invocations
- pass `--print`, `--explain`, version, and help requests straight through instead of attempting cache-key and dep-info work
- cover both `--print file-names` and `--print=file-names`, including complete value consumption

## Why

Substrate's wasm builder invokes `rustc src/lib.rs --crate-name dummy_crate --print=file-names` 60 times per benchmark. Rustc prints the prospective artifact name and intentionally emits no dep-info. Kache dropped the query flag while parsing, then treated the crate/source pair as a compilation and ran a dep-info pre-pass that could only fail.

This removes the remaining actionable dep-info-refusal class tracked in #431. Paired field traces show the remaining 263 divergent keys are unchanged and originate in two runtime `OUT_DIR` crates (`expander`, `scratch`), 12 differing native static libraries, generated wasm sources, and their Cargo metadata/`extern` cascades. Kache must keep runtime `OUT_DIR` absolute: a cached proc macro would otherwise write generated files into the donor clone.

Closes #431.

## Validation

- red-before regression: source-bearing print query returned no refusal reason
- green-after regression: both print spellings return only `NotPrimary`, consume their value, and source-bearing version/help queries stay non-primary
- mutation regressions kill the two missed parser mutants; monotonic query-value advancement avoids the non-progressing arithmetic mutant
- `cargo test -j 1 --workspace` (2,079 Kache unit tests plus workspace integration/doc tests)
- `cargo clippy -j 1 --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Substrate evidence

| Metric | `main` | Fixed head |
|---|---:|---:|
| dep-info refusals | 60 | 0 |
| measured passthrough compilations | 73 | 13 |
| key stability | 72.6% (697/960) | 72.6% (697/960) |
| divergent keys | 263 | 263 |

- baseline trace: https://github.com/kunobi-ninja/kache/actions/runs/32705726288
- fixed-head trace: https://github.com/kunobi-ninja/kache/actions/runs/32707893241
