### PR TITLE
fix(cc): cache trivial auto var pattern init

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1815,6 +1815,17 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         source: "Issue #114 — fp-contract codegen knob.",
         dialect: None,
     },
+    FlagSpec {
+        // Clang's automatic-variable hardening mode changes generated code and
+        // is forwarded verbatim to `-cc1`, so the resolved-token hash safely
+        // distinguishes it from the default mode. Keep the row exact on the
+        // Firefox-reported spelling; adjacent modes remain fail-closed until
+        // there is workload evidence for them.
+        matcher: Matcher::Exact("-ftrivial-auto-var-init=pattern"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #849 — Firefox automatic-variable pattern initialization; Apple clang forwards the value to -cc1 verbatim (verified -###).",
+        dialect: None,
+    },
     // ── Codegen knobs: one sorted stem list, BOTH polarities ──
     //
     // `-f(?:no-)?<stem>` matches `-f<stem>` AND `-fno-<stem>` for every stem
@@ -6514,6 +6525,46 @@ mod tests {
             "-fsanitize-undefined-strip-path-components=0",
             "-fsanitize-undefined-strip-path-components=2",
             "-fsanitize-undefined-strip-path-components=-2",
+        ] {
+            assert_eq!(
+                classify_cc_flag(flag, Dialect::Gnu),
+                None,
+                "{flag} is not modeled and must keep refusing"
+            );
+        }
+    }
+
+    /// Firefox enables Clang's automatic-variable pattern initialization as a
+    /// hardening mode (#849). It affects generated code, and Clang preserves
+    /// the option verbatim in the resolved `-cc1` invocation, so it must be
+    /// accepted as probe-keyed rather than passed through.
+    #[test]
+    fn caches_trivial_auto_var_init_pattern_issue_849() {
+        let flag = "-ftrivial-auto-var-init=pattern";
+        assert_eq!(
+            classify_cc_flag(flag, Dialect::Gnu),
+            Some(FlagClass::CapturedByProbe),
+            "{flag} must key through the resolved invocation"
+        );
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o", flag, "-O0"])).unwrap();
+        assert!(
+            parsed.refuse_reasons(&[]).is_empty(),
+            "Firefox compile with {flag} must cache: {:?}",
+            parsed.refuse_reasons(&[])
+        );
+        assert!(cc_flags_need_resolved_invocation(&parsed));
+    }
+
+    /// The #849 row intentionally covers only the reported mode. Other valid
+    /// Clang modes and malformed neighbouring spellings remain conservative
+    /// passthroughs instead of being accepted by a broad prefix.
+    #[test]
+    fn trivial_auto_var_init_other_spellings_still_refuse_issue_849() {
+        for flag in [
+            "-ftrivial-auto-var-init",
+            "-ftrivial-auto-var-init=zero",
+            "-ftrivial-auto-var-init=uninitialized",
+            "-ftrivial-auto-var-init=patterns",
         ] {
             assert_eq!(
                 classify_cc_flag(flag, Dialect::Gnu),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2103,6 +2103,88 @@ fn test_cc_gdwarf2_caches_and_keys_dwarf_version_issue_838() {
     );
 }
 
+/// True when the host `cc` accepts Firefox's Clang automatic-variable
+/// hardening mode. GCC and older Clang versions may reject it, so they cannot
+/// exercise the issue #849 path.
+fn cc_accepts_trivial_auto_var_init_pattern(dir: &Path) -> bool {
+    let source = dir.join("auto-var-init-probe.c");
+    if std::fs::write(
+        &source,
+        "int auto_var_init_probe(void) { int value; return value; }\n",
+    )
+    .is_err()
+    {
+        return false;
+    }
+    std::process::Command::new("cc")
+        .arg("-c")
+        .arg(&source)
+        .arg("-o")
+        .arg(dir.join("auto-var-init-probe.o"))
+        .args(["-ftrivial-auto-var-init=pattern", "-O0"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Live end-to-end for #849: the reported Firefox hardening flag must produce
+/// a normal cold cache store and warm hit, while the default initialization
+/// mode remains a distinct cache key.
+#[test]
+fn test_cc_trivial_auto_var_init_pattern_caches_issue_849() {
+    let probe_dir = TempDir::new().unwrap();
+    if !cc_accepts_trivial_auto_var_init_pattern(probe_dir.path()) {
+        eprintln!("skipping: `cc` does not accept -ftrivial-auto-var-init=pattern");
+        return;
+    }
+    build_kache();
+    if !kache_caches_probe_keyed_flags(probe_dir.path()) {
+        eprintln!("skipping: probe-keyed flags are not cacheable on this host");
+        return;
+    }
+
+    let work = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    std::fs::write(
+        work.path().join("tu.c"),
+        "int use_auto_var(void) { int value; return value; }\n",
+    )
+    .unwrap();
+
+    let with_flag = [
+        "cc",
+        "-c",
+        "tu.c",
+        "-o",
+        "tu.o",
+        "-ftrivial-auto-var-init=pattern",
+        "-O0",
+        "-g0",
+    ];
+    run_kache_cc(work.path(), cache_dir.path(), &with_flag);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(
+        report["summary"]["misses"].as_u64(),
+        Some(1),
+        "cold compile with the #849 flag must be cached, not passed through: {report}"
+    );
+
+    std::fs::remove_file(work.path().join("tu.o")).unwrap();
+    run_kache_cc(work.path(), cache_dir.path(), &with_flag);
+    let report = kache_report(cache_dir.path());
+    assert_cc_report_counts(&report, 1, 1);
+
+    let without_flag = ["cc", "-c", "tu.c", "-o", "tu.o", "-O0", "-g0"];
+    std::fs::remove_file(work.path().join("tu.o")).unwrap();
+    run_kache_cc(work.path(), cache_dir.path(), &without_flag);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(
+        report["summary"]["local_hits"].as_u64(),
+        Some(1),
+        "the flag-less compile must not reuse the pattern-initialized entry: {report}"
+    );
+}
+
 #[test]
 fn test_cc_depinfo_sidecar_restores_on_hit_and_new_mf_path() {
     build_kache();


### PR DESCRIPTION
Closes #849.

Classifies the reported `-ftrivial-auto-var-init=pattern` Clang hardening flag as `CapturedByProbe`, because it is preserved in the resolved `-cc1` invocation and therefore safely differentiates cache keys. Adjacent modes remain fail-closed.

Adds classifier boundary tests and a live cold-store/warm-hit integration regression.

Local validation:
- `cargo fmt --all -- --check`
- `cargo test --bin kache compiler::cc::tests` (209 passed)
- `cargo test --test integration_test test_cc_trivial_auto_var_init_pattern_caches_issue_849 -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`