### PR TITLE
feat(bench): add OpenDAL as a nightly compile-cache scenario

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,8 +1,8 @@
 name: Bench
 
 # Clone benchmark — builds kache from THIS ref and runs the cross-clone
-# cold/warm scenarios (Firefox, Substrate, SurrealDB, LLVM) against one shared
-# cache, then
+# cold/warm scenarios (Firefox, Substrate, SurrealDB, OpenDAL, LLVM) against
+# one shared cache, then
 # uploads the reports. This is the heavy, hours-long, tens-of-GB-disk job the
 # bench engine's doc-comment says is "intentionally NOT wired into [PR] CI": it
 # lives in its own workflow so it never blocks a push/PR.
@@ -31,7 +31,7 @@ on:
       scenario:
         description: "Which scenario(s) to run"
         type: choice
-        options: [all, substrate, surrealdb, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows]
+        options: [all, substrate, surrealdb, opendal, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows]
         default: all
       extra_args:
         description: "Extra args appended to `just bench <profile>` (e.g. --skip-clone, --retry)"
@@ -87,6 +87,11 @@ jobs:
           # deps (rocksdb, grpcio, quickjs) that build outside kache. Comparable
           # weight to substrate; same native-prereq set (already installed below).
           surrealdb='{"name":"surrealdb","cmd":"bench surrealdb","dir":"bench-surrealdb","timeout":180,"min_free_gb":80}'
+          # OpenDAL core (apache/opendal `core/` workspace) with the portable
+          # service-feature set — mid-size pure-Rust, lighter than surrealdb.
+          # aws-lc-sys (rustls) compiles outside kache; cmake + a C compiler
+          # are already in the apt step below.
+          opendal='{"name":"opendal","cmd":"bench opendal","dir":"bench-opendal","timeout":120,"min_free_gb":40}'
           # Full cold Firefox build is the long pole — hours. `bench firefox`
           # resolves to the exact `bench-firefox` scenario: `--profile firefox`
           # is a name SUBSTRING match that also catches `bench-firefox-windows`,
@@ -110,6 +115,7 @@ jobs:
           case "$SCENARIO" in
             substrate)            inc="[$substrate]" ;;
             surrealdb)            inc="[$surrealdb]" ;;
+            opendal)              inc="[$opendal]" ;;
             firefox)              inc="[$firefox]" ;;
             firefox-sccache)      inc="[$firefox_sccache]" ;;
             llvm)                 inc="[$llvm]" ;;
@@ -120,7 +126,7 @@ jobs:
             # and wastefully run the whole Linux `all` matrix alongside.
             firefox-windows)      inc="[]" ;;
             firefox-pull-windows) inc="[]" ;;
-            *)                    inc="[$substrate,$surrealdb,$firefox,$firefox_sccache,$llvm,$firefox_pull]" ;;
+            *)                    inc="[$substrate,$surrealdb,$opendal,$firefox,$firefox_sccache,$llvm,$firefox_pull]" ;;
           esac
           echo "matrix={\"include\":$inc}" >> "$GITHUB_OUTPUT"
           if [ "$inc" = "[]" ]; then
@@ -163,7 +169,8 @@ jobs:
       # needs around the build: substrate links rocksdb/secp256k1 and needs
       # protoc + clang + cmake + openssl headers (SurrealDB's default features
       # need the same set — rocksdb bindgen wants libclang, storage-tikv/grpcio
-      # wants protoc); Firefox's `./mach bootstrap`
+      # wants protoc; OpenDAL's rustls/aws-lc-sys wants cmake + a C compiler);
+      # Firefox's `./mach bootstrap`
       # pulls its own clang/rust toolchain but still needs python3 + common
       # archive/file utilities present first; the LLVM scenario drives CMake
       # with the Ninja generator, so it needs ninja-build. git/curl are needed by

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ just bench-trace firefox   # also emit key-diff.{json,md}
 just bench-sccache         # list sccache-backed benchmark profiles
 just bench-sccache firefox # same Firefox shape, with sccache
 just bench substrate       # Rust-heavy polkadot-sdk benchmark (tens of min to ~1.5h, ~20-40 GB)
+just bench opendal         # Apache OpenDAL core workspace (minutes, mid-size Rust)
 just bench llvm            # almost-pure C/C++ CMake benchmark (tens of min, large scratch)
 ```
 
@@ -252,7 +253,7 @@ but not required to understand kache hit/miss behavior.
 
 Each benchmark scenario uses a **per-scenario scratch dir** — `./tmp/bench/<scenario>` by default (override with `--work-dir`) — so firefox, firefox-sccache, substrate, and any other scenario **coexist** without clobbering each other's clones, cache, or logs; `rm -rf tmp/bench` cleans them all. A `work_dir` lock refuses a second run pointed at the same scratch dir. Concurrent runs on one host invalidate the wall-clock numbers (CPU/IO/RAM contention), so run benchmarks sequentially or on separate hosts.
 
-Each project is described by a [scenario](scenarios/) (`scenarios/bench-*/scenario.toml`) — repo/ref, how to wire kache or sccache in, and how to build. The Substrate probe is `RUSTC_WRAPPER`-only: it caches the Rust compile surface — the polkadot node's dependency tree plus the nested wasm-runtime compiles — while native C deps (rocksdb, secp256k1) compile outside kache's view by design. Needs `protoc`, `clang`, `cmake`, `pkg-config` installed.
+Each project is described by a [scenario](scenarios/) (`scenarios/bench-*/scenario.toml`) — repo/ref, how to wire kache or sccache in, and how to build. The Substrate probe is `RUSTC_WRAPPER`-only: it caches the Rust compile surface — the polkadot node's dependency tree plus the nested wasm-runtime compiles — while native C deps (rocksdb, secp256k1) compile outside kache's view by design. Needs `protoc`, `clang`, `cmake`, `pkg-config` installed. OpenDAL is the same shape against `apache/opendal`'s `core/` workspace and a portable service-feature set; `aws-lc-sys` (rustls) compiles outside kache.
 
 See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
 

--- a/crates/kache-e2e/src/bench_profile.rs
+++ b/crates/kache-e2e/src/bench_profile.rs
@@ -1006,6 +1006,33 @@ diff --git a/hello.txt b/hello.txt
         );
     }
 
+    /// The shipped OpenDAL scenario wires kache via `RUSTC_WRAPPER` only
+    /// (no file injection, no CC/CXX — aws-lc-sys stays outside kache),
+    /// builds the `core/` workspace with the portable service-feature set,
+    /// and wipes `core/target` between phases.
+    #[test]
+    fn shipped_opendal_profile_is_rustc_wrapper_only() {
+        let p = BenchProfile::load(&repo_profile("opendal")).expect("opendal.toml loads");
+        assert_eq!(p.name, "bench-opendal");
+        assert_eq!(p.objdir, "core/target");
+        assert!(p.files.is_empty(), "opendal uses RUSTC_WRAPPER only");
+        assert!(
+            p.env.is_empty(),
+            "no extra env — CARGO_INCREMENTAL is an engine baseline, not a profile var"
+        );
+        let build = p.build_command(Path::new("/k"));
+        assert!(build.contains("cd core"), "{build}");
+        assert!(
+            build.contains("cargo build --release --locked --features"),
+            "{build}"
+        );
+        assert!(build.contains("services-s3"), "{build}");
+        assert!(
+            !build.contains("services-rocksdb"),
+            "rocksdb needs a preinstalled native lib"
+        );
+    }
+
     #[test]
     fn source_ref_next_parses_and_marks_pull() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/kache-e2e/src/scenario.rs
+++ b/crates/kache-e2e/src/scenario.rs
@@ -546,6 +546,14 @@ mod tests {
         assert_eq!(firefox.source_kind, SourceKind::Clone);
         assert!(firefox.tags.contains(&"suite:bench".to_string()));
 
+        let opendal = scenarios
+            .iter()
+            .find(|scenario| scenario.name == "bench-opendal")
+            .unwrap();
+        assert_eq!(opendal.source_kind, SourceKind::Clone);
+        assert!(opendal.tags.contains(&"suite:bench".to_string()));
+        assert!(opendal.tags.contains(&"project:opendal".to_string()));
+
         let c_hello = scenarios
             .iter()
             .find(|scenario| scenario.name == "e2e-c-hello")

--- a/scenarios/bench-opendal/scenario.toml
+++ b/scenarios/bench-opendal/scenario.toml
@@ -1,0 +1,96 @@
+# OpenDAL compile-cache benchmark scenario for kache-scenario.
+# A mid-size Rust workspace (the Apache OpenDAL core) — kache wires in via
+# RUSTC_WRAPPER only (set by the engine), caching every crate compile in the
+# `opendal` facade's dependency graph. Native C/C++ that rustls/aws-lc-sys
+# pulls in compiles OUTSIDE kache by design (no CC/CXX wrapper here); only
+# the Rust crates are cached. Mirrors substrate / surrealdb.
+name = "bench-opendal"
+tags = ["suite:bench", "project:opendal", "backend:kache", "lang:rust"]
+
+requires = ["cargo", "rustc"]
+
+# OpenDAL ships rust-toolchain.toml with channel = "stable" at the repo
+# root, so — like surrealdb — there is nothing to pin here: rustup
+# auto-selects that toolchain on the first cargo invocation in the tree,
+# and the bench workflow clears RUSTUP_TOOLCHAIN so the file is honoured.
+# The Cargo workspace lives under `core/` (no root Cargo.toml). The feature
+# set is OpenDAL's own portable `build_all_platforms` list: common object-
+# storage / HTTP / embedded services, excluding ones that need a
+# preinstalled native library (rocksdb, foundationdb, hdfs) or that are
+# known-broken on some hosts (sftp). System deps are NOT auto-installed —
+# the bench runner already provisions a C compiler + cmake + protoc (see
+# .github/workflows/bench.yml), and the echo below documents them for a
+# local run.
+setup = [
+  "echo '[bench] opendal selected features need system deps: a C/C++ compiler + cmake (aws-lc-sys via rustls), protoc (tikv). macOS: brew install cmake protobuf. Debian: apt install build-essential cmake protobuf-compiler pkg-config.'",
+]
+
+# Build the `opendal` facade from `core/` with the portable service set.
+# Cross-clone cache-key portability (the headline metric this bench
+# measures): each clone builds at a different absolute path, so pin
+# native-build paths/determinism the same way bench-surrealdb does. These
+# knobs change build PATHS and timestamps, not WHAT is built.
+build = """
+repo="$(pwd -P)"
+prefix_map="-ffile-prefix-map=$repo=. -fdebug-prefix-map=$repo=. -fmacro-prefix-map=$repo=."
+export CFLAGS="${CFLAGS:-} $prefix_map"
+export CXXFLAGS="${CXXFLAGS:-} $prefix_map"
+export SOURCE_DATE_EPOCH=1735689600
+export ZERO_AR_DATE=1
+export KACHE_BASE_DIR="$repo"
+
+cd core
+FEATURES=(
+  services-alluxio
+  services-azblob
+  services-azdls
+  services-cacache
+  services-cos
+  services-dashmap
+  services-dropbox
+  services-etcd
+  services-fs
+  services-ftp
+  services-gcs
+  services-gdrive
+  services-ghac
+  services-http
+  services-hf
+  services-ipfs
+  services-ipmfs
+  services-memcached
+  services-memory
+  services-mini-moka
+  services-moka
+  services-obs
+  services-onedrive
+  services-oss
+  services-persy
+  services-postgresql
+  services-redb
+  services-redis
+  services-s3
+  services-seafile
+  services-sled
+  services-swift
+  services-tikv
+  services-vercel-artifacts
+  services-webdav
+  services-webhdfs
+)
+cargo build --release --locked --features "${FEATURES[*]}"
+"""
+
+[source]
+kind = "clone"
+repo = "https://github.com/apache/opendal.git"
+# Latest stable release as of 2026-08-21. rust-toolchain.toml is
+# channel = "stable" (honoured automatically; see setup note). Cargo
+# workspace + lockfile live under `core/`.
+ref    = "v0.58.2"
+objdir = "core/target"
+
+[checks.assert.warm]
+min_key_stability_pct = 50.0
+max_passthrough_pct = 40.0
+max_errors = 0


### PR DESCRIPTION
## Summary
- Add `bench-opendal`: clone `apache/opendal` at `v0.58.2` and build the `core/` workspace with OpenDAL's portable service-feature set (RUSTC_WRAPPER only; aws-lc-sys stays outside kache).
- Wire it into the nightly Bench workflow (`just bench opendal`, dispatch option, and the `all` matrix) so we can keep tracking cross-clone key stability on a widely used Rust project.
- Addresses the OpenDAL half of #848 (LanceDB is still open).

## Test plan
- [x] `cargo test -p kache-e2e --lib -- shipped_opendal_profile_is_rustc_wrapper_only`
- [x] `kache-scenario --list --select suite:bench --select backend:kache --select project:opendal` resolves to `opendal`
- [ ] `just bench opendal` on a bench runner (cold + warm; not run locally in this PR)


Made with [Cursor](https://cursor.com)