### PR TITLE
ci: require owners for private-runner workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Private-runner workflows and benchmark definitions execute commands on
+# infrastructure owned by Kunobi. Changes to these paths require approval from
+# a trusted repository administrator.
+/.github/CODEOWNERS @jleni @emmanuelm41 @ainhoa-a
+/.github/workflows/ @jleni @emmanuelm41 @ainhoa-a
+/Justfile @jleni @emmanuelm41 @ainhoa-a
+/crates/kache-e2e/ @jleni @emmanuelm41 @ainhoa-a
+/scenarios/bench-*/ @jleni @emmanuelm41 @ainhoa-a


### PR DESCRIPTION
## Summary

- add CODEOWNERS for all workflows and benchmark execution surfaces
- require approval from a trusted repository administrator before those changes can merge
- protect CODEOWNERS itself from unreviewed weakening

## Enforcement

`main` branch protection now has `require_code_owner_reviews: true`.

## Runner boundary

- Windows runners are already restricted by their organization runner group to `bench.yml@main`
- Linux ARC is a shared ephemeral pool used by several repositories; fully restricting execution requires a dedicated ARC runner group/scale set

## Validation

- GitHub CODEOWNERS validation reports no errors
- `git diff --check`