### PR TITLE
fix(daemon): treat remote import failures as misses

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -38,6 +38,7 @@ buildRustPackage {
       ../assets
       ../crates
       ../src
+      ../tests/fixtures/mock_cc_lc_all.sh
     ];
   };
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -13951,6 +13951,12 @@ mod tests {
         put_test_object(&client, &test_pack_object_key(&key, "serde"), &pack).await;
         let daemon = Arc::new(Daemon::new(config.clone()));
         assert!(daemon.remote_backend.set(client).is_ok());
+        daemon.install_plan(
+            "test-session",
+            "test-plan",
+            "test",
+            std::iter::once(key.clone()),
+        );
 
         let response = daemon
             .handle_prefetch(&PrefetchRequest {
@@ -14019,6 +14025,20 @@ mod tests {
         let transfer = latest_transfer(&daemon);
         assert!(!transfer.ok);
         assert_eq!(transfer.compressed_bytes, pack.len() as u64);
+        {
+            let active_plan = daemon
+                .active_plan
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            assert!(
+                active_plan
+                    .as_ref()
+                    .expect("test plan should remain active")
+                    .downloaded
+                    .is_empty(),
+                "a failed local import must not be attributed as a plan download"
+            );
+        }
         assert!(!daemon.prefetched_keys.read().await.contains(&key));
         assert!(!entry_dir.exists());
         assert!(!Store::open(&config).unwrap().contains(&key));

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12365,6 +12365,69 @@ mod tests {
         }
     }
 
+    struct BlockingV3Backend {
+        inner: Arc<dyn crate::remote_backend::RemoteBackend>,
+        v3_get_started: tokio::sync::mpsc::UnboundedSender<u64>,
+        release_v3_get: Arc<tokio::sync::Semaphore>,
+        v3_gets: AtomicU64,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::remote_backend::RemoteBackend for BlockingV3Backend {
+        async fn head(&self, key: &str) -> Result<bool> {
+            self.inner.head(key).await
+        }
+
+        async fn get(
+            &self,
+            key: &str,
+            max_bytes: Option<u64>,
+        ) -> Result<Option<crate::remote_backend::GetObject>> {
+            if key.contains("/v3/packs/") {
+                let ordinal = self.v3_gets.fetch_add(1, Ordering::SeqCst) + 1;
+                let _ = self.v3_get_started.send(ordinal);
+                let permit = self
+                    .release_v3_get
+                    .acquire()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("v3 GET test gate closed"))?;
+                permit.forget();
+            }
+            self.inner.get(key, max_bytes).await
+        }
+
+        async fn put(&self, key: &str, body: Vec<u8>, content_type: Option<&str>) -> Result<()> {
+            self.inner.put(key, body, content_type).await
+        }
+
+        async fn list(&self, prefix: &str) -> Result<Vec<String>> {
+            self.inner.list(prefix).await
+        }
+
+        fn describe(&self, key: &str) -> String {
+            self.inner.describe(key)
+        }
+    }
+
+    async fn wait_for_download_waiter(daemon: &Daemon, key: &str) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let attached = {
+                    let downloading = daemon.downloading.read().await;
+                    downloading
+                        .get(key)
+                        .is_some_and(|notify| Arc::strong_count(notify) > 1)
+                };
+                if attached {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("same-key request must attach to the active download claim");
+    }
+
     #[tokio::test]
     async fn test_socket_remote_check_miss_with_injected_mock_client() {
         // Remote configured + an empty in-memory backend: handle_remote_check
@@ -13524,6 +13587,159 @@ mod tests {
             "failed extraction must not leave meta.json that a waiter can mistake for a hit"
         );
         assert!(!Store::open(&config).unwrap().contains(&key));
+    }
+
+    #[tokio::test]
+    async fn concurrent_remote_check_waiter_retries_after_leader_import_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        config.prefetch_enabled = false;
+        let key = test_cache_key("concurrent-import-failure");
+        let pack = build_entry_pack(&key, "serde");
+        let entry_dir = config.store_dir().join(&key);
+        std::fs::create_dir_all(config.store_dir()).unwrap();
+        std::fs::write(config.store_dir().join("blobs"), b"not a directory").unwrap();
+
+        let inner = test_remote_backend();
+        put_test_object(&inner, &test_manifest_object_key(&key, "serde"), b"{}").await;
+        put_test_object(&inner, &test_pack_object_key(&key, "serde"), &pack).await;
+        let (v3_started_tx, mut v3_started_rx) = tokio::sync::mpsc::unbounded_channel();
+        let release_v3_get = Arc::new(tokio::sync::Semaphore::new(0));
+        let gated = Arc::new(BlockingV3Backend {
+            inner,
+            v3_get_started: v3_started_tx,
+            release_v3_get: release_v3_get.clone(),
+            v3_gets: AtomicU64::new(0),
+        });
+        let backend: Arc<dyn crate::remote_backend::RemoteBackend> = gated.clone();
+        let daemon = Arc::new(Daemon::new(config));
+        assert!(daemon.remote_backend.set(backend).is_ok());
+        daemon.signal_warming_complete();
+
+        let request = RemoteCheckRequest {
+            key: key.clone(),
+            entry_dir: entry_dir.to_string_lossy().into_owned(),
+            crate_name: "serde".into(),
+            deadline_ms: None,
+        };
+        let leader = {
+            let daemon = daemon.clone();
+            let request = request.clone();
+            tokio::spawn(async move {
+                daemon
+                    .handle_remote_check_leader(&request, RemoteDeadline::from_secs(10))
+                    .await
+            })
+        };
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), v3_started_rx.recv())
+                .await
+                .expect("leader must reach its gated v3 GET"),
+            Some(1)
+        );
+
+        let waiter = {
+            let daemon = daemon.clone();
+            tokio::spawn(async move {
+                daemon
+                    .handle_remote_check_leader(&request, RemoteDeadline::from_secs(10))
+                    .await
+            })
+        };
+        wait_for_download_waiter(&daemon, &key).await;
+
+        // Let the first valid pack finish. Its local import fails, releases the
+        // claim, and wakes the attached waiter. The waiter must re-claim and
+        // start a second GET; returning a hit from stale meta would skip it.
+        release_v3_get.add_permits(1);
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), v3_started_rx.recv())
+                .await
+                .expect("waiter must retry rather than report the failed leader as a hit"),
+            Some(2)
+        );
+        let leader_response = tokio::time::timeout(Duration::from_secs(5), leader)
+            .await
+            .expect("leader must finish after its GET is released")
+            .expect("leader task must not panic");
+        assert_eq!(leader_response.found, Some(false));
+
+        release_v3_get.add_permits(1);
+        let waiter_response = tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("waiter must finish after its retry is released")
+            .expect("waiter task must not panic");
+        assert_eq!(waiter_response.found, Some(false));
+        assert_eq!(gated.v3_gets.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            daemon
+                .transfer_counters
+                .downloads_completed
+                .load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            daemon
+                .transfer_counters
+                .downloads_failed
+                .load(Ordering::Relaxed),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_check_waiter_rejects_uncommitted_meta_after_leader_import_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        config.prefetch_enabled = false;
+        let key = test_cache_key("waiter-uncommitted-meta");
+        let entry_dir = config.store_dir().join(&key);
+        let daemon = Arc::new(Daemon::new(config.clone()));
+        let backend: Arc<dyn crate::remote_backend::RemoteBackend> = Arc::new(PanicOnGetBackend);
+        assert!(daemon.remote_backend.set(backend).is_ok());
+        daemon.signal_warming_complete();
+
+        // Model a leader that has the download claim and lands meta.json, but
+        // whose Store import fails before publishing a row. Keeping the residue
+        // deliberately exercises the committed-state check independently of
+        // best-effort cleanup.
+        assert!(claim_download(&daemon.downloading, &key).await.is_none());
+        let failed_leader = DownloadingGuard::new(daemon.downloading.clone(), key.clone());
+        let request = RemoteCheckRequest {
+            key: key.clone(),
+            entry_dir: entry_dir.to_string_lossy().into_owned(),
+            crate_name: "serde".into(),
+            deadline_ms: None,
+        };
+        let waiter = {
+            let daemon = daemon.clone();
+            tokio::spawn(async move {
+                daemon
+                    .handle_remote_check_leader(&request, RemoteDeadline::from_secs(10))
+                    .await
+            })
+        };
+        wait_for_download_waiter(&daemon, &key).await;
+
+        std::fs::create_dir_all(&entry_dir).unwrap();
+        std::fs::write(entry_dir.join("meta.json"), b"{}").unwrap();
+        let store = Store::open(&config).unwrap();
+        assert!(store.import_downloaded_entry(&key).is_err());
+        assert!(entry_dir.join("meta.json").exists());
+        assert!(!store.contains(&key));
+        drop(failed_leader);
+
+        let response = tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("failed leader must wake the waiter")
+            .expect("waiter task must not panic");
+        assert_eq!(
+            response.found,
+            Some(false),
+            "meta.json without a committed Store row is never a hit"
+        );
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3552,8 +3552,17 @@ impl Daemon {
                 .fetch_add(join_start.elapsed().as_millis() as u64, Ordering::Relaxed);
             match outcome {
                 JoinOutcome::Found => {
-                    let was_prefetched = self.prefetched_keys.read().await.contains(&req.key);
-                    return Response::found_prefetched(true, was_prefetched);
+                    // `meta.json` is only a wake-up hint: extraction writes it
+                    // before Store publication, and an import failure may leave
+                    // residue. Only a committed Store row is a cache hit.
+                    let committed = self
+                        .with_store(|store| Ok(store.contains(&req.key)))
+                        .unwrap_or(false);
+                    if committed {
+                        let was_prefetched = self.prefetched_keys.read().await.contains(&req.key);
+                        return Response::found_prefetched(true, was_prefetched);
+                    }
+                    return Response::found(false);
                 }
                 JoinOutcome::Reclaimed => reclaimed = true,
                 JoinOutcome::GaveUp => {
@@ -3582,7 +3591,11 @@ impl Daemon {
         // the claim we now hold so we don't destructively re-download over
         // the freshly published entry (#620, cross-family review finding —
         // the same re-check-under-claim defence the prefetch path uses).
-        if reclaimed && self.entry_dir_for(&req.key).join("meta.json").exists() {
+        if reclaimed
+            && self
+                .with_store(|store| Ok(store.contains(&req.key)))
+                .unwrap_or(false)
+        {
             let was_prefetched = self.prefetched_keys.read().await.contains(&req.key);
             return Response::found_prefetched(true, was_prefetched);
         }
@@ -3655,14 +3668,25 @@ impl Daemon {
                 }
                 let (import_result, import_lock_wait_ms, import_ms) =
                     self.with_store_timed(|store| store.import_restored_entry(&req.key));
-                if let Err(e) = import_result {
-                    tracing::warn!("failed to import downloaded entry {}: {e}", &req.key);
-                }
+                let import_ok = match import_result {
+                    Ok(()) => true,
+                    Err(e) => {
+                        tracing::warn!("failed to import downloaded entry {}: {e:#}", &req.key);
+                        false
+                    }
+                };
                 let elapsed_ms = start.elapsed().as_millis() as u64;
                 let finished_at_unix_ms = unix_time_ms();
-                self.transfer_counters
-                    .downloads_completed
-                    .fetch_add(1, Ordering::Relaxed);
+                if import_ok {
+                    self.transfer_counters
+                        .downloads_completed
+                        .fetch_add(1, Ordering::Relaxed);
+                } else {
+                    self.transfer_counters
+                        .downloads_failed
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+                // The pack crossed the wire even when local publication failed.
                 self.transfer_counters
                     .bytes_downloaded
                     .fetch_add(dl.compressed_bytes, Ordering::Relaxed);
@@ -3693,11 +3717,11 @@ impl Daemon {
                     head_checks_ms: 0,
                     blobs_skipped: dl.blobs_skipped,
                     blobs_total: dl.blobs_total,
-                    ok: true,
+                    ok: import_ok,
                     timestamp: finished_at_unix_ms / 1_000,
                 })
                 .await;
-                Response::found(true)
+                Response::found(import_ok)
             }
             Err(e) if classify_remote_error(&e) == RemoteErrorClass::Miss => {
                 // GET 404 = clean miss (#485 Phase 0). Reached when a
@@ -4598,22 +4622,34 @@ impl Daemon {
                             }
                             let (import_result, import_lock_wait_ms, import_ms) =
                                 d.with_store_timed(|store| store.import_restored_entry(&key));
-                            if let Err(e) = import_result {
-                                tracing::warn!("prefetch import failed for {}: {e}", key);
-                            }
+                            let import_ok = match import_result {
+                                Ok(()) => true,
+                                Err(e) => {
+                                    tracing::warn!("prefetch import failed for {}: {e:#}", key);
+                                    false
+                                }
+                            };
                             let elapsed_ms = start.elapsed().as_millis() as u64;
                             let finished_at_unix_ms = unix_time_ms();
-                            d.transfer_counters
-                                .downloads_completed
-                                .fetch_add(1, Ordering::Relaxed);
+                            if import_ok {
+                                d.transfer_counters
+                                    .downloads_completed
+                                    .fetch_add(1, Ordering::Relaxed);
+                                d.prefetch_stats
+                                    .downloads_completed
+                                    .fetch_add(1, Ordering::Relaxed);
+                            } else {
+                                d.transfer_counters
+                                    .downloads_failed
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                            // The pack crossed the wire even when local
+                            // publication failed, so preserve byte telemetry.
                             d.transfer_counters
                                 .bytes_downloaded
                                 .fetch_add(dl.compressed_bytes, Ordering::Relaxed);
                             // Phase-0 telemetry: the prefetch-attributed subset
                             // of the transfer counters above.
-                            d.prefetch_stats
-                                .downloads_completed
-                                .fetch_add(1, Ordering::Relaxed);
                             d.prefetch_stats
                                 .bytes_downloaded
                                 .fetch_add(dl.compressed_bytes, Ordering::Relaxed);
@@ -4622,7 +4658,7 @@ impl Daemon {
                                 .fetch_add(dl.compressed_bytes, Ordering::Relaxed);
                             // Per-plan attribution (#583 P0.5): byte-accurate
                             // downloaded set for the session summary.
-                            {
+                            if import_ok {
                                 let mut plan =
                                     d.active_plan.lock().unwrap_or_else(|p| p.into_inner());
                                 if let Some(p) = plan.as_mut() {
@@ -4656,10 +4692,13 @@ impl Daemon {
                                 head_checks_ms: 0,
                                 blobs_skipped: dl.blobs_skipped,
                                 blobs_total: dl.blobs_total,
-                                ok: true,
+                                ok: import_ok,
                                 timestamp: finished_at_unix_ms / 1_000,
                             })
                             .await;
+                            if !import_ok {
+                                return;
+                            }
                             // Track as prefetched for PrefetchHit attribution.
                             // Bound the set: a long-lived daemon that
                             // prefetches many distinct keys would otherwise
@@ -5779,7 +5818,7 @@ fn download_join_deadline(
 /// Outcome of waiting behind another task's in-flight download of a key.
 #[derive(Debug, PartialEq, Eq)]
 enum JoinOutcome {
-    /// The leader landed the entry (meta.json exists); use it.
+    /// The leader left `meta.json`; the caller must verify committed Store state.
     Found,
     /// The leader failed and this task won the atomic re-claim: it is now
     /// the leader and MUST release the claim via [`DownloadingGuard`].
@@ -13420,6 +13459,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn remote_check_import_failure_is_not_reported_as_hit() {
+        // The v3 GET/extraction can succeed while local publication fails. A
+        // regular file at `store/blobs` deterministically makes the import's
+        // `create_dir_all(store/blobs/<shard>)` fail on every platform, without
+        // weakening or corrupting the otherwise-valid remote pack.
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        config.prefetch_enabled = false;
+        let key = test_cache_key("download-import-failure");
+        let pack = build_entry_pack(&key, "serde");
+        let entry_dir = config.store_dir().join(&key);
+        std::fs::create_dir_all(config.store_dir()).unwrap();
+        std::fs::write(config.store_dir().join("blobs"), b"not a directory").unwrap();
+
+        let client = test_remote_backend();
+        put_test_object(&client, &test_manifest_object_key(&key, "serde"), b"{}").await;
+        put_test_object(&client, &test_pack_object_key(&key, "serde"), &pack).await;
+        let daemon = Arc::new(Daemon::new(config.clone()));
+        assert!(daemon.remote_backend.set(client).is_ok());
+
+        let response = daemon
+            .handle_remote_check(&RemoteCheckRequest {
+                key: key.clone(),
+                entry_dir: entry_dir.to_string_lossy().into_owned(),
+                crate_name: "serde".into(),
+                deadline_ms: None,
+            })
+            .await;
+
+        assert!(
+            response.ok,
+            "a cache fault must degrade to a miss: {response:?}"
+        );
+        assert_eq!(response.found, Some(false));
+        assert_eq!(
+            daemon
+                .transfer_counters
+                .downloads_completed
+                .load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            daemon
+                .transfer_counters
+                .downloads_failed
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            daemon
+                .transfer_counters
+                .bytes_downloaded
+                .load(Ordering::Relaxed),
+            pack.len() as u64,
+            "a local import failure must not hide bytes already transferred"
+        );
+        let transfer = latest_transfer(&daemon);
+        assert!(!transfer.ok);
+        assert_eq!(transfer.compressed_bytes, pack.len() as u64);
+        assert!(
+            !entry_dir.exists(),
+            "failed extraction must not leave meta.json that a waiter can mistake for a hit"
+        );
+        assert!(!Store::open(&config).unwrap().contains(&key));
+    }
+
+    #[tokio::test]
     async fn stale_meta_json_does_not_short_circuit_a_first_claim_leader() {
         // The under-claim meta.json re-check (#620) applies ONLY to a waiter
         // that won the re-claim after a failed leader; a first-claim leader
@@ -13611,6 +13718,94 @@ mod tests {
         assert_v3_transfer_timestamps(&latest_transfer(&daemon));
         // Nothing was imported.
         assert!(!config.store_dir().join(key).join("meta.json").exists());
+    }
+
+    #[tokio::test]
+    async fn prefetch_import_failure_is_counted_as_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        let key = test_cache_key("prefetch-import-failure");
+        let pack = build_entry_pack(&key, "serde");
+        let entry_dir = config.store_dir().join(&key);
+        std::fs::create_dir_all(config.store_dir()).unwrap();
+        std::fs::write(config.store_dir().join("blobs"), b"not a directory").unwrap();
+
+        let client = test_remote_backend();
+        put_test_object(&client, &test_pack_object_key(&key, "serde"), &pack).await;
+        let daemon = Arc::new(Daemon::new(config.clone()));
+        assert!(daemon.remote_backend.set(client).is_ok());
+
+        let response = daemon
+            .handle_prefetch(&PrefetchRequest {
+                keys: vec![(key.clone(), "serde".into())],
+                warm_all: false,
+            })
+            .await;
+        assert!(
+            response.ok,
+            "prefetch dispatch should remain fire-and-forget"
+        );
+
+        let completed = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let failed = daemon
+                    .transfer_counters
+                    .downloads_failed
+                    .load(Ordering::Relaxed);
+                let has_event = daemon
+                    .recent_transfers
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .back()
+                    .is_some();
+                if failed == 1 && has_event {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(
+            completed.is_ok(),
+            "prefetch import failure was not recorded"
+        );
+
+        assert_eq!(
+            daemon
+                .transfer_counters
+                .downloads_completed
+                .load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            daemon
+                .prefetch_stats
+                .downloads_completed
+                .load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            daemon
+                .transfer_counters
+                .bytes_downloaded
+                .load(Ordering::Relaxed),
+            pack.len() as u64,
+            "a local import failure must not hide bytes already transferred"
+        );
+        assert_eq!(
+            daemon
+                .prefetch_stats
+                .bytes_downloaded
+                .load(Ordering::Relaxed),
+            pack.len() as u64
+        );
+        let transfer = latest_transfer(&daemon);
+        assert!(!transfer.ok);
+        assert_eq!(transfer.compressed_bytes, pack.len() as u64);
+        assert!(!daemon.prefetched_keys.read().await.contains(&key));
+        assert!(!entry_dir.exists());
+        assert!(!Store::open(&config).unwrap().contains(&key));
     }
 
     #[tokio::test]

--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -1158,25 +1158,12 @@ mod tests {
     #[test]
     fn probe_spawns_pin_lc_all_c() {
         let temp = TempDir::new().unwrap();
-        let log_file = temp.path().join("lc_all.log");
-        let script_body = format!(
-            r#"printf '%s\n' "$LC_ALL" >> "{log}"
-if [ "$1" = "--version" ]; then
-    echo "mock-cc 1.0"
-    exit 0
-fi
-if [ "$1" = "-###" ]; then
-    echo ' /usr/lib/gcc/cc1 -quiet -O2 foo.c -o foo.s' >&2
-    exit 0
-fi
-if [ "$1" = "-E" ]; then
-    echo 'KACHE_PROBE_GNU'
-    exit 0
-fi
-exit 0"#,
-            log = log_file.display()
-        );
-        let script = create_mock_probe_script(temp.path(), "mock_cc", &script_body);
+        let _cache_guard = set_test_cache_dir(temp.path());
+        // This fixture is checked in, not written immediately before exec.
+        // Runtime-created scripts can race another test's fork and fail with
+        // ETXTBSY under coverage even after the writer itself is closed.
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/mock_cc_lc_all.sh");
         let compiler = script.to_str().unwrap();
 
         let req = ProbeRequest {
@@ -1201,11 +1188,7 @@ exit 0"#,
             other => panic!("expected Resolved diagnostic, got: {other:?}"),
         }
 
-        let recorded = std::fs::read_to_string(&log_file).unwrap();
-        let lines: Vec<&str> = recorded.lines().collect();
-        assert!(!lines.is_empty(), "expected compiler to be spawned");
-        for line in &lines {
-            assert_eq!(*line, "C", "expected LC_ALL=C, got: {line}");
-        }
+        // The fixture exits non-zero unless every spawn pins LC_ALL=C, so
+        // reaching each successful assertion above proves the environment.
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -2206,9 +2206,58 @@ impl Store {
     /// Import a restored entry into the local store.
     ///
     /// This is the format-agnostic seam future remote layouts should call.
-    /// Today it is equivalent to `import_downloaded_entry()`.
+    /// A failed import must not leave an uncommitted `meta.json` behind: daemon
+    /// download waiters use the extracted directory as a wake-up hint, and the
+    /// residue could otherwise be mistaken for a published entry. Cleanup is
+    /// serialized with Store publishers and preserves any committed generation
+    /// that won the race.
     pub fn import_restored_entry(&self, cache_key: &str) -> Result<()> {
-        self.import_downloaded_entry(cache_key)
+        match self.import_downloaded_entry(cache_key) {
+            Ok(()) => Ok(()),
+            Err(import_error) => match self.discard_uncommitted_restored_entry(cache_key) {
+                Ok(()) => Err(import_error),
+                Err(cleanup_error) => Err(import_error.context(format!(
+                    "also failed to discard uncommitted restored entry: {cleanup_error:#}"
+                ))),
+            },
+        }
+    }
+
+    /// Remove extraction residue only when no committed row owns this key.
+    ///
+    /// The no-op write acquires SQLite's cross-process writer lock before the
+    /// row check and keeps it through directory removal. A concurrent publisher
+    /// therefore either commits first (and is preserved) or publishes after the
+    /// stale directory is gone.
+    fn discard_uncommitted_restored_entry(&self, cache_key: &str) -> Result<()> {
+        if !crate::cache_key::is_valid_cache_key(cache_key) {
+            anyhow::bail!("refusing to discard invalid restored cache key");
+        }
+
+        let tx = self.db.unchecked_transaction()?;
+        tx.execute("UPDATE entries SET cache_key = cache_key WHERE 1 = 0", [])?;
+        let committed: i64 = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM entries WHERE cache_key = ?1 AND committed = 1)",
+            params![cache_key],
+            |row| row.get(0),
+        )?;
+        if committed == 0 {
+            let entry_dir = self.entry_dir(cache_key);
+            match fs::remove_dir_all(&entry_dir) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "removing uncommitted restored entry {}",
+                            entry_dir.display()
+                        )
+                    });
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(())
     }
 
     /// Install one already-verified artifact into the content-addressed blob

--- a/src/store.rs
+++ b/src/store.rs
@@ -2225,28 +2225,33 @@ impl Store {
 
     /// Remove extraction residue only when no committed row owns this key.
     ///
-    /// The no-op write acquires SQLite's cross-process writer lock before the
-    /// row check and keeps it through directory removal. A concurrent publisher
-    /// therefore either commits first (and is preserved) or publishes after the
-    /// stale directory is gone.
+    /// An immediate transaction acquires SQLite's cross-process writer lock
+    /// before the row check and keeps it through directory removal. A concurrent
+    /// publisher therefore either commits first (and is preserved) or publishes
+    /// after the stale directory is gone.
     fn discard_uncommitted_restored_entry(&self, cache_key: &str) -> Result<()> {
-        self.discard_uncommitted_restored_entry_inner(cache_key, || {})
+        self.discard_uncommitted_restored_entry_inner(cache_key, || {}, || {})
     }
 
     fn discard_uncommitted_restored_entry_inner(
         &self,
         cache_key: &str,
         before_write_lock: impl FnOnce(),
+        after_write_lock: impl FnOnce(),
     ) -> Result<()> {
         if !crate::cache_key::is_valid_cache_key(cache_key) {
             anyhow::bail!("refusing to discard invalid restored cache key");
         }
 
-        let tx = self.db.unchecked_transaction()?;
-        // The test hook makes the publication ordering observable without
-        // weakening the production lock or relying on scheduler sleeps.
+        // The test hooks make both sides of lock acquisition observable
+        // without weakening the production lock or relying on scheduler
+        // sleeps.
         before_write_lock();
-        tx.execute("UPDATE entries SET cache_key = cache_key WHERE 1 = 0", [])?;
+        let tx = rusqlite::Transaction::new_unchecked(
+            &self.db,
+            rusqlite::TransactionBehavior::Immediate,
+        )?;
+        after_write_lock();
         let committed: i64 = tx.query_row(
             "SELECT EXISTS(SELECT 1 FROM entries WHERE cache_key = ?1 AND committed = 1)",
             params![cache_key],
@@ -8301,9 +8306,13 @@ mod tests {
             .expect("publisher must reach its pre-commit point");
         let cleanup_key = key.clone();
         let cleanup = std::thread::spawn(move || {
-            cleanup_store.discard_uncommitted_restored_entry_inner(&cleanup_key, || {
-                cleanup_attempt_tx.send(()).unwrap();
-            })
+            cleanup_store.discard_uncommitted_restored_entry_inner(
+                &cleanup_key,
+                || {
+                    cleanup_attempt_tx.send(()).unwrap();
+                },
+                || {},
+            )
         });
 
         publisher.join().unwrap();
@@ -8319,6 +8328,120 @@ mod tests {
             meta_json,
             "cleanup must not remove or replace the generation that committed first"
         );
+    }
+
+    #[test]
+    fn failed_restore_cleanup_holds_the_writer_lock_through_removal() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let cleanup_store = Store::open(&config).unwrap();
+        let contender_store = Store::open(&config).unwrap();
+        let key = blake3::hash(b"restore-cleanup-first").to_hex().to_string();
+        let entry_dir = cleanup_store.entry_dir(&key);
+        fs::create_dir_all(&entry_dir).unwrap();
+        fs::write(entry_dir.join("meta.json"), b"stale restore").unwrap();
+
+        let (locked_tx, locked_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        let cleanup_key = key.clone();
+        let cleanup = std::thread::spawn(move || {
+            cleanup_store.discard_uncommitted_restored_entry_inner(
+                &cleanup_key,
+                || {},
+                || {
+                    locked_tx.send(()).unwrap();
+                    release_rx
+                        .recv_timeout(Duration::from_secs(5))
+                        .expect("test must release the cleanup writer lock");
+                },
+            )
+        });
+
+        locked_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("cleanup must acquire its writer lock");
+        contender_store.db.busy_timeout(Duration::ZERO).unwrap();
+        let lock_error = match rusqlite::Transaction::new_unchecked(
+            &contender_store.db,
+            rusqlite::TransactionBehavior::Immediate,
+        ) {
+            Ok(transaction) => {
+                drop(transaction);
+                panic!("another publisher acquired SQLite's writer lock during cleanup");
+            }
+            Err(error) => error,
+        };
+        assert!(
+            matches!(
+                lock_error,
+                SqlError::SqliteFailure(code, _)
+                    if matches!(code.code, ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
+            ),
+            "unexpected competing-writer result: {lock_error}"
+        );
+
+        release_tx.send(()).unwrap();
+        cleanup
+            .join()
+            .unwrap()
+            .expect("cleanup should remove the uncommitted residue");
+        assert!(!entry_dir.exists());
+
+        let output = dir.path().join("published.rlib");
+        fs::write(&output, b"published after cleanup").unwrap();
+        contender_store
+            .put(
+                &key,
+                "published",
+                &["rlib".into()],
+                &[],
+                "host",
+                "dev",
+                &[(output, "published.rlib".into())],
+                "",
+                "",
+            )
+            .expect("a publisher must succeed after cleanup releases the lock");
+        assert!(contender_store.contains(&key));
+        assert!(entry_dir.join("meta.json").is_file());
+    }
+
+    #[test]
+    fn failed_restore_cleanup_accepts_an_already_missing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let key = blake3::hash(b"already-missing-restore")
+            .to_hex()
+            .to_string();
+
+        assert!(!store.entry_dir(&key).exists());
+        store
+            .discard_uncommitted_restored_entry(&key)
+            .expect("an already-absent restore has nothing left to clean up");
+    }
+
+    #[test]
+    fn failed_restore_cleanup_reports_non_directory_residue() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let key = blake3::hash(b"non-directory-restore-residue")
+            .to_hex()
+            .to_string();
+        let entry_path = store.entry_dir(&key);
+        fs::write(&entry_path, b"not a directory").unwrap();
+
+        let error = store
+            .discard_uncommitted_restored_entry(&key)
+            .expect_err("non-directory residue must not be silently accepted");
+        assert!(
+            error
+                .to_string()
+                .contains("removing uncommitted restored entry"),
+            "unexpected cleanup error: {error:#}"
+        );
+        assert!(entry_path.is_file());
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -2230,11 +2230,22 @@ impl Store {
     /// therefore either commits first (and is preserved) or publishes after the
     /// stale directory is gone.
     fn discard_uncommitted_restored_entry(&self, cache_key: &str) -> Result<()> {
+        self.discard_uncommitted_restored_entry_inner(cache_key, || {})
+    }
+
+    fn discard_uncommitted_restored_entry_inner(
+        &self,
+        cache_key: &str,
+        before_write_lock: impl FnOnce(),
+    ) -> Result<()> {
         if !crate::cache_key::is_valid_cache_key(cache_key) {
             anyhow::bail!("refusing to discard invalid restored cache key");
         }
 
         let tx = self.db.unchecked_transaction()?;
+        // The test hook makes the publication ordering observable without
+        // weakening the production lock or relying on scheduler sleeps.
+        before_write_lock();
         tx.execute("UPDATE entries SET cache_key = cache_key WHERE 1 = 0", [])?;
         let committed: i64 = tx.query_row(
             "SELECT EXISTS(SELECT 1 FROM entries WHERE cache_key = ?1 AND committed = 1)",
@@ -8231,6 +8242,83 @@ mod tests {
             "expected 'missing file' error, got: {err}"
         );
         assert!(!store.contains("incomplete_key"));
+    }
+
+    #[test]
+    fn failed_restore_cleanup_preserves_a_concurrent_committed_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let publisher_store = Store::open(&config).unwrap();
+        let cleanup_store = Store::open(&config).unwrap();
+        let key = blake3::hash(b"restore-cleanup-publication-race")
+            .to_hex()
+            .to_string();
+        let entry_dir = config.store_dir().join(&key);
+        let meta_json = serde_json::to_string_pretty(&EntryMeta {
+            cache_key: key.clone(),
+            key_schema: crate::cache_key::CACHE_KEY_VERSION,
+            crate_name: "published".into(),
+            crate_types: vec!["lib".into()],
+            files: Vec::new(),
+            stdout: String::new(),
+            stderr: String::new(),
+            features: Vec::new(),
+            target: String::new(),
+            profile: "dev".into(),
+            compile_time_ms: 0,
+            emit_kinds: Vec::new(),
+        })
+        .unwrap();
+
+        // Hold a publisher's SQLite write transaction after materializing its
+        // meta.json but before commit. The cleanup announces the exact point at
+        // which it is about to request the same writer lock; only then does the
+        // publisher commit. This fixes the ordering without scheduler sleeps.
+        let (published_tx, published_rx) = std::sync::mpsc::sync_channel(0);
+        let (cleanup_attempt_tx, cleanup_attempt_rx) = std::sync::mpsc::sync_channel(0);
+        let publisher_key = key.clone();
+        let publisher_entry_dir = entry_dir.clone();
+        let publisher_meta = meta_json.clone();
+        let publisher = std::thread::spawn(move || {
+            let tx = publisher_store.db.unchecked_transaction().unwrap();
+            tx.execute(
+                "INSERT INTO entries (cache_key, crate_name, size, committed) \
+                 VALUES (?1, 'published', 0, 1)",
+                params![publisher_key],
+            )
+            .unwrap();
+            fs::create_dir_all(&publisher_entry_dir).unwrap();
+            fs::write(publisher_entry_dir.join("meta.json"), publisher_meta).unwrap();
+            published_tx.send(()).unwrap();
+            cleanup_attempt_rx
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .expect("cleanup must attempt the writer lock");
+            tx.commit().unwrap();
+        });
+
+        published_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("publisher must reach its pre-commit point");
+        let cleanup_key = key.clone();
+        let cleanup = std::thread::spawn(move || {
+            cleanup_store.discard_uncommitted_restored_entry_inner(&cleanup_key, || {
+                cleanup_attempt_tx.send(()).unwrap();
+            })
+        });
+
+        publisher.join().unwrap();
+        cleanup
+            .join()
+            .unwrap()
+            .expect("cleanup should observe and preserve the committed winner");
+
+        let store = Store::open(&config).unwrap();
+        assert!(store.contains(&key));
+        assert_eq!(
+            fs::read_to_string(entry_dir.join("meta.json")).unwrap(),
+            meta_json,
+            "cleanup must not remove or replace the generation that committed first"
+        );
     }
 
     #[test]

--- a/tests/fixtures/mock_cc_lc_all.sh
+++ b/tests/fixtures/mock_cc_lc_all.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ "${LC_ALL:-}" != "C" ]; then
+    printf 'expected LC_ALL=C, got %s\n' "${LC_ALL:-<unset>}" >&2
+    exit 91
+fi
+
+case "${1:-}" in
+    --version)
+        printf '%s\n' 'mock-cc 1.0'
+        ;;
+    -###)
+        printf '%s\n' ' /usr/lib/gcc/cc1 -quiet -O2 foo.c -o foo.s' >&2
+        ;;
+    -E)
+        printf '%s\n' 'KACHE_PROBE_GNU'
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Treat a successful remote transfer followed by a failed local Store import as a cache miss and failed end-to-end download, while retaining transferred-byte telemetry.
- Prevent prefetch success, plan, and prefetched-key attribution when local publication failed.
- Make same-key waiters verify committed Store state and retry after a failed leader import.
- Remove uncommitted restore residue under an explicit SQLite writer transaction so cleanup cannot delete a concurrently committed generation.

Advances #761 and #696.

## Reliability coverage

- Deterministic demand, prefetch, same-key leader/waiter, and stale-metadata failure tests.
- Deterministic publisher-first and cleanup-first Store races, including writer-lock exclusion, post-cleanup publication, missing residue, and non-directory obstruction.
- No scheduler sleeps in the new concurrency tests.

## Validation

- [x] `cargo test --locked --workspace -- --test-threads=16`
- [x] `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Changed-line mutation run: 12 tested, 10 caught, 2 build-unviable, 0 survivors/timeouts
- [x] Independent correctness review: GO

The bounded local test concurrency avoids the repository's already-documented macOS `EMFILE` mode at the default 256-FD soft limit; Nix checks already raise that limit to 4096 for #756.

## CI follow-up

- [x] Linux coverage exposed a pre-existing `ETXTBSY` race in a runtime-written mock compiler fixture.
- [x] Replaced it with a checked-in executable POSIX fixture that fails unless every probe receives `LC_ALL=C`; targeted all-feature validation and independent review pass.
- [x] Added that exact test-only fixture to the Nix source fileset after the package check proved it was otherwise omitted; source evaluation preserves executable mode and the Nix formatting check passes.

## Post-#830 integration

- [x] Rebased onto current `main` (`fc78069`) with #830 async transfer logging and #842 probe changes preserved alongside import-failure accounting.
- [x] All five rebased commits have valid SSH signatures.
- [x] Post-rebase `cargo test --locked --bin kache -- --test-threads=16`: 2181 passed, 0 failed, 2 ignored.
- [x] Strict workspace/all-target/all-feature Clippy, formatting, and diff checks pass.
