### PR TITLE
fix: reconcile blob index from committed metadata

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4982,6 +4982,8 @@ pub struct VerifyOutcome {
     pub orphaned_blobs: usize,
     /// Corrupted entries `--repair` actually removed.
     pub corrupted_removed: usize,
+    /// Derived blob-index rows that disagree with committed entry metadata.
+    pub index_drift: usize,
 }
 
 impl VerifyOutcome {
@@ -4989,7 +4991,7 @@ impl VerifyOutcome {
     /// run must fail on. Repair removes corrupted entries, so anything it
     /// could not remove still counts (kunobi-ninja/kache#176).
     pub fn unresolved_integrity_findings(&self) -> usize {
-        self.corrupted_entries - self.corrupted_removed
+        self.corrupted_entries - self.corrupted_removed + self.index_drift
     }
 }
 
@@ -5270,6 +5272,40 @@ pub fn verify(config: &Config, checksums: bool, repair: bool) -> Result<VerifyOu
         }
     }
 
+    // `entries` plus each committed meta.json are authoritative; `blobs` and
+    // `entry_blobs` are derived acceleration structures. Compare them under
+    // the store write lock so a concurrent publisher/remover cannot create a
+    // transient mismatch, and rebuild them atomically when requested (#819).
+    let index_drift = if repair {
+        match store.reconcile_blob_index() {
+            Ok(drift) => {
+                if drift.total() > 0 {
+                    println!(
+                        "Repairing: reconciled {} entry mappings and {} blob rows.",
+                        drift.entry_mappings, drift.blobs
+                    );
+                }
+                0
+            }
+            Err(e) => {
+                tracing::warn!("blob index reconciliation failed: {e:#}");
+                1
+            }
+        }
+    } else if corrupted_entries == 0 {
+        match store.blob_index_drift() {
+            Ok(drift) => drift.total(),
+            Err(e) => {
+                tracing::warn!("blob index verification failed: {e:#}");
+                1
+            }
+        }
+    } else {
+        // Corrupt metadata is already an unresolved integrity finding and
+        // cannot safely serve as the source of truth for a graph comparison.
+        0
+    };
+
     // Repair: reclaim orphaned blob files (counted above). These are never
     // reclaimed by normal GC, so without this they leak invisibly to
     // size-based eviction. A small grace leaves any blob a concurrent build
@@ -5298,12 +5334,13 @@ pub fn verify(config: &Config, checksums: bool, repair: bool) -> Result<VerifyOu
         "  Blobs: {} total, {} orphaned, {} missing, {} scrubbed, {} checksum failures",
         total_blobs_on_disk, orphaned_blobs, missing_blobs, blobs_scrubbed, checksum_failures
     );
+    println!("  Blob index drift: {index_drift}");
     println!("  Store size: {}", ByteSize(store_size));
 
-    if (corrupted_entries > 0 || orphaned_blobs > 0) && !repair {
+    if (corrupted_entries > 0 || orphaned_blobs > 0 || index_drift > 0) && !repair {
         println!();
         println!(
-            "Tip: run `kache doctor --repair` to remove corrupted entries and reclaim orphaned blobs."
+            "Tip: run `kache doctor --repair` to remove corrupted entries, reconcile the blob index, and reclaim orphaned blobs."
         );
     }
 
@@ -5315,6 +5352,7 @@ pub fn verify(config: &Config, checksums: bool, repair: bool) -> Result<VerifyOu
         checksum_failures,
         orphaned_blobs,
         corrupted_removed,
+        index_drift,
     })
 }
 
@@ -8082,6 +8120,37 @@ mod tests {
         assert!(store2.get("validkey").unwrap().is_some());
         assert!(store2.get("missingblobkey").unwrap().is_none());
         verify(&config, false, false).expect("a second verify pass should succeed");
+    }
+
+    #[test]
+    fn verify_reports_and_repairs_blob_index_drift() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = save_manifest_config(dir.path().join("cache"), None);
+        put_entry(&config, "driftkey", "drift", dir.path());
+        let store = Store::open(&config).unwrap();
+        let hash = store.get("driftkey").unwrap().unwrap().files[0]
+            .hash
+            .clone();
+        drop(store);
+
+        let db = crate::store::open_index_db(&config.index_db_path()).unwrap();
+        db.execute(
+            "UPDATE blobs SET refcount = 77 WHERE hash = ?1",
+            rusqlite::params![hash],
+        )
+        .unwrap();
+        drop(db);
+
+        let drifted = verify(&config, false, false).unwrap();
+        assert_eq!(drifted.index_drift, 1, "{drifted:?}");
+        assert_eq!(drifted.unresolved_integrity_findings(), 1, "{drifted:?}");
+
+        let repaired = verify(&config, false, true).unwrap();
+        assert_eq!(repaired.index_drift, 0, "{repaired:?}");
+        assert_eq!(repaired.unresolved_integrity_findings(), 0, "{repaired:?}");
+        let clean = verify(&config, false, false).unwrap();
+        assert_eq!(clean.index_drift, 0, "{clean:?}");
+        assert_eq!(clean.unresolved_integrity_findings(), 0, "{clean:?}");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4995,6 +4995,27 @@ impl VerifyOutcome {
     }
 }
 
+fn reconciled_index_message(drift: crate::store::BlobIndexDrift) -> Option<String> {
+    (drift.total() != 0).then(|| {
+        format!(
+            "Repairing: reconciled {} entry mappings and {} blob rows.",
+            drift.entry_mappings, drift.blobs
+        )
+    })
+}
+
+fn should_print_repair_tip(
+    corrupted_entries: usize,
+    orphaned_blobs: usize,
+    index_drift: usize,
+    repair: bool,
+) -> bool {
+    let findings = corrupted_entries
+        .saturating_add(orphaned_blobs)
+        .saturating_add(index_drift);
+    !repair && findings != 0
+}
+
 /// Hash each unique blob **once**, streaming, across a bounded worker pool,
 /// and return the hashes whose bytes no longer match their content address
 /// (kunobi-ninja/kache#176).
@@ -5279,11 +5300,8 @@ pub fn verify(config: &Config, checksums: bool, repair: bool) -> Result<VerifyOu
     let index_drift = if repair {
         match store.reconcile_blob_index() {
             Ok(drift) => {
-                if drift.total() > 0 {
-                    println!(
-                        "Repairing: reconciled {} entry mappings and {} blob rows.",
-                        drift.entry_mappings, drift.blobs
-                    );
+                if let Some(message) = reconciled_index_message(drift) {
+                    println!("{message}");
                 }
                 0
             }
@@ -5337,7 +5355,7 @@ pub fn verify(config: &Config, checksums: bool, repair: bool) -> Result<VerifyOu
     println!("  Blob index drift: {index_drift}");
     println!("  Store size: {}", ByteSize(store_size));
 
-    if (corrupted_entries > 0 || orphaned_blobs > 0 || index_drift > 0) && !repair {
+    if should_print_repair_tip(corrupted_entries, orphaned_blobs, index_drift, repair) {
         println!();
         println!(
             "Tip: run `kache doctor --repair` to remove corrupted entries, reconcile the blob index, and reclaim orphaned blobs."
@@ -8069,6 +8087,28 @@ mod tests {
         assert!(
             err.to_string().contains("No remote configured"),
             "got: {err}"
+        );
+    }
+
+    #[test]
+    fn repair_tip_and_reconciliation_message_cover_every_boundary() {
+        assert!(!should_print_repair_tip(0, 0, 0, false));
+        assert!(should_print_repair_tip(1, 0, 0, false));
+        assert!(should_print_repair_tip(0, 1, 0, false));
+        assert!(should_print_repair_tip(0, 0, 1, false));
+        assert!(!should_print_repair_tip(1, 1, 1, true));
+
+        assert_eq!(
+            reconciled_index_message(crate::store::BlobIndexDrift::default()),
+            None
+        );
+        assert_eq!(
+            reconciled_index_message(crate::store::BlobIndexDrift {
+                entry_mappings: 1,
+                blobs: 2,
+            })
+            .as_deref(),
+            Some("Repairing: reconciled 1 entry mappings and 2 blob rows.")
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -655,6 +655,28 @@ pub struct OrphanSweepStats {
     pub bytes_reclaimed: u64,
 }
 
+/// Difference between the derived SQLite blob index and committed entry
+/// metadata, which is the store's authoritative reference graph (#819).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BlobIndexDrift {
+    /// `entry_blobs` rows that are missing, stale, or have the wrong count.
+    pub entry_mappings: usize,
+    /// `blobs` rows that are missing, stale, or have the wrong size/refcount.
+    pub blobs: usize,
+}
+
+impl BlobIndexDrift {
+    pub fn total(self) -> usize {
+        self.entry_mappings + self.blobs
+    }
+}
+
+#[derive(Default)]
+struct AuthoritativeBlobIndex {
+    entry_mappings: std::collections::BTreeMap<(String, String), i64>,
+    blobs: std::collections::BTreeMap<String, (i64, i64)>,
+}
+
 /// The local content-addressed store.
 pub struct Store {
     config: Config,
@@ -2265,6 +2287,171 @@ impl Store {
             }
         }
         Ok(imported)
+    }
+
+    /// Read the authoritative blob reference graph from committed entry
+    /// metadata. The caller must hold SQLite's write lock so a publisher or
+    /// remover cannot change the row/meta pairing during the scan (#819).
+    fn authoritative_blob_index(&self, conn: &Connection) -> Result<AuthoritativeBlobIndex> {
+        let keys: Vec<String> = {
+            let mut stmt = conn
+                .prepare("SELECT cache_key FROM entries WHERE committed = 1 ORDER BY cache_key")?;
+            stmt.query_map([], |row| row.get(0))?
+                .collect::<Result<Vec<_>, _>>()?
+        };
+        let mut index = AuthoritativeBlobIndex::default();
+        for key in keys {
+            let meta_path = self.entry_dir(&key).join("meta.json");
+            let content = fs::read_to_string(&meta_path)
+                .with_context(|| format!("entry {key}: reading authoritative meta.json"))?;
+            let meta: EntryMeta = serde_json::from_str(&content)
+                .with_context(|| format!("entry {key}: parsing authoritative meta.json"))?;
+            for file in &meta.files {
+                if !crate::remote_layout::is_blob_hash(&file.hash)
+                    || !crate::remote_layout::is_safe_artifact_name(&file.name)
+                {
+                    anyhow::bail!("entry {key}: invalid blob metadata");
+                }
+                let blob_path = self.blob_path(&file.hash);
+                let actual_size = fs::metadata(&blob_path)
+                    .with_context(|| format!("entry {key}: reading blob {}", file.hash))?
+                    .len();
+                if actual_size != file.size {
+                    anyhow::bail!(
+                        "entry {key}: blob {} size mismatch (expected {}, got {})",
+                        file.hash,
+                        file.size,
+                        actual_size
+                    );
+                }
+
+                *index
+                    .entry_mappings
+                    .entry((key.clone(), file.hash.clone()))
+                    .or_insert(0) += 1;
+                match index.blobs.entry(file.hash.clone()) {
+                    std::collections::btree_map::Entry::Vacant(slot) => {
+                        slot.insert((file.size as i64, 1));
+                    }
+                    std::collections::btree_map::Entry::Occupied(mut slot) => {
+                        let (size, refs) = slot.get_mut();
+                        if *size != file.size as i64 {
+                            anyhow::bail!(
+                                "blob {} has conflicting sizes in committed metadata",
+                                file.hash
+                            );
+                        }
+                        *refs += 1;
+                    }
+                }
+            }
+        }
+        Ok(index)
+    }
+
+    fn indexed_blob_graph(&self, conn: &Connection) -> Result<AuthoritativeBlobIndex> {
+        let entry_mappings = {
+            let mut stmt = conn.prepare("SELECT cache_key, hash, refs FROM entry_blobs")?;
+            stmt.query_map([], |row| Ok(((row.get(0)?, row.get(1)?), row.get(2)?)))?
+                .collect::<Result<std::collections::BTreeMap<_, _>, _>>()?
+        };
+        let blobs = {
+            let mut stmt = conn.prepare("SELECT hash, size, refcount FROM blobs")?;
+            stmt.query_map([], |row| Ok((row.get(0)?, (row.get(1)?, row.get(2)?))))?
+                .collect::<Result<std::collections::BTreeMap<_, _>, _>>()?
+        };
+        Ok(AuthoritativeBlobIndex {
+            entry_mappings,
+            blobs,
+        })
+    }
+
+    fn compare_blob_indexes(
+        expected: &AuthoritativeBlobIndex,
+        actual: &AuthoritativeBlobIndex,
+    ) -> BlobIndexDrift {
+        let entry_mappings = expected
+            .entry_mappings
+            .keys()
+            .chain(actual.entry_mappings.keys())
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .filter(|key| expected.entry_mappings.get(*key) != actual.entry_mappings.get(*key))
+            .count();
+        let blobs = expected
+            .blobs
+            .keys()
+            .chain(actual.blobs.keys())
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .filter(|hash| expected.blobs.get(*hash) != actual.blobs.get(*hash))
+            .count();
+        BlobIndexDrift {
+            entry_mappings,
+            blobs,
+        }
+    }
+
+    /// Verify that `entry_blobs` and `blobs` exactly match committed entry
+    /// metadata. The write lock makes the filesystem/SQLite comparison stable.
+    pub fn blob_index_drift(&self) -> Result<BlobIndexDrift> {
+        self.db.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| {
+            let expected = self.authoritative_blob_index(&self.db)?;
+            let actual = self.indexed_blob_graph(&self.db)?;
+            Ok(Self::compare_blob_indexes(&expected, &actual))
+        })();
+        match result {
+            Ok(drift) => {
+                self.db.execute_batch("COMMIT")?;
+                Ok(drift)
+            }
+            Err(error) => {
+                let _ = self.db.execute_batch("ROLLBACK");
+                Err(error)
+            }
+        }
+    }
+
+    /// Rebuild only the derived blob graph from committed entry metadata.
+    /// Physical orphan reclamation deliberately happens after this transaction
+    /// through [`Self::sweep_orphan_blobs`], never while SQL can roll back.
+    pub fn reconcile_blob_index(&self) -> Result<BlobIndexDrift> {
+        self.db.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> Result<BlobIndexDrift> {
+            let expected = self.authoritative_blob_index(&self.db)?;
+            let actual = self.indexed_blob_graph(&self.db)?;
+            let drift = Self::compare_blob_indexes(&expected, &actual);
+            if drift.total() == 0 {
+                return Ok(drift);
+            }
+
+            self.db.execute("DELETE FROM entry_blobs", [])?;
+            self.db.execute("DELETE FROM blobs", [])?;
+            for ((cache_key, hash), refs) in &expected.entry_mappings {
+                self.db.execute(
+                    "INSERT INTO entry_blobs (cache_key, hash, refs) VALUES (?1, ?2, ?3)",
+                    params![cache_key, hash, refs],
+                )?;
+            }
+            for (hash, (size, refcount)) in &expected.blobs {
+                self.db.execute(
+                    "INSERT INTO blobs (hash, size, refcount) VALUES (?1, ?2, ?3)",
+                    params![hash, size, refcount],
+                )?;
+            }
+            Ok(drift)
+        })();
+        match result {
+            Ok(drift) => {
+                self.db.execute_batch("COMMIT")?;
+                Ok(drift)
+            }
+            Err(error) => {
+                let _ = self.db.execute_batch("ROLLBACK");
+                Err(error)
+            }
+        }
     }
 
     /// Rebuild the `entries` and `blobs` rows by scanning the store's per-entry
@@ -4717,6 +4904,154 @@ mod tests {
             .unwrap();
         assert_eq!(stats.removed, 0);
         assert!(orphan_path.exists());
+    }
+
+    #[test]
+    fn reconcile_blob_index_repairs_refcounts_and_stale_rows_idempotently() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let payload = b"shared authoritative blob";
+
+        for key in ["repair_a", "repair_b"] {
+            let output = dir.path().join(format!("{key}.rlib"));
+            fs::write(&output, payload).unwrap();
+            store
+                .put(
+                    key,
+                    "repairlib",
+                    &["lib".to_string()],
+                    &[],
+                    "host",
+                    "dev",
+                    &[(output, format!("lib{key}.rlib"))],
+                    "",
+                    "",
+                )
+                .unwrap();
+        }
+        let hash = store.get("repair_a").unwrap().unwrap().files[0]
+            .hash
+            .clone();
+        let stale_hash = "f".repeat(64);
+        let stale_path = store.blob_path(&stale_hash);
+        fs::create_dir_all(stale_path.parent().unwrap()).unwrap();
+        fs::write(&stale_path, b"stale indexed blob").unwrap();
+
+        store
+            .db
+            .execute(
+                "UPDATE blobs SET refcount = 41 WHERE hash = ?1",
+                params![hash],
+            )
+            .unwrap();
+        store
+            .db
+            .execute(
+                "UPDATE entry_blobs SET refs = 7 WHERE cache_key = 'repair_a'",
+                [],
+            )
+            .unwrap();
+        store
+            .db
+            .execute(
+                "INSERT INTO blobs (hash, size, refcount) VALUES (?1, ?2, 9)",
+                params![stale_hash, b"stale indexed blob".len() as i64],
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.blob_index_drift().unwrap(),
+            BlobIndexDrift {
+                entry_mappings: 1,
+                blobs: 2,
+            }
+        );
+        assert_eq!(
+            store.reconcile_blob_index().unwrap(),
+            BlobIndexDrift {
+                entry_mappings: 1,
+                blobs: 2,
+            }
+        );
+        assert_eq!(store.blob_index_drift().unwrap(), BlobIndexDrift::default());
+        assert_eq!(
+            store.reconcile_blob_index().unwrap(),
+            BlobIndexDrift::default()
+        );
+
+        let refcount: i64 = store
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(refcount, 2);
+        assert_eq!(
+            store
+                .db
+                .query_row(
+                    "SELECT COUNT(*) FROM blobs WHERE hash = ?1",
+                    params![stale_hash],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        let swept = store.sweep_orphan_blobs(Duration::ZERO).unwrap();
+        assert_eq!(swept.removed, 1);
+        assert!(!stale_path.exists());
+    }
+
+    #[test]
+    fn reconcile_blob_index_fails_closed_on_unreadable_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let output = dir.path().join("output.rlib");
+        fs::write(&output, b"authoritative bytes").unwrap();
+        store
+            .put(
+                "repair_bad_meta",
+                "repairlib",
+                &["lib".to_string()],
+                &[],
+                "host",
+                "dev",
+                &[(output, "librepair.rlib".to_string())],
+                "",
+                "",
+            )
+            .unwrap();
+        let hash = store.get("repair_bad_meta").unwrap().unwrap().files[0]
+            .hash
+            .clone();
+        store
+            .db
+            .execute(
+                "UPDATE blobs SET refcount = 9 WHERE hash = ?1",
+                params![hash],
+            )
+            .unwrap();
+        fs::write(
+            store.entry_dir("repair_bad_meta").join("meta.json"),
+            b"not json",
+        )
+        .unwrap();
+
+        let error = store.reconcile_blob_index().unwrap_err().to_string();
+        assert!(error.contains("parsing authoritative meta.json"), "{error}");
+        let refcount: i64 = store
+            .db
+            .query_row(
+                "SELECT refcount FROM blobs WHERE hash = ?1",
+                params![hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(refcount, 9, "failed repair must leave the index untouched");
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -5055,6 +5055,42 @@ mod tests {
     }
 
     #[test]
+    fn reconcile_blob_index_rejects_each_invalid_metadata_dimension() {
+        for invalid_hash in [true, false] {
+            let dir = tempfile::tempdir().unwrap();
+            let config = test_config(dir.path());
+            let store = Store::open(&config).unwrap();
+            let output = dir.path().join("output.rlib");
+            fs::write(&output, b"valid blob bytes").unwrap();
+            store
+                .put(
+                    "repair_invalid_metadata",
+                    "repairlib",
+                    &["lib".to_string()],
+                    &[],
+                    "host",
+                    "dev",
+                    &[(output, "librepair.rlib".to_string())],
+                    "",
+                    "",
+                )
+                .unwrap();
+            let meta_path = store.entry_dir("repair_invalid_metadata").join("meta.json");
+            let mut meta: EntryMeta =
+                serde_json::from_str(&fs::read_to_string(&meta_path).unwrap()).unwrap();
+            if invalid_hash {
+                meta.files[0].hash = "not-a-content-hash".to_string();
+            } else {
+                meta.files[0].name = "../unsafe.rlib".to_string();
+            }
+            fs::write(&meta_path, serde_json::to_vec(&meta).unwrap()).unwrap();
+
+            let error = store.reconcile_blob_index().unwrap_err().to_string();
+            assert!(error.contains("invalid blob metadata"), "{error}");
+        }
+    }
+
+    #[test]
     fn store_ingest_accounts_new_blob_bytes_by_mechanism() {
         // A new-blob put must record the artifact's bytes against exactly one
         // store-ingest counter — reflink, hardlink, or copy depending on the


### PR DESCRIPTION
Closes #819.

## What changed
- compare `entry_blobs` and `blobs` with committed `meta.json` under the SQLite write lock
- make `doctor --verify` fail on derived-index drift
- make `doctor --repair` rebuild mappings/refcounts atomically and reclaim files only after commit
- fail closed on unreadable or contradictory authoritative metadata
- cover wrong refcounts, stale indexed blobs, idempotence, rollback, and CLI convergence

## Validation
- `cargo test -q reconcile_blob_index`
- `cargo test -q verify_reports_and_repairs_blob_index_drift`
- `cargo test -q verify_detects_missing_blob_and_missing_meta_then_repairs`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`