### PR TITLE
fix(cc): cache zstd builds using -fmerge-all-constants

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1851,14 +1851,14 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         matcher: Matcher::Regex(concat!(
             r"-f(?:no-)?(?:",
             "associative-math|data-sections|fast-math|finite-math-only|",
-            "function-sections|math-errno|omit-frame-pointer|reciprocal-math|",
-            "rounding-math|semantic-interposition|signaling-nans|signed-zeros|",
-            "strict-aliasing|trapping-math|unsafe-math-optimizations|unwind-tables|",
-            "wrapv",
+            "function-sections|math-errno|merge-all-constants|omit-frame-pointer|",
+            "reciprocal-math|rounding-math|semantic-interposition|signaling-nans|",
+            "signed-zeros|strict-aliasing|trapping-math|unsafe-math-optimizations|",
+            "unwind-tables|wrapv",
             ")",
         )),
         class: FlagClass::CapturedByProbe,
-        source: "#114/#245/#418/#422/#426/#580 — codegen knobs, both polarities, resolved into -cc1 tokens. One sorted stem per knob covers -f<stem> AND -fno-<stem> (prevents the missed-polarity passthrough class).",
+        source: "#114/#245/#418/#422/#426/#580/#856 — codegen knobs, both polarities, resolved into -cc1 tokens. One sorted stem per knob covers -f<stem> AND -fno-<stem> (prevents the missed-polarity passthrough class).",
         dialect: None,
     },
     FlagSpec {
@@ -6699,6 +6699,9 @@ mod tests {
             "-mfma",
             "-mavx512f",
             "-mno-sse3",
+            // zstd-sys merge-all-constants knob (#856)
+            "-fmerge-all-constants",
+            "-fno-merge-all-constants",
         ] {
             let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
             assert!(
@@ -6760,6 +6763,7 @@ mod tests {
             "trapping-math",
             "semantic-interposition",
             "math-errno",
+            "merge-all-constants",
             "strict-aliasing",
             "function-sections",
             "data-sections",
@@ -6840,6 +6844,40 @@ mod tests {
             classify_cc_flag("-momit-leaf-frame-pointer", Dialect::Gnu),
             None,
             "-momit-leaf-frame-pointer is not modeled and must keep refusing"
+        );
+    }
+
+    /// zstd-sys 2.0.16 adds `-fmerge-all-constants` via `flag_if_supported`
+    /// on every translation unit (#856). The flag changes codegen, and Apple
+    /// clang preserves the enabled form in the resolved `-cc1` stream, so
+    /// both polarities are CapturedByProbe. The disabled form may
+    /// canonicalize to the default mode when the probe emits no extra token.
+    #[test]
+    fn zstd_sys_merge_all_constants_caches_issue_856() {
+        for flag in ["-fmerge-all-constants", "-fno-merge-all-constants"] {
+            assert_eq!(
+                classify_cc_flag(flag, Dialect::Gnu),
+                Some(FlagClass::CapturedByProbe),
+                "{flag} must key through the resolved invocation"
+            );
+            let parsed =
+                CcArgs::parse(&s(&["cc", "-c", "zstd.c", "-o", "zstd.o", flag, "-O0"])).unwrap();
+            assert!(
+                parsed.refuse_reasons(&[]).is_empty(),
+                "zstd-sys compile with {flag} must cache: {:?}",
+                parsed.refuse_reasons(&[])
+            );
+            assert!(
+                cc_flags_need_resolved_invocation(&parsed),
+                "{flag} must force the resolved invocation"
+            );
+        }
+        // Adjacent gcc spelling stays unmodeled: `-fmerge-constants` is a
+        // different knob and must not ride in on the stem list.
+        assert_eq!(
+            classify_cc_flag("-fmerge-constants", Dialect::Gnu),
+            None,
+            "-fmerge-constants is a different knob and must keep refusing"
         );
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2185,6 +2185,138 @@ fn test_cc_trivial_auto_var_init_pattern_caches_issue_849() {
     );
 }
 
+/// True when the host `cc` accepts zstd-sys's merge-all-constants knob.
+/// gcc and clang both have it; a cl-like driver does not, so a host that
+/// rejects the spelling cannot exercise #856.
+fn cc_accepts_merge_all_constants(dir: &Path) -> bool {
+    let source = dir.join("merge-all-constants-probe.c");
+    if std::fs::write(&source, "int merge_probe(void) { return 0; }\n").is_err() {
+        return false;
+    }
+    std::process::Command::new("cc")
+        .arg("-c")
+        .arg(&source)
+        .arg("-o")
+        .arg(dir.join("merge-all-constants-probe.o"))
+        .args(["-fmerge-all-constants", "-O0", "-g0"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Live end-to-end for #856: zstd-sys's `-fmerge-all-constants` must cache,
+/// hit on an identical second compile, and stay keyed apart from the
+/// default mode. `-fno-merge-all-constants` is accepted and may share the
+/// default key when the resolved tokens are identical.
+#[test]
+fn test_cc_merge_all_constants_keys_on_probe_issue_856() {
+    let probe_dir = TempDir::new().unwrap();
+    if !cc_accepts_merge_all_constants(probe_dir.path()) {
+        eprintln!("skipping: `cc` does not accept -fmerge-all-constants");
+        return;
+    }
+    build_kache();
+    if !kache_caches_probe_keyed_flags(probe_dir.path()) {
+        eprintln!("skipping: probe-keyed flags are not cacheable on this host");
+        return;
+    }
+
+    let work = TempDir::new().unwrap();
+    let cache_dir = TempDir::new().unwrap();
+    std::fs::write(work.path().join("tu.c"), "int tu(void) { return 7; }\n").unwrap();
+
+    let enabled = [
+        "cc",
+        "-c",
+        "tu.c",
+        "-o",
+        "tu.o",
+        "-fmerge-all-constants",
+        "-O0",
+        "-g0",
+    ];
+    run_kache_cc(work.path(), cache_dir.path(), &enabled);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(
+        report["summary"]["misses"].as_u64(),
+        Some(1),
+        "cold -fmerge-all-constants compile must be cached, not passed \
+         through.\n`cc -###` said:\n{}\nevents.jsonl:\n{}",
+        cc_probe_stderr_head(work.path(), &enabled[1..]),
+        std::fs::read_to_string(cache_dir.path().join("events.jsonl"))
+            .unwrap_or_else(|e| format!("(unreadable: {e})"))
+    );
+
+    std::fs::remove_file(work.path().join("tu.o")).unwrap();
+    run_kache_cc(work.path(), cache_dir.path(), &enabled);
+    let report = kache_report(cache_dir.path());
+    assert_cc_report_counts(&report, 1, 1);
+
+    // Default mode must not reuse the enabled key. Asserted as "local_hits
+    // did not grow": the objects can be byte-identical and record as a
+    // `dup`. A false HIT is the only wrong answer.
+    let default_mode = ["cc", "-c", "tu.c", "-o", "tu.o", "-O0", "-g0"];
+    std::fs::remove_file(work.path().join("tu.o")).unwrap();
+    run_kache_cc(work.path(), cache_dir.path(), &default_mode);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(
+        report["summary"]["local_hits"].as_u64(),
+        Some(1),
+        "default merge-constants mode must not hit the \
+         -fmerge-all-constants entry: {report}"
+    );
+
+    // Disabled polarity must classify (not passthrough) and must not reuse
+    // the enabled key. It may share the default key when the probe emits no
+    // extra token (Apple clang 21).
+    let disabled = [
+        "cc",
+        "-c",
+        "tu.c",
+        "-o",
+        "tu.o",
+        "-fno-merge-all-constants",
+        "-O0",
+        "-g0",
+    ];
+    std::fs::remove_file(work.path().join("tu.o")).unwrap();
+    run_kache_cc(work.path(), cache_dir.path(), &disabled);
+    let report = kache_report(cache_dir.path());
+    assert_eq!(
+        report["summary"]["passthroughs"].as_u64().unwrap_or(0),
+        0,
+        "-fno-merge-all-constants must cache, not pass through: {report}"
+    );
+
+    let events = report["all_events"]
+        .as_array()
+        .expect("report should include all_events");
+    assert_eq!(events.len(), 4, "expected one event per compile: {report}");
+    let keys: Vec<&str> = events
+        .iter()
+        .map(|event| {
+            let key = event["cache_key"].as_str().unwrap_or_default();
+            assert!(
+                !key.is_empty(),
+                "every event should carry a cache key: {event}"
+            );
+            key
+        })
+        .collect();
+    assert_eq!(
+        keys[0], keys[1],
+        "the repeated enabled compile must reuse its own key: {report}"
+    );
+    assert_ne!(
+        keys[0], keys[2],
+        "enabled mode must not reuse the default key: {report}"
+    );
+    assert_ne!(
+        keys[0], keys[3],
+        "enabled mode must not reuse the disabled key: {report}"
+    );
+}
+
 #[test]
 fn test_cc_depinfo_sidecar_restores_on_hit_and_new_mf_path() {
     build_kache();


### PR DESCRIPTION
Closes #856.

Classifies `-fmerge-all-constants` and `-fno-merge-all-constants` as `CapturedByProbe` via the existing sorted codegen-knob stem list. zstd-sys emits the enabled form on every translation unit; Apple clang preserves it in the resolved `-cc1` stream, so enabled mode keys apart from the default. The disabled form is accepted and may canonicalize to the default when the probe tokens match. Adjacent `-fmerge-constants` stays fail-closed.

Adds classifier polarity/boundary tests and a live cold-store/warm-hit integration regression.

Local validation:
- `cargo test --bin kache -- zstd_sys_merge_all_constants_caches_issue_856 codegen_knob_stems_classify_in_both_polarities cc_flags_table_classifies_known_cache_safe_flags`
- `cargo test --test integration_test -- test_cc_merge_all_constants_keys_on_probe_issue_856 --nocapture`


Made with [Cursor](https://cursor.com)