### PR TITLE
feat(bench): add Lance as a compile-cache scenario

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,8 +1,8 @@
 name: Bench
 
 # Clone benchmark — builds kache from THIS ref and runs the cross-clone
-# cold/warm scenarios (Firefox, Substrate, SurrealDB, LLVM) against one shared
-# cache, then
+# cold/warm scenarios (Firefox, Substrate, SurrealDB, Lance, LLVM) against one
+# shared cache, then
 # uploads the reports. This is the heavy, hours-long, tens-of-GB-disk job the
 # bench engine's doc-comment says is "intentionally NOT wired into [PR] CI": it
 # lives in its own workflow so it never blocks a push/PR.
@@ -31,7 +31,7 @@ on:
       scenario:
         description: "Which scenario(s) to run"
         type: choice
-        options: [all, substrate, surrealdb, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows]
+        options: [all, substrate, surrealdb, lance, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows]
         default: all
       extra_args:
         description: "Extra args appended to `just bench <profile>` (e.g. --skip-clone, --retry)"
@@ -87,6 +87,11 @@ jobs:
           # deps (rocksdb, grpcio, quickjs) that build outside kache. Comparable
           # weight to substrate; same native-prereq set (already installed below).
           surrealdb='{"name":"surrealdb","cmd":"bench surrealdb","dir":"bench-surrealdb","timeout":180,"min_free_gb":80}'
+          # Lance's `lance` crate at default features — a large pure-Rust
+          # workspace (Arrow, DataFusion, object-store backends, prost codegen).
+          # Needs protoc + openssl headers (already installed below). Lighter
+          # than surrealdb: no rocksdb/grpcio/quickjs native compile.
+          lance='{"name":"lance","cmd":"bench lance","dir":"bench-lance","timeout":180,"min_free_gb":60}'
           # Full cold Firefox build is the long pole — hours. `bench firefox`
           # resolves to the exact `bench-firefox` scenario: `--profile firefox`
           # is a name SUBSTRING match that also catches `bench-firefox-windows`,
@@ -110,6 +115,7 @@ jobs:
           case "$SCENARIO" in
             substrate)            inc="[$substrate]" ;;
             surrealdb)            inc="[$surrealdb]" ;;
+            lance)                inc="[$lance]" ;;
             firefox)              inc="[$firefox]" ;;
             firefox-sccache)      inc="[$firefox_sccache]" ;;
             llvm)                 inc="[$llvm]" ;;
@@ -120,7 +126,7 @@ jobs:
             # and wastefully run the whole Linux `all` matrix alongside.
             firefox-windows)      inc="[]" ;;
             firefox-pull-windows) inc="[]" ;;
-            *)                    inc="[$substrate,$surrealdb,$firefox,$firefox_sccache,$llvm,$firefox_pull]" ;;
+            *)                    inc="[$substrate,$surrealdb,$lance,$firefox,$firefox_sccache,$llvm,$firefox_pull]" ;;
           esac
           echo "matrix={\"include\":$inc}" >> "$GITHUB_OUTPUT"
           if [ "$inc" = "[]" ]; then
@@ -163,7 +169,8 @@ jobs:
       # needs around the build: substrate links rocksdb/secp256k1 and needs
       # protoc + clang + cmake + openssl headers (SurrealDB's default features
       # need the same set — rocksdb bindgen wants libclang, storage-tikv/grpcio
-      # wants protoc); Firefox's `./mach bootstrap`
+      # wants protoc; Lance's prost-build wants protoc and a few default-feature
+      # backends want openssl headers); Firefox's `./mach bootstrap`
       # pulls its own clang/rust toolchain but still needs python3 + common
       # archive/file utilities present first; the LLVM scenario drives CMake
       # with the Ninja generator, so it needs ninja-build. git/curl are needed by

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ just bench-trace firefox   # also emit key-diff.{json,md}
 just bench-sccache         # list sccache-backed benchmark profiles
 just bench-sccache firefox # same Firefox shape, with sccache
 just bench substrate       # Rust-heavy polkadot-sdk benchmark (tens of min to ~1.5h, ~20-40 GB)
+just bench lance           # Rust-heavy lance crate benchmark (Arrow/DataFusion, tens of min, ~20-40 GB)
 just bench llvm            # almost-pure C/C++ CMake benchmark (tens of min, large scratch)
 ```
 
@@ -250,7 +251,7 @@ the build system can be merged into the same Perfetto view when they share, or
 are normalized to, the same timebase; they are useful for target-level context
 but not required to understand kache hit/miss behavior.
 
-Each benchmark scenario uses a **per-scenario scratch dir** — `./tmp/bench/<scenario>` by default (override with `--work-dir`) — so firefox, firefox-sccache, substrate, and any other scenario **coexist** without clobbering each other's clones, cache, or logs; `rm -rf tmp/bench` cleans them all. A `work_dir` lock refuses a second run pointed at the same scratch dir. Concurrent runs on one host invalidate the wall-clock numbers (CPU/IO/RAM contention), so run benchmarks sequentially or on separate hosts.
+Each benchmark scenario uses a **per-scenario scratch dir** — `./tmp/bench/<scenario>` by default (override with `--work-dir`) — so firefox, firefox-sccache, substrate, lance, and any other scenario **coexist** without clobbering each other's clones, cache, or logs; `rm -rf tmp/bench` cleans them all. A `work_dir` lock refuses a second run pointed at the same scratch dir. Concurrent runs on one host invalidate the wall-clock numbers (CPU/IO/RAM contention), so run benchmarks sequentially or on separate hosts.
 
 Each project is described by a [scenario](scenarios/) (`scenarios/bench-*/scenario.toml`) — repo/ref, how to wire kache or sccache in, and how to build. The Substrate probe is `RUSTC_WRAPPER`-only: it caches the Rust compile surface — the polkadot node's dependency tree plus the nested wasm-runtime compiles — while native C deps (rocksdb, secp256k1) compile outside kache's view by design. Needs `protoc`, `clang`, `cmake`, `pkg-config` installed.
 

--- a/crates/kache-e2e/src/bench_profile.rs
+++ b/crates/kache-e2e/src/bench_profile.rs
@@ -1006,6 +1006,32 @@ diff --git a/hello.txt b/hello.txt
         );
     }
 
+    /// The shipped Lance scenario wires kache via `RUSTC_WRAPPER` only
+    /// (no file injection, no CC/CXX — optional fp16 kernels stay off),
+    /// honours the tree's rust-toolchain.toml, and builds the `lance` crate.
+    #[test]
+    fn shipped_lance_profile_is_rustc_wrapper_only() {
+        let p = BenchProfile::load(&repo_profile("lance")).expect("lance.toml loads");
+        assert_eq!(p.name, "bench-lance");
+        assert_eq!(p.objdir, "target");
+        assert_eq!(p.repo, "https://github.com/lance-format/lance.git");
+        assert_eq!(p.git_ref, "v10.0.0");
+        assert!(p.files.is_empty(), "lance uses RUSTC_WRAPPER only");
+        assert!(
+            p.env.is_empty(),
+            "no extra env — CARGO_INCREMENTAL is an engine baseline, not a profile var"
+        );
+        assert!(p.requires.iter().any(|tool| tool == "protoc"));
+        assert!(
+            p.build_command(Path::new("/k"))
+                .contains("cargo build --release -p lance")
+        );
+        assert!(
+            p.build_command(Path::new("/k")).contains("KACHE_BASE_DIR"),
+            "cross-clone path portability must be set in the build script"
+        );
+    }
+
     #[test]
     fn source_ref_next_parses_and_marks_pull() {
         let dir = tempfile::tempdir().unwrap();

--- a/scenarios/bench-lance/scenario.toml
+++ b/scenarios/bench-lance/scenario.toml
@@ -1,0 +1,47 @@
+# Lance compile-cache benchmark scenario for kache-scenario.
+# A large pure-Rust Cargo workspace — kache wires in via RUSTC_WRAPPER only
+# (set by the engine), caching every crate compile in the `lance` library's
+# dependency graph (Arrow, DataFusion, object-store backends, prost codegen).
+# Default features do not compile the optional C fp16 kernels or the bundled
+# protobuf-src build; those stay outside this workload by design.
+name = "bench-lance"
+tags = ["suite:bench", "project:lance", "backend:kache", "lang:rust"]
+
+requires = ["cargo", "rustc", "protoc"]
+
+# Lance ships a rust-toolchain.toml (channel = "1.97.0"), so there is nothing
+# to pin here: rustup auto-installs and selects that toolchain on the first
+# cargo invocation in the tree, and the bench workflow clears RUSTUP_TOOLCHAIN
+# so the file is honoured. System protobuf (`protoc`) is required by
+# prost-build; openssl headers / pkg-config are needed by a few default-feature
+# cloud backends. They are NOT auto-installed — the bench runner already
+# provisions them (see .github/workflows/bench.yml), and the echo below
+# documents them for a local run.
+setup = [
+  "echo '[bench] lance default features need system deps: protoc (REQUIRED), pkg-config, openssl headers, a C compiler. macOS: brew install protobuf pkg-config openssl. Debian: apt install protobuf-compiler pkg-config libssl-dev build-essential.'",
+]
+
+# Build the `lance` crate with its DEFAULT features (aws, azure, gcp, oss,
+# huggingface, tencent, tos, goosefs, geo) — i.e. what Lance actually ships.
+# No RUSTUP_TOOLCHAIN pin: the tree's rust-toolchain.toml drives toolchain
+# selection. KACHE_BASE_DIR keeps checkout-absolute paths (OUT_DIR from
+# prost-build, CARGO_MANIFEST_DIR) portable across the two clones so the
+# headline cross-clone metric is measuring kache, not path baking.
+build = """
+src="$(pwd -P)"
+export KACHE_BASE_DIR="$src"
+cargo build --release -p lance
+"""
+
+[source]
+kind = "clone"
+repo = "https://github.com/lance-format/lance.git"
+# Latest stable release as of 2026-08-27. This tag pins Rust via
+# rust-toolchain.toml (channel "1.97.0"), honoured automatically (see setup note).
+ref    = "v10.0.0"
+objdir = "target"
+
+[checks.assert.warm]
+min_key_stability_pct = 50.0
+max_passthrough_pct = 40.0
+max_errors = 0


### PR DESCRIPTION
## Summary

Part of #848.

Adds `bench-lance` so nightly (and `just bench lance`) can track compile-cache hits on a real Arrow/DataFusion workspace. The scenario clones `lance-format/lance` at `v10.0.0`, builds `cargo build --release -p lance` through `RUSTC_WRAPPER` only, and asserts the same warm-phase floors as Substrate/SurrealDB.

OpenDAL is left for a follow-up; this PR is Lance only.

## Test plan

- [x] `cargo test -p kache-e2e --lib -- shipped_lance_profile_is_rustc_wrapper_only all_shipped_bench_schemas_load`
- [x] `kache-scenario --list --select suite:bench --select backend:kache` shows `lance`
- [ ] Full cold/warm `just bench lance` (tens of minutes, ~20-40 GB; not run locally)

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests) — fmt and the new bench-profile tests pass; full workspace `just check` was not re-run
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [x] User-visible changes (CLI, config, output) are reflected in the README or relevant docs

Made with [Cursor](https://cursor.com)