### PR TITLE
ci: enforce complete workspace coverage scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,11 @@ jobs:
           fi
         env:
           RUSTC_WRAPPER: ""
-      - name: Check coverage threshold (88%)
+      - name: Check coverage scope and threshold (88%)
         # Enforced on PRs too, not just push: in a trunk-based model a PR that
         # drops coverage must fail before merge, not after on the main push.
         run: |
+          just coverage-scope-check
           python3 -c "
           import json, sys
           data = json.load(open('tmp/llvm-cov/coverage.json'))

--- a/Justfile
+++ b/Justfile
@@ -284,12 +284,34 @@ helm-lint:
 # JSON drives the CI threshold check; HTML is uploaded as a CI artifact
 # (and opened locally by `coverage-open`). `--no-report` collects
 # coverage once; the two `report` invocations then emit the formats
-# from that single test run.
+# from that single test run. Unlike the collection command, the `report`
+# subcommand has no `--workspace` flag, so every workspace package must be
+# selected explicitly or its instrumented objects silently disappear.
+# Collect and report coverage for the complete Cargo workspace.
 [group('coverage')]
 coverage:
   cargo llvm-cov --all-features --workspace --no-report
-  cargo llvm-cov report --html --output-dir tmp/llvm-cov
-  cargo llvm-cov report --json --output-path tmp/llvm-cov/coverage.json
+  cargo llvm-cov report \
+    --package kache \
+    --package kache-core \
+    --package kache-e2e \
+    --package kache-service \
+    --html --output-dir tmp/llvm-cov
+  cargo llvm-cov report \
+    --package kache \
+    --package kache-core \
+    --package kache-e2e \
+    --package kache-service \
+    --json --output-path tmp/llvm-cov/coverage.json
+  just coverage-scope-check
+
+# Fail closed if a report omits any Cargo workspace member. This is separate
+# from the percentage threshold: an excellent percentage over an incomplete
+# package set is not workspace coverage.
+# Verify that coverage JSON contains every Cargo workspace member.
+[group('coverage')]
+coverage-scope-check COVERAGE_JSON="tmp/llvm-cov/coverage.json":
+  ./scripts/check-coverage-scope.sh "{{COVERAGE_JSON}}"
 
 # Run cargo-llvm-cov and open the HTML report locally.
 [group('coverage')]

--- a/scripts/check-coverage-scope.sh
+++ b/scripts/check-coverage-scope.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Assert that an llvm-cov JSON report contains product source from every Cargo
+# workspace member. A percentage over only the default package is otherwise a
+# plausible-looking but incomplete workspace gate.
+#
+# Membership and source roots come from `cargo metadata`, not a mirrored list,
+# so adding a fifth member makes this check fail until coverage reports it too.
+#
+# Usage: scripts/check-coverage-scope.sh [coverage-json]
+# Exit: 0 when every member is represented; 1 on missing/malformed input.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+coverage_json="${1:-tmp/llvm-cov/coverage.json}"
+
+ROOT="$root" COVERAGE_JSON="$coverage_json" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+root = Path(os.environ["ROOT"]).resolve()
+coverage_path = Path(os.environ["COVERAGE_JSON"])
+if not coverage_path.is_absolute():
+    coverage_path = root / coverage_path
+
+
+def fail(message, details=()):
+    print(f"coverage scope FAILED: {message}", file=sys.stderr)
+    for detail in details:
+        print(f"  - {detail}", file=sys.stderr)
+    sys.exit(1)
+
+
+try:
+    with coverage_path.open(encoding="utf-8") as stream:
+        coverage = json.load(stream)
+except FileNotFoundError:
+    fail(f"report not found: {coverage_path}")
+except (OSError, UnicodeError, json.JSONDecodeError) as error:
+    fail(f"cannot read {coverage_path}: {error}")
+if not isinstance(coverage, dict):
+    fail(f"{coverage_path} root must be a JSON object")
+
+try:
+    metadata_process = subprocess.run(
+        [
+            "cargo",
+            "metadata",
+            "--locked",
+            "--no-deps",
+            "--format-version",
+            "1",
+        ],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    metadata = json.loads(metadata_process.stdout)
+except (OSError, subprocess.CalledProcessError, json.JSONDecodeError) as error:
+    fail(f"cannot resolve Cargo workspace metadata: {error}")
+if not isinstance(metadata, dict):
+    fail("cargo metadata root is not a JSON object")
+
+data = coverage.get("data")
+if not isinstance(data, list) or not data:
+    fail(f"{coverage_path} has no llvm-cov data entries")
+
+
+def normalized(raw_path):
+    path = Path(raw_path)
+    if not path.is_absolute():
+        path = root / path
+    return os.path.normcase(os.path.realpath(path))
+
+
+covered_files = set()
+for entry in data:
+    if not isinstance(entry, dict):
+        continue
+    files = entry.get("files", [])
+    if not isinstance(files, list):
+        continue
+    for file_entry in files:
+        if not isinstance(file_entry, dict):
+            continue
+        filename = file_entry.get("filename")
+        if isinstance(filename, str) and filename:
+            covered_files.add(normalized(filename))
+if not covered_files:
+    fail(f"{coverage_path} contains no covered source files")
+
+raw_workspace_ids = metadata.get("workspace_members", [])
+if not isinstance(raw_workspace_ids, list) or not raw_workspace_ids:
+    fail("cargo metadata contains no workspace members")
+workspace_ids = {
+    package_id for package_id in raw_workspace_ids if isinstance(package_id, str)
+}
+if len(workspace_ids) != len(raw_workspace_ids):
+    fail("cargo metadata contains malformed workspace member IDs")
+
+raw_packages = metadata.get("packages", [])
+if not isinstance(raw_packages, list):
+    fail("cargo metadata packages field is not a list")
+packages_by_id = {
+    package.get("id"): package
+    for package in raw_packages
+    if isinstance(package, dict) and package.get("id")
+}
+missing_metadata = sorted(workspace_ids - packages_by_id.keys())
+if missing_metadata:
+    fail("cargo metadata omitted workspace package records", missing_metadata)
+
+primary_kinds = {"bin", "lib", "rlib", "dylib", "cdylib", "staticlib", "proc-macro"}
+
+
+def is_within(path, directory):
+    try:
+        return os.path.commonpath((path, directory)) == directory
+    except ValueError:
+        # Different Windows drives cannot contain one another.
+        return False
+
+
+missing_members = []
+represented = []
+for package_id in workspace_ids:
+    package = packages_by_id[package_id]
+    source_roots = {
+        os.path.dirname(normalized(target["src_path"]))
+        for target in package.get("targets", [])
+        if isinstance(target, dict)
+        and isinstance(target.get("src_path"), str)
+        and primary_kinds.intersection(target.get("kind", []))
+    }
+    if not source_roots:
+        fail(f"workspace member {package['name']!r} has no primary source target")
+
+    matches = sorted(
+        filename
+        for filename in covered_files
+        if any(is_within(filename, source_root) for source_root in source_roots)
+    )
+    if matches:
+        represented.append((package["name"], matches[0]))
+    else:
+        roots = ", ".join(sorted(source_roots))
+        missing_members.append(f"{package['name']}: expected a source file under {roots}")
+
+if missing_members:
+    fail(
+        "llvm-cov JSON omits workspace member source; report every package explicitly",
+        sorted(missing_members),
+    )
+
+print(f"coverage scope OK: {len(represented)}/{len(workspace_ids)} workspace members present")
+for name, filename in sorted(represented):
+    try:
+        display = Path(filename).relative_to(root)
+    except ValueError:
+        display = Path(filename)
+    print(f"  - {name}: {display}")
+PY


### PR DESCRIPTION
## Summary

- report coverage for every Cargo workspace package, not only the root `kache` package
- derive the expected workspace members and source roots from `cargo metadata`
- fail closed before the 88% threshold if llvm-cov JSON omits any member

`cargo llvm-cov 0.8.7 report` does not accept `--workspace`, so the report commands select all four current packages explicitly. The metadata-derived guard ensures adding another member cannot silently narrow the gate.

## Validation

- complete synthetic report: 4/4 members accepted
- report missing `kache-e2e`: rejected
- all four repeated `report --package` arguments parse under pinned cargo-llvm-cov 0.8.7
- Just parse/dry-run
- ShellCheck
- workflow YAML parse
- `cargo fmt --all -- --check`
- `git diff --check`

The full instrumented workspace run is intentionally left to CI.
