### PR TITLE
fix(rustc): key all outcome-affecting lint configuration

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -4,76 +4,71 @@ use std::path::{Path, PathBuf};
 
 use crate::compiler::rustc::RustcCompiler;
 
-/// rustc flags that affect only diagnostics, lint levels, or queries — never
+/// rustc flags that affect only diagnostics formatting or queries — never
 /// the emitted artifact bytes. Their separated value (`--flag value`) is
 /// skipped during parsing so neither the flag nor its value reaches the
 /// `residual_args` catch-all and over-keys the result (kunobi-ninja/kache#324).
 ///
-/// Deny-level lint gates (`-D`, `--deny`, `-F`, `--forbid`) are deliberately
-/// NOT listed here even though they cannot change a successful compile's
-/// object bytes: they change whether the compilation *fails*, and a cache hit
-/// replays success — see [`OUTCOME_AFFECTING_VALUE_FLAGS`].
+/// Lint configuration is deliberately NOT listed here even when it cannot
+/// change a successful compile's object bytes: lint levels and `--check-cfg`
+/// can change whether compilation fails, and a cache hit replays success — see
+/// [`OUTCOME_AFFECTING_VALUE_FLAGS`].
 const IGNORED_VALUE_FLAGS: &[&str] = &[
     "--error-format",
     "--json",
     "--color",
     "--diagnostic-width",
-    "--check-cfg",
     "--print",
     "--explain",
-    "-W",
-    "--warn",
-    "-A",
-    "--allow",
 ];
 
-/// Attached (`--flag=value` / `-Xvalue`) forms of the diagnostics / lint flags
-/// above, plus the single-letter lint prefixes (`-Wunused`, `-Dwarnings`). Used
-/// to drop the attached spellings from the cache key alongside their separated
-/// counterparts in [`IGNORED_VALUE_FLAGS`].
-///
-/// The `-D` / `-F` prefixes are intentionally absent: those spellings are
-/// outcome-affecting and captured by [`OUTCOME_LINT_ATTACHED_PREFIXES`] before
-/// this list is consulted.
+/// Attached (`--flag=value`) forms of the diagnostics/query flags above.
 const IGNORED_ATTACHED_PREFIXES: &[&str] = &[
     "--error-format=",
     "--json=",
     "--color=",
     "--diagnostic-width=",
-    "--check-cfg=",
     "--print=",
     "--explain=",
-    "--warn=",
-    "--allow=",
-    "-W",
-    "-A",
 ];
 
-/// rustc flags that can flip the compile's *outcome* from failure to success
+/// rustc flags that can flip the compile's *outcome* between failure and success
 /// without changing the object bytes of the successful compile. A cache hit
 /// replays success, so two invocations differing only here MUST NOT share a
-/// key — otherwise one stored under "warnings allowed" would serve green to a
-/// build that `-D warnings` should have failed (review finding #2). Each is
+/// key. Every lint level is included: `-A dead_code` can override
+/// `-D warnings`, while `-W missing_docs` can become fatal under that same
+/// group gate. `--check-cfg` controls which cfg names/values trigger the
+/// `unexpected_cfgs` lint. Each flag is
 /// captured with its value into [`RustcArgs::outcome_lint_flags`] and folded
 /// into the cache key.
 const OUTCOME_AFFECTING_VALUE_FLAGS: &[&str] = &[
+    "-W",           // warn: can become fatal under a deny-level group
+    "--warn",       // long form of -W
+    "-A",           // allow: can relax an otherwise fatal lint
+    "--allow",      // long form of -A
     "-D",           // deny: warnings of the named lint become hard errors
     "--deny",       // long form of -D
     "-F",           // forbid: like deny, cannot be re-allowed downstream
     "--forbid",     // long form of -F
     "--force-warn", // forces warn level; overrides attribute-level deny/allow
     "--cap-lints", // caps every lint level; changes effective levels (cargo passes --cap-lints allow)
+    "--check-cfg", // changes which cfg names/values unexpected_cfgs accepts
 ];
 
-/// Attached forms (`--deny=warnings`, `-Dwarnings`, …) of
+/// Attached forms (`--deny=warnings`, `-Dwarnings`, `--check-cfg=cfg(...)`, …) of
 /// [`OUTCOME_AFFECTING_VALUE_FLAGS`]. Bare `-D` / `-F` prefixes match any
-/// attached value (`-Dwarnings`, `-Funused`) because rustc defines no other
-/// flag beginning with those spellings; the long forms use explicit `=`.
+/// attached value because rustc defines no other flag beginning with those
+/// spellings; the same applies to `-W` / `-A`.
 const OUTCOME_LINT_ATTACHED_PREFIXES: &[&str] = &[
+    "--warn=",
+    "--allow=",
     "--deny=",
     "--forbid=",
     "--force-warn=",
     "--cap-lints=",
+    "--check-cfg=",
+    "-W",
+    "-A",
     "-D",
     "-F",
 ];
@@ -294,12 +289,12 @@ pub struct RustcArgs {
     /// future rustc flag) yet were previously invisible to the cache key, so
     /// they are folded in under a versioned tag (kunobi-ninja/kache#324).
     pub residual_args: Vec<String>,
-    /// Outcome-affecting lint gates (`-D`/`--deny`/`--forbid`/`-F`,
-    /// `--force-warn`, `--cap-lints`) captured as flag+value token pairs in
-    /// argv order, including attached spellings (`-Dwarnings`). These cannot
-    /// change a successful compile's object bytes but DO change whether the
+    /// Outcome-affecting lint configuration (`-A`/`-W`/`-D`/`-F`, their long
+    /// forms, `--force-warn`, `--cap-lints`, and `--check-cfg`) captured as
+    /// flag+value token pairs in argv order, including attached spellings.
+    /// These cannot change successful object bytes but DO change whether the
     /// compile fails, and hits replay success — so they are folded into the
-    /// cache key (see `cache_key.rs`; review finding #2).
+    /// cache key.
     pub outcome_lint_flags: Vec<String>,
     /// Whether this is a `--test` compilation (test harness binary)
     pub is_test: bool,
@@ -583,7 +578,7 @@ impl RustcArgs {
                 "-V" | "--version" | "-h" | "--help" | "-vV" => {
                     is_query = true;
                 }
-                // Outcome-affecting lint gates: capture flag + value for the
+                // Outcome-affecting lint configuration: capture flag + value for the
                 // cache key before the generic diagnostics drop below. Must
                 // precede the IGNORED_* arms — classification is first-match
                 // (review finding #2).
@@ -971,7 +966,7 @@ fn record_codegen_opt(parsed: &mut RustcArgs, value: &str) {
 mod tests {
     use super::*;
 
-    /// Outcome-affecting lint gates must be captured exactly — flag AND
+    /// Outcome-affecting lint configuration must be captured exactly — flag AND
     /// value, separated and attached spellings — and must not leak into the
     /// residual catch-all. Asserting the captured tokens directly (not just
     /// "the key changed") pins the parse indices: a wrong skip or a wrong
@@ -1010,10 +1005,33 @@ mod tests {
         let long_attached = parse(&["--forbid=unused"]);
         assert_eq!(long_attached.outcome_lint_flags, ["--forbid=unused"]);
 
-        // Diagnostics-only levels stay out of the capture (#324).
-        let warn = parse(&["-W", "unused"]);
-        assert!(warn.outcome_lint_flags.is_empty());
-        assert!(warn.residual_args.is_empty());
+        let remaining_forms: &[(&[&str], &[&str])] = &[
+            (&["-W", "unused"], &["-W", "unused"]),
+            (&["-Wunused"], &["-Wunused"]),
+            (&["--warn", "unused"], &["--warn", "unused"]),
+            (&["--warn=unused"], &["--warn=unused"]),
+            (&["-A", "dead_code"], &["-A", "dead_code"]),
+            (&["-Adead_code"], &["-Adead_code"]),
+            (&["--allow", "dead_code"], &["--allow", "dead_code"]),
+            (&["--allow=dead_code"], &["--allow=dead_code"]),
+            (
+                &["--check-cfg", "cfg(feature, values(\"extra\"))"],
+                &["--check-cfg", "cfg(feature, values(\"extra\"))"],
+            ),
+            (&["--check-cfg=cfg(test)"], &["--check-cfg=cfg(test)"]),
+        ];
+        for (argv, expected) in remaining_forms {
+            let parsed = parse(argv);
+            assert_eq!(
+                parsed.outcome_lint_flags, *expected,
+                "wrong outcome capture for {argv:?}"
+            );
+            assert!(
+                parsed.residual_args.is_empty(),
+                "outcome flags leaked into residual for {argv:?}: {:?}",
+                parsed.residual_args
+            );
+        }
     }
 
     /// The two sides of the #627 join have to agree: what a producer records

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -218,7 +218,14 @@ use std::path::{Path, PathBuf};
 // Cargo process using target_2 expanded that donor suffix, failed
 // validate-on-hit, evicted the entry, and recompiled. The stored dep-info bytes
 // change, so the bump makes every incorrectly owned v26 blob unreachable.
-pub(crate) const CACHE_KEY_VERSION: u32 = 27;
+//
+// v28: every rustc lint-setting flag and `--check-cfg` now participates in
+// the outcome key. v27 ignored `-W`/`-A` and check-cfg expectation sets, so a
+// successful compile could be replayed after an allow was removed, a warning
+// was enabled beneath a deny group, or accepted cfg values were tightened.
+// v0.16.0 shipped v27, so the bump also protects mixed fleets from consuming
+// already-persisted false-success entries.
+pub(crate) const CACHE_KEY_VERSION: u32 = 28;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
 /// Collapse runs of ASCII whitespace into single spaces and trim
@@ -1394,17 +1401,16 @@ pub fn compute_cache_key(
         );
     }
 
-    // Outcome-affecting lint gates (-D/--deny/--forbid/-F/--force-warn/
-    // --cap-lints, review finding #2): deny-level lints turn warnings into
-    // hard errors, so two invocations differing only here can disagree about
-    // whether the compile succeeded while producing identical object bytes.
+    // Outcome-affecting lint configuration (-A/-W/-D/-F, their long forms,
+    // --force-warn, --cap-lints, and --check-cfg): two invocations differing
+    // only here can disagree about whether compilation succeeded while
+    // producing identical object bytes on success. In particular, allow/warn
+    // levels interact with deny groups, and --check-cfg feeds unexpected_cfgs.
     // A hit replays success, which would flip a build that `-D warnings`
     // should have failed to green. The flags are captured during parsing
-    // (see `OUTCOME_AFFECTING_VALUE_FLAGS` in args.rs) and folded here
-    // normalized, only when non-empty — the common case (no lint gates) is
-    // byte-identical to prior keys, so no CACHE_KEY_VERSION bump is required
-    // (same precedent as residual_args above). Entries stored before this
-    // change simply miss once gates appear.
+    // (see `OUTCOME_AFFECTING_VALUE_FLAGS` in args.rs) and folded here. v28
+    // invalidates prior entries because v27 was released with these inputs
+    // missing and old clients can still populate that shared schema.
     //
     // Folded in ARGV ORDER, deliberately unsorted. The captured vector is a
     // flat token stream (`-D`, `warnings`, `--force-warn`, `deprecated`), so
@@ -1414,13 +1420,12 @@ pub fn compute_cache_key(
     // meaningful (the last level named for a lint wins). A stable argv order
     // for a given build config means keeping it costs no hits.
     if !args.outcome_lint_flags.is_empty() {
-        let outcome_lints: Vec<String> = args
-            .outcome_lint_flags
-            .iter()
-            .map(|tok| path_normalizer.normalize(tok))
-            .collect();
         hasher.set_group("outcome_lints");
-        for tok in &outcome_lints {
+        for tok in &args.outcome_lint_flags {
+            // Fold raw: check-cfg accepts arbitrary string values, including
+            // path-looking text. Path normalization could collapse two
+            // distinct accepted-value sets and reopen a false hit.
+            // The leak check is observability-only; it never rewrites the key.
             check_for_path_leak(tok, "outcome_lint");
             fold_field(&mut hasher, b"outcome_lint.v1:", tok.as_bytes());
             tracing::trace!("[key:{}] outcome_lint:{}", crate_name, tok);
@@ -5424,9 +5429,9 @@ mod tests {
     /// fold and over-key the result. Guards the same invariant as the
     /// `key_matrix_*_does_not_change_key` tests for flags cargo passes routinely.
     ///
-    /// Outcome-affecting lint gates (`--cap-lints`, `--force-warn`, deny-level
-    /// flags) are deliberately NOT in this list: they must change the key —
-    /// see `key_matrix_outcome_lint_gate_changes_key`.
+    /// Outcome-affecting lint configuration is deliberately NOT in this list:
+    /// every lint level and `--check-cfg` must change the key —
+    /// see `key_matrix_outcome_lint_configuration_changes_key`.
     #[test]
     fn residual_strips_diagnostic_and_query_flags() {
         let _lock = key_test_lock();
@@ -5436,12 +5441,9 @@ mod tests {
 
         let base = key_of_flags(&flag_base(&source, &[]));
         for extra in [
-            vec!["--check-cfg", "cfg(foo)"],
             vec!["--diagnostic-width=80"],
             vec!["--json=artifacts"],
             vec!["--color", "always"],
-            vec!["-W", "unused"],
-            vec!["-Wunused"],
             vec!["--verbose"],
         ] {
             assert_eq!(
@@ -8489,13 +8491,12 @@ pub fn value() -> (&'static str, u8) {
     // over-keying (a missed hit) — the test will fail and surface it
     // rather than silently weakening the key.
     //
-    // Deny-level lint gates are deliberately absent from this section:
-    // they also cannot change a successful compile's bytes, but they
-    // change whether the compile FAILS, and a hit replays success — so
-    // they must change the key. See the "outcome lint" tests below.
+    // All lint configuration is deliberately absent from this section: it
+    // cannot change successful artifact bytes, but it can change whether the
+    // compile FAILS, and a hit replays success. See the tests below.
 
     #[test]
-    fn key_matrix_outcome_lint_gate_changes_key() {
+    fn key_matrix_outcome_lint_configuration_changes_key() {
         // `-D warnings` promotes warnings to hard errors: two builds
         // differing only here can disagree about whether the compile
         // succeeded while emitting byte-identical objects on success.
@@ -8519,6 +8520,14 @@ pub fn value() -> (&'static str, u8) {
         with_cap.extend(["--cap-lints".to_string(), "allow".to_string()]);
         let mut with_attached = base_args(&source);
         with_attached.push("-Dwarnings".to_string());
+        let mut with_warn = base_args(&source);
+        with_warn.extend(["-W".to_string(), "unused".to_string()]);
+        let mut with_allow = base_args(&source);
+        with_allow.extend(["-A".to_string(), "dead_code".to_string()]);
+        let mut with_check_cfg = base_args(&source);
+        with_check_cfg.extend(["--check-cfg".to_string(), "cfg(foo)".to_string()]);
+        let mut with_other_check_cfg = base_args(&source);
+        with_other_check_cfg.push("--check-cfg=cfg(bar)".to_string());
 
         assert_ne!(
             key_for(&base),
@@ -8542,21 +8551,70 @@ pub fn value() -> (&'static str, u8) {
             "separated (`-D warnings`) and attached (`-Dwarnings`) spellings \
              carry different tokens; each keys distinctly by design"
         );
-        // Diagnostics-only levels stay out of the key (#324): -W/-A never
-        // flip the outcome, so keying them would only cost hits.
-        let mut with_warn = base_args(&source);
-        with_warn.extend(["-W".to_string(), "unused".to_string()]);
-        let mut with_allow = base_args(&source);
-        with_allow.extend(["-A".to_string(), "dead_code".to_string()]);
-        assert_eq!(
+        assert_ne!(
             key_for(&base),
             key_for(&with_warn),
-            "-W stays diagnostics-only: it cannot flip the outcome"
+            "-W can activate a lint that a deny group makes fatal"
         );
-        assert_eq!(
+        assert_ne!(
             key_for(&base),
             key_for(&with_allow),
-            "-A stays diagnostics-only: it cannot flip the outcome"
+            "-A can relax an otherwise fatal lint"
+        );
+        assert_ne!(
+            key_for(&base),
+            key_for(&with_check_cfg),
+            "--check-cfg controls the unexpected_cfgs outcome"
+        );
+        assert_ne!(
+            key_for(&with_check_cfg),
+            key_for(&with_other_check_cfg),
+            "different accepted cfg sets must not share a key"
+        );
+    }
+
+    #[test]
+    fn check_cfg_values_are_not_path_normalized() {
+        if !rustc_available() {
+            return;
+        }
+        let _lock = key_test_lock();
+        let root = tempfile::tempdir().unwrap();
+        let key_at = |workspace: &Path, with_check_cfg: bool| {
+            std::fs::create_dir_all(workspace).unwrap();
+            let source = workspace.join("lib.rs");
+            std::fs::write(&source, b"pub fn hello() {}").unwrap();
+            let mut args = base_args(&source);
+            if with_check_cfg {
+                let semantic_path = workspace
+                    .join("generated")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                args.extend([
+                    "--check-cfg".to_string(),
+                    format!("cfg(build_path, values(\"{semantic_path}\"))"),
+                ]);
+            }
+            let parsed = RustcArgs::parse(&args).unwrap();
+            compute_cache_key(
+                &parsed,
+                &FileHasher::new(),
+                &PathNormalizer::from_env(Some(workspace)),
+            )
+            .unwrap()
+        };
+
+        let workspace_a = root.path().join("checkout-a");
+        let workspace_b = root.path().join("checkout-b");
+        assert_eq!(
+            key_at(&workspace_a, false),
+            key_at(&workspace_b, false),
+            "the control must prove ordinary workspace paths normalize portably"
+        );
+        assert_ne!(
+            key_at(&workspace_a, true),
+            key_at(&workspace_b, true),
+            "path-looking check-cfg values are semantic strings and must stay raw"
         );
     }
 

--- a/tests/cache_key_underkeying_test.rs
+++ b/tests/cache_key_underkeying_test.rs
@@ -17,6 +17,8 @@
 //!   - `-O` / `-g` — shorthand codegen flags whose order relative to explicit
 //!     `-C` overrides is last-wins.
 //!   - direct `--remap-path-prefix` — changes embedded source/debug paths.
+//!   - lint configuration / `--check-cfg` — can change a compile from success
+//!     to failure, which a cache hit must never replay as success.
 //!
 //! `-L dependency=` (cargo's rlib search, redundant with the content-hashed
 //! `--extern`) must NOT affect the key, or every target-dir move would bust
@@ -48,6 +50,10 @@ fn rustc_sysroot() -> String {
     String::from_utf8(out.stdout).unwrap().trim().to_string()
 }
 
+fn toml_path(path: &Path) -> String {
+    toml::Value::String(path.to_string_lossy().into_owned()).to_string()
+}
+
 /// Compile a trivial rlib through kache-as-RUSTC_WRAPPER with `extra` flags
 /// appended to the rustc argv. Asserts the compile succeeds.
 fn run_kache_rustc(cache_dir: &Path, out_dir: &Path, src: &Path, extra: &[&str]) {
@@ -61,6 +67,22 @@ fn run_kache_rustc_from(
     extra: &[&str],
     cwd: Option<&Path>,
 ) {
+    let (args, output) = kache_rustc_output_from(cache_dir, out_dir, src, extra, cwd);
+
+    assert!(
+        output.status.success(),
+        "kache rustc failed.\nargs: {args:?}\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn kache_rustc_output_from(
+    cache_dir: &Path,
+    out_dir: &Path,
+    src: &Path,
+    extra: &[&str],
+    cwd: Option<&Path>,
+) -> (Vec<String>, std::process::Output) {
     let mut args: Vec<String> = vec![
         rustc_path(),
         "--crate-name".into(),
@@ -76,24 +98,35 @@ fn run_kache_rustc_from(
     ];
     args.extend(extra.iter().map(|s| s.to_string()));
 
+    let config_path = isolated_config_path(cache_dir);
+    std::fs::write(
+        &config_path,
+        format!(
+            "[cache]\nlocal_only = true\nignore_env = true\nlocal_store = {}\nruntime_dir = {}\n",
+            toml_path(cache_dir),
+            toml_path(cache_dir)
+        ),
+    )
+    .unwrap();
     let mut command = std::process::Command::new(kache_binary());
     command
         .args(&args)
         .env("KACHE_CACHE_DIR", cache_dir)
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
+        .env("KACHE_CONFIG", config_path)
         .env("KACHE_LOG", "kache=info")
+        .env_remove("KACHE_DISABLED")
+        .env_remove("KACHE_NAMESPACE")
+        .env_remove("KACHE_BASE_DIR")
+        .env_remove("KACHE_SOCKET_PATH")
+        .env_remove("KACHE_ACTIVE")
+        .env_remove("KACHE_FAMILY_PROBE_ACTIVE")
         .env_remove("RUSTC_WRAPPER")
         .env_remove("CARGO_BUILD_RUSTC_WRAPPER");
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }
     let output = command.output().expect("failed to run kache rustc");
-
-    assert!(
-        output.status.success(),
-        "kache rustc failed.\nargs: {args:?}\nstderr: {}",
-        String::from_utf8_lossy(&output.stderr),
-    );
+    (args, output)
 }
 
 /// `(compiled, local_hits)` from `kache report` over this isolated cache dir.
@@ -106,6 +139,12 @@ fn compiled_hit_counts(cache_dir: &Path) -> (u64, u64) {
         .args(["report", "--format", "json", "--since", "1h"])
         .env("KACHE_CACHE_DIR", cache_dir)
         .env("KACHE_CONFIG", isolated_config_path(cache_dir))
+        .env_remove("KACHE_DISABLED")
+        .env_remove("KACHE_NAMESPACE")
+        .env_remove("KACHE_BASE_DIR")
+        .env_remove("KACHE_SOCKET_PATH")
+        .env_remove("KACHE_ACTIVE")
+        .env_remove("KACHE_FAMILY_PROBE_ACTIVE")
         .output()
         .expect("failed to run kache report");
     assert!(output.status.success(), "kache report failed");
@@ -121,6 +160,76 @@ fn fresh_src() -> (TempDir, PathBuf) {
     let src = dir.path().join("lib.rs");
     std::fs::write(&src, b"pub fn f() -> u32 { 42 }\n").unwrap();
     (dir, src)
+}
+
+/// `--check-cfg` defines the accepted cfg names and values. Tightening that
+/// set under `-D unexpected_cfgs` must run rustc and fail, never replay the
+/// success cached under the earlier accepted set.
+#[test]
+fn check_cfg_change_cannot_replay_cached_success() {
+    build_kache();
+    let cache_dir = TempDir::new().unwrap();
+    let out = TempDir::new().unwrap();
+    let src_dir = TempDir::new().unwrap();
+    let src = src_dir.path().join("lib.rs");
+    std::fs::write(
+        &src,
+        b"#[cfg(accepted)]\npub fn accepted() -> bool { true }\n",
+    )
+    .unwrap();
+
+    let accepted = ["-D", "unexpected_cfgs", "--check-cfg", "cfg(accepted)"];
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &accepted); // miss
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &accepted); // hit
+    assert_eq!(
+        compiled_hit_counts(cache_dir.path()),
+        (1, 1),
+        "the accepted invocation must prove a real cache hit before the negative control"
+    );
+
+    let rejected = ["-D", "unexpected_cfgs", "--check-cfg", "cfg(other)"];
+    let (args, output) =
+        kache_rustc_output_from(cache_dir.path(), out.path(), &src, &rejected, None);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success()
+            && stderr.contains("unexpected `cfg` condition name")
+            && stderr.contains("accepted"),
+        "tightened --check-cfg must execute rustc and reject the source, not replay success.\n\
+         args: {args:?}\nstderr: {stderr}"
+    );
+}
+
+/// Allow/warn levels are outcome-affecting when they interact with deny
+/// groups. Removing an allow that made a compile green must not hit that entry.
+#[test]
+fn allow_override_change_cannot_replay_cached_success() {
+    build_kache();
+    let cache_dir = TempDir::new().unwrap();
+    let out = TempDir::new().unwrap();
+    let src_dir = TempDir::new().unwrap();
+    let src = src_dir.path().join("lib.rs");
+    std::fs::write(&src, b"fn intentionally_unused() {}\n").unwrap();
+
+    let allowed = ["-D", "warnings", "-A", "dead_code"];
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &allowed); // miss
+    run_kache_rustc(cache_dir.path(), out.path(), &src, &allowed); // hit
+    assert_eq!(
+        compiled_hit_counts(cache_dir.path()),
+        (1, 1),
+        "the allowed invocation must prove a real cache hit before the negative control"
+    );
+
+    let denied = ["-D", "warnings"];
+    let (args, output) = kache_rustc_output_from(cache_dir.path(), out.path(), &src, &denied, None);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success()
+            && stderr.contains("intentionally_unused")
+            && stderr.contains("never used"),
+        "removing -A dead_code must execute rustc and fail, not replay success.\n\
+         args: {args:?}\nstderr: {stderr}"
+    );
 }
 
 /// Rustc applies `-O` and `-Copt-level` in argv order. Reversing them must


### PR DESCRIPTION
## Summary

- key every stable rustc lint-setting form (`-A/-W/-D/-F` and long/attached forms)
- key `--check-cfg` expectation sets raw and in argv order
- bump the shared cache schema from v27 to v28
- add process regressions that prove tightened lint/cfg rules run rustc and fail instead of replaying cached success

## Root cause

v0.16.0 ignored `--check-cfg`, `-W`, and `-A`. A successful build could therefore be reused after accepted cfg values were tightened, an allow was removed, or a warning became fatal under a deny group.

The reproduced Cargo case was:

1. declare feature `extra`, with `unexpected_cfgs = "deny"`; compile and cache success;
2. remove the feature so Cargo changes `--check-cfg ... values("extra")` to `values()`;
3. Kache v27 returned `local_hit`, `compiler_runs=0`, while direct Cargo correctly failed.

v28 is required because a released v27 entry that ignored an allow/check-cfg flag can otherwise collide with a new invocation where that flag is absent. The version is shared with C/C++ keys, so this intentionally causes one cold rebuild across compiler families.

Old v0.16 clients remain unsafe until upgraded. After upgrading all clients, `kache gc --stale-schema` can reclaim v27 entries.

## Validation

- minimized live pre-fix Cargo reproduction plus direct-compiler negative control
- `cargo test --locked --bin kache --quiet` (2,158 passed)
- `cargo test --locked --test cache_key_underkeying_test` (10 passed)
- same process suite with poisoned Kache bypass/remote environment
- parser, key-matrix, raw-value, and stale-schema focused tests
- `cargo clippy --locked --bin kache --test cache_key_underkeying_test -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
