### PR TITLE
feat(remote): add immutable packed prefetch

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -149,6 +149,16 @@ gitignore = true
 # than the already-observed assertion failure. Exclude only that whole-body
 # replacement; the override resolver and every branch inside the real method
 # remain mutation-tested.
+#
+# The packed-prefetch format has three inclusive-boundary operator mutants
+# that cannot change an observable result. A catalog which passed structural
+# validation cannot approach the 64 MiB encode cap: its 65,536 fixed-shape
+# entries, 16,384 pack wrappers, and two 4 KiB selector fields remain far
+# below it. On decode, an object of exactly the 16-byte header length has no
+# JSON index/payload and is rejected either way; likewise an index ending at
+# EOF has no payload for the required non-empty, non-zero-length entry set.
+# Exact-limit and first-real-overshoot tests retain coverage of every reachable
+# boundary on the corresponding decode/build paths.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -181,4 +191,7 @@ exclude_re = [
     "replace report_key_divergence with \\(\\)",
     "delete ! in install_shims",
     "replace Config::socket_path .* with Default::default",
+    "src/remote_pack.rs:351:20: replace > with (>=|==) in encode_catalog",
+    "src/remote_pack.rs:309:20: replace < with <= in decode_pack",
+    "src/remote_pack.rs:324:22: replace > with >= in decode_pack",
 ]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -602,6 +602,23 @@ pub(crate) fn render_stats(snap: &StatsSnapshot, config: &Config, hours: u64) ->
             "Planning:   {} advisory / {} fallback plans (last: {} candidates)",
             pf.plans_advisory, pf.plans_fallback, pf.last_plan_candidates,
         ));
+        if pf.pack_requests_total + pf.v3_requests_total > 0 {
+            lines.push(format!(
+                "Transport:  pack {} requests / {}, v3 {} requests / {}; {} validation failures, {} v3 fallbacks",
+                pf.pack_requests_total,
+                ByteSize(pf.pack_bytes_downloaded),
+                pf.v3_requests_total,
+                ByteSize(pf.v3_bytes_downloaded),
+                pf.pack_validation_failures,
+                pf.pack_fallback_entries,
+            ));
+        }
+        if pf.last_plan_wall_ms > 0 {
+            lines.push(format!(
+                "Plan wall:  {} ms last / {} ms total",
+                pf.last_plan_wall_ms, pf.plan_wall_ms_total,
+            ));
+        }
         if pf.last_list_key_count > 0 {
             let (refresh_secs, refresh_source) = match &snap.daemon_effective_config {
                 Some(eff) => (eff.remote_key_cache_refresh_secs, ""),
@@ -7562,6 +7579,14 @@ mod tests {
             list_failures_total: 0,
             list_duration_ms_total: 0,
             list_keys_total: 0,
+            pack_requests_total: 3,
+            pack_bytes_downloaded: 4096,
+            v3_requests_total: 1,
+            v3_bytes_downloaded: 1024,
+            pack_validation_failures: 1,
+            pack_fallback_entries: 1,
+            last_plan_wall_ms: 250,
+            plan_wall_ms_total: 500,
         };
         let mut eff = effective_config_like(&config);
         eff.remote_key_cache_refresh_secs = 7;
@@ -7571,6 +7596,9 @@ mod tests {
         assert!(out.contains("2 used (50%)"));
         assert!(out.contains("CANCELLED"));
         assert!(out.contains("Planning:   1 advisory / 2 fallback plans (last: 7 candidates)"));
+        assert!(out.contains("Transport:  pack 3 requests"));
+        assert!(out.contains("v3 1 requests"));
+        assert!(out.contains("Plan wall:  250 ms last / 500 ms total"));
         assert!(out.contains("Key LIST:   250000 keys in 88 ms (refreshes every 7s)"));
         assert!(!out.contains("daemon did not report its cadence"));
         assert!(out.contains("Join-wait:  5 waits, 1234 ms total"));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7630,6 +7630,23 @@ mod tests {
             "zero listed keys must not render a LIST status line: {out}"
         );
         snap.prefetch.last_list_key_count = 250_000;
+
+        // Transport activity is the sum of two independent counters.  Neither
+        // a zero total nor a zero wall clock sample should render a line.
+        snap.prefetch.pack_requests_total = 0;
+        snap.prefetch.v3_requests_total = 0;
+        snap.prefetch.last_plan_wall_ms = 0;
+        let out = render_stats(&snap, &config, 24).join("\n");
+        assert!(!out.contains("Transport:"));
+        assert!(!out.contains("Plan wall:"));
+
+        snap.prefetch.pack_requests_total = 1;
+        let out = render_stats(&snap, &config, 24).join("\n");
+        assert!(out.contains("Transport:  pack 1 requests"));
+        snap.prefetch.pack_requests_total = 0;
+        snap.prefetch.v3_requests_total = 1;
+        let out = render_stats(&snap, &config, 24).join("\n");
+        assert!(out.contains("v3 1 requests"));
     }
 
     /// A daemon-shaped [`crate::daemon::EffectiveConfig`] mirroring `config`,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4074,7 +4074,7 @@ impl Daemon {
             for entry in decoded.entries {
                 let key = &entry.descriptor.cache_key;
                 let entry_dir = self.entry_dir_for(key);
-                if entry_dir.exists() || claim_download(&self.downloading, key).await.is_some() {
+                if !try_claim_packed_download(&self.downloading, key, &entry_dir).await {
                     continue;
                 }
                 let guard = DownloadingGuard::new(self.downloading.clone(), key.clone());
@@ -5858,6 +5858,20 @@ async fn claim_download(
             None
         }
     }
+}
+
+/// Claim a packed entry only when it is absent on disk and no other download
+/// already owns the key. Keeping both rejection cases behind this seam makes
+/// the short-circuit contract deterministic to test.
+async fn try_claim_packed_download(
+    downloading: &RwLock<HashMap<String, Arc<Notify>>>,
+    key: &str,
+    entry_dir: &Path,
+) -> bool {
+    if entry_dir.exists() {
+        return false;
+    }
+    claim_download(downloading, key).await.is_none()
 }
 
 /// Releases a download claim when dropped: removes the key from the
@@ -12670,6 +12684,20 @@ mod tests {
         build_entry_pack_with_meta(key, crate_name).0
     }
 
+    #[test]
+    fn packed_prefetch_context_is_derived_from_a_complete_build_intent() {
+        let intent = kache_core::BuildIntent {
+            crate_names: vec!["serde".into()],
+            namespace: Some("linux/toolchain/release".into()),
+            cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+        };
+        let context = PackPrefetchContext::from_intent(&intent)
+            .expect("a namespaced lockfile intent must enable catalog discovery");
+        assert_eq!(context.namespace, "linux/toolchain/release");
+        assert_eq!(context.shard_hashes.len(), 1);
+        assert!(crate::cache_key::is_valid_cache_key(&context.selector));
+    }
+
     async fn seed_packed_catalog(
         backend: &Arc<dyn crate::remote_backend::RemoteBackend>,
         context: &PackPrefetchContext,
@@ -12756,6 +12784,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut config = test_config(dir.path());
         config.remote = Some(test_remote_config());
+        config.prefetch_max_bytes = 0;
         let backend = test_remote_backend();
         let daemon = Arc::new(Daemon::new(config));
         assert!(daemon.remote_backend.set(backend.clone()).is_ok());
@@ -12790,6 +12819,13 @@ mod tests {
             None,
         )
         .await;
+
+        let sentinel = test_cache_key("existing-prefetched-key");
+        daemon
+            .prefetched_keys
+            .write()
+            .await
+            .insert(sentinel.clone());
 
         let response = daemon
             .handle_prefetch_with_context(
@@ -12831,6 +12867,10 @@ mod tests {
                 .load(Ordering::Relaxed),
             0
         );
+        let prefetched = daemon.prefetched_keys.read().await;
+        assert!(prefetched.contains(&sentinel));
+        assert!(prefetched.contains(&key_a));
+        assert!(prefetched.contains(&key_b));
     }
 
     #[tokio::test]
@@ -13020,6 +13060,101 @@ mod tests {
             Some(b"corrupt immutable pack".to_vec()),
         )
         .await;
+        put_test_object(&backend, &test_pack_object_key(&key, "serde"), &payload).await;
+
+        let response = daemon
+            .handle_prefetch_with_context(
+                &PrefetchRequest {
+                    keys: vec![(key.clone(), "serde".into())],
+                    warm_all: false,
+                },
+                Some(context),
+                Instant::now(),
+            )
+            .await;
+        assert!(response.ok);
+        wait_for_store_entry(&daemon, &key).await;
+        assert_eq!(
+            daemon
+                .prefetch_stats
+                .v3_requests_total
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            daemon
+                .prefetch_stats
+                .pack_fallback_entries
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert!(
+            daemon
+                .prefetch_stats
+                .pack_validation_failures
+                .load(Ordering::Relaxed)
+                >= 1
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_filename_timestamp_mismatch_rejects_context_and_uses_v3() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        let backend = test_remote_backend();
+        let daemon = Arc::new(Daemon::new(config));
+        assert!(daemon.remote_backend.set(backend.clone()).is_ok());
+        let context = PackPrefetchContext::from_deps(
+            crate::cli::default_manifest_key(),
+            "linux/toolchain/release",
+            &[("serde".to_string(), "1.0.0".to_string())],
+        )
+        .unwrap();
+        let key = test_cache_key("catalog-created-at-mismatch");
+        let (payload, meta_digest) = build_entry_pack_with_meta(&key, "serde");
+        let built = crate::remote_pack::build_pack(
+            "prefix",
+            vec![crate::remote_pack::PackInputEntry {
+                cache_key: key.clone(),
+                crate_name: "serde".into(),
+                meta_digest: meta_digest.clone(),
+                payload: payload.clone(),
+            }],
+            crate::remote_pack::DEFAULT_MAX_PACK_BYTES,
+        )
+        .unwrap();
+        put_test_object(&backend, &built.object_key, &built.bytes).await;
+        let created_at_ms = epoch_ms();
+        let catalog = crate::remote_pack::PackCatalog {
+            version: crate::remote_pack::CATALOG_VERSION,
+            key_schema: crate::cache_key::CACHE_KEY_VERSION,
+            manifest_key: context.manifest_key.clone(),
+            namespace: context.namespace.clone(),
+            selector_hash: context.selector.clone(),
+            shard_hashes: context.shard_hashes.clone(),
+            created_at_ms,
+            expires_at_ms: created_at_ms + 60_000,
+            packs: vec![crate::remote_pack::CatalogPackRef {
+                digest: built.digest,
+                pack_bytes: built.bytes.len() as u64,
+                entries: vec![crate::remote_pack::CatalogEntry {
+                    cache_key: key.clone(),
+                    crate_name: "serde".into(),
+                    meta_digest,
+                }],
+            }],
+            fallback_entries: Vec::new(),
+        };
+        let encoded = crate::remote_pack::encode_catalog("prefix", catalog).unwrap();
+        let mismatched_key = crate::remote_pack::catalog_object_key(
+            "prefix",
+            &context.selector,
+            created_at_ms + 1,
+            &encoded.digest,
+        )
+        .unwrap();
+        put_test_object(&backend, &mismatched_key, &encoded.bytes).await;
         put_test_object(&backend, &test_pack_object_key(&key, "serde"), &payload).await;
 
         let response = daemon
@@ -15570,6 +15705,37 @@ mod tests {
         let config = test_config(dir.path());
         let daemon = Daemon::new(config);
         assert!(daemon.downloading.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn packed_download_claim_rejects_disk_and_inflight_entries_independently() {
+        let tmp = tempfile::tempdir().unwrap();
+        let map = RwLock::new(HashMap::new());
+
+        let existing_key = test_cache_key("packed-existing-on-disk");
+        let existing_dir = tmp.path().join("existing");
+        std::fs::create_dir_all(&existing_dir).unwrap();
+        assert!(
+            !try_claim_packed_download(&map, &existing_key, &existing_dir).await,
+            "an on-disk entry must not be claimed again"
+        );
+        assert!(map.read().await.is_empty());
+
+        let inflight_key = test_cache_key("packed-inflight");
+        assert!(claim_download(&map, &inflight_key).await.is_none());
+        assert!(
+            !try_claim_packed_download(&map, &inflight_key, &tmp.path().join("absent")).await,
+            "an in-flight entry must not acquire a second claim"
+        );
+
+        let fresh_key = test_cache_key("packed-fresh");
+        assert!(
+            try_claim_packed_download(&map, &fresh_key, &tmp.path().join("fresh")).await,
+            "an absent unclaimed entry must become the download leader"
+        );
+        let claims = map.read().await;
+        assert!(claims.contains_key(&inflight_key));
+        assert!(claims.contains_key(&fresh_key));
     }
 
     /// Waiter-side wait, mirroring the pattern in `handle_remote_check`:

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -901,6 +901,47 @@ impl PrefetchRequest {
     }
 }
 
+#[derive(Debug, Clone)]
+struct PackPrefetchContext {
+    manifest_key: String,
+    namespace: String,
+    shard_hashes: Vec<String>,
+    selector: String,
+}
+
+impl PackPrefetchContext {
+    fn from_deps(manifest_key: String, namespace: &str, deps: &[(String, String)]) -> Result<Self> {
+        if deps.is_empty() {
+            anyhow::bail!("packed-prefetch requires Cargo.lock dependencies");
+        }
+        let mut shard_hashes = crate::shards::compute_shards(namespace, deps)
+            .shards
+            .into_iter()
+            .map(|(hash, _)| hash)
+            .collect::<Vec<_>>();
+        shard_hashes.sort();
+        let selector = crate::remote_pack::selector_hash(
+            &manifest_key,
+            namespace,
+            &shard_hashes,
+            crate::cache_key::CACHE_KEY_VERSION,
+        )?;
+        Ok(Self {
+            manifest_key,
+            namespace: namespace.to_string(),
+            shard_hashes,
+            selector,
+        })
+    }
+
+    fn from_intent(intent: &kache_core::BuildIntent) -> Option<Self> {
+        let namespace = intent.namespace.as_deref()?;
+        let manifest_key = std::env::var("KACHE_MANIFEST_KEY")
+            .unwrap_or_else(|_| crate::cli::default_manifest_key());
+        Self::from_deps(manifest_key, namespace, &intent.cargo_lock_deps).ok()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BuildStartedRequest {
     #[serde(default)]
@@ -1192,6 +1233,25 @@ pub struct PrefetchStatsSnapshot {
     pub list_duration_ms_total: u64,
     #[serde(default)]
     pub list_keys_total: u64,
+    /// Remote operations used by packed-prefetch discovery and pack GETs.
+    #[serde(default)]
+    pub pack_requests_total: u64,
+    #[serde(default)]
+    pub pack_bytes_downloaded: u64,
+    /// Existing object-by-object v3 GETs started by speculative prefetch.
+    #[serde(default)]
+    pub v3_requests_total: u64,
+    #[serde(default)]
+    pub v3_bytes_downloaded: u64,
+    #[serde(default)]
+    pub pack_validation_failures: u64,
+    #[serde(default)]
+    pub pack_fallback_entries: u64,
+    /// Real wall time from plan dispatch through its final import/fallback.
+    #[serde(default)]
+    pub last_plan_wall_ms: u64,
+    #[serde(default)]
+    pub plan_wall_ms_total: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1642,6 +1702,14 @@ pub(crate) struct PrefetchStats {
     pub list_failures_total: std::sync::atomic::AtomicU64,
     pub list_duration_ms_total: std::sync::atomic::AtomicU64,
     pub list_keys_total: std::sync::atomic::AtomicU64,
+    pub pack_requests_total: std::sync::atomic::AtomicU64,
+    pub pack_bytes_downloaded: std::sync::atomic::AtomicU64,
+    pub v3_requests_total: std::sync::atomic::AtomicU64,
+    pub v3_bytes_downloaded: std::sync::atomic::AtomicU64,
+    pub pack_validation_failures: std::sync::atomic::AtomicU64,
+    pub pack_fallback_entries: std::sync::atomic::AtomicU64,
+    pub last_plan_wall_ms: std::sync::atomic::AtomicU64,
+    pub plan_wall_ms_total: std::sync::atomic::AtomicU64,
 }
 
 impl PrefetchStats {
@@ -1663,6 +1731,14 @@ impl PrefetchStats {
             list_failures_total: 0.into(),
             list_duration_ms_total: 0.into(),
             list_keys_total: 0.into(),
+            pack_requests_total: 0.into(),
+            pack_bytes_downloaded: 0.into(),
+            v3_requests_total: 0.into(),
+            v3_bytes_downloaded: 0.into(),
+            pack_validation_failures: 0.into(),
+            pack_fallback_entries: 0.into(),
+            last_plan_wall_ms: 0.into(),
+            plan_wall_ms_total: 0.into(),
         }
     }
 }
@@ -2528,6 +2604,14 @@ impl Daemon {
                 list_failures_total: ps.list_failures_total.load(Ordering::Relaxed),
                 list_duration_ms_total: ps.list_duration_ms_total.load(Ordering::Relaxed),
                 list_keys_total: ps.list_keys_total.load(Ordering::Relaxed),
+                pack_requests_total: ps.pack_requests_total.load(Ordering::Relaxed),
+                pack_bytes_downloaded: ps.pack_bytes_downloaded.load(Ordering::Relaxed),
+                v3_requests_total: ps.v3_requests_total.load(Ordering::Relaxed),
+                v3_bytes_downloaded: ps.v3_bytes_downloaded.load(Ordering::Relaxed),
+                pack_validation_failures: ps.pack_validation_failures.load(Ordering::Relaxed),
+                pack_fallback_entries: ps.pack_fallback_entries.load(Ordering::Relaxed),
+                last_plan_wall_ms: ps.last_plan_wall_ms.load(Ordering::Relaxed),
+                plan_wall_ms_total: ps.plan_wall_ms_total.load(Ordering::Relaxed),
             },
             in_flight,
             effective_config: Some(self.effective_config.clone()),
@@ -3680,9 +3764,425 @@ impl Daemon {
         Response::ok_batch(results)
     }
 
+    async fn packed_prefetch_list(
+        &self,
+        backend: &dyn crate::remote_backend::RemoteBackend,
+        prefix: &str,
+    ) -> Result<Vec<String>> {
+        let breaker = self
+            .remote_breaker
+            .try_acquire(RemoteOperation::PrefetchGet)
+            .ok_or_else(|| anyhow::anyhow!("remote read breaker open"))?;
+        let deadline = RemoteDeadline::from_secs(self.config.remote_restore_timeout_secs);
+        let gate = deadline
+            .run("pack catalog gate", async {
+                self.prefetch_gate
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("prefetch gate closed"))
+            })
+            .await?;
+        let semaphore = deadline
+            .run("pack catalog LIST queue", async {
+                self.s3_semaphore
+                    .acquire()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("remote semaphore closed"))
+            })
+            .await?;
+        self.prefetch_stats
+            .pack_requests_total
+            .fetch_add(1, Ordering::Relaxed);
+        let result = deadline
+            .run("pack catalog LIST", backend.list(prefix))
+            .await;
+        drop(semaphore);
+        drop(gate);
+        match result {
+            Ok(objects) => {
+                breaker.success();
+                Ok(objects)
+            }
+            Err(error) => {
+                let class = classify_remote_error(&error);
+                breaker.failure(class, &format!("packed-prefetch LIST failed: {error:#}"));
+                Err(error)
+            }
+        }
+    }
+
+    async fn packed_prefetch_get(
+        &self,
+        backend: &dyn crate::remote_backend::RemoteBackend,
+        key: &str,
+        max_bytes: u64,
+        stage: &'static str,
+    ) -> Result<Option<crate::remote_backend::GetObject>> {
+        let breaker = self
+            .remote_breaker
+            .try_acquire(RemoteOperation::PrefetchGet)
+            .ok_or_else(|| anyhow::anyhow!("remote read breaker open"))?;
+        let deadline = RemoteDeadline::from_secs(self.config.remote_restore_timeout_secs);
+        let gate = deadline
+            .run("packed-prefetch gate", async {
+                self.prefetch_gate
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("prefetch gate closed"))
+            })
+            .await?;
+        let semaphore = deadline
+            .run("packed-prefetch GET queue", async {
+                self.s3_semaphore
+                    .acquire()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("remote semaphore closed"))
+            })
+            .await?;
+        self.prefetch_stats
+            .pack_requests_total
+            .fetch_add(1, Ordering::Relaxed);
+        let result = deadline.run(stage, backend.get(key, Some(max_bytes))).await;
+        drop(semaphore);
+        drop(gate);
+        match result {
+            Ok(object) => {
+                breaker.success();
+                if let Some(object) = &object {
+                    self.prefetch_stats
+                        .pack_bytes_downloaded
+                        .fetch_add(object.body.len() as u64, Ordering::Relaxed);
+                }
+                Ok(object)
+            }
+            Err(error) => {
+                let class = classify_remote_error(&error);
+                breaker.failure(class, &format!("{stage} failed: {error:#}"));
+                Err(error)
+            }
+        }
+    }
+
+    /// Try the manifest-level immutable pack catalog, returning candidate keys
+    /// successfully imported. Every other candidate remains eligible for the
+    /// existing v3 coordinator below.
+    async fn try_packed_prefetch(
+        self: &Arc<Self>,
+        context: &PackPrefetchContext,
+        backend: &Arc<dyn crate::remote_backend::RemoteBackend>,
+        remote: &crate::config::RemoteConfig,
+        candidates: &[(String, String, PathBuf)],
+        bytes_at_plan_start: u64,
+    ) -> HashSet<String> {
+        let wanted = candidates
+            .iter()
+            .map(|(key, _, _)| key.clone())
+            .collect::<HashSet<_>>();
+        let mut imported = HashSet::new();
+        let catalog_prefix =
+            match crate::remote_pack::catalog_prefix(&remote.prefix, &context.selector) {
+                Ok(prefix) => prefix,
+                Err(error) => {
+                    tracing::warn!("packed-prefetch selector rejected: {error:#}");
+                    return imported;
+                }
+            };
+        let objects = match self
+            .packed_prefetch_list(backend.as_ref(), &catalog_prefix)
+            .await
+        {
+            Ok(objects) => objects,
+            Err(error) => {
+                tracing::debug!("packed-prefetch catalog discovery failed: {error:#}");
+                self.prefetch_stats
+                    .pack_fallback_entries
+                    .fetch_add(wanted.len() as u64, Ordering::Relaxed);
+                return imported;
+            }
+        };
+        let catalog_ref = match crate::remote_pack::latest_catalog_object(
+            &remote.prefix,
+            &context.selector,
+            &objects,
+        ) {
+            Ok(Some(catalog)) => catalog,
+            Ok(None) => {
+                self.prefetch_stats
+                    .pack_fallback_entries
+                    .fetch_add(wanted.len() as u64, Ordering::Relaxed);
+                return imported;
+            }
+            Err(error) => {
+                tracing::warn!("packed-prefetch catalog key rejected: {error:#}");
+                self.prefetch_stats
+                    .pack_validation_failures
+                    .fetch_add(1, Ordering::Relaxed);
+                self.prefetch_stats
+                    .pack_fallback_entries
+                    .fetch_add(wanted.len() as u64, Ordering::Relaxed);
+                return imported;
+            }
+        };
+        let Some(catalog_object) = self
+            .packed_prefetch_get(
+                backend.as_ref(),
+                &catalog_ref.object_key,
+                crate::remote_pack::MAX_CATALOG_BYTES as u64,
+                "packed-prefetch catalog GET",
+            )
+            .await
+            .ok()
+            .flatten()
+        else {
+            self.prefetch_stats
+                .pack_fallback_entries
+                .fetch_add(wanted.len() as u64, Ordering::Relaxed);
+            return imported;
+        };
+        let now_ms = epoch_ms();
+        let catalog = match crate::remote_pack::decode_catalog_for_selector(
+            &catalog_object.body,
+            &catalog_ref.digest,
+            &context.selector,
+            now_ms,
+        ) {
+            Ok(catalog)
+                if catalog.created_at_ms == catalog_ref.created_at_ms
+                    && catalog.manifest_key == context.manifest_key
+                    && catalog.namespace == context.namespace
+                    && catalog.shard_hashes == context.shard_hashes =>
+            {
+                catalog
+            }
+            Ok(_) => {
+                tracing::warn!("packed-prefetch catalog context binding mismatch");
+                self.prefetch_stats
+                    .pack_validation_failures
+                    .fetch_add(1, Ordering::Relaxed);
+                self.prefetch_stats
+                    .pack_fallback_entries
+                    .fetch_add(wanted.len() as u64, Ordering::Relaxed);
+                return imported;
+            }
+            Err(error) => {
+                tracing::warn!("packed-prefetch catalog validation failed: {error:#}");
+                self.prefetch_stats
+                    .pack_validation_failures
+                    .fetch_add(1, Ordering::Relaxed);
+                self.prefetch_stats
+                    .pack_fallback_entries
+                    .fetch_add(wanted.len() as u64, Ordering::Relaxed);
+                return imported;
+            }
+        };
+
+        let selected = catalog
+            .packs
+            .iter()
+            .filter(|pack| {
+                pack.entries
+                    .iter()
+                    .any(|entry| wanted.contains(&entry.cache_key))
+            })
+            .collect::<Vec<_>>();
+        let already_spent = self
+            .prefetch_stats
+            .bytes_downloaded
+            .load(Ordering::Relaxed)
+            .saturating_sub(bytes_at_plan_start);
+        let mut reserved = 0u64;
+        let admitted = selected
+            .into_iter()
+            .filter(|pack| {
+                if self.config.prefetch_max_bytes == 0 {
+                    return true;
+                }
+                let fits = pack.pack_bytes
+                    <= self
+                        .config
+                        .prefetch_max_bytes
+                        .saturating_sub(already_spent.saturating_add(reserved));
+                if fits {
+                    reserved = reserved.saturating_add(pack.pack_bytes);
+                }
+                fits
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        use futures::StreamExt as _;
+        let mut fetched = futures::stream::iter(admitted)
+            .map(|pack_ref| async move {
+                let pack_key =
+                    crate::remote_pack::pack_object_key(&remote.prefix, &pack_ref.digest);
+                let object = match pack_key {
+                    Ok(key) => self
+                        .packed_prefetch_get(
+                            backend.as_ref(),
+                            &key,
+                            crate::remote_pack::DEFAULT_MAX_PACK_BYTES,
+                            "packed-prefetch pack GET",
+                        )
+                        .await
+                        .ok()
+                        .flatten(),
+                    Err(error) => {
+                        tracing::warn!("packed-prefetch pack key rejected: {error:#}");
+                        self.prefetch_stats
+                            .pack_validation_failures
+                            .fetch_add(1, Ordering::Relaxed);
+                        None
+                    }
+                };
+                (pack_ref, object)
+            })
+            .buffer_unordered(prefetch_concurrency_cap(self.config.s3_concurrency))
+            .collect::<Vec<_>>()
+            .await;
+        fetched.sort_by(|(left, _), (right, _)| left.digest.cmp(&right.digest));
+
+        let mut verified = Vec::new();
+        for (pack_ref, pack_object) in fetched {
+            let Some(pack_object) = pack_object else {
+                continue;
+            };
+            let decoded = match crate::remote_pack::decode_catalog_pack(
+                &pack_object.body,
+                &pack_ref,
+                crate::remote_pack::DEFAULT_MAX_PACK_BYTES,
+            ) {
+                Ok(decoded) => decoded,
+                Err(error) => {
+                    tracing::warn!("packed-prefetch pack validation failed: {error:#}");
+                    self.prefetch_stats
+                        .pack_validation_failures
+                        .fetch_add(1, Ordering::Relaxed);
+                    continue;
+                }
+            };
+            self.transfer_counters
+                .downloads_completed
+                .fetch_add(1, Ordering::Relaxed);
+            self.transfer_counters
+                .bytes_downloaded
+                .fetch_add(pack_object.body.len() as u64, Ordering::Relaxed);
+            self.prefetch_stats
+                .bytes_downloaded
+                .fetch_add(pack_object.body.len() as u64, Ordering::Relaxed);
+
+            for entry in decoded.entries {
+                let key = &entry.descriptor.cache_key;
+                let entry_dir = self.entry_dir_for(key);
+                if entry_dir.exists() || claim_download(&self.downloading, key).await.is_some() {
+                    continue;
+                }
+                let guard = DownloadingGuard::new(self.downloading.clone(), key.clone());
+                match crate::remote_layout::extract_verified_prefetch_entry(
+                    key,
+                    &entry.descriptor.crate_name,
+                    &entry.descriptor.meta_digest,
+                    entry.payload,
+                    &entry_dir,
+                    None,
+                ) {
+                    Ok(extracted) => verified.push((extracted, guard, entry.payload.len() as u64)),
+                    Err(error) => {
+                        tracing::warn!(
+                            key = key_prefix(key),
+                            "packed-prefetch entry validation failed: {error:#}"
+                        );
+                        self.prefetch_stats
+                            .pack_validation_failures
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }
+        }
+
+        let batch = verified
+            .iter()
+            .map(|(entry, _, _)| entry.restored.clone())
+            .collect::<Vec<_>>();
+        if !batch.is_empty() {
+            let import_start = Instant::now();
+            match self.with_store(|store| store.import_verified_restored_entries(&batch)) {
+                Ok(_) => {
+                    let original_bytes = verified
+                        .iter()
+                        .map(|(entry, _, _)| entry.original_bytes)
+                        .sum::<u64>();
+                    let extract_ms = verified
+                        .iter()
+                        .map(|(entry, _, _)| entry.extract_ms)
+                        .sum::<u64>();
+                    for (entry, _, payload_bytes) in &verified {
+                        let key = &entry.restored.cache_key;
+                        imported.insert(key.clone());
+                        self.note_key_present(key, &entry.restored.meta.crate_name)
+                            .await;
+                        {
+                            let mut plan =
+                                self.active_plan.lock().unwrap_or_else(|p| p.into_inner());
+                            if let Some(plan) = plan.as_mut() {
+                                plan.record_download(key, *payload_bytes);
+                            }
+                        }
+                    }
+                    self.prefetch_stats
+                        .downloads_completed
+                        .fetch_add(batch.len() as u64, Ordering::Relaxed);
+                    tracing::info!(
+                        entries = batch.len(),
+                        original_bytes,
+                        extract_ms,
+                        import_ms = import_start.elapsed().as_millis() as u64,
+                        "packed-prefetch batch imported"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!("packed-prefetch batch import failed: {error:#}");
+                    self.prefetch_stats
+                        .pack_validation_failures
+                        .fetch_add(1, Ordering::Relaxed);
+                    for (entry, _, _) in &verified {
+                        let _ =
+                            std::fs::remove_dir_all(self.entry_dir_for(&entry.restored.cache_key));
+                    }
+                }
+            }
+        }
+        drop(verified);
+
+        if !imported.is_empty() {
+            const MAX_PREFETCHED_KEYS: usize = 50_000;
+            let mut prefetched = self.prefetched_keys.write().await;
+            if prefetched.len().saturating_add(imported.len()) >= MAX_PREFETCHED_KEYS {
+                prefetched.clear();
+                self.prefetch_used_keys.write().await.clear();
+            }
+            prefetched.extend(imported.iter().cloned());
+        }
+        self.prefetch_stats.pack_fallback_entries.fetch_add(
+            wanted.difference(&imported).count() as u64,
+            Ordering::Relaxed,
+        );
+        imported
+    }
+
     /// Handle a prefetch request: fire-and-forget background downloads.
     /// Spawns a single coordinator task that processes keys with bounded concurrency.
     pub async fn handle_prefetch(self: &Arc<Self>, req: &PrefetchRequest) -> Response {
+        self.handle_prefetch_with_context(req, None, Instant::now())
+            .await
+    }
+
+    async fn handle_prefetch_with_context(
+        self: &Arc<Self>,
+        req: &PrefetchRequest,
+        pack_context: Option<PackPrefetchContext>,
+        plan_started_at: Instant,
+    ) -> Response {
         if !self.config.prefetch_enabled {
             tracing::debug!("prefetch request ignored: speculative prefetch disabled");
             return Response::ok();
@@ -3700,6 +4200,7 @@ impl Daemon {
             Err(error) => return Response::err(format!("remote backend init failed: {error:#}")),
         };
         let backend = Arc::clone(backend);
+        let bytes_at_plan_start = self.prefetch_stats.bytes_downloaded.load(Ordering::Relaxed);
 
         // Filter to keys that need downloading: (cache_key, crate_name, entry_dir)
         let mut keys_to_fetch: Vec<(String, String, PathBuf)> = Vec::new();
@@ -3823,6 +4324,31 @@ impl Daemon {
             );
         }
 
+        if let Some(context) = pack_context.as_ref() {
+            let packed = self
+                .try_packed_prefetch(
+                    context,
+                    &backend,
+                    remote,
+                    &keys_to_fetch,
+                    bytes_at_plan_start,
+                )
+                .await;
+            keys_to_fetch.retain(|(key, _, _)| !packed.contains(key));
+        }
+        let count = keys_to_fetch.len();
+        if count == 0 {
+            let wall_ms = plan_started_at.elapsed().as_millis() as u64;
+            self.prefetch_stats
+                .last_plan_wall_ms
+                .store(wall_ms, Ordering::Relaxed);
+            self.prefetch_stats
+                .plan_wall_ms_total
+                .fetch_add(wall_ms, Ordering::Relaxed);
+            tracing::info!(wall_ms, "prefetch: packed plan complete");
+            return Response::ok();
+        }
+
         // Candidates are deliberately NOT claimed here (kunobi-ninja/kache#613).
         // Claiming the whole plan up front put every candidate in `downloading`
         // before any of them was being downloaded, so a wrapper demanding a key
@@ -3857,10 +4383,7 @@ impl Daemon {
             // was in flight when it tripped, at most `max_concurrent` objects.
             // A hard cap needs counted, cancellable reads in the backend.
             let byte_budget = daemon.config.prefetch_max_bytes;
-            let bytes_at_start = daemon
-                .prefetch_stats
-                .bytes_downloaded
-                .load(Ordering::Relaxed);
+            let bytes_at_start = bytes_at_plan_start;
             let deadline = match daemon.config.prefetch_deadline_secs {
                 0 => None,
                 secs => Some(Instant::now() + Duration::from_secs(secs)),
@@ -4021,6 +4544,9 @@ impl Daemon {
                     let blobs_dir = d.config.store_dir().join("blobs");
                     let started_at_unix_ms = unix_time_ms();
                     let start = Instant::now();
+                    d.prefetch_stats
+                        .v3_requests_total
+                        .fetch_add(1, Ordering::Relaxed);
                     let download_result = item_deadline
                         .run(
                             "prefetch GET and extraction",
@@ -4066,6 +4592,9 @@ impl Daemon {
                                 .fetch_add(1, Ordering::Relaxed);
                             d.prefetch_stats
                                 .bytes_downloaded
+                                .fetch_add(dl.compressed_bytes, Ordering::Relaxed);
+                            d.prefetch_stats
+                                .v3_bytes_downloaded
                                 .fetch_add(dl.compressed_bytes, Ordering::Relaxed);
                             // Per-plan attribution (#583 P0.5): byte-accurate
                             // downloaded set for the session summary.
@@ -4183,7 +4712,16 @@ impl Daemon {
             // Drain remaining
             use futures::StreamExt;
             while in_flight.next().await.is_some() {}
-            tracing::info!("prefetch: completed {} downloads", count);
+            let wall_ms = plan_started_at.elapsed().as_millis() as u64;
+            daemon
+                .prefetch_stats
+                .last_plan_wall_ms
+                .store(wall_ms, Ordering::Relaxed);
+            daemon
+                .prefetch_stats
+                .plan_wall_ms_total
+                .fetch_add(wall_ms, Ordering::Relaxed);
+            tracing::info!(wall_ms, "prefetch: completed {} downloads", count);
         });
 
         tracing::info!("prefetch: queued {} downloads", count);
@@ -4284,6 +4822,8 @@ impl Daemon {
     }
 
     pub async fn handle_build_started(self: &Arc<Self>, req: &BuildStartedRequest) -> Response {
+        let plan_started_at = Instant::now();
+        let pack_context = PackPrefetchContext::from_intent(&req.intent);
         let Some(_remote) = &self.config.remote else {
             return Response::err("no remote configured");
         };
@@ -4329,7 +4869,13 @@ impl Daemon {
                             "advisory",
                             prefetch_req.keys.iter().map(|(k, _)| k.clone()),
                         );
-                        let resp = self.handle_prefetch(&prefetch_req).await;
+                        let resp = self
+                            .handle_prefetch_with_context(
+                                &prefetch_req,
+                                pack_context.clone(),
+                                plan_started_at,
+                            )
+                            .await;
                         if resp.ok {
                             self.prefetch_stats
                                 .plans_advisory
@@ -4409,7 +4955,8 @@ impl Daemon {
             "fallback",
             prefetch_req.keys.iter().map(|(k, _)| k.clone()),
         );
-        self.handle_prefetch(&prefetch_req).await
+        self.handle_prefetch_with_context(&prefetch_req, pack_context, plan_started_at)
+            .await
     }
 
     /// After a successful upload, check if store exceeds max_size → LRU eviction.
@@ -5668,6 +6215,7 @@ async fn shard_prefetch_for_deps(
     namespace: &str,
     deps: &[(String, String)],
 ) -> anyhow::Result<usize> {
+    let plan_started_at = Instant::now();
     let shard_set = crate::shards::compute_shards(namespace, deps);
 
     tracing::info!(
@@ -5755,7 +6303,12 @@ async fn shard_prefetch_for_deps(
         keys: prefetch_keys,
         warm_all: false,
     };
-    let resp = daemon.handle_prefetch(&req).await;
+    let manifest_key =
+        std::env::var("KACHE_MANIFEST_KEY").unwrap_or_else(|_| crate::cli::default_manifest_key());
+    let pack_context = PackPrefetchContext::from_deps(manifest_key, namespace, deps).ok();
+    let resp = daemon
+        .handle_prefetch_with_context(&req, pack_context, plan_started_at)
+        .await;
     if !resp.ok {
         anyhow::bail!(
             "prefetch failed: {}",
@@ -9475,6 +10028,14 @@ mod tests {
             list_failures_total: 1,
             list_duration_ms_total: 900,
             list_keys_total: 63007,
+            pack_requests_total: 5,
+            pack_bytes_downloaded: 4096,
+            v3_requests_total: 2,
+            v3_bytes_downloaded: 1024,
+            pack_validation_failures: 1,
+            pack_fallback_entries: 2,
+            last_plan_wall_ms: 123,
+            plan_wall_ms_total: 456,
         };
         let json = serde_json::to_string(&snap).unwrap();
         let back: PrefetchStatsSnapshot = serde_json::from_str(&json).unwrap();
@@ -11639,6 +12200,43 @@ mod tests {
         }
     }
 
+    struct BlockingPackBackend {
+        inner: Arc<dyn crate::remote_backend::RemoteBackend>,
+        pack_started: Arc<Notify>,
+        release_pack: Arc<Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::remote_backend::RemoteBackend for BlockingPackBackend {
+        async fn head(&self, key: &str) -> Result<bool> {
+            self.inner.head(key).await
+        }
+
+        async fn get(
+            &self,
+            key: &str,
+            max_bytes: Option<u64>,
+        ) -> Result<Option<crate::remote_backend::GetObject>> {
+            if key.contains("/v4/prefetch/packs/") {
+                self.pack_started.notify_waiters();
+                self.release_pack.notified().await;
+            }
+            self.inner.get(key, max_bytes).await
+        }
+
+        async fn put(&self, key: &str, body: Vec<u8>, content_type: Option<&str>) -> Result<()> {
+            self.inner.put(key, body, content_type).await
+        }
+
+        async fn list(&self, prefix: &str) -> Result<Vec<String>> {
+            self.inner.list(prefix).await
+        }
+
+        fn describe(&self, key: &str) -> String {
+            self.inner.describe(key)
+        }
+    }
+
     #[tokio::test]
     async fn test_socket_remote_check_miss_with_injected_mock_client() {
         // Remote configured + an empty in-memory backend: handle_remote_check
@@ -12050,7 +12648,7 @@ mod tests {
     }
 
     /// Build a valid v3 entry pack for `key` from a throwaway store.
-    fn build_entry_pack(key: &str, crate_name: &str) -> Vec<u8> {
+    fn build_entry_pack_with_meta(key: &str, crate_name: &str) -> (Vec<u8>, String) {
         let tmp = tempfile::tempdir().unwrap();
         let cfg = test_config(tmp.path());
         let store = Store::open(&cfg).unwrap();
@@ -12072,10 +12670,420 @@ mod tests {
             )
             .unwrap();
         let entry_dir = store.entry_dir(key);
-        let meta: crate::store::EntryMeta =
-            serde_json::from_slice(&std::fs::read(entry_dir.join("meta.json")).unwrap()).unwrap();
-        crate::remote_layout::create_entry_pack_zstd(&entry_dir, &store.blobs_dir(), &meta, 3)
-            .unwrap()
+        let meta_bytes = std::fs::read(entry_dir.join("meta.json")).unwrap();
+        let meta: crate::store::EntryMeta = serde_json::from_slice(&meta_bytes).unwrap();
+        let packed =
+            crate::remote_layout::create_entry_pack_zstd(&entry_dir, &store.blobs_dir(), &meta, 3)
+                .unwrap();
+        (packed, blake3::hash(&meta_bytes).to_hex().to_string())
+    }
+
+    fn build_entry_pack(key: &str, crate_name: &str) -> Vec<u8> {
+        build_entry_pack_with_meta(key, crate_name).0
+    }
+
+    async fn seed_packed_catalog(
+        backend: &Arc<dyn crate::remote_backend::RemoteBackend>,
+        context: &PackPrefetchContext,
+        entries: Vec<crate::remote_pack::PackInputEntry>,
+        object_override: Option<Vec<u8>>,
+    ) -> crate::remote_pack::BuiltPack {
+        let built = crate::remote_pack::build_pack(
+            "prefix",
+            entries,
+            crate::remote_pack::DEFAULT_MAX_PACK_BYTES,
+        )
+        .unwrap();
+        put_test_object(
+            backend,
+            &built.object_key,
+            object_override.as_deref().unwrap_or(&built.bytes),
+        )
+        .await;
+        let created_at_ms = epoch_ms();
+        let catalog = crate::remote_pack::PackCatalog {
+            version: crate::remote_pack::CATALOG_VERSION,
+            key_schema: crate::cache_key::CACHE_KEY_VERSION,
+            manifest_key: context.manifest_key.clone(),
+            namespace: context.namespace.clone(),
+            selector_hash: context.selector.clone(),
+            shard_hashes: context.shard_hashes.clone(),
+            created_at_ms,
+            expires_at_ms: created_at_ms + 60_000,
+            packs: vec![crate::remote_pack::CatalogPackRef {
+                digest: built.digest.clone(),
+                pack_bytes: built.bytes.len() as u64,
+                entries: built
+                    .index
+                    .entries
+                    .iter()
+                    .map(|entry| crate::remote_pack::CatalogEntry {
+                        cache_key: entry.cache_key.clone(),
+                        crate_name: entry.crate_name.clone(),
+                        meta_digest: entry.meta_digest.clone(),
+                    })
+                    .collect(),
+            }],
+            fallback_entries: Vec::new(),
+        };
+        let encoded = crate::remote_pack::encode_catalog("prefix", catalog).unwrap();
+        put_test_object(backend, &encoded.object_key, &encoded.bytes).await;
+        built
+    }
+
+    async fn wait_for_store_entry(daemon: &Arc<Daemon>, key: &str) {
+        for _ in 0..200 {
+            if daemon
+                .with_store(|store| Ok(store.get(key)?.is_some()))
+                .unwrap_or(false)
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("timed out waiting for imported entry {}", key_prefix(key));
+    }
+
+    fn traversal_entry_payload() -> Vec<u8> {
+        let body = b"escape";
+        let mut header = [0u8; 512];
+        header[..13].copy_from_slice(b"../escape.txt");
+        header[100..107].copy_from_slice(b"0000644");
+        let size = format!("{:011o}", body.len());
+        header[124..135].copy_from_slice(size.as_bytes());
+        header[156] = b'0';
+        header[148..156].fill(b' ');
+        let checksum: u32 = header.iter().map(|byte| u32::from(*byte)).sum();
+        header[148..156].copy_from_slice(format!("{checksum:06o}\0 ").as_bytes());
+        let mut tar = Vec::new();
+        tar.extend_from_slice(&header);
+        tar.extend_from_slice(body);
+        tar.extend(std::iter::repeat_n(0, 512 - body.len()));
+        tar.extend(std::iter::repeat_n(0, 1024));
+        zstd::stream::encode_all(std::io::Cursor::new(tar), 3).unwrap()
+    }
+
+    #[tokio::test]
+    async fn packed_prefetch_discovers_one_pack_and_batch_imports_all_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        let backend = test_remote_backend();
+        let daemon = Arc::new(Daemon::new(config));
+        assert!(daemon.remote_backend.set(backend.clone()).is_ok());
+        let deps = vec![("serde".to_string(), "1.0.0".to_string())];
+        let context = PackPrefetchContext::from_deps(
+            crate::cli::default_manifest_key(),
+            "linux/toolchain/release",
+            &deps,
+        )
+        .unwrap();
+        let key_a = test_cache_key("packed-batch-a");
+        let key_b = test_cache_key("packed-batch-b");
+        let (payload_a, meta_a) = build_entry_pack_with_meta(&key_a, "serde");
+        let (payload_b, meta_b) = build_entry_pack_with_meta(&key_b, "tokio");
+        seed_packed_catalog(
+            &backend,
+            &context,
+            vec![
+                crate::remote_pack::PackInputEntry {
+                    cache_key: key_a.clone(),
+                    crate_name: "serde".into(),
+                    meta_digest: meta_a,
+                    payload: payload_a,
+                },
+                crate::remote_pack::PackInputEntry {
+                    cache_key: key_b.clone(),
+                    crate_name: "tokio".into(),
+                    meta_digest: meta_b,
+                    payload: payload_b,
+                },
+            ],
+            None,
+        )
+        .await;
+
+        let response = daemon
+            .handle_prefetch_with_context(
+                &PrefetchRequest {
+                    keys: vec![
+                        (key_a.clone(), "serde".into()),
+                        (key_b.clone(), "tokio".into()),
+                    ],
+                    warm_all: false,
+                },
+                Some(context),
+                Instant::now(),
+            )
+            .await;
+        assert!(response.ok);
+        assert!(
+            daemon
+                .with_store(|store| Ok(store.get(&key_a)?.is_some()))
+                .unwrap()
+        );
+        assert!(
+            daemon
+                .with_store(|store| Ok(store.get(&key_b)?.is_some()))
+                .unwrap()
+        );
+        assert_eq!(
+            daemon
+                .prefetch_stats
+                .pack_requests_total
+                .load(Ordering::Relaxed),
+            3
+        );
+        assert_eq!(
+            daemon
+                .prefetch_stats
+                .v3_requests_total
+                .load(Ordering::Relaxed),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn demand_v3_read_completes_while_a_prefetch_pack_is_blocked() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        let inner = test_remote_backend();
+        let deps = vec![("serde".to_string(), "1.0.0".to_string())];
+        let context = PackPrefetchContext::from_deps(
+            crate::cli::default_manifest_key(),
+            "linux/toolchain/release",
+            &deps,
+        )
+        .unwrap();
+        let packed_key = test_cache_key("blocked-prefetch-pack");
+        let (packed_payload, packed_meta) = build_entry_pack_with_meta(&packed_key, "serde");
+        seed_packed_catalog(
+            &inner,
+            &context,
+            vec![crate::remote_pack::PackInputEntry {
+                cache_key: packed_key.clone(),
+                crate_name: "serde".into(),
+                meta_digest: packed_meta,
+                payload: packed_payload,
+            }],
+            None,
+        )
+        .await;
+
+        let demand_key = test_cache_key("demand-during-packed-prefetch");
+        let demand_payload = build_entry_pack(&demand_key, "tokio");
+        put_test_object(
+            &inner,
+            &test_manifest_object_key(&demand_key, "tokio"),
+            b"{}",
+        )
+        .await;
+        put_test_object(
+            &inner,
+            &test_pack_object_key(&demand_key, "tokio"),
+            &demand_payload,
+        )
+        .await;
+
+        let pack_started = Arc::new(Notify::new());
+        let release_pack = Arc::new(Notify::new());
+        let backend: Arc<dyn crate::remote_backend::RemoteBackend> =
+            Arc::new(BlockingPackBackend {
+                inner,
+                pack_started: pack_started.clone(),
+                release_pack: release_pack.clone(),
+            });
+        let daemon = Arc::new(Daemon::new(config));
+        assert!(daemon.remote_backend.set(backend).is_ok());
+
+        let started = pack_started.notified();
+        tokio::pin!(started);
+        started.as_mut().enable();
+        let packed_daemon = daemon.clone();
+        let packed = tokio::spawn(async move {
+            packed_daemon
+                .handle_prefetch_with_context(
+                    &PrefetchRequest {
+                        keys: vec![(packed_key, "serde".into())],
+                        warm_all: false,
+                    },
+                    Some(context),
+                    Instant::now(),
+                )
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), started)
+            .await
+            .expect("pack GET should block in the injected backend");
+
+        let demand = tokio::time::timeout(
+            Duration::from_secs(1),
+            daemon.handle_remote_check(&RemoteCheckRequest {
+                key: demand_key.clone(),
+                entry_dir: daemon
+                    .entry_dir_for(&demand_key)
+                    .to_string_lossy()
+                    .into_owned(),
+                crate_name: "tokio".into(),
+                deadline_ms: None,
+            }),
+        )
+        .await
+        .expect("demand v3 read must not wait for the pack GET");
+        assert_eq!(demand.found, Some(true));
+
+        release_pack.notify_waiters();
+        assert!(packed.await.unwrap().ok);
+    }
+
+    #[tokio::test]
+    async fn corrupt_pack_falls_back_only_to_the_existing_v3_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        let backend = test_remote_backend();
+        let daemon = Arc::new(Daemon::new(config));
+        assert!(daemon.remote_backend.set(backend.clone()).is_ok());
+        let deps = vec![("serde".to_string(), "1.0.0".to_string())];
+        let context = PackPrefetchContext::from_deps(
+            crate::cli::default_manifest_key(),
+            "linux/toolchain/release",
+            &deps,
+        )
+        .unwrap();
+        let key = test_cache_key("packed-corrupt-fallback");
+        let (payload, meta_digest) = build_entry_pack_with_meta(&key, "serde");
+        seed_packed_catalog(
+            &backend,
+            &context,
+            vec![crate::remote_pack::PackInputEntry {
+                cache_key: key.clone(),
+                crate_name: "serde".into(),
+                meta_digest,
+                payload: payload.clone(),
+            }],
+            Some(b"corrupt immutable pack".to_vec()),
+        )
+        .await;
+        put_test_object(&backend, &test_pack_object_key(&key, "serde"), &payload).await;
+
+        let response = daemon
+            .handle_prefetch_with_context(
+                &PrefetchRequest {
+                    keys: vec![(key.clone(), "serde".into())],
+                    warm_all: false,
+                },
+                Some(context),
+                Instant::now(),
+            )
+            .await;
+        assert!(response.ok);
+        wait_for_store_entry(&daemon, &key).await;
+        assert_eq!(
+            daemon
+                .prefetch_stats
+                .v3_requests_total
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            daemon
+                .prefetch_stats
+                .pack_fallback_entries
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert!(
+            daemon
+                .prefetch_stats
+                .pack_validation_failures
+                .load(Ordering::Relaxed)
+                >= 1
+        );
+    }
+
+    #[tokio::test]
+    async fn traversal_in_one_pack_entry_preserves_valid_batch_and_falls_back_per_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        let backend = test_remote_backend();
+        let daemon = Arc::new(Daemon::new(config));
+        assert!(daemon.remote_backend.set(backend.clone()).is_ok());
+        let deps = vec![("serde".to_string(), "1.0.0".to_string())];
+        let context = PackPrefetchContext::from_deps(
+            crate::cli::default_manifest_key(),
+            "linux/toolchain/release",
+            &deps,
+        )
+        .unwrap();
+        let good_key = test_cache_key("packed-partial-good");
+        let bad_key = test_cache_key("packed-partial-traversal");
+        let (good_payload, good_meta) = build_entry_pack_with_meta(&good_key, "serde");
+        let (fallback_payload, _) = build_entry_pack_with_meta(&bad_key, "tokio");
+        seed_packed_catalog(
+            &backend,
+            &context,
+            vec![
+                crate::remote_pack::PackInputEntry {
+                    cache_key: good_key.clone(),
+                    crate_name: "serde".into(),
+                    meta_digest: good_meta,
+                    payload: good_payload,
+                },
+                crate::remote_pack::PackInputEntry {
+                    cache_key: bad_key.clone(),
+                    crate_name: "tokio".into(),
+                    meta_digest: blake3::hash(b"malicious-meta").to_hex().to_string(),
+                    payload: traversal_entry_payload(),
+                },
+            ],
+            None,
+        )
+        .await;
+        put_test_object(
+            &backend,
+            &test_pack_object_key(&bad_key, "tokio"),
+            &fallback_payload,
+        )
+        .await;
+
+        let response = daemon
+            .handle_prefetch_with_context(
+                &PrefetchRequest {
+                    keys: vec![
+                        (good_key.clone(), "serde".into()),
+                        (bad_key.clone(), "tokio".into()),
+                    ],
+                    warm_all: false,
+                },
+                Some(context),
+                Instant::now(),
+            )
+            .await;
+        assert!(response.ok);
+        wait_for_store_entry(&daemon, &bad_key).await;
+        assert!(
+            daemon
+                .with_store(|store| Ok(store.get(&good_key)?.is_some()))
+                .unwrap()
+        );
+        assert!(!dir.path().join("escape.txt").exists());
+        assert_eq!(
+            daemon
+                .prefetch_stats
+                .v3_requests_total
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            daemon
+                .prefetch_stats
+                .pack_fallback_entries
+                .load(Ordering::Relaxed),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4324,31 +4324,6 @@ impl Daemon {
             );
         }
 
-        if let Some(context) = pack_context.as_ref() {
-            let packed = self
-                .try_packed_prefetch(
-                    context,
-                    &backend,
-                    remote,
-                    &keys_to_fetch,
-                    bytes_at_plan_start,
-                )
-                .await;
-            keys_to_fetch.retain(|(key, _, _)| !packed.contains(key));
-        }
-        let count = keys_to_fetch.len();
-        if count == 0 {
-            let wall_ms = plan_started_at.elapsed().as_millis() as u64;
-            self.prefetch_stats
-                .last_plan_wall_ms
-                .store(wall_ms, Ordering::Relaxed);
-            self.prefetch_stats
-                .plan_wall_ms_total
-                .fetch_add(wall_ms, Ordering::Relaxed);
-            tracing::info!(wall_ms, "prefetch: packed plan complete");
-            return Response::ok();
-        }
-
         // Candidates are deliberately NOT claimed here (kunobi-ninja/kache#613).
         // Claiming the whole plan up front put every candidate in `downloading`
         // before any of them was being downloaded, so a wrapper demanding a key
@@ -4364,6 +4339,19 @@ impl Daemon {
         let remote_config = (*remote).clone();
         let cancel_rx = self.prefetch_cancel.subscribe();
         tokio::spawn(async move {
+            if let Some(context) = pack_context.as_ref() {
+                let packed = daemon
+                    .try_packed_prefetch(
+                        context,
+                        &backend,
+                        &remote_config,
+                        &keys_to_fetch,
+                        bytes_at_plan_start,
+                    )
+                    .await;
+                keys_to_fetch.retain(|(key, _, _)| !packed.contains(key));
+            }
+
             let mut in_flight = futures::stream::FuturesUnordered::new();
             // Speculative prefetch is capped BELOW the S3 permit pool so an
             // interactive RemoteCheck can always acquire a permit without
@@ -12817,6 +12805,8 @@ mod tests {
             )
             .await;
         assert!(response.ok);
+        wait_for_store_entry(&daemon, &key_a).await;
+        wait_for_store_entry(&daemon, &key_b).await;
         assert!(
             daemon
                 .with_store(|store| Ok(store.get(&key_a)?.is_some()))
@@ -12841,6 +12831,70 @@ mod tests {
                 .load(Ordering::Relaxed),
             0
         );
+    }
+
+    #[tokio::test]
+    async fn packed_prefetch_response_returns_before_blocked_pack_get() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        let inner = test_remote_backend();
+        let context = PackPrefetchContext::from_deps(
+            crate::cli::default_manifest_key(),
+            "linux/toolchain/release",
+            &[("serde".to_string(), "1.0.0".to_string())],
+        )
+        .unwrap();
+        let key = test_cache_key("nonblocking-prefetch-pack");
+        let (payload, meta_digest) = build_entry_pack_with_meta(&key, "serde");
+        seed_packed_catalog(
+            &inner,
+            &context,
+            vec![crate::remote_pack::PackInputEntry {
+                cache_key: key.clone(),
+                crate_name: "serde".into(),
+                meta_digest,
+                payload,
+            }],
+            None,
+        )
+        .await;
+
+        let pack_started = Arc::new(Notify::new());
+        let release_pack = Arc::new(Notify::new());
+        let backend: Arc<dyn crate::remote_backend::RemoteBackend> =
+            Arc::new(BlockingPackBackend {
+                inner,
+                pack_started: pack_started.clone(),
+                release_pack: release_pack.clone(),
+            });
+        let daemon = Arc::new(Daemon::new(config));
+        assert!(daemon.remote_backend.set(backend).is_ok());
+
+        let started = pack_started.notified();
+        tokio::pin!(started);
+        started.as_mut().enable();
+        let response = tokio::time::timeout(
+            Duration::from_millis(250),
+            daemon.handle_prefetch_with_context(
+                &PrefetchRequest {
+                    keys: vec![(key.clone(), "serde".into())],
+                    warm_all: false,
+                },
+                Some(context),
+                Instant::now(),
+            ),
+        )
+        .await
+        .expect("prefetch acknowledgement must not await the pack GET");
+        assert!(response.ok);
+        tokio::time::timeout(Duration::from_secs(1), started)
+            .await
+            .expect("background coordinator should start the pack GET");
+        assert!(!daemon.entry_dir_for(&key).exists());
+
+        release_pack.notify_waiters();
+        wait_for_store_entry(&daemon, &key).await;
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod probe;
 mod remote;
 mod remote_backend;
 mod remote_layout;
+mod remote_pack;
 mod remote_plan;
 mod remote_resilience;
 mod report;

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -70,6 +70,14 @@ pub struct GetObject {
     pub body_ms: u64,
 }
 
+/// Outcome of an atomic create-only remote publication.
+#[allow(dead_code)] // consumed by the packed-prefetch publisher in the next slice
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PutIfAbsentResult {
+    Created,
+    AlreadyExists,
+}
+
 /// Byte-object transport backing the remote cache.
 ///
 /// Absence is not an error: `head` answers `false` and `get` answers `None`, so
@@ -89,6 +97,20 @@ pub trait RemoteBackend: Send + Sync {
 
     /// Store `body` at `key`.
     async fn put(&self, key: &str, body: Vec<u8>, content_type: Option<&str>) -> Result<()>;
+
+    /// Store `body` only when `key` is absent, atomically.
+    ///
+    /// Implementations must never emulate this with HEAD followed by PUT: that
+    /// race would let two publishers overwrite an immutable transport object.
+    #[allow(dead_code)] // consumed by the packed-prefetch publisher in the next slice
+    async fn put_if_absent(
+        &self,
+        _key: &str,
+        _body: Vec<u8>,
+        _content_type: Option<&str>,
+    ) -> Result<PutIfAbsentResult> {
+        anyhow::bail!("remote backend does not support atomic create-only publication")
+    }
 
     /// File keys under `prefix`.
     async fn list(&self, prefix: &str) -> Result<Vec<String>>;
@@ -328,6 +350,33 @@ impl RemoteBackend for OpenDalBackend {
         result
             .map(|_| ())
             .map_err(|error| self.contextual_error("PUT", key, error))
+    }
+
+    async fn put_if_absent(
+        &self,
+        key: &str,
+        body: Vec<u8>,
+        content_type: Option<&str>,
+    ) -> Result<PutIfAbsentResult> {
+        self.validate_key("CREATE", key, false)?;
+        self.verify_write_containment(key)?;
+        let request = self.operator.write_with(key, body).if_not_exists(true);
+        let result = match content_type {
+            Some(content_type) => request.content_type(content_type).await,
+            None => request.await,
+        };
+        match result {
+            Ok(_) => Ok(PutIfAbsentResult::Created),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    ErrorKind::ConditionNotMatch | ErrorKind::AlreadyExists
+                ) =>
+            {
+                Ok(PutIfAbsentResult::AlreadyExists)
+            }
+            Err(error) => Err(self.contextual_error("CREATE", key, error)),
+        }
     }
 
     async fn list(&self, prefix: &str) -> Result<Vec<String>> {
@@ -917,6 +966,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_only_put_preserves_the_first_object() {
+        let backend = memory_backend();
+
+        assert_eq!(
+            backend
+                .put_if_absent("immutable/key", b"first".to_vec(), None)
+                .await
+                .unwrap(),
+            PutIfAbsentResult::Created
+        );
+        assert_eq!(
+            backend
+                .put_if_absent("immutable/key", b"second".to_vec(), None)
+                .await
+                .unwrap(),
+            PutIfAbsentResult::AlreadyExists
+        );
+        assert_eq!(
+            backend
+                .get("immutable/key", None)
+                .await
+                .unwrap()
+                .unwrap()
+                .body,
+            "first"
+        );
+    }
+
+    #[tokio::test]
     async fn get_refuses_an_object_over_the_cap() {
         let backend = memory_backend();
         backend.put("key", b"hello".to_vec(), None).await.unwrap();
@@ -1191,6 +1269,45 @@ mod tests {
             request.to_ascii_lowercase().contains("\r\ncontent-md5:"),
             "{request}"
         );
+    }
+
+    #[tokio::test]
+    async fn s3_wire_create_only_put_uses_a_conditional_request() {
+        let conflict = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+            <Error><Code>PreconditionFailed</Code><Message>already exists</Message>\
+            <RequestId>test</RequestId></Error>";
+        let (endpoint, requests) = mock_http_server(vec![
+            http_response("200 OK", ""),
+            http_response("412 Precondition Failed", conflict),
+        ])
+        .await;
+        let backend = anonymous_s3_backend(&endpoint);
+
+        assert_eq!(
+            backend
+                .put_if_absent("immutable", b"first".to_vec(), None)
+                .await
+                .unwrap(),
+            PutIfAbsentResult::Created
+        );
+        assert_eq!(
+            backend
+                .put_if_absent("immutable", b"second".to_vec(), None)
+                .await
+                .unwrap(),
+            PutIfAbsentResult::AlreadyExists
+        );
+
+        let requests = requests.await.unwrap();
+        assert_eq!(requests.len(), 2);
+        for request in requests {
+            assert!(
+                request
+                    .to_ascii_lowercase()
+                    .contains("\r\nif-none-match: *\r\n"),
+                "{request}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -367,15 +367,10 @@ impl RemoteBackend for OpenDalBackend {
         };
         match result {
             Ok(_) => Ok(PutIfAbsentResult::Created),
-            Err(error)
-                if matches!(
-                    error.kind(),
-                    ErrorKind::ConditionNotMatch | ErrorKind::AlreadyExists
-                ) =>
-            {
-                Ok(PutIfAbsentResult::AlreadyExists)
-            }
-            Err(error) => Err(self.contextual_error("CREATE", key, error)),
+            Err(error) => match classify_create_error(error.kind()) {
+                Some(outcome) => Ok(outcome),
+                None => Err(self.contextual_error("CREATE", key, error)),
+            },
         }
     }
 
@@ -479,6 +474,18 @@ fn verify_complete_body(advertised: Option<u64>, read: u64, description: &str) -
         anyhow::bail!("{description} truncated: read {read} bytes, expected {advertised}");
     }
     Ok(())
+}
+
+/// Only failed create preconditions mean that an immutable object already won
+/// the publication race. Authentication, transport, and storage failures must
+/// remain errors rather than being reported as a harmless duplicate.
+fn classify_create_error(kind: ErrorKind) -> Option<PutIfAbsentResult> {
+    match kind {
+        ErrorKind::ConditionNotMatch | ErrorKind::AlreadyExists => {
+            Some(PutIfAbsentResult::AlreadyExists)
+        }
+        _ => None,
+    }
 }
 
 fn without_retry_layer(operator: Operator) -> Operator {
@@ -992,6 +999,20 @@ mod tests {
                 .body,
             "first"
         );
+    }
+
+    #[test]
+    fn create_only_error_classification_is_exact() {
+        assert_eq!(
+            classify_create_error(ErrorKind::ConditionNotMatch),
+            Some(PutIfAbsentResult::AlreadyExists)
+        );
+        assert_eq!(
+            classify_create_error(ErrorKind::AlreadyExists),
+            Some(PutIfAbsentResult::AlreadyExists)
+        );
+        assert_eq!(classify_create_error(ErrorKind::PermissionDenied), None);
+        assert_eq!(classify_create_error(ErrorKind::Unexpected), None);
     }
 
     #[tokio::test]

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -725,8 +725,8 @@ fn copy_dir_all_until(src: &Path, dst: &Path, deadline: Option<Instant>) -> Resu
 mod tests {
     use super::{
         DeadlineReader, DeadlineWriter, HashingWriter, RemoteLayout, V3Manifest, blob_path,
-        copy_dir_all, create_entry_pack_zstd, extract_entry_pack, is_blob_hash, is_rooted_path,
-        is_safe_artifact_name, v3_manifest_key, v3_pack_key,
+        copy_dir_all, create_entry_pack_zstd, extract_entry_pack, extract_verified_prefetch_entry,
+        is_blob_hash, is_rooted_path, is_safe_artifact_name, v3_manifest_key, v3_pack_key,
     };
     use crate::config::{
         Config, DEFAULT_DAEMON_IDLE_TIMEOUT_SECS, DEFAULT_REMOTE_NEGATIVE_TTL_SECS,
@@ -996,6 +996,88 @@ mod tests {
         assert_eq!(std::fs::read(blob).unwrap(), b"hello world");
         assert!(restore_entry_dir.join("meta.json").exists());
         assert!(!restore_entry_dir.join("libfoo.rlib").exists());
+    }
+
+    #[test]
+    fn packed_prefetch_checks_each_outer_and_inner_binding_independently() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = min_config(tmp.path().join("cache"));
+        let store = Store::open(&config).unwrap();
+        let key = blake3::hash(b"packed-binding-key").to_hex().to_string();
+        let other_key = blake3::hash(b"other-packed-binding-key")
+            .to_hex()
+            .to_string();
+        let source = tmp.path().join("source.rlib");
+        std::fs::write(&source, b"packed binding artifact").unwrap();
+        store
+            .put(
+                &key,
+                "serde",
+                &["lib".to_string()],
+                &[],
+                "x86_64-unknown-linux-gnu",
+                "debug",
+                &[(source, "libserde.rlib".to_string())],
+                "",
+                "",
+            )
+            .unwrap();
+        let entry_dir = store.entry_dir(&key);
+        let meta: EntryMeta =
+            serde_json::from_slice(&std::fs::read(entry_dir.join("meta.json")).unwrap()).unwrap();
+        let meta_digest = blake3::hash(&std::fs::read(entry_dir.join("meta.json")).unwrap())
+            .to_hex()
+            .to_string();
+        let packed = create_entry_pack_zstd(&entry_dir, &store.blobs_dir(), &meta, 3).unwrap();
+
+        for (cache_key, crate_name, expected_error) in [
+            ("invalid", "serde", "invalid packed-prefetch entry binding"),
+            (
+                key.as_str(),
+                "../unsafe",
+                "invalid packed-prefetch entry binding",
+            ),
+            (
+                other_key.as_str(),
+                "serde",
+                "packed-prefetch cache-key or crate binding mismatch",
+            ),
+            (
+                key.as_str(),
+                "tokio",
+                "packed-prefetch cache-key or crate binding mismatch",
+            ),
+        ] {
+            let restored = tmp
+                .path()
+                .join(format!("restored-{}", blake3::hash(cache_key.as_bytes())));
+            let err = extract_verified_prefetch_entry(
+                cache_key,
+                crate_name,
+                &meta_digest,
+                &packed,
+                &restored,
+                None,
+            )
+            .err()
+            .expect("a mismatched binding must be rejected");
+            assert!(
+                err.to_string().contains(expected_error),
+                "expected {expected_error:?}, got {err}"
+            );
+            assert!(!restored.exists());
+        }
+
+        let restored = tmp.path().join("restored-invalid-meta-digest");
+        let err =
+            extract_verified_prefetch_entry(&key, "serde", "invalid", &packed, &restored, None)
+                .err()
+                .expect("a malformed metadata digest must be rejected at the outer binding gate");
+        assert!(
+            err.to_string()
+                .contains("invalid packed-prefetch entry binding")
+        );
+        assert!(!restored.exists());
     }
 
     #[test]

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use crate::config::RemoteConfig;
 use crate::remote::{DownloadResult, UploadResult};
 use crate::remote_backend::RemoteBackend;
-use crate::store::EntryMeta;
+use crate::store::{EntryMeta, VerifiedRestoredEntry};
 
 const V3_ROOT: &str = "v3";
 const V3_MANIFESTS: &str = "manifests";
@@ -51,6 +51,21 @@ pub struct RemoteLayout<'a> {
 pub struct RemoteUploadResult {
     pub format: &'static str,
     pub transfer: UploadResult,
+}
+
+/// A packed-prefetch entry validated while its artifact bytes were streamed
+/// to disk. The store can batch-register this without hashing the artifacts a
+/// second time.
+pub(crate) struct VerifiedPackEntry {
+    pub restored: VerifiedRestoredEntry,
+    pub original_bytes: u64,
+    pub extract_ms: u64,
+}
+
+struct ExpectedEntryBinding<'a> {
+    cache_key: &'a str,
+    crate_name: &'a str,
+    meta_digest: &'a str,
 }
 
 impl<'a> RemoteLayout<'a> {
@@ -120,14 +135,14 @@ impl<'a> RemoteLayout<'a> {
         decoder
             .window_log_max(MAX_ZSTD_WINDOW_LOG)
             .context("setting v3 zstd window-log cap")?;
-        let original_bytes = extract_entry_pack_until(decoder, entry_dir, deadline)?;
+        let extracted = extract_entry_pack_until(decoder, entry_dir, deadline, None)?;
         let extract_ms = extract_start.elapsed().as_millis() as u64;
 
         Ok(DownloadResult {
             format: "v3",
             object_key,
             compressed_bytes: compressed_len,
-            original_bytes,
+            original_bytes: extracted.original_bytes,
             network_ms: request_ms + body_ms,
             request_ms,
             body_ms,
@@ -278,6 +293,54 @@ impl<'a> RemoteLayout<'a> {
 
         Ok(keys)
     }
+}
+
+/// Extract one existing v3 payload carried inside an immutable prefetch pack.
+/// The outer pack binds cache key, crate and exact `meta.json` digest; this
+/// function verifies those bindings plus every artifact hash before publishing
+/// the entry directory.
+pub(crate) fn extract_verified_prefetch_entry(
+    cache_key: &str,
+    crate_name: &str,
+    meta_digest: &str,
+    payload: &[u8],
+    entry_dir: &Path,
+    deadline: Option<Instant>,
+) -> Result<VerifiedPackEntry> {
+    if !crate::cache_key::is_valid_cache_key(cache_key)
+        || !crate::cache_key::is_valid_crate_name(crate_name)
+        || !crate::cache_key::is_valid_cache_key(meta_digest)
+    {
+        bail!("invalid packed-prefetch entry binding");
+    }
+    let extract_start = Instant::now();
+    let guarded = DeadlineReader {
+        inner: std::io::Cursor::new(payload),
+        deadline,
+    };
+    let mut decoder = zstd::stream::Decoder::new(guarded)
+        .context("creating packed-prefetch entry zstd decoder")?;
+    decoder
+        .window_log_max(MAX_ZSTD_WINDOW_LOG)
+        .context("setting packed-prefetch zstd window-log cap")?;
+    let extracted = extract_entry_pack_until(
+        decoder,
+        entry_dir,
+        deadline,
+        Some(ExpectedEntryBinding {
+            cache_key,
+            crate_name,
+            meta_digest,
+        }),
+    )?;
+    Ok(VerifiedPackEntry {
+        restored: VerifiedRestoredEntry {
+            cache_key: cache_key.to_string(),
+            meta: extracted.meta,
+        },
+        original_bytes: extracted.original_bytes,
+        extract_ms: extract_start.elapsed().as_millis() as u64,
+    })
 }
 
 fn v3_manifest_key(prefix: &str, cache_key: &str, crate_name: &str) -> String {
@@ -471,14 +534,20 @@ fn is_rooted_path(path: &Path) -> bool {
 
 #[cfg(test)]
 fn extract_entry_pack<R: std::io::Read>(reader: R, dest_dir: &Path) -> Result<u64> {
-    extract_entry_pack_until(reader, dest_dir, None)
+    Ok(extract_entry_pack_until(reader, dest_dir, None, None)?.original_bytes)
+}
+
+struct ExtractedEntry {
+    original_bytes: u64,
+    meta: EntryMeta,
 }
 
 fn extract_entry_pack_until<R: std::io::Read>(
     reader: R,
     dest_dir: &Path,
     deadline: Option<Instant>,
-) -> Result<u64> {
+    expected: Option<ExpectedEntryBinding<'_>>,
+) -> Result<ExtractedEntry> {
     deadline_io_check(deadline, "extraction setup")?;
     let parent = dest_dir.parent().unwrap_or(Path::new("/tmp"));
     std::fs::create_dir_all(parent)?;
@@ -555,6 +624,27 @@ fn extract_entry_pack_until<R: std::io::Read>(
         std::fs::read_to_string(&meta_path).context("reading downloaded meta.json")?;
     let meta: EntryMeta =
         serde_json::from_str(&meta_content).context("parsing downloaded meta.json")?;
+    if meta.key_schema != crate::cache_key::CACHE_KEY_VERSION {
+        bail!(
+            "downloaded entry uses incompatible key schema {}",
+            meta.key_schema
+        );
+    }
+    if let Some(expected) = expected {
+        if meta.cache_key != expected.cache_key || meta.crate_name != expected.crate_name {
+            bail!("packed-prefetch cache-key or crate binding mismatch");
+        }
+        let actual_meta_digest = computed_hashes
+            .get(Path::new("meta.json"))
+            .context("missing streamed meta.json digest")?;
+        if actual_meta_digest != expected.meta_digest {
+            bail!(
+                "packed-prefetch meta.json digest mismatch (expected {}, got {})",
+                expected.meta_digest,
+                actual_meta_digest
+            );
+        }
+    }
     // Validate declared fields from the untrusted meta.json before they flow
     // into hash/path logic (#211). A malformed hash or an unsafe file name is a
     // hostile/corrupt remote — reject loudly rather than build a bad path.
@@ -566,12 +656,7 @@ fn extract_entry_pack_until<R: std::io::Read>(
                 cached_file.hash
             );
         }
-        let name = Path::new(&cached_file.name);
-        if is_rooted_path(name)
-            || name
-                .components()
-                .any(|c| c == std::path::Component::ParentDir)
-        {
+        if !is_safe_artifact_name(&cached_file.name) {
             bail!(
                 "downloaded entry declares an unsafe file name: {:?}",
                 cached_file.name
@@ -608,7 +693,10 @@ fn extract_entry_pack_until<R: std::io::Read>(
 
     deadline_io_check(deadline, "entry publication")?;
 
-    Ok(total_bytes)
+    Ok(ExtractedEntry {
+        original_bytes: total_bytes,
+        meta,
+    })
 }
 
 #[cfg(test)]

--- a/src/remote_pack.rs
+++ b/src/remote_pack.rs
@@ -25,7 +25,7 @@ pub(crate) const CATALOG_CONTENT_TYPE: &str = "application/vnd.kache.prefetch-ca
 const PACK_MAGIC: &[u8; 8] = b"KACHPK01";
 const PACK_HEADER_BYTES: usize = PACK_MAGIC.len() + size_of::<u64>();
 const MAX_PACK_INDEX_BYTES: usize = 16 * 1024 * 1024;
-const MAX_CATALOG_BYTES: usize = 64 * 1024 * 1024;
+pub(crate) const MAX_CATALOG_BYTES: usize = 64 * 1024 * 1024;
 const MAX_PACK_ENTRIES: usize = 65_536;
 const MAX_CATALOG_PACKS: usize = 16_384;
 const MAX_SELECTOR_TEXT_BYTES: usize = 4096;
@@ -127,6 +127,13 @@ pub(crate) struct EncodedCatalog {
     pub digest: String,
     pub object_key: String,
     pub catalog: PackCatalog,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CatalogObjectRef {
+    pub object_key: String,
+    pub created_at_ms: u64,
+    pub digest: String,
 }
 
 /// Stable selector for one manifest/build namespace and Cargo.lock shard set.
@@ -375,6 +382,81 @@ pub(crate) fn decode_catalog(bytes: &[u8], expected_digest: &str) -> Result<Pack
         bail!("prefetch pack catalog is not canonically ordered");
     }
     Ok(catalog)
+}
+
+pub(crate) fn decode_catalog_for_selector(
+    bytes: &[u8],
+    expected_digest: &str,
+    expected_selector: &str,
+    now_ms: u64,
+) -> Result<PackCatalog> {
+    let catalog = decode_catalog(bytes, expected_digest)?;
+    if catalog.selector_hash != expected_selector {
+        bail!("prefetch catalog does not match the requested selector");
+    }
+    if catalog.expires_at_ms <= now_ms {
+        bail!("prefetch catalog expired at {}", catalog.expires_at_ms);
+    }
+    Ok(catalog)
+}
+
+/// Choose the newest syntactically valid immutable catalog object. Catalog
+/// contents remain untrusted until [`decode_catalog_for_selector`] succeeds.
+pub(crate) fn latest_catalog_object(
+    prefix: &str,
+    selector: &str,
+    object_keys: &[String],
+) -> Result<Option<CatalogObjectRef>> {
+    let expected_prefix = catalog_prefix(prefix, selector)?;
+    Ok(object_keys
+        .iter()
+        .filter_map(|key| parse_catalog_object_ref(&expected_prefix, key))
+        .max_by(|left, right| {
+            (left.created_at_ms, &left.digest).cmp(&(right.created_at_ms, &right.digest))
+        }))
+}
+
+fn parse_catalog_object_ref(prefix: &str, key: &str) -> Option<CatalogObjectRef> {
+    let filename = key.strip_prefix(prefix)?.strip_suffix(".json")?;
+    let (created_at, digest) = filename.split_once('-')?;
+    if created_at.len() != 20 || !created_at.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    if validate_digest("catalog digest", digest).is_err() {
+        return None;
+    }
+    Some(CatalogObjectRef {
+        object_key: key.to_string(),
+        created_at_ms: created_at.parse().ok()?,
+        digest: digest.to_string(),
+    })
+}
+
+pub(crate) fn decode_catalog_pack<'a>(
+    bytes: &'a [u8],
+    pack: &CatalogPackRef,
+    max_bytes: u64,
+) -> Result<DecodedPack<'a>> {
+    if bytes.len() as u64 != pack.pack_bytes {
+        bail!(
+            "prefetch pack size mismatch (catalog {}, object {})",
+            pack.pack_bytes,
+            bytes.len()
+        );
+    }
+    let decoded = decode_pack(bytes, &pack.digest, max_bytes)?;
+    if decoded.entries.len() != pack.entries.len() {
+        bail!("prefetch pack entry count does not match its catalog");
+    }
+    for (decoded, catalog) in decoded.entries.iter().zip(&pack.entries) {
+        if decoded.descriptor.cache_key != catalog.cache_key
+            || decoded.descriptor.crate_name != catalog.crate_name
+            || decoded.descriptor.meta_digest != catalog.meta_digest
+        {
+            bail!("prefetch pack index does not match its catalog binding");
+        }
+    }
+    Ok(decoded)
 }
 
 fn canonicalize_catalog(mut catalog: PackCatalog) -> Result<PackCatalog> {

--- a/src/remote_pack.rs
+++ b/src/remote_pack.rs
@@ -1,0 +1,808 @@
+//! Immutable multi-entry transport packs for speculative remote prefetch.
+//!
+//! A pack is a thin frame around existing v3 entry-pack payloads, not another
+//! compression layer. That keeps byte overhead bounded and lets the importer
+//! reuse established per-entry zstd/tar validation:
+//!
+//! `KACHPK01 | index_len: u64 LE | PackIndex JSON | v3 payloads...`
+//!
+//! Offsets are relative to the payload section, avoiding a circular dependency
+//! between JSON length and encoded offsets.
+
+#![allow(dead_code)] // foundations consumed by publisher/discovery slices
+
+use std::collections::HashSet;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+pub(crate) const PACK_VERSION: u32 = 1;
+pub(crate) const CATALOG_VERSION: u32 = 1;
+pub(crate) const DEFAULT_MAX_PACK_BYTES: u64 = 256 * 1024 * 1024;
+pub(crate) const PACK_CONTENT_TYPE: &str = "application/vnd.kache.prefetch-pack.v1";
+pub(crate) const CATALOG_CONTENT_TYPE: &str = "application/vnd.kache.prefetch-catalog.v1+json";
+
+const PACK_MAGIC: &[u8; 8] = b"KACHPK01";
+const PACK_HEADER_BYTES: usize = PACK_MAGIC.len() + size_of::<u64>();
+const MAX_PACK_INDEX_BYTES: usize = 16 * 1024 * 1024;
+const MAX_CATALOG_BYTES: usize = 64 * 1024 * 1024;
+const MAX_PACK_ENTRIES: usize = 65_536;
+const MAX_CATALOG_PACKS: usize = 16_384;
+const MAX_SELECTOR_TEXT_BYTES: usize = 4096;
+
+#[derive(Debug, Clone)]
+pub(crate) struct PackInputEntry {
+    pub cache_key: String,
+    pub crate_name: String,
+    /// BLAKE3 of the exact `meta.json` carried by `payload`.
+    pub meta_digest: String,
+    /// Existing v3 tar.zst entry-pack bytes.
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PackIndexEntry {
+    pub cache_key: String,
+    pub crate_name: String,
+    pub meta_digest: String,
+    /// Byte offset relative to the first payload byte.
+    pub offset: u64,
+    pub length: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PackIndex {
+    pub version: u32,
+    pub key_schema: u32,
+    pub entries: Vec<PackIndexEntry>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BuiltPack {
+    pub bytes: Vec<u8>,
+    pub digest: String,
+    pub object_key: String,
+    pub index: PackIndex,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DecodedPackEntry<'a> {
+    pub descriptor: PackIndexEntry,
+    pub payload: &'a [u8],
+}
+
+#[derive(Debug)]
+pub(crate) struct DecodedPack<'a> {
+    pub index: PackIndex,
+    pub entries: Vec<DecodedPackEntry<'a>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CatalogEntry {
+    pub cache_key: String,
+    pub crate_name: String,
+    pub meta_digest: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CatalogPackRef {
+    pub digest: String,
+    pub pack_bytes: u64,
+    pub entries: Vec<CatalogEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PackCatalog {
+    pub version: u32,
+    pub key_schema: u32,
+    pub manifest_key: String,
+    pub namespace: String,
+    pub selector_hash: String,
+    pub shard_hashes: Vec<String>,
+    pub created_at_ms: u64,
+    pub expires_at_ms: u64,
+    pub packs: Vec<CatalogPackRef>,
+    /// Entries deliberately left on v3, for example one entry larger than the
+    /// pack cap. Discovery schedules these through the compatibility path.
+    pub fallback_entries: Vec<CatalogEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PackMeta {
+    pub version: u32,
+    pub digest: String,
+    pub pack_bytes: u64,
+    pub created_at_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct EncodedCatalog {
+    pub bytes: Vec<u8>,
+    pub digest: String,
+    pub object_key: String,
+    pub catalog: PackCatalog,
+}
+
+/// Stable selector for one manifest/build namespace and Cargo.lock shard set.
+/// Raw user-controlled text is length-prefixed into BLAKE3 and never used as an
+/// object-key path component.
+pub(crate) fn selector_hash(
+    manifest_key: &str,
+    namespace: &str,
+    shard_hashes: &[String],
+    key_schema: u32,
+) -> Result<String> {
+    validate_selector_text("manifest key", manifest_key)?;
+    validate_selector_text("namespace", namespace)?;
+    let mut shards = shard_hashes.to_vec();
+    shards.sort();
+    if shards.windows(2).any(|pair| pair[0] == pair[1]) {
+        bail!("selector contains duplicate Cargo.lock shard hashes");
+    }
+    for shard in &shards {
+        validate_digest("Cargo.lock shard hash", shard)?;
+    }
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"kache-prefetch-selector-v1");
+    hash_field(&mut hasher, manifest_key.as_bytes());
+    hash_field(&mut hasher, namespace.as_bytes());
+    hasher.update(&key_schema.to_le_bytes());
+    hasher.update(&(shards.len() as u64).to_le_bytes());
+    for shard in &shards {
+        hash_field(&mut hasher, shard.as_bytes());
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+pub(crate) fn pack_object_key(prefix: &str, digest: &str) -> Result<String> {
+    validate_digest("pack digest", digest)?;
+    Ok(crate::config::join_remote_key(
+        prefix,
+        &format!("v4/prefetch/packs/{}/{}.kpack", &digest[..2], digest),
+    ))
+}
+
+pub(crate) fn pack_meta_object_key(prefix: &str, digest: &str) -> Result<String> {
+    validate_digest("pack digest", digest)?;
+    Ok(crate::config::join_remote_key(
+        prefix,
+        &format!("v4/prefetch/pack-meta/{digest}.json"),
+    ))
+}
+
+pub(crate) fn catalog_prefix(prefix: &str, selector: &str) -> Result<String> {
+    validate_digest("catalog selector", selector)?;
+    Ok(crate::config::join_remote_key(
+        prefix,
+        &format!("v4/prefetch/catalogs/{selector}/"),
+    ))
+}
+
+pub(crate) fn catalog_object_key(
+    prefix: &str,
+    selector: &str,
+    created_at_ms: u64,
+    digest: &str,
+) -> Result<String> {
+    validate_digest("catalog selector", selector)?;
+    validate_digest("catalog digest", digest)?;
+    Ok(crate::config::join_remote_key(
+        prefix,
+        &format!("v4/prefetch/catalogs/{selector}/{created_at_ms:020}-{digest}.json"),
+    ))
+}
+
+pub(crate) fn build_pack(
+    prefix: &str,
+    mut entries: Vec<PackInputEntry>,
+    max_bytes: u64,
+) -> Result<BuiltPack> {
+    validate_pack_cap(max_bytes)?;
+    if entries.is_empty() {
+        bail!("cannot build an empty prefetch pack");
+    }
+    if entries.len() > MAX_PACK_ENTRIES {
+        bail!("prefetch pack has too many entries: {}", entries.len());
+    }
+    entries.sort_by(|left, right| {
+        (&left.cache_key, &left.crate_name).cmp(&(&right.cache_key, &right.crate_name))
+    });
+
+    let mut index_entries = Vec::with_capacity(entries.len());
+    let mut next_offset = 0_u64;
+    let mut previous_key: Option<&str> = None;
+    for entry in &entries {
+        validate_entry_fields(&entry.cache_key, &entry.crate_name, &entry.meta_digest)?;
+        if previous_key == Some(entry.cache_key.as_str()) {
+            bail!(
+                "prefetch pack contains duplicate cache key {}",
+                entry.cache_key
+            );
+        }
+        previous_key = Some(&entry.cache_key);
+        if entry.payload.is_empty() {
+            bail!(
+                "prefetch pack entry {} has an empty v3 payload",
+                entry.cache_key
+            );
+        }
+        let length = u64::try_from(entry.payload.len()).context("entry payload length overflow")?;
+        index_entries.push(PackIndexEntry {
+            cache_key: entry.cache_key.clone(),
+            crate_name: entry.crate_name.clone(),
+            meta_digest: entry.meta_digest.clone(),
+            offset: next_offset,
+            length,
+        });
+        next_offset = next_offset
+            .checked_add(length)
+            .context("prefetch pack payload length overflow")?;
+    }
+
+    let index = PackIndex {
+        version: PACK_VERSION,
+        key_schema: crate::cache_key::CACHE_KEY_VERSION,
+        entries: index_entries,
+    };
+    let index_json = serde_json::to_vec(&index).context("serializing prefetch pack index")?;
+    if index_json.len() > MAX_PACK_INDEX_BYTES {
+        bail!("prefetch pack index exceeds {MAX_PACK_INDEX_BYTES} bytes");
+    }
+    let payload_len = usize::try_from(next_offset).context("prefetch payload length overflow")?;
+    let total_len = PACK_HEADER_BYTES
+        .checked_add(index_json.len())
+        .and_then(|len| len.checked_add(payload_len))
+        .context("prefetch pack length overflow")?;
+    if total_len as u64 > max_bytes {
+        bail!("prefetch pack is {total_len} bytes, above the {max_bytes}-byte cap");
+    }
+
+    let mut bytes = Vec::with_capacity(total_len);
+    bytes.extend_from_slice(PACK_MAGIC);
+    bytes.extend_from_slice(&(index_json.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(&index_json);
+    for entry in entries {
+        bytes.extend_from_slice(&entry.payload);
+    }
+    debug_assert_eq!(bytes.len(), total_len);
+    let digest = blake3::hash(&bytes).to_hex().to_string();
+    let object_key = pack_object_key(prefix, &digest)?;
+    Ok(BuiltPack {
+        bytes,
+        digest,
+        object_key,
+        index,
+    })
+}
+
+pub(crate) fn decode_pack<'a>(
+    bytes: &'a [u8],
+    expected_digest: &str,
+    max_bytes: u64,
+) -> Result<DecodedPack<'a>> {
+    validate_pack_cap(max_bytes)?;
+    validate_digest("expected pack digest", expected_digest)?;
+    if bytes.len() as u64 > max_bytes {
+        bail!(
+            "prefetch pack is {} bytes, above the {max_bytes}-byte cap",
+            bytes.len()
+        );
+    }
+    let actual_digest = blake3::hash(bytes).to_hex().to_string();
+    if actual_digest != expected_digest {
+        bail!("prefetch pack digest mismatch (expected {expected_digest}, got {actual_digest})");
+    }
+    if bytes.len() < PACK_HEADER_BYTES || &bytes[..PACK_MAGIC.len()] != PACK_MAGIC {
+        bail!("invalid prefetch pack magic or truncated header");
+    }
+    let index_len = u64::from_le_bytes(
+        bytes[PACK_MAGIC.len()..PACK_HEADER_BYTES]
+            .try_into()
+            .expect("fixed-size header slice"),
+    );
+    let index_len = usize::try_from(index_len).context("prefetch pack index length overflow")?;
+    if index_len > MAX_PACK_INDEX_BYTES {
+        bail!("prefetch pack index exceeds {MAX_PACK_INDEX_BYTES} bytes");
+    }
+    let payload_start = PACK_HEADER_BYTES
+        .checked_add(index_len)
+        .context("prefetch pack index length overflow")?;
+    if payload_start > bytes.len() {
+        bail!("prefetch pack index length exceeds object length");
+    }
+    let index: PackIndex = serde_json::from_slice(&bytes[PACK_HEADER_BYTES..payload_start])
+        .context("parsing prefetch pack index")?;
+    let payload = &bytes[payload_start..];
+    validate_pack_index(&index, payload.len())?;
+
+    let entries = index
+        .entries
+        .iter()
+        .map(|entry| {
+            let start = usize::try_from(entry.offset).expect("validated offset fits usize");
+            let end = usize::try_from(entry.offset + entry.length)
+                .expect("validated payload end fits usize");
+            DecodedPackEntry {
+                descriptor: entry.clone(),
+                payload: &payload[start..end],
+            }
+        })
+        .collect();
+    Ok(DecodedPack { index, entries })
+}
+
+pub(crate) fn encode_catalog(prefix: &str, catalog: PackCatalog) -> Result<EncodedCatalog> {
+    let catalog = canonicalize_catalog(catalog)?;
+    let bytes = serde_json::to_vec(&catalog).context("serializing prefetch pack catalog")?;
+    if bytes.len() > MAX_CATALOG_BYTES {
+        bail!("prefetch pack catalog exceeds {MAX_CATALOG_BYTES} bytes");
+    }
+    let digest = blake3::hash(&bytes).to_hex().to_string();
+    let object_key = catalog_object_key(
+        prefix,
+        &catalog.selector_hash,
+        catalog.created_at_ms,
+        &digest,
+    )?;
+    Ok(EncodedCatalog {
+        bytes,
+        digest,
+        object_key,
+        catalog,
+    })
+}
+
+pub(crate) fn decode_catalog(bytes: &[u8], expected_digest: &str) -> Result<PackCatalog> {
+    validate_digest("expected catalog digest", expected_digest)?;
+    if bytes.len() > MAX_CATALOG_BYTES {
+        bail!("prefetch pack catalog exceeds {MAX_CATALOG_BYTES} bytes");
+    }
+    let actual_digest = blake3::hash(bytes).to_hex().to_string();
+    if actual_digest != expected_digest {
+        bail!("prefetch catalog digest mismatch (expected {expected_digest}, got {actual_digest})");
+    }
+    let catalog: PackCatalog =
+        serde_json::from_slice(bytes).context("parsing prefetch pack catalog")?;
+    let canonical = canonicalize_catalog(catalog.clone())?;
+    if canonical != catalog {
+        bail!("prefetch pack catalog is not canonically ordered");
+    }
+    Ok(catalog)
+}
+
+fn canonicalize_catalog(mut catalog: PackCatalog) -> Result<PackCatalog> {
+    catalog.shard_hashes.sort();
+    for pack in &mut catalog.packs {
+        pack.entries.sort_by(|left, right| {
+            (&left.cache_key, &left.crate_name).cmp(&(&right.cache_key, &right.crate_name))
+        });
+    }
+    catalog
+        .packs
+        .sort_by(|left, right| left.digest.cmp(&right.digest));
+    catalog.fallback_entries.sort_by(|left, right| {
+        (&left.cache_key, &left.crate_name).cmp(&(&right.cache_key, &right.crate_name))
+    });
+    validate_catalog(&catalog)?;
+    Ok(catalog)
+}
+
+fn validate_catalog(catalog: &PackCatalog) -> Result<()> {
+    if catalog.version != CATALOG_VERSION {
+        bail!("unsupported prefetch catalog version {}", catalog.version);
+    }
+    if catalog.key_schema != crate::cache_key::CACHE_KEY_VERSION {
+        bail!(
+            "prefetch catalog key schema {} does not match current recipe {}",
+            catalog.key_schema,
+            crate::cache_key::CACHE_KEY_VERSION
+        );
+    }
+    validate_selector_text("manifest key", &catalog.manifest_key)?;
+    validate_selector_text("namespace", &catalog.namespace)?;
+    if catalog.created_at_ms >= catalog.expires_at_ms {
+        bail!("prefetch catalog expiry must be after creation");
+    }
+    if catalog
+        .shard_hashes
+        .windows(2)
+        .any(|pair| pair[0] == pair[1])
+    {
+        bail!("prefetch catalog contains duplicate Cargo.lock shard hashes");
+    }
+    for shard in &catalog.shard_hashes {
+        validate_digest("Cargo.lock shard hash", shard)?;
+    }
+    let expected_selector = selector_hash(
+        &catalog.manifest_key,
+        &catalog.namespace,
+        &catalog.shard_hashes,
+        catalog.key_schema,
+    )?;
+    if catalog.selector_hash != expected_selector {
+        bail!(
+            "prefetch catalog selector mismatch (expected {expected_selector}, got {})",
+            catalog.selector_hash
+        );
+    }
+    if catalog.packs.len() > MAX_CATALOG_PACKS {
+        bail!(
+            "prefetch catalog has too many packs: {}",
+            catalog.packs.len()
+        );
+    }
+
+    let mut pack_digests = HashSet::new();
+    let mut cache_keys = HashSet::new();
+    let mut total_entries = 0usize;
+    for pack in &catalog.packs {
+        validate_digest("pack digest", &pack.digest)?;
+        if !pack_digests.insert(&pack.digest) {
+            bail!("prefetch catalog contains duplicate pack {}", pack.digest);
+        }
+        if pack.pack_bytes == 0 || pack.pack_bytes > DEFAULT_MAX_PACK_BYTES {
+            bail!(
+                "prefetch catalog pack {} has invalid size {}",
+                pack.digest,
+                pack.pack_bytes
+            );
+        }
+        if pack.entries.is_empty() || pack.entries.len() > MAX_PACK_ENTRIES {
+            bail!(
+                "prefetch catalog pack {} has an invalid entry count",
+                pack.digest
+            );
+        }
+        for entry in &pack.entries {
+            validate_entry(entry)?;
+            if !cache_keys.insert(&entry.cache_key) {
+                bail!(
+                    "prefetch catalog contains duplicate cache key {}",
+                    entry.cache_key
+                );
+            }
+        }
+        total_entries = total_entries
+            .checked_add(pack.entries.len())
+            .context("prefetch catalog entry count overflow")?;
+    }
+    for entry in &catalog.fallback_entries {
+        validate_entry(entry)?;
+        if !cache_keys.insert(&entry.cache_key) {
+            bail!(
+                "prefetch catalog contains duplicate cache key {}",
+                entry.cache_key
+            );
+        }
+    }
+    total_entries = total_entries
+        .checked_add(catalog.fallback_entries.len())
+        .context("prefetch catalog entry count overflow")?;
+    if total_entries > MAX_PACK_ENTRIES {
+        bail!("prefetch catalog has too many entries: {total_entries}");
+    }
+    Ok(())
+}
+
+fn validate_pack_index(index: &PackIndex, payload_len: usize) -> Result<()> {
+    if index.version != PACK_VERSION {
+        bail!("unsupported prefetch pack version {}", index.version);
+    }
+    if index.key_schema != crate::cache_key::CACHE_KEY_VERSION {
+        bail!(
+            "prefetch pack key schema {} does not match current recipe {}",
+            index.key_schema,
+            crate::cache_key::CACHE_KEY_VERSION
+        );
+    }
+    if index.entries.is_empty() || index.entries.len() > MAX_PACK_ENTRIES {
+        bail!("prefetch pack has an invalid entry count");
+    }
+    let mut expected_offset = 0_u64;
+    let mut previous_key: Option<&str> = None;
+    for entry in &index.entries {
+        validate_entry_fields(&entry.cache_key, &entry.crate_name, &entry.meta_digest)?;
+        if previous_key.is_some_and(|previous| previous >= entry.cache_key.as_str()) {
+            bail!("prefetch pack entries are duplicated or not canonically ordered");
+        }
+        previous_key = Some(&entry.cache_key);
+        if entry.offset != expected_offset || entry.length == 0 {
+            bail!("prefetch pack entry frames overlap, contain a gap, or are empty");
+        }
+        expected_offset = expected_offset
+            .checked_add(entry.length)
+            .context("prefetch pack frame length overflow")?;
+    }
+    if expected_offset != payload_len as u64 {
+        bail!(
+            "prefetch pack frame lengths total {expected_offset} bytes, object contains {payload_len}"
+        );
+    }
+    Ok(())
+}
+
+fn validate_pack_cap(max_bytes: u64) -> Result<()> {
+    if max_bytes == 0 || max_bytes > DEFAULT_MAX_PACK_BYTES {
+        bail!(
+            "prefetch pack cap must be between 1 and {DEFAULT_MAX_PACK_BYTES} bytes, got {max_bytes}"
+        );
+    }
+    Ok(())
+}
+
+fn validate_entry(entry: &CatalogEntry) -> Result<()> {
+    validate_entry_fields(&entry.cache_key, &entry.crate_name, &entry.meta_digest)
+}
+
+fn validate_entry_fields(cache_key: &str, crate_name: &str, meta_digest: &str) -> Result<()> {
+    if !crate::cache_key::is_valid_cache_key(cache_key) {
+        bail!("prefetch metadata contains invalid cache key {cache_key:?}");
+    }
+    if !crate::cache_key::is_valid_crate_name(crate_name) {
+        bail!("prefetch metadata contains unsafe crate name {crate_name:?}");
+    }
+    validate_digest("entry metadata digest", meta_digest)
+}
+
+fn validate_digest(label: &str, value: &str) -> Result<()> {
+    if !crate::cache_key::is_valid_cache_key(value) {
+        bail!("{label} is not a lowercase BLAKE3 digest: {value:?}");
+    }
+    Ok(())
+}
+
+fn validate_selector_text(label: &str, value: &str) -> Result<()> {
+    if value.is_empty()
+        || value.len() > MAX_SELECTOR_TEXT_BYTES
+        || value.chars().any(char::is_control)
+    {
+        bail!("prefetch {label} is empty, too long, or contains control characters");
+    }
+    Ok(())
+}
+
+fn hash_field(hasher: &mut blake3::Hasher, value: &[u8]) {
+    hasher.update(&(value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(label: &str) -> String {
+        blake3::hash(label.as_bytes()).to_hex().to_string()
+    }
+
+    fn input(label: &str, crate_name: &str, payload: &[u8]) -> PackInputEntry {
+        PackInputEntry {
+            cache_key: digest(label),
+            crate_name: crate_name.to_string(),
+            meta_digest: digest(&format!("meta-{label}")),
+            payload: payload.to_vec(),
+        }
+    }
+
+    #[test]
+    fn pack_encoding_is_deterministic_and_round_trips() {
+        let one = input("one", "serde", b"first-v3-pack");
+        let two = input("two", "tokio", b"second-v3-pack");
+
+        let forward = build_pack("artifacts", vec![one.clone(), two.clone()], 4096).unwrap();
+        let reversed = build_pack("artifacts", vec![two, one], 4096).unwrap();
+        assert_eq!(forward.bytes, reversed.bytes);
+        assert_eq!(forward.digest, reversed.digest);
+        assert_eq!(
+            forward.object_key,
+            format!(
+                "artifacts/v4/prefetch/packs/{}/{}.kpack",
+                &forward.digest[..2],
+                forward.digest
+            )
+        );
+
+        let decoded = decode_pack(&forward.bytes, &forward.digest, 4096).unwrap();
+        assert_eq!(decoded.entries.len(), 2);
+        let by_key = decoded
+            .entries
+            .iter()
+            .map(|entry| (entry.descriptor.cache_key.as_str(), entry.payload))
+            .collect::<std::collections::HashMap<_, _>>();
+        assert_eq!(
+            by_key.get(digest("one").as_str()).copied(),
+            Some(b"first-v3-pack".as_slice())
+        );
+        assert_eq!(
+            by_key.get(digest("two").as_str()).copied(),
+            Some(b"second-v3-pack".as_slice())
+        );
+    }
+
+    #[test]
+    fn pack_rejects_duplicates_traversal_digest_length_and_cap_violations() {
+        let one = input("one", "serde", b"first");
+        assert!(build_pack("", vec![one.clone(), one.clone()], 4096).is_err());
+
+        let mut traversal = one.clone();
+        traversal.crate_name = "../escape".to_string();
+        assert!(build_pack("", vec![traversal], 4096).is_err());
+
+        let built = build_pack("", vec![one], 4096).unwrap();
+        assert!(build_pack("", vec![input("tiny-cap", "serde", b"x")], 1).is_err());
+        assert!(decode_pack(&built.bytes, &digest("wrong"), 4096).is_err());
+        assert!(decode_pack(&built.bytes, &built.digest, 1).is_err());
+
+        let mut truncated = built.bytes.clone();
+        truncated.pop();
+        let truncated_digest = blake3::hash(&truncated).to_hex().to_string();
+        assert!(decode_pack(&truncated, &truncated_digest, 4096).is_err());
+
+        let mut gap = built.bytes.clone();
+        let index_len = u64::from_le_bytes(gap[8..16].try_into().unwrap()) as usize;
+        let mut index: PackIndex = serde_json::from_slice(&gap[16..16 + index_len]).unwrap();
+        index.entries[0].offset = 1;
+        let changed = serde_json::to_vec(&index).unwrap();
+        assert_eq!(
+            changed.len(),
+            index_len,
+            "fixture must preserve index framing"
+        );
+        gap[16..16 + index_len].copy_from_slice(&changed);
+        let gap_digest = blake3::hash(&gap).to_hex().to_string();
+        assert!(decode_pack(&gap, &gap_digest, 4096).is_err());
+
+        let mut wrong_recipe = built.bytes.clone();
+        let index_len = u64::from_le_bytes(wrong_recipe[8..16].try_into().unwrap()) as usize;
+        let mut index: PackIndex =
+            serde_json::from_slice(&wrong_recipe[16..16 + index_len]).unwrap();
+        index.key_schema -= 1;
+        let changed = serde_json::to_vec(&index).unwrap();
+        assert_eq!(changed.len(), index_len);
+        wrong_recipe[16..16 + index_len].copy_from_slice(&changed);
+        let wrong_recipe_digest = blake3::hash(&wrong_recipe).to_hex().to_string();
+        assert!(decode_pack(&wrong_recipe, &wrong_recipe_digest, 4096).is_err());
+    }
+
+    #[test]
+    fn object_keys_accept_only_digests_not_path_components() {
+        assert!(pack_object_key("", "../escape").is_err());
+        assert!(pack_meta_object_key("", &"A".repeat(64)).is_err());
+        assert!(catalog_prefix("", "a/b").is_err());
+    }
+
+    #[test]
+    fn selector_and_catalog_are_order_independent_and_content_addressed() {
+        let shard_a = digest("shard-a");
+        let shard_b = digest("shard-b");
+        let selector_a = selector_hash(
+            "x86_64-unknown-linux-gnu",
+            "trusted/linux/release",
+            &[shard_a.clone(), shard_b.clone()],
+            crate::cache_key::CACHE_KEY_VERSION,
+        )
+        .unwrap();
+        let selector_b = selector_hash(
+            "x86_64-unknown-linux-gnu",
+            "trusted/linux/release",
+            &[shard_b, shard_a],
+            crate::cache_key::CACHE_KEY_VERSION,
+        )
+        .unwrap();
+        assert_eq!(selector_a, selector_b);
+
+        let entry = CatalogEntry {
+            cache_key: digest("one"),
+            crate_name: "serde".to_string(),
+            meta_digest: digest("meta-one"),
+        };
+        let catalog = PackCatalog {
+            version: CATALOG_VERSION,
+            key_schema: crate::cache_key::CACHE_KEY_VERSION,
+            manifest_key: "x86_64-unknown-linux-gnu".to_string(),
+            namespace: "trusted/linux/release".to_string(),
+            selector_hash: selector_a.clone(),
+            shard_hashes: vec![digest("shard-b"), digest("shard-a")],
+            created_at_ms: 100,
+            expires_at_ms: 200,
+            packs: vec![CatalogPackRef {
+                digest: digest("pack"),
+                pack_bytes: 123,
+                entries: vec![entry],
+            }],
+            fallback_entries: Vec::new(),
+        };
+        let encoded = encode_catalog("artifacts", catalog).unwrap();
+        let mut sorted_shards = vec![digest("shard-a"), digest("shard-b")];
+        sorted_shards.sort();
+        assert_eq!(encoded.catalog.shard_hashes, sorted_shards);
+        assert_eq!(
+            encoded.object_key,
+            format!(
+                "artifacts/v4/prefetch/catalogs/{}/{:020}-{}.json",
+                selector_a, 100, encoded.digest
+            )
+        );
+        assert_eq!(
+            decode_catalog(&encoded.bytes, &encoded.digest).unwrap(),
+            encoded.catalog
+        );
+    }
+
+    #[test]
+    fn catalog_rejects_duplicate_or_unsafe_entries() {
+        let shard = digest("shard");
+        let selector = selector_hash(
+            "target",
+            "namespace",
+            std::slice::from_ref(&shard),
+            crate::cache_key::CACHE_KEY_VERSION,
+        )
+        .unwrap();
+        let entry = CatalogEntry {
+            cache_key: digest("one"),
+            crate_name: "serde".to_string(),
+            meta_digest: digest("meta-one"),
+        };
+        let catalog = PackCatalog {
+            version: CATALOG_VERSION,
+            key_schema: crate::cache_key::CACHE_KEY_VERSION,
+            manifest_key: "target".to_string(),
+            namespace: "namespace".to_string(),
+            selector_hash: selector,
+            shard_hashes: vec![shard],
+            created_at_ms: 100,
+            expires_at_ms: 200,
+            packs: vec![CatalogPackRef {
+                digest: digest("pack"),
+                pack_bytes: 100,
+                entries: vec![entry.clone()],
+            }],
+            fallback_entries: vec![entry],
+        };
+        assert!(encode_catalog("", catalog).is_err());
+    }
+
+    #[test]
+    fn catalog_rejects_wrong_recipe_selector_digest_and_expiry() {
+        let shard = digest("shard");
+        let selector = selector_hash(
+            "target",
+            "namespace",
+            std::slice::from_ref(&shard),
+            crate::cache_key::CACHE_KEY_VERSION,
+        )
+        .unwrap();
+        let base = PackCatalog {
+            version: CATALOG_VERSION,
+            key_schema: crate::cache_key::CACHE_KEY_VERSION,
+            manifest_key: "target".to_string(),
+            namespace: "namespace".to_string(),
+            selector_hash: selector,
+            shard_hashes: vec![shard],
+            created_at_ms: 100,
+            expires_at_ms: 200,
+            packs: Vec::new(),
+            fallback_entries: Vec::new(),
+        };
+
+        let mut wrong_recipe = base.clone();
+        wrong_recipe.key_schema -= 1;
+        assert!(encode_catalog("", wrong_recipe).is_err());
+        let mut wrong_selector = base.clone();
+        wrong_selector.selector_hash = digest("wrong");
+        assert!(encode_catalog("", wrong_selector).is_err());
+        let mut expired = base.clone();
+        expired.expires_at_ms = expired.created_at_ms;
+        assert!(encode_catalog("", expired).is_err());
+
+        let encoded = encode_catalog("", base).unwrap();
+        assert!(decode_catalog(&encoded.bytes, &digest("wrong")).is_err());
+    }
+}

--- a/src/remote_pack.rs
+++ b/src/remote_pack.rs
@@ -672,6 +672,68 @@ mod tests {
         }
     }
 
+    fn catalog_entry(index: usize) -> CatalogEntry {
+        CatalogEntry {
+            cache_key: digest(&format!("entry-{index:05}")),
+            crate_name: "x".to_string(),
+            meta_digest: digest(&format!("meta-{index:05}")),
+        }
+    }
+
+    fn catalog_with(
+        packs: Vec<CatalogPackRef>,
+        fallback_entries: Vec<CatalogEntry>,
+    ) -> PackCatalog {
+        let shard = digest("boundary-shard");
+        PackCatalog {
+            version: CATALOG_VERSION,
+            key_schema: crate::cache_key::CACHE_KEY_VERSION,
+            manifest_key: "target".to_string(),
+            namespace: "namespace".to_string(),
+            selector_hash: selector_hash(
+                "target",
+                "namespace",
+                std::slice::from_ref(&shard),
+                crate::cache_key::CACHE_KEY_VERSION,
+            )
+            .unwrap(),
+            shard_hashes: vec![shard],
+            created_at_ms: 100,
+            expires_at_ms: 200,
+            packs,
+            fallback_entries,
+        }
+    }
+
+    fn index_entries(count: usize) -> Vec<PackIndexEntry> {
+        let mut entries = (0..count)
+            .map(|index| PackIndexEntry {
+                cache_key: digest(&format!("index-{index:05}")),
+                crate_name: "x".to_string(),
+                meta_digest: digest(&format!("index-meta-{index:05}")),
+                offset: 0,
+                length: 1,
+            })
+            .collect::<Vec<_>>();
+        entries.sort_by(|left, right| left.cache_key.cmp(&right.cache_key));
+        for (offset, entry) in entries.iter_mut().enumerate() {
+            entry.offset = offset as u64;
+        }
+        entries
+    }
+
+    fn framed_index(index: &PackIndex, padded_index_len: usize) -> Vec<u8> {
+        let mut json = serde_json::to_vec(index).unwrap();
+        assert!(json.len() <= padded_index_len);
+        json.resize(padded_index_len, b' ');
+        let mut bytes = Vec::with_capacity(PACK_HEADER_BYTES + json.len() + 1);
+        bytes.extend_from_slice(PACK_MAGIC);
+        bytes.extend_from_slice(&(json.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&json);
+        bytes.push(b'x');
+        bytes
+    }
+
     #[test]
     fn pack_encoding_is_deterministic_and_round_trips() {
         let one = input("one", "serde", b"first-v3-pack");
@@ -750,6 +812,348 @@ mod tests {
         wrong_recipe[16..16 + index_len].copy_from_slice(&changed);
         let wrong_recipe_digest = blake3::hash(&wrong_recipe).to_hex().to_string();
         assert!(decode_pack(&wrong_recipe, &wrong_recipe_digest, 4096).is_err());
+    }
+
+    #[test]
+    fn protocol_limits_and_inclusive_boundaries_are_exact() {
+        assert_eq!(DEFAULT_MAX_PACK_BYTES, 256 * 1024 * 1024);
+        assert_eq!(MAX_PACK_INDEX_BYTES, 16 * 1024 * 1024);
+        assert_eq!(MAX_CATALOG_BYTES, 64 * 1024 * 1024);
+
+        assert!(validate_pack_cap(0).is_err());
+        assert!(validate_pack_cap(DEFAULT_MAX_PACK_BYTES).is_ok());
+        assert!(validate_pack_cap(DEFAULT_MAX_PACK_BYTES + 1).is_err());
+
+        let shard = digest("selector-boundary");
+        assert!(
+            selector_hash(
+                &"a".repeat(MAX_SELECTOR_TEXT_BYTES),
+                "n",
+                std::slice::from_ref(&shard),
+                crate::cache_key::CACHE_KEY_VERSION,
+            )
+            .is_ok()
+        );
+        assert!(
+            selector_hash(
+                &"a".repeat(MAX_SELECTOR_TEXT_BYTES + 1),
+                "n",
+                std::slice::from_ref(&shard),
+                crate::cache_key::CACHE_KEY_VERSION,
+            )
+            .is_err()
+        );
+        assert!(
+            selector_hash(
+                "target",
+                "bad\nnamespace",
+                std::slice::from_ref(&shard),
+                crate::cache_key::CACHE_KEY_VERSION,
+            )
+            .is_err()
+        );
+        assert!(
+            selector_hash(
+                "",
+                "namespace",
+                &[shard],
+                crate::cache_key::CACHE_KEY_VERSION,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn length_prefixes_keep_selector_fields_unambiguous() {
+        let without_shards = Vec::new();
+        let ab_c = selector_hash(
+            "ab",
+            "c",
+            &without_shards,
+            crate::cache_key::CACHE_KEY_VERSION,
+        )
+        .unwrap();
+        let a_bc = selector_hash(
+            "a",
+            "bc",
+            &without_shards,
+            crate::cache_key::CACHE_KEY_VERSION,
+        )
+        .unwrap();
+        assert_ne!(ab_c, a_bc);
+    }
+
+    #[test]
+    fn pack_size_caps_accept_the_limit_and_reject_real_overshoot() {
+        let entry = input("cap-boundary", "serde", b"payload");
+        let built = build_pack("", vec![entry.clone()], 4096).unwrap();
+        let exact = built.bytes.len() as u64;
+        assert!(build_pack("", vec![entry.clone()], exact).is_ok());
+        assert!(build_pack("", vec![entry], exact - 2).is_err());
+        assert!(decode_pack(&built.bytes, &built.digest, exact).is_ok());
+        assert!(decode_pack(&built.bytes, &built.digest, exact - 2).is_err());
+    }
+
+    #[test]
+    fn decoder_checks_magic_index_span_and_index_byte_boundaries_independently() {
+        let built = build_pack("", vec![input("magic", "serde", b"x")], 4096).unwrap();
+        let mut bad_magic = built.bytes.clone();
+        bad_magic[0] ^= 1;
+        let digest = blake3::hash(&bad_magic).to_hex().to_string();
+        assert!(decode_pack(&bad_magic, &digest, 4096).is_err());
+
+        let mut short_index = Vec::from(PACK_MAGIC.as_slice());
+        short_index.extend_from_slice(&1_u64.to_le_bytes());
+        let digest = blake3::hash(&short_index).to_hex().to_string();
+        assert!(decode_pack(&short_index, &digest, 4096).is_err());
+        let truncated_header = &short_index[..PACK_HEADER_BYTES - 1];
+        let digest = blake3::hash(truncated_header).to_hex().to_string();
+        assert!(decode_pack(truncated_header, &digest, 4096).is_err());
+
+        let index = PackIndex {
+            version: PACK_VERSION,
+            key_schema: crate::cache_key::CACHE_KEY_VERSION,
+            entries: index_entries(1),
+        };
+        let at_limit = framed_index(&index, MAX_PACK_INDEX_BYTES);
+        let digest = blake3::hash(&at_limit).to_hex().to_string();
+        assert!(decode_pack(&at_limit, &digest, DEFAULT_MAX_PACK_BYTES).is_ok());
+
+        let over_limit = framed_index(&index, MAX_PACK_INDEX_BYTES + 2);
+        let digest = blake3::hash(&over_limit).to_hex().to_string();
+        assert!(decode_pack(&over_limit, &digest, DEFAULT_MAX_PACK_BYTES).is_err());
+    }
+
+    #[test]
+    fn pack_index_entry_count_accepts_exact_limit_only() {
+        let exact = PackIndex {
+            version: PACK_VERSION,
+            key_schema: crate::cache_key::CACHE_KEY_VERSION,
+            entries: index_entries(MAX_PACK_ENTRIES),
+        };
+        assert!(validate_pack_index(&exact, MAX_PACK_ENTRIES).is_ok());
+
+        let over = PackIndex {
+            entries: index_entries(MAX_PACK_ENTRIES + 1),
+            ..exact
+        };
+        assert!(validate_pack_index(&over, MAX_PACK_ENTRIES + 1).is_err());
+        let empty = PackIndex {
+            version: PACK_VERSION,
+            key_schema: crate::cache_key::CACHE_KEY_VERSION,
+            entries: Vec::new(),
+        };
+        assert!(validate_pack_index(&empty, 0).is_err());
+    }
+
+    #[test]
+    fn pack_builder_entry_count_accepts_exact_limit_only() {
+        let inputs = |count| {
+            (0..count)
+                .map(|index| PackInputEntry {
+                    cache_key: digest(&format!("build-{index:05}")),
+                    crate_name: "x".to_string(),
+                    meta_digest: digest(&format!("build-meta-{index:05}")),
+                    payload: vec![b'x'],
+                })
+                .collect::<Vec<_>>()
+        };
+        let mut exact_index_inputs = inputs(MAX_PACK_ENTRIES);
+        let base_index = PackIndex {
+            version: PACK_VERSION,
+            key_schema: crate::cache_key::CACHE_KEY_VERSION,
+            entries: exact_index_inputs
+                .iter()
+                .enumerate()
+                .map(|(offset, entry)| PackIndexEntry {
+                    cache_key: entry.cache_key.clone(),
+                    crate_name: entry.crate_name.clone(),
+                    meta_digest: entry.meta_digest.clone(),
+                    offset: offset as u64,
+                    length: 1,
+                })
+                .collect(),
+        };
+        let mut remaining = MAX_PACK_INDEX_BYTES - serde_json::to_vec(&base_index).unwrap().len();
+        for entry in &mut exact_index_inputs {
+            let extra = remaining.min(127);
+            entry.crate_name.push_str(&"x".repeat(extra));
+            remaining -= extra;
+            if remaining == 0 {
+                break;
+            }
+        }
+        assert_eq!(remaining, 0, "entry fields must span the exact index cap");
+        let exact = build_pack("", exact_index_inputs.clone(), DEFAULT_MAX_PACK_BYTES).unwrap();
+        assert_eq!(
+            serde_json::to_vec(&exact.index).unwrap().len(),
+            MAX_PACK_INDEX_BYTES
+        );
+        let expandable = exact_index_inputs
+            .iter_mut()
+            .find(|entry| entry.crate_name.len() < 128)
+            .expect("at least one crate field remains expandable");
+        expandable.crate_name.push('x');
+        assert!(
+            build_pack("", exact_index_inputs, DEFAULT_MAX_PACK_BYTES).is_err(),
+            "one byte above the index cap must be rejected"
+        );
+        assert!(build_pack("", inputs(MAX_PACK_ENTRIES + 1), DEFAULT_MAX_PACK_BYTES,).is_err());
+        assert!(build_pack("", inputs(MAX_PACK_ENTRIES + 2), DEFAULT_MAX_PACK_BYTES,).is_err());
+    }
+
+    #[test]
+    fn catalog_pack_size_and_entry_limits_are_independent() {
+        let entry = catalog_entry(0);
+        let valid_pack = |pack_bytes, entries| CatalogPackRef {
+            digest: digest("boundary-pack"),
+            pack_bytes,
+            entries,
+        };
+        assert!(
+            encode_catalog(
+                "",
+                catalog_with(
+                    vec![valid_pack(DEFAULT_MAX_PACK_BYTES, vec![entry.clone()])],
+                    Vec::new(),
+                ),
+            )
+            .is_ok()
+        );
+        assert!(
+            encode_catalog(
+                "",
+                catalog_with(vec![valid_pack(0, vec![entry.clone()])], Vec::new()),
+            )
+            .is_err()
+        );
+        assert!(
+            encode_catalog(
+                "",
+                catalog_with(
+                    vec![valid_pack(DEFAULT_MAX_PACK_BYTES + 1, vec![entry])],
+                    Vec::new(),
+                ),
+            )
+            .is_err()
+        );
+
+        let exact_entries = (0..MAX_PACK_ENTRIES).map(catalog_entry).collect();
+        assert!(
+            encode_catalog(
+                "",
+                catalog_with(vec![valid_pack(1, exact_entries)], Vec::new()),
+            )
+            .is_ok()
+        );
+        let over_entries = (0..=MAX_PACK_ENTRIES).map(catalog_entry).collect();
+        assert!(
+            encode_catalog(
+                "",
+                catalog_with(vec![valid_pack(1, over_entries)], Vec::new()),
+            )
+            .is_err()
+        );
+        assert!(
+            encode_catalog(
+                "",
+                catalog_with(vec![valid_pack(1, Vec::new())], Vec::new()),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn catalog_total_entry_and_pack_count_limits_are_inclusive() {
+        let exact_fallback = (0..MAX_PACK_ENTRIES).map(catalog_entry).collect();
+        assert!(encode_catalog("", catalog_with(Vec::new(), exact_fallback)).is_ok());
+        let over_fallback = (0..=MAX_PACK_ENTRIES).map(catalog_entry).collect();
+        assert!(encode_catalog("", catalog_with(Vec::new(), over_fallback)).is_err());
+
+        let packs = (0..MAX_CATALOG_PACKS)
+            .map(|index| CatalogPackRef {
+                digest: digest(&format!("pack-{index}")),
+                pack_bytes: 1,
+                entries: vec![catalog_entry(index)],
+            })
+            .collect::<Vec<_>>();
+        assert!(encode_catalog("", catalog_with(packs.clone(), Vec::new())).is_ok());
+        let mut over = packs;
+        over.push(CatalogPackRef {
+            digest: digest("pack-over-limit"),
+            pack_bytes: 1,
+            entries: vec![catalog_entry(MAX_CATALOG_PACKS)],
+        });
+        assert!(encode_catalog("", catalog_with(over, Vec::new())).is_err());
+    }
+
+    #[test]
+    fn catalog_decoder_accepts_exact_byte_limit_and_rejects_overshoot() {
+        let encoded = encode_catalog("", catalog_with(Vec::new(), vec![catalog_entry(0)])).unwrap();
+        let mut bytes = encoded.bytes;
+        bytes.resize(MAX_CATALOG_BYTES, b' ');
+        let digest = blake3::hash(&bytes).to_hex().to_string();
+        assert!(decode_catalog(&bytes, &digest).is_ok());
+
+        bytes.push(b' ');
+        let digest = blake3::hash(&bytes).to_hex().to_string();
+        assert!(decode_catalog(&bytes, &digest).is_err());
+    }
+
+    #[test]
+    fn catalog_pack_binding_rejects_each_mismatch_independently() {
+        let built = build_pack("", vec![input("binding", "serde", b"payload")], 4096).unwrap();
+        let descriptor = &built.index.entries[0];
+        let base = CatalogPackRef {
+            digest: built.digest.clone(),
+            pack_bytes: built.bytes.len() as u64,
+            entries: vec![CatalogEntry {
+                cache_key: descriptor.cache_key.clone(),
+                crate_name: descriptor.crate_name.clone(),
+                meta_digest: descriptor.meta_digest.clone(),
+            }],
+        };
+        assert!(decode_catalog_pack(&built.bytes, &base, 4096).is_ok());
+
+        let mut wrong_crate = base.clone();
+        wrong_crate.entries[0].crate_name = "tokio".to_string();
+        assert!(decode_catalog_pack(&built.bytes, &wrong_crate, 4096).is_err());
+        let mut wrong_meta = base.clone();
+        wrong_meta.entries[0].meta_digest = digest("wrong-meta");
+        assert!(decode_catalog_pack(&built.bytes, &wrong_meta, 4096).is_err());
+        let mut wrong_key = base.clone();
+        wrong_key.entries[0].cache_key = digest("wrong-key");
+        assert!(decode_catalog_pack(&built.bytes, &wrong_key, 4096).is_err());
+        let mut wrong_count = base.clone();
+        wrong_count.entries.push(catalog_entry(99));
+        assert!(decode_catalog_pack(&built.bytes, &wrong_count, 4096).is_err());
+        let mut wrong_size = base;
+        wrong_size.pack_bytes += 1;
+        assert!(decode_catalog_pack(&built.bytes, &wrong_size, 4096).is_err());
+    }
+
+    #[test]
+    fn catalog_rejects_an_individually_unsafe_fallback_entry() {
+        let mut unsafe_entry = catalog_entry(0);
+        unsafe_entry.crate_name = "../escape".to_string();
+        assert!(encode_catalog("", catalog_with(Vec::new(), vec![unsafe_entry])).is_err());
+    }
+
+    #[test]
+    fn catalog_discovery_filters_bad_timestamp_shape_and_digits_separately() {
+        let selector = digest("discovery-selector");
+        let prefix = catalog_prefix("root", &selector).unwrap();
+        let valid_digest = digest("catalog");
+        let valid = format!("{prefix}{:020}-{valid_digest}.json", 7);
+        let bad_width = format!("{prefix}7-{valid_digest}.json");
+        let bad_digits = format!("{prefix}0000000000000000000x-{valid_digest}.json");
+        assert!(parse_catalog_object_ref(&prefix, &bad_width).is_none());
+        assert!(parse_catalog_object_ref(&prefix, &bad_digits).is_none());
+        let latest =
+            latest_catalog_object("root", &selector, &[bad_width, bad_digits, valid.clone()])
+                .unwrap()
+                .unwrap();
+        assert_eq!(latest.object_key, valid);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -2068,6 +2068,24 @@ impl Store {
         self.import_downloaded_entry(cache_key)
     }
 
+    /// Install one already-verified artifact into the content-addressed blob
+    /// store. A missing source is a distinct integrity race, not a generic
+    /// rename failure, so keep that decision directly testable.
+    fn install_verified_blob(&self, entry_dir: &Path, file: &CachedFile) -> Result<()> {
+        let blob = self.blob_path(&file.hash);
+        if !blob.is_file() {
+            let artifact = entry_dir.join(&file.name);
+            if !artifact.is_file() {
+                anyhow::bail!("verified restored blob vanished during batch import");
+            }
+            fs::create_dir_all(blob.parent().expect("blob path has a parent"))?;
+            fs::rename(&artifact, &blob)?;
+            crate::atomic::fsync_file(&blob)?;
+            set_blob_readonly(&blob);
+        }
+        Ok(())
+    }
+
     /// Import already stream-verified restored entries with one SQLite
     /// transaction for the whole batch.
     ///
@@ -2226,17 +2244,7 @@ impl Store {
                         params![file.hash],
                     )?;
                 }
-                let blob = self.blob_path(&file.hash);
-                if !blob.is_file() {
-                    let artifact = entry_dir.join(&file.name);
-                    if !artifact.is_file() {
-                        anyhow::bail!("verified restored blob vanished during batch import");
-                    }
-                    fs::create_dir_all(blob.parent().expect("blob path has a parent"))?;
-                    fs::rename(&artifact, &blob)?;
-                    crate::atomic::fsync_file(&blob)?;
-                    set_blob_readonly(&blob);
-                }
+                self.install_verified_blob(&entry_dir, file)?;
             }
             record_entry_blobs(&tx, &entry.cache_key, &meta.files)?;
             tx.execute(
@@ -10215,6 +10223,142 @@ mod tests {
         for key in keys {
             assert!(store.get(&key).unwrap().is_some());
         }
+        let refcounts: Vec<i64> = store
+            .db
+            .prepare("SELECT refcount FROM blobs ORDER BY hash")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(refcounts, vec![1, 1]);
+    }
+
+    fn write_verified_fixture(
+        store: &Store,
+        key: &str,
+        meta_key: &str,
+        artifact_name: &str,
+        hash_override: Option<String>,
+    ) -> VerifiedRestoredEntry {
+        let contents = b"verified fixture artifact";
+        let entry_dir = store.entry_dir(key);
+        let artifact = entry_dir.join(artifact_name);
+        std::fs::create_dir_all(artifact.parent().unwrap()).unwrap();
+        std::fs::write(&artifact, contents).unwrap();
+        let meta = EntryMeta {
+            cache_key: meta_key.to_string(),
+            key_schema: crate::cache_key::CACHE_KEY_VERSION,
+            crate_name: "fixture".to_string(),
+            crate_types: vec!["lib".to_string()],
+            files: vec![CachedFile {
+                name: artifact_name.to_string(),
+                size: contents.len() as u64,
+                hash: hash_override.unwrap_or_else(|| blake3::hash(contents).to_hex().to_string()),
+                executable: false,
+            }],
+            stdout: String::new(),
+            stderr: String::new(),
+            features: Vec::new(),
+            target: "x86_64-unknown-linux-gnu".to_string(),
+            profile: "dev".to_string(),
+            compile_time_ms: 1,
+            emit_kinds: Vec::new(),
+        };
+        std::fs::write(
+            entry_dir.join("meta.json"),
+            serde_json::to_vec_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+        VerifiedRestoredEntry {
+            cache_key: key.to_string(),
+            meta,
+        }
+    }
+
+    #[test]
+    fn verified_batch_import_checks_each_cache_key_binding_independently() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(&test_config(tmp.path())).unwrap();
+        let invalid = write_verified_fixture(&store, "invalid", "invalid", "lib.rlib", None);
+        assert!(store.import_verified_restored_entries(&[invalid]).is_err());
+
+        let key = blake3::hash(b"valid-outer-key").to_hex().to_string();
+        let other = blake3::hash(b"different-meta-key").to_hex().to_string();
+        let mismatched = write_verified_fixture(&store, &key, &other, "lib.rlib", None);
+        assert!(
+            store
+                .import_verified_restored_entries(&[mismatched])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn verified_batch_import_checks_each_artifact_field_independently() {
+        for (label, name, hash_override) in [
+            ("unsafe-name", "nested/lib.rlib", None),
+            ("invalid-hash", "lib.rlib", Some("g".repeat(64))),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            let store = Store::open(&test_config(tmp.path())).unwrap();
+            let key = blake3::hash(label.as_bytes()).to_hex().to_string();
+            let entry = write_verified_fixture(&store, &key, &key, name, hash_override);
+            assert!(
+                store.import_verified_restored_entries(&[entry]).is_err(),
+                "{label} must be rejected independently"
+            );
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(&test_config(tmp.path())).unwrap();
+        let key = blake3::hash(b"duplicate-artifact").to_hex().to_string();
+        let mut entry = write_verified_fixture(&store, &key, &key, "lib.rlib", None);
+        entry.meta.files.push(entry.meta.files[0].clone());
+        std::fs::write(
+            store.entry_dir(&key).join("meta.json"),
+            serde_json::to_vec_pretty(&entry.meta).unwrap(),
+        )
+        .unwrap();
+        assert!(store.import_verified_restored_entries(&[entry]).is_err());
+    }
+
+    #[test]
+    fn verified_batch_import_never_rewrites_an_existing_content_addressed_blob() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(&test_config(tmp.path())).unwrap();
+        let key = blake3::hash(b"existing-immutable-blob")
+            .to_hex()
+            .to_string();
+        let entry = write_verified_fixture(&store, &key, &key, "lib.rlib", None);
+        let blob = store.blob_path(&entry.meta.files[0].hash);
+        std::fs::create_dir_all(blob.parent().unwrap()).unwrap();
+        std::fs::write(&blob, b"pre-existing immutable blob").unwrap();
+
+        assert_eq!(store.import_verified_restored_entries(&[entry]).unwrap(), 1);
+        assert_eq!(std::fs::read(blob).unwrap(), b"pre-existing immutable blob");
+    }
+
+    #[test]
+    fn verified_blob_install_reports_a_vanished_source_before_rename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(&test_config(tmp.path())).unwrap();
+        let file = CachedFile {
+            name: "lib.rlib".to_string(),
+            size: 7,
+            hash: blake3::hash(b"missing verified artifact")
+                .to_hex()
+                .to_string(),
+            executable: false,
+        };
+
+        let error = store
+            .install_verified_blob(&tmp.path().join("missing-entry"), &file)
+            .expect_err("a vanished verified source must fail")
+            .to_string();
+        assert!(
+            error.contains("verified restored blob vanished during batch import"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -15,6 +15,16 @@ pub struct StorePutResult {
     pub new_blobs: u32,
 }
 
+/// An entry whose remote bytes and declared artifact hashes were verified in
+/// the same pass that extracted them. Construction stays inside the remote
+/// transport boundary; the store still re-checks metadata, paths and lengths,
+/// but deliberately does not read every artifact a second time.
+#[derive(Debug, Clone)]
+pub(crate) struct VerifiedRestoredEntry {
+    pub cache_key: String,
+    pub meta: EntryMeta,
+}
+
 impl StorePutResult {
     pub fn is_full_dup(self) -> bool {
         self.output_blobs > 0 && self.duplicate_blobs == self.output_blobs
@@ -2056,6 +2066,166 @@ impl Store {
     /// Today it is equivalent to `import_downloaded_entry()`.
     pub fn import_restored_entry(&self, cache_key: &str) -> Result<()> {
         self.import_downloaded_entry(cache_key)
+    }
+
+    /// Import already stream-verified restored entries with one SQLite
+    /// transaction for the whole batch.
+    ///
+    /// Artifact content is not hashed again: callers may only construct
+    /// [`VerifiedRestoredEntry`] after extraction verified each byte against
+    /// `meta.files[].hash`. This method still performs a complete metadata and
+    /// on-disk length preflight before moving blobs or opening the transaction.
+    pub(crate) fn import_verified_restored_entries(
+        &self,
+        entries: &[VerifiedRestoredEntry],
+    ) -> Result<usize> {
+        let mut cache_keys = std::collections::HashSet::new();
+        for entry in entries {
+            if !crate::cache_key::is_valid_cache_key(&entry.cache_key)
+                || entry.meta.cache_key != entry.cache_key
+            {
+                anyhow::bail!("verified restore has an invalid cache-key binding");
+            }
+            if entry.meta.key_schema != crate::cache_key::CACHE_KEY_VERSION {
+                anyhow::bail!(
+                    "verified restore {} uses incompatible key schema {}",
+                    &entry.cache_key[..16],
+                    entry.meta.key_schema
+                );
+            }
+            if !crate::cache_key::is_valid_crate_name(&entry.meta.crate_name) {
+                anyhow::bail!("verified restore has an unsafe crate name");
+            }
+            if !cache_keys.insert(entry.cache_key.as_str()) {
+                anyhow::bail!("verified restore batch contains a duplicate cache key");
+            }
+
+            let entry_dir = self.entry_dir(&entry.cache_key);
+            let meta_bytes = fs::read(entry_dir.join("meta.json"))
+                .context("reading stream-verified entry metadata")?;
+            let disk_meta: EntryMeta = serde_json::from_slice(&meta_bytes)
+                .context("parsing stream-verified entry metadata")?;
+            if disk_meta != entry.meta {
+                anyhow::bail!("verified restore metadata changed after extraction");
+            }
+
+            let mut artifact_names = std::collections::HashSet::new();
+            for file in &entry.meta.files {
+                if !crate::remote_layout::is_safe_artifact_name(&file.name)
+                    || !crate::cache_key::is_valid_cache_key(&file.hash)
+                    || !artifact_names.insert(file.name.as_str())
+                {
+                    anyhow::bail!(
+                        "verified restore contains unsafe or duplicate artifact metadata"
+                    );
+                }
+                let artifact = entry_dir.join(&file.name);
+                let actual_size = fs::metadata(&artifact)
+                    .with_context(|| format!("stat verified artifact {}", file.name))?
+                    .len();
+                if actual_size != file.size {
+                    anyhow::bail!(
+                        "verified artifact {} size mismatch (expected {}, got {})",
+                        file.name,
+                        file.size,
+                        actual_size
+                    );
+                }
+            }
+        }
+
+        // Make every content-addressed blob durable before the database can
+        // advertise a reference to it. Existing blobs leave the extracted copy
+        // in place as the in-transaction race fallback below.
+        for entry in entries {
+            let entry_dir = self.entry_dir(&entry.cache_key);
+            for file in &entry.meta.files {
+                let blob = self.blob_path(&file.hash);
+                if !blob.is_file() {
+                    let artifact = entry_dir.join(&file.name);
+                    fs::create_dir_all(blob.parent().expect("blob path has a parent"))
+                        .context("creating verified blob shard directory")?;
+                    fs::rename(&artifact, &blob).with_context(|| {
+                        format!(
+                            "moving verified artifact {} to blob store",
+                            artifact.display()
+                        )
+                    })?;
+                    crate::atomic::fsync_file(&blob)
+                        .context("flushing verified restored blob to disk")?;
+                    set_blob_readonly(&blob);
+                }
+            }
+        }
+
+        let tx = self.db.unchecked_transaction()?;
+        let mut imported = 0usize;
+        for entry in entries {
+            let meta = &entry.meta;
+            let total_size: u64 = meta.files.iter().map(|file| file.size).sum();
+            let crate_type = meta.crate_types.join(",");
+            let content_hash = compute_content_hash(&meta.files);
+            let inserted = tx.execute(
+                "INSERT OR IGNORE INTO entries (cache_key, crate_name, crate_type, profile, num_features, size, content_hash, compile_time_ms, key_schema, committed) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0)",
+                params![
+                    entry.cache_key,
+                    meta.crate_name,
+                    crate_type,
+                    meta.profile,
+                    meta.features.len() as i64,
+                    total_size as i64,
+                    content_hash,
+                    meta.compile_time_ms as i64,
+                    meta.key_schema
+                ],
+            )?;
+            if inserted == 0 {
+                continue;
+            }
+
+            let entry_dir = self.entry_dir(&entry.cache_key);
+            for file in &meta.files {
+                let added = tx.execute(
+                    "INSERT OR IGNORE INTO blobs (hash, size, refcount) VALUES (?1, ?2, 1)",
+                    params![file.hash, file.size as i64],
+                )?;
+                if added == 0 {
+                    tx.execute(
+                        "UPDATE blobs SET refcount = refcount + 1 WHERE hash = ?1",
+                        params![file.hash],
+                    )?;
+                }
+                let blob = self.blob_path(&file.hash);
+                if !blob.is_file() {
+                    let artifact = entry_dir.join(&file.name);
+                    if !artifact.is_file() {
+                        anyhow::bail!("verified restored blob vanished during batch import");
+                    }
+                    fs::create_dir_all(blob.parent().expect("blob path has a parent"))?;
+                    fs::rename(&artifact, &blob)?;
+                    crate::atomic::fsync_file(&blob)?;
+                    set_blob_readonly(&blob);
+                }
+            }
+            record_entry_blobs(&tx, &entry.cache_key, &meta.files)?;
+            tx.execute(
+                "UPDATE entries SET committed = 1 WHERE cache_key = ?1",
+                params![entry.cache_key],
+            )?;
+            imported += 1;
+        }
+        tx.commit()?;
+
+        for entry in entries {
+            let entry_dir = self.entry_dir(&entry.cache_key);
+            for file in &entry.meta.files {
+                let artifact = entry_dir.join(&file.name);
+                if artifact.is_file() {
+                    let _ = fs::remove_file(artifact);
+                }
+            }
+        }
+        Ok(imported)
     }
 
     /// Rebuild the `entries` and `blobs` rows by scanning the store's per-entry
@@ -9934,6 +10104,79 @@ mod tests {
             )
             .unwrap();
         assert_eq!(ch.len(), 64);
+    }
+
+    #[test]
+    fn verified_batch_import_is_atomic_and_registers_every_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path());
+        let store = Store::open(&config).unwrap();
+        let keys = [
+            blake3::hash(b"packed-batch-a").to_hex().to_string(),
+            blake3::hash(b"packed-batch-b").to_hex().to_string(),
+        ];
+
+        let mut verified = Vec::new();
+        for (index, key) in keys.iter().enumerate() {
+            let entry_dir = store.entry_dir(key);
+            std::fs::create_dir_all(&entry_dir).unwrap();
+            let artifact = entry_dir.join(format!("lib{index}.rlib"));
+            let contents = format!("verified packed artifact {index}");
+            std::fs::write(&artifact, contents.as_bytes()).unwrap();
+            let meta = EntryMeta {
+                cache_key: key.clone(),
+                key_schema: crate::cache_key::CACHE_KEY_VERSION,
+                crate_name: format!("crate{index}"),
+                crate_types: vec!["lib".to_string()],
+                files: vec![CachedFile {
+                    name: format!("lib{index}.rlib"),
+                    size: contents.len() as u64,
+                    hash: blake3::hash(contents.as_bytes()).to_hex().to_string(),
+                    executable: false,
+                }],
+                stdout: String::new(),
+                stderr: String::new(),
+                features: vec![],
+                target: "x86_64-unknown-linux-gnu".to_string(),
+                profile: "dev".to_string(),
+                compile_time_ms: 1,
+                emit_kinds: Vec::new(),
+            };
+            std::fs::write(
+                entry_dir.join("meta.json"),
+                serde_json::to_vec_pretty(&meta).unwrap(),
+            )
+            .unwrap();
+            verified.push(VerifiedRestoredEntry {
+                cache_key: key.clone(),
+                meta,
+            });
+        }
+
+        let original_size = verified[1].meta.files[0].size;
+        verified[1].meta.files[0].size += 1;
+        assert!(store.import_verified_restored_entries(&verified).is_err());
+        let rows: i64 = store
+            .db
+            .query_row("SELECT COUNT(*) FROM entries", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(rows, 0, "a failed preflight must register no batch rows");
+
+        verified[1].meta.files[0].size = original_size;
+        let imported = store.import_verified_restored_entries(&verified).unwrap();
+        assert_eq!(imported, 2);
+        let rows: i64 = store
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM entries WHERE committed = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(rows, 2);
+        for key in keys {
+            assert!(store.get(&key).unwrap().is_some());
+        }
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -2165,6 +2165,37 @@ impl Store {
             let total_size: u64 = meta.files.iter().map(|file| file.size).sum();
             let crate_type = meta.crate_types.join(",");
             let content_hash = compute_content_hash(&meta.files);
+            // A crash or legacy importer may have left an uncommitted row.
+            // It is not a cache hit and must not permanently block a verified
+            // replacement through INSERT OR IGNORE. Undo any partial mapping
+            // bookkeeping in this same transaction before replacing it.
+            tx.execute(
+                "UPDATE blobs
+                 SET refcount = MAX(0, refcount - COALESCE((
+                     SELECT refs FROM entry_blobs
+                     WHERE cache_key = ?1 AND hash = blobs.hash
+                 ), 0))
+                 WHERE hash IN (
+                     SELECT hash FROM entry_blobs WHERE cache_key = ?1
+                 ) AND EXISTS (
+                     SELECT 1 FROM entries
+                     WHERE cache_key = ?1 AND committed = 0
+                 )",
+                params![entry.cache_key],
+            )?;
+            tx.execute(
+                "DELETE FROM entry_blobs
+                 WHERE cache_key = ?1 AND EXISTS (
+                     SELECT 1 FROM entries
+                     WHERE cache_key = ?1 AND committed = 0
+                 )",
+                params![entry.cache_key],
+            )?;
+            tx.execute(
+                "DELETE FROM entries WHERE cache_key = ?1 AND committed = 0",
+                params![entry.cache_key],
+            )?;
+            tx.execute("DELETE FROM blobs WHERE refcount <= 0", [])?;
             let inserted = tx.execute(
                 "INSERT OR IGNORE INTO entries (cache_key, crate_name, crate_type, profile, num_features, size, content_hash, compile_time_ms, key_schema, committed) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0)",
                 params![
@@ -10163,6 +10194,13 @@ mod tests {
         assert_eq!(rows, 0, "a failed preflight must register no batch rows");
 
         verified[1].meta.files[0].size = original_size;
+        store
+            .db
+            .execute(
+                "INSERT INTO entries (cache_key, crate_name, crate_type, profile, num_features, size, content_hash, compile_time_ms, key_schema, committed) VALUES (?1, 'stale', 'lib', 'dev', 0, 0, 'stale', 0, ?2, 0)",
+                params![keys[0], crate::cache_key::CACHE_KEY_VERSION],
+            )
+            .unwrap();
         let imported = store.import_verified_restored_entries(&verified).unwrap();
         assert_eq!(imported, 2);
         let rows: i64 = store


### PR DESCRIPTION
## Summary

- add deterministic immutable multi-entry pack/catalog codecs, selectors, and content-addressed keys
- reject digest, length, recipe, duplicate, traversal, framing, expiry, entry-count, and 256 MiB cap violations
- add create-only backend support, including S3 `If-None-Match: *`
- discover the newest valid catalog from manifest/namespace/Cargo.lock shard context
- fetch bounded packs, stream-verify each artifact once, and batch-import verified entries in one transaction
- preserve valid siblings when one packed entry is invalid and fall back per key to existing v3 objects
- keep packed prefetch asynchronous and leave demand v3 reads available while a pack GET is blocked
- report pack/v3 requests and bytes, validation/fallback counts, and real plan wall time

## Remaining scope

The immutable pack publisher is not implemented yet. It must group entries deterministically, verify or publish v3 fallback before publishing a catalog, create pack metadata before the catalog, and prove concurrent create-only publication. Adding that remote-publication capability is explicitly approval-gated; no live S3/R2 publication is authorized by this PR.

Representative object/pack five-run proof remains part of #812 acceptance after the publisher, compatible release, and controlled caller rollout.

## Validation

- full binary suite: 2,094 passed
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- rebased onto current `origin/main` (`f2f8be1`); exact-head CI is running for `cb696e4`

Part of #812 and #810.
