### PR TITLE
feat(cc): key ring's Darwin debug flag -gfull via the resolved probe

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -2000,6 +2000,19 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         source: "Issue #838 — DWARF v2 emission; cc-rs default on Apple targets.",
         dialect: None,
     },
+    // ring's Darwin build.rs requires full debug information so Apple's
+    // dead strip can see which symbols are used. Apple clang's `-###`
+    // resolves `-gfull` to `-debug-info-kind=standalone -dwarf-version=5`,
+    // the same cc1 tokens as ordinary `-g` on that compiler; a no-debug
+    // invocation has neither. Exact, not a `-g*` prefix: neighbouring
+    // Apple spellings such as `-gused` stay refused until a workload
+    // needs them. (Issue #857)
+    FlagSpec {
+        matcher: Matcher::Exact("-gfull"),
+        class: FlagClass::CapturedByProbe,
+        source: "Issue #857 — Darwin full debug info; ring 0.17 dead-strip contract. Apple clang -### resolves it to standalone DWARF; keyed via those tokens.",
+        dialect: None,
+    },
     FlagSpec {
         matcher: Matcher::Exact("-gsimple-template-names"),
         class: FlagClass::CapturedByProbe,
@@ -7102,6 +7115,50 @@ mod tests {
         );
     }
 
+    /// ring's Darwin build.rs adds `-gfull` so Apple dead stripping can
+    /// see used symbols (kunobi-ninja/kache#857). The flag changes DWARF
+    /// sections, so it must be `CapturedByProbe`: the resolved `-###`
+    /// tokens (`-debug-info-kind=standalone`, `-dwarf-version=N`) key
+    /// it, and a driver whose probe cannot establish the effect must
+    /// fail closed rather than under-key.
+    #[test]
+    fn classifier_accepts_gfull_issue_857() {
+        assert_eq!(
+            classify_cc_flag("-gfull", Dialect::Gnu),
+            Some(FlagClass::CapturedByProbe),
+            "-gfull must key through the resolved invocation"
+        );
+        let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", "-gfull"]);
+        assert!(
+            descs.is_empty(),
+            "-gfull should be classified (#857), got: {descs:?}"
+        );
+        let parsed = CcArgs::parse(&s(&["cc", "-c", "foo.c", "-o", "foo.o", "-gfull"])).unwrap();
+        assert!(
+            parsed.refuse_reasons(&[]).is_empty(),
+            "ring Darwin compile with -gfull must cache: {:?}",
+            parsed.refuse_reasons(&[])
+        );
+        assert!(
+            cc_flags_need_resolved_invocation(&parsed),
+            "-gfull is probe-keyed and must force the resolved invocation"
+        );
+    }
+
+    /// The #857 row is exact on the observed Apple spelling. The other
+    /// Darwin dead-strip debug mode (`-gused`) and neighbouring `-g*`
+    /// lookalikes stay refused until a workload needs them.
+    #[test]
+    fn gfull_neighbours_still_refuse_issue_857() {
+        for flag in ["-gused", "-gfuller", "-gfull-dwarf"] {
+            assert_eq!(
+                classify_cc_flag(flag, Dialect::Gnu),
+                None,
+                "{flag} is not modeled and must keep refusing"
+            );
+        }
+    }
+
     /// The argument-wrapper pair must work *together* on one
     /// invocation — that's the canonical clang usage shape
     /// (`--start-no-unused-arguments … <flags> … --end-no-unused-arguments`).
@@ -8179,7 +8236,7 @@ mod tests {
         // before the preprocessor hash runs. Every `CapturedByProbe`
         // shape fails closed here; `-gdwarf-2` pins the #838 row.
         let compiler = CcCompiler::new();
-        for flag in ["-fno-rtti", "-gdwarf-2"] {
+        for flag in ["-fno-rtti", "-gdwarf-2", "-gfull"] {
             let parsed = compiler
                 .parse(&s(&["true", "-c", "foo.c", "-o", "foo.o", flag]))
                 .unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2103,6 +2103,91 @@ fn test_cc_gdwarf2_caches_and_keys_dwarf_version_issue_838() {
     );
 }
 
+/// True if `cc` on PATH accepts `-gfull`, checked by actually compiling
+/// with it. GCC and cl-like drivers reject the Apple spelling and have
+/// nothing to say about #857.
+fn cc_accepts_gfull(dir: &Path) -> bool {
+    let source = dir.join("gfull-support.c");
+    if std::fs::write(&source, "int gfull_support(void) { return 0; }\n").is_err() {
+        return false;
+    }
+    std::process::Command::new("cc")
+        .args(["-c", "-O0"])
+        .arg(&source)
+        .arg("-o")
+        .arg(dir.join("gfull-support.o"))
+        .arg("-gfull")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+/// ring adds `-gfull` on Apple ABI targets so Darwin dead stripping can
+/// see used symbols (#857). The flag is `CapturedByProbe`: Apple clang
+/// `-###` resolves it to `-debug-info-kind=standalone -dwarf-version=5`,
+/// so the no-debug baseline must key apart while an identical second
+/// compile hits. Where `-g` resolves to the same cc1 tokens it may share
+/// the key; this test only requires the no-debug invocation to stay
+/// distinct.
+#[test]
+fn test_cc_gfull_caches_and_keys_apart_from_no_debug_issue_857() {
+    let probe_dir = TempDir::new().unwrap();
+    if !cc_accepts_gfull(probe_dir.path()) {
+        eprintln!(
+            "skipping: `cc` does not accept -gfull \
+             (non-Apple driver, or no cc on PATH)"
+        );
+        return;
+    }
+
+    build_kache();
+    if !kache_caches_probe_keyed_flags(probe_dir.path()) {
+        eprintln!("skipping: probe-keyed flags are not cacheable on this host");
+        return;
+    }
+    let cache_dir = TempDir::new().unwrap();
+    let work = TempDir::new().unwrap();
+    std::fs::write(work.path().join("tu.c"), "int tu(void) { return 7; }\n").unwrap();
+    let object = work.path().join("tu.o");
+
+    let compile = |extra: &[&str]| {
+        let _ = std::fs::remove_file(&object);
+        let mut args = vec!["cc", "-c", "tu.c", "-o", "tu.o", "-O0"];
+        args.extend_from_slice(extra);
+        run_kache_cc(work.path(), cache_dir.path(), &args);
+        assert!(object.exists(), "compile must produce tu.o: {args:?}");
+    };
+
+    compile(&["-gfull"]);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(
+        report["summary"]["misses"].as_u64(),
+        Some(1),
+        "cold -gfull compile must be cached, not passed through.\nevents.jsonl:\n{}",
+        std::fs::read_to_string(cache_dir.path().join("events.jsonl"))
+            .unwrap_or_else(|e| format!("(unreadable: {e})"))
+    );
+    assert_cc_report_counts(&report, 1, 0);
+
+    compile(&["-gfull"]);
+    let report = kache_report(cache_dir.path());
+    assert_cc_report_counts(&report, 1, 1);
+
+    compile(&[]);
+    let report = kache_report(cache_dir.path());
+    let summary = &report["summary"];
+    assert_eq!(
+        summary["local_hits"].as_u64(),
+        Some(1),
+        "no-debug must not reuse the -gfull entry: {report}"
+    );
+    assert_eq!(
+        summary["misses"].as_u64().unwrap_or(0) + summary["dups"].as_u64().unwrap_or(0),
+        2,
+        "no-debug should have compiled under its own key: {report}"
+    );
+}
+
 /// True when the host `cc` accepts Firefox's Clang automatic-variable
 /// hardening mode. GCC and older Clang versions may reject it, so they cannot
 /// exercise the issue #849 path.


### PR DESCRIPTION
## Summary

Closes #857.

ring's Darwin build.rs adds `-gfull` so Apple dead stripping can see used symbols. Unclassified, the flag refused every ring translation unit into passthrough — 24 TUs on a Lance `cargo check --locked -p lance --lib` with an otherwise warm local cache.

The flag is classified `CapturedByProbe`: Apple clang `-###` resolves it to `-debug-info-kind=standalone -dwarf-version=5`, the same cc1 tokens as ordinary `-g` on that compiler, while a no-debug invocation has neither. The resolved-token hash therefore keys `-gfull` apart from no-debug; where `-g` and `-gfull` resolve identically they may share a key. A driver whose probe cannot establish the effect keeps refusing fail-closed. The row is exact — neighbouring Apple spellings such as `-gused` stay unmodeled.

## Test plan

- [x] Unit: `-gfull` classifies as `CapturedByProbe`, does not refuse, and forces the resolved invocation (`classifier_accepts_gfull_issue_857`)
- [x] Unit: `-gused` / `-gfuller` / `-gfull-dwarf` still refuse (`gfull_neighbours_still_refuse_issue_857`)
- [x] Unit: an unresolvable probe fail-closes for `-gfull` (`cache_key_refuses_probe_captured_flags_without_resolved_invocation`)
- [x] Live integration: cold compile caches (no passthrough), re-run hits, no-debug maps to a distinct key (`test_cc_gfull_caches_and_keys_apart_from_no_debug_issue_857`, verified on Apple clang)

## Checklist

- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [x] User-visible changes (CLI, config, output) are reflected in the README or relevant docs — no CLI/config/output change; docs do not enumerate individual flags


Made with [Cursor](https://cursor.com)