### PR TITLE
chore(release): prepare 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "kache-service"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more, with S3 and shared-filesystem remotes."
 license = "Apache-2.0"
@@ -36,7 +36,7 @@ reqsign-aws-v4 = { version = "=3.0.2", default-features = false }
 reqsign-core = { version = "=3.1.0", default-features = false }
 # Direct dep so OpenDAL/reqwest can use ring without reintroducing aws-lc.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.15.1", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.16.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/charts/kache-service/Chart.yaml
+++ b/charts/kache-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kache-service
 description: Advisory remote planner service for kache
 type: application
-version: 0.15.1
-appVersion: "0.15.1"
+version: 0.16.0
+appVersion: "0.16.0"
 keywords:
   - rust
   - cache

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Version bump for the 0.16.0 release. Ships since v0.15.1:

- #824 feat(cc): key the cross-target flag class cc-rs injects (`-mabi=`, `-mfloat-abi=`, `-mfpu=`, `-mthumb`, `-mcmodel=`) — cross-compiled C units become cacheable (#823)
- #822 fix: enforce IPC peer identity, key lint outcome gates, close put TOCTOU
- #820 fix: reconcile blob index from committed metadata
- #818 fix(report): flag inconsistent store accounting

Minor bump: #824 adds new cacheability (feat).

After merge: tag `v0.16.0` on the merge commit to trigger the release. kache-action installs the latest release, so kunobi-ninja/kache#823 users pick this up automatically together with kache-action#25.

## Checklist

- [x] Version bumped in workspace + crates + Helm chart (same shape as #817)
- [x] `cargo update --workspace` refreshed the lock
- [x] `cargo check` clean