### PR TITLE
fix(release): fetch ancestry before advancing stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1200,7 +1200,13 @@ jobs:
     permissions:
       contents: write
     steps:
+      # The default depth-1 tag checkout marks the release commit as shallow,
+      # so Git cannot prove that updating an existing stable branch is a
+      # fast-forward and rejects the push with "fetch first". Keep the plain
+      # non-force push below as the safety gate, but give it full ancestry.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
       - name: Fast-forward stable to the released tag
         run: git push origin HEAD:refs/heads/stable
 


### PR DESCRIPTION
## Summary

- fetch full Git ancestry in the GA-only stable branch job
- retain the existing non-force push as the fast-forward safety gate

## Why

The v0.15.0 release built and published successfully, but the final stable update failed with fetch first. actions/checkout used the default depth-1 tag checkout, marking the release commit as shallow, so Git could not validate the existing stable branch update as a fast-forward.

Current stable at v0.14.2 was verified as an ancestor of v0.15.0 and was advanced manually after the failure.

## Validation

- reproduced from release run 32724350335, job 97435607323
- verified git merge-base --is-ancestor origin/stable v0.15.0 succeeds
- git diff --check

Release run: https://github.com/kunobi-ninja/kache/actions/runs/32724350335
