### PR TITLE
fix(key): survive non-UTF-8 environments and multi-byte leak windows

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -527,6 +527,49 @@ fn env_name_key_bytes(name: &std::ffi::OsStr) -> Vec<u8> {
     env_os_key_bytes(name)
 }
 
+/// Env text as key bytes: the exact UTF-8 bytes when the text is valid
+/// UTF-8, or `0xFF`-tagged lossless OS bytes when it isn't.
+///
+/// The valid arm is byte-identical to hashing the `String` that
+/// `std::env::vars()` used to yield, so keys for all-UTF-8 environments
+/// (every one cargo itself constructs) are unchanged. The tag byte never
+/// occurs in valid UTF-8, so the two arms cannot collide — and unlike
+/// `to_string_lossy`, distinct invalid sequences stay distinct instead
+/// of merging under U+FFFD (see [`env_os_key_bytes`]).
+fn env_text_key_bytes(text: &std::ffi::OsStr) -> Vec<u8> {
+    match text.to_str() {
+        Some(utf8) => utf8.as_bytes().to_vec(),
+        None => {
+            let mut bytes = vec![0xff];
+            bytes.extend(env_os_key_bytes(text));
+            bytes
+        }
+    }
+}
+
+/// The `CARGO_CFG_*` pairs of an environment, sorted by name.
+///
+/// Takes `vars_os` pairs rather than `vars()`, which panics if *any*
+/// environment variable holds non-UTF-8 — even one this filter would
+/// discard. Pairs stay `OsString` so the hasher can fold them
+/// losslessly via [`env_text_key_bytes`].
+///
+/// The primary sort key is the lossy name — the same order the old
+/// `String` sort produced for every valid-UTF-8 environment. The
+/// lossless tiebreak pins two names that collide under U+FFFD to a
+/// deterministic order instead of platform iteration order.
+fn cargo_cfg_pairs(
+    vars: impl Iterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
+) -> Vec<(std::ffi::OsString, std::ffi::OsString)> {
+    let mut pairs: Vec<(std::ffi::OsString, std::ffi::OsString)> = vars
+        .filter(|(name, _)| name.to_string_lossy().starts_with("CARGO_CFG_"))
+        .collect();
+    pairs.sort_by_cached_key(|(name, _)| {
+        (name.to_string_lossy().into_owned(), env_os_key_bytes(name))
+    });
+    pairs
+}
+
 /// Does any `key_env_vars` pattern select the env var `name`?
 ///
 /// Exact match, or prefix match when the pattern ends in `*`. ASCII
@@ -1433,22 +1476,21 @@ pub fn compute_cache_key(
     }
 
     // Relevant CARGO_CFG_* env vars (sorted for determinism —
-    // std::env::vars() iteration order is platform-defined and not stable)
+    // environment iteration order is platform-defined and not stable)
     hasher.set_group("env_cfg");
-    let mut cargo_cfgs: Vec<(String, String)> = std::env::vars()
-        .filter(|(k, _)| k.starts_with("CARGO_CFG_"))
-        .collect();
-    cargo_cfgs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let cargo_cfgs = cargo_cfg_pairs(std::env::vars_os());
     tracing::trace!("[key:{}] cargo_cfg_count={}", crate_name, cargo_cfgs.len());
     for (key, value) in &cargo_cfgs {
         // Cargo derives CARGO_CFG_* from `--cfg` flags. Build scripts (and
         // mozbuild specifically) emit cfgs that can embed absolute paths;
         // those land here uncensored. Flag leaks so the offending var
-        // name is visible in the warn.
-        check_for_path_leak(value, &format!("cargo_cfg:{key}"));
-        hasher.update(key.as_bytes());
+        // name is visible in the warn. The lossy forms are diagnostic
+        // only; the hash folds the lossless bytes.
+        let key_lossy = key.to_string_lossy();
+        check_for_path_leak(&value.to_string_lossy(), &format!("cargo_cfg:{key_lossy}"));
+        hasher.update(&env_text_key_bytes(key));
         hasher.update(b"=");
-        hasher.update(value.as_bytes());
+        hasher.update(&env_text_key_bytes(value));
         hasher.update(b"\n");
     }
 
@@ -4528,6 +4570,68 @@ mod tests {
             env_os_key_bytes(OsStr::new("normal"))
         );
         assert!(env_os_key_bytes(OsStr::new("")).is_empty());
+    }
+
+    #[test]
+    fn cargo_cfg_pairs_filters_and_sorts() {
+        use std::ffi::OsString;
+        let pairs = cargo_cfg_pairs(
+            [
+                (OsString::from("CARGO_CFG_ZED"), OsString::from("1")),
+                (OsString::from("PATH"), OsString::from("/usr/bin")),
+                (OsString::from("CARGO_CFG_ABI"), OsString::from("eabi")),
+                (OsString::from("CARGO_PKG_NAME"), OsString::from("x")),
+            ]
+            .into_iter(),
+        );
+        assert_eq!(
+            pairs,
+            vec![
+                (OsString::from("CARGO_CFG_ABI"), OsString::from("eabi")),
+                (OsString::from("CARGO_CFG_ZED"), OsString::from("1")),
+            ]
+        );
+    }
+
+    /// A non-UTF-8 variable anywhere in the environment used to panic the
+    /// whole key computation via `std::env::vars()`; now the unrelated
+    /// variable is filtered out and a `CARGO_CFG_*` pair survives with its
+    /// exact bytes.
+    #[cfg(unix)]
+    #[test]
+    fn cargo_cfg_pairs_tolerates_non_utf8_environments() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+        let invalid = OsString::from_vec(vec![b'a', 0xff, b'b']);
+        let pairs = cargo_cfg_pairs(
+            [
+                (OsString::from_vec(vec![0xff, 0xfe]), invalid.clone()),
+                (OsString::from("CARGO_CFG_RAW"), invalid.clone()),
+            ]
+            .into_iter(),
+        );
+        assert_eq!(pairs, vec![(OsString::from("CARGO_CFG_RAW"), invalid)]);
+    }
+
+    /// Valid UTF-8 folds byte-identically to the old `vars()`-string
+    /// hashing (no key change without a version bump); invalid sequences
+    /// fold losslessly and distinctly instead of merging under U+FFFD.
+    #[test]
+    fn env_text_key_bytes_preserves_utf8_and_distinguishes_invalid() {
+        use std::ffi::OsStr;
+        assert_eq!(
+            env_text_key_bytes(OsStr::new("target_os=\"linux\"")),
+            b"target_os=\"linux\"".to_vec()
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+            let a = env_text_key_bytes(OsStr::from_bytes(&[b'x', 0xff]));
+            let b = env_text_key_bytes(OsStr::from_bytes(&[b'x', 0xfe]));
+            assert_ne!(a, b);
+            // Tagged: cannot collide with any valid-UTF-8 value's bytes.
+            assert_eq!(a[0], 0xff);
+        }
     }
 
     #[test]

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -1204,17 +1204,31 @@ pub(crate) fn check_for_path_leak(value: &str, context: &str) {
             // Show a small window around the leak to make it easier
             // to identify (env var name etc.) without dumping the
             // whole value, which could be huge.
-            let start = idx.saturating_sub(40);
-            let end = (idx + prefix.len() + 40).min(value.len());
             tracing::warn!(
                 "residual absolute path detected in `{}` (prefix `{}`): ...{}...",
                 context,
                 prefix,
-                &value[start..end]
+                leak_window(value, idx, prefix.len())
             );
             return;
         }
     }
+}
+
+/// The ±40-byte window of `value` around the leak found at byte `idx`,
+/// widened outward to char boundaries: `find` returns a byte offset, so
+/// either edge of the raw window can land inside a multi-byte character
+/// and slicing there would panic.
+fn leak_window(value: &str, idx: usize, prefix_len: usize) -> &str {
+    let mut start = idx.saturating_sub(40);
+    while !value.is_char_boundary(start) {
+        start -= 1;
+    }
+    let mut end = (idx + prefix_len + 40).min(value.len());
+    while !value.is_char_boundary(end) {
+        end += 1;
+    }
+    &value[start..end]
 }
 
 /// Back-compat shim retained for `PathNormalizer::normalize` callers.
@@ -1641,6 +1655,31 @@ mod tests {
                 "{off:?} should disable it"
             );
         }
+    }
+
+    /// A leaked path surrounded by multi-byte characters puts both raw
+    /// window edges (`idx - 40`, `idx + prefix_len + 40`) inside a
+    /// character; the window must widen to boundaries instead of
+    /// panicking (kache review finding: char-boundary slice panic).
+    #[test]
+    fn leak_window_widens_to_char_boundaries() {
+        // 20 three-byte chars on each side; the 8-byte leak in the
+        // middle makes both `60 - 40 = 20` and `60 + 6 + 40 = 106`
+        // land mid-character.
+        let value = format!("{}{}{}", "日".repeat(20), "/home/us", "本".repeat(20));
+        let idx = value.find("/home/").expect("leak present");
+        assert!(!value.is_char_boundary(idx.saturating_sub(40)));
+        assert!(!value.is_char_boundary(idx + "/home/".len() + 40));
+
+        let window = leak_window(&value, idx, "/home/".len());
+        assert!(window.contains("/home/us"));
+
+        // Degenerate shapes stay in-bounds: leak at the very start,
+        // at the very end, and a value shorter than the window.
+        assert_eq!(leak_window("/home/x", 0, "/home/".len()), "/home/x");
+        let tail = format!("{}{}", "あ".repeat(30), "/home/y");
+        let idx = tail.find("/home/").expect("leak present");
+        assert!(leak_window(&tail, idx, "/home/".len()).ends_with("/home/y"));
     }
 
     #[test]

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -1190,7 +1190,7 @@ fn parse_rustc_normalize_toggle(value: Option<&str>) -> bool {
 /// `"codegen:link-arg"`, `"cargo_cfg:MOZ_OBJ_DIR"`). It surfaces in the
 /// warn so the offending field is identifiable without re-running with
 /// trace-level logging.
-pub(crate) fn check_for_path_leak(value: &str, context: &str) {
+pub(crate) fn check_for_path_leak(value: &str, context: &str) -> bool {
     const SUSPICIOUS_PREFIXES: &[&str] = &[
         "/Users/",       // macOS home
         "/home/",        // Linux home
@@ -1210,9 +1210,10 @@ pub(crate) fn check_for_path_leak(value: &str, context: &str) {
                 prefix,
                 leak_window(value, idx, prefix.len())
             );
-            return;
+            return true;
         }
     }
+    false
 }
 
 /// The ±40-byte window of `value` around the leak found at byte `idx`,
@@ -1220,14 +1221,23 @@ pub(crate) fn check_for_path_leak(value: &str, context: &str) {
 /// either edge of the raw window can land inside a multi-byte character
 /// and slicing there would panic.
 fn leak_window(value: &str, idx: usize, prefix_len: usize) -> &str {
-    let mut start = idx.saturating_sub(40);
-    while !value.is_char_boundary(start) {
-        start -= 1;
-    }
-    let mut end = (idx + prefix_len + 40).min(value.len());
-    while !value.is_char_boundary(end) {
-        end += 1;
-    }
+    let raw_start = idx.saturating_sub(40);
+    let start = value
+        .char_indices()
+        .map(|(offset, _)| offset)
+        .take_while(|&offset| offset <= raw_start)
+        .last()
+        .unwrap_or(0);
+    let raw_end = idx
+        .saturating_add(prefix_len)
+        .saturating_add(40)
+        .min(value.len());
+    let end = value
+        .char_indices()
+        .map(|(offset, _)| offset)
+        .chain(std::iter::once(value.len()))
+        .find(|&offset| offset >= raw_end)
+        .expect("the string length always bounds the requested window");
     &value[start..end]
 }
 
@@ -1684,6 +1694,18 @@ mod tests {
         let tail = format!("{}{}", "あ".repeat(30), "/home/y");
         let idx = tail.find("/home/").expect("leak present");
         assert_eq!(leak_window(&tail, idx, "/home/".len()), &tail[48..]);
+    }
+
+    #[test]
+    fn path_leak_check_reports_presence_and_absence() {
+        assert!(check_for_path_leak(
+            "prefix /home/example/project suffix",
+            "test"
+        ));
+        assert!(!check_for_path_leak(
+            "a relative/path with no machine-local prefix",
+            "test"
+        ));
     }
 
     #[test]

--- a/src/path_normalizer.rs
+++ b/src/path_normalizer.rs
@@ -1672,14 +1672,18 @@ mod tests {
         assert!(!value.is_char_boundary(idx + "/home/".len() + 40));
 
         let window = leak_window(&value, idx, "/home/".len());
-        assert!(window.contains("/home/us"));
+        // Exact edges, not just containment: the start must widen
+        // BACKWARD to byte 18 (a `+= 1` walk forward to 21 still yields
+        // a valid window) and the end forward only to byte 107 (a
+        // miscomputed raw end clamps to `len` and still slices fine).
+        assert_eq!(window, &value[18..107]);
 
         // Degenerate shapes stay in-bounds: leak at the very start,
         // at the very end, and a value shorter than the window.
         assert_eq!(leak_window("/home/x", 0, "/home/".len()), "/home/x");
         let tail = format!("{}{}", "あ".repeat(30), "/home/y");
         let idx = tail.find("/home/").expect("leak present");
-        assert!(leak_window(&tail, idx, "/home/".len()).ends_with("/home/y"));
+        assert_eq!(leak_window(&tail, idx, "/home/".len()), &tail[48..]);
     }
 
     #[test]

--- a/src/probe/cache.rs
+++ b/src/probe/cache.rs
@@ -24,7 +24,41 @@ const PROBE_SUBDIR: &str = "probes";
 /// compiler change `mtime` alone would miss. Deriving the key is a
 /// `stat`, not a process fork.
 pub fn probe_key(prober_id: &str, req: &ProbeRequest<'_>) -> Option<String> {
-    probe_key_with_env(prober_id, req, std::env::vars())
+    probe_key_with_env(
+        prober_id,
+        req,
+        std::env::vars_os().map(fingerprint_env_pair),
+    )
+}
+
+/// A `vars_os` pair as fingerprint text. Converted here rather than via
+/// `std::env::vars()`, which panics if *any* environment variable holds
+/// non-UTF-8 — even one the fingerprint would ignore.
+fn fingerprint_env_pair(
+    (name, value): (std::ffi::OsString, std::ffi::OsString),
+) -> (String, String) {
+    (fingerprint_text(name), fingerprint_text(value))
+}
+
+/// Valid UTF-8 (the only kind the fingerprinted build tools produce)
+/// passes through verbatim, so probe keys are unchanged. Non-UTF-8 text
+/// becomes a U+FFFD-tagged hex dump of its lossless encoded bytes: unlike
+/// `to_string_lossy`, distinct invalid sequences stay distinct and sort
+/// deterministically. (A valid value that textually equals such a dump
+/// could alias one — accepted: this is a probe memo key, and the worst
+/// case of the old behavior was aborting the compile.)
+fn fingerprint_text(text: std::ffi::OsString) -> String {
+    match text.into_string() {
+        Ok(utf8) => utf8,
+        Err(os) => {
+            use std::fmt::Write as _;
+            let mut out = String::from('\u{fffd}');
+            for byte in os.as_encoded_bytes() {
+                let _ = write!(out, "{byte:02x}");
+            }
+            out
+        }
+    }
 }
 
 /// Content-addressed key for a probe evaluated against an explicit
@@ -247,6 +281,33 @@ mod tests {
             key_args: &[],
             per_tu_paths: &[],
             windows_aware: true,
+        }
+    }
+
+    #[test]
+    fn fingerprint_env_pair_passes_utf8_verbatim_and_keeps_invalid_distinct() {
+        use std::ffi::OsString;
+        assert_eq!(
+            fingerprint_env_pair((OsString::from("SDKROOT"), OsString::from("/sdk"))),
+            ("SDKROOT".to_string(), "/sdk".to_string())
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStringExt;
+            // The shape that made `std::env::vars()` panic mid-key. Two
+            // different invalid values must stay two different
+            // fingerprints (lossy conversion would merge them).
+            let a = fingerprint_env_pair((
+                OsString::from_vec(vec![b'x', 0xff]),
+                OsString::from_vec(vec![b'x', 0xff]),
+            ));
+            let b = fingerprint_env_pair((
+                OsString::from_vec(vec![b'x', 0xfe]),
+                OsString::from_vec(vec![b'x', 0xfe]),
+            ));
+            assert_ne!(a, b);
+            assert!(a.0.starts_with('\u{fffd}'));
+            assert_eq!(a.1, "\u{fffd}78ff");
         }
     }
 


### PR DESCRIPTION
## Summary

Two runtime panic fixes from the full `main` review (follow-ups to #822, findings 4 and 5):

**1. A non-UTF-8 environment variable no longer aborts the compile** (`cache_key.rs`, `probe/cache.rs`)
- `std::env::vars()` panics if *any* process env var holds non-UTF-8, even one kache never reads. Both remaining call sites (the `CARGO_CFG_*` key fold and the probe env fingerprint) now iterate `vars_os()`.
- Valid UTF-8 folds byte-identically to the old path, so keys are unchanged with no `CACHE_KEY_VERSION` bump.
- Invalid sequences key losslessly and distinctly instead of merging under U+FFFD: the key fold tags raw OS bytes with `0xFF` (a byte that cannot appear in valid UTF-8), and the probe fingerprint uses a U+FFFD-tagged hex dump of the encoded bytes. Sort order for colliding lossy names is pinned by a lossless tiebreak.

**2. The path-leak warning slices on char boundaries** (`path_normalizer.rs`)
- The diagnostic window around a detected path leak used raw byte offsets (`idx - 40`, `idx + prefix_len + 40`) that can land inside a multi-byte character and panic mid-key-computation.
- Extracted as `leak_window`, which widens outward to `is_char_boundary` positions; both loop edges provably terminate (offset 0 and `len` are always boundaries).

## Test plan

- [x] New tests: `leak_window` boundary widening (multi-byte chars at both raw edges, leak at start/end, short values); `cargo_cfg_pairs` filter/sort plus non-UTF-8 tolerance; `env_text_key_bytes` UTF-8 byte identity and invalid distinctness; probe `fingerprint_env_pair` verbatim pass-through and invalid distinctness
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --bin kache`: 2162 tests pass

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [x] No user-visible CLI/config/output changes requiring docs updates

## Rebase and mutation follow-up

- Rebased onto current `main` (`ccbd806`).
- `check_for_path_leak` now exposes positive/negative outcomes to tests.
- `leak_window` uses finite UTF-8 boundary searches, eliminating the assignment mutants that could loop forever.
- Local: 2,164 binary tests, strict all-target Clippy, and 6/6 focused mutants caught.
- GitHub CI at `c0d295b`: 18 passed, 3 expected release skips, 0 failed/pending/cancelled.