### PR TITLE
feat(cc): key the cross-target flag class cc-rs injects (-mabi=, -mfloat-abi=, -mfpu=, -mthumb, -mcmodel=)

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2141,26 +2141,75 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         source: "Issue #115 — architecture selection. `Prefix` is safe because the probe resolves the value into target-cpu/target-feature tokens.",
         dialect: None,
     },
+    // ── Cross-target ABI / ISA-state selectors (issue #823) ──
+    //
+    // The Rust `cc` crate injects these on its own for cross targets:
+    // `-mabi=` (riscv), `-mfloat-abi=` + `-mfpu=` (arm), `-mthumb` (thumbv*)
+    // — so refusing any one of them makes every cross-compiled C TU on that
+    // architecture uncacheable, not just hand-written invocations.
+    //
+    // Each is `RawKeyed`, deliberately NOT `CapturedByProbe` like their
+    // `-march=` neighbour. Every value in these sets is a closed enumeration
+    // with no host-relative member (there is no `-mabi=native` the way
+    // `-mtune=`/`-mcpu=` have one), so the flag text alone determines the
+    // object — the exact property a verbatim fold keys. Clang does lower
+    // them into the resolved cc1 line (verified: `-### --target=
+    // riscv64-unknown-linux-gnu -mabi=lp64d` yields `"-target-abi" "lp64d"`
+    // against `"lp64"` for `-mabi=lp64`), so the probe would key them on
+    // clang — but probe-captured soundness would rest on every supported
+    // driver spelling the effect into that line, and a driver that omitted
+    // it would serve one ABI's object to the other: a broken binary, not a
+    // missed hit. The verbatim fold cannot do that.
     FlagSpec {
-        // `-mabi=` selects the target ABI: `lp64d`/`lp64`/`ilp32` on riscv,
-        // `ms`/`sysv` on x86-64, `aapcs-linux` on arm. It changes the object
-        // materially — a cross build refused to cache without it — and the
-        // value is a closed enumeration with no host-relative member (there
-        // is no `-mabi=native`, unlike `-mtune=`/`-mcpu=`), so the flag text
-        // alone determines the effect. That makes `RawKeyed` exact here.
-        //
-        // Deliberately NOT `CapturedByProbe` like its `-march=` neighbour.
-        // Clang does lower it into the resolved cc1 line (verified:
-        // `-### --target=riscv64-unknown-linux-gnu -mabi=lp64d` yields
-        // `"-target-abi" "lp64d"` against `"lp64"` for `-mabi=lp64`), so the
-        // probe would key it on clang. But probe-captured soundness would
-        // then rest on every supported driver spelling the ABI into that
-        // line, and a driver that omitted it would serve one ABI's object to
-        // the other — a broken binary, not a missed hit. Folding the flag
-        // verbatim costs only exact-spelling keying and cannot do that.
+        // Target ABI: `lp64d`/`lp64`/`ilp32` on riscv, `ms`/`sysv` on
+        // x86-64, `aapcs-linux` on arm.
         matcher: Matcher::Prefix("-mabi="),
         class: FlagClass::RawKeyed,
-        source: "Issue #823 — target ABI selection. Closed value set with no host-relative member, so the argument text is exact; keyed verbatim rather than via the probe so soundness does not depend on driver-specific cc1 spelling.",
+        source: "Issue #823 — target ABI selection; closed value set, keyed verbatim.",
+        dialect: None,
+    },
+    FlagSpec {
+        // Float ABI: `soft` / `softfp` / `hard`. cc-rs injects
+        // `-mfloat-abi=hard` for every *eabihf target.
+        matcher: Matcher::Prefix("-mfloat-abi="),
+        class: FlagClass::RawKeyed,
+        source: "Issue #823 — arm float ABI; closed value set (soft/softfp/hard), keyed verbatim.",
+        dialect: None,
+    },
+    FlagSpec {
+        // Code model: `tiny`/`small`/`kernel`/`medium`/`large` (x86,
+        // aarch64), `medlow`/`medany` (riscv). Common in riscv firmware
+        // and kernel builds.
+        matcher: Matcher::Prefix("-mcmodel="),
+        class: FlagClass::RawKeyed,
+        source: "Issue #823 — code model; closed value set, keyed verbatim.",
+        dialect: None,
+    },
+    FlagSpec {
+        // Concrete arm FPU names — the standardized set gcc and clang
+        // both document. cc-rs injects `vfpv3-d16` / `vfp` / `neon`.
+        //
+        // `-mfpu=auto` is DELIBERATELY not matched and keeps refusing: it
+        // resolves from `-march`/`-mcpu` (and the toolchain's configured
+        // default when those are absent) inside cc1, so its text does not
+        // determine the object, and gcc's driver passes the literal `auto`
+        // to cc1 — the probe cannot capture the resolution either.
+        matcher: Matcher::Regex(
+            r"-mfpu=(?:none|vfp|vfpv2|vfpv3(?:-fp16|-d16(?:-fp16)?|xd(?:-fp16)?)?|vfpv4(?:-d16)?|fpv4-sp-d16|fpv5-(?:sp-)?d16|fp-armv8(?:-fullfp16)?|neon(?:-fp16|-vfpv3|-vfpv4|-fp-armv8)?|crypto-neon-fp-armv8)",
+        ),
+        class: FlagClass::RawKeyed,
+        source: "Issue #823 — concrete arm FPU selection; enumerated so `-mfpu=auto` (resolved inside cc1, not text-deterministic) still refuses.",
+        dialect: None,
+    },
+    FlagSpec {
+        // Instruction-set state: Thumb vs ARM encoding, both polarities —
+        // conflicting occurrences are last-one-wins, which the raw fold
+        // preserves because it hashes in argv order with duplicates kept.
+        // Valueless and text-deterministic; cc-rs injects `-mthumb` for
+        // thumbv* targets.
+        matcher: Matcher::Regex(r"-m(?:(?:no-)?thumb|arm)"),
+        class: FlagClass::RawKeyed,
+        source: "Issue #823 — arm/thumb instruction-set state, keyed verbatim in argv order.",
         dialect: None,
     },
     FlagSpec {
@@ -7021,6 +7070,18 @@ mod tests {
             "-mabi=sysv", // x86-64
             "-mabi=ms",
             "-mabi=aapcs-linux", // arm
+            // The rest of the class the `cc` crate injects for cross targets:
+            "-mfloat-abi=hard",
+            "-mfloat-abi=softfp",
+            "-mfloat-abi=soft",
+            "-mfpu=vfpv3-d16", // cc-rs armv7-eabihf default
+            "-mfpu=neon",
+            "-mfpu=vfp",
+            "-mfpu=crypto-neon-fp-armv8",
+            "-mthumb",
+            "-marm",
+            "-mcmodel=medany", // riscv firmware/kernel staple
+            "-mcmodel=large",
         ] {
             assert_eq!(
                 classify_cc_flag(flag, Dialect::Gnu),
@@ -7049,6 +7110,25 @@ mod tests {
         assert_ne!(raw("-mabi=lp64d"), raw("-mabi=lp64"));
         assert_ne!(raw("-mabi=sysv"), raw("-mabi=ms"));
         assert_ne!(plain, raw("-mabi=lp64d"), "an ABI gate must move the key");
+        assert_ne!(raw("-mfloat-abi=hard"), raw("-mfloat-abi=soft"));
+        assert_ne!(raw("-mfpu=neon"), raw("-mfpu=vfpv3-d16"));
+        assert_ne!(raw("-mthumb"), raw("-marm"));
+        assert_ne!(raw("-mcmodel=medany"), raw("-mcmodel=medlow"));
+        // Conflicting occurrences are last-one-wins for the compiler, so the
+        // fold must preserve argv ORDER (and duplicates): `-mthumb -marm`
+        // ends in ARM state, the reverse in Thumb state.
+        let raw2 = |a: &str, b: &str| {
+            cc_raw_flags_for_key(
+                &CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o", a, b])).unwrap(),
+                &[],
+            )
+        };
+        assert_ne!(
+            raw2("-mthumb", "-marm"),
+            raw2("-marm", "-mthumb"),
+            "conflicting ISA-state flags are last-one-wins; order must key"
+        );
+        assert_ne!(raw("-mthumb"), raw("-mno-thumb"));
     }
 
     /// The exact `ring` invocation from issue #823. Every flag in it has to
@@ -7107,17 +7187,49 @@ mod tests {
         assert!(cc_flags_need_resolved_invocation(&parsed));
     }
 
-    /// The `-mabi=` row must not widen into the neighbouring value-taking
-    /// `-m` knobs. `-mtune=`/`-mcpu=` accept `native`, whose meaning depends
-    /// on the host rather than the flag, so they stay refused until they are
-    /// modeled deliberately.
+    /// The flags the `cc` crate injects on its own for
+    /// `armv7-unknown-linux-gnueabihf` (cc-rs `lib.rs`: `-march=armv7-a
+    /// -mfpu=vfpv3-d16 -mfloat-abi=hard`), plus `-mthumb` for the thumbv7
+    /// variants. No hand-written build file mentions these — refusing any
+    /// one of them silently uncaches every arm cross build.
     #[test]
-    fn other_value_taking_m_knobs_still_refuse_issue_823() {
+    fn cc_rs_armv7_injected_flags_are_cacheable_issue_823() {
+        let argv = s(&[
+            "arm-linux-gnueabihf-gcc",
+            "-O2",
+            "-ffunction-sections",
+            "-fdata-sections",
+            "-fPIC",
+            "-march=armv7-a",
+            "-mthumb",
+            "-mfpu=vfpv3-d16",
+            "-mfloat-abi=hard",
+            "-o",
+            "/build/out/foo.o",
+            "-c",
+            "foo.c",
+        ]);
+        let parsed = CcArgs::parse(&argv).unwrap();
+        assert!(
+            parsed.refuse_reasons(&[]).is_empty(),
+            "the cc-rs armv7 invocation must cache: {:?}",
+            parsed.refuse_reasons(&[])
+        );
+        assert!(cc_flags_need_resolved_invocation(&parsed));
+    }
+
+    /// The #823 rows must not widen into the host-relative `-m` knobs.
+    /// `-mtune=`/`-mcpu=` accept `native` and `-mfpu=` accepts `auto` —
+    /// values whose meaning depends on the host or the toolchain's
+    /// configured defaults rather than on the flag text — so they stay
+    /// refused until modeled deliberately.
+    #[test]
+    fn host_relative_m_knobs_still_refuse_issue_823() {
         for flag in &[
             "-mtune=native",
             "-mtune=skylake",
             "-mcpu=native",
-            "-mcmodel=medany",
+            "-mfpu=auto",
         ] {
             assert_eq!(
                 classify_cc_flag(flag, Dialect::Gnu),
@@ -7526,7 +7638,9 @@ mod tests {
             // and tuning knobs the SIMD regex must NOT swallow.
             "-mtune=skylake",
             "-mfpmath=sse",
-            "-mcmodel=large",
+            // (`-mcmodel=` moved to the modeled #823 class; `-mfpu=auto`
+            // resolves inside cc1 so its text is not the object.)
+            "-mfpu=auto",
         ] {
             let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
             assert!(

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2142,6 +2142,28 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         dialect: None,
     },
     FlagSpec {
+        // `-mabi=` selects the target ABI: `lp64d`/`lp64`/`ilp32` on riscv,
+        // `ms`/`sysv` on x86-64, `aapcs-linux` on arm. It changes the object
+        // materially — a cross build refused to cache without it — and the
+        // value is a closed enumeration with no host-relative member (there
+        // is no `-mabi=native`, unlike `-mtune=`/`-mcpu=`), so the flag text
+        // alone determines the effect. That makes `RawKeyed` exact here.
+        //
+        // Deliberately NOT `CapturedByProbe` like its `-march=` neighbour.
+        // Clang does lower it into the resolved cc1 line (verified:
+        // `-### --target=riscv64-unknown-linux-gnu -mabi=lp64d` yields
+        // `"-target-abi" "lp64d"` against `"lp64"` for `-mabi=lp64`), so the
+        // probe would key it on clang. But probe-captured soundness would
+        // then rest on every supported driver spelling the ABI into that
+        // line, and a driver that omitted it would serve one ABI's object to
+        // the other — a broken binary, not a missed hit. Folding the flag
+        // verbatim costs only exact-spelling keying and cannot do that.
+        matcher: Matcher::Prefix("-mabi="),
+        class: FlagClass::RawKeyed,
+        source: "Issue #823 — target ABI selection. Closed value set with no host-relative member, so the argument text is exact; keyed verbatim rather than via the probe so soundness does not depend on driver-specific cc1 spelling.",
+        dialect: None,
+    },
+    FlagSpec {
         matcher: Matcher::Exact("-msimd128"),
         class: FlagClass::CapturedByProbe,
         source: "Issue #115 — WASM SIMD128 enable.",
@@ -2156,8 +2178,9 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         // The nightly Firefox bench passed media/codec TUs through on
         // `-mavx -mbmi2 -mf16c`; the set below covers the x86 codec ISA family
         // (libvpx/dav1d/aom). Enumerated explicitly (with optional `no-`)
-        // rather than opening `-m*`, so value-taking knobs (`-mtune=`,
-        // `-mcmodel=`, `-mabi=`) and unmodeled `-m` flags still refuse.
+        // rather than opening `-m*`, so the remaining value-taking knobs
+        // (`-mtune=`, `-mcpu=`, `-mcmodel=`) and unmodeled `-m` flags still
+        // refuse. `-mabi=` is modeled separately above.
         matcher: Matcher::Regex(
             r"^-m(?:no-)?(?:32|64|mmx|sse|sse2|sse3|ssse3|sse4|sse4\.1|sse4\.2|sse4a|avx|avx2|avx512[a-z0-9]+|fma|fma4|f16c|bmi|bmi2|abm|popcnt|lzcnt|aes|vaes|pclmul|vpclmulqdq|gfni|sha|movbe|rdrnd|rdseed|adx|fsgsbase|xsave|xsaveopt|xsavec|xsaves|prfchw|clflushopt|clwb|cldemote|fxsr)$",
         ),
@@ -6984,6 +7007,124 @@ mod tests {
         assert_ne!(plain, err, "-Werror must change the keyed flags");
         assert_ne!(err, both, "-Wno-error must distinguish from bare -Werror");
         assert_ne!(no_err, both);
+    }
+
+    /// Issue #823: `-mabi=` selects the target ABI, so it must be keyed.
+    /// It refused before, which is why a cross-compiled C TU never cached;
+    /// it now folds verbatim, and each ABI keys distinctly.
+    #[test]
+    fn mabi_is_raw_keyed_and_cacheable_issue_823() {
+        for flag in &[
+            "-mabi=lp64d", // riscv64 hard-float — the issue #823 invocation
+            "-mabi=lp64",  // riscv64 soft-float: a different object
+            "-mabi=ilp32",
+            "-mabi=sysv", // x86-64
+            "-mabi=ms",
+            "-mabi=aapcs-linux", // arm
+        ] {
+            assert_eq!(
+                classify_cc_flag(flag, Dialect::Gnu),
+                Some(FlagClass::RawKeyed),
+                "{flag} selects the ABI and must be folded into the key verbatim"
+            );
+            let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o", flag])).unwrap();
+            assert!(
+                parsed.refuse_reasons(&[]).is_empty(),
+                "{flag} should be cacheable: {:?}",
+                parsed.refuse_reasons(&[])
+            );
+        }
+        // Distinct ABIs must fold to distinct raw keys: serving an lp64d
+        // object to an lp64 build is a broken binary, not a missed hit.
+        let raw = |abi: &str| {
+            cc_raw_flags_for_key(
+                &CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o", abi])).unwrap(),
+                &[],
+            )
+        };
+        let plain = cc_raw_flags_for_key(
+            &CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o"])).unwrap(),
+            &[],
+        );
+        assert_ne!(raw("-mabi=lp64d"), raw("-mabi=lp64"));
+        assert_ne!(raw("-mabi=sysv"), raw("-mabi=ms"));
+        assert_ne!(plain, raw("-mabi=lp64d"), "an ABI gate must move the key");
+    }
+
+    /// The exact `ring` invocation from issue #823. Every flag in it has to
+    /// be modeled for the TU to cache at all; `-mabi=lp64d` was the one that
+    /// refused, so this pins the whole argv rather than the flag alone.
+    #[test]
+    fn ring_cross_compile_invocation_is_cacheable_issue_823() {
+        let argv = s(&[
+            "cc",
+            "-O0",
+            "-ffunction-sections",
+            "-fdata-sections",
+            "-fPIC",
+            "-g",
+            "-gdwarf-4",
+            "-fno-omit-frame-pointer",
+            "-march=rv64gc",
+            "-mabi=lp64d",
+            "-I",
+            "/cargo/registry/ring-0.17.14/include",
+            "-I",
+            "/cargo/registry/ring-0.17.14/pregenerated",
+            "-Wall",
+            "-Wextra",
+            "-fvisibility=hidden",
+            "-std=c1x",
+            "-Wbad-function-cast",
+            "-Wcast-align",
+            "-Wcast-qual",
+            "-Wconversion",
+            "-Wmissing-field-initializers",
+            "-Wmissing-include-dirs",
+            "-Wnested-externs",
+            "-Wredundant-decls",
+            "-Wshadow",
+            "-Wsign-compare",
+            "-Wsign-conversion",
+            "-Wstrict-prototypes",
+            "-Wundef",
+            "-Wuninitialized",
+            "-g3",
+            "-DNDEBUG",
+            "-o",
+            "/build/out/25ac62e5b3c53843-curve25519.o",
+            "-c",
+            "/cargo/registry/ring-0.17.14/crypto/curve25519/curve25519.c",
+        ]);
+        let parsed = CcArgs::parse(&argv).unwrap();
+        assert!(
+            parsed.refuse_reasons(&[]).is_empty(),
+            "the #823 invocation must cache: {:?}",
+            parsed.refuse_reasons(&[])
+        );
+        // `-march=` is probe-captured, so this argv must resolve `-###`
+        // before it can key — the ABI fold does not replace that.
+        assert!(cc_flags_need_resolved_invocation(&parsed));
+    }
+
+    /// The `-mabi=` row must not widen into the neighbouring value-taking
+    /// `-m` knobs. `-mtune=`/`-mcpu=` accept `native`, whose meaning depends
+    /// on the host rather than the flag, so they stay refused until they are
+    /// modeled deliberately.
+    #[test]
+    fn other_value_taking_m_knobs_still_refuse_issue_823() {
+        for flag in &[
+            "-mtune=native",
+            "-mtune=skylake",
+            "-mcpu=native",
+            "-mcmodel=medany",
+        ] {
+            assert_eq!(
+                classify_cc_flag(flag, Dialect::Gnu),
+                None,
+                "{flag} is not modeled and must keep refusing"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Any invocation carrying `-mabi=` refused outright (`cc unsupported flag(s): -mabi=lp64d — not yet`) — that is the `ring` build in #823. But the instance is not the class: the Rust `cc` crate *injects* target-machine flags on its own for cross targets — `-mfloat-abi=hard` and `-mfpu=vfpv3-d16` for every `*eabihf` target, `-mthumb` for `thumbv*` — so an `-mabi=`-only fix would leave every arm cross build refusing on flags no build file ever mentions. This models the class:

| Flag | Classification | Note |
|---|---|---|
| `-mabi=` | `RawKeyed`, prefix | `lp64d`/`lp64`/`ilp32` (riscv), `ms`/`sysv` (x86-64) |
| `-mfloat-abi=` | `RawKeyed`, prefix | closed set: `soft`/`softfp`/`hard` |
| `-mcmodel=` | `RawKeyed`, prefix | `medlow`/`medany` (riscv), `tiny`…`large` |
| `-mfpu=` | `RawKeyed`, enumerated concrete FPU names | **`auto` keeps refusing** — it resolves from `-march`/`-mcpu`/toolchain defaults *inside cc1*, so its text is not the object, and gcc's driver passes the literal `auto` through, so the probe cannot capture the resolution either |
| `-mthumb` / `-mno-thumb` / `-marm` | `RawKeyed` | conflicting occurrences are last-one-wins; the raw fold hashes argv order with duplicates kept, so orderings key distinctly (pinned by test) |

Every keyed value set is closed with no host-relative member (there is no `-mabi=native` the way `-mtune=`/`-mcpu=` have one), so the flag text alone determines the object — exactly what a verbatim fold keys. Deliberately not `CapturedByProbe`: clang does lower these into the resolved cc1 line (verified: `-### --target=riscv64-unknown-linux-gnu -mabi=lp64d` → `"-target-abi" "lp64d"`), but probe soundness would rest on every driver spelling the effect into that line, and a driver that omitted it would serve one ABI's object to a build expecting the other — a broken binary, not a missed hit.

`-mtune=`, `-mcpu=` (accept `native`) and `-mfpu=auto` stay refused, pinned by test so these rows cannot widen into the host-relative knobs.

Cross-checked with an independent codex review leg, which converged on the same classification and demanded the ordered/duplicate-preserving fold (already how `cc_raw_flags:` hashes — argv order, length-prefixed) plus the `-mno-thumb` polarity, both now covered.

Note this makes cross C units cacheable; it does not by itself fix #823, where a bare `CC="kache cc"` from kache-action routes riscv compiles to the host gcc. That half lands in kache-action.

## Test plan

- [x] `mabi_is_raw_keyed_and_cacheable_issue_823`: classification + cacheability across the class; per-value key distinctness (`lp64d`≠`lp64`, `sysv`≠`ms`, `hard`≠`soft`, `neon`≠`vfpv3-d16`, `medany`≠`medlow`, present≠absent); `-mthumb -marm` vs `-marm -mthumb` key distinctly (last-one-wins ordering)
- [x] `ring_cross_compile_invocation_is_cacheable_issue_823`: the exact argv from #823 — fails without the change (`Unsupported("cc unsupported flag(s): -mabi=lp64d — not yet")`)
- [x] `cc_rs_armv7_injected_flags_are_cacheable_issue_823`: the exact flag set cc-rs injects for `armv7-unknown-linux-gnueabihf`
- [x] `host_relative_m_knobs_still_refuse_issue_823`: `-mtune=`, `-mcpu=`, `-mfpu=auto` keep refusing
- [x] `cargo test --bin kache`: 2157 pass; `cargo fmt --check` + `cargo clippy --all-targets` clean

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [x] No user-visible CLI/config/output changes requiring docs updates