### PR TITLE
ci: guard Unix test resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Run repo verification
         # kache-action exports the installed release version; self-checks must
         # compile with Cargo.toml's version from this PR.
-        run: env -u KACHE_VERSION just ci
+        run: env -u KACHE_VERSION ./scripts/with-test-resources.sh just ci
         timeout-minutes: 30
       - name: Check crates.io package metadata
         run: |
@@ -395,7 +395,7 @@ jobs:
           CARGO_INCREMENTAL: "1"
         run: |
           test -s tmp/mutants/pr.diff
-          cargo mutants \
+          ./scripts/with-test-resources.sh cargo mutants \
             --workspace \
             --all-features \
             --in-diff tmp/mutants/pr.diff \
@@ -967,7 +967,7 @@ jobs:
       - name: cargo test (workspace)
         run: |
           rustc --version && cargo --version
-          cargo test --workspace
+          ./scripts/with-test-resources.sh cargo test --workspace
         timeout-minutes: 30
         env:
           RUSTC_WRAPPER: ""

--- a/Justfile
+++ b/Justfile
@@ -13,11 +13,11 @@ default:
 
 # Run all local quality checks.
 [group('dev')]
-check: fmt-check lint test
+check: fmt-check lint test-resource-guard-check test
 
 # Mirror the repo CI verification flow.
 [group('dev')]
-ci: fmt-check lint image-service-print helm-lint coverage
+ci: fmt-check lint image-service-print helm-lint test-resource-guard-check coverage
 
 # Auto-fix formatting and clippy warnings.
 [group('dev')]
@@ -59,7 +59,13 @@ image-service-release:
 # Run the full workspace test suite.
 [group('dev')]
 test:
-  cargo test --workspace
+  ./scripts/with-test-resources.sh cargo test --workspace
+
+# Verify both the raised-limit and bounded-thread fallback paths without
+# changing the invoking shell's resource limits.
+[group('dev')]
+test-resource-guard-check:
+  ./scripts/test-with-test-resources.sh
 
 # Model-check the bounded planner invariants. Install the pinned verifier with:
 # cargo install --locked kani-verifier --version 0.67.0 && cargo kani setup
@@ -82,7 +88,7 @@ mutants-service *ARGS:
 # mutants-core and mutants-service. DIFF must describe the current working tree.
 [group('dev')]
 mutants-diff DIFF *ARGS:
-  cargo mutants --workspace --all-features --in-diff "{{DIFF}}" --exclude 'crates/kache-core/**' --exclude 'crates/kache-service/**' --baseline run --timeout 300 --build-timeout 600 --output tmp/mutants/diff {{ARGS}}
+  ./scripts/with-test-resources.sh cargo mutants --workspace --all-features --in-diff "{{DIFF}}" --exclude 'crates/kache-core/**' --exclude 'crates/kache-service/**' --baseline run --timeout 300 --build-timeout 600 --output tmp/mutants/diff {{ARGS}}
 
 # Audit dependencies with cargo-deny (advisories + licenses + bans +
 # sources; config and documented exceptions in `deny.toml`). Runs once
@@ -290,7 +296,7 @@ helm-lint:
 # Collect and report coverage for the complete Cargo workspace.
 [group('coverage')]
 coverage:
-  cargo llvm-cov --all-features --workspace --no-report
+  ./scripts/with-test-resources.sh cargo llvm-cov --all-features --workspace --no-report
   cargo llvm-cov report \
     --package kache \
     --package kache-core \
@@ -316,7 +322,7 @@ coverage-scope-check COVERAGE_JSON="tmp/llvm-cov/coverage.json":
 # Run cargo-llvm-cov and open the HTML report locally.
 [group('coverage')]
 coverage-open:
-  cargo llvm-cov --all-features --workspace --html --output-dir tmp/llvm-cov
+  ./scripts/with-test-resources.sh cargo llvm-cov --all-features --workspace --html --output-dir tmp/llvm-cov
   open tmp/llvm-cov/html/index.html || \
     xdg-open tmp/llvm-cov/html/index.html || true
 

--- a/scripts/test-with-test-resources.sh
+++ b/scripts/test-with-test-resources.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Deterministic checks for with-test-resources.sh. Every limit change happens
+# in a subshell, so the caller's soft/hard limits are never modified.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+wrapper="$script_dir/with-test-resources.sh"
+
+case "$(uname -s 2>/dev/null || true)" in
+  CYGWIN* | MINGW* | MSYS*)
+    echo "test-resource guard: Windows uses native process resources; skipped"
+    exit 0
+    ;;
+esac
+
+is_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+hard_nofile="$(ulimit -Hn)"
+if [ "$hard_nofile" = "unlimited" ] || {
+  is_positive_integer "$hard_nofile" && ((10#$hard_nofile >= 4096))
+}; then
+  (
+    unset RUST_TEST_THREADS
+    ulimit -Sn 64
+    # shellcheck disable=SC2016 # Evaluated by the child Bash.
+    "$wrapper" bash -c '
+      soft="$(ulimit -Sn)"
+      if [ "$soft" != unlimited ] && [ "$soft" -lt 4096 ]; then
+        echo "soft nofile was not raised: $soft" >&2
+        exit 1
+      fi
+      [ "${RUST_TEST_THREADS+x}" != x ]
+    '
+  )
+else
+  echo "test-resource guard: hard nofile below 4096; raise-path check skipped"
+fi
+
+# Make 4096 unreachable in this subshell and prove an existing lower setting
+# is preserved rather than increased.
+(
+  ulimit -Sn 64
+  ulimit -Hn 64
+  # shellcheck disable=SC2016 # Evaluated by the child Bash.
+  RUST_TEST_THREADS=1 "$wrapper" bash -c '
+    [ "$(ulimit -Sn)" -eq 64 ]
+    [ "$RUST_TEST_THREADS" -eq 1 ]
+  '
+)
+
+# With no explicit setting, the fallback must be positive and no greater than
+# either its conservative cap or the host concurrency visible to the child.
+(
+  ulimit -Sn 64
+  ulimit -Hn 64
+  unset RUST_TEST_THREADS
+  # shellcheck disable=SC2016 # Evaluated by the child Bash.
+  "$wrapper" bash -c '
+    case "$RUST_TEST_THREADS" in
+      "" | *[!0-9]* | 0) exit 1 ;;
+    esac
+    [ "$RUST_TEST_THREADS" -le 8 ]
+    detected="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+    case "$detected" in
+      "" | *[!0-9]* | 0) detected=1 ;;
+    esac
+    [ "$RUST_TEST_THREADS" -le "$detected" ]
+  '
+)
+
+set +e
+"$wrapper" >/dev/null 2>&1
+usage_status=$?
+set -e
+if [ "$usage_status" -ne 64 ]; then
+  echo "wrapper without a command returned $usage_status, expected 64" >&2
+  exit 1
+fi
+
+echo "test-resource guard: all checks passed"

--- a/scripts/with-test-resources.sh
+++ b/scripts/with-test-resources.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Run a test-bearing command with enough file descriptors for Kache's parallel
+# suite. Low Unix soft limits can otherwise surface unrelated policy failures
+# when filesystem operations fail closed under EMFILE (#756).
+set -euo pipefail
+
+target_nofile=4096
+fallback_max_threads=8
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <command> [args...]" >&2
+  exit 64
+fi
+
+is_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+limit_is_sufficient() {
+  local limit="$1"
+  if [ "$limit" = "unlimited" ]; then
+    return 0
+  fi
+  is_positive_integer "$limit" && ((10#$limit >= target_nofile))
+}
+
+available_test_threads() {
+  local detected
+  detected="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+  if is_positive_integer "$detected"; then
+    printf '%s\n' "$detected"
+  else
+    # Unknown is not permission to increase concurrency. One is the only
+    # conservative fallback when the host cannot report its CPU allowance.
+    printf '1\n'
+  fi
+}
+
+# Windows has no POSIX RLIMIT_NOFILE. Git Bash can execute this wrapper for
+# local Just recipes, but the command itself should remain native there.
+case "$(uname -s 2>/dev/null || true)" in
+  CYGWIN* | MINGW* | MSYS*) exec "$@" ;;
+esac
+
+soft_nofile="$(ulimit -Sn 2>/dev/null || true)"
+if limit_is_sufficient "$soft_nofile"; then
+  exec "$@"
+fi
+
+if ulimit -Sn "$target_nofile" 2>/dev/null; then
+  raised_nofile="$(ulimit -Sn 2>/dev/null || true)"
+  if limit_is_sufficient "$raised_nofile"; then
+    exec "$@"
+  fi
+fi
+
+# A builder may have a hard limit below 4096. Bound libtest only in that case;
+# never raise an explicit setting or the host's available parallelism.
+available_threads="$(available_test_threads)"
+fallback_threads="$available_threads"
+if [ "${RUST_TEST_THREADS+x}" = "x" ]; then
+  if ! is_positive_integer "$RUST_TEST_THREADS"; then
+    echo "invalid RUST_TEST_THREADS=$RUST_TEST_THREADS: expected a positive integer" >&2
+    exit 64
+  fi
+  fallback_threads="$RUST_TEST_THREADS"
+fi
+if ((10#$fallback_threads > 10#$available_threads)); then
+  fallback_threads="$available_threads"
+fi
+if ((10#$fallback_threads > fallback_max_threads)); then
+  fallback_threads="$fallback_max_threads"
+fi
+export RUST_TEST_THREADS="$fallback_threads"
+
+printf \
+  'warning: could not raise soft nofile limit %s to %s; capping Rust test threads at %s\n' \
+  "${soft_nofile:-unknown}" "$target_nofile" "$fallback_threads" >&2
+exec "$@"


### PR DESCRIPTION
## Summary

- add one Unix test-resource wrapper that raises the soft file-descriptor limit to 4096 when permitted
- fall back to a conservative `RUST_TEST_THREADS` cap only when the host hard limit prevents the raise
- cover both raise and fallback behavior with deterministic shell tests
- use the guard for local workspace tests, Linux/macOS CI, coverage, and diff mutation testing; keep Windows native

## Why

The full parallel suite can exhaust a low Unix `RLIMIT_NOFILE` (notably macOS's 256 default) and turn unrelated filesystem operations into misleading policy-test failures. Nix already carried a one-off limit raise; this makes the protection consistent at every full-suite entry point without imposing a fixed thread count on capable hosts.

## Validation

- `just test`: 2,172 main tests passed, 2 ignored; all integration, workspace-crate, and doc tests passed
- wrapper self-test directly and through `just test-resource-guard-check`
- Bash syntax and ShellCheck 0.11
- Justfile parse plus affected recipe dry-runs
- workflow YAML parse
- `cargo fmt --all -- --check`
- `git diff --check`
- independent review: no blockers

The initial sandboxed run had three expected `ps`/`pgrep` failures because process listing is denied there; the unrestricted full rerun was green.
