### PR TITLE
fix: close the remaining majors from the main review (refcounts, purge locking, async flocks, TUI restore)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -469,7 +469,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         timeout-minutes: 10
 
       # Fail fast with an explicit checklist if a Firefox build prerequisite is
@@ -540,7 +540,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Install tools via mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           # Pin mise CLI — see ci.yml (v2026.6.10 regression).
           version: 2026.6.9
@@ -635,7 +635,7 @@ jobs:
 
       - name: Upload bench reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-firefox-pull-windows
           # Reports live under the SHORT work dir (`$RUNNER_TEMP/b`), not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           version: 2026.6.9
           cache: false
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - uses: kunobi-ninja/kache-action@49398d37113c616fdb61be434cb497e3c2c8f3e6 # v1
+      - uses: kunobi-ninja/kache-action@eeafa81c39bb1b268304fd144523de074e0f793b # v1
         with:
           github-cache: "true"
           cache-executables: "false"
@@ -1227,7 +1227,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
       - name: Package & push Helm chart
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,11 @@ jobs:
           version: 2026.6.9
           cache: false
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - uses: kunobi-ninja/kache-action@eeafa81c39bb1b268304fd144523de074e0f793b # v1
+      # Held at a pre-runtime-dir revision: newer kache-action exports
+      # KACHE_RUNTIME_DIR into the job env, and the test suite is not yet
+      # hermetic against it (integration tests read events.jsonl from the
+      # cache dir; daemon unit tests would share one runtime dir).
+      - uses: kunobi-ninja/kache-action@49398d37113c616fdb61be434cb497e3c2c8f3e6 # v1
         with:
           github-cache: "true"
           cache-executables: "false"

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -435,7 +435,7 @@ jobs:
     outputs:
       pkgs: ${{ steps.list.outputs.pkgs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - id: list
         run: |
           set -euo pipefail
@@ -456,7 +456,7 @@ jobs:
       # fetch-depth: 0 is load-bearing for the -git packages below: their
       # pkgver embeds `git rev-list --count HEAD`, and the default depth-1
       # checkout would count 1 commit no matter the real history.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,6 +3031,7 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
+ "subtle",
  "surrealdb",
  "tempfile",
  "tokio",

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -21,6 +21,7 @@ kunobi-auth = { git = "https://github.com/kunobi-ninja/kunobi-auth.git", tag = "
 kunobi-ha = { git = "https://github.com/kunobi-ninja/kunobi-ha.git", branch = "main" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+subtle = "2"
 surrealdb = { version = "3.0.5", features = ["kv-surrealkv"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal", "sync"] }
 tracing = "0.1"

--- a/crates/kache-service/src/lib.rs
+++ b/crates/kache-service/src/lib.rs
@@ -319,13 +319,20 @@ async fn readyz(State(state): State<AppState>) -> Result<Json<HealthResponse>, S
 
 impl AuthnProvider for AppState {
     async fn authenticate(&self, token: &str) -> Result<AuthIdentity, AuthError> {
+        // Constant-time comparison: a plain `==` short-circuits on the
+        // first differing byte, letting a network peer binary-search the
+        // token one byte at a time from response timing. Only the length
+        // check can leak, which a random bearer token doesn't hinge on.
+        use subtle::ConstantTimeEq;
         match self.token.as_deref() {
-            Some(expected) if token == expected => Ok(AuthIdentity {
-                provider: "kache".to_string(),
-                identity: "planner-client".to_string(),
-                method: "token".to_string(),
-                claims: HashMap::new(),
-            }),
+            Some(expected) if bool::from(token.as_bytes().ct_eq(expected.as_bytes())) => {
+                Ok(AuthIdentity {
+                    provider: "kache".to_string(),
+                    identity: "planner-client".to_string(),
+                    method: "token".to_string(),
+                    claims: HashMap::new(),
+                })
+            }
             Some(_) => Err(AuthError::Unauthorized("invalid bearer token".to_string())),
             None => Ok(AuthIdentity {
                 provider: "kache".to_string(),

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -3612,10 +3612,10 @@ pub(crate) fn get_rustc_commit_hash(rustc: &Path) -> Option<String> {
 ///
 /// Prefers an explicit `--sysroot` (already parsed into [`RustcArgs::sysroot`]);
 /// otherwise runs `rustc --print sysroot` once and file-caches it like the
-/// version probe. NOTE: the cache key is the binary path + mtime, matching
-/// [`get_rustc_version`]; it does not fold `RUSTUP_TOOLCHAIN`, so a rustup shim
-/// pointed at different toolchains via that env var could serve a stale sysroot.
-/// Pre-existing limitation shared with `get_rustc_version`; out of scope here.
+/// version probe. The cache key folds the binary path + mtime plus the rustup
+/// toolchain-selection state, so a shim redirected to another toolchain
+/// re-probes instead of serving a stale sysroot (see
+/// [`toolchain_selector_fingerprint`]).
 pub(crate) fn get_rustc_sysroot(args: &RustcArgs) -> Option<PathBuf> {
     if let Some(sysroot) = &args.sysroot {
         return Some(sysroot.clone());
@@ -3659,7 +3659,8 @@ fn write_tool_version_cache(binary: &Path, prefix: &str, version: &str) {
 
 /// Build the cache-file path: `<cache_dir>/<prefix>-<hash>.txt` where the hash
 /// is derived from the binary's canonical path + mtime so it auto-invalidates
-/// when the toolchain is updated.
+/// when the toolchain is updated, plus the rustup toolchain-selection state
+/// (see [`toolchain_selector_fingerprint`]).
 fn tool_version_cache_path(binary: &Path, prefix: &str) -> Option<std::path::PathBuf> {
     let canon = std::fs::canonicalize(binary).ok()?;
     let mtime = std::fs::metadata(&canon)
@@ -3669,9 +3670,85 @@ fn tool_version_cache_path(binary: &Path, prefix: &str) -> Option<std::path::Pat
         .duration_since(std::time::UNIX_EPOCH)
         .ok()?
         .as_secs();
-    let key = format!("{}:{}", canon.display(), mtime);
+    let key = format!(
+        "{}:{}:{}",
+        canon.display(),
+        mtime,
+        toolchain_selector_fingerprint(
+            std::env::var_os("RUSTUP_TOOLCHAIN").as_deref(),
+            std::env::current_dir().ok().as_deref(),
+            rustup_settings_path().as_deref(),
+        )
+    );
     let hash = blake3::hash(key.as_bytes()).to_hex();
     Some(crate::config::default_cache_dir().join(format!("{}-{}.txt", prefix, &hash[..16])))
+}
+
+/// The rustup toolchain-selection state that can redirect an unchanged shim
+/// binary (`~/.cargo/bin/rustc` is rustup itself) to a different toolchain:
+/// path + mtime alone then serve a stale version, sysroot, or linker string
+/// across a `RUSTUP_TOOLCHAIN` change, an edited `rust-toolchain{,.toml}`,
+/// or a `rustup default` switch (which rewrites `settings.toml`).
+///
+/// Selector files fold by content digest, not mtime: these are tiny files,
+/// and a digest catches an edit within one mtime second or under a
+/// preserved timestamp. The nearest directory with either toolchain-file
+/// spelling contributes BOTH spellings, sidestepping rustup's precedence
+/// rules entirely — whichever file actually wins, changing it changes the
+/// fingerprint. For a non-shim binary all this costs is a cheap re-probe
+/// on the rare occasions the selection state changes.
+fn toolchain_selector_fingerprint(
+    rustup_toolchain: Option<&std::ffi::OsStr>,
+    cwd: Option<&Path>,
+    rustup_settings: Option<&Path>,
+) -> String {
+    let mut fp = String::new();
+    if let Some(toolchain) = rustup_toolchain {
+        fp.push_str("env:");
+        fp.push_str(&toolchain.to_string_lossy());
+    }
+    // Rustup resolves toolchain files from the cwd upward; the nearest
+    // directory holding one ends the search.
+    if let Some(cwd) = cwd {
+        'search: for dir in cwd.ancestors() {
+            let mut found = false;
+            for name in ["rust-toolchain", "rust-toolchain.toml"] {
+                let candidate = dir.join(name);
+                if let Some(digest) = file_digest(&candidate) {
+                    fp.push_str(";file:");
+                    fp.push_str(&candidate.to_string_lossy());
+                    fp.push(':');
+                    fp.push_str(&digest);
+                    found = true;
+                }
+            }
+            if found {
+                break 'search;
+            }
+        }
+    }
+    if let Some(settings) = rustup_settings
+        && let Some(digest) = file_digest(settings)
+    {
+        fp.push_str(";default:");
+        fp.push_str(&digest);
+    }
+    fp
+}
+
+/// `$RUSTUP_HOME/settings.toml` (or its `~/.rustup` default), which records
+/// the `rustup default` toolchain.
+fn rustup_settings_path() -> Option<std::path::PathBuf> {
+    let home = std::env::var_os("RUSTUP_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".rustup")))?;
+    Some(home.join("settings.toml"))
+}
+
+/// Content digest of a small selector file, or `None` if unreadable.
+fn file_digest(path: &Path) -> Option<String> {
+    let bytes = std::fs::read(path).ok()?;
+    Some(blake3::hash(&bytes).to_hex()[..16].to_string())
 }
 
 /// Get the host target triple.
@@ -4570,6 +4647,61 @@ mod tests {
             env_os_key_bytes(OsStr::new("normal"))
         );
         assert!(env_os_key_bytes(OsStr::new("")).is_empty());
+    }
+
+    /// Every rustup mechanism that can redirect an unchanged shim binary
+    /// must move the tool-version memo key: `RUSTUP_TOOLCHAIN`, the
+    /// nearest `rust-toolchain{,.toml}` up from the cwd, and the
+    /// `settings.toml` behind `rustup default`.
+    #[test]
+    fn toolchain_selector_fingerprint_tracks_every_selection_source() {
+        use std::ffi::OsStr;
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("workspace").join("member");
+        std::fs::create_dir_all(&project).unwrap();
+
+        let base = toolchain_selector_fingerprint(None, Some(&project), None);
+        assert_eq!(base, "", "no selection state folds to a stable empty");
+
+        let pinned =
+            toolchain_selector_fingerprint(Some(OsStr::new("1.93.0")), Some(&project), None);
+        assert_ne!(pinned, base);
+        assert_ne!(
+            toolchain_selector_fingerprint(Some(OsStr::new("nightly")), Some(&project), None),
+            pinned,
+            "different overrides must fingerprint differently"
+        );
+
+        // The nearest directory with a toolchain file ends the ancestor
+        // walk, and BOTH spellings fold so rustup's precedence between
+        // them never matters: editing either one moves the fingerprint.
+        std::fs::write(dir.path().join("workspace").join("rust-toolchain"), "1.88").unwrap();
+        std::fs::write(
+            dir.path().join("workspace").join("rust-toolchain.toml"),
+            "[toolchain]\nchannel = \"1.90\"\n",
+        )
+        .unwrap();
+        let with_files = toolchain_selector_fingerprint(None, Some(&project), None);
+        assert_eq!(with_files.matches(";file:").count(), 2, "{with_files}");
+        std::fs::write(dir.path().join("workspace").join("rust-toolchain"), "1.89").unwrap();
+        let with_edited = toolchain_selector_fingerprint(None, Some(&project), None);
+        assert_ne!(
+            with_edited, with_files,
+            "editing the bare file must move the fingerprint even though \
+             the .toml sibling is untouched"
+        );
+
+        let settings = dir.path().join("settings.toml");
+        std::fs::write(&settings, "default_toolchain = \"stable\"").unwrap();
+        let with_default = toolchain_selector_fingerprint(None, Some(&project), Some(&settings));
+        assert!(with_default.contains("default:"), "{with_default}");
+        assert_ne!(with_default, base);
+        std::fs::write(&settings, "default_toolchain = \"beta\"").unwrap();
+        assert_ne!(
+            toolchain_selector_fingerprint(None, Some(&project), Some(&settings)),
+            with_default,
+            "a rustup default switch must move the fingerprint"
+        );
     }
 
     #[test]

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -4767,6 +4767,68 @@ mod tests {
     }
 
     #[test]
+    fn tool_version_cache_path_is_a_named_file_in_the_cache_dir() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("rustc");
+        std::fs::write(&binary, b"test rustc").unwrap();
+
+        let cache_file = tool_version_cache_path(&binary, "rustc-ver")
+            .expect("a readable binary must produce a cache path");
+        let cache_dir = crate::config::default_cache_dir();
+        assert_eq!(cache_file.parent(), Some(cache_dir.as_path()));
+
+        let file_name = cache_file
+            .file_name()
+            .expect("cache path must name a file")
+            .to_string_lossy();
+        let digest = file_name
+            .strip_prefix("rustc-ver-")
+            .and_then(|name| name.strip_suffix(".txt"))
+            .expect("cache file must retain its prefix and extension");
+        assert_eq!(digest.len(), 16, "cache file uses the short BLAKE3 digest");
+        assert!(digest.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    #[ignore = "spawned by the explicit RUSTUP_HOME regression"]
+    fn rustup_settings_path_explicit_home_fixture() {
+        let expected_home = std::env::var_os("KACHE_TEST_RUSTUP_HOME")
+            .map(std::path::PathBuf::from)
+            .expect("fixture requires its isolated expected home");
+
+        assert_eq!(
+            rustup_settings_path(),
+            Some(expected_home.join("settings.toml"))
+        );
+    }
+
+    #[test]
+    fn tool_version_cache_uses_settings_under_explicit_rustup_home() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = std::process::Command::new(
+            std::env::current_exe().expect("resolve cache-key test executable"),
+        )
+        .args([
+            "--ignored",
+            "--exact",
+            "cache_key::tests::rustup_settings_path_explicit_home_fixture",
+            "--test-threads=1",
+        ])
+        .env("RUSTUP_HOME", dir.path())
+        .env("KACHE_TEST_RUSTUP_HOME", dir.path())
+        .output()
+        .expect("spawn isolated RUSTUP_HOME fixture");
+
+        assert!(
+            output.status.success(),
+            "isolated RUSTUP_HOME fixture failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
     fn apply_key_env_vars_keeps_distinct_path_values_distinct() {
         let _lock = key_test_lock();
         let base = "deadbeef".to_string();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2848,11 +2848,7 @@ fn draw_clean(
 
 /// Recursively find and remove target/ directories (TUI selector).
 pub fn clean(dry_run: bool, yes: bool) -> Result<()> {
-    use crossterm::ExecutableCommand;
     use crossterm::event::{self, Event, KeyEventKind};
-    use crossterm::terminal::{
-        EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
-    };
     use ratatui::prelude::*;
     use std::io::stdout;
 
@@ -2894,37 +2890,36 @@ pub fn clean(dry_run: bool, yes: bool) -> Result<()> {
     let mut selected: Vec<bool> = vec![false; targets.len()];
     let mut cursor: usize = 0;
 
-    enable_raw_mode()?;
-    stdout().execute(EnterAlternateScreen)?;
+    // Scoped so the guard restores the terminal before the post-TUI
+    // summary prints to the real screen.
+    let result = {
+        let _terminal_mode = crate::tui::TerminalModeGuard::enter()?;
+        let backend = CrosstermBackend::new(stdout());
+        let mut terminal = Terminal::new(backend)?;
 
-    let backend = CrosstermBackend::new(stdout());
-    let mut terminal = Terminal::new(backend)?;
+        loop {
+            terminal.draw(|frame| draw_clean(frame, &targets, &selected, cursor, &root))?;
 
-    let result = loop {
-        terminal.draw(|frame| draw_clean(frame, &targets, &selected, cursor, &root))?;
-
-        if event::poll(std::time::Duration::from_millis(100))?
-            && let Event::Key(key) = event::read()?
-            && key.kind == KeyEventKind::Press
-        {
-            match clean_handle_key(key.code, &mut selected, &mut cursor, targets.len()) {
-                CleanStep::Cancel => break None,
-                CleanStep::Confirm => {
-                    let to_remove: Vec<_> = targets
-                        .iter()
-                        .zip(selected.iter())
-                        .filter(|(_, s)| **s)
-                        .map(|(t, _)| RemovalTarget::from_entry(t))
-                        .collect();
-                    break Some(to_remove);
+            if event::poll(std::time::Duration::from_millis(100))?
+                && let Event::Key(key) = event::read()?
+                && key.kind == KeyEventKind::Press
+            {
+                match clean_handle_key(key.code, &mut selected, &mut cursor, targets.len()) {
+                    CleanStep::Cancel => break None,
+                    CleanStep::Confirm => {
+                        let to_remove: Vec<_> = targets
+                            .iter()
+                            .zip(selected.iter())
+                            .filter(|(_, s)| **s)
+                            .map(|(t, _)| RemovalTarget::from_entry(t))
+                            .collect();
+                        break Some(to_remove);
+                    }
+                    CleanStep::Continue => {}
                 }
-                CleanStep::Continue => {}
             }
         }
     };
-
-    disable_raw_mode()?;
-    stdout().execute(LeaveAlternateScreen)?;
 
     // Process deletions outside TUI
     match result {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2705,6 +2705,23 @@ fn clean_handle_key(
     CleanStep::Continue
 }
 
+/// Ignore key-repeat/release notifications: one physical key press must apply
+/// exactly one selector action on terminals that report all key event kinds.
+fn clean_handle_event(
+    event: crossterm::event::Event,
+    selected: &mut [bool],
+    cursor: &mut usize,
+    len: usize,
+) -> CleanStep {
+    use crossterm::event::{Event, KeyEventKind};
+    match event {
+        Event::Key(key) if key.kind == KeyEventKind::Press => {
+            clean_handle_key(key.code, selected, cursor, len)
+        }
+        _ => CleanStep::Continue,
+    }
+}
+
 /// Render one frame of the interactive `clean` selector. Extracted from the
 /// event loop so it can be unit-tested against a ratatui `TestBackend` with a
 /// fixed `targets`/`selected`/`cursor` state (the real loop owns the terminal).
@@ -2848,7 +2865,7 @@ fn draw_clean(
 
 /// Recursively find and remove target/ directories (TUI selector).
 pub fn clean(dry_run: bool, yes: bool) -> Result<()> {
-    use crossterm::event::{self, Event, KeyEventKind};
+    use crossterm::event;
     use ratatui::prelude::*;
     use std::io::stdout;
 
@@ -2900,11 +2917,9 @@ pub fn clean(dry_run: bool, yes: bool) -> Result<()> {
         loop {
             terminal.draw(|frame| draw_clean(frame, &targets, &selected, cursor, &root))?;
 
-            if event::poll(std::time::Duration::from_millis(100))?
-                && let Event::Key(key) = event::read()?
-                && key.kind == KeyEventKind::Press
-            {
-                match clean_handle_key(key.code, &mut selected, &mut cursor, targets.len()) {
+            if event::poll(std::time::Duration::from_millis(100))? {
+                match clean_handle_event(event::read()?, &mut selected, &mut cursor, targets.len())
+                {
                     CleanStep::Cancel => break None,
                     CleanStep::Confirm => {
                         let to_remove: Vec<_> = targets
@@ -9848,6 +9863,51 @@ mod tests {
         assert_eq!(
             clean_handle_key(KeyCode::Char('z'), &mut selected, &mut cursor, 1),
             CleanStep::Continue
+        );
+    }
+
+    #[test]
+    fn clean_event_applies_press_but_ignores_release() {
+        use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+        let key_event = |kind| {
+            Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Char('q'),
+                KeyModifiers::NONE,
+                kind,
+            ))
+        };
+        let mut selected = vec![false];
+        let mut cursor = 0;
+
+        assert_eq!(
+            clean_handle_event(
+                key_event(KeyEventKind::Release),
+                &mut selected,
+                &mut cursor,
+                1,
+            ),
+            CleanStep::Continue,
+            "key release must not repeat the action"
+        );
+        assert_eq!(
+            clean_handle_event(
+                key_event(KeyEventKind::Repeat),
+                &mut selected,
+                &mut cursor,
+                1,
+            ),
+            CleanStep::Continue,
+            "key repeat must not repeat the action"
+        );
+        assert_eq!(
+            clean_handle_event(
+                key_event(KeyEventKind::Press),
+                &mut selected,
+                &mut cursor,
+                1,
+            ),
+            CleanStep::Cancel,
+            "key press must apply the action"
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2620,6 +2620,13 @@ pub fn gc(config: &Config, max_age_hours: Option<u64>, stale_schema: bool) -> Re
 pub fn purge(config: &Config, crate_filter: Option<&str>) -> Result<()> {
     let store = Store::open(config)?;
 
+    // Purge is a bulk mutation like a GC sweep, so it holds the same
+    // cross-process lock every GC driver takes: a sweep either finishes
+    // before the purge starts or sees the store only after the purge is
+    // done, never a half-wiped one. Per-blob safety against concurrent
+    // builds still comes from the delete-row-first transactional gates.
+    let _gc_lock = store.acquire_gc_lock().context("locking GC for purge")?;
+
     if let Some(name) = crate_filter {
         let entries = store.list_entries("name")?;
         let mut removed = 0;
@@ -7479,6 +7486,45 @@ mod tests {
                 .exists(),
             "corrupt entry remains accounted-for after skipped purge"
         );
+    }
+
+    /// Purge is a bulk mutation and must serialize behind the same
+    /// cross-process lock every GC driver takes; unlocked, a purge can
+    /// interleave with a live sweep and each observes the other's
+    /// half-removed state.
+    #[test]
+    fn purge_waits_for_the_gc_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = save_manifest_config(dir.path().join("cache"), None);
+        put_entry(&config, "purgelockkey", "locked", dir.path());
+
+        let store = crate::store::Store::open(&config).unwrap();
+        let gc_lock = store.try_gc_lock().unwrap().expect("uncontended lock");
+
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let cfg = config.clone();
+        let worker = std::thread::spawn(move || {
+            let result = purge(&cfg, None);
+            let _ = done_tx.send(());
+            result
+        });
+
+        // While the "sweep" holds gc.lock the purge must not complete.
+        // (A scheduling hiccup can only delay the mutant's completion
+        // signal, never produce a false failure for the real code.)
+        assert!(
+            done_rx
+                .recv_timeout(std::time::Duration::from_millis(300))
+                .is_err(),
+            "purge completed while the GC lock was held"
+        );
+        drop(gc_lock);
+        done_rx
+            .recv_timeout(std::time::Duration::from_secs(30))
+            .expect("purge proceeds once the GC lock is released");
+        worker.join().unwrap().expect("purge succeeds");
+        let store = crate::store::Store::open(&config).unwrap();
+        assert_eq!(store.entry_count().unwrap(), 0, "store cleared");
     }
 
     #[test]

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -1,9 +1,5 @@
 use anyhow::Result;
-use crossterm::ExecutableCommand;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
-use crossterm::terminal::{
-    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
-};
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 use std::io::stdout;
@@ -934,16 +930,10 @@ pub fn run_config_editor() -> Result<()> {
     // Run initial validation
     run_all_validation(&mut state.fields);
 
-    enable_raw_mode()?;
-    stdout().execute(EnterAlternateScreen)?;
+    let _terminal_mode = crate::tui::TerminalModeGuard::enter()?;
     let mut terminal = ratatui::Terminal::new(CrosstermBackend::new(stdout()))?;
 
-    let result = run_event_loop(&mut terminal, &mut state);
-
-    disable_raw_mode()?;
-    stdout().execute(LeaveAlternateScreen)?;
-
-    result
+    run_event_loop(&mut terminal, &mut state)
 }
 
 /// Build the editor's starting state from a loaded config.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12268,7 +12268,8 @@ mod tests {
     struct BlockingPackBackend {
         inner: Arc<dyn crate::remote_backend::RemoteBackend>,
         pack_started: Arc<Notify>,
-        release_pack: Arc<Notify>,
+        release_pack: Arc<tokio::sync::Semaphore>,
+        v3_get_started: Option<Arc<Notify>>,
     }
 
     #[async_trait::async_trait]
@@ -12284,7 +12285,15 @@ mod tests {
         ) -> Result<Option<crate::remote_backend::GetObject>> {
             if key.contains("/v4/prefetch/packs/") {
                 self.pack_started.notify_waiters();
-                self.release_pack.notified().await;
+                let _release = self
+                    .release_pack
+                    .acquire()
+                    .await
+                    .expect("test release semaphore stays open");
+            } else if key.contains("/v3/packs/")
+                && let Some(started) = &self.v3_get_started
+            {
+                started.notify_waiters();
             }
             self.inner.get(key, max_bytes).await
         }
@@ -12964,12 +12973,13 @@ mod tests {
         .await;
 
         let pack_started = Arc::new(Notify::new());
-        let release_pack = Arc::new(Notify::new());
+        let release_pack = Arc::new(tokio::sync::Semaphore::new(0));
         let backend: Arc<dyn crate::remote_backend::RemoteBackend> =
             Arc::new(BlockingPackBackend {
                 inner,
                 pack_started: pack_started.clone(),
                 release_pack: release_pack.clone(),
+                v3_get_started: None,
             });
         let daemon = Arc::new(Daemon::new(config));
         assert!(daemon.remote_backend.set(backend).is_ok());
@@ -12978,7 +12988,7 @@ mod tests {
         tokio::pin!(started);
         started.as_mut().enable();
         let response = tokio::time::timeout(
-            Duration::from_millis(250),
+            Duration::from_secs(10),
             daemon.handle_prefetch_with_context(
                 &PrefetchRequest {
                     keys: vec![(key.clone(), "serde".into())],
@@ -12991,12 +13001,12 @@ mod tests {
         .await
         .expect("prefetch acknowledgement must not await the pack GET");
         assert!(response.ok);
-        tokio::time::timeout(Duration::from_secs(1), started)
+        tokio::time::timeout(Duration::from_secs(10), started)
             .await
             .expect("background coordinator should start the pack GET");
         assert!(!daemon.entry_dir_for(&key).exists());
 
-        release_pack.notify_waiters();
+        release_pack.add_permits(1);
         wait_for_store_entry(&daemon, &key).await;
     }
 
@@ -13044,15 +13054,18 @@ mod tests {
         .await;
 
         let pack_started = Arc::new(Notify::new());
-        let release_pack = Arc::new(Notify::new());
+        let release_pack = Arc::new(tokio::sync::Semaphore::new(0));
+        let v3_get_started = Arc::new(Notify::new());
         let backend: Arc<dyn crate::remote_backend::RemoteBackend> =
             Arc::new(BlockingPackBackend {
                 inner,
                 pack_started: pack_started.clone(),
                 release_pack: release_pack.clone(),
+                v3_get_started: Some(v3_get_started.clone()),
             });
         let daemon = Arc::new(Daemon::new(config));
         assert!(daemon.remote_backend.set(backend).is_ok());
+        daemon.signal_warming_complete();
 
         let started = pack_started.notified();
         tokio::pin!(started);
@@ -13070,27 +13083,38 @@ mod tests {
                 )
                 .await
         });
-        tokio::time::timeout(Duration::from_secs(1), started)
+        tokio::time::timeout(Duration::from_secs(10), started)
             .await
             .expect("pack GET should block in the injected backend");
 
-        let demand = tokio::time::timeout(
-            Duration::from_secs(1),
-            daemon.handle_remote_check(&RemoteCheckRequest {
-                key: demand_key.clone(),
-                entry_dir: daemon
-                    .entry_dir_for(&demand_key)
-                    .to_string_lossy()
-                    .into_owned(),
-                crate_name: "tokio".into(),
-                deadline_ms: None,
-            }),
-        )
-        .await
-        .expect("demand v3 read must not wait for the pack GET");
+        let v3_started = v3_get_started.notified();
+        tokio::pin!(v3_started);
+        v3_started.as_mut().enable();
+        let demand_daemon = daemon.clone();
+        let demand_entry_dir = daemon
+            .entry_dir_for(&demand_key)
+            .to_string_lossy()
+            .into_owned();
+        let demand_task = tokio::spawn(async move {
+            demand_daemon
+                .handle_remote_check(&RemoteCheckRequest {
+                    key: demand_key.clone(),
+                    entry_dir: demand_entry_dir,
+                    crate_name: "tokio".into(),
+                    deadline_ms: None,
+                })
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(10), v3_started)
+            .await
+            .expect("demand v3 GET must start while the pack GET remains blocked");
+        let demand = tokio::time::timeout(Duration::from_secs(10), demand_task)
+            .await
+            .expect("demand v3 read must complete while the pack GET remains blocked")
+            .expect("demand task must not panic");
         assert_eq!(demand.found, Some(true));
 
-        release_pack.notify_waiters();
+        release_pack.add_permits(1);
         assert!(packed.await.unwrap().ok);
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2400,11 +2400,30 @@ impl Daemon {
         self.warming_tx.send_replace(true);
     }
 
-    fn push_transfer_event(&self, event: TransferEvent) {
-        // Persist to JSONL — warn on failure but never fail the transfer
-        if let Err(e) = events::log_transfer(&self.config.transfer_log_path(), &event) {
-            tracing::warn!("failed to log transfer event: {e}");
-        }
+    async fn push_transfer_event(&self, event: TransferEvent) {
+        // Persist to JSONL — warn on failure but never fail the transfer.
+        // The append takes a cross-process file lock on the sidecar log,
+        // so it runs on the blocking pool: every caller is an async
+        // upload/download path, and a contended or stalled log must not
+        // park an async worker thread (#281).
+        let path = self.config.transfer_log_path();
+        let event = match tokio::task::spawn_blocking(move || {
+            let logged = events::log_transfer(&path, &event);
+            (event, logged)
+        })
+        .await
+        {
+            Ok((event, logged)) => {
+                if let Err(e) = logged {
+                    tracing::warn!("failed to log transfer event: {e}");
+                }
+                event
+            }
+            Err(e) => {
+                tracing::warn!("transfer log task failed: {e}");
+                return;
+            }
+        };
         if let Ok(mut q) = self.recent_transfers.lock() {
             if q.len() >= RECENT_TRANSFERS_CAP {
                 q.pop_front();
@@ -2908,10 +2927,23 @@ impl Daemon {
         if self.config.remote.is_none() {
             return Response::err("no remote configured");
         }
-        let normalized_job = match persist_upload_job(&self.config, job) {
-            Ok(job) => job,
-            Err(error) => {
+        // Intent publication blocks on the cross-process GC lock (a
+        // concurrent sweep can hold it for seconds) plus store open and
+        // `std::fs` work — park it on the blocking pool like the other
+        // store-touching handlers (#281) instead of an async worker.
+        let persist_config = self.config.clone();
+        let persist_job = job.clone();
+        let normalized_job = match tokio::task::spawn_blocking(move || {
+            persist_upload_job(&persist_config, &persist_job)
+        })
+        .await
+        {
+            Ok(Ok(job)) => job,
+            Ok(Err(error)) => {
                 return Response::err(format!("persisting upload intent failed: {error:#}"));
+            }
+            Err(error) => {
+                return Response::err(format!("persisting upload intent failed: {error}"));
             }
         };
 
@@ -3152,7 +3184,8 @@ impl Daemon {
                     blobs_total: 0,
                     ok: true,
                     timestamp: finished_at_unix_ms / 1_000,
-                });
+                })
+                .await;
                 // A successful PUT flips the key positive immediately:
                 // key-cache insert + negative-cache invalidation (#564).
                 self.note_key_present(&job.key, &job.crate_name).await;
@@ -3197,7 +3230,8 @@ impl Daemon {
                     blobs_total: 0,
                     ok: false,
                     timestamp: finished_at_unix_ms / 1_000,
-                });
+                })
+                .await;
                 let class = classify_remote_error(&e);
                 put_breaker.failure(class, &format!("remote upload failed ({class:?}): {e:#}"));
                 tracing::warn!(
@@ -3661,7 +3695,8 @@ impl Daemon {
                     blobs_total: dl.blobs_total,
                     ok: true,
                     timestamp: finished_at_unix_ms / 1_000,
-                });
+                })
+                .await;
                 Response::found(true)
             }
             Err(e) if classify_remote_error(&e) == RemoteErrorClass::Miss => {
@@ -3715,7 +3750,8 @@ impl Daemon {
                     blobs_total: 0,
                     ok: false,
                     timestamp: finished_at_unix_ms / 1_000,
-                });
+                })
+                .await;
                 // Feed the breaker with the failure class (#327) so a dead or
                 // stalling remote degrades and later restores skip S3
                 // entirely. A Timeout (transport deadline or the restore
@@ -4622,7 +4658,8 @@ impl Daemon {
                                 blobs_total: dl.blobs_total,
                                 ok: true,
                                 timestamp: finished_at_unix_ms / 1_000,
-                            });
+                            })
+                            .await;
                             // Track as prefetched for PrefetchHit attribution.
                             // Bound the set: a long-lived daemon that
                             // prefetches many distinct keys would otherwise
@@ -4690,7 +4727,8 @@ impl Daemon {
                                 blobs_total: 0,
                                 ok: false,
                                 timestamp: finished_at_unix_ms / 1_000,
-                            });
+                            })
+                            .await;
                             tracing::warn!("prefetch download failed for {}: {e}", key);
                         }
                     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9579,6 +9579,13 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[ignore = "spawned by the daemon PID-discovery regression"]
+    fn fake_daemon_process_fixture() {
+        std::thread::sleep(Duration::from_secs(30));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn find_daemon_pids_finds_a_process_running_the_kache_executable() {
         // The negative test below cannot tell "correctly excluded the
         // bystander" from "found nothing at all", which is what a broken
@@ -9591,24 +9598,32 @@ mod tests {
         // `pgrep -f` sees.
         //
         // Needs the same tools find_daemon_pids does. The Nix build sandbox
-        // has neither `pgrep` nor `ps` (nor a `/bin/sleep` to copy), and
-        // asserting there would only pin the sandbox, not the behaviour.
-        let (Some(sleep_bin), Some(_pgrep), Some(_ps)) = (
-            find_in_path("sleep"),
-            find_in_path("pgrep"),
-            find_in_path("ps"),
-        ) else {
+        // has neither `pgrep` nor `ps`, and asserting there would only pin the
+        // sandbox, not the behaviour.
+        let (Some(_pgrep), Some(_ps)) = (find_in_path("pgrep"), find_in_path("ps")) else {
             return;
         };
 
-        let dir = tempfile::tempdir().unwrap();
+        // Reuse this test executable as the sleeping fixture. Keeping the
+        // temporary hard link beside it guarantees one filesystem and avoids
+        // Linux's copy-then-exec ETXTBSY race under coverage.
+        let current_exe = std::env::current_exe().expect("resolve test executable");
+        let dir = tempfile::tempdir_in(current_exe.parent().expect("test executable parent"))
+            .expect("create fake daemon directory");
         let bin_dir = dir.path().join("kache daemon run");
         std::fs::create_dir_all(&bin_dir).unwrap();
         let fake = bin_dir.join("kache");
-        std::fs::copy(&sleep_bin, &fake).unwrap();
+        std::fs::hard_link(&current_exe, &fake).expect("hard-link test executable as kache");
 
         let mut child = std::process::Command::new(&fake)
-            .arg("30")
+            .args([
+                "--ignored",
+                "--exact",
+                "daemon::tests::fake_daemon_process_fixture",
+                "--test-threads=1",
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
             .spawn()
             .expect("spawn fake daemon");
         let fake_pid = child.id();

--- a/src/store.rs
+++ b/src/store.rs
@@ -1952,6 +1952,32 @@ impl Store {
         let crate_type_str = crate_types.join(",");
         let num_features = features.len() as i64;
         let tx = self.db.unchecked_transaction()?;
+        // A prior generation of this cache_key may still hold blob
+        // references — most commonly a stranded row whose removal was
+        // refused (#276) and that this put is about to overwrite via
+        // INSERT OR REPLACE. Release them inside this same transaction,
+        // before this generation's increments and before
+        // `record_entry_blobs` drops the old mapping: skipped, the old
+        // generation's hashes keep a refcount no mapping accounts for
+        // (never reaching zero, never reclaimed), and hashes shared by
+        // both generations double-count. Unconditional on `committed`,
+        // unlike the import path's variant: a committed-but-stranded row
+        // is exactly the shape that funnels back into put.
+        tx.execute(
+            "UPDATE blobs
+             SET refcount = MAX(0, refcount - COALESCE((
+                 SELECT refs FROM entry_blobs
+                 WHERE cache_key = ?1 AND hash = blobs.hash
+             ), 0))
+             WHERE hash IN (
+                 SELECT hash FROM entry_blobs WHERE cache_key = ?1
+             )",
+            params![cache_key],
+        )?;
+        // Rows released to zero would otherwise read as index drift; the
+        // blob files themselves stay for the orphan sweep (or an
+        // immediate re-reference by the loop below).
+        tx.execute("DELETE FROM blobs WHERE refcount <= 0", [])?;
         for (file, (source, use_source_hardlink)) in meta.files.iter().zip(sources.iter()) {
             let inserted = tx.execute(
                 "INSERT OR IGNORE INTO blobs (hash, size, refcount) VALUES (?1, ?2, 1)",
@@ -7645,6 +7671,78 @@ mod tests {
             )
             .unwrap();
         assert_eq!(still_there, 1, "entry row must survive a refused removal");
+    }
+
+    /// The resolution path the #276 comments promise: a refused removal
+    /// leaves the row "until a fresh put (INSERT OR REPLACE) overwrites
+    /// it". That re-put must also release the stranded generation's blob
+    /// references — stacking new increments on top leaks the old hashes
+    /// (a refcount no mapping accounts for never reaches zero) and
+    /// double-counts hashes shared by both generations.
+    #[test]
+    fn reput_over_refused_removal_releases_stale_refcounts() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+
+        let refcount_sum = |s: &Store| -> i64 {
+            s.db.query_row("SELECT COALESCE(SUM(refcount), 0) FROM blobs", [], |r| {
+                r.get(0)
+            })
+            .unwrap()
+        };
+        let put = |s: &Store, content: &[u8]| {
+            let output = dir.path().join("lib.rlib");
+            std::fs::write(&output, content).unwrap();
+            s.put(
+                "strand1",
+                "c1",
+                &["lib".into()],
+                &[],
+                "",
+                "dev",
+                &[(output, "lib.rlib".into())],
+                "",
+                "",
+            )
+            .unwrap();
+        };
+
+        put(&store, b"generation one");
+        assert_eq!(refcount_sum(&store), 1);
+
+        // Strand the row: meta.json gone, DB row present. Removal
+        // refuses (#276), and lookup's discarded-error path then drives
+        // a miss, a recompile, and this re-put over the surviving row.
+        std::fs::remove_file(store.entry_dir("strand1").join("meta.json")).unwrap();
+        assert!(store.remove_entry("strand1").is_err());
+        put(&store, b"generation two");
+
+        assert_eq!(
+            refcount_sum(&store),
+            1,
+            "re-put must release the stranded generation's references"
+        );
+        let mapped: i64 = store
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM entry_blobs WHERE cache_key = 'strand1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(mapped, 1, "exactly the new generation's mapping remains");
+        assert_eq!(
+            store.blob_index_drift().unwrap().total(),
+            0,
+            "index must match the committed meta with no doctor repair"
+        );
+
+        // Same-content re-put: the shared hash must stay at one
+        // reference, not accumulate one per generation.
+        put(&store, b"generation two");
+        assert_eq!(refcount_sum(&store), 1, "shared hash must not double-count");
+        assert_eq!(store.blob_index_drift().unwrap().total(), 0);
     }
 
     /// An unreadable meta.json (EACCES, not NotFound) must refuse through the

--- a/src/store.rs
+++ b/src/store.rs
@@ -1962,7 +1962,10 @@ impl Store {
         // (never reaching zero, never reclaimed), and hashes shared by
         // both generations double-count. Unconditional on `committed`,
         // unlike the import path's variant: a committed-but-stranded row
-        // is exactly the shape that funnels back into put.
+        // is exactly the shape that funnels back into put. Pre-#608 rows
+        // whose mapping the GC backfill hasn't materialized yet still
+        // slip through (there is nothing to decrement by); those remain
+        // `doctor --repair` / reconcile territory.
         tx.execute(
             "UPDATE blobs
              SET refcount = MAX(0, refcount - COALESCE((
@@ -4262,20 +4265,30 @@ impl Store {
     /// Clear the entire store.
     ///
     /// Index rows drop first, in one transaction: once it commits no
-    /// reader can begin a restore from a purged entry, and a racing
-    /// publisher's registration serializes wholly before it (purged with
-    /// the rest) or wholly after (its rows survive; a later re-put heals
-    /// its files). The filesystem wipe then runs against a store the
-    /// index no longer references, so a crash mid-wipe strands at worst
-    /// orphan files for the sweep — never index rows pointing at deleted
-    /// blobs, which the old wipe-then-delete order could leave.
+    /// reader can begin a restore from a purged entry, and the
+    /// filesystem wipe then runs against a store the index no longer
+    /// references — a crash mid-wipe strands at worst orphan files for
+    /// the sweep, never the pre-existing rows dangling over deleted
+    /// blobs that the old wipe-then-delete order could leave.
+    ///
+    /// Publishers don't take `gc.lock`, so a put can still commit a
+    /// fresh row while the wipe is deleting the files it just staged.
+    /// The second row-deletion pass reduces that to the store's
+    /// tolerated shapes: a row committed before the pass is dropped
+    /// (its files become sweepable orphans), and one committed after it
+    /// at worst lands stranded — the refuse-removal / miss / re-put
+    /// path that already recovers it.
     pub fn clear(&self) -> Result<()> {
-        let tx = self.db.unchecked_transaction()?;
-        tx.execute("DELETE FROM entries", [])?;
-        tx.execute("DELETE FROM entry_blobs", [])?;
-        tx.execute("DELETE FROM blobs", [])?;
-        tx.execute("DELETE FROM incremental_dirs", [])?;
-        tx.commit()?;
+        let drop_index_rows = || -> Result<()> {
+            let tx = self.db.unchecked_transaction()?;
+            tx.execute("DELETE FROM entries", [])?;
+            tx.execute("DELETE FROM entry_blobs", [])?;
+            tx.execute("DELETE FROM blobs", [])?;
+            tx.execute("DELETE FROM incremental_dirs", [])?;
+            tx.commit()?;
+            Ok(())
+        };
+        drop_index_rows()?;
         let store_dir = self.config.store_dir();
         if store_dir.exists() {
             // Make everything writable recursively, then remove all subdirs
@@ -4287,7 +4300,7 @@ impl Store {
                 }
             }
         }
-        Ok(())
+        drop_index_rows()
     }
 
     /// Recursively make all files in a directory writable so they can be deleted.

--- a/src/store.rs
+++ b/src/store.rs
@@ -7715,8 +7715,13 @@ mod tests {
             })
             .unwrap()
         };
-        let put = |s: &Store, content: &[u8]| {
-            let output = dir.path().join("lib.rlib");
+        // Each generation compiles to a fresh source path: put ingests by
+        // hardlink where reflinks are unavailable (ext4), sharing the
+        // store blob's read-only inode with the source, so rewriting one
+        // path across generations would EACCES on Linux while APFS
+        // reflinks mask it (the #822 snapshot-test lesson).
+        let put = |s: &Store, generation: &str, content: &[u8]| {
+            let output = dir.path().join(format!("lib-{generation}.rlib"));
             std::fs::write(&output, content).unwrap();
             s.put(
                 "strand1",
@@ -7732,7 +7737,7 @@ mod tests {
             .unwrap();
         };
 
-        put(&store, b"generation one");
+        put(&store, "one", b"generation one");
         assert_eq!(refcount_sum(&store), 1);
 
         // Strand the row: meta.json gone, DB row present. Removal
@@ -7740,7 +7745,7 @@ mod tests {
         // a miss, a recompile, and this re-put over the surviving row.
         std::fs::remove_file(store.entry_dir("strand1").join("meta.json")).unwrap();
         assert!(store.remove_entry("strand1").is_err());
-        put(&store, b"generation two");
+        put(&store, "two", b"generation two");
 
         assert_eq!(
             refcount_sum(&store),
@@ -7764,7 +7769,7 @@ mod tests {
 
         // Same-content re-put: the shared hash must stay at one
         // reference, not accumulate one per generation.
-        put(&store, b"generation two");
+        put(&store, "two-again", b"generation two");
         assert_eq!(refcount_sum(&store), 1, "shared hash must not double-count");
         assert_eq!(store.blob_index_drift().unwrap().total(), 0);
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -4260,7 +4260,22 @@ impl Store {
     }
 
     /// Clear the entire store.
+    ///
+    /// Index rows drop first, in one transaction: once it commits no
+    /// reader can begin a restore from a purged entry, and a racing
+    /// publisher's registration serializes wholly before it (purged with
+    /// the rest) or wholly after (its rows survive; a later re-put heals
+    /// its files). The filesystem wipe then runs against a store the
+    /// index no longer references, so a crash mid-wipe strands at worst
+    /// orphan files for the sweep — never index rows pointing at deleted
+    /// blobs, which the old wipe-then-delete order could leave.
     pub fn clear(&self) -> Result<()> {
+        let tx = self.db.unchecked_transaction()?;
+        tx.execute("DELETE FROM entries", [])?;
+        tx.execute("DELETE FROM entry_blobs", [])?;
+        tx.execute("DELETE FROM blobs", [])?;
+        tx.execute("DELETE FROM incremental_dirs", [])?;
+        tx.commit()?;
         let store_dir = self.config.store_dir();
         if store_dir.exists() {
             // Make everything writable recursively, then remove all subdirs
@@ -4272,10 +4287,6 @@ impl Store {
                 }
             }
         }
-        self.db.execute("DELETE FROM entries", [])?;
-        self.db.execute("DELETE FROM entry_blobs", [])?;
-        self.db.execute("DELETE FROM blobs", [])?;
-        self.db.execute("DELETE FROM incremental_dirs", [])?;
         Ok(())
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -16,6 +16,52 @@ use crate::config::Config;
 use crate::daemon;
 use crate::events::{self, BuildEvent, EventRecord, EventResult, EventTailer, HeartbeatEvent};
 
+// ── Terminal mode guard ────────────────────────────────────────────────────
+
+/// RAII owner of the crossterm raw-mode + alternate-screen pair, shared by
+/// every TUI entry point (monitor, config editor, interactive clean).
+///
+/// The straight-line "enable, run, disable" shape leaks a broken terminal
+/// on every early exit: a `?` between enable and disable returns with raw
+/// mode still on, and a panic unwinds past the restore entirely. Restoring
+/// in `Drop` covers both. A process-wide panic hook additionally restores
+/// the terminal *before* the panic message prints, so it lands on the
+/// user's real screen instead of vanishing with the alternate one.
+pub(crate) struct TerminalModeGuard;
+
+impl TerminalModeGuard {
+    pub(crate) fn enter() -> Result<Self> {
+        static PANIC_HOOK: std::sync::Once = std::sync::Once::new();
+        PANIC_HOOK.call_once(|| {
+            let previous = std::panic::take_hook();
+            std::panic::set_hook(Box::new(move |info| {
+                restore_terminal();
+                previous(info);
+            }));
+        });
+        enable_raw_mode()?;
+        if let Err(e) = stdout().execute(EnterAlternateScreen) {
+            // No guard exists yet to undo the half-entered state.
+            let _ = disable_raw_mode();
+            return Err(e.into());
+        }
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalModeGuard {
+    fn drop(&mut self) {
+        restore_terminal();
+    }
+}
+
+/// Idempotent: leaving the main screen buffer and disabling an already
+/// disabled raw mode are no-ops, so the hook and the guard can both run.
+fn restore_terminal() {
+    let _ = stdout().execute(LeaveAlternateScreen);
+    let _ = disable_raw_mode();
+}
+
 // ── Tabs & panels ──────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -421,8 +467,7 @@ const SNAPSHOT_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Run the TUI monitor dashboard.
 pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
-    enable_raw_mode()?;
-    stdout().execute(EnterAlternateScreen)?;
+    let _terminal_mode = TerminalModeGuard::enter()?;
 
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::new(backend)?;
@@ -625,8 +670,6 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
         }
     }
 
-    disable_raw_mode()?;
-    stdout().execute(LeaveAlternateScreen)?;
     Ok(())
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -41,8 +41,10 @@ impl TerminalModeGuard {
         });
         enable_raw_mode()?;
         if let Err(e) = stdout().execute(EnterAlternateScreen) {
-            // No guard exists yet to undo the half-entered state.
-            let _ = disable_raw_mode();
+            // No guard exists yet to undo the half-entered state — and
+            // the escape sequence may have been written before the error
+            // surfaced, so leave the alternate screen too.
+            restore_terminal();
             return Err(e.into());
         }
         Ok(Self)

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -29,6 +29,11 @@ use crate::events::{self, BuildEvent, EventRecord, EventResult, EventTailer, Hea
 /// user's real screen instead of vanishing with the alternate one.
 pub(crate) struct TerminalModeGuard;
 
+#[cfg(test)]
+std::thread_local! {
+    static TERMINAL_RESTORE_OBSERVED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
 impl TerminalModeGuard {
     pub(crate) fn enter() -> Result<Self> {
         static PANIC_HOOK: std::sync::Once = std::sync::Once::new();
@@ -60,6 +65,8 @@ impl Drop for TerminalModeGuard {
 /// Idempotent: leaving the main screen buffer and disabling an already
 /// disabled raw mode are no-ops, so the hook and the guard can both run.
 fn restore_terminal() {
+    #[cfg(test)]
+    TERMINAL_RESTORE_OBSERVED.with(|observed| observed.set(true));
     let _ = stdout().execute(LeaveAlternateScreen);
     let _ = disable_raw_mode();
 }
@@ -2125,6 +2132,24 @@ fn draw_passthrough_help(frame: &mut Frame, state: &AppState, area: Rect) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn terminal_restore_was_observed(action: impl FnOnce()) -> bool {
+        TERMINAL_RESTORE_OBSERVED.with(|observed| observed.set(false));
+        action();
+        TERMINAL_RESTORE_OBSERVED.with(std::cell::Cell::get)
+    }
+
+    #[test]
+    fn terminal_restore_function_runs_the_cleanup_path() {
+        assert!(terminal_restore_was_observed(restore_terminal));
+    }
+
+    #[test]
+    fn terminal_restore_guard_runs_on_drop() {
+        assert!(terminal_restore_was_observed(|| {
+            let _guard = TerminalModeGuard;
+        }));
+    }
 
     #[test]
     fn test_tab_needs_entries_only_for_store() {


### PR DESCRIPTION
## Summary

The remaining majors from the full `main` review (follow-ups to #822 and the 4/5 panic fixes), re-verified against current main before fixing:

**1. Re-put releases the prior generation's blob refcounts** (`store.rs`)
- A put over a surviving row for the same cache_key (most commonly a stranded row whose removal was refused, #276) stacked new refcount increments on top of the old generation's: old hashes kept a refcount no mapping accounted for and were never reclaimed, and shared hashes double-counted. #820 only made this repairable by hand via `doctor --repair`.
- The registration transaction now releases the previous generation's references first, mirroring the import path's reconciliation but unconditional on committed state. Pre-#608 rows with no `entry_blobs` mapping yet remain doctor territory (documented inline).

**2. `kache purge` serializes behind the GC lock; `clear()` is ordered for crash and race tolerance** (`cli.rs`, `store.rs`)
- Purge ran with no cross-process synchronization at all; it now holds `gc.lock` like every GC/eviction driver.
- `clear()` drops the four index tables in one transaction before the filesystem wipe, and re-drops them after it. A crash or a racing publisher (puts do not take `gc.lock`) converges to the store's tolerated shapes (orphan files for the sweep, or the stranded row that the refuse/miss/re-put path recovers), never the old order's dangling rows over deleted blobs.

**3. Upload-path file locks stay off async workers** (`daemon.rs`)
- `handle_upload` published the durable upload intent synchronously, blocking a Tokio worker on the cross-process `gc.lock` flock for as long as a concurrent sweep held it. The sibling store-touching handlers already use the blocking pool (#281); the intent publication now does too.
- The transfer-log JSONL append (a cross-process flock on the sidecar log, called from every async upload/download path) moves to the blocking pool with it.

**4. TUIs restore the terminal on every exit path** (`tui.rs`, `config_tui.rs`, `cli.rs`)
- All three TUI entry points (monitor, config editor, interactive clean) enabled raw mode and the alternate screen in a straight line: any `?` in the event loop returned with the terminal raw, and a panic unwound past the restore.
- A shared RAII guard owns the pair, and a once-installed panic hook restores the terminal before the panic message prints so it lands on the real screen.

**Minors** (`kache-service`, `cache_key.rs`, workflows)
- The planner bearer token was compared with a short-circuiting `==`; now constant-time via `subtle`.
- The rustc version/sysroot/linker memo was keyed on binary path + mtime only, so a rustup shim redirected to another toolchain (env override, `rust-toolchain{,.toml}`, or `rustup default`) served stale strings. The key now folds the selection state: the env var plus content digests of both toolchain-file spellings (sidestepping rustup precedence) and `settings.toml`.
- The six remaining tag-pinned workflow actions are SHA-pinned. Advancing the `kache-action` pin was attempted and reverted: current v1 exports `KACHE_RUNTIME_DIR` into the job env and the test suite is not hermetic against it yet (adaptive integration tests read `events.jsonl` from their fixture cache dir, daemon unit tests would share one runtime dir). The pin should move together with test-hermeticity work.

Review finding 7 (`pre_clean_outputs`) was re-verified and intentionally not changed: the candidate list, symlink/writable guards, and identity refusal already bound it, and deleting read-only files at crate-identity output paths is the documented tradeoff for restored 0444 hardlinks.

## Test plan

- [x] New tests: re-put over a refused removal restores `refcount == sum(refs)` with zero `blob_index_drift` (fresh and same-content generations); purge blocks while another handle holds `gc.lock` and completes after release; toolchain selector fingerprint tracks env override, edits to either toolchain-file spelling, and `settings.toml` changes
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --bin kache` (2160 tests) and the kache-service suite (38 tests) pass

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [x] No user-visible CLI/config/output changes requiring docs updates


## Post-rebase verification

- [x] Rebased onto current `main` (`dfd3266`); all 11 branch commits have valid SSH signatures
- [x] Replaced the copied-executable ETXTBSY race and blocked-pack timing dependency with deterministic structural fixtures
- [x] Targeted mutation checks catch all 7 survivors reported by the previous CI run
- [x] `cargo test --locked --bin kache`: 2172 passed, 0 failed, 2 ignored
- [x] Strict workspace/all-target/all-feature Clippy, `cargo fmt --check`, and `git diff --check` pass
