### PR TITLE
fix(cc): cache compiles carrying -mno-omit-leaf-frame-pointer

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1860,6 +1860,22 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         dialect: None,
     },
     FlagSpec {
+        // `-mno-omit-leaf-frame-pointer` (clang): forces frame pointers for
+        // leaf functions too. Current cc-rs emits it when Rust requests
+        // forced frame pointers, and in debug-mode tool setup alongside
+        // `-fno-omit-frame-pointer` — so it lands on every aws-lc-sys TU of
+        // a macOS debug build (#839). Real codegen effect: clang's `-###`
+        // resolves it to `-mframe-pointer=all` against the default
+        // `-mframe-pointer=non-leaf`, which the resolved-token hash
+        // separates. gcc spells the equivalent knob `-momit-leaf-frame-
+        // pointer` (opposite default, same `-m` shape); a driver whose
+        // `-###` doesn't resolve keeps refusing fail-closed.
+        matcher: Matcher::Exact("-mno-omit-leaf-frame-pointer"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #839 — cc-rs forced-frame-pointer flag (aws-lc-sys debug builds); clang -### resolves to -mframe-pointer=all.",
+        dialect: None,
+    },
+    FlagSpec {
         matcher: Matcher::Exact("-pthread"),
         class: FlagClass::CapturedByProbe,
         source: "Issue #114 — pthread feature switch (also visible via _REENTRANT in preprocessor).",
@@ -6651,6 +6667,44 @@ mod tests {
         assert!(
             !descs.iter().any(|d| d.contains("unsupported flag")),
             "the Firefox omit-fp + SIMD combo must no longer refuse, got: {descs:?}"
+        );
+    }
+
+    #[test]
+    fn cc_rs_no_omit_leaf_frame_pointer_no_longer_refuses_issue_839() {
+        // cc-rs emits `-mno-omit-leaf-frame-pointer` when Rust requests forced
+        // frame pointers, and in debug-mode tool setup — every aws-lc-sys TU
+        // of a macOS debug build passed through on it (#839). The flag is
+        // CapturedByProbe: it must classify clean AND force the resolved
+        // invocation (clang `-###` resolves it to `-mframe-pointer=all`,
+        // against the default `-mframe-pointer=non-leaf`, so the key
+        // separates the two codegen modes; an unresolvable probe refuses
+        // fail-closed instead of under-keying).
+        let argv = s(&[
+            "cc",
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o",
+            "-O0",
+            "-fno-omit-frame-pointer",
+            "-mno-omit-leaf-frame-pointer",
+        ]);
+        let parsed = CcArgs::parse(&argv).unwrap();
+        assert!(
+            parsed.refuse_reasons(&[]).is_empty(),
+            "the cc-rs forced-frame-pointer invocation must cache: {:?}",
+            parsed.refuse_reasons(&[])
+        );
+        assert!(
+            cc_flags_need_resolved_invocation(&parsed),
+            "-mno-omit-leaf-frame-pointer must force the resolved invocation"
+        );
+        // The related-but-distinct gcc spelling stays unmodeled.
+        assert_eq!(
+            classify_cc_flag("-momit-leaf-frame-pointer", Dialect::Gnu),
+            None,
+            "-momit-leaf-frame-pointer is not modeled and must keep refusing"
         );
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1771,6 +1771,110 @@ fn test_cc_forced_include_and_param_converge_across_clones_issue_580() {
     );
 }
 
+/// cc-rs emits `-mno-omit-leaf-frame-pointer` when Rust requests forced
+/// frame pointers (and in debug-mode tool setup), so every aws-lc-sys TU of
+/// a macOS debug build passed through on it (#839). The flag is
+/// `CapturedByProbe`: clang's `-###` resolves it to `-mframe-pointer=all`
+/// against the default `-mframe-pointer=non-leaf`, so the resolved-token
+/// hash must key the two codegen modes apart.
+///
+/// Gated like the other probe-keyed tests: a driver that rejects the flag or
+/// a host whose `cc -###` cannot resolve skips rather than false-fails.
+#[test]
+fn test_cc_no_omit_leaf_frame_pointer_keys_on_probe_issue_839() {
+    let probe_dir = TempDir::new().unwrap();
+    let gate_src = probe_dir.path().join("gate.c");
+    std::fs::write(&gate_src, "int gate(void) { return 0; }\n").unwrap();
+    let accepts = std::process::Command::new("cc")
+        .arg("-c")
+        .arg(&gate_src)
+        .arg("-o")
+        .arg(probe_dir.path().join("gate.o"))
+        .args(["-mno-omit-leaf-frame-pointer", "-O0", "-g0"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !accepts {
+        eprintln!("skipping: `cc` does not accept -mno-omit-leaf-frame-pointer");
+        return;
+    }
+    build_kache();
+    if !kache_caches_probe_keyed_flags(probe_dir.path()) {
+        eprintln!("skipping: probe-keyed flags are not cacheable on this host");
+        return;
+    }
+
+    let work = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    std::fs::write(work.path().join("tu.c"), "int tu(void) { return 7; }\n").unwrap();
+
+    // Cold: compiles and stores. A passthrough records no miss, so this is
+    // what proves the flag classified at all.
+    let flagged = [
+        "cc",
+        "-c",
+        "tu.c",
+        "-o",
+        "tu.o",
+        "-mno-omit-leaf-frame-pointer",
+        "-O0",
+        "-g0",
+    ];
+    run_kache_cc(work.path(), cache_dir.path(), &flagged);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(
+        report["summary"]["misses"].as_u64(),
+        Some(1),
+        "cold -mno-omit-leaf-frame-pointer compile must be cached, not passed \
+         through.\n`cc -###` said:\n{}\nevents.jsonl:\n{}",
+        cc_probe_stderr_head(work.path(), &flagged[1..]),
+        std::fs::read_to_string(cache_dir.path().join("events.jsonl"))
+            .unwrap_or_else(|e| format!("(unreadable: {e})"))
+    );
+
+    // The entry is real: the same compile hits it.
+    std::fs::remove_file(work.path().join("tu.o")).unwrap();
+    run_kache_cc(work.path(), cache_dir.path(), &flagged);
+    let report = kache_report(cache_dir.path());
+    assert_cc_report_counts(&report, 1, 1);
+
+    // The default frame-pointer mode must NOT hit the flagged entry: clang
+    // resolves the two to `-mframe-pointer=all` vs `-mframe-pointer=non-leaf`
+    // in the cc1 stream, so a false hit would mean the probe under-keys a
+    // codegen difference. Asserted as "local_hits did not grow" (a distinct
+    // key with byte-identical output records as a `dup`, not a miss).
+    let default_mode = ["cc", "-c", "tu.c", "-o", "tu.o", "-O0", "-g0"];
+    std::fs::remove_file(work.path().join("tu.o")).unwrap();
+    run_kache_cc(work.path(), cache_dir.path(), &default_mode);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(
+        report["summary"]["local_hits"].as_u64(),
+        Some(1),
+        "default -mframe-pointer=non-leaf must not hit the \
+         -mno-omit-leaf-frame-pointer entry: {report}"
+    );
+
+    // Key-level proof from the events: three compiles, two flag modes,
+    // exactly two distinct cache keys.
+    let events = report["all_events"]
+        .as_array()
+        .expect("report should include all_events");
+    assert_eq!(events.len(), 3, "expected one event per compile: {report}");
+    let keys: std::collections::BTreeSet<&str> = events
+        .iter()
+        .map(|e| {
+            let key = e["cache_key"].as_str().unwrap_or_default();
+            assert!(!key.is_empty(), "every event should carry a cache key: {e}");
+            key
+        })
+        .collect();
+    assert_eq!(
+        keys.len(),
+        2,
+        "the two frame-pointer modes must map to distinct cache keys: {report}"
+    );
+}
+
 #[test]
 fn test_cc_depinfo_sidecar_restores_on_hit_and_new_mf_path() {
     build_kache();


### PR DESCRIPTION
## Summary

Closes #839.

cc-rs emits `-mno-omit-leaf-frame-pointer` when Rust requests forced frame pointers, and in debug-mode tool setup alongside `-fno-omit-frame-pointer` — so every macOS debug/test build of a workspace with native deps passed these TUs through uncached (374 passthroughs in the issue's 24h sample, rooted in aws-lc-sys).

The flag is classified `CapturedByProbe`: clang `-###` resolves it to `-mframe-pointer=all` against the default `-mframe-pointer=non-leaf`, so the resolved-token hash keys the two codegen modes apart. A driver whose probe cannot resolve keeps refusing fail-closed; the gcc spelling `-momit-leaf-frame-pointer` stays unmodeled.

## Test plan

- [x] Unit: the cc-rs invocation shape classifies clean, forces the resolved invocation, and `-momit-leaf-frame-pointer` still refuses (`cc_rs_no_omit_leaf_frame_pointer_no_longer_refuses_issue_839`)
- [x] Live integration: cold compile caches (no passthrough), re-run hits, the default frame-pointer mode maps to a distinct cache key (`test_cc_no_omit_leaf_frame_pointer_keys_on_probe_issue_839`, verified on Apple clang 21 where `-###` emits `-mframe-pointer=all` vs `non-leaf`)
- [x] Full `compiler::cc` unit suite passes

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests) — fmt and tests pass; clippy has 3 pre-existing errors in `remote_backend.rs`/`tui.rs`/`wrapper.rs` that reproduce on unmodified `main`
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [x] User-visible changes (CLI, config, output) are reflected in the README or relevant docs — no CLI/config/output change; docs do not enumerate individual flags
