### PR TITLE
docs: rewrite Kache documentation for clarity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,17 @@ env:
   KACHE_LOG: kache=debug
 
 jobs:
-  # Skip the build matrix on docs-only PRs (*.md, *.mdx, docs/**), which compile
-  # nothing. Heavy jobs gate on `code`. We use a job-level `if`, not trigger
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check routes and source parity
+        run: bash scripts/check-docs.sh
+
+  # Skip the build matrix on docs-only PRs (*.md, *.mdx, docs/**); the `docs`
+  # job still validates them. Heavy jobs gate on `code`. We use a job-level `if`, not trigger
   # `paths-ignore`: the required checks must still report, and a *skipped* job
   # counts as success while a never-created one wedges branch protection at
   # "pending". Fails open (runs everything) on non-PR events or any API error.

--- a/README.md
+++ b/README.md
@@ -1,358 +1,140 @@
-# kache
-
+[![CI](https://github.com/kunobi-ninja/kache/actions/workflows/ci.yml/badge.svg)](https://github.com/kunobi-ninja/kache/actions/workflows/ci.yml)
+[![Bench](https://github.com/kunobi-ninja/kache/actions/workflows/bench.yml/badge.svg)](https://github.com/kunobi-ninja/kache/actions/workflows/bench.yml)
 [![Crates.io](https://img.shields.io/crates/v/kache.svg)](https://crates.io/crates/kache)
-[![CI](https://github.com/kunobi-ninja/kache/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/kunobi-ninja/kache/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.95-blue.svg)](Cargo.toml)
+[![Documentation](https://img.shields.io/badge/docs-kunobi.ninja-blue)](https://kunobi.ninja/docs/kache)
 
-Content-addressed build cache for Rust and C/C++ object compiles. Local hits use zero-copy restores where safe — reflinks where supported and, on Unix, one exclusive hardlink consumer — plus S3 or shared-filesystem remotes for Rust artifact sharing.
+# Kache
 
-A drop-in `RUSTC_WRAPPER` for Rust and a `cc` / `c++` compiler wrapper for C/C++ object compiles. Cache keys are blake3 hashes of normalized compiler inputs; cache hits prefer a reflink (copy-on-write clone) where the filesystem supports it (APFS, btrfs, XFS-with-reflink). On Unix without CoW, one immutable target may hardlink to a blob while additional consumers receive private copies. Windows restores copy by default; unrestricted hardlink sharing is an explicit legacy opt-in. Identical blobs are stored once in the cache. Optional S3 (AWS, Ceph, MinIO, R2) or shared-filesystem sync shares Rust artifacts across machines.
+Kache is a local-first compiler cache for Rust and C/C++. It stores build outputs by content, reuses them across worktrees, and can copy them to S3-compatible or filesystem remotes.
 
-Local Rust caching, local C/C++ object caching, and direct S3/shared-filesystem sync are working today. C/C++ artifacts are local-only for now; unsupported compiler shapes pass through to the real compiler.
+## Try it without changing your setup
 
-**PREVIEW:** a remote planner that prefetches from workspace manifests, dependency history, and build intent — warming the right artifacts before rustc asks for them. The daemon already calls a planner when `KACHE_PLANNER_ENDPOINT` is set; the hosted service is still preview.
+Install Kache:
 
-![kache: cold build populates the store, then `cargo clean && cargo build` restores every artifact zero-copy](assets/demo.gif)
-
-> Cold compile populates kache's store, `cargo clean` wipes `target/`, and the second build pulls every artifact back zero-copy. The recording is reproducible — see [`assets/demo/`](assets/demo/) for the Dockerfile and tape script.
-
-## Why local kache is fast
-
-kache is useful even before remote cache is configured:
-
-- Local hits prefer zero-copy restores into `target/`: reflink where supported; on Unix without CoW, one safe hardlink carrier for immutable artifacts and private copies for additional consumers. Windows copies by default.
-- The store is content-addressed by blake3 hash, so identical artifact blobs are stored once in the cache.
-- Misses compile normally, then kache records the outputs for future builds.
-- The daemon is optional for local caching. If it is not running, local hits and misses still work; remote checks, uploads, and prefetching degrade gracefully.
-- Kache normally prefers exact artifact hits, but automatically learns rapidly changing Cargo units and gives them isolated, bounded rustc incremental reuse. This speeds source-churn workloads such as mutation testing without tool-specific setup.
-
-## Screenshots
-
-`kache monitor` — live cache dashboard (Build / Projects / Store / Transfer / Passthrough tabs):
-
-![kache monitor TUI cycling through tabs against a populated cache](assets/monitor.gif)
-
-`kache clean` — find target/ dirs and see what's already in the kache store:
-
-![kache clean TUI listing target/ dirs with cached percentages](assets/clean.gif)
-
-## Install
-
-```sh
-# mise (recommended)
-mise use -g github:kunobi-ninja/kache@latest
-
-# cargo (build from source)
+```bash
 cargo install kache
-
-# cargo-binstall (downloads pre-built binary, requires cargo-binstall)
-cargo binstall kache
 ```
 
-### OS package managers
+Run two clean builds from a Rust project:
 
-**Homebrew (macOS):**
-
-```sh
-# Stable
-brew install kunobi-ninja/kunobi/kache
-
-# Pre-release channel (RC/beta)
-brew install kunobi-ninja/kunobi/kache-unstable
+```bash
+RUSTC_WRAPPER=kache cargo build
+cargo clean
+KACHE_PROGRESS=hits RUSTC_WRAPPER=kache cargo build
+kache stats
 ```
 
-**APT (Debian/Ubuntu):**
+`cargo clean` is only for this demonstration. Kache normally helps when Cargo would otherwise compile an input it has seen before, such as in another worktree or after changing toolchains and changing back.
 
-```sh
-# Add the signing key (KMS-rooted OpenPGP cert), dearmored into a keyring
-sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://r2.kunobi.com/kache/apt/gpg.key \
-  | sudo gpg --dearmor -o /etc/apt/keyrings/kache.gpg
+The commands above do not edit Cargo configuration or install a service. To keep Kache enabled:
 
-# Add the repository — use `stable` for releases, `unstable` for RC/beta builds
-echo "deb [signed-by=/etc/apt/keyrings/kache.gpg] https://r2.kunobi.com/kache/apt stable main" \
-  | sudo tee /etc/apt/sources.list.d/kache.list
-
-sudo apt update
-sudo apt install kache
-```
-
-**winget (Windows):**
-
-```powershell
-# Stable
-winget install kunobi-ninja.kache
-
-# Pre-release channel (RC/beta)
-winget install kunobi-ninja.kache.Unstable
-```
-
-**Scoop (Windows):**
-
-```powershell
-scoop bucket add kunobi https://github.com/kunobi-ninja/scoop-kunobi
-
-# Stable
-scoop install kunobi/kache
-
-# Pre-release channel (RC/beta)
-scoop install kunobi/kache-unstable
-```
-
-**Chocolatey (Windows):**
-
-```powershell
-# Stable
-choco install kache
-
-# Pre-release channel (RC/beta)
-choco install kache --pre
-```
-
-**AUR (Arch Linux):**
-
-Pick one (all provide the `kache` command):
-
-```sh
-paru -S kache-bin   # official prebuilt binary — recommended, no compile
-paru -S kache-git   # official, builds the latest main from source
-paru -S kache       # community-maintained, builds the latest release from source
-```
-
-## Quick start
-
-```sh
-# Interactive setup: configures $CARGO_HOME/config.toml (default ~/.cargo),
-# installs the background daemon as a login service, and starts it.
+```bash
 kache init
-
-# Or accept all defaults non-interactively:
-kache init -y
-
-# Verify with:
-kache doctor
 ```
 
-`kache init` is idempotent — re-run it any time to repair configuration. Use `kache init --check` to preview the changes without touching any files. If you prefer to configure things by hand, just export `RUSTC_WRAPPER=kache` or add it to `$CARGO_HOME/config.toml` (usually `~/.cargo`) under `[build]`.
+Review the proposed changes without applying them:
 
-## Use in CI
+```bash
+kache init --check
+```
 
-[`kache-action`](https://github.com/kunobi-ninja/kache-action) installs kache, wires it as `RUSTC_WRAPPER`, and persists the cache between runs. Drop one line into your workflow:
+Use `kache init --no-service` if you want persistent Cargo configuration without an OS service.
+
+## What Kache caches
+
+| Workload | Status | Notes |
+| --- | --- | --- |
+| Rust libraries and build scripts | Supported | Use `RUSTC_WRAPPER=kache` or `kache init` |
+| Rust executables | Supported on Linux and macOS | Disabled by default on Windows |
+| C and C++ object files | Supported | Use compiler shims or set the compiler launcher |
+| Local storage | Built in | Content-addressed store with garbage collection |
+| S3-compatible remote storage | Built in | Includes AWS S3, MinIO, and Cloudflare R2 |
+| Filesystem remote storage | Built in | Useful for shared disks and CI volumes |
+
+Need to choose between compiler caches? Read [Kache or sccache?](https://kunobi.ninja/docs/kache/getting-started/comparison).
+
+## Tested nightly on real projects
+
+The scheduled [benchmark workflow](https://github.com/kunobi-ninja/kache/actions/workflows/bench.yml) runs real cold/warm builds of Firefox, LLVM, Substrate, SurrealDB, and Lance on Linux, compares Firefox with sccache, and exercises Firefox on Windows. It also measures how much of a Firefox build survives a source update.
+
+Each run checks its own measurement validity and uploads reports, traces, and logs for 30 days. Treat timing or hit-rate numbers as evidence only when the individual job succeeds and its benchmark verdict is `ok`.
+
+## CI
+
+The official action installs Kache and wires it into the build:
 
 ```yaml
 - uses: kunobi-ninja/kache-action@v1
+
+- run: cargo build --locked
 ```
 
-That uses GitHub Actions cache by default. For S3-backed caching shared across repos or runners, pass `s3-bucket` plus credentials — see the action's README for the full input list.
+See the [CI guide](https://kunobi.ninja/docs/kache/remote-cache/ci) for GitHub Actions and shell-based CI examples.
 
-## C/C++ caching
+## C and C++
 
-Alongside the rustc wrapper, kache can cache **C/C++ object compiles** as a `cc` / `c++` wrapper. It recognizes `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++` (plus versioned variants like `gcc-13` and target-prefixed cross compilers like `arm-linux-gnueabihf-gcc`), and `clang-cl` or any `--driver-mode=cl` invocation (clang in MSVC driver mode) — on every OS, not just Windows, since recognition keys off the driver mode rather than the host. For unrecognized compiler wrapper names (such as custom scripts, symlinks/copies of gcc, or thin shims), kache dynamically detects the compiler family via `-E` preprocessor probing. The wrapper executable itself must accept the usual preprocessor CLI (forwarding `-E` and defining `__clang__` or `__GNUC__`). Note that nested multi-token wrappers (e.g., `kache ccache gcc`) are not expanded. clang-cl is what mozconfigs and the `cc` crate use on Windows:
+Create compiler-name shims, then put their directory first in `PATH`:
 
-```sh
-# POSIX (gcc / clang)
-export CC="kache cc"
-export CXX="kache c++"
+```bash
+kache install-shims ~/.local/lib/kache/shims
+export PATH="$HOME/.local/lib/kache/shims:$PATH"
+cmake -S . -B build
+cmake --build build
 ```
 
-```bat
-:: Windows (clang-cl) — e.g. the CC env var a mozconfig / the cc crate reads
-set "CC=kache clang-cl"
+Kache inspects the real compiler invocation. Unsupported or unsafe invocations pass through to the compiler instead of being cached.
+
+## Storage and remotes
+
+The default local cache is:
+
+- Linux: `$XDG_CACHE_HOME/kache` or `~/.cache/kache`
+- macOS: `~/Library/Caches/kache`
+- Windows: `%LOCALAPPDATA%\kache`
+
+Open the configuration editor with `kache config`, or edit the TOML file directly. A minimal S3-compatible remote looks like this:
+
+```toml
+[cache.remote]
+type = "s3"
+bucket = "my-build-cache"
+region = "us-east-1"
 ```
 
-**What's cached today:** single-source `-c` object compiles (e.g. `cc -c foo.c -o foo.o`, `c++ -c foo.cpp -o foo.o`, or `clang-cl -c foo.c -Fofoo.obj`). The cache key is the preprocessor expansion (`cc -E -P` for gcc/clang, `clang-cl /EP` for clang-cl, with `SOURCE_DATE_EPOCH` forced to `0` so `__DATE__`/`__TIME__` expand deterministically) plus compiler identity, target arch, and codegen flags — so any header change invalidates it. On a hit the object (`.o`, or `.obj` for clang-cl) and its `.d` dep-info restore without re-running the compiler. Any flag kache hasn't classified is **refused** — the invocation passes through to the real compiler rather than risk a silently-wrong object.
+Credentials come from the standard AWS environment variables or credential chain. See [S3 setup](https://kunobi.ninja/docs/kache/remote-cache/s3-setup) and [filesystem setup](https://kunobi.ninja/docs/kache/remote-cache/filesystem-setup).
 
-For **gcc/clang** the key is portable across machines and worktrees (paths are normalized via `-ffile-prefix-map`). Set `KACHE_BASE_DIR` to a user-declared root that gets stripped from the key, covering paths the derived source/build roots miss — e.g. objdir-built units whose `__FILE__` points above the derived root — for cross-checkout hits the automatic roots can't reach. If path normalization ever miscaches, `KACHE_CC_PATH_NORMALIZE=0` is the escape hatch: keys become path-literal (no cross-machine sharing, zero normalization risk). For **clang-cl** the key is already **machine-local**: clang-cl ignores `-ffile-prefix-map`, so kache keeps literal paths in the key — correct local hits, but no cross-machine sharing yet. clang-cl **debug** compiles (`/Z7`, `/Zi`, `-Z7`, or a `-g` form) are cached too: clang-cl embeds debug info straight into the `.obj` (there's no separate compile-time PDB), so kache folds the CodeView path inputs that object embeds — source path, output name, and compilation dir — into the same machine-local key.
+## Useful commands
 
-**Not cached yet** (these pass through): link / whole-program steps, multi-source and multi-arch invocations, response-file (`@file`) invocations, precompiled headers, modules, coverage, and split-DWARF; for clang-cl also `-bigobj` and `-showIncludes`. C/C++ caching is also **local-only** for now — the Rust path's remote sharing doesn't extend to `cc` artifacts yet.
+```bash
+kache monitor                 # live build and cache activity
+kache stats                   # non-interactive summary
+kache doctor                  # setup and integrity checks
+kache why-miss <crate>        # explain the latest miss
+kache list                    # inspect cached entries
+kache gc                      # enforce cache limits
+kache sync                    # pull from and push to the configured remote
+kache daemon status           # inspect the background service
+```
 
-C/C++ caching is live but still conservative by design: when in doubt, kache misses rather than serve a wrong artifact. See [C/C++ caching](docs/getting-started/c-cpp.mdx) for setup, status, and limitations. Scope and remaining work are tracked in [#49](https://github.com/kunobi-ninja/kache/issues/49).
+Run `kache help <command>` for exact flags. The [command reference](https://kunobi.ninja/docs/kache/commands/reference) covers every top-level command.
+
+## Documentation
+
+- [Install Kache](https://kunobi.ninja/docs/kache/getting-started/installation)
+- [Quick start](https://kunobi.ninja/docs/kache/getting-started/quick-start)
+- [Configuration](https://kunobi.ninja/docs/kache/getting-started/configuration)
+- [How cache keys work](https://kunobi.ninja/docs/kache/how-it-works/cache-key)
+- [Daemon lifecycle](https://kunobi.ninja/docs/kache/daemon/lifecycle)
+- [Benchmarks](https://kunobi.ninja/docs/kache/benchmarks)
 
 ## Development
 
-```sh
-mise install
-just
-just check
-just ci
+```bash
+git clone https://github.com/kunobi-ninja/kache.git
+cd kache
+cargo test --workspace --all-features
 ```
 
-The repo uses `just` as its single task runner. `mise.toml` pins the local Rust baseline and the `just` binary, while the `Justfile` keeps `RUSTC_WRAPPER` empty so kache never tries to build itself through kache.
+See [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
-## Benchmarks
-
-`kache-scenario` is the native benchmark and reporting harness. It builds real
-projects twice against one shared compiler cache: a cold build in one checkout,
-then a warm build in a second checkout at a different absolute path. That shape
-exercises the work kache is designed for: fresh CI workspaces, branch switches,
-worktrees, and agent-created clones that should reuse the same compiled bytes.
-
-The benchmark is self-diagnosing. For kache runs it captures cache reports,
-wrapper logs, build logs, Perfetto/Chrome trace JSON, cross-clone key-stability,
-path-leak samples, passthrough reasons, storage accounting, and an explicit
-verdict. For sccache comparison runs it isolates the sccache daemon/cache,
-validates the cache location/base-dir wiring, and stores sccache stats beside
-the same cold/warm build logs.
-
-Firefox is the headline stress case: a huge mixed Rust + C/C++ build driven by
-mozbuild. kache intentionally still passes through unsupported shapes such as
-link/whole-program steps, multi-source units, preprocessor-only probes, and any
-still-unmodeled flags; those passthroughs are reported so the benchmark shows
-both today's wins and the next optimization targets. Adding another workload is a
-scenario-file addition, not a runner rewrite — the LLVM scenario is one such
-almost-pure-C/C++ counterpart.
-
-Firefox benchmarking measures two dimensions: the *spatial* axis (path variation across clones) and the *temporal* axis (source changes over time):
-
-- **`bench-firefox` / `bench-firefox-windows`** — the *spatial* axis: build the *same* pinned ref in two worktrees at *different* absolute paths (cold clone, then warm clone), and report cache hit rates. This exercises the cross-clone case that real CI shares.
-
-- **`bench-firefox-pull` / `bench-firefox-pull-windows`** — the *temporal* axis
-  (issue #477): build one checkout at ref A, `git checkout` a ~1-day-later ref B
-  in the **same** worktree, rebuild, and report how much of the full TU set kache
-  still hit. Vanilla Firefox (no reproducibility patches, no `MOZ_BUILD_DATE`
-  pin), so it reflects a real `./mach build` user. Complements the cross-clone
-  `bench-firefox*` scenarios, which vary the *path* instead of *time*. The hit
-  rate is warn-only while we baseline it. Note: a real user's post-pull build is
-  incremental and faster than this hit rate implies — the bench forces a full
-  rebuild so kache is asked about every TU.
-
-```sh
-just bench                 # list kache-backed benchmark profiles
-just bench firefox         # full cold + warm Firefox benchmark (tens of min to hours, ~50 GB)
-just bench-retry firefox   # restore the cold snapshot, re-measure warm only (~25 min)
-just bench-trace firefox   # also emit key-diff.{json,md}
-just bench-sccache         # list sccache-backed benchmark profiles
-just bench-sccache firefox # same Firefox shape, with sccache
-just bench substrate       # Rust-heavy polkadot-sdk benchmark (tens of min to ~1.5h, ~20-40 GB)
-just bench lance           # Rust-heavy lance crate benchmark (Arrow/DataFusion, tens of min, ~20-40 GB)
-just bench llvm            # almost-pure C/C++ CMake benchmark (tens of min, large scratch)
-```
-
-Each run writes root-level "latest run" artifacts under
-`tmp/bench/<scenario>/`:
-
-- `report-{cold,warm}.json` and `.md` from `kache report`
-- `trace-{cold,warm}.json`, a native Perfetto/Chrome trace (`traceEvents`)
-- `build-{cold,warm}.log` and `wrapper-{cold,warm}.log`
-- `<scenario>.json`, the benchmark summary including tool versions
-- `key-diff.{json,md}` when `just bench-trace` is used
-- `report-*.sccache.json` and `report-*.sccache-adv.txt` for sccache runs
-
-Those root files are overwritten by the next run so `--retry` has a stable
-latest snapshot. Every completed run is also archived to
-`tmp/bench/<scenario>/runs/<YYYYMMDDTHHMMSSZ>-<backend>-<pid>/`, so repeated
-kache and sccache measurements accumulate without clobbering each other.
-
-The trace files can be opened directly in Perfetto or Chrome's trace viewer.
-They already contain kache-native timings, outcomes, routes, reasons, cache
-keys, byte counts, and compiler/preprocessor/probe counts. External traces from
-the build system can be merged into the same Perfetto view when they share, or
-are normalized to, the same timebase; they are useful for target-level context
-but not required to understand kache hit/miss behavior.
-
-Each benchmark scenario uses a **per-scenario scratch dir** — `./tmp/bench/<scenario>` by default (override with `--work-dir`) — so firefox, firefox-sccache, substrate, lance, and any other scenario **coexist** without clobbering each other's clones, cache, or logs; `rm -rf tmp/bench` cleans them all. A `work_dir` lock refuses a second run pointed at the same scratch dir. Concurrent runs on one host invalidate the wall-clock numbers (CPU/IO/RAM contention), so run benchmarks sequentially or on separate hosts.
-
-Each project is described by a [scenario](scenarios/) (`scenarios/bench-*/scenario.toml`) — repo/ref, how to wire kache or sccache in, and how to build. The Substrate probe is `RUSTC_WRAPPER`-only: it caches the Rust compile surface — the polkadot node's dependency tree plus the nested wasm-runtime compiles — while native C deps (rocksdb, secp256k1) compile outside kache's view by design. Needs `protoc`, `clang`, `cmake`, `pkg-config` installed.
-
-See [`scenarios/README.md`](scenarios/README.md) for the scenario format.
-
-## Commands
-
-| Command | Description |
-|---|---|
-| `kache` | Print help (bare invocation) |
-| `kache init [-y] [--no-service] [--check]` | Interactive setup: cargo wrapper + service install + daemon start |
-| `kache cargo -- <build\|check> [args...]` | Keep an existing Cargo unit fresh when an ancestor symlinks Cargo home's array-valued `build.rustflags` |
-| `kache doctor [--fix [--purge-sccache]] [--verify] [--checksums] [--repair]` | Diagnose setup; `--fix` migrates from sccache, `--verify` checks cache integrity, `--checksums` also hashes blobs, `--repair` deletes corrupted entries |
-| `kache monitor [--since <dur>]` | Live TUI dashboard showing build events, cache stats, and project breakdown |
-| `kache stats [--since <dur>]` | Non-interactive cache stats summary |
-| `kache list [<crate>] [--sort name\|size\|hits\|age] [--no-pager]` | List cached entries, or show details for a specific crate (paged when interactive) |
-| `kache why-miss <crate>` | Explain why a specific crate missed the cache |
-| `kache report [--format text\|json\|markdown\|github\|perfetto\|chrome-trace] [--since <dur>] [--top <n>] [--output <path>]` | Generate a detailed hit/dup/miss build report or Perfetto/Chrome trace (`--top` defaults to 10) |
-| `kache sync [--manifest-path <path>] [--pull] [--push] [--all] [--workspace] [--dry-run]` | Synchronize the local cache with its configured remote (pull + push); `--manifest-path` controls the push-side workspace filter; `--workspace` scopes the pull to workspace members only (one LIST per member) |
-| `kache save-manifest [--manifest-key <key>] [--namespace <ns>]` | Save a build manifest for future prefetch warming; `--manifest-key` overrides the default host-target-triple key |
-| `kache gc [--max-age <dur>]` | Garbage collect — LRU eviction or age-based cleanup |
-| `kache purge [--crate-name <name>]` | Wipe entire cache or entries for a specific crate |
-| `kache clean [-n \| --dry-run] [-y \| --yes]` | Find and delete `target/` directories with cache breakdown (interactive; `-n` previews, `-y` removes all non-interactively for scripts/cron) |
-| `kache config` | Open the TUI configuration editor |
-| `kache completions <shell>` | Print shell completion script (bash, zsh, fish, elvish, powershell) |
-| `kache daemon` | Show daemon and service status |
-| `kache daemon status` | Show daemon and service status (explicit form) |
-| `kache daemon run` | Start the persistent background daemon (foreground) |
-| `kache daemon start` | Start daemon in background (returns immediately) |
-| `kache daemon stop` | Stop a running daemon |
-| `kache daemon restart` | Restart daemon (via launchd/systemd if installed, else manual) |
-| `kache daemon install` | Install daemon as a system service (launchd/systemd) |
-| `kache daemon uninstall` | Remove the daemon service |
-| `kache daemon log` | Stream daemon logs |
-
-Durations use days, hours, or bare hours: `7d`, `24h`, `1h`, `48`.
-
-## Remote cache and configuration
-
-`kache sync` can pull from and push to S3-compatible storage or a shared filesystem directly, without the daemon. Pulls are filtered by the current workspace's `Cargo.lock` by default. See [Sync](docs/remote-cache/sync.mdx) for the full command behavior and remote layout.
-
-Configuration is available through `kache config`, environment variables, or config files. Environment variables win over config files, and project-local `.kache.toml` files are supported. See [Configuration](docs/getting-started/configuration.mdx) for the full reference.
-
-## Architecture
-
-- **Wrapper**: `RUSTC_WRAPPER` intercepts rustc calls, computes blake3 cache keys, and restores hits with a reflink where supported, an exclusive Unix hardlink, or a private copy
-- **Daemon**: Background process handles async remote uploads, checks, and prefetch. Auto-restarts when binary is updated
-- **Store**: content-addressed blobs under `{cache_dir}/store/blobs/<prefix>/<hash>`, indexed by a SQLite DB; cache hits reflink, exclusively hardlink on Unix, or copy those blobs into `target/`
-- **Cache keys**: Deterministic blake3 hash of rustc version, crate name, source, dependencies, and normalized flags — portable across machines
-
-## Remote service
-
-**SOON:** server-side kache is the next milestone. The deployment model, auth integration, and HA behavior are still hardening — treat the planner service and chart as a preview today.
-
-An optional remote planner service lives in [`crates/kache-service`](crates/kache-service). It persists planner state in an embedded SurrealDB database, serves planner endpoints over HTTP, and safely returns `use_fallback` when the database has no matching candidates.
-
-Useful commands:
-
-```sh
-just build-service
-just image-service
-just image-service-release
-cargo run -p kache-service
-helm upgrade --install kache-service ./charts/kache-service
-```
-
-The chart in [`charts/kache-service`](charts/kache-service) is intentionally small: one `Deployment`, one `Service`, optional `PersistentVolumeClaim`, security defaults, health probes, optional `kunobi-auth` bearer-token wiring through an existing `Secret`, and optional `kunobi-ha` Lease-based leader election. It does not bundle ingress or cluster-level policy.
-
-Bearer-token auth is enabled by pointing the chart at an existing secret. Clients must send the same token through `KACHE_PLANNER_TOKEN`.
-
-```yaml
-auth:
-  existingSecret: kache-planner-token
-  existingSecretKey: token
-```
-
-The service stores its embedded planner database at `/var/lib/kache/planner.db` by default. The chart supports either ephemeral storage for preview/dev environments or a PVC for persisted state:
-
-```yaml
-planner:
-  dbPath: /var/lib/kache/planner.db
-  persistence:
-    enabled: true
-    type: pvc
-    mountPath: /var/lib/kache
-    size: 10Gi
-```
-
-For bootstrap/migration only, the service can still import a legacy JSON planner snapshot on startup via `KACHE_PLANNER_SEED_STATE_FILE`.
-
-For highly available deployments, enable leader election and raise the replica count. Followers stay healthy but not ready until they acquire the Kubernetes Lease:
-
-```yaml
-replicaCount: 2
-ha:
-  enabled: true
-  leaseName: kache-service
-```
-
-When combining HA with PVC-backed planner state, use storage that can be mounted by all scheduled replicas, or keep `replicaCount: 1`.
-
-## Contributing
-
-Bug reports, feature ideas, and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev setup, coding conventions, and PR process. To report a security vulnerability privately, follow [SECURITY.md](SECURITY.md).
+Kache is licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ Run `kache help <command>` for exact flags. The [command reference](https://kuno
 - [Daemon lifecycle](https://kunobi.ninja/docs/kache/daemon/lifecycle)
 - [Benchmarks](https://kunobi.ninja/docs/kache/benchmarks)
 
+## Questions and gaps
+
+- [Open a bug report](https://github.com/kunobi-ninja/kache/issues/new?template=bug_report.md) when Kache behaves differently from the documentation.
+- [Request a feature](https://github.com/kunobi-ninja/kache/issues/new?template=feature_request.md) for a missing compiler, remote backend, or build workflow.
+
 ## Development
 
 ```bash

--- a/docs/benchmarks.mdx
+++ b/docs/benchmarks.mdx
@@ -10,7 +10,7 @@ The repository benchmark harness builds real projects in separate checkouts. Thi
 The [Bench workflow](https://github.com/kunobi-ninja/kache/actions/workflows/bench.yml) is scheduled every night at 04:37 UTC. It runs:
 
 - Firefox cold/warm builds on Linux and Windows
-- LLVM, Substrate, and SurrealDB cold/warm builds
+- LLVM, Substrate, SurrealDB, and Lance cold/warm builds
 - Firefox through sccache for comparison
 - Firefox source-update builds on Linux and Windows
 
@@ -24,6 +24,7 @@ A scheduled run is not automatically a valid result. Check that the individual j
 just bench                 # list Kache scenarios
 just bench firefox
 just bench substrate
+just bench lance
 just bench llvm
 just bench-retry firefox   # reuse the saved cold state
 just bench-trace firefox   # include key-diff artifacts

--- a/docs/benchmarks.mdx
+++ b/docs/benchmarks.mdx
@@ -1,95 +1,71 @@
 ---
 title: Benchmarks and reports
-description: Run real cold/warm benchmark scenarios, compare kache with sccache, and inspect native reports and Perfetto traces.
+description: Measure cold, local-hit, remote-hit, and cross-checkout behavior
 ---
 
-# Benchmarks and reports
+The repository benchmark harness builds real projects in separate checkouts. This tests wall time and whether path normalization produces portable keys.
 
-`kache-scenario` runs real projects through the shape kache is built for:
+## Nightly benchmark matrix
 
-1. Build a fresh checkout with an empty cache.
-2. Build a second checkout at a different absolute path against the populated cache.
-3. Report hit rate, speedup, storage reuse, key stability, passthrough reasons, and logs.
+The [Bench workflow](https://github.com/kunobi-ninja/kache/actions/workflows/bench.yml) is scheduled every night at 04:37 UTC. It runs:
 
-This catches both performance wins and portability failures. A cache key that
-accidentally depends on the checkout path will miss in the warm build.
+- Firefox cold/warm builds on Linux and Windows
+- LLVM, Substrate, and SurrealDB cold/warm builds
+- Firefox through sccache for comparison
+- Firefox source-update builds on Linux and Windows
 
-## Run a benchmark
+Jobs upload their reports, Perfetto traces, and logs even when a benchmark fails. GitHub retains those artifacts for 30 days.
 
-```sh
-just bench                 # list kache-backed benchmark profiles
-just bench firefox         # full cold + warm Firefox benchmark
-just bench substrate       # Rust-heavy polkadot-sdk benchmark
-just bench llvm            # almost-pure C/C++ CMake benchmark
-just bench-retry firefox   # restore the cold snapshot, re-measure warm only
-just bench-trace firefox   # also emit key-diff.{json,md}
+A scheduled run is not automatically a valid result. Check that the individual job succeeded and that its benchmark verdict is `ok` before using its timing or hit-rate numbers.
 
-just bench-sccache         # list sccache-backed benchmark profiles
-just bench-sccache firefox # same Firefox shape, with sccache
+## Run a scenario
+
+```bash
+just bench                 # list Kache scenarios
+just bench firefox
+just bench substrate
+just bench llvm
+just bench-retry firefox   # reuse the saved cold state
+just bench-trace firefox   # include key-diff artifacts
+
+just bench-sccache
+just bench-sccache firefox
 ```
 
-Benchmarks are intentionally large. Firefox is a mixed Rust + C/C++ build that
-runs for tens of minutes to hours and needs roughly 50 GB of scratch; substrate
-is Rust-heavy and lighter. Run them sequentially on an otherwise quiet host;
-concurrent builds make wall-clock results noisy.
+Firefox is a large mixed Rust/C++ workload and needs about 50 GB of scratch space. Run benchmark builds sequentially on an otherwise quiet host.
 
-## Is it working?
+## Trust the verdict first
 
-The headline numbers (cold/warm wall-clock, speedup, and hit rate) live in the
-`<scenario>.json` summary, but they are only meaningful when the run's
-`verdict` is `ok`. A `DEGRADED RUN` verdict means a guard tripped: a key leaked
-across checkouts, a clone missed for a non-path reason, or sccache changed cache
-location between phases. Treat the speedup as suspect until the listed issues are
-addressed. Check the verdict first, then the speedup.
+Each summary has a `verdict`. Use timing and hit-rate results only when it is `ok`. A degraded verdict can mean checkout-path leakage, an unexpected miss, or inconsistent cache placement.
 
-## Read the output
+Compare medians from several runs. Keep repository revision, toolchain, machine, target, profile, and remote location fixed.
 
-Each scenario writes its latest artifacts under `tmp/bench/<scenario>/`:
+## Output
 
-- `report-{cold,warm}.json` and `.md` from `kache report`
-- `trace-{cold,warm}.json` for Perfetto or Chrome trace viewer
-- `build-{cold,warm}.log` and `wrapper-{cold,warm}.log`
-- `<scenario>.json`, the summary including the cache tool version
-- `key-diff.{json,md}` when `just bench-trace` is used
-- `report-*.sccache.json` and `report-*.sccache-adv.txt` for sccache runs
+Latest artifacts are under `tmp/bench/<scenario>/`:
 
-Root-level artifacts are overwritten by the next run so `--retry` can find the
-latest cold snapshot. Completed runs are also archived under:
+- cold and warm JSON/Markdown reports
+- Perfetto-compatible trace files
+- build and wrapper logs
+- scenario summary with tool version
+- optional key-diff JSON and Markdown
+- sccache reports for comparison runs
 
-```text
-tmp/bench/<scenario>/runs/<YYYYMMDDTHHMMSSZ>-<backend>-<pid>/
+Completed runs are archived below `tmp/bench/<scenario>/runs/` so later runs do not erase the evidence.
+
+## Reports outside the harness
+
+```bash
+kache report --format text --since 24h
+kache report --format json --output report.json
+kache report --format trace --output trace.json
+kache report --format markdown --root "$PWD"
 ```
 
-That keeps repeated kache and sccache measurements side by side.
-
-## Perfetto traces
-
-`trace-cold.json` and `trace-warm.json` are native Chrome/Perfetto trace files.
-They contain complete events with kache timing, result, route, reason, cache key,
-artifact size, and compiler/preprocessor/probe counts.
-
-External build-system traces can be merged into the same Perfetto view when they
-share, or are normalized to, the same timebase. They are useful for target-level
-context, but kache's own hit/miss timeline does not depend on another tracing
-tool.
-
-## sccache comparison
-
-`just bench-sccache firefox` runs the same Firefox cold/warm shape through
-sccache. The harness uses an isolated sccache daemon and cache directory, then
-checks the reported cache location and base-dir settings before trusting the
-numbers. If cold and warm phases use different sccache cache locations, the run
-is invalid.
+`trace`, `perfetto`, and `chrome-trace` produce the same trace format. Open it in Perfetto or Chrome's trace viewer.
 
 ## Add a workload
 
-Benchmarks are scenario files under `scenarios/bench-*`. A scenario declares the
-repo/ref, wrapper wiring, setup, build command, tags, and optional patch files.
-Adding a workload is a new scenario directory, not a runner rewrite. The shipped
-scenarios are the worked examples: `bench-firefox` (mixed Rust + C/C++ via
-mozbuild), `bench-substrate` (Rust-only `RUSTC_WRAPPER`), and `bench-llvm`
-(almost-pure C/C++ via CMake compiler launchers).
+Benchmark definitions live under `scenarios/bench-*`. A scenario declares its repository, revision, setup, wrapper wiring, build command, and optional patches. Start from `bench-firefox`, `bench-substrate`, or `bench-llvm` and read the [scenario format](https://github.com/kunobi-ninja/kache/tree/main/scenarios#readme).
 
-See [`scenarios/README.md`](https://github.com/kunobi-ninja/kache/tree/main/scenarios#readme)
-for the scenario format, and the [`kache report`](/docs/commands/reference)
-reference for the trace and report formats these artifacts use.
+For choosing a cache before benchmarking, see [Kache or sccache?](/docs/getting-started/comparison).

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -1,478 +1,230 @@
 ---
 title: Command reference
-description: All kache CLI commands with flags and examples.
+description: Every top-level Kache command, its purpose, and common flags
 ---
 
-# Command reference
+Run `kache <command> --help` for the exact syntax in your installed version.
 
-When invoked without arguments, kache prints `--help` and exits — it does not open the TUI monitor (launch it explicitly with `kache monitor`). When invoked with a subcommand, it runs that command. When invoked as `RUSTC_WRAPPER` (detected by the rustc path in argv[1]), it operates as a transparent build cache.
-
-## Quick reference
-
-| Command | Description |
-|---|---|
-| `kache` | Print `--help` and exit (use `kache monitor` for the live TUI) |
-| `kache init [-y] [--no-service] [--check]` | Interactive setup: cargo wrapper + service install + daemon start |
-| `kache cargo -- <build\|check> [args...]` | Keep existing Cargo units fresh when Cargo discovers a canonical duplicate of Cargo-home `build.rustflags` |
-| `kache monitor [--since <dur>]` | Open the live TUI dashboard, optionally scoped to a time window |
-| `kache stats [--since <dur>]` | One-shot stats snapshot, no interactive UI |
-| `kache list [<crate>] [--sort <field>] [--no-pager]` | List cache entries or show details for one crate |
-| `kache why-miss <crate>` | Diagnose why a crate keeps missing the cache |
-| `kache report [--format <fmt>] [--since <dur>] [--root <path>] [--output <path>] [--top <n>]` | Build report in text / json / trace / markdown / github format |
-| `kache gc [--max-age <dur> \| --stale-schema]` | Evict entries by LRU, age, or obsolete key schema |
-| `kache purge [--crate-name <name>]` | Wipe entire cache or entries for one crate |
-| `kache clean [-n \| --dry-run] [-y \| --yes]` | Find and remove `target/` directories (interactive; `-n` previews, `-y` removes all non-interactively) |
-| `kache sync [flags]` | Sync local cache with a configured remote |
-| `kache save-manifest [--manifest-key <key>] [--namespace <ns>]` | Save a build manifest for future prefetch warming |
-| `kache doctor [--fix [--purge-sccache]] [--verify] [--checksums] [--repair]` | Diagnose and fix setup issues; verify cache integrity |
-| `kache config` | Open the TUI configuration editor |
-| `kache completions <shell>` | Print shell completion script (bash, zsh, fish, elvish, powershell) |
-| `kache daemon [subcommand]` | Manage the background daemon |
-
-Duration arguments accept days or hours: `7d`, `24h`, or a bare number of hours like `48`. Minutes are not supported — a value like `30m` fails to parse and silently falls back to the default.
-
----
-
-## `kache init`
-
-```sh
-kache init [-y] [--no-service] [--check]
-```
-
-Interactive setup. Edits `~/.cargo/config.toml` (or the legacy extensionless `~/.cargo/config` if that file already exists) to set `rustc-wrapper = "kache"`, installs the daemon as a login service (launchd on macOS, systemd user unit on Linux, Task Scheduler on Windows), and starts it. Idempotent — safe to re-run any time to repair configuration.
-
-```sh
-kache init                # interactive prompts
-kache init -y             # accept all defaults non-interactively
-kache init --no-service   # configure cargo wrapper but skip the system service install
-kache init --check        # report what init would do, change nothing
-```
-
-If you'd rather wire things up manually, see [Quick start](/docs/getting-started/quick-start#manual-setup-without-kache-init).
-
----
+| Command | Purpose |
+| --- | --- |
+| `cargo` | Run Cargo with duplicate Cargo-home rustflags collapsed |
+| `list` | Inspect local entries |
+| `gc` | Evict local entries |
+| `purge` | Remove local cache entries |
+| `clean` | Remove Cargo target directories below the current directory |
+| `init` | Configure Cargo and optionally install the daemon service |
+| `doctor` | Diagnose setup and store integrity |
+| `sync` | Pull from and push to a remote |
+| `save-manifest` | Publish build metadata for later prefetch |
+| `daemon` | Inspect and manage the background daemon |
+| `monitor` | Open the live dashboard |
+| `stats` | Print a non-interactive summary |
+| `why-miss` | Explain a crate's recent key change |
+| `report` | Produce text, Markdown, JSON, or trace output |
+| `config` | Open the configuration editor |
+| `install-shims` | Create Unix compiler-name symlinks |
+| `completions` | Generate shell completion scripts |
 
 ## `kache cargo`
 
-```sh
-kache cargo -- check
-kache cargo -- build --workspace
+```bash
+kache cargo -- build
+kache cargo -- test --workspace
 ```
 
-Runs Cargo's built-in `build` or `check` from the current directory with its
-arguments unchanged. It also keeps Cargo's intermediate build state under
-`{workspace-root}/target` while leaving final artifacts in the selected target
-directory. Cargo 1.91 introduced this `build-dir` split. It prevents a shared
-`CARGO_TARGET_DIR` from carrying fingerprints between worktrees and declaring
-the wrong unit `Fresh` before `RUSTC_WRAPPER` can run. Each worktree owns its
-freshness state, while Kache still shares compiled artifacts. Set
-`CARGO_BUILD_BUILD_DIR` explicitly, or configure `[build] build-dir`, to retain
-a different build-dir policy; Kache does not override either form.
-
-If Cargo's
-ancestor search finds a symlink to the selected Cargo-home config, Cargo would
-normally merge the same array-valued `build.rustflags` twice and re-key every
-unit. This front-end identifies that duplicate by canonical path, contributes
-the Cargo-home array once, and passes the corrected argument sequence to Cargo.
-User-authored repeated flags inside one config and contributions from distinct
-config files remain repeated and ordered.
-
-Normalization is deliberately conservative. Existing `RUSTFLAGS` or encoded
-flags take precedence unchanged. Config includes, target-specific rustflags,
-string-form rustflags, and rustflags supplied through `[env]` run unchanged
-with a warning rather than risk reproducing Cargo's selection rules
-incorrectly. Cargo `-C`/`--config`, unstable flags, `install`, aliases, and
-external subcommands pass through unchanged. Config paths and contents are
-revalidated immediately before Cargo starts; concurrent config editing should
-still be avoided. Ordinary `cargo` remains supported. Use this front-end for
-the canonical-config alias case or when final artifacts intentionally share a
-target directory across worktrees.
-
-The command prevents Cargo's spurious rebuild in an existing target directory.
-It does not alias Kache entries across different rustflags transport sources;
-an empty target still uses Kache's normal exact-key safety.
-
----
-
-## `kache monitor`
-
-```sh
-kache monitor [--since <duration>]
-```
-
-Opens the live TUI dashboard. `--since` controls how far back the build event log is read when the monitor starts. Defaults to showing all available events. The Passthrough tab lists uncached invocations with their reason and fallback/direct route.
-
-```sh
-kache monitor --since 24h
-```
-
-See [Monitor](/docs/monitor) for a full description of the tabs and fields.
-
----
-
-## `kache stats`
-
-```sh
-kache stats [--since <duration>]
-```
-
-Prints a one-shot cache statistics summary to stdout without opening the interactive UI. Useful for CI log output or scripting.
-
-When connected to a daemon, the command renders the daemon's effective store,
-dedup, session, remote, prefetch, and remote-index data. If this process read a
-different config path, file snapshot, or value, stderr names both sides and the
-daemon's value remains authoritative. If no daemon is reachable, the command
-announces when it starts one and notes that a manually started daemon inherits
-that process's environment.
-
-```sh
-kache stats --since 7d
-```
-
----
+Pass Cargo arguments after `--`. On Cargo 1.91 or newer, this command can keep intermediate worktree state separate while coordinating a shared final target directory.
 
 ## `kache list`
 
-```sh
-kache list [<crate-name>] [--sort name|size|hits|age] [--no-pager]
+```bash
+kache list
+kache list serde
+kache list --sort size --no-pager
 ```
 
-Without a crate name, lists all cached entries with sort control. With a crate name, shows all cached entries for that specific crate including cache keys, artifact sizes, features, and targets.
+Sort values are `name`, `size`, `hits`, and `age`.
 
-```sh
-kache list                    # all entries, sorted by name
-kache list --sort size        # largest first
-kache list --sort hits        # most frequently used first
-kache list serde              # all entries for serde
-```
-
-### Paging
-
-When stdout is a terminal, populated summary and crate-detail listings are sent
-to a pager. The platform default is `less -FRX` on Unix and `more.com` on
-Windows. `--no-pager` prints directly. The pager is chosen from `KACHE_PAGER`,
-then `$PAGER`, then that platform default; an empty value or the single command
-`cat` disables paging. Piped or redirected output is never paged.
-
-Pager values are parsed directly into a program and arguments, without a shell.
-Single or double quotes may group whitespace (for example,
-`KACHE_PAGER='"/opt/My Pager/less" -FRX'`), but shell expansion and operators are
-not interpreted. An invalid value or a program that cannot be started falls
-back to direct output. Quitting a running pager stops delivery without
-reprinting the listing.
-
----
-
-## `kache report`
-
-```sh
-kache report [--format text|json|trace|perfetto|chrome-trace|markdown|github] [--since <duration>] [--root <path>] [--output <path>] [--top <n>]
-```
-
-Generates a detailed report of recent build activity: per-crate hit/dup/miss counts, cumulative time saved, transfer activity, and store stats. Useful for sharing CI results in a PR comment or feeding the data into other tools.
-
-Reports keep cache outcomes separate:
-
-- `hit` means kache restored the artifact without running the compiler.
-- `dup` means the cache key missed, the compiler ran, and the compiled bytes already existed in the local store.
-- `miss` means the cache key missed, the compiler ran, and at least one output blob was new.
-
-Hit rate counts hits only. Compiled work is reported as `dups + misses`.
-
-`--top <n>` limits how many crates appear in the per-crate breakdown (default 10).
-
-```sh
-kache report                                  # text to stdout
-kache report --format markdown --since 24h    # markdown summary, last 24 hours
-kache report --format github --output report.md   # GitHub-flavored, written to a file
-kache report --format json | jq                   # machine-readable summary
-kache report --format perfetto --output trace.json    # Chrome trace / Perfetto import
-KACHE_EVENT_ROOT="$PWD" cargo build
-kache report --format perfetto --root "$PWD" --since 24h --output trace.json
-```
-
-For timeline analysis, JSON reports include a `timeline` window plus a top-level `traceEvents` array and `displayTimeUnit: "ms"` hint. `--format trace`, `--format perfetto`, and `--format chrome-trace` emit only those trace-viewer fields for Chrome trace / Perfetto import. Each trace event is a complete event (`ph: "X"`) with microsecond `ts` / `dur` fields and kache result details in `args`. Per-invocation entries in `all_events`, `top_hits`, and `top_misses` also include `root`, `start_time`, `end_time`, `start_unix_ms`, and `end_unix_ms` alongside the result, cache key, elapsed time, compile time, overhead, artifact size, and compiler/preprocessor/probe counts. Use `--root <path>` to isolate a benchmark checkout/build tree when the event log contains other compilations. kache derives `root` automatically where possible; benchmark harnesses can set `KACHE_EVENT_ROOT` to stamp all wrapper events with an explicit root. External build-system traces can be merged into the same Perfetto view when they share, or are normalized to, the same timebase, but kache's own hit/miss timeline does not depend on another tracing tool.
-
-The `github` format is friendly for posting as a PR comment via `gh pr comment --body-file`.
-
-Remote-transfer reports distinguish actual elapsed throughput from diagnostic service-time rates. `observed_throughput_mbps` divides the bytes covered by exact transfer timestamps by `observed_span_ms` (earliest start through latest finish), so overlapping downloads are counted once in wall time; `max_concurrent_downloads` reports their peak overlap. The legacy `throughput_mbps`, `network_throughput_mbps`, and `body_throughput_mbps` fields remain for compatibility, but divide by cumulative per-transfer service time and are not wall-clock throughput. Transfer-event schema v3 includes SQLite import in end-to-end elapsed time and reports import lock wait separately from import execution.
-
-### JSON report schema and compatibility
-
-`kache report --format json` emits structured, machine-readable telemetry adhering to a versioned output contract:
-
-- **`schema_version`**: A top-level integer (currently `1`) defining the contract version. A formal JSON Schema definition is maintained at [`docs/commands/report.schema.json`](./report.schema.json).
-- **Machine codes vs. descriptive text**:
-  - Stable result, route, and bypass codes are separated from freeform human diagnostics.
-  - **`result`**: Stable outcome codes (`"local_hit"`, `"prefetch_hit"`, `"remote_hit"`, `"dup"`, `"miss"`, `"error"`, `"passthrough"`, `"skipped"`).
-  - **`route`**: Stable dispatch routes (`"direct"`, `"fallback"`, `"skipped"`, `"n/a"`).
-  - **`reason` categories**: Structured prefix categories (`"not-a-compile"`, `"unsupported"`, etc.) that separate query/probe invocations from real compile refusals.
-  - Freeform strings (`passthrough_reason`, `store_error`, `lookup_rejection`, `suggestions`) provide diagnostics and should not be relied upon for exact string matching across releases.
-- **Compatibility contract**:
-  - **Additive extensions**: Adding new fields or non-breaking metrics to objects does not increment `schema_version`. Machine readers MUST ignore unrecognized fields.
-  - **Breaking changes**: Removing fields, renaming fields, changing field data types, or altering code semantics increments `schema_version`.
-
----
-
-## `kache save-manifest`
-
-```sh
-kache save-manifest [--manifest-key <key>] [--namespace <ns>]
-```
-
-Records the resolved set of crates / cache keys for the current workspace as a build manifest. The remote planner (see [Remote service](/docs/remote-service)) consumes manifests to warm prefetch hints for future runs that look like the same workspace.
-
-- `--manifest-key <key>` overrides the manifest key (defaults to the host target triple).
-- `--namespace <ns>` enables content-addressed shard uploads (requires a `Cargo.lock`); it can also be supplied via the `KACHE_NAMESPACE` environment variable, with the flag taking precedence. With no namespace, only the monolithic manifest is uploaded and shard upload is skipped.
-
-```sh
-kache save-manifest                           # upload the monolithic manifest only
-kache save-manifest --namespace ci-main       # also upload shards, tagged by environment
-```
-
-Saving a manifest is cheap; it is safe to run at the end of a CI build alongside `kache sync --push`.
-
----
+Interactive output uses `KACHE_PAGER`, then `PAGER`, then a platform default. `--no-pager` writes directly.
 
 ## `kache gc`
 
-```sh
-kache gc [--max-age <duration> | --stale-schema]
+```bash
+kache gc
+kache gc --max-age 7d
+kache gc --stale-schema
 ```
 
-Runs garbage collection. Without an option, applies the automatic policy: opt-in age retention from `KACHE_GC_MAX_AGE_HOURS` (default `0`, disabled) first, then duplicate and size-pressure eviction against the recomputed physical store size. Size pressure fires above `KACHE_MAX_SIZE` and evicts down to 90% of that cap. Duplicate cleanup is bounded by the same target and removes an entry only when backfilled metadata proves positive physical reclaim; unknown legacy entries are kept. The command reports each policy separately. With `--max-age`, runs only the requested age policy regardless of store size.
+A bare run enforces configured size and age policies. `--max-age` runs the requested age policy. `--stale-schema` removes entries created with old or unrecorded key schemas and conflicts with `--max-age`.
 
-`--stale-schema` is an explicit key-upgrade cleanup. It retains entries created by the running cache-key recipe and removes entries from older recipes, including legacy entries whose recipe was not recorded. Ordinary upgrades and automatic GC do not remove those legacy entries. This mode runs locally under the cross-process GC lock and cannot be combined with `--max-age`.
-
-During a rolling upgrade, the automatic and `--max-age` modes verify GC policy v2 before mutation and use a `gc_v2` command that older daemons reject without evicting. If the daemon cannot provide v2 semantics and per-policy reporting, the command reruns the requested policy locally under the same cross-process GC lock. The stale-schema mode always runs locally because older daemons do not know the running binary's key recipe.
-
-```sh
-kache gc                  # automatic configured policy (age first, then pressure)
-kache gc --max-age 30d    # remove anything unused for 30 days
-kache gc --max-age 7d     # aggressive cleanup before a release build
-kache gc --stale-schema   # reclaim entries orphaned by cache-key recipe changes
-```
-
-If `clean_incremental` is enabled (the default), GC removes tracked incremental compilation directories that previous wrapper invocations registered. Normal cached invocations also remove the current Cargo incremental dir eagerly. Adaptive and forced preserve-incremental compiles use separate state that kache never registers for GC; `cargo clean` still removes it with the target profile.
-
----
+GC affects only the local store.
 
 ## `kache purge`
 
-```sh
-kache purge [--crate-name <name>]
+```bash
+kache purge --crate-name serde
+kache purge
 ```
 
-Removes cache entries permanently. Without `--crate-name`, wipes the entire local cache. With `--crate-name`, removes only entries for that crate. This does not affect the remote cache.
-
-```sh
-kache purge                        # wipe everything
-kache purge --crate-name tokio     # remove all tokio entries
-```
-
-<Callout type="warn">
-`kache purge` without a crate name removes your entire local cache. The next build will be a full cold build.
-</Callout>
-
----
+With no crate name, `purge` wipes the entire local cache after confirmation.
 
 ## `kache clean`
 
-```sh
-kache clean [-n | --dry-run] [-y | --yes]
+```bash
+kache clean
+kache clean --dry-run --yes
+kache clean --yes
 ```
 
-Recursively finds all `target/` directories under the current directory and removes them. Reports disk usage per directory before deleting, including how much appears to share storage with another file. Kache restores normally create that state, but the filesystem probe cannot prove that every other reference belongs to Kache's store.
+`clean` recursively finds `target/` directories below the current directory. The default opens a selector. Use `--dry-run --yes` before a scripted `--yes` run.
 
-With no flags, `clean` opens an interactive selector (shown below). For scripts and cron, pass `-y`/`--yes` to skip the selector and remove **every** `target/` directory found, or `-n`/`--dry-run` to preview what would be removed without deleting. If both are given, `--dry-run` wins.
+## `kache init`
 
-![kache clean TUI listing target/ dirs with cached percentages and per-directory breakdown](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/clean.gif)
-
-Static layout for reference:
-
-```text
-┌ kache clean ──────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ 8 dirs (73.2 GiB total, 7.4 GiB cached)    Selected: 0 (est. 0 B)                                                 │
-└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-┌ Select directories to remove ─────────────────────────────────────────────────────────────────────────────────────┐
-│ [ ]  workspace/compiler-core/target                                             34.7 GiB    5.7 GiB [debug, release]│
-│ [ ]  workspace/build-cache/target                                               15.4 GiB   49.1 MiB [debug, release]│
-│ [ ]  workspace/desktop-app/crates/app/target                                    13.8 GiB    9.4 MiB [debug]         │
-│ [ ]  workspace/service-api/target                                                3.0 GiB  239.2 MiB [debug]         │
-│ [ ]  workspace/frontend/packages/graph-core/target                               2.2 GiB  635.6 MiB [debug]         │
-│ [ ]  workspace/auth-service/target                                               1.5 GiB  727.4 MiB [debug]         │
-│ [ ]  workspace/metrics/target                                                    1.5 GiB        0 B [debug]         │
-│ [ ]  workspace/frontend/packages/ipc-plugin/target                               1.1 GiB  152.8 MiB [debug]         │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-┌ workspace/compiler-core/target — 34.7 GiB total, 5.7 GiB cached (16%) ────────────────────────────────────────────┐
-│  incremental:        0 B   build:  433.3 MiB   deps (local):   28.4 GiB                                           │
-│  fingerprint:    5.9 MiB   binaries: 239.5 MiB   other:           6.9 KiB                                         │
-└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ space: toggle  a: select all  n: select none  enter: delete selected  q: cancel                                   │
-└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```bash
+kache init
+kache init --check
+kache init --no-service
+kache init --yes
 ```
 
-```sh
-kache clean              # interactive selector
-kache clean -n           # preview what would be deleted (alias: --dry-run)
-kache clean -y           # non-interactive: delete all target/ dirs (alias: --yes)
-```
-
-This is useful for freeing disk space when you're done with a project or before a fresh build.
-
-Freed-space totals are labelled as estimates. On macOS and Linux, the scan uses private extent bytes for partially shared reflinks and includes binary-shaped artifacts. On macOS, Linux, and Windows, it counts a file identity only once when all of its hardlinks are inside one `target/`. The output explains any gap from apparent size as storage that is shared, sparse, or duplicate; it does not assume every shared extent or hardlink belongs to kache's store.
-
-The estimate is calculated independently per `target/`, so deleting several selected directories that share links or clones can reclaim more than their summed estimates. The real post-delete filesystem delta can also differ because unsupported filesystems fall back to apparent sizes, files can change after the scan, and a failed recursive removal may already have deleted part of a tree. Before deletion, Kache verifies that each path is still the same non-symlink directory it scanned. The after-removal summary includes only directories whose removal returned success, but remains a scan-time estimate.
-
-<Callout type="info">
-On macOS, the scan skips TCC-protected locations (`/System`, `/Library`, `/private`, `/Applications`, `/Volumes`, and home folders like `~/Desktop`, `~/Documents`, `~/Downloads`, `~/Library`, `~/Pictures`) to avoid permission prompts, so `target/` directories under those paths are never found or cleaned.
-</Callout>
-
----
-
-## `kache sync`
-
-```sh
-kache sync [--pull] [--push] [--all] [--workspace] [--allow-partial] [--dry-run] [--manifest-path <path>]
-```
-
-Synchronizes the local cache with the configured S3 or filesystem remote. See
-[Sync](/docs/remote-cache/sync) for a full walkthrough.
-
-```sh
-kache sync                 # pull missing + push new artifacts
-kache sync --pull          # download only, filtered to current workspace
-kache sync --pull --all    # download everything in the remote
-kache sync --push          # upload only
-kache sync --allow-partial # ignore transfer/import failures and exit 0
-kache sync --dry-run       # preview transfers, make no changes
-```
-
-**Exit status.** By default, `kache sync` exits non-zero if any transfer, store-open, or entry import fails. All scheduled operations drain to completion before returning. When `--allow-partial` is passed, `kache sync` exits `0` even if some transfers or imports fail.
-
----
-
-## `kache why-miss`
-
-```sh
-kache why-miss <crate-name>
-```
-
-Compares the cache key from the most recent recorded entry for the given crate against the current build inputs, and reports which component of the key changed. Useful for diagnosing persistent cache misses.
-
-```sh
-kache why-miss tokio
-```
-
----
+`--check` reports proposed changes without writing. `--no-service` skips login-service installation.
 
 ## `kache doctor`
 
-```sh
-kache doctor [--fix [--purge-sccache]] [--verify] [--checksums] [--repair]
-```
-
-Diagnoses common setup issues: missing `RUSTC_WRAPPER`, conflicting wrappers, config file problems, and daemon connectivity. Without `--fix`, it only reports issues.
-
-An installed daemon service is recommended but not mandatory. If a healthy
-on-demand daemon is already reachable, `doctor` reports the missing service as
-a passing runtime configuration instead of directing you to replace it.
-
-The verify family checks cache integrity:
-
-- `--verify` checks entry, blob, and metadata integrity (orphaned/missing blobs).
-- `--checksums` additionally re-hashes blob contents to catch silent corruption (slower; implies `--verify`). Each unique blob is hashed once, streamed rather than read into memory, across a bounded worker pool — a blob shared by many entries costs one hash, not one per entry.
-- `--repair` removes corrupted entries and sweeps orphaned blobs (implies `--verify`).
-
-**Exit status.** When any verify flag is used, kache exits non-zero if integrity findings remain unresolved — corrupted entries, missing blobs, or checksum failures — so a scheduled run can gate a CI job. With `--repair`, the exit is zero once repair has cleared them and non-zero only for what it could not remove. Orphaned blobs are reported but never fail the run: they are reclaimable space, not wrong bytes, and GC clears them on its own.
-
-```sh
-kache doctor           # diagnose only
-kache doctor --fix     # attempt to fix detected issues
-kache doctor --verify  # check cache integrity
-kache doctor --repair  # remove corrupted entries
-
-# CI: fail the job on silent corruption
+```bash
+kache doctor
+kache doctor --fix
+kache doctor --verify
 kache doctor --checksums
+kache doctor --repair
 ```
 
-If you're migrating from sccache, `--fix` handles the migration automatically. `--purge-sccache` additionally removes sccache's cache and binary:
+- `--fix` repairs supported setup issues and can migrate sccache configuration.
+- `--purge-sccache` also removes sccache data and requires `--fix`.
+- `--verify` checks entries, blobs, and metadata.
+- `--checksums` also hashes blob contents and implies `--verify`.
+- `--repair` removes corrupted entries and implies `--verify`.
 
-```sh
-kache doctor --fix --purge-sccache
+Review destructive options before running them.
+
+## `kache sync`
+
+```bash
+kache sync
+kache sync --pull
+kache sync --push
+kache sync --dry-run
+kache sync --pull --workspace
+kache sync --pull --all
 ```
 
----
+Options:
 
-## `kache config`
+| Flag | Effect |
+| --- | --- |
+| `--manifest-path <PATH>` | Select Cargo manifest for push-side workspace filtering |
+| `--pull` | Skip uploads |
+| `--push` | Skip downloads |
+| `--dry-run` | Plan without transfer |
+| `--all` | Ignore normal pull filtering |
+| `--workspace` | Scope pull discovery to workspace members; conflicts with `--all` |
+| `--allow-partial` | Exit successfully despite reported transfer/import failures |
 
-```sh
-kache config
+See [Sync](/docs/remote-cache/sync) for filtering semantics.
+
+## `kache save-manifest`
+
+```bash
+kache save-manifest
+kache save-manifest --manifest-key x86_64-linux-release
+kache save-manifest --namespace x86_64-unknown-linux-gnu/rustc-hash/release
 ```
 
-Opens the TUI configuration editor. Shows all config fields, their current values, and which ones are overridden by environment variables. Saves changes to the active config file: `$KACHE_CONFIG` if set, else the nearest `.kache.toml` in a parent directory, else the global `~/.config/kache/config.toml` (`$XDG_CONFIG_HOME/kache/config.toml`).
-
----
-
-## `kache completions`
-
-```sh
-kache completions <shell>
-```
-
-Prints a completion script for the given shell to stdout. Supported shells: `bash`, `zsh`, `fish`, `elvish`, `powershell`. Does not require a valid kache config.
-
-Install examples:
-
-```sh
-# zsh — write to a directory on fpath, then restart the shell
-mkdir -p ~/.zfunc
-kache completions zsh > ~/.zfunc/_kache
-# ensure fpath+=(~/.zfunc) before compinit, then: exec zsh
-
-# bash
-kache completions bash > ~/.local/share/bash-completion/completions/kache
-
-# fish
-kache completions fish > ~/.config/fish/completions/kache.fish
-```
-
-Alternatively, load completions for the current session:
-
-```sh
-eval "$(kache completions bash)"  # bash
-eval "$(kache completions zsh)"   # zsh (compinit must already be active)
-kache completions fish | source   # fish
-```
-
----
+The default manifest key is the host target triple. A namespace plus `Cargo.lock` also publishes content-addressed shards.
 
 ## `kache daemon`
 
-```sh
-kache daemon                  # show daemon status: service install state, running/offline, socket path, log location, daemon version/epoch
-kache daemon status           # same as above (explicit alias)
-kache daemon start            # start in background, wait until ready
-kache daemon stop             # graceful shutdown
-kache daemon restart          # restart (via launchd/systemd/Task Scheduler if installed, else manual)
-kache daemon run              # start in foreground (for debugging)
-kache daemon install          # install as a system service (launchd/systemd/Task Scheduler)
-kache daemon uninstall        # remove the system service
-kache daemon log              # stream the daemon log
+```bash
+kache daemon             # status
+kache daemon status
+kache daemon run
+kache daemon start
+kache daemon stop
+kache daemon restart
+kache daemon install
+kache daemon uninstall
+kache daemon log
 ```
 
-See [Daemon lifecycle](/docs/daemon/lifecycle) for details on service installation and the auto-restart behavior.
+See [Daemon lifecycle](/docs/daemon/lifecycle).
+
+## `kache monitor`
+
+```bash
+kache monitor
+kache monitor --since 7d
+```
+
+See [Monitor](/docs/monitor).
+
+## `kache stats`
+
+```bash
+kache stats
+kache stats --since 1h
+```
+
+The default window is 24 hours.
+
+## `kache why-miss`
+
+```bash
+kache why-miss serde
+```
+
+The command compares recorded key material for the named rustc crate and reports changed input groups.
+
+## `kache report`
+
+```bash
+kache report --format text --since 24h
+kache report --format markdown --root "$PWD"
+kache report --format json --output report.json
+kache report --format trace --output trace.json
+```
+
+| Flag | Default | Values or purpose |
+| --- | --- | --- |
+| `--format` | `text` | `json`, `trace`, `perfetto`, `chrome-trace`, `markdown`, `github`, `text` |
+| `--since` | `24h` | Event window |
+| `--root` | all roots | Include events from one build tree |
+| `--output`, `-o` | stdout | Write to a file |
+| `--top` | `10` | Number of ranked entries |
+
+`trace`, `perfetto`, and `chrome-trace` select the same trace representation. The JSON contract is documented by [`report.schema.json`](https://github.com/kunobi-ninja/kache/blob/main/docs/commands/report.schema.json).
+
+## `kache config`
+
+```bash
+kache config
+```
+
+This command can open even when the current config file is invalid. See [Configuration](/docs/getting-started/configuration).
+
+## `kache install-shims`
+
+```bash
+kache install-shims ~/.local/lib/kache/shims
+kache install-shims --force ~/.local/lib/kache/shims
+```
+
+This Unix command creates `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++` symlinks to Kache. Put the directory before the real compilers in `PATH`.
+
+## `kache completions`
+
+```bash
+kache completions zsh > ~/.zfunc/_kache
+kache completions bash > ~/.local/share/bash-completion/completions/kache
+kache completions fish > ~/.config/fish/completions/kache.fish
+```
+
+Supported shells are Bash, Elvish, Fish, PowerShell, and Zsh.

--- a/docs/daemon/lifecycle.mdx
+++ b/docs/daemon/lifecycle.mdx
@@ -1,119 +1,61 @@
 ---
-title: Lifecycle
-description: Starting, stopping, installing as a service, and how the daemon handles binary updates.
+title: Daemon lifecycle
+description: Start, stop, install, update, and troubleshoot the daemon
 ---
 
-# Lifecycle
+## Commands
 
-## Starting and stopping
-
-```sh
-kache daemon start      # start in background, blocks until the socket is ready
-kache daemon stop       # graceful shutdown (drains pending uploads, up to 30s)
-kache daemon restart    # restart in place (service-manager kickstart, else stop + fresh spawn)
-kache daemon            # status: binary version/epoch, service install state, running/stopped, socket path, log location, and (if running) the daemon's version/epoch
-kache daemon log        # stream the daemon log (follows like tail -f)
+```bash
+kache daemon             # status
+kache daemon start       # background process; waits for readiness
+kache daemon stop        # graceful drain, bounded to 30 seconds
+kache daemon restart     # service-manager restart or manual replacement
+kache daemon run         # foreground process
+kache daemon log         # follow logs
 ```
 
-`kache daemon restart` recovers a wedged daemon in three tiers: it first asks the service manager (launchd/systemd) to kickstart it, then falls back to killing any lingering `kache daemon run` processes and wiping stale socket/lock/state files, then spawns a fresh background daemon.
+Use `KACHE_LOG=kache=debug kache daemon run` for foreground debugging.
 
-`kache daemon run` starts the daemon in the foreground. This is mostly useful for debugging. By default only warnings and errors print to stderr; set `KACHE_LOG=kache=info` (or `kache=debug`) for verbose daemon logs.
+## Install a login service
 
-## Installing as a system service
+```bash
+kache daemon install
+```
 
-For the daemon to survive reboots and start automatically, install it as a system service.
+On macOS this installs `~/Library/LaunchAgents/ninja.kunobi.kache.plist`. On Linux it installs and enables the `kache.service` systemd user unit.
 
-<Tabs items={["macOS (launchd)", "Linux (systemd)"]}>
-  <Tab value="macOS (launchd)">
-    ```sh
-    kache daemon install
-    ```
+Remove either service with:
 
-    This creates a launchd plist at `~/Library/LaunchAgents/ninja.kunobi.kache.plist` and loads it. The daemon will start on login and restart if it crashes.
+```bash
+kache daemon uninstall
+```
 
-    On macOS 15 and newer, the first connection to a cache server on the local
-    network may show a **Local Network** permission prompt for kache. Allow it;
-    you can review the decision later under **System Settings > Privacy &
-    Security > Local Network**. Kache embeds the usage description in its binary
-    and associates the LaunchAgent with that identity.
+On current macOS releases, the first connection to a LAN cache endpoint may ask for Local Network permission. If an older service installation reports `No route to host`, reinstall it with the current Kache binary.
 
-    If an older installation instead logs `No route to host (os error 65)` for
-    a LAN endpoint, reinstall the service with the current binary. As a safe
-    fallback, `kache daemon uninstall` lets the next terminal build start an
-    on-demand daemon under the terminal's Local Network permission.
+## Updates and config changes
 
-    To remove it:
+The daemon records the running binary's build epoch. A newer client asks an older daemon to drain and exit. The service manager restarts installed services; otherwise later background work starts a fresh daemon.
 
-    ```sh
-    kache daemon uninstall
-    ```
-  </Tab>
-  <Tab value="Linux (systemd)">
-    ```sh
-    kache daemon install
-    ```
-
-    This creates a systemd user unit (`kache.service`) and enables it. The daemon runs under your user session.
-
-    ```sh
-    systemctl --user status kache.service
-    journalctl --user -u kache.service   # logs (or use `kache daemon log`)
-    ```
-
-    To remove it:
-
-    ```sh
-    kache daemon uninstall
-    ```
-  </Tab>
-</Tabs>
-
-## Automatic restart on binary update
-
-When you update kache, the old daemon and the new wrapper would disagree on RPC protocol versions. kache handles this automatically.
-
-Each process tracks a **build epoch** — the modification time of the kache binary. The daemon reads the client's epoch from incoming Upload/Stats/BuildStarted requests; when a client binary is newer, the daemon sets its own shutdown flag and self-terminates once in-flight work drains. If it was installed as a service, launchd/systemd restarts it with the new binary; otherwise the next upload or CLI/monitor command auto-starts it. The next RPC call hits the fresh daemon. You never need to manually restart the daemon after an update.
-
-The daemon applies the same self-restart to **config changes**. It loads its config once at startup, so it periodically re-fingerprints the active config file; when the file changes on disk (e.g. you edit `local_max_size`), it schedules the same graceful restart and comes back up with the new config — no manual `kache daemon stop` needed. Only the config *file* is watched: a running process's environment is fixed, so `KACHE_*` env overrides apply only to freshly started daemons. A manually managed daemon must be stopped and started from the intended environment. An installed service inherits its service definition, not the shell that invokes `kache daemon restart`.
-
-<Callout type="info">
-Restarting the daemon adds no latency to in-progress rustc invocations: the remote-check hot path never starts the daemon (it skips straight to compilation on a miss). Only the background upload path will lazily (re)start a downed daemon.
-</Callout>
+The daemon also fingerprints the active config file and restarts after it changes. Environment is fixed at process start, so changing an export requires a daemon started from the new environment. An installed service uses its stored environment.
 
 ## Idle shutdown
 
-The daemon runs indefinitely by default. You can opt into automatic shutdown after a stretch with no connections; it is re-spawned on the next build.
+The default idle timeout is disabled:
 
 ```toml
-# config.toml
 [cache]
-daemon_idle_timeout_secs = 600   # opt into exit after 10 min idle; 0 disables
+daemon_idle_timeout_secs = 600
 ```
 
-You can also set `KACHE_DAEMON_IDLE_TIMEOUT` (seconds). **The default is `0`, which disables the watchdog.** Set it to a positive number to opt into idle shutdown; otherwise the daemon runs until you stop it, the binary updates, or the OS signals it.
-
-## Lifecycle internals
-
-A few behaviors worth knowing about:
-
-- **Single instance**: a second `kache daemon run` exits cleanly (code 0) if another process holds the run lock or the socket is already live, so launchd/systemd `KeepAlive` won't loop. Stale socket files are removed on startup when nothing is listening.
-- **Background log file**: auto-started daemons write stderr to `<socket>.log` next to the daemon socket (under `KACHE_RUNTIME_DIR` unless `KACHE_SOCKET_PATH` overrides it). It is reset to a `--- log rotated ---` marker once it grows past 2 MiB. `kache daemon log` tails this file.
-- **Graceful drain**: on shutdown the daemon closes its upload queue and waits up to 30 s for in-flight remote uploads to finish before aborting workers.
+The equivalent environment variable is `KACHE_DAEMON_IDLE_TIMEOUT`. A later build can start the daemon again.
 
 ## Offline behavior
 
-If the daemon is down or unreachable when the wrapper makes an RPC call, the wrapper continues without it. This affects:
+When the daemon cannot be reached:
 
-- **Remote checks**: skipped — the wrapper goes straight to compilation on a local miss
-- **Upload jobs**: the wrapper records each validated intent under `<cache_dir>/upload-queue` before sending it. First publication is create-only and serialized with GC; the daemon idempotently reuses that durable file. Every GC policy keeps the intent's local payload until the daemon retires the file after confirming the object is present. The daemon replays remaining intents after restart and defers availability failures without failing the build.
-- **Prefetch**: skipped for the current build session
+- local hits and local stores continue
+- exact remote checks and prefetch are skipped
+- validated upload intents remain in `<cache_dir>/upload-queue`
+- a later daemon replays queued uploads before retiring their files
 
-The monitor shows `daemon: offline` when the daemon hasn't responded in the last refresh cycle. Common causes:
-
-| Symptom | Likely cause |
-|---|---|
-| `daemon: offline` after reboot | Service not installed, or install is user-scoped and session hasn't started |
-| `daemon: offline` after update | Epoch mismatch restart in progress — wait a second and refresh |
-| `daemon: offline` continuously | Check `kache daemon log` for startup errors |
-
-When the monitor shows `daemon: offline`, it falls back to reading the local store and event log directly, so the Build and Store tabs still show accurate data.
+The monitor falls back to direct store and event-log reads. Check `kache daemon log` when it remains offline.

--- a/docs/daemon/overview.mdx
+++ b/docs/daemon/overview.mdx
@@ -1,64 +1,42 @@
 ---
-title: Overview
-description: What the daemon does, when it matters, and when you can skip it.
+title: Daemon overview
+description: What the background daemon owns and what still works without it
 ---
 
-# Daemon
+The daemon keeps network and maintenance work away from compiler processes. Local cache lookup and storage do not require it.
 
-The daemon is a background process that handles everything that shouldn't block the build. The wrapper process is on cargo's critical path — every millisecond it adds to a rustc invocation adds to your build time. Anything that involves network I/O or heavy computation goes to the daemon instead.
+## Responsibilities
 
-## What the daemon handles
+- Download an exact entry after a local miss.
+- Upload newly stored entries in the background.
+- Replay durable upload intents after a restart.
+- Prefetch likely entries at the start of a build session.
+- Refresh the remote key index used by fallback planning.
+- Run garbage collection at startup and every six hours.
 
-**Upload queue.** After a cache miss and successful compilation, the wrapper hands the daemon a reference to the freshly stored entry and returns immediately. The daemon reads it from the local store and uploads to the configured remote in the background. No build time is spent waiting for uploads.
+Set `cache.prefetch_enabled = false` or `KACHE_PREFETCH_ENABLED=0` to disable speculative prefetch while retaining exact remote checks and uploads.
 
-**Remote checks.** Before compiling a crate that missed locally, the wrapper asks the daemon to check the remote for the artifact. The daemon downloads it if found, then signals the wrapper to restore from the local store.
+## When it is required
 
-**Prefetch.** At the start of a new build session, the wrapper detects that a build is beginning (via a timestamped marker file), runs `cargo metadata` to get the full dependency graph, and sends the daemon a prefetch hint with all crate names in topological order. The daemon prefetches them from the remote before cargo even asks for them, turning remote hits into local hits for the rest of the build.
+Local-only caching works with no daemon. A configured remote needs the daemon for reads, writes, and prefetch. If the daemon is unavailable, the wrapper continues with the local store and compiles an exact remote miss locally.
 
-The prefetch hint fires once per build session (with a 5-minute cooldown) to avoid redundant work across sequential cargo commands in CI — `cargo check`, `cargo clippy`, `cargo test` may all run within the same session window.
+## Endpoint placement
 
-Prefetch is optional. Set `KACHE_PREFETCH_ENABLED=0` or `[cache] prefetch_enabled = false` on a long-lived runner whose persistent local store is already warm. The daemon then skips manifest warming, build-start planning, direct prefetch requests, and remote key-cache population. Exact-key remote checks and background uploads remain enabled.
+On Unix the default socket is `<runtime_dir>/daemon.sock`. Windows derives a named-pipe identity from the configured path. Override the runtime root with `KACHE_RUNTIME_DIR` or only the endpoint with an absolute `KACHE_SOCKET_PATH`.
 
-When prefetch is enabled, the fallback planner maintains a remote key index. `KACHE_REMOTE_KEY_CACHE_REFRESH_SECS` / `cache.remote_key_cache_refresh_secs` controls its refresh interval; `0` performs one initial population and disables periodic refreshes.
+Use a short, user-owned runtime directory. Unix socket paths are length-limited, and shared temporary directories allow another local user to interfere with adjacent lock and state files.
 
-**Garbage collection.** The daemon runs a GC sweep immediately on startup and then every 6 hours — eviction, dedup, orphan-blob cleanup, and incremental-dir pruning — so the store stays bounded without blocking any build.
+Every client and daemon process must resolve the same runtime and socket settings. Installed services do not inherit later shell exports; put persistent values in the config or service definition.
 
-<Callout type="info">
-When a planner endpoint ([Remote service](/docs/remote-service)) is configured, the daemon asks it first and prefetches its ranked candidates from prior builds — useful on cold runners where `cargo metadata` alone underprefetches. Otherwise it falls back to the metadata/local planner; nothing else is needed. The client support ships in the daemon today; the hosted planner service is still in preview.
-</Callout>
+## Basic commands
 
-## When the daemon is optional
-
-If you're using kache locally with no remote configured, you don't need the daemon. Local caching works entirely without it — the wrapper reads and writes the local store directly.
-
-The daemon becomes necessary as soon as you configure a remote cache. Without it:
-
-- New artifacts won't be uploaded to the remote
-- The cache won't be checked before a local miss triggers compilation
-- Prefetch won't run
-
-You'll still get local cache hits from previous builds, but the remote is effectively inert.
-
-## Communication
-
-The wrapper communicates with the daemon over a Unix socket at `<runtime_dir>/daemon.sock` (on Windows this becomes a named pipe). The runtime dir defaults to the cache dir for compatibility and can be set with `KACHE_RUNTIME_DIR` or `[cache] runtime_dir`; the socket alone can be overridden with `KACHE_SOCKET_PATH`. RPC calls are synchronous from the wrapper's perspective but non-blocking — the remote check has a 3-second timeout, so even a hung daemon caps the added latency.
-
-`KACHE_SOCKET_PATH` exists for one specific failure: unix sockets cap the path at 104 bytes on macOS and 108 on Linux, so a deep `runtime_dir` (nested worktrees, long CI checkout paths) makes `<runtime_dir>/daemon.sock` unbindable and the daemon never comes up. Pointing the socket at a short path fixes it without moving either directory.
-
-Pick a short directory that only you can write to — `$XDG_RUNTIME_DIR/kache` on Linux or a CI job's private temporary directory. Avoid shared `/tmp` paths: the daemon keeps its lock, state, and log files next to the socket, and another local user could create those files or bind the socket first. Values must be absolute. Unusable `KACHE_SOCKET_PATH` values are logged and fall back to `<runtime_dir>/daemon.sock`.
-
-Every process has to agree on `KACHE_RUNTIME_DIR` and any socket override: the wrapper, CLI, and daemon each resolve them at startup. If you run the daemon under launchd or systemd (`kache service install`), the generated service doesn't inherit your shell profile, so put persistent settings in the config file or the service definition.
-
-On Windows nothing is bound at the path: it is hashed into a named pipe (`\\.\pipe\kache-daemon-<hash>`), so `KACHE_SOCKET_PATH` still selects *which* daemon you talk to, and the unix length limit doesn't apply. The daemon still writes its lock, state, and log files next to the configured path, so pick a directory you own there too.
-
-If the daemon is unreachable (not running, stale socket, or timeout), the wrapper silently skips the daemon — logging at debug level only on a connect/timeout error — and continues without it. The monitor shows `daemon: offline` in this state, but local cache data is still displayed.
-
-## Starting the daemon
-
-```sh
-kache daemon start     # start in background, returns when ready
-kache daemon           # show status (service, running state, socket, log path, version)
-kache daemon log       # tail the daemon log
+```bash
+kache daemon start
+kache daemon status
+kache daemon log
+kache daemon stop
 ```
 
-For persistent operation, install as a system service — see [Lifecycle](/docs/daemon/lifecycle).
+Bare `kache daemon` is an alias for `kache daemon status`.
+
+See [Lifecycle](/docs/daemon/lifecycle) for service installation and restart behavior.

--- a/docs/deduplication.mdx
+++ b/docs/deduplication.mdx
@@ -1,64 +1,43 @@
 ---
 title: Deduplication
-description: How content-addressed storage and zero-copy restores eliminate redundant disk usage.
+description: How Kache shares output bytes and restores them safely
 ---
 
-# Deduplication
-
-Rust's build system compiles the same crate multiple times in a workspace — once per unique combination of features, targets, and profiles. Without a cache, each compilation writes a fresh copy of the output files. kache avoids this through two mechanisms: content-addressed storage and zero-copy restores (reflink where the filesystem supports it, hardlink or copy otherwise).
+Kache saves disk in two independent places: inside the store and between the store and build trees.
 
 ## Content-addressed blobs
 
-Every compiled artifact stored in kache's local store is named after its blake3 hash. If two different crate compilations produce identical output — which happens frequently for crates that appear in multiple feature sets — they share a single blob file. Only one physical copy exists on disk, no matter how many cache entries reference it.
+Each output blob is named by its BLAKE3 content hash:
 
-The store directory layout looks like this:
-
-```
-~/.cache/kache/
-└── store/
-    └── blobs/
-        ├── ab/
-        │   └── abcdef1234...   ← a blob, named by hash
-        └── cd/
-            └── cdabef5678...
+```text
+<cache-dir>/store/blobs/ab/abcdef...
 ```
 
-The cache directory is `~/.cache/kache` on Linux, `~/Library/Caches/kache` on macOS, and `%LOCALAPPDATA%\kache` on Windows; override it with `KACHE_CACHE_DIR`. Blobs live two levels deep, under `store/blobs/<first-2-hex>/<hash>`; cache-entry directories (`<cache_key>/meta.json`) sit directly under `store/`.
+Entries refer to blobs through metadata and the SQLite index. Identical bytes share one blob even when they came from different cache keys. Garbage collection removes a blob only after no entry needs it.
 
-The SQLite index (`index.db`, a sibling of `store/`, not inside it) tracks which blobs belong to which cache entries. When an entry is evicted by GC, the blob is removed only if no other entry references it.
+## Restore methods
 
-## Zero-copy restores
+Kache chooses the safest available method per artifact:
 
-When kache restores a cache hit, it doesn't copy blob files into `target/` if it can avoid it. On every platform it first tries a **reflink** — a copy-on-write clone that is zero-copy *and* gives the restored file an independent inode — where the filesystem supports it (APFS on macOS, btrfs, XFS with reflink, the common dev case). Mutations to a reflinked file never propagate back to the cache blob.
+1. copy-on-write clone on APFS, ReFS, btrfs, or reflink-capable XFS
+2. one exclusive Unix hardlink carrier for immutable `.rlib` and `.rmeta` artifacts
+3. byte copy
 
-On filesystems without copy-on-write (e.g. ext4 without `reflink`, tmpfs, NTFS), kache falls back per platform and artifact type:
+Executable and loadable outputs use clone or copy, never the hardlink fallback, because signing, stripping, or another consumer may modify them. Windows copies on non-CoW volumes unless the unsafe `windows_hardlink` option is enabled.
 
-- **Exclusive hardlink on Unix** for immutable artifacts (`.rlib` / `.rmeta`): when the blob has no existing target consumer, one target may share its inode. Additional target trees get private copies so their required restore-time mtime stamp cannot change a file another linker is reading. A hardlink that fails — for example across mount points — also falls back to a plain copy.
-- **Copy** for mutable, OS-loaded outputs (`bin`, `dylib`, `cdylib`, `proc-macro`): the build may modify the file after linking (codesigning, stripping), so kache never hardlinks these. Where reflink is available they are still reflinked (then made executable); only the non-CoW fallback is a byte copy.
-- **Copy on Windows by default** for every non-CoW restore. The `windows_hardlink` legacy opt-in permits unrestricted hardlink sharing, but is unsafe for concurrent builds and consumers that mutate outputs.
+Reflinks have independent inodes. A later write copies changed blocks instead of modifying the store blob.
 
-Under the default settings, the shared-inode property holds only on Unix and only for the blob plus its single hardlink carrier. Reflinks share physical blocks through copy-on-write while giving every restore its own inode; additional Unix non-CoW consumers trade that storage sharing for active-reader safety.
+## Monitor metrics
 
-## The dedup line in the monitor
+The monitor separates:
 
-The monitor header carries a single dedup line, for example:
+- `Dedup`: logical bytes avoided by content-addressed blob sharing
+- `Blobs`: physical blob bytes in the store
+- `Hardlinks`: Unix bytes shared through the hardlink fallback
+- `Scan`: whether link accounting is running or complete
 
-```
-Dedup: 1.2 GiB saved (38.4%)    Blobs: 1.9 GiB physical    Hardlinks: 240 MiB via 312 hardlinks    Scan: idle
-```
+A zero hardlink count is normal on copy-on-write filesystems. Their sharing is reflected by filesystem allocation, not inode link count.
 
-The pieces map to two independent measurements:
+## `dup` build events
 
-- **`Dedup: <bytes> saved (<pct>%)` / `Blobs: <bytes> physical`** — content-addressed blob savings: how much is saved by storing each unique output once (logical − physical blob bytes), and the physical size of the blob store. This figure is cross-platform.
-- **`Hardlinks: <bytes> via <N> hardlinks`** — the inode-link scan: bytes that the hardlink fallback keeps from being separate copies, summed from blob link counts. When no blob has extra links this reads `none — restores prefer reflink/CoW` — the expected state on copy-on-write filesystems (APFS, btrfs, XFS-with-reflink), where restores are reflinks with independent inodes (so `nlink` stays 1) and the real savings are the cross-platform `Dedup` figure above. This scan is Unix-only; on Windows it always reports zero, because Windows does not expose a portable inode link count.
-- **`Scan: <calculating | idle | not scanned>`** — `calculating` means the background scan is running right now, `idle` means it finished and is waiting for the next interval, `not scanned` means it hasn't run yet. A freshly built project may not be reflected until the next scan.
-
-The dedup line is informational — it doesn't affect behavior and doesn't need to reach any particular value to confirm kache is working correctly.
-
-## `dup` events are different
-
-The monitor's `dup` outcome is not the same thing as the dedup storage
-line above. A `dup` event means a cache key missed, the compiler ran, and the
-compiled output hashes were already present before storing. That usually points
-to equivalent builds under different keys, such as over-specific arguments,
-paths, or environment inputs. It still counts as compiled work.
+A `dup` event is not a restore and is not the dedup metric. It means the cache key missed, the compiler ran, and all resulting blobs were already present. Repeated dups can expose noisy or over-specific key inputs.

--- a/docs/getting-started/c-cpp.mdx
+++ b/docs/getting-started/c-cpp.mdx
@@ -1,98 +1,89 @@
 ---
 title: C/C++ caching
-description: Wrap cc, c++, gcc, clang, and clang-cl for local object-compile caching.
+description: Cache supported GCC, Clang, and clang-cl object compilations
 ---
 
-# C/C++ caching
+Kache caches conservative, single-source C and C++ object compilations. If it cannot prove that an invocation is safe to cache, it runs the real compiler unchanged.
 
-kache can wrap C and C++ compilers in addition to rustc. This path is live for local object compiles and intentionally conservative: if kache cannot model an invocation safely, it passes through to the real compiler.
+## Set up the wrapper
 
-## Setup
+For build systems that honor `CC` and `CXX`:
 
-For Make, CMake, autotools, or build scripts that honor `CC` / `CXX`:
-
-```sh
+```bash
 export CC="kache cc"
 export CXX="kache c++"
 ```
 
-For Cargo build scripts that use the Rust `cc` crate, also declare `kache` as a known wrapper so the crate keeps the real compiler argument:
+The Rust `cc` crate also needs to know that `kache` is a wrapper:
 
-```sh
-export CC_KNOWN_WRAPPER_CUSTOM="kache"
+```bash
+export CC_KNOWN_WRAPPER_CUSTOM=kache
 ```
 
-For clang-cl / MSVC-driver mode:
+For build systems that call compiler names directly, install shims on Unix:
 
-```bat
-set "CC=kache clang-cl"
+```bash
+kache install-shims ~/.local/lib/kache/shims
+export PATH="$HOME/.local/lib/kache/shims:$PATH"
 ```
 
-kache recognizes `cc`, `c++`, `gcc`, `g++`, `clang`, `clang++`, versioned variants like `gcc-13`, target-prefixed cross compilers like `arm-linux-gnueabihf-gcc`, `clang-cl`, and `clang --driver-mode=cl`. Any other compiler wrapper names that miss this allowlist are dynamically detected via `-E` preprocessor probing.
+Kache creates `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++` symlinks. Keep the real compilers later in `PATH`; Kache skips paths that resolve back to itself.
 
-## What Is Cached
+For clang-cl driver mode:
 
-kache caches single-source object compiles:
+```powershell
+$env:CC = "kache clang-cl"
+```
 
-```sh
+## Cached invocations
+
+Supported shapes compile one source into one object:
+
+```bash
 cc -c src/foo.c -o build/foo.o
 c++ -c src/foo.cpp -o build/foo.o
-clang-cl -c foo.c -Fofoo.obj
+clang-cl /c foo.c /Fofoo.obj
 ```
 
-On a hit, kache restores the object file and dep-info sidecar without re-running the compiler. The key includes:
+The key includes preprocessor output, compiler identity, modeled code-generation options, and normalized paths. Header changes therefore invalidate the entry.
 
-- preprocessor output, so header edits invalidate the object
-- compiler identity and resolved target/codegen flags
-- source path normalization for gcc/clang
-- CodeView path inputs for clang-cl debug compiles (`/Z7`, `-Z7`, `-g`)
+Kache recognizes GCC, Clang, Apple Clang, clang-cl, versioned names such as `gcc-13`, and target-prefixed compiler names. It can probe other wrapper names to identify the underlying compiler family.
 
-For gcc/clang, keys are portable across worktrees when paths normalize cleanly. Use `KACHE_BASE_DIR` for checkout, container mount, or shared source/build prefixes the automatic detection cannot strip.
+## Portability
 
-For clang-cl debug builds, keys are machine-local. clang-cl embeds CodeView paths in the `.obj` and does not honor `-ffile-prefix-map`, so kache keeps those paths literal instead of pretending the object is portable.
+GCC and Clang entries can be reused across worktrees when source and build paths normalize cleanly. Set `KACHE_BASE_DIR` when the automatic roots do not cover a container mount or out-of-tree layout:
 
-## Out-of-tree builds
-
-kache supports out-of-tree C/C++ builds, including sibling CMake-style layouts:
-
-```sh
-cmake -S source -B build
-cmake --build build
-```
-
-The cache key normalizes both source and build roots when kache can derive them from the compiler invocation. If generated sources, configured headers, or `__FILE__` paths point above those roots, set `KACHE_BASE_DIR` to the common parent so the same object can hit across fresh checkouts:
-
-```sh
+```bash
 KACHE_BASE_DIR="$PWD" cmake --build build
 ```
 
-## What Passes Through
+clang-cl debug objects remain machine-local because CodeView records paths that clang-cl does not remap.
 
-These shapes compile normally but are not cached yet:
+## Passthroughs
 
-- link or whole-program steps
-- multi-source or multi-arch invocations
-- response files (`@file`)
+Kache currently passes through:
+
+- link and whole-program steps
+- multi-source or multi-architecture invocations
+- response files
 - precompiled headers and modules
-- coverage and split-DWARF
-- clang-cl `-bigobj` and `-showIncludes`
-- flags kache has not classified
+- coverage and split-DWARF builds
+- flags it has not classified
 
-C/C++ artifacts are local-only today. Remote sync and sharing apply to Rust artifacts, not `cc` objects.
+C/C++ entries are local-only. Remote sync currently handles Rust entries.
 
-## Diagnosing Passthroughs
+Inspect passthrough reasons in the monitor or logs:
 
-Use `kache monitor` and open the Passthrough tab, or run with debug logging:
-
-```sh
+```bash
+kache monitor
 KACHE_LOG=kache=debug make
 ```
 
-If a safe flag is missing from kache's built-in allow-list, opt it in locally:
+You can opt a known-safe flag into the local model:
 
 ```toml title=".kache.toml"
 [cc]
-extra_allowlist_flags = ["-ffunction-sections", "-fdata-sections"]
+extra_allowlist_flags = ["-ffunction-sections"]
 ```
 
-The flag is folded into the key verbatim. Avoid host-dependent values like `-march=native`, because the same spelling can produce different objects on different CPUs.
+Kache folds the spelling into the key. Do not allow flags whose meaning depends on the host, such as `-march=native`.

--- a/docs/getting-started/comparison.mdx
+++ b/docs/getting-started/comparison.mdx
@@ -1,0 +1,62 @@
+---
+title: Kache or sccache?
+description: Choose a compiler cache based on the workflow you need
+---
+
+Kache and [sccache](https://github.com/mozilla/sccache#readme) both avoid repeated compiler work. They differ more in workflow than in headline purpose.
+
+This page describes the current projects; it does not claim that one cache is universally faster. Test the same repository, toolchain, runner, and remote before deciding.
+
+## Main differences
+
+| Question | Kache | sccache |
+| --- | --- | --- |
+| Primary workflow | Local-first cache with optional explicit remote synchronization | Client-server compiler cache with local and remote storage |
+| Rust setup | `RUSTC_WRAPPER=kache`, `kache init`, or `kache cargo` | `RUSTC_WRAPPER=sccache` |
+| C/C++ setup | Compiler-name shims or build-system launcher configuration | Compiler wrapper or build-system launcher configuration |
+| Remote backends | S3-compatible storage and filesystem paths | S3, Redis, Memcached, GCS, Azure, GitHub Actions, WebDAV, and others listed by sccache |
+| Inspection | `monitor`, `stats`, `why-miss`, `report`, `list`, and `doctor` | `--show-stats`, logs, and server commands |
+| Remote transfer | On-demand restore plus `sync`, manifests, and prefetch | Remote access is part of normal server operation |
+| Rust executables | Cacheable by default on Linux and macOS | Rust crates that invoke the system linker are not cached, according to the sccache README |
+| Incremental Rust builds | Kache disables or isolates incremental state according to its configured policy | Incrementally compiled Rust crates are not cached, according to the sccache README |
+| Fallback | Can hand Kache passthroughs to another wrapper with `KACHE_FALLBACK` | No Kache-specific handoff needed |
+
+## Choose Kache when
+
+- You want cache entries shared across local worktrees without a remote.
+- You want to inspect individual events and ask why a compile missed.
+- You want explicit pull, push, manifest, and prefetch controls for CI.
+- Caching eligible Rust executable and linker outputs matters to your workload.
+
+## Choose sccache when
+
+- You need one of its additional remote backends.
+- Your existing CI or development environment already operates sccache reliably.
+- You need its broader documented compiler set, including CUDA or HIP.
+- Your team prefers its established client-server workflow.
+
+## Measure your own build
+
+Compare cold, local-hit, and remote-hit cases separately. Keep these fixed:
+
+- repository revision and lockfile
+- compiler and linker versions
+- target triple and build profile
+- machine or CI runner class
+- remote region and credentials
+
+Run several samples after one warm-up and compare medians. A count-based hit rate does not show how much compile time was avoided, so record wall time as well.
+
+Kache can generate benchmark artifacts with `kache report` and the repository benchmark harness. See [Benchmarks](/docs/benchmarks).
+
+## Use sccache as a fallback
+
+Kache can pass compiler invocations it declines to cache to sccache:
+
+```bash
+export KACHE_FALLBACK=sccache
+export RUSTC_WRAPPER=kache
+cargo build
+```
+
+The fallback only receives passthrough work. Kache still owns the invocations it decides to cache or isolate.

--- a/docs/getting-started/comparison.mdx
+++ b/docs/getting-started/comparison.mdx
@@ -3,7 +3,7 @@ title: Kache or sccache?
 description: Choose a compiler cache based on the workflow you need
 ---
 
-Kache and [sccache](https://github.com/mozilla/sccache#readme) both avoid repeated compiler work. They differ more in workflow than in headline purpose.
+Kache and [sccache](https://github.com/mozilla/sccache#readme) both avoid repeated compiler work. This page explains the differences for teams moving to Kache or deciding whether it covers their build today.
 
 This page describes the current projects; it does not claim that one cache is universally faster. Test the same repository, toolchain, runner, and remote before deciding.
 
@@ -28,12 +28,13 @@ This page describes the current projects; it does not claim that one cache is un
 - You want explicit pull, push, manifest, and prefetch controls for CI.
 - Caching eligible Rust executable and linker outputs matters to your workload.
 
-## Choose sccache when
+## Where Kache may not fit yet
 
 - You need one of its additional remote backends.
-- Your existing CI or development environment already operates sccache reliably.
-- You need its broader documented compiler set, including CUDA or HIP.
-- Your team prefers its established client-server workflow.
+- You need a compiler Kache does not support yet, such as CUDA or HIP.
+- You must keep an existing sccache deployment unchanged during a migration.
+
+If a missing compiler, backend, or workflow blocks your use of Kache, [open a feature request](https://github.com/kunobi-ninja/kache/issues/new?template=feature_request.md). Include the build command, compiler or backend, and why the fallback described below does not fit. Concrete workloads help us prioritize support.
 
 ## Measure your own build
 
@@ -49,9 +50,9 @@ Run several samples after one warm-up and compare medians. A count-based hit rat
 
 Kache can generate benchmark artifacts with `kache report` and the repository benchmark harness. See [Benchmarks](/docs/benchmarks).
 
-## Use sccache as a fallback
+## Keep sccache during migration
 
-Kache can pass compiler invocations it declines to cache to sccache:
+You can put Kache in front of an existing sccache setup. Kache passes compiler invocations it declines to cache to sccache:
 
 ```bash
 export KACHE_FALLBACK=sccache
@@ -59,4 +60,4 @@ export RUSTC_WRAPPER=kache
 cargo build
 ```
 
-The fallback only receives passthrough work. Kache still owns the invocations it decides to cache or isolate.
+The fallback only receives passthrough work. Kache still owns the invocations it decides to cache or isolate. Remove the fallback when Kache covers the remaining workload.

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -1,632 +1,215 @@
 ---
 title: Configuration
-description: Config file, environment variables, and the TUI editor.
+description: Configure Kache with TOML files and environment variables
 ---
 
-# Configuration
+Kache resolves settings in this order:
 
-kache reads configuration from three places, in order of priority:
+1. environment variable
+2. config file
+3. built-in default
 
-1. **Environment variables** — always win, useful for CI overrides
-2. **Config file** — selected from the config file priority below
-3. **Defaults** — sensible values that work without any configuration
+`KACHE_DISABLED`, `KACHE_CONFIG`, `KACHE_SOCKET_PATH`, logging controls, progress controls, and credentials are operational settings. They do not all have TOML equivalents.
 
 ## Config file
 
-The config file is TOML. You can edit it directly or use the TUI editor:
+Open the editor:
 
-```sh
+```bash
 kache config
 ```
 
-The TUI editor surfaces the common fields with their current values, marks which ones are coming from env vars (those are read-only and the cursor skips them), and lets you toggle or edit the rest interactively. Navigate with the arrows or `j`/`k`, jump between sections with Tab/Shift-Tab, Enter edits a field, Space toggles a boolean, `s` (or Ctrl-S) saves, and `q`/Esc quits with an unsaved-changes prompt. Some advanced sections — `[cache.planner]`, `[cc]`, `[paths]`, `[workspace]`, `cache.path_only_env_vars`, `cache.incremental_crates`, and `cache.key_env_vars` — have no form fields and are preserved verbatim on save.
+Or edit TOML directly. Kache chooses the first file in this order:
 
-Config file priority:
+1. `KACHE_CONFIG`
+2. the nearest `.kache.toml`, walking up from the current directory
+3. `$XDG_CONFIG_HOME/kache/config.toml` or `~/.config/kache/config.toml`
 
-1. `KACHE_CONFIG`, when set
-2. The nearest project-local `.kache.toml`, walking up from the current directory
-3. User config at `~/.config/kache/config.toml`, respecting `XDG_CONFIG_HOME`
+The editor covers common fields and preserves advanced tables it does not expose.
 
-kache currently compiles two remote types: `s3` and `filesystem`.
+```toml title="~/.config/kache/config.toml"
+[cache]
+local_max_size = "50GiB"
+cache_executables = true
 
-<Tabs items={["S3", "Filesystem"]}>
-  <Tab value="S3">
-    ```toml title="~/.config/kache/config.toml"
-    [cache.remote]
-    type = "s3"
-    bucket = "my-build-cache"
-    endpoint = "https://s3.example.com"   # omit for AWS S3
-    profile = "my-aws-profile"            # omit to use the default credential chain
-    ```
-  </Tab>
-  <Tab value="Filesystem">
-    ```toml title="~/.config/kache/config.toml"
-    [cache.remote]
-    type = "filesystem"
-    path = "/mnt/shared-kache"
-    prefix = "artifacts"
-    ```
+[cache.remote]
+type = "s3"
+bucket = "my-build-cache"
+region = "us-east-1"
+```
 
-    `atomic_write_dir` is optional and defaults to
-    `/mnt/shared-kache/.kache-tmp`. See [Filesystem setup](/docs/remote-cache/filesystem-setup)
-    before overriding it.
-  </Tab>
-</Tabs>
+Use `type = "filesystem"` with `path = "/mnt/kache"` for a shared filesystem remote. Only `s3` and `filesystem` are compiled remote backends.
 
-Other OpenDAL services are not included in the kache binary. Existing S3
-configuration names remain compatible: a legacy `[cache.remote]` table without
-`type = "s3"` and an environment-only setup rooted in `KACHE_S3_BUCKET` still
-select S3; the other `KACHE_S3_*` overrides remain available. See the
-[S3 migration boundaries](/docs/remote-cache/s3-setup#opendal-migration-boundaries)
-for AWS SDK-specific cases that need attention.
+## Core settings
 
-## All settings
+| Environment | TOML key | Default | Purpose |
+| --- | --- | --- | --- |
+| `KACHE_CACHE_DIR` | `cache.local_store` | OS cache directory | Persistent store |
+| `KACHE_RUNTIME_DIR` | `cache.runtime_dir` | local store | Socket, locks, logs, state, and session markers |
+| `KACHE_SOCKET_PATH` | none | `<runtime_dir>/daemon.sock` | Absolute daemon endpoint override |
+| `KACHE_MAX_SIZE` | `cache.local_max_size` | `50GiB` | Registered blob bytes allowed before GC |
+| `KACHE_AUTO_GC` | `cache.auto_gc` | `true` | Spawn throttled background GC under size pressure |
+| `KACHE_GC_MAX_AGE_HOURS` | `cache.gc_max_age_hours` | `0` | Automatic age retention; `0` disables it |
+| `KACHE_MIN_STORE_COMPILE_MS` | `cache.min_store_compile_ms` | `0` | Skip local retention for faster compiles; `0` stores all eligible results |
+| `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd level, clamped to 1 through 22 |
+| none | `cache.event_log_max_size` | `10MiB` | Rotate the event log after this size |
+| none | `cache.event_log_keep_lines` | `1000` | Lines retained when the event log rotates |
+| `KACHE_DISABLED` | none | `false` | Pass all compiler work through when set to `1` or `true` |
+| `KACHE_LOCAL_ONLY` | `cache.local_only` | `false` | Ignore all remote and planner configuration while keeping local caching |
+| `KACHE_REMOTE_READONLY` | `cache.remote_readonly` | `false` | Allow remote reads but suppress remote writes |
 
-| Environment variable | Config key | Default | Description |
-|---|---|---|---|
-| `KACHE_CACHE_DIR` | `cache.local_store` | `~/Library/Caches/kache` on macOS, `~/.cache/kache` on Linux | Local cache directory |
-| `KACHE_RUNTIME_DIR` | `cache.runtime_dir` | `<cache_dir>` | Job/process-lifetime state directory: daemon socket, locks, state and background log, event/transfer/summary logs, and build-session markers. Give concurrent jobs sharing one local store distinct runtime directories |
-| `KACHE_SOCKET_PATH` | — | `<runtime_dir>/daemon.sock` | Daemon socket path, for when a deep `runtime_dir` pushes the socket past the platform's unix-socket path limit. Operational and security-sensitive: it decides where clients look for the daemon, so `ignore_env` does **not** cover it (see [Daemon socket placement](/docs/daemon/overview#communication)). Must be absolute; an unusable value warns and falls back to the default |
-| `KACHE_MAX_SIZE` | `cache.local_max_size` | `50GiB` | Maximum local store size, measured as **registered blob content bytes** (each deduplicated blob counted once, not once per entry referencing it; index and metadata overhead sit outside the sum). GC fires above this cap and evicts down to 90%, creating a 10% hysteresis band |
-| `KACHE_AUTO_GC` | `cache.auto_gc` | `true` | Opportunistic size-pressure GC: after storing a new entry the wrapper runs a cheap, throttled (5 min) store-size check and spawns a detached background `kache gc` when the store exceeds `local_max_size` by more than 10%. Keeps the size cap enforced even when no daemon is running (local-only builds). Set to `0`/`false` to rely solely on daemon GC and manual `kache gc` |
-| `KACHE_MIN_STORE_COMPILE_MS` | `cache.min_store_compile_ms` | `0` | Local put-side admission control: a compile faster than this many milliseconds is not retained. `0` (default) stores everything. For Rust artifacts, a configured writable remote bypasses this gate so its staging and publication path is preserved; read-only remotes still honor the threshold. C/C++ artifacts are local-only and always honor it. This is separate from `KACHE_MIN_COMPILE_MS`, which gates remote prefetch downloads |
-| `KACHE_GC_MAX_AGE_HOURS` | `cache.gc_max_age_hours` | `0` (disabled) | Opt-in age-retention hours for automatic GC. A bare `kache gc` sends its effective configured value to the daemon; daemon-periodic and background sweeps use their own effective config. An explicit `kache gc --max-age <duration>` runs only the requested age policy |
-| `KACHE_CONFIG` | — | — | Explicit config file path; overrides the project-local `.kache.toml` / XDG resolution |
-| `KACHE_BASE_DIR` | — | — | Path prefix stripped from cache keys (collapsed to `<BASE_DIR>`) for checkout / container-mount paths the automatic sentinels don't catch — the analog of ccache's `CCACHE_BASEDIR` (see [Cache key](/docs/how-it-works/cache-key)) |
-| — (file-only) | `paths.base_dirs` | `[]` | Extra absolute path prefixes for container mounts, Snap, Flatpak, AppImage, or custom roots; each maps to a distinct deterministic sentinel (see [Extra path prefixes](#extra-path-prefixes)) |
-| — (file-only) | `cache.remote.type` | — | Remote type: `s3` or `filesystem`. A legacy S3 table or `KACHE_S3_BUCKET` still selects S3 when this is omitted |
-| — (file-only) | `cache.remote.path` | — | Shared root directory for a `filesystem` remote |
-| — (file-only) | `cache.remote.atomic_write_dir` | `<path>/.kache-tmp` | Staging directory for filesystem-remote atomic writes; must be on the same filesystem as `path` |
-| `KACHE_S3_BUCKET` | `cache.remote.bucket` | — | S3 bucket name |
-| `KACHE_S3_ENDPOINT` | `cache.remote.endpoint` | — | S3 endpoint URL (required for Ceph, MinIO, R2) |
-| `KACHE_S3_REGION` | `cache.remote.region` | `us-east-1` | AWS region |
-| `KACHE_S3_PREFIX` | `cache.remote.prefix` | `artifacts` | Object or path prefix. The environment override is retained for S3; filesystem remotes configure it in the file |
-| `KACHE_S3_PROFILE` | `cache.remote.profile` | — | AWS credentials profile |
-| `KACHE_S3_USER_AGENT` | `cache.remote.user_agent` | — | Custom User-Agent header for S3 HTTP requests |
-| `KACHE_S3_ACCESS_KEY` | — | — | Explicit S3 access key |
-| `KACHE_S3_SECRET_KEY` | — | — | Explicit S3 secret key |
-| `KACHE_CACHE_EXECUTABLES` | `cache.cache_executables` | `true` on Linux/macOS, `false` on Windows | Also cache user-facing executables (`bin` crates and `--test` binaries). dylib/cdylib/proc-macro are always cached and are unaffected by this flag. On Linux, DWARF is embedded in the binary so a restored executable debugs like a fresh one; on macOS, kache bakes a `.dSYM` at store time and restores it next to the binary so `lldb` keeps source-level symbols ([#319](https://github.com/kunobi-ninja/kache/issues/319)); Windows (`.pdb` path) still references debug info outside the binary, so it stays off pending the equivalent work |
-| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Auto-clean tracked incremental dirs during GC; active builds also remove the current crate's incremental dir eagerly. Env is on unless the value is exactly `0` or `false` (case-insensitive) |
-| `KACHE_ADAPTIVE_INCREMENTAL` | `cache.adaptive_incremental` | `true` | Automatically learn rapidly changing Cargo-primary units after repeated source/dependency misses, then use isolated incremental state for a bounded run before probing the exact artifact cache again. Kache directly owns learned compiles and eligible user-facing executables already excluded by `cache_executables=false` when no fallback is configured; declined compiles otherwise retain the configured fallback. No mutation-tool detection or project setup. Disable with `0`/`false` |
-| `KACHE_PRESERVE_INCREMENTAL` | `cache.preserve_incremental` | `false` | Force every rustc invocation carrying a safe Cargo incremental path to bypass artifact caching and reuse isolated incremental state. Normally unnecessary; useful as a diagnostic/benchmark override. Cargo's dev and test profiles already enable incremental compilation unless a project, environment, or custom profile disables it |
-| `KACHE_INCREMENTAL_CRATES` | `cache.incremental_crates` | `[]` | For eligible Cargo-primary rustc invocations, listed crate names bypass artifact caching and use the adaptive policy's isolated incremental directory and exclusive lease without waiting for its learning heuristic. Unsafe layouts, declared hidden inputs, exclusions, or lease contention retain the normal safe cache/passthrough path with Cargo's original incremental argument stripped. User-facing executables first follow `cache_executables`; an intentional managed passthrough is available only when no fallback owns the compile. Entries match the actual rustc `--crate-name` with `-`/`_` treated as equal; a Cargo package name is not authoritative because its targets may have different names. The env value is comma/whitespace-separated and replaces the file list |
-| `KACHE_VERIFY_RESTORES` | — | `off` | Re-hash restored blobs before serving hits: `off`, `sampled` (~1/16 hits), or `always`. `1`/`true` map to `always` |
-| — | `cache.exclude` | `[]` | Source-path glob patterns that bypass kache and compile normally without lookup, store, or upload |
-| — | `cache.bypass_crates` | `[]` | Exact crate names that bypass kache and compile normally |
-| — | `cache.bypass_argv` | `[]` | Argument substrings that bypass kache and compile normally |
-| — | `cache.bypass_env` | `[]` | `NAME=VALUE` (exact value) or `NAME` (presence) env rules that bypass kache and compile normally |
-| `KACHE_COMPRESSION_LEVEL` | `cache.compression_level` | `3` | Zstd compression level (1–22) |
-| `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `16` | Max concurrent remote operations; the legacy S3 name applies to both remote types |
-| `KACHE_PREFETCH_ENABLED` | `cache.prefetch_enabled` | `true` | Enable speculative manifest/advisory/fallback prefetch. Set to `0`/`false` on long-lived warm runners to skip manifest warming, build-start planning, and the whole-remote key index. Exact-key remote checks and background uploads remain enabled. A running daemon cannot see environment changes; prefer the watched config file for persistent or service-managed daemons |
-| `KACHE_REMOTE_KEY_CACHE_REFRESH_SECS` | `cache.remote_key_cache_refresh_secs` | `60` | Remote key-index refresh interval used by speculative fallback planning. A negative index entry suppresses an exact remote HEAD only while the index is fresh, for at most `min(refresh × 5, 300s)`. `0` performs one initial population, never treats negative entries as authoritative, and disables periodic refresh. Ignored when `prefetch_enabled = false` |
-| `KACHE_PREFETCH_MAX_KEYS` | `cache.prefetch_max_keys` | `2000` | Max cache entries one prefetch plan may download; `0` = unlimited |
-| `KACHE_PREFETCH_MAX_BYTES` | `cache.prefetch_max_bytes` | `2GiB` | Max compressed bytes one prefetch plan may download; `0` = unlimited. Soft cap: downloads already in flight still finish, so overshoot is bounded by the prefetch concurrency |
-| `KACHE_PREFETCH_DEADLINE_SECS` | `cache.prefetch_deadline_secs` | `300` | How long a prefetch plan may keep starting downloads; `0` = no deadline |
-| `KACHE_S3_POOL_IDLE_SECS` | `cache.s3_pool_idle_secs` | `300` | How long an idle S3 connection is kept in the HTTP pool. Higher values reuse warm TLS sessions across build phases; lower this if you sit behind a load balancer that drops idle connections aggressively |
-| `KACHE_REMOTE_RESTORE_TIMEOUT_SECS` | `cache.remote_restore_timeout_secs` | `300` | One monotonic daemon deadline for a remote operation, including concurrency queues, HEAD/LIST, GET/PUT, and restore decompression/extraction. Synchronous compiler-wrapper demand retains its legacy hard 3s end-to-end ceiling across mixed versions; the wrapper sends that budget and this setting may only tighten it. Demand expiry reports a miss so rustc recompiles; background work is deferred or skipped safely. `0` disables the configured background deadline but does not remove the 3s demand ceiling (transport connect/read-inactivity limits still apply) |
-| `KACHE_REMOTE_NEGATIVE_TTL_SECS` | `cache.remote_negative_ttl_secs` | `60` | How long the daemon remembers a definitive remote miss (404 only — never timeouts, 5xx, or credential errors) so parallel wrappers demanding the same absent key share one first check instead of stampeding S3. Successful uploads invalidate misses immediately, and per-key generations prevent late HEAD/GET/prefetch results from undoing newer knowledge. `0` disables the negative cache |
-| `KACHE_DAEMON_IDLE_TIMEOUT` | `cache.daemon_idle_timeout_secs` | `0` | Idle daemon shutdown timeout in seconds (`0` disables auto-shutdown) |
-| `KACHE_KEY_SALT` | `cache.key_salt` | — | Opaque string folded into every cache key. Change it to force a cold cache on a toolchain change kache cannot otherwise see (see [Cache-key salt](#cache-key-salt)) |
-| `KACHE_CC_EXTRA_ALLOWLIST_FLAGS` | `cc.extra_allowlist_flags` | `[]` | C/C++ flags to opt into caching that kache's built-in allow-list doesn't yet model (see [Extra cc allowlist flags](#extra-cc-allowlist-flags)). Env value is whitespace-separated |
-| `KACHE_DISABLED` | — | `false` | Disable caching entirely (pass-through to rustc). Env-only, no config key: `1` or `true` (case-insensitive) disables; any other value — including `0`, `false`, or unset — leaves caching on |
-| `KACHE_LOCAL_ONLY` | `cache.local_only` | `false` | Strict local-only mode: ignore **all** remote and planner config/env (no configured remote, no planner endpoint, no egress) for a guaranteed-hermetic build. Local caching stays fully on — unlike `KACHE_DISABLED`. `1`/`true` enables; env wins over the file (an explicit `0` overrides `local_only = true`) |
-| `KACHE_REMOTE_READONLY` | `cache.remote_readonly` | `false` | Read-only remote consumer mode: when enabled, kache performs remote cache reads/restores as normal, but suppresses all remote uploads (including the sync push phase and manifest saving). `1`/`true` enables; env wins over the file (an explicit `0` overrides `remote_readonly = true`) |
-| `KACHE_WINDOWS_HARDLINK` | `cache.windows_hardlink` | `false` | Windows only: restore cache hits on non-CoW volumes (NTFS) via hardlink instead of copy, deduplicating the working tree against the store. Opt in **only** if your build never deletes or rewrites a restored output in place and never runs concurrent builds against the same store — mutations corrupt the shared blob, and restore-time timestamp changes can abort an active reader (#794). ReFS (Dev Drive) volumes always block-clone regardless of this flag |
-| `KACHE_STORAGE_LAYOUT_ADVICE` | `cache.storage_layout_advice` | `true` | Surface an advisory (deduplicated, at most once per 5-minute window) when a cache hit is restored by copy because the storage layout prevents zero-copy dedup: no copy-on-write on the volume, cache and build tree on different volumes, or an inconclusive capability probe. Set to `0`/`false` when the layout is intentional (e.g. an NTFS-only machine that cannot host a ReFS Dev Drive); genuine clone faults are still reported |
-| `KACHE_HEARTBEAT_SECS` | `cache.heartbeat_secs` | `30` | In-flight compile heartbeat cadence: while a cache-miss compile runs longer than one cadence, kache appends a structured `heartbeat` line to `events.jsonl`. With `KACHE_PROGRESS=verbose`/`all`, it also prints `still compiling <crate> — 4m20s elapsed (typical: 7m51s, ETA 3m31s)` to stderr. The typical/ETA figures come from the median of the crate's recent recorded compile times. `0` disables both sinks |
-| `KACHE_EXPLAIN_MISS` | `cache.explain_miss` | `false` | Miss diagnostics: on a cache miss for a crate that previously hit in the same build tree, print which key input group changed (`key changed in: args, env_deps`) and record it on the miss event. Costs one event-log read per miss, so enable it only while investigating unexpected misses |
-| — (file-only) | `cache.ignore_env` | `false` | Make the config file authoritative by ignoring `KACHE_*` env overrides for file-backed settings (see [Pinning config against env](#pinning-config-against-env)) |
-| `KACHE_FALLBACK` | `cache.fallback` | — | Secondary compiler-wrapper for ordinary passed-through compiles; kache runs `<fallback> <compiler> <args>` when it declines to cache outside its directly owned adaptive lane. `off`/`none`/empty disables |
-| `KACHE_PATH_ONLY_ENV_VARS` | `cache.path_only_env_vars` | `[]` | Plain path-locator env vars, plus optional `rustc_crate_name:VAR` force assertions for one crate. Env value is comma/whitespace-separated and replaces the file list (see [Path-only env vars](#path-only-env-vars)) |
-| `KACHE_KEY_ENV_VARS` | `cache.key_env_vars` | `[]` | Env vars to fold into every cache key, for values a proc macro reads at expansion time that the compiler never reports. Exact names or a trailing-`*` prefix glob. Env value is comma/whitespace-separated and replaces the file list (see [Env vars that steer expansion](#env-vars-that-steer-expansion)) |
-| `KACHE_PLANNER_ENDPOINT` | `cache.planner.endpoint` | — | Prefetch-planner service URL; setting it enables the planner client. Empty/whitespace is treated as unset |
-| `KACHE_PLANNER_TIMEOUT_MS` | `cache.planner.timeout_ms` | `750` | Planner request timeout in milliseconds |
-| `KACHE_PLANNER_TOKEN` | `cache.planner.token` | — | Bearer credential sent with planner requests |
-| `KACHE_NAMESPACE` | — | — | Enables content-addressed shard uploads/prefetch (requires a `Cargo.lock`); the `kache save-manifest --namespace` flag takes precedence. Unset uploads only the monolithic manifest |
-| `KACHE_EVENT_ROOT` | — | auto-detected | Explicit root path stamped on wrapper events for report filtering; useful for benchmark harnesses that share a cache/event log |
-| `KACHE_LOG` | — | `kache=warn` * | Log level for stderr output |
-| `KACHE_LOG_FILE` | — | `kache=info` * | Log level for the file log |
-| `KACHE_PROGRESS` | — | (off) | Per-crate progress lines to stderr: `1`/`hits` prints cache hits only; `verbose`/`all` also prints dups, misses, and in-flight heartbeats; unset or anything else stays silent |
-| `KACHE_PAGER` | — | `$PAGER`, then `less -FRX` on Unix / `more.com` on Windows | Pager program and arguments for populated interactive `kache list` output. Empty or the single command `cat` disables paging; see the [command reference](/docs/commands/reference#paging) for the safe argv format |
+On macOS the default store is `~/Library/Caches/kache`; on Linux it is `$XDG_CACHE_HOME/kache` or `~/.cache/kache`; on Windows it is under `%LOCALAPPDATA%`.
 
-\* In wrapper mode (`RUSTC_WRAPPER`, the common path) stderr logging defaults to **off** and the file log is **disabled** unless `KACHE_LOG_FILE` is set explicitly. The `kache=warn` / `kache=info` defaults apply to CLI and daemon invocations.
+## Compiler policy
 
-## Prefetch policy by runner lifetime
+| Environment | TOML key | Default | Purpose |
+| --- | --- | --- | --- |
+| `KACHE_CACHE_EXECUTABLES` | `cache.cache_executables` | Linux/macOS: `true`; Windows: `false` | Cache eligible Rust bins and test executables |
+| `KACHE_CLEAN_INCREMENTAL` | `cache.clean_incremental` | `true` | Remove tracked incremental directories during cleanup |
+| `KACHE_ADAPTIVE_INCREMENTAL` | `cache.adaptive_incremental` | `true` | Learn rapidly changing Cargo units and give them isolated incremental state |
+| `KACHE_PRESERVE_INCREMENTAL` | `cache.preserve_incremental` | `false` | Force eligible Cargo units onto isolated incremental state |
+| `KACHE_INCREMENTAL_CRATES` | `cache.incremental_crates` | `[]` | Force listed rustc crate names onto that incremental path |
+| `KACHE_MODIFIED_INPUT_GUARD` | `cache.modified_input_guard` | `false` | Do not store a result when a keyed input changed at or after build start |
+| `KACHE_FALLBACK` | `cache.fallback` | none | Wrapper used for ordinary Kache passthroughs |
+| none | `cache.exclude` | `[]` | Source-path globs that bypass Kache |
+| none | `cache.bypass_crates` | `[]` | Exact rustc crate names that bypass Kache |
+| none | `cache.bypass_argv` | `[]` | Argument substrings that bypass Kache |
+| none | `cache.bypass_env` | `[]` | `NAME` or `NAME=VALUE` rules that bypass Kache |
+| `KACHE_CC_EXTRA_ALLOWLIST_FLAGS` | `cc.extra_allowlist_flags` | `[]` | Exact C/C++ flag spellings accepted in addition to the built-in model |
 
-Speculative prefetch is designed to hide remote latency on a cold runner by downloading likely artifacts before rustc asks for their exact keys. It is optional: exact-key remote lookup and background uploads use separate daemon paths.
+Bypass rules can only reduce caching:
 
-For a long-lived runner with a persistent local store, speculative prefetch can cost more than it saves. The local store is already warm, while fallback planning may have to index a large shared remote and choose among many variants of the same crate name. Disable speculation without disabling the remote cache:
+```toml title=".kache.toml"
+[cache]
+exclude = ["vendor/problematic/**"]
+bypass_crates = ["generated_bindings"]
+bypass_argv = ["--cfg", "uncacheable_mode"]
+bypass_env = ["SPECIAL_BUILD=1"]
+```
+
+## Cache-key controls
+
+| Environment | TOML key | Default | Purpose |
+| --- | --- | --- | --- |
+| `KACHE_KEY_SALT` | `cache.key_salt` | none | Opaque value folded into every key |
+| `KACHE_BASE_DIR` | none | none | One extra path prefix normalized as `<BASE_DIR>` |
+| none | `paths.base_dirs` | `[]` | Additional absolute prefixes with distinct stable sentinels |
+| `KACHE_PATH_ONLY_ENV_VARS` | `cache.path_only_env_vars` | `[]` | Path locator variables eligible for safe normalization |
+| `KACHE_KEY_ENV_VARS` | `cache.key_env_vars` | `[]` | Environment read by proc macros but not reported by rustc |
+| `KACHE_VERIFY_RESTORES` | none | `off` | Re-hash `sampled` or `always` before restoring |
+
+Use a key salt when an unobserved toolchain component changes output:
 
 ```toml
 [cache]
-prefetch_enabled = false
+key_salt = "sysroot-2026-08"
 ```
 
-This mode keeps local hits, exact remote hits, and asynchronous uploads. It skips startup manifest warming, build-start advisory/fallback planning, direct prefetch requests, and remote key-cache population. The daemon watches the config file and restarts when it changes. A running daemon cannot see a changed `KACHE_PREFETCH_ENABLED`; stop and start a manually managed daemon from the intended environment. An installed launchd/systemd/Task Scheduler service keeps the environment in its service definition, so a shell export followed by `kache daemon restart` does not apply that export.
+Keep `paths.base_dirs` narrow. Normalizing unrelated roots to stable sentinels can make different inputs appear equal.
 
-For cold or ephemeral CI, leave prefetch enabled and use build-shape-specific manifest keys and namespaces. If periodic discovery is useful but a 60-second full listing is too frequent, keep prefetch enabled and raise `remote_key_cache_refresh_secs`. Raising it reduces LIST frequency, but stale negative entries are authoritative for no more than five minutes; after that, exact misses fall through to a remote HEAD probe. Set the interval to `0` for one startup population with no refresh: positive entries and fallback planning still use that snapshot, while negative entries never suppress exact remote lookup.
+`key_env_vars` accepts exact names and trailing-star prefix patterns:
 
-## Excluding Sources
-
-Use `cache.exclude` when a source file should compile normally but never use kache:
-
-```toml title=".kache.toml"
+```toml
 [cache]
-exclude = [
-  "crates/problematic-rust-crate/**",
-  "vendor/problematic-c-lib/**",
-  "$CARGO_HOME/registry/src/**/some-crate-*/**",
-]
+key_env_vars = ["BOLTFFI_*"]
 ```
 
-Patterns are globs matched against the compiler's primary source path. Relative patterns are matched relative to the current build directory and, when kache can infer it, the Cargo workspace root. Excluded invocations bypass local lookup, remote lookup, store, and upload.
+Values are hashed exactly and are not written to event logs. A changing value such as a job ID will destroy hit rate.
 
-Exclude patterns support `~`, `$VAR`, and `${VAR}` expansion. `$CARGO_HOME` falls back to Cargo's default `~/.cargo` when the environment variable is not set, so registry-source exclusions work on default Cargo installs.
+## Hidden compile-time inputs
 
-### Bypass rules
+Some macros read files that rustc does not report. Put `kache.toml` without a leading dot next to the crate manifest:
 
-`cache.exclude` keys on the source path. When the reason a compile must not be
-cached is the *invocation* rather than the file, three sibling lists match on
-the crate name, the argv, and the environment:
-
-```toml title=".kache.toml"
-[cache]
-# Exact crate names.
-bypass_crates = ["my-mutants-runner"]
-# Substring of any single argument.
-bypass_argv = ["--cfg=live_db"]
-# `NAME=VALUE` for an exact value, or bare `NAME` for presence alone.
-bypass_env = ["SQLX_OFFLINE=false"]
-```
-
-The motivating case is an online `sqlx` build: it validates queries against
-live database state that no environment value captures, so two compiles with
-identical sources and environment can legitimately produce different results.
-Adding the variable to `key_env_vars` only *separates* those compiles into
-distinct keys, and still caches them. Declining to cache is the sound answer.
-
-Rules are evaluated before any cache-key work, so a match costs nothing, and
-they are fail-closed by construction: a rule can only mean "do not cache",
-never "force cache", so a misconfigured rule costs hit rate and can never
-produce a wrong artifact. A bypassed compile is reported as a passthrough
-naming the rule that fired, visible in `kache report`.
-
-## Pinning config against env
-
-By default every `KACHE_*` environment variable **wins** over the config file — convenient for CI overrides, but it means a stray machine-global export can silently change behavior. The riskiest case is `KACHE_KEY_SALT`: a leaked export would shift *every* cache key without a word.
-
-Set `ignore_env` to make a pinned config authoritative:
-
-```toml title=".kache.toml"
-[cache]
-ignore_env = true
-key_salt = "v3-toolchain-abc"
-```
-
-With this, kache ignores the `KACHE_*` overrides for **file-backed settings** (cache/runtime dirs, max size, key salt, fallback, remote/planner settings, the toggles, etc.) and takes the file value (or built-in default) instead. When an ignored override is actually set, kache logs a warning naming it, so the suppression is never silent.
-
-`ignore_env` is **file-only** by design — an env var can't re-enable env overrides, or the lockdown would be trivially undone by the same stray export it defends against. It deliberately does **not** cover bootstrap/operational vars that have no file representation (`KACHE_CONFIG`, `KACHE_DISABLED`, `KACHE_SOCKET_PATH`, `KACHE_LOG` / `KACHE_LOG_FILE` / `KACHE_PROGRESS`, `KACHE_PAGER`, `KACHE_NAMESPACE`, `KACHE_BASE_DIR`) or S3 credentials (`KACHE_S3_ACCESS_KEY` / `KACHE_S3_SECRET_KEY`), which are secrets rather than config.
-
-`KACHE_SOCKET_PATH` is the one to watch in that list. Most others log or locate;
-`KACHE_PAGER` only selects a display program when a user explicitly runs a
-populated, interactive `kache list`. The socket variable moves the IPC endpoint,
-so a stray machine-global export redirects every client to a different daemon
-even under a pinned config. Treat it as a trust boundary rather than a setting
-`ignore_env` protects you from, and see [Daemon socket placement](/docs/daemon/overview#communication) for where to put it.
-
-## Cache-key salt
-
-kache's cache key captures everything it can *observe* about a compile: the rustc version, the target, flags, source and dependency hashes, and the linker's `--version` banner. Native Linux OS-loaded outputs also key the host GNU libc or musl version, while portable rlibs and cross-target outputs exclude that host-only signal. The observable set is **not** complete for toolchain changes that leave every reported version unchanged — for example a custom or cross-target libc/sysroot replacement, a distro patch that retains the same upstream libc version, a hidden `mold`/linker change, or a Nix store rebuild that swaps the ELF interpreter baked into a binary.
-
-When that happens, the key does not move, so a stale artifact can be restored. On Nix in particular, a `nixpkgs` bump followed by `nix store gc` can leave a restored executable pointing at a garbage-collected interpreter — an error no `cargo clean` can fix, because the key never changed.
-
-`key_salt` is an opaque string folded into every cache key. Set it to a value that *does* change when your toolchain changes — a hash of the toolchain closure, a store-path digest, a date, a CI build id — and that change re-keys the cache (a cold miss) instead of serving a stale hit:
-
-```toml title=".kache.toml"
-[cache]
-key_salt = "nixpkgs-a1b2c3d-mold-2.40"
-```
-
-Or compute it from the toolchain itself:
-
-```sh
-export KACHE_KEY_SALT="$(nix eval --raw .#devShells.default.outPath | sha256sum | cut -c1-16)"
-```
-
-The salt is hashed raw; its meaning is entirely yours. An unset or empty value has **no effect** — keys are byte-identical to not setting it — so it is safe to leave off until you need it. A misconfigured salt can only cost hit rate (an extra miss), never cause a wrong artifact to be restored.
-
-## Extra cache-key inputs
-
-kache keys a crate on what the compiler reports — source files, `--extern` dependencies, flags. Some crates also read files **at compile time that the compiler never reports**, so kache can't see them change:
-
-- sqlx's `query!` macro reads `.sqlx/query-*.json` (the offline query cache)
-- migration macros read `migrations/`
-- codegen / macros that `include!` data files by a path rustc doesn't surface
-
-Edit one of those and the `.rs` files are unchanged, so the key doesn't move — and kache would restore the previously-compiled artifact (a stale hit). Declare those files so a change to them re-keys the crate.
-
-Add a `kache.toml` next to the crate's `Cargo.toml`:
-
-```toml title="my-app/db/kache.toml"
+```toml title="crates/db/kache.toml"
 extra_inputs = [
   ".sqlx/**/*.json",
   "migrations/**/*.sql",
 ]
 ```
 
-Globs are relative to the crate directory. A bare directory is fine — `.sqlx` and `.sqlx/` both mean "everything under it." The matched files' contents are folded into that crate's key. Patterns must use stable literal paths; `$ENV` and `~` expansion is rejected because Cargo cannot observe that expansion changing.
+Matches are relative to that crate. Kache folds their paths and contents into its key and adds bounded watches to Cargo dep-info. Invalid or unreadable declarations fail closed.
 
-A pattern **may** reach outside the crate with `..` or an absolute path when a build genuinely depends on a shared tree above the crates or a machine-specific file. That's allowed and stays fail-safe, but it makes the crate's key host- or layout-specific (kache logs a warning), so it no longer shares across machines or worktrees — prefer a co-located input where you can.
+For a workspace-root input used by a provider package and its direct consumers:
 
-This is **opt-in and scoped per crate**: a crate with no `kache.toml` is unaffected, and one crate's `extra_inputs` never *implicitly* touch a sibling crate's key. Declared matches only add inputs to the key, but the declaration must cover every hidden compile-time input; an omitted file cannot be tracked. Each file is folded as its crate-relative path plus content hash, so moving the worktree doesn't bust the cache, but swapping two matched files' contents (where order matters, like sqlx migrations) does re-key. The declared patterns are folded too, so editing `kache.toml` itself re-keys — even when it currently matches nothing.
-
-`extra_inputs = []` leaves the cache key unchanged but still makes Cargo watch
-`kache.toml`, so activating the declaration later works in an already-warm target.
-
-### Workspace-shared provider inputs
-
-Use the project config when several packages share one workspace-root input, or
-when a proc macro reads that input while it executes inside a dependent crate:
-
-```toml title="<workspace-root>/.kache.toml"
+```toml title=".kache.toml"
 [[workspace.extra_inputs]]
 crates = ["query-macros"]
 inputs = [".sqlx/**/*.json"]
 propagate_to_dependents = true
 ```
 
-- `crates` contains exact Cargo **package names**. Selector globs are rejected,
-  and every Rust target in a selected package (library, binary, example, and so
-  on) folds the package's digest. For propagation, Kache maps the package's
-  library/proc-macro target from `[lib].name` or Cargo's default `-` to `_`
-  conversion; `propagate_to_dependents = true` is rejected for a bin-only
-  package.
-- `inputs` are relative to the workspace root; absolute paths and `..` are
-  rejected. Their workspace-relative paths and contents form a relocation-stable
-  digest.
-- The selected package's targets fold that digest. With
-  `propagate_to_dependents = true`, each direct `--extern` consumer also folds
-  it—even when the provider artifact is byte-identical, as happens when a proc
-  macro reads the file only while expanding the consumer. A two-hop dependent
-  then re-keys normally from the rebuilt direct consumer artifact.
+Workspace rules are accepted only from the `.kache.toml` beside the active Cargo workspace manifest. After adding a declaration to a target Cargo already considers fresh, rebuild that package once.
 
-Kache verifies propagation against the producer artifact's Cargo dep-info, so
-two packages exposing the same library crate name are not guessed by name. A
-legacy artifact without the provider marker must be rebuilt once.
+## Remote settings
 
-The table is honored only when the active config is exactly
-`<workspace-root>/.kache.toml`, beside a Cargo manifest containing `[workspace]`.
-An explicit or global `KACHE_CONFIG` elsewhere cannot inject workspace rules.
-Cargo `members` path globs are supported, but every selected provider must
-resolve to an explicit member. Crates that are neither selected providers nor
-direct consumers of a propagated provider retain their existing key bytes, as
-do projects without this table. Workspace rules are Rust/Cargo-only and are
-additive with a provider's co-located `kache.toml`.
+| Environment | TOML key | Default | Purpose |
+| --- | --- | --- | --- |
+| none | `cache.remote.type` | inferred as S3 for legacy config | `s3` or `filesystem` |
+| `KACHE_S3_BUCKET` | `cache.remote.bucket` | none | S3 bucket |
+| `KACHE_S3_ENDPOINT` | `cache.remote.endpoint` | AWS | Custom S3-compatible endpoint |
+| `KACHE_S3_REGION` | `cache.remote.region` | `us-east-1` | Region |
+| `KACHE_S3_PREFIX` | `cache.remote.prefix` | `artifacts` | Object prefix |
+| `KACHE_S3_PROFILE` | `cache.remote.profile` | credential-chain default | AWS profile |
+| `KACHE_S3_USER_AGENT` | `cache.remote.user_agent` | none | Custom HTTP User-Agent |
+| none | `cache.remote.path` | none | Filesystem remote root |
+| none | `cache.remote.atomic_write_dir` | `<path>/.kache-tmp` | Same-filesystem staging directory |
+| `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `16` | Concurrent operations for either backend |
+| `KACHE_S3_POOL_IDLE_SECS` | `cache.s3_pool_idle_secs` | `300` | S3 connection pool idle time |
+| `KACHE_REMOTE_RESTORE_TIMEOUT_SECS` | `cache.remote_restore_timeout_secs` | `300` | Daemon operation deadline; wrapper demand remains capped at three seconds |
+| `KACHE_REMOTE_NEGATIVE_TTL_SECS` | `cache.remote_negative_ttl_secs` | `60` | Cache definitive remote 404 results |
 
-<Callout type="warn">
-  Keep patterns narrow. Kache rejects watches rooted at the crate root, an
-  ancestor of it, or the filesystem root. A narrower watch that still matches
-  an unusually large number of files is allowed with a warning, but re-walks
-  that tree on every compile and re-keys on every matching change.
-</Callout>
+Credentials resolve from explicit `KACHE_S3_ACCESS_KEY` and `KACHE_S3_SECRET_KEY`, standard AWS variables, the selected AWS profile, web identity, container credentials, then instance credentials.
 
-Invalid declarations, unreadable inputs, broad root watches, and symlinked
-dependencies fail closed with an actionable error; Kache never silently drops
-one from Cargo freshness tracking.
+See [S3 setup](/docs/remote-cache/s3-setup) or [filesystem setup](/docs/remote-cache/filesystem-setup).
 
-After a Kache-instrumented build, Kache adds `kache.toml` and bounded watches for
-its declared inputs to rustc's Cargo-facing dep-info. Cargo can then notice an
-in-place edit, addition, deletion, or declaration change and invoke Kache to
-recompute the key; no Kache-specific `build.rs` is required.
-Older cache entries are completed when Kache restores them, so the artifact
-cache itself does not need to be cleared. If Kache must pass such a crate
-through, it bypasses the configured fallback cache because that wrapper cannot
-see Kache's extra-input digest.
-Adaptive and forced incremental lanes remain disabled for declared hidden
-inputs; Kache uses the normal cache or safe passthrough path instead.
+## Prefetch and planner
 
-<Callout type="warn">
-  Cargo cannot retroactively learn dependencies for an already-fresh target.
-  After upgrading from Kache 0.13 or earlier—or after adding `kache.toml` or a
-  workspace rule to a target that is already Cargo-fresh—rebuild the affected
-  package once (for example, `cargo clean -p <package> && cargo build`). Later
-  declared-input changes are tracked automatically.
-</Callout>
+| Environment | TOML key | Default | Purpose |
+| --- | --- | --- | --- |
+| `KACHE_PREFETCH_ENABLED` | `cache.prefetch_enabled` | `true` | Enable speculative manifest and planner prefetch |
+| `KACHE_REMOTE_KEY_CACHE_REFRESH_SECS` | `cache.remote_key_cache_refresh_secs` | `60` | Refresh the fallback planner's remote key index; `0` means initial load only |
+| `KACHE_PREFETCH_MAX_KEYS` | `cache.prefetch_max_keys` | `2000` | Entries allowed per plan; `0` is unlimited |
+| `KACHE_PREFETCH_MAX_BYTES` | `cache.prefetch_max_bytes` | `2GiB` | Compressed bytes allowed per plan; in-flight downloads may finish |
+| `KACHE_PREFETCH_DEADLINE_SECS` | `cache.prefetch_deadline_secs` | `300` | Time during which a plan may start downloads; `0` disables the deadline |
+| `KACHE_PLANNER_ENDPOINT` | `cache.planner.endpoint` | none | Planner service URL |
+| `KACHE_PLANNER_TIMEOUT_MS` | `cache.planner.timeout_ms` | `750` | Planner request timeout |
+| `KACHE_PLANNER_TOKEN` | `cache.planner.token` | none | Bearer token |
+| `KACHE_NAMESPACE` | none | none | Shard namespace used by manifest upload and prefetch |
 
-<Callout type="warn">
-  Cargo's unstable checksum-freshness mode cannot checksum directory watches,
-  which are needed to detect glob additions and deletions. Kache currently
-  rejects an active `extra_inputs` declaration in that mode instead of risking
-  stale output. Use Cargo's normal freshness. If checksum freshness is required,
-  run the whole Cargo command with `KACHE_DISABLED=1`; because Kache then cannot
-  inject these dependencies, keep equivalent `cargo:rerun-if-changed` directives
-  until checksum support lands. Non-Cargo build systems must likewise provide
-  their own freshness mechanism.
-</Callout>
+On a long-lived runner with a warm local store, speculative prefetch may be unnecessary:
 
-<Callout type="info">
-  `kache.toml` (no leading dot) is **only** for `extra_inputs`. It is distinct
-  from the project config `.kache.toml`; any other key in it is a loud error.
-</Callout>
-
-## Extra path prefixes
-
-Use the file-only `[paths].base_dirs` list when automatic workspace/home/temp
-detection and the legacy single `KACHE_BASE_DIR` do not cover paths baked into
-artifacts—for example container mounts, `/snap`, `/var/lib/flatpak`, an
-AppImage mount, or a custom toolchain root:
-
-```toml title=".kache.toml"
-[paths]
-base_dirs = ["/snap", "/var/lib/flatpak", "/work"]
-```
-
-Entries must be absolute, narrower than a filesystem root, and contain no `..`. They need not exist on every
-machine, so a shared project config remains usable outside the container or
-sandbox. kache sorts the normalized entries independently of TOML order,
-assigns each one a distinct `<BASE_DIR_N>` key sentinel and
-`/kache/base-dir-N` compiler path, and uses the longest configured prefix when
-entries overlap. The configured roots feed both rustc and gcc/clang key inputs
-and emitted prefix maps. `KACHE_BASE_DIR` remains supported as the separate
-legacy `<BASE_DIR>` rule.
-
-<Callout type="warn">
-  Path normalization removes distinctions and therefore merges cache keys. An
-  over-broad root, or differently paired lists on two machines, can make
-  genuinely different inputs look identical and restore a wrong artifact.
-  C/C++ compiler prefix maps use raw byte-prefix semantics: for example,
-  `/work` also matches `/workspace`. Rust mappings are path-component aware.
-  Choose narrow, unambiguous roots, commit the same `.kache.toml` for every
-  cache participant, and review this warning and kache's per-entry audit log
-  when this list is active.
-</Callout>
-
-## Path-only env vars
-
-By default kache normalizes the absolute path baked into `OUT_DIR` so the cache key stays portable across machines and worktrees. Some builds set other env vars that serve the same role — they only point at a generated file that a crate `include!`s, and their absolute value should not bust the key (e.g. Firefox's `BUILDCONFIG_RS` / `MOZ_TOPOBJDIR`).
-
-`cache.path_only_env_vars` opts those vars into the same path-only treatment:
-
-```toml title=".kache.toml"
+```toml
 [cache]
-path_only_env_vars = ["BUILDCONFIG_RS", "MOZ_TOPOBJDIR"]
+prefetch_enabled = false
 ```
 
-Or via the environment (comma- or whitespace-separated; replaces the file list entirely):
+Exact remote lookup and background upload continue to work.
 
-```sh
-export KACHE_PATH_ONLY_ENV_VARS="BUILDCONFIG_RS MOZ_TOPOBJDIR"
-```
+## Daemon, events, and diagnostics
 
-Plain `VAR` entries still require kache to prove that the value only locates an included source file. For a known false positive in one crate, `rustc_crate_name:VAR` explicitly bypasses the include and runtime-value scans for only that pair:
+| Environment | TOML key | Default | Purpose |
+| --- | --- | --- | --- |
+| `KACHE_DAEMON_IDLE_TIMEOUT` | `cache.daemon_idle_timeout_secs` | `0` | Stop after idle seconds; `0` keeps it running |
+| `KACHE_LOCAL_HIT_DAEMON` | `cache.local_hit_daemon` | `false` | Experimental daemon-assisted local lookup with local fallback |
+| `KACHE_HEARTBEAT_SECS` | `cache.heartbeat_secs` | `30` | Event heartbeat cadence for long miss compiles; `0` disables it |
+| `KACHE_EXPLAIN_MISS` | `cache.explain_miss` | `false` | Record changed key groups on repeat misses |
+| `KACHE_STORAGE_LAYOUT_ADVICE` | `cache.storage_layout_advice` | `true` | Warn when storage layout forces copies |
+| `KACHE_WINDOWS_HARDLINK` | `cache.windows_hardlink` | `false` | Unsafe opt-in hardlink restores on non-CoW Windows volumes |
+| `KACHE_PROGRESS` | none | off | `hits` or `verbose` compiler progress |
+| `KACHE_LOG` | none | CLI: `kache=warn`; wrapper: off | Stderr tracing filter |
+| `KACHE_LOG_FILE` | none | CLI/daemon: `kache=info`; wrapper: off | File tracing filter and wrapper opt-in |
+| `KACHE_EVENT_ROOT` | none | detected | Root attached to events for report filtering |
+| `KACHE_PAGER` | none | platform pager | Pager command for `kache list` |
 
-```toml title=".kache.toml"
+## Pin file-backed settings
+
+Set `cache.ignore_env` in a controlled project config to ignore environment overrides for settings that also exist in TOML:
+
+```toml
 [cache]
-path_only_env_vars = ["cef_dll_sys:OUT_DIR"]
+ignore_env = true
 ```
 
-Use rustc's crate name (hyphens become underscores). This force form is a correctness assertion: only use it when the compiled artifact cannot observe the value. `CARGO_MANIFEST_DIR` cannot be forced because erasing it can restore an artifact containing another checkout's path. An empty list leaves only the built-in `OUT_DIR` behavior.
+It does not suppress `KACHE_DISABLED`, `KACHE_CONFIG`, `KACHE_SOCKET_PATH`, credentials, logging, progress, or other environment-only controls. Kache warns when it ignores a set variable.
 
-## Env vars that steer expansion
-
-kache keys the compile-time environment a build *bakes in* — the `env!()` and `option_env!()` values rustc reports in dep-info. A **proc macro** that calls `std::env::var` while expanding is a different story: rustc has no way to report it, so the command line, the source hashes, and the `--extern` set are byte-identical whether or not the var is set, while the emitted artifact is not.
-
-That is a real failure mode, not a hypothetical one. In [#635](https://github.com/kunobi-ninja/kache/issues/635) a two-phase build ran the same crate graph twice — once with `BOLTFFI_BINDING_EXPANSION=1`, where the `#[export]` macro strips itself from dependency crates and emits no trait impls, and once without. The dependency crate's rustc invocation was identical in both phases, so both compiles keyed the same and the normal build restored the stripped 264 KiB artifact instead of building the 620 KiB one. It surfaced as a missing trait impl at compile time; the same mechanism can just as easily produce a wrong binary that builds cleanly.
-
-`cache.key_env_vars` declares the vars that steer expansion so the two modes get distinct entries:
-
-```toml title=".kache.toml"
-[cache]
-key_env_vars = ["BOLTFFI_*"]
-```
-
-Or via the environment (comma- or whitespace-separated; replaces the file list entirely):
-
-```sh
-export KACHE_KEY_ENV_VARS="BOLTFFI_BINDING_EXPANSION,BOLTFFI_SURFACE"
-```
-
-Semantics:
-
-- **Exact names, or a trailing `*` prefix glob.** `BOLTFFI_*` selects every var starting with `BOLTFFI_`; `APP_MODE` selects only that name. Matching is ASCII case-insensitive, so a Windows environment behaves like a Unix one. A `*` anywhere but the end is a literal character — `A*B` matches a variable actually named `A*B` — and kache warns when it sees one, since that is almost never what someone meant.
-- **Turning it on re-keys the crate.** The declared patterns are folded, not just the matched values — otherwise the build that leaves the vars unset would land back on the poisoned entry that made you reach for this setting. Expect one cold rebuild after adding or editing the list.
-- **Only vars actually set are folded**, as `NAME=VALUE` pairs. Set-to-empty and unset are distinct, matching what `std::env::var` reports.
-- **Declaration spelling doesn't matter.** The list is upper-cased, sorted and deduplicated before it is folded, so two teammates writing `BOLTFFI_*` and `boltffi_*` in either order still share a cache.
-- **Values are folded exactly**, as their raw OS bytes. See the warning below.
-- **Off by default.** An empty list has no effect; keys are byte-identical to not setting it.
-- **Union-only.** A misdeclared pattern can cost a cache miss, never restore a wrong artifact.
-
-<Callout type="warn">
-  Declared values are **not** path-normalized, unlike most paths kache keys. A
-  macro is free to paste a variable's value straight into the code it emits, so
-  two checkout paths that would collapse to the same `<BASE_DIR>` sentinel can
-  still produce different artifacts — normalizing them would reintroduce the
-  wrong-hit this setting exists to prevent. The consequence is that a declared
-  variable holding a machine-local path (`BOLTFFI_ROOT=/home/alice/proj`) makes
-  that crate's key machine-specific and stops it sharing across hosts. Prefer
-  declaring the switch a macro actually branches on
-  (`BOLTFFI_BINDING_EXPANSION`) over a broad `BOLTFFI_*` glob that sweeps in
-  path variables too.
-</Callout>
-
-Keep the list to vars that genuinely change what a macro emits. Naming something that varies per build — a timestamp, a job id, `PWD` — gives every compile its own key and disables caching for the whole workspace. `"*"` is a valid pattern and folds the entire environment, but for the same reason it is close to a cache-off switch, and it makes every credential in the process contribute to your cache keys.
-
-Values are never written to logs or events — only variable names appear at `KACHE_LOG=trace` — but they do influence the resulting cache key, which is stored and (with a remote) transmitted. Treat a declared secret as hashed, not as hidden.
-
-<Callout type="info">
-`proc_macro::tracked_env` would let a macro register these reads with the compiler and make this configuration unnecessary. It is still unstable, so for now the vars have to be declared. Other compiler caches share the limitation.
-</Callout>
-
-If you would rather not cache the affected crate at all, [`cache.exclude`](#excluding-sources) takes a source-path glob and bypasses kache entirely for those compiles.
-
-## Extra cc allowlist flags
-
-kache caches a C/C++ compile only when it recognizes every flag on the command line. Its cc flag classifier is an **allow-list**: each flag is one kache has reasoned about and knows how to key. Anything unrecognized is refused and the compile passes through uncached — the safe default, since a flag kache doesn't model could change the object file without changing the key.
-
-For setup and the current C/C++ support matrix, see [C/C++ caching](/docs/getting-started/c-cpp).
-
-**Supported compilers and dialects.** kache wraps the GNU-dialect drivers (`cc`, `c++`, `gcc`, `g++`, `clang`, `clang++`; POSIX) and the MSVC-dialect `clang-cl` (Windows, or `clang --driver-mode=cl`). The two dialects have separate allow-lists, so each flag is classified in the spelling its compiler actually uses — e.g. `-fno-rtti` (GNU) vs `-GR-` (clang-cl), `-std=c++20` vs `-std:c++20`. For clang-cl, debug info (`/Z7` / `-Z7` / `-g`) **is** cached (machine-local — clang-cl embeds CodeView paths in the `.obj`), while `-bigobj` and `-showIncludes` are still deliberately **refused** (passed through) for now; the common MSVC codegen set (`-EH*`, `-GR`/`-GS`, `-guard:`, `-std:`, `-fms-compatibility-version=`, `/O*`, `-Gy`/`-Gw`, `-MD`/`-MT`, …) is modeled. `extra_allowlist_flags` entries below are matched against command-line tokens verbatim, so list them in whichever dialect your compiler speaks (a `/`-spelled clang-cl flag included).
-
-The cost is that a common-but-unlisted flag disables caching for that compile until kache ships a release adding it. `cc.extra_allowlist_flags` lets you opt such a flag in locally, ahead of official support:
-
-```toml title=".kache.toml"
-[cc]
-extra_allowlist_flags = ["-ffunction-sections", "-fdata-sections", "-fno-rtti"]
-```
-
-Or via the environment (whitespace-separated; overrides the file):
-
-```sh
-export KACHE_CC_EXTRA_ALLOWLIST_FLAGS="-ffunction-sections -fdata-sections"
-```
-
-Semantics:
-
-- **Exact match.** An entry matches a command-line token character-for-character — no prefixes or wildcards. List each value you use (e.g. `-march=armv8.2-a`, not `-march=`).
-- **Hashed verbatim.** A matched flag that's actually present is folded into the cache key as its literal string, so a different flag (or value) always produces a different key — it can never miscache *by value*.
-- **Add-only.** This can only make kache *stop refusing* a flag. It cannot override structural refusals — link mode, coverage instrumentation, multi-`-arch`, precompiled headers, modules, and the like still pass through.
-- **Off by default.** An empty list has no effect; keys are byte-identical to not setting it.
-
-<Callout type="warn">
-Avoid host-dependent flags like `-march=native`. The string is identical on every machine but compiles to different objects per CPU, so hashing it verbatim collides across hosts — a cache hit on one machine can restore an object built for another. List explicit architectures instead.
-</Callout>
-
-To confirm it took effect, run with `KACHE_LOG=kache=debug`: the cc flag-classify summary gains a `user-allowed` count, and the flag no longer appears in any `unsupported flag(s): … — passthrough` line. At `kache=trace` each accepted flag logs as `user-allowed (config)` and each one folded into the key logs as `cc_extra_flag=`.
-
-## S3 credential resolution order
-
-Remote S3 credentials are resolved in this order:
-
-1. `KACHE_S3_ACCESS_KEY` + `KACHE_S3_SECRET_KEY`
-2. Standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
-3. Static credentials in the selected profile (`KACHE_S3_PROFILE`, `cache.remote.profile`, `AWS_PROFILE`, then `default`)
-4. Legacy inline SSO, then `credential_process` for the selected profile
-5. Environment-based web identity, ECS/task credentials, then EC2 instance credentials
-
-For Ceph, MinIO, or R2, set `cache.remote.endpoint` or `KACHE_S3_ENDPOINT`.
-
-```toml title="Ceph example"
-[cache.remote]
-type = "s3"
-bucket = "build-cache"
-endpoint = "https://s3.example.com"
-profile = "ceph"
-```
-
-## Composing with other compiler wrappers
-
-kache works as a `RUSTC_WRAPPER` and composes with a second wrapper in either direction.
-
-**Behind another workspace wrapper** (`RUSTC_WORKSPACE_WRAPPER`, e.g. `clippy-driver`): when cargo has both `RUSTC_WRAPPER=kache` and a `RUSTC_WORKSPACE_WRAPPER` set, it invokes `kache <workspace-wrapper> <rustc> <args>`. kache detects that the inner argument is itself a compiler, forwards the real rustc path as the workspace wrapper expects, and keys/caches around it. `cargo clippy` (which drives `clippy-driver`) is handled the same way — no extra configuration needed.
-
-**In front of another wrapper** — when you want a second wrapper to cache the compiles kache *declines*: set [`KACHE_FALLBACK`](#all-settings) (or `cache.fallback`). kache then runs `<fallback> <compiler> <args>` for passed-through invocations, so e.g. sccache gets a chance at the compiles kache won't cache.
-
-<Callout type="info">
-  `KACHE_DISABLED=1` makes kache a transparent shim (no lookup, store, or
-  upload) while still stripping incremental flags unless
-  `KACHE_PRESERVE_INCREMENTAL=1` is set — useful to temporarily
-  bypass kache in a wrapper chain without unsetting the env var. Only `1` or
-  `true` (case-insensitive) disable; `0`/`false`/unset leave caching on.
-</Callout>
-
-## Restore verification
-
-By default, a hit checks recorded metadata and blob size, then restores the blob. Set `KACHE_VERIFY_RESTORES=sampled` to content-hash roughly one in sixteen hits, or `KACHE_VERIFY_RESTORES=always` to hash every restored blob before serving it:
-
-```sh
-KACHE_VERIFY_RESTORES=sampled cargo build
-```
-
-`sampled` is useful as cheap background coverage for silent disk corruption. `always` is stricter but adds an extra full read of every restored blob.
-
-## Size values
-
-Size fields (`KACHE_MAX_SIZE`, `cache.local_max_size`) accept human-friendly strings:
-
-```
-50GiB   10GB   512MiB   1024MB
-```
-
-## Log levels
-
-`KACHE_LOG` follows the `tracing` subscriber syntax:
-
-```sh
-KACHE_LOG=kache=debug   # verbose, useful when diagnosing cache misses
-KACHE_LOG=kache=info    # operational detail
-KACHE_LOG=kache=warn    # default — only surface real problems
-```
-
-The file log is written to `~/Library/Logs/kache/kache.log` on macOS and `~/.cache/kache/kache.log` elsewhere. It rotates automatically when it exceeds 5 MB.
-
-## Local store layout
-
-```
-<cache_dir>/               # Linux: ~/.cache/kache · macOS: ~/Library/Caches/kache · Windows: %LOCALAPPDATA%\kache
-├── store/
-│   ├── blobs/
-│   │   └── ab/
-│   │       └── abcdef...   # content-addressed blob (blake3), stored once
-│   └── <cache_key>/
-│       └── meta.json       # entry metadata; references its blobs by hash
-│   └── gc.lock             # serializes store-wide GC
-├── index.db                # SQLite index (WAL mode) — sibling of store/, not inside it
-└── upload-queue/           # durable remote-upload intents
-
-<runtime_dir>/              # defaults to <cache_dir>; set per job when sharing a store
-├── events.jsonl            # build event log
-├── transfers.jsonl         # transfer log
-├── summaries.jsonl         # build-session summaries
-├── .build-sessions/        # build-session markers
-└── daemon.sock             # IPC socket; daemon locks/state/log live beside it
-```
-
-The whole cache directory is excluded from Time Machine and Spotlight on macOS automatically — on first start the daemon sets a `tmutil` exclusion and a `.metadata_never_index` sentinel.
-
-### Concurrent jobs on one trusted runner
-
-Jobs on the same host may reuse one persistent local store while running a daemon per job. Keep `KACHE_CACHE_DIR` on a host-local disk, and give each job a private `KACHE_RUNTIME_DIR` (for example, the CI system's per-job temporary directory):
-
-```sh
-export KACHE_CACHE_DIR=/var/lib/kache/trusted-rust
-export KACHE_RUNTIME_DIR="$RUNNER_TEMP/kache-runtime"
-```
-
-Do this only inside one trust domain. Any job that can write the shared store can influence later cache hits, so untrusted pull requests must use a different runner group or a different mounted cache directory. Never share `KACHE_RUNTIME_DIR` between concurrent jobs; the persistent SQLite index, blob store, upload queue, and GC coordination remain under `KACHE_CACHE_DIR`.
-
-## Containers and cross-compilation
-
-kache's index (`index.db`) is a SQLite database, and SQLite needs reliable file locking from the filesystem it lives on — plus shared memory, in WAL mode. A normal local cache directory provides both. A cache directory **shared across machine or OS boundaries** does not.
-
-The usual way to hit this is bind-mounting your host cache directory into a build container — for example [`cross`](https://github.com/cross-rs/cross), Docker, or Podman:
-
-- The directory is mounted from the host into the container, so `index.db` is opened from two different operating systems at once.
-- A kache daemon on the host typically holds `index.db` open in WAL mode for the duration of the build, and that WAL state cannot be shared with the process inside the container.
-
-When kache can't open the index it falls back to building **uncached** — your build still succeeds, just with no cache hits or stores — and prints a one-time warning:
-
-```
-[kache] the cache index could not be opened after retries (...).
-[kache] Caching is disabled for this build — compilation still succeeds,
-[kache] just without cache hits or stores (everything builds uncached).
-[kache] ...
-[kache] → set KACHE_CACHE_DIR to a fast, local, single-machine path
-```
-
-**Give the container its own cache directory.** Point `KACHE_CACHE_DIR` at a path the container alone uses — ideally a dedicated volume so the cache persists across runs:
-
-```sh
-# inside the container / cross build — a container-local volume, NOT the host's cache dir
-export KACHE_CACHE_DIR=/kache-cache
-```
-
-Don't bind-mount the host's cache directory into the container. Sharing it gains little anyway: host and cross builds target different platforms and feature sets, so they produce different cache keys and would not reuse each other's entries.
-
-<Callout type="info">
-  The same rule applies to network filesystems (NFS, SMB/CIFS, 9p) and any
-  setup where more than one machine touches the same directory: keep
-  `KACHE_CACHE_DIR` on a fast, local disk owned by a single machine. To reuse
-  build artifacts *across* machines, configure an [S3 remote](/docs/remote-cache/s3-setup)
-  or a separate [filesystem remote](/docs/remote-cache/filesystem-setup). Only
-  the filesystem remote's `path` belongs on the shared mount.
-</Callout>
+The daemon reads configuration at startup and watches the active config file. File changes trigger a graceful restart. Environment changes require starting a new daemon from that environment; an installed service uses its service definition, not your current shell.

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -1,270 +1,119 @@
 ---
 title: Installation
-description: How to install kache — mise, cargo-binstall, source, Nix, or an OS package manager (Homebrew, APT, winget, Scoop, Chocolatey, AUR).
+description: Install Kache from a release, package manager, crates.io, or Nix
 ---
 
-# Installation
+Kache requires Rust 1.95 when built from source. Release binaries have no Rust runtime dependency.
 
-kache requires Rust 1.95 or later and is built with the 2024 edition (`Cargo.toml` `edition = "2024"`). The binary is self-contained — no runtime dependencies.
+## Recommended methods
 
-## Methods
-
-<Tabs items={["mise (recommended)", "cargo-binstall", "from source"]}>
-  <Tab value="mise (recommended)">
-    [mise](https://mise.jdx.dev) downloads the pre-built binary from GitHub releases and pins the version per project or globally.
-
-    ```sh
-    # install globally
+<Tabs items={["mise", "cargo-binstall", "cargo install"]}>
+  <Tab value="mise">
+    ```bash
     mise use -g github:kunobi-ninja/kache@latest
-
-    # or pin a specific version
-    mise use -g github:kunobi-ninja/kache@0.5.0
     ```
 
-    To pin kache in your project so every contributor gets the same version, add it to your `mise.toml`:
+    To pin Kache in a project:
 
-    ```toml
+    ```toml title="mise.toml"
     [tools]
     "github:kunobi-ninja/kache" = "latest"
     ```
-
-    Running `mise install` in the project root will install the pinned version.
   </Tab>
   <Tab value="cargo-binstall">
-    [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) downloads the pre-built binary from GitHub releases without compiling.
-
-    ```sh
+    ```bash
     cargo binstall kache
     ```
 
-    Every release (including RCs) is published to crates.io, so the plain crate
-    name works. To install an unreleased branch build instead, use the `--git`
-    form: `cargo binstall --git https://github.com/kunobi-ninja/kache kache`.
-
-    If a pre-built binary isn't available for your target, use the source install method below.
+    This downloads a release binary when one exists for your target.
   </Tab>
-  <Tab value="from source">
-    ```sh
+  <Tab value="cargo install">
+    ```bash
     cargo install kache
     ```
 
-    This compiles kache with your local toolchain. It takes a couple of minutes
-    and works on Linux, macOS, and Windows (with the MSVC toolchain). To build an
-    unreleased branch instead, use `cargo install --git https://github.com/kunobi-ninja/kache kache`.
+    Cargo builds Kache with your local Rust toolchain.
   </Tab>
 </Tabs>
 
-<Callout type="info">
-  The methods above install the latest **stable** release. Release-candidates are
-  published but never resolve as "latest", so request one explicitly:
-  `cargo install kache --version 0.6.0-rc.1` (or `cargo binstall kache@0.6.0-rc.1`).
-</Callout>
+Release candidates do not resolve as `latest`. Request their full `x.y.z-rc.n` version explicitly.
 
-## OS package managers
+## Package managers
 
-kache is also published to Homebrew, APT, winget, Scoop, Chocolatey, and the AUR. Most have both a **stable** channel and an **unstable** channel (release-candidates / betas).
-
-<Tabs items={["Homebrew (macOS)", "APT (Debian/Ubuntu)", "winget (Windows)", "Scoop (Windows)", "Chocolatey (Windows)", "AUR (Arch Linux)"]}>
-  <Tab value="Homebrew (macOS)">
-    ```sh
-    # Stable
+<Tabs items={["Homebrew", "APT", "Windows", "AUR"]}>
+  <Tab value="Homebrew">
+    ```bash
     brew install kunobi-ninja/kunobi/kache
-
-    # Unstable (RC/beta)
-    brew install kunobi-ninja/kunobi/kache-unstable
     ```
-  </Tab>
-  <Tab value="APT (Debian/Ubuntu)">
-    Install the signing key once, then add the repo — `stable` or `unstable` suite:
 
-    ```sh
-    # Signing key (KMS-rooted OpenPGP cert), dearmored into a keyring
+    Use `kunobi-ninja/kunobi/kache-unstable` for release candidates and betas.
+  </Tab>
+  <Tab value="APT">
+    ```bash
     sudo mkdir -p /etc/apt/keyrings
     curl -fsSL https://r2.kunobi.com/kache/apt/gpg.key \
       | sudo gpg --dearmor -o /etc/apt/keyrings/kache.gpg
-
-    # Stable
     echo "deb [signed-by=/etc/apt/keyrings/kache.gpg] https://r2.kunobi.com/kache/apt stable main" \
       | sudo tee /etc/apt/sources.list.d/kache.list
-
-    # Unstable (RC/beta) — swap the suite instead:
-    # echo "deb [signed-by=/etc/apt/keyrings/kache.gpg] https://r2.kunobi.com/kache/apt unstable main" \
-    #   | sudo tee /etc/apt/sources.list.d/kache.list
-
-    sudo apt update && sudo apt install kache
+    sudo apt update
+    sudo apt install kache
     ```
 
-    <Callout type="info">
-      Stable `.deb`s also land in the `unstable` suite, so an `unstable` subscriber still receives GA releases.
-    </Callout>
+    Replace `stable` with `unstable` to receive prereleases as well as stable releases.
   </Tab>
-  <Tab value="winget (Windows)">
+  <Tab value="Windows">
     ```powershell
-    # Stable
     winget install kunobi-ninja.kache
-
-    # Unstable (RC/beta)
-    winget install kunobi-ninja.kache.Unstable
-    ```
-  </Tab>
-  <Tab value="Scoop (Windows)">
-    Add the Kunobi bucket once, then install from it:
-
-    ```powershell
+    # or
     scoop bucket add kunobi https://github.com/kunobi-ninja/scoop-kunobi
-
-    # Stable
     scoop install kunobi/kache
-
-    # Unstable (RC/beta)
-    scoop install kunobi/kache-unstable
-    ```
-
-    <Callout type="info">
-      `kache` and `kache-unstable` both provide a `kache` command. With both installed, run `scoop reset kache-unstable` (or `scoop reset kache`) to choose which one the `kache` shim points at.
-    </Callout>
-  </Tab>
-  <Tab value="Chocolatey (Windows)">
-    ```powershell
-    # Stable
+    # or
     choco install kache
-
-    # Unstable (RC/beta) — same package, pre-release versions
-    choco install kache --pre
     ```
+
+    The corresponding prerelease packages are `kunobi-ninja.kache.Unstable`, `kunobi/kache-unstable`, and `choco install kache --pre`.
   </Tab>
-  <Tab value="AUR (Arch Linux)">
-    Three packages are available (all provide the `kache` command — install one):
-
-    ```sh
-    # Official prebuilt binary — recommended (statically linked, x86_64 + aarch64, no compile)
+  <Tab value="AUR">
+    ```bash
     paru -S kache-bin
-
-    # Official, builds the latest main from source
-    paru -S kache-git
-
-    # Community-maintained, builds the latest release from source
-    paru -S kache
     ```
 
-    <Callout type="info">
-      `kache-bin` and `kache-git` are the official Kunobi packages; `kache` is a community-maintained source build.
-    </Callout>
+    `kache-bin` is the official prebuilt package. `kache-git` builds the current main branch; the community `kache` package builds a release from source.
   </Tab>
 </Tabs>
 
-## Compiler shims (transparent interception)
-
-Setting `CC`/`CXX` per project does not scale when you support many
-differently structured builds. A shim directory routes every compiler call on
-the machine through kache with one `PATH` change and no per-project edits:
-
-```sh
-kache install-shims ~/.kache/shims
-export PATH="$HOME/.kache/shims:$PATH"
-```
-
-That creates symlinks named `cc`, `c++`, `gcc`, `g++`, `clang` and `clang++`,
-all pointing at the kache binary. When a build invokes one, kache recognizes
-that it was called under a compiler name, finds the real compiler behind the
-shim, and wraps it.
-
-Two rules make or break it:
-
-- The shim directory must come **before** your real toolchain on `PATH`.
-  Appended, it is never consulted and nothing happens.
-- The real compilers must still be reachable on `PATH` behind it, because
-  kache runs them. If every `cc` on `PATH` is a shim, kache says so and exits
-  rather than recursing.
-
-The real compiler is found by skipping any `PATH` entry that resolves to the
-kache binary, so several shim directories, relative entries, and symlinked
-entries all behave.
-
-Unix only for now: it relies on symlinks, and the Windows `.exe` shim story
-differs. Use `CC`/`CXX` there. C/C++ caching is still experimental, so treat
-machine-wide interception as opt-in.
-
 ## Nix
 
-The repo is a flake. Unlike the methods above it builds kache from source, with the Rust toolchain pinned in `rust-toolchain.toml` rather than whatever rustc your nixpkgs happens to ship. Use the `stable` branch: it advances only after a non-prerelease GitHub release has passed the gated release build. The default `main` branch contains unreleased development work.
+The `stable` branch follows released versions:
 
-```sh
-# Run it once without installing
+```bash
 nix run github:kunobi-ninja/kache/stable -- --version
-
-# Install into your profile
 nix profile install github:kunobi-ninja/kache/stable
 ```
 
-To consume it from your own flake, add the input and apply the overlay. The overlay provides `pkgs.kache` and `pkgs.kache-rust-toolchain`. Following `stable`, `nix flake update` moves you from one release to the next and never onto unreleased commits:
+Pin a release tag when updates must be explicit:
 
-```nix
-{
-  inputs.kache.url = "github:kunobi-ninja/kache/stable";
-
-  outputs = { nixpkgs, kache, ... }: {
-    # ...
-    nixpkgs.overlays = [ kache.overlays.default ];
-    environment.systemPackages = [ pkgs.kache ];
-  };
-}
+```bash
+nix profile install github:kunobi-ninja/kache/v0.14.2
 ```
 
-If you want a version that never moves at all, pin a release tag instead: `github:kunobi-ninja/kache/v0.14.2`. A tag ref is inert under `nix flake update`; bump it yourself when you want a new version.
+The flake also exports an overlay, NixOS module, and nix-darwin module. See the repository [`flake.nix`](https://github.com/kunobi-ninja/kache/blob/main/flake.nix) for their current names and options.
 
-There is also a NixOS and nix-darwin module that installs kache, writes `config.toml`, optionally sets `RUSTC_WRAPPER` system-wide, and runs the daemon as a systemd user service (Linux) or launchd agent (macOS):
+## Supported release targets
 
-```nix
-{
-  imports = [ kache.nixosModules.default ];  # or kache.darwinModules.default
+| Platform | Architectures |
+| --- | --- |
+| Linux, musl | x86_64, aarch64 |
+| macOS | x86_64, Apple silicon |
+| Windows, MSVC | x86_64, ARM64 |
 
-  services.kache = {
-    enable = true;
-    daemon.enable = true;
-    settings.cache = {
-      local_max_size = "50GB";
-      remote = {
-        type = "s3";
-        bucket = "my-kache-bucket";
-      };
-    };
-  };
-}
-```
+Other Rust-supported targets may work through `cargo install`, but they are not release-tested targets.
 
-Apply `kache.overlays.default` alongside the module. `services.kache.package` defaults to `pkgs.kache` from the overlay; without it the module falls back to building against nixpkgs' rustc, which can be older than the crate's `rust-version`.
+## Verify the install
 
-<Callout type="info">
-  The flake builds for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.
-  Intel macOS (`x86_64-darwin`) is absent because nixpkgs 26.11 dropped the
-  platform, not because kache dropped it: the pre-built `x86_64-apple-darwin`
-  binary and `cargo install` both still work there.
-</Callout>
-
-Contributors can get the pinned toolchain plus `just` and `cargo-deny` with `nix develop`. `mise` remains the primary tool manager for the repo.
-
-## Supported platforms
-
-Pre-built binaries are available for:
-
-| Target | Notes |
-|---|---|
-| `x86_64-unknown-linux-musl` | Statically linked, works on any Linux |
-| `aarch64-unknown-linux-musl` | ARM Linux (AWS Graviton, etc.) |
-| `x86_64-apple-darwin` | Intel macOS |
-| `aarch64-apple-darwin` | Apple Silicon |
-| `x86_64-pc-windows-msvc` | Windows x64 (MSVC) |
-| `aarch64-pc-windows-msvc` | Windows ARM64 (MSVC) |
-
-## Verify the installation
-
-```sh
+```bash
 kache --version
+kache doctor
 ```
 
-You should see a version string like `kache 0.5.0`. If the command isn't found, make sure the binary is on your `PATH` (mise handles this automatically).
-
-## Next: enable kache for cargo
-
-Installing the binary doesn't yet wire it into cargo. Run `kache init` to configure your cargo config (`~/.cargo/config.toml`, or the legacy `~/.cargo/config` if that file already exists), install the daemon as a login service, and start it — see [Quick start](/docs/getting-started/quick-start) for the full walkthrough.
+Next, follow the [quick start](/docs/getting-started/quick-start).

--- a/docs/getting-started/meta.json
+++ b/docs/getting-started/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Getting Started",
-  "pages": ["installation", "quick-start", "c-cpp", "configuration"]
+  "pages": ["installation", "quick-start", "comparison", "c-cpp", "configuration"]
 }

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -1,172 +1,90 @@
 ---
 title: Quick start
-description: Run kache init, watch a cold build populate the cache, then see the second build restore every artifact with zero-copy reflinks.
+description: Try Kache safely, then choose whether to enable it permanently
 ---
 
-# Quick start
+## Try Kache in one shell
 
-The fastest path is `kache init`. It edits `~/.cargo/config.toml` to set `rustc-wrapper = "kache"`, installs the background daemon as a login service, and starts it. The whole flow takes a few seconds and is idempotent — re-run it any time to repair configuration.
-
-```sh
-# interactive setup
-kache init
-
-# or accept all defaults non-interactively
-kache init -y
-
-# skip the login service if you'd rather start the daemon manually
-kache init --no-service
-
-# check what init would do without changing anything
-kache init --check
-```
-
-After `kache init`, your next `cargo build` is already cached. The first run is a normal cold compile; the second run restores everything from kache's store with zero-copy reflinks (copy-on-write) where the filesystem supports it, and hardlink or copy otherwise.
-
-<Callout type="warning" title="Do not share one Cargo target directory across live worktrees">
-  With ordinary `cargo`, share Kache's cache but give each worktree its own
-  `CARGO_TARGET_DIR`. Cargo can declare an older worktree's unit `Fresh` from
-  shared fingerprint state without invoking `RUSTC_WRAPPER`, so no compiler
-  cache can validate that unit. If final artifacts must share one target, use
-  `kache cargo -- build` on Cargo 1.91+: it keeps intermediate fingerprints
-  worktree-local while Kache shares compiled artifacts.
-</Callout>
-
-![kache: cold build populates the store, then `cargo clean && cargo build` restores every artifact with zero-copy reflinks](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/demo.gif)
-
-## Verify the setup
-
-```sh
-kache doctor
-```
-
-`doctor` checks for a working `RUSTC_WRAPPER`, conflicting wrappers (e.g. sccache), config file problems, and daemon connectivity. Add `--fix` to apply automatic repairs. For store integrity, `--verify` walks the store and checks entries, blobs, and metadata; add `--checksums` to also recompute and verify blob content hashes (slower); `--repair` removes corrupted entries.
-
-## Manual setup (without `kache init`)
-
-If you'd rather wire things up yourself:
-
-<Steps>
-  <Step>
-    **Set the wrapper for your current shell session**
-
-    ```sh
-    export RUSTC_WRAPPER=kache
-    ```
-
-    Or persist it in `~/.cargo/config.toml` so it applies to every project:
-
-    ```toml title="~/.cargo/config.toml"
-    [build]
-    rustc-wrapper = "kache"
-    ```
-
-    The `~/.cargo/config.toml` approach is more convenient for daily use. The env var is handy for CI or when you want to test kache on a single project without changing global config.
-  </Step>
-
-  <Step>
-    **Run a build**
-
-    ```sh
-    cargo build
-    ```
-
-    The first build runs normally — kache compiles each crate and stores the result. You'll see normal cargo output.
-  </Step>
-
-  <Step>
-    **Run the build again**
-
-    ```sh
-    cargo clean && cargo build
-    ```
-
-    This time, kache restores every crate from the cache with zero-copy reflinks (hardlink or copy where the filesystem has no copy-on-write). Cargo should complete in seconds for a project with no source changes.
-  </Step>
-
-  <Step>
-    **Open the monitor**
-
-    ```sh
-    kache monitor
-    ```
-
-    The TUI monitor opens and shows the Build tab with the events from the last run — each crate listed as a local hit or miss with timing. Press `q` to quit. (Running bare `kache` prints help; use `kache monitor` to open the dashboard.)
-  </Step>
-</Steps>
-
-## How to tell it's working
-
-kache can print a one-line summary to stderr per crate, off by default. Enable it with `KACHE_PROGRESS=1` (or `hits`) to show hits, or `KACHE_PROGRESS=verbose` (or `all`) to also show dups and misses:
-
-```
-[kache] serde: local hit (2ms, 1.2 MB)
-[kache] tokio: local hit (3ms, 4.8 MB)
-[kache] myapp: miss (1.4s, 892 KB)
-```
-
-The `miss` line only appears at `KACHE_PROGRESS=verbose`; at `KACHE_PROGRESS=1`/`hits` only hit lines are shown. For a live view, open the monitor instead with `kache monitor`.
-
-Verbose progress also prints `still compiling` heartbeats for misses that outlive the configured heartbeat cadence. They stay off by default because Cargo caches compiler-wrapper stderr and can replay old progress on later builds.
-
-After upgrading from kache 0.12, already-cached heartbeat lines can keep replaying until the affected crates rebuild. Clean the project's Cargo target directory if they must be removed immediately.
-
-You can also check the cache state directly:
-
-```sh
-kache list               # all cached crates, sorted by name
-kache list serde         # details for a specific crate
-kache stats              # one-shot summary (no UI)
-```
-
-## What kache does not cache
-
-On Linux, kache caches user-facing executables (`bin` crates and `--test` harnesses) by default: DWARF lives inside the binary, so a restored executable debugs exactly like a freshly linked one. On macOS and Windows it skips them by default, because their debug info is referenced from *outside* the binary (macOS `N_OSO` records point at per-build object files; a Windows `.exe` records its `.pdb` path), so a restored binary would lose source-level debugging — see [#319](https://github.com/kunobi-ninja/kache/issues/319). Dynamic libraries (`dylib`, `cdylib`) and proc-macros stay cached everywhere regardless. Override either way with `KACHE_CACHE_EXECUTABLES=1`/`=0` or `cache_executables` in the config file.
-
-For ordinary builds, kache strips `-C incremental=...` and prefers exact local
-or remote artifacts. Rapid source churn is different: mutation testing, for
-example, presents a new source hash on almost every build while rustc can reuse
-most prior work.
-
-Kache detects that pattern automatically. After a normal miss and a successful
-incremental seed, it temporarily bypasses key work for that Cargo-primary unit,
-using per-unit state and a cross-process lock. The lane is bounded; kache then
-probes the exact artifact cache again, so a repeated revision can still hit.
-Stable dependencies and non-adaptive cache rejections continue through the
-normal Kache/fallback pipeline. Learned units run directly through Kache.
-Eligible user-facing test/bin units already excluded by
-`cache_executables=false` do too when no fallback is configured; otherwise
-their normal passthrough honors the configured fallback.
-
-No special mutation command is needed:
+From a Rust project:
 
 ```bash
-cargo mutants
+RUSTC_WRAPPER=kache cargo build
+cargo clean
+KACHE_PROGRESS=hits RUSTC_WRAPPER=kache cargo build
+kache stats
 ```
 
-Cargo's dev and test profiles already enable incremental compilation by
-default, so `CARGO_INCREMENTAL=1` is unnecessary unless your project,
-environment, or custom profile disabled it. Set `KACHE_ADAPTIVE_INCREMENTAL=0`
-to disable learning, or `KACHE_PRESERVE_INCREMENTAL=1` to force the incremental
-lane for diagnostics and benchmarks. Custom incremental layouts fail closed to
-normal kache behavior.
+The first build fills the local cache. `cargo clean` makes Cargo request the same outputs again, so the second build can demonstrate restores. Do not add `cargo clean` to a normal build workflow.
 
-## C/C++ object compiles
+This trial does not edit Cargo configuration or install a service.
 
-kache can also wrap C/C++ compilers for local object-compile caching:
+## Enable Kache permanently
 
-```sh
-export CC="kache cc"
-export CXX="kache c++"
+```bash
+kache init
 ```
 
-This is separate from `RUSTC_WRAPPER`: supported single-source `-c` compiles are cached, while link steps and unmodeled compiler shapes pass through. See [C/C++ caching](/docs/getting-started/c-cpp).
+`init` configures Cargo, installs the daemon as a login service, and starts it. It is safe to run again when repairing a setup.
 
-## Disabling kache temporarily
+Useful variants:
 
-```sh
+```bash
+kache init --check       # print proposed changes only
+kache init --no-service  # configure Cargo without a login service
+kache init --yes         # accept defaults without prompts
+```
+
+To configure Cargo yourself, use either the environment or Cargo config:
+
+```bash
+export RUSTC_WRAPPER=kache
+```
+
+```toml title="~/.cargo/config.toml"
+[build]
+rustc-wrapper = "kache"
+```
+
+## Check the setup
+
+```bash
+kache doctor
+kache monitor
+```
+
+`doctor` checks wrapper configuration, conflicting wrappers, config parsing, and daemon access. `monitor` shows hits, misses, passthroughs, store use, and remote transfers.
+
+For a non-interactive check:
+
+```bash
+kache stats
+kache list
+```
+
+## Worktrees
+
+Share the Kache store across worktrees, but give concurrent Cargo builds separate target directories. Cargo owns `target/` fingerprints and can mark a unit fresh without invoking any compiler wrapper.
+
+On Cargo 1.91 or newer, this command keeps intermediate fingerprints worktree-local while allowing final target output to be shared:
+
+```bash
+kache cargo -- build
+```
+
+Otherwise set a distinct `CARGO_TARGET_DIR` per live worktree.
+
+## Executables and incremental builds
+
+Kache caches eligible Rust executables by default on Linux and macOS. The default is off on Windows because executable debug information still refers to an external PDB path. Override the policy with `KACHE_CACHE_EXECUTABLES` or `cache.cache_executables`.
+
+Normal artifact-cached builds strip Cargo's incremental directory argument. Adaptive incremental mode, enabled by default, learns rapidly changing Cargo units and temporarily gives them isolated incremental state. Use `KACHE_ADAPTIVE_INCREMENTAL=0` to turn that off or `KACHE_PRESERVE_INCREMENTAL=1` to force the incremental path for diagnostics.
+
+## Temporarily disable caching
+
+```bash
 KACHE_DISABLED=1 cargo build
 ```
 
-Even when disabled, kache strips incremental flags to avoid the APFS issue on
-macOS unless `KACHE_PRESERVE_INCREMENTAL=1` is explicitly set.
+This keeps the wrapper in place but passes compiler work through.
+
+For C and C++, continue with [C/C++ caching](/docs/getting-started/c-cpp).

--- a/docs/how-it-works/architecture.mdx
+++ b/docs/how-it-works/architecture.mdx
@@ -1,86 +1,70 @@
 ---
 title: Architecture
-description: The three pieces of kache — wrapper, store, and daemon — and how a build flows through them.
+description: How the compiler wrapper, local store, and daemon divide the work
 ---
 
-# Architecture
+Kache has three parts: a compiler wrapper, a local store, and an optional daemon.
 
-kache is made of three independent pieces that work together: the **wrapper**, the **local store**, and the **daemon**. Understanding what each one does makes it easier to configure kache correctly and diagnose problems when they appear.
+## Build path
 
-## The wrapper
+For an eligible compiler invocation, the wrapper:
 
-When cargo builds a Rust project, it invokes rustc once per compilation unit. Setting `RUSTC_WRAPPER=kache` tells cargo to call kache instead, passing the real rustc path as the first argument.
+1. parses the compiler arguments and discovers inputs
+2. computes a BLAKE3 cache key
+3. checks the local store
+4. asks the daemon for an exact remote result after a local miss
+5. takes a per-key lock and checks locally again
+6. runs the compiler if the entry is still absent
+7. stores outputs as content-addressed blobs
+8. queues a remote upload when a writable remote is configured
 
-kache detects this mode automatically: if its first argument looks like a path to rustc or `clippy-driver`, it runs as a wrapper. Otherwise it runs as the CLI.
+The second local check prevents duplicate work when another process fills the same key while this process waits for the lock.
 
-For each rustc invocation, the wrapper does this:
+| Result | Compiler ran | Meaning |
+| --- | ---: | --- |
+| `local_hit` | No | Entry was already in the local store |
+| `prefetch_hit` | No | Background prefetch had placed the entry locally |
+| `remote_hit` | No | Exact remote lookup downloaded the entry |
+| `miss` | Yes | The key and at least one output blob were new |
+| `dup` | Yes | The key was new but all output blobs already existed |
+| `passthrough` | Yes | Policy declined to cache the invocation |
 
-```
-parse args
-    ↓
-compute blake3 cache key
-    ↓
-check local store ──── hit → restore via reflink → done
-    ↓ miss
-check remote (via daemon) ── hit → restore via reflink → done
-    ↓ miss
-acquire per-key build lock
-    ↓
-re-check local store ── peer committed → restore via reflink → done
-    ↓ still absent
-run rustc
-    ↓
-store output files in content-addressed blobs
-    ↓
-send upload job to daemon (async)
-    ↓
-release lock
-```
+A `dup` is compiled work. It often means two over-specific keys produced the same bytes.
 
-The lock prevents duplicate compilation when cargo spawns multiple parallel rustc processes for the same crate (which can happen in certain workspace configurations). A process that loses the lock waits for the winner's result and restores from the cache instead of compiling. A process that acquires the lock re-checks the store before compiling, covering a peer that committed between the initial lookup and lock acquisition.
+## Local store
 
-Build outcomes are separated into three cacheable cases:
+The store contains:
 
-| Outcome | Cache key | Compiler ran? | Blob content | Meaning |
-|---|---|---:|---|---|
-| `hit` | Found | No | Already known | kache restored from an existing entry |
-| `dup` | Missed | Yes | Already known | a new key produced bytes kache already had |
-| `miss` | Missed | Yes | New | a new key produced at least one new blob |
+- `index.db`, a SQLite index of entries and their blobs
+- `store/blobs/<prefix>/<hash>`, the content-addressed output files
+- entry metadata under `store/<cache-key>/`
 
-`hit` is shown as one row, but kache records three hit kinds in the event log — `local_hit`, `prefetch_hit`, and `remote_hit` — distinguished by where the entry was found. Invocations that bypass the cache (non-primary, excluded, or a skipped executable) record a fourth outcome, `passthrough`.
+Identical output bytes share one blob. Restores first try copy-on-write cloning. Unix can use a restricted hardlink fallback for immutable artifacts; other cases copy. Executables and loadable libraries are never hardlinked because later tools may mutate them.
 
-`dup` is a cache-key/content outcome, not the same thing as the storage
-deduplication metric. A high `dup` count can point to over-specific cache keys
-or noisy inputs, because different keys are compiling to identical bytes.
+See [Deduplication](/docs/deduplication) for platform details.
 
-Non-primary invocations — rustc calls with no source file, like dependency probing — pass straight through without touching the cache.
+## Daemon
 
-## The local store
+The daemon owns remote work and periodic maintenance:
 
-The store lives under your platform cache dir — `~/Library/Caches/kache` on macOS, `~/.cache/kache` on Linux (`$XDG_CACHE_HOME/kache`), `%LOCALAPPDATA%\kache` on Windows — and has two parts:
+- exact remote checks and downloads
+- background uploads and durable upload replay
+- speculative prefetch
+- scheduled garbage collection
+- monitor statistics that require live transfer state
 
-**SQLite index (`index.db`)** tracks every cache entry: crate name, cache key, file list, feature flags, target, and profile. It runs in WAL mode with a 5-second busy timeout so 300+ parallel rustc processes can all hit it without contention.
+The wrapper connects through `<runtime_dir>/daemon.sock` on Unix or a named pipe on Windows. A daemon failure does not break compilation: local caching continues and remote work is skipped or deferred.
 
-**Content-addressed blobs (`store/blobs/`)** hold the actual compiled files, sharded into 256 subdirectories by the first two hex chars of the hash. Each blob is named after its blake3 hash, so two crates that happen to produce an identical artifact share the same physical file. When kache restores a cache hit it reflinks the blob into the build's output dir on copy-on-write filesystems (APFS, btrfs, XFS-with-reflink): zero-copy, but with an independent inode so a later write never mutates the cache blob.
+See [Daemon overview](/docs/daemon/overview) and [Lifecycle](/docs/daemon/lifecycle).
 
-On Unix filesystems without reflink, kache permits one target to hardlink each immutable artifact (`.rlib` / `.rmeta`) to its blob. Additional target consumers use private copies so their restore-time mtime stamp cannot affect an active linker in another tree. Files that may be mutated post-build (executables, dylibs, proc-macros) always use the private-copy fallback. Windows defaults to private copies for all non-CoW restores; its legacy hardlink mode is an explicit, concurrency-unsafe opt-in.
+## Interception boundary
 
-## The daemon
+As `RUSTC_WRAPPER`, Kache sees rustc and workspace-wrapper invocations. It does not wrap Cargo itself or arbitrary tools. Rust link work driven by rustc can be cached when the artifact policy allows it; an independently invoked linker is outside this path.
 
-The daemon is a long-running background process that handles everything async: uploading new artifacts to the configured remote, checking it before a build starts, and prefetching artifacts for upcoming crates.
+C/C++ caching is separate. Kache must be invoked as the compiler wrapper or through a compiler-name shim, and currently caches supported object compilations locally.
 
-The wrapper communicates with the daemon over a Unix socket (`daemon.sock` inside the runtime dir, which defaults to the cache dir; a named pipe on Windows) using lightweight RPC calls. Local-only calls — queuing an upload, a cached remote-check answer — return in well under a millisecond; a remote check that reaches the configured backend takes as long as that round-trip. If the daemon is down, the wrapper continues without it — local caching works normally, remote features degrade gracefully.
+## Planner
 
-The daemon runs as a separate binary invocation (`kache daemon run`) and can be managed as a system service via launchd (macOS) or systemd (Linux). See [Daemon lifecycle](/docs/daemon/lifecycle) for details.
+Without a planner service, the daemon can prefetch from manifests, Cargo metadata, remote indexes, and local history. With `cache.planner.endpoint` or `KACHE_PLANNER_ENDPOINT`, it first asks the preview planner for ranked candidates. A fallback response returns the client to its local planning path.
 
-## What kache does not touch
-
-As a `RUSTC_WRAPPER`, kache intercepts only `rustc` and `clippy-driver` invocations — not `cargo`, `ld`, or any other tool; linking, proc-macro expansion, and build scripts run unmodified. Separately, kache can be set as `CC` / `CXX` to wrap a C/C++ compiler — `gcc`/`clang`, or `clang` in MSVC driver mode (`clang-cl` / `--driver-mode=cl`, as used by mozconfigs and the `cc` crate on Windows) — for local object-compile caching. That path is independent of the rustc wrapper. See [C/C++ caching](/docs/getting-started/c-cpp).
-
-Executables — `bin` crates and `--test` harness binaries — are cached by default on Linux and skipped by default on macOS and Windows, where debug info is referenced from outside the binary (see [#319](https://github.com/kunobi-ninja/kache/issues/319) and `cache_executables`). dylib, cdylib, and proc-macro crates stay cached everywhere. Restored executables are independent copies rather than hardlinks, so a post-build `strip` or code-signing step cannot write back into a store blob. The final binary is often the single most expensive unit on a warm build's critical path, so caching it is worth materially more than its one-unit share suggests.
-
-## The remote planner
-
-By default, prefetch is driven entirely by the client running `cargo metadata` and asking the daemon to pull every crate in the resolved graph from the configured remote. This is good but not optimal — the metadata pass is workspace-local and can't reason about which artifacts are *most* likely to hit on the current toolchain / target / feature set.
-
-A separate planner service (see [Remote service](/docs/remote-service)) accepts manifests from clients (`kache save-manifest`), stores them in an embedded database, and replies to prefetch queries with a ranked candidate list. The client path is already wired: when `KACHE_PLANNER_ENDPOINT` is set, the daemon asks the planner before each build. When the planner has no useful data it returns a fallback disposition and the client behaves exactly as it does without it. The planner is purely additive — local caching, remote sync, and metadata-driven prefetch keep working with no planner configured. (The hosted planner service itself is still in preview.)
+The planner does not affect local correctness or exact-key lookup. See [Remote service](/docs/remote-service).

--- a/docs/how-it-works/cache-key.mdx
+++ b/docs/how-it-works/cache-key.mdx
@@ -1,108 +1,82 @@
 ---
 title: Cache key
-description: What goes into the blake3 cache key and why keys are portable across machines.
+description: Inputs, normalization, and tools for explaining a cache miss
 ---
 
-# Cache key
+Kache hashes the inputs that can change compiler output and normalizes machine-local paths that should not. Missing a real input risks a wrong hit; retaining harmless machine identity causes avoidable misses.
 
-The cache key is a blake3 hash that uniquely identifies one compiled artifact. Two rustc invocations that would produce identical output must produce the same key. Two invocations that differ in any input that affects the output must produce different keys.
+## Rust key inputs
 
-Getting this right is the core correctness challenge in any build cache. A false positive (same key, different output) corrupts the build. A false negative (different keys, identical output) wastes time.
+The exact set depends on the invocation. It can include:
 
-## What's in the key
+- rustc identity and target
+- linker identity for outputs that invoke linking
+- crate name, crate types, edition, cfg values, and features
+- source and included file contents discovered through dep-info
+- code-generation flags, rustflags, and requested emit kinds
+- the contents of `--extern` dependencies
+- compile-time environment values rustc reports
+- native libc identity for host-loaded Linux outputs
+- configured salt, extra inputs, and declared environment inputs
 
-The principle is simple: **anything that changes the compiled output goes into the key; anything that's just machine-local noise is normalized out.** That's what lets one machine restore what another built.
+Incremental directory names and harmless local path spellings are excluded or normalized.
 
-What goes in (change any of these and the crate re-keys):
+The live implementation is the authority. Use `kache why-miss` and trace logging to see the components for a particular build.
 
-- **Toolchain identity** — the `rustc --version --verbose` banner (commit hash + host triple), plus the linker's `--version` for outputs that actually link.
-- **What you're compiling** — crate name, types, and edition; and every source file the crate reads. kache finds them with a `--emit=dep-info` pre-pass, so modules, `include!()` targets, and build-script output are all covered, and hashes each by content.
-- **How you're compiling it** — target triple, feature/`cfg` flags, codegen (`-C`) options, `RUSTFLAGS`, and the active `--emit` set (so a `cargo check` entry is never served to a `cargo build`).
-- **What it depends on** — each `--extern` rlib/rmeta, hashed by content, so a dependency change propagates to everything downstream.
-- **Compile-time environment** — the `env!()` / `option_env!()` values a build bakes in. These are the reads rustc reports; an env var a **proc macro** reads with `std::env::var` while expanding is invisible to the compiler and has to be declared (see [`key_env_vars`](/getting-started/configuration#env-vars-that-steer-expansion)).
-- **Native Linux libc** — for OS-loaded outputs (`bin`, `dylib`, `cdylib`, and proc-macros), the GNU libc or musl version. Portable rlibs and cross-target outputs deliberately exclude this host-only signal.
+## Path normalization
 
-What's deliberately left out (machine-local, doesn't affect output): the incremental-compilation directory, the linker path (its *identity* is captured via `--version` instead), and absolute build/checkout paths — those are normalized to stable sentinels so the key is the same regardless of where you built. See [Cross-machine portability](#cross-machine-portability).
+Kache maps known roots to stable sentinels before hashing and asks the compiler to emit matching remapped paths. This allows equivalent worktrees and runners to share entries.
 
-<Callout type="info">
-The authoritative, always-current list for any specific build is what kache actually logs — `kache why-miss <crate>` and `KACHE_LOG=trace` print every component it hashed (see [Debugging cache misses](#debugging-cache-misses)). Prefer that over a hand-kept enumeration, which drifts as the keying logic evolves.
-</Callout>
+Common mappings include the workspace, Cargo home, Rustup home, temporary directory, target directory, and configured base directories. Add a missing root with `KACHE_BASE_DIR` or `paths.base_dirs`.
 
-### Tuning the key
+Do not choose an overly broad base directory. Normalization deliberately merges path identities; two genuinely different inputs must not map to the same sentinel.
 
-A few opt-in knobs, all no-ops by default:
+Disable Rust path normalization for a local profiling or debugging session:
 
-- **`KACHE_BASE_DIR`** — declare a path prefix to strip from the key (collapsed to `<BASE_DIR>`). Use it for checkout or container-mount paths the automatic sentinels don't catch, so out-of-tree builds still share hits.
-- **`paths.base_dirs`** — a deterministic file-config list for multiple container, sandbox, or custom roots. Each entry maps to its own sentinel; longest match wins. This is a correctness-sensitive key-merging option, so read the [safety warning](/getting-started/configuration#extra-path-prefixes).
-- **`KACHE_KEY_SALT` / `cache.key_salt`** — fold an opaque string into every key to force a cold cache when the toolchain changes in a way kache cannot observe (a custom/cross-target libc or sysroot change, a same-version distro libc patch, a Nix closure rebuild, or a hidden linker change). See [Configuration](/getting-started/configuration#cache-key-salt).
-- **`kache.toml` extra inputs** — declare files the compiler reads but never reports (sqlx's `.sqlx/`, `migrations/`, `include!`'d data) so editing them re-keys the crate. See [Configuration](/getting-started/configuration#extra-cache-key-inputs).
-- **`path_only_env_vars`** — plain path-locator env vars, plus narrowly scoped `rustc_crate_name:VAR` assertions for known scan false positives. See [Configuration](/getting-started/configuration#path-only-env-vars).
-- **`key_env_vars`** — env vars a proc macro reads at expansion time. rustc reports only `env!`/`option_env!` reads, so a macro branching on `std::env::var` produces different code from an identical command line; declaring the var separates the two. See [Configuration](/getting-started/configuration#env-vars-that-steer-expansion).
-
-## Cross-machine portability
-
-The key is designed to be the same on any machine that has the same:
-
-- Rust toolchain version
-- Target triple
-- Source code
-- Feature flags and cfg values
-- RUSTFLAGS (after path normalization)
-- Native Linux libc version, when the output is OS-loaded rather than a portable rlib
-
-This is what makes the remote cache useful in CI: a developer's laptop and a fresh CI runner with the same toolchain produce identical keys, so CI can restore what the developer already built.
-
-## Debugging cached binaries
-
-The same `--remap-path-prefix` rules that make artifacts portable also rewrite the paths baked into debug info. So the DWARF (or PDB on Windows) in a cached binary refers to your sources through stable, machine-independent paths instead of the local path it was compiled at. Those paths are chosen so profilers and debuggers can resolve them:
-
-| Real location | Path baked into debug info |
-|---|---|
-| the repo / workspace checkout | `/proc/self/cwd` (Linux) or `/kache/workspace` |
-| rust std / core sources | `/rustc/<commit-hash>/...` (the upstream form) |
-| registry + git deps (`~/.cargo`) | `/kache/.cargo/registry/src/...` |
-| `~/.rustup` toolchain files | `/kache/rustup` |
-| `KACHE_BASE_DIR`, `paths.base_dirs`, `$HOME`, tempdir, `$CARGO_TARGET_DIR` | `/kache/base-dir`, `/kache/base-dir-N`, `/kache/home`, `/kache/tmp`, `/kache/target` |
-
-The paths are absolute, so a debugger or profiler never composes them into nonsense, and machine-independent, so one cached binary is valid in every checkout.
-
-**samply / the [Firefox Profiler](https://github.com/mstange/samply) resolve most of this with no configuration.** std sources (`/rustc/<hash>/...`) are fetched from `github.com/rust-lang/rust`, and dependency sources (`/kache/.cargo/registry/src/...`) from crates.io, exactly as they are for a plain cargo build. That works on **every OS**, because it depends on the path *shape*, not on `/proc`.
-
-Your own workspace sources are the exception, and here the OS matters:
-
-- **Linux:** they resolve with no configuration, as long as you run the profiler from the workspace root. `/proc/self/cwd` is a kernel-provided symlink to the reading process's working directory, so the profiler opens the real files.
-- **macOS / Windows:** there is no `/proc`, so workspace sources use the fixed `/kache/workspace` prefix. gdb/lldb can map that back (below), but samply currently has no source-map setting, so *workspace* sources are not resolved there yet (std and dependency sources still are). Closing that gap needs an upstream samply feature; it is tracked in the [#485 follow-up](https://github.com/kunobi-ninja/kache/issues/485). If you need workspace sources in samply on macOS/Windows today, use the `KACHE_RUSTC_PATH_NORMALIZE=0` opt-out below.
-
-For **gdb / lldb**, map the workspace prefix back to your checkout. On Linux, launching the debugger from the workspace root usually makes this unnecessary (`/proc/self/cwd` already points there); elsewhere:
-
-```sh title="gdb"
-# in ~/.gdbinit or at the prompt
-set substitute-path /kache/workspace /abs/path/to/your/checkout
+```bash
+KACHE_RUSTC_PATH_NORMALIZE=0 cargo build
 ```
 
-```sh title="lldb"
-# in ~/.lldbinit or at the prompt
-settings set target.source-map /kache/workspace /abs/path/to/your/checkout
+That puts real paths in debug information and makes the key local to those path identities. C/C++ has the corresponding `KACHE_CC_PATH_NORMALIZE=0` control.
+
+Coverage-instrumented Rust builds use real paths and a separate, path-local key namespace so coverage tools can find source files.
+
+## Debugger source maps
+
+On macOS and Windows, map the stable workspace prefix back to your checkout:
+
+```text title="gdb"
+set substitute-path /kache/workspace /absolute/path/to/checkout
 ```
 
-Add `substitute-path` / `source-map` entries for `/kache/.cargo` or `/kache/rustup` if you want to step into dependency or std sources from a local copy instead of fetching them.
-
-If you would rather have your real local paths baked in with no mapping at all, set `KACHE_RUSTC_PATH_NORMALIZE=0` (see below).
-
-This page describes the **rustc** artifact cache. C/C++ object compiles (`cc` / `c++` / `clang-cl`, see [C/C++ caching](/docs/getting-started/c-cpp)) are keyed separately, and their `-ffile-prefix-map` targets follow the same scheme (`/proc/self/cwd` for the build directory on Linux, `/kache/cc-root`, `/kache/sdkroot`, and so on). clang-cl debug compiles (`/Z7` / `-Z7` / `-g`) *are* cached, but the key stays machine-local: clang-cl embeds CodeView paths directly in the `.obj` (no separate PDB) and ignores `-ffile-prefix-map`, so kache keeps those paths literal in the key rather than remapping them, giving correct local hits but no cross-machine sharing.
-
-**Coverage builds are exempt.** When coverage instrumentation is active (`-C instrument-coverage`), kache skips path remapping entirely, so tools like `cargo-llvm-cov` and tarpaulin map profiling data back to real source paths with no extra configuration. Skipping the remap also changes the key, so coverage builds keep a separate cache from regular ones — and, because the artifact then bakes real machine-local paths, that key includes the build's local path identity too (same mechanism as the opt-out below), so coverage artifacts only share when the baked path identity matches — different checkouts or tool roots get different keys.
-
-**Opting out entirely.** If you profile or debug locally and would rather have real source paths baked into debug info than configure a source map — e.g. so [samply](https://github.com/mstange/samply) / the Firefox Profiler resolve sources with no setup — set `KACHE_RUSTC_PATH_NORMALIZE=0`. kache then injects no `--remap-path-prefix` flags and rustc records the real machine-local paths (this is the rustc analog of `KACHE_CC_PATH_NORMALIZE=0` for C/C++). The trade-off: the key hashes `remap:none` **plus the build's real local path identity** (working directory, `$CARGO_HOME`/`$RUSTUP_HOME`/`$HOME`/tempdir roots) — a separate namespace from remapped builds *and* from other checkouts, so these real-path artifacts only share when the baked path identity matches — different checkouts or tool roots get different keys (the rustc analog of cc's path-literal keys). Accepted tokens are the same as the cc toggle — `0` / `false` / `off` / `no` disable it; anything else (including unset) keeps normalization on, which is the default so ordinary builds stay portable.
-
-## Debugging cache misses
-
-If a crate keeps missing when you expect a hit, use `kache why-miss <crate-name>`. It compares the cache key from the last known entry against the current build and reports which input changed.
-
-For full key-component details, run the command `why-miss` prints:
-
-```sh
-KACHE_LOG=trace cargo build -p <crate-name> 2>&1 | grep '\[key:<crate-name>\]'
+```text title="lldb"
+settings set target.source-map /kache/workspace /absolute/path/to/checkout
 ```
 
-This logs every component being hashed during key computation. As a defense-in-depth check, a `KACHE_LOG=warn` run also flags any residual machine-local absolute path that survives normalization (matching prefixes like `/Users/`, `/home/`, `/private/tmp/`, `/var/folders/`, `C:\Users\`), naming the offending key field — a fast signal that something is leaking a per-machine path into the key.
+Linux workspace paths use `/proc/self/cwd` when possible, so running the debugger from the workspace root usually resolves them directly.
+
+## Inputs the compiler does not report
+
+Use these controls only for a real hidden input:
+
+- `cache.key_salt` or `KACHE_KEY_SALT` for an opaque toolchain boundary
+- crate `kache.toml` for files read during compilation but absent from dep-info
+- `workspace.extra_inputs` for workspace-root provider inputs
+- `cache.key_env_vars` for environment read by proc macros through `std::env`
+- `cache.path_only_env_vars` for locator variables proven not to affect emitted bytes
+
+See [Configuration](/docs/getting-started/configuration) for syntax and safety limits.
+
+## Explain a miss
+
+```bash
+kache why-miss my_crate
+```
+
+The command compares recent key material for that crate and prints changed groups. For individual components, run the trace command it suggests, typically:
+
+```bash
+KACHE_LOG=trace cargo build -p my_crate 2>&1 | grep '\[key:my_crate\]'
+```
+
+Warnings also identify residual absolute paths that survive normalization.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -53,7 +53,7 @@ Kache passes unsupported compiler invocations through unchanged. A passthrough i
 
 ## Tested nightly on real projects
 
-The [nightly benchmark workflow](https://github.com/kunobi-ninja/kache/actions/workflows/bench.yml) runs cold/warm builds of Firefox, LLVM, Substrate, and SurrealDB, including Firefox runs on Linux and Windows and a side-by-side sccache run. Reports, traces, and logs are retained for 30 days.
+The [nightly benchmark workflow](https://github.com/kunobi-ninja/kache/actions/workflows/bench.yml) runs cold/warm builds of Firefox, LLVM, Substrate, SurrealDB, and Lance, including Firefox runs on Linux and Windows and a side-by-side sccache run. Reports, traces, and logs are retained for 30 days.
 
 Benchmark numbers count only when the individual job succeeds and its self-checking verdict is `ok`.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,64 +1,84 @@
 ---
-title: kache
-description: Content-addressed build cache for Rust and C/C++ object compiles, with zero-copy local restores where safe plus S3 or filesystem sharing.
+title: Kache
+description: A local-first compiler cache for Rust and C/C++ builds
 ---
 
-# Introduction
+Kache stores compiler outputs by content and reuses them across builds, repositories, and worktrees. The local cache works on its own. S3-compatible and filesystem remotes are optional.
 
-**kache** is a drop-in `RUSTC_WRAPPER` for Rust and a `cc` / `c++` compiler wrapper for C/C++ object compiles. Cache keys are blake3 hashes of normalized compiler inputs; cache hits prefer reflinks. On Unix without CoW, one immutable target may hardlink to a blob while additional consumers receive private copies. Windows restores copy by default; unrestricted hardlink sharing is an explicit legacy opt-in. Identical blobs are stored once in the cache. An optional S3-compatible or shared-filesystem remote shares Rust artifacts across machines.
+## Decide first
 
-Local Rust caching, local C/C++ object caching, and direct remote sync are working today. C/C++ artifacts are local-only for now; unsupported compiler shapes pass through to the real compiler.
+- Use Kache if you want shared caching across worktrees, local-first operation, built-in inspection tools, or explicit cache synchronization.
+- Read [Kache or sccache?](/docs/getting-started/comparison) if you are comparing compiler caches.
+- Start with a temporary wrapper if you want to evaluate Kache without changing Cargo configuration or installing a service.
 
-<Callout type="info">
-**PREVIEW:** a remote planner that prefetches from workspace manifests, dependency history, and build intent — warming the right artifacts before rustc asks for them. The daemon already calls a planner when `KACHE_PLANNER_ENDPOINT` is set; the hosted service is still preview. See [Remote service](/docs/remote-service).
-</Callout>
+## Five-minute Rust trial
 
-![kache: cold build populates the store, then `cargo clean && cargo build` restores every artifact zero-copy](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/demo.gif)
+Install Kache:
 
-> Cold compile populates kache's store, `cargo clean` wipes `target/`, and the second build pulls every artifact back zero-copy (reflink, falling back to hardlink/copy).
-
-## Why local kache is fast
-
-kache is useful even before remote cache is configured:
-
-- **Zero-copy where safe.** Local hits use reflink (copy-on-write) where supported. On Unix without CoW, one immutable target may hardlink to a blob; additional consumers use private copies so restore timestamps cannot disturb active readers. Windows copies by default.
-- **Content-addressed storage.** The store is keyed by blake3 hash, so identical artifact blobs are stored once in the cache.
-- **Compile-then-record on misses.** Misses compile normally, then kache records the outputs for future builds.
-- **Daemon-optional locally.** If the daemon is not running, local hits and misses still work; remote checks, uploads, and prefetching degrade gracefully.
-- **Adaptive source-churn builds.** Exact artifacts remain the default. After repeated source-only misses, kache temporarily gives the affected Cargo unit isolated rustc incremental state, which speeds mutation tests and similar workloads without detecting a particular tool or requiring project setup.
-
-## Try it
-
-```sh
-# install
-mise use -g github:kunobi-ninja/kache@latest
-
-# interactive setup: cargo wrapper + login service + daemon start
-kache init
-
-# verify
-kache doctor
+```bash
+cargo install kache
 ```
 
-`kache init` is idempotent — re-run it any time to repair configuration. Prefer to wire things by hand? Just export `RUSTC_WRAPPER=kache` or set `rustc-wrapper = "kache"` under `[build]` in `~/.cargo/config.toml`.
+From a Rust project, run:
 
-## Architecture in one screen
+```bash
+RUSTC_WRAPPER=kache cargo build
+cargo clean
+KACHE_PROGRESS=hits RUSTC_WRAPPER=kache cargo build
+kache stats
+```
 
-- **Wrapper** — `RUSTC_WRAPPER` intercepts rustc calls; `CC="kache cc"` and `CXX="kache c++"` intercept supported C/C++ object compiles. Hits use a reflink where supported, an exclusive Unix hardlink, or a private copy.
-- **Daemon** — background process handles async remote uploads, checks, and prefetch. Auto-restarts on binary update.
-- **Store** — SQLite index at `{cache_dir}/index.db`, plus content-addressed blobs under `{cache_dir}/store/blobs/`; hits restore those blobs into `target/` with a reflink, exclusive Unix hardlink, or private copy.
-- **Cache keys** — deterministic blake3 hash of rustc version, crate name, source, dependencies, and normalized flags — portable across machines.
+The second build should report cache hits. `cargo clean` forces Cargo to ask the compiler for the same outputs again; it is only needed for this demonstration.
+
+Nothing above edits your Cargo configuration. When you are ready to keep Kache enabled, run:
+
+```bash
+kache init
+```
+
+Use `kache init --check` to preview the changes, or `kache init --no-service` to skip OS service installation.
+
+## Current support
+
+| Area | Support |
+| --- | --- |
+| Rust libraries and build scripts | Linux, macOS, and Windows |
+| Rust executables | Enabled by default on Linux and macOS; disabled by default on Windows |
+| C and C++ object compilation | GCC, Clang, Apple Clang, and MSVC-compatible invocations that Kache can model safely |
+| Local cache | Content-addressed storage with automatic garbage collection |
+| Remote cache | S3-compatible and filesystem backends |
+| Build visibility | Live monitor, stats, miss explanations, and reports |
+
+Kache passes unsupported compiler invocations through unchanged. A passthrough is not a cache hit or miss; inspect its reason in the monitor's Passthrough tab or debug logs.
+
+## Tested nightly on real projects
+
+The [nightly benchmark workflow](https://github.com/kunobi-ninja/kache/actions/workflows/bench.yml) runs cold/warm builds of Firefox, LLVM, Substrate, and SurrealDB, including Firefox runs on Linux and Windows and a side-by-side sccache run. Reports, traces, and logs are retained for 30 days.
+
+Benchmark numbers count only when the individual job succeeds and its self-checking verdict is `ok`.
+
+## Go further
 
 <Cards>
-  <Card title="Installation" href="/docs/getting-started/installation" description="mise, cargo-binstall, or build from source" />
-  <Card title="Quick start" href="/docs/getting-started/quick-start" description="kache init, first build, verifying hits" />
-  <Card title="C/C++ caching" href="/docs/getting-started/c-cpp" description="Wrap cc, c++, gcc, clang, and clang-cl object compiles" />
-  <Card title="How it works" href="/docs/how-it-works/architecture" description="Wrapper, store, daemon — the full picture" />
-  <Card title="Cache key" href="/docs/how-it-works/cache-key" description="What's hashed and why keys are portable" />
-  <Card title="S3 remote cache" href="/docs/remote-cache/s3-setup" description="AWS, R2, Ceph, MinIO — same config" />
-  <Card title="Filesystem remote cache" href="/docs/remote-cache/filesystem-setup" description="Share artifacts through a mounted directory" />
-  <Card title="CI setup" href="/docs/remote-cache/ci" description="GitHub Actions one-liner via kache-action" />
-  <Card title="Monitor" href="/docs/monitor" description="Live TUI dashboard for builds, store, transfers" />
-  <Card title="Benchmarks" href="/docs/benchmarks" description="Cold/warm scenarios, sccache comparison, reports, and Perfetto traces" />
-  <Card title="Commands" href="/docs/commands/reference" description="Every CLI subcommand with flags and examples" />
+  <Card title="Install" href="/docs/getting-started/installation">
+    Packages, binaries, source builds, and platform notes.
+  </Card>
+  <Card title="Quick start" href="/docs/getting-started/quick-start">
+    Enable Kache for a project or across Cargo builds.
+  </Card>
+  <Card title="C and C++" href="/docs/getting-started/c-cpp">
+    Set up compiler shims and check what is cached.
+  </Card>
+  <Card title="Remote cache" href="/docs/remote-cache/s3-setup">
+    Share entries through S3-compatible or filesystem storage.
+  </Card>
+  <Card title="Command reference" href="/docs/commands/reference">
+    Exact commands and common flags.
+  </Card>
+  <Card title="How it works" href="/docs/how-it-works/architecture">
+    Cache keys, storage, daemon behavior, and correctness boundaries.
+  </Card>
+  <Card title="Benchmarks" href="/docs/benchmarks">
+    Nightly real-project runs, local scenarios, reports, and traces.
+  </Card>
 </Cards>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -82,3 +82,7 @@ Benchmark numbers count only when the individual job succeeds and its self-check
     Nightly real-project runs, local scenarios, reports, and traces.
   </Card>
 </Cards>
+
+## Feedback
+
+If Kache behaves differently from these docs, [open a bug report](https://github.com/kunobi-ninja/kache/issues/new?template=bug_report.md). For a missing compiler, remote backend, or workflow, [open a feature request](https://github.com/kunobi-ninja/kache/issues/new?template=feature_request.md).

--- a/docs/monitor.mdx
+++ b/docs/monitor.mdx
@@ -1,133 +1,58 @@
 ---
 title: Monitor
-description: Reading and using the live TUI dashboard.
+description: Read live cache, build, storage, and transfer state
 ---
 
-# Monitor
+Open the terminal dashboard:
 
-`kache monitor` opens a live TUI dashboard that shows what's happening in your cache in real time. It refreshes automatically and doesn't require the daemon to be running: the monitor makes a best-effort attempt to start one in the background for richer stats, but still works via direct store and event-log reads if the daemon is unavailable (the Transfer line then reads `n/a (daemon offline)`).
-
-![kache monitor TUI cycling through Build, Projects, Store, Transfer, and Passthrough tabs against a populated cache](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/monitor.gif)
-
-Static layout for reference:
-
-```text
- [1] Build   [2] Projects  [3] Store   [4] Transfer   [5] Passthrough
-┌ kache monitor ────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│  Store: 45.0 GiB / 50.0 GiB [ 90.1%]    11004 entries                                                             │
-│  Hit rate: 61% count | 42% weighted | 79% miss-time    Remote: not configured                                     │
-│  Dedup: 8.2 GiB saved (18.1%)    Blobs: 36.9 GiB physical    Hardlinks: 4.9 GiB via 7023 hardlinks    Scan: idle  │
-│  Transfer: ↑ 0 uploading  ↓ 0 downloading                                                                         │
-│  rustc-wrapper=kache via ~/.cargo/config.toml ✓    unknown                                                        │
-│  kache vX.Y.Z (epoch 1777305862)    daemon: vX.Y.Z (epoch 1777305862)    Cache: ~/Library/Caches/kache            │
-│                                                                                                                   │
-└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-┌ Live Build ───────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-│                                                                                                                   │
-└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-┌ Hit Rate (recent) ────────────────────────────────────────────────────────────────────────────────────────────────┐
-│  No data yet                                                                                                      │
-│                                                                                                                   │
-│                                                                                                                   │
-└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-  q: quit  f: filter  ↑↓: scroll  Tab: next  c: clear  1-5: tabs
+```bash
+kache monitor
+kache monitor --since 1h
 ```
+
+The monitor attempts to start the daemon for transfer statistics. It still reads the local store and event log if the daemon is unavailable.
+
+![Kache monitor showing build, project, store, transfer, and passthrough tabs](https://raw.githubusercontent.com/kunobi-ninja/kache/main/assets/monitor.gif)
 
 ## Header
 
-The header line at the top of the monitor shows the current state of your local store and remote:
-
-| Field | What it means |
-|---|---|
-| `Store` | Bytes used vs. the configured maximum (`KACHE_MAX_SIZE`) |
-| `Hit rate` | Three headline rates over the window: `count` (% of builds served from cache), `weighted` (% of compile-time saved), and `miss-time` (% of wall-time spent in misses). Falls back to `local \| remote \| miss` percentages when compile-time data is unavailable |
-| `Dedup` | Logical bytes saved by storing shared blobs once |
-| `Blobs` | Physical bytes used by blob files in the local store |
-| `Hardlinks` | Unix-only inode-link scan: extra bytes saved because store blobs are hardlinked into `target/` instead of copied. Reads `none — restores prefer reflink/CoW` on copy-on-write filesystems (APFS, btrfs, XFS-with-reflink), where restores are reflinks (independent inodes) and the real savings show up under `Dedup` instead — a zero here is not a problem |
-| `Scan` | Whether the background hardlink scan is still calculating, scanning, or idle |
-| `Transfer` | Number of uploads and downloads currently in-flight via the daemon |
+| Field | Meaning |
+| --- | --- |
+| `Store` | Registered blob bytes and configured maximum |
+| `Hit rate` | Count rate, compile-time-weighted rate, and miss-time share when timing exists |
+| `Remote` | Effective remote state |
+| `Dedup` | Logical bytes avoided by shared content blobs |
+| `Blobs` | Physical blob bytes |
+| `Hardlinks` | Unix hardlink fallback savings; zero is normal on CoW filesystems |
+| `Transfer` | Active daemon uploads and downloads |
+| wrapper and versions | Cargo wrapper source, client version, daemon version, and cache path |
 
 ## Tabs
 
-### 1 — Build
+1. `Build` shows compiler events, outcome, action, timing, and size.
+2. `Projects` lists observed target directories and disk use. Press `r` to rescan.
+3. `Store` lists cache entries. Press `s` to change sort order.
+4. `Transfer` shows recent remote uploads and downloads.
+5. `Passthrough` shows the route, exit code, and reason for uncached invocations.
 
-A live event stream showing every rustc invocation kache handled, as a table with Status (outcome glyph + word), Crate, Action (what kache actually did — built+cached / restored / downloaded), Compile (compile-phase time, shown only for misses and dups), Total (wall time), and Size. New events appear at the bottom.
+`dup` means the compiler ran after a key miss but produced blobs already in the store. It is not a cache hit.
 
-`dup` means the cache key missed and the compiler ran, but every unique output
-blob already existed in the local store before the store step. It is a
-diagnostic signal for over-specific keys or noisy inputs, but it still counts as
-compiled work rather than a cache hit.
+## Keys
 
-This is separate from the `Dedup` storage metric. `Dedup` estimates hardlink and
-content-addressed storage savings; `dup` identifies compiles that produced
-already-known bytes under a different cache key.
-
-The `--since` flag controls how far back the event log is read when the monitor opens:
-
-```sh
-kache monitor --since 1h    # show last hour
-kache monitor --since 7d    # show last 7 days
+```text
+q                 quit
+Tab               next tab
+1 2 3 4 5         select a tab
+Up / Down         scroll
+f                 filter the current supported tab
+s                 change Store sort
+c                 clear Build events
+r                 rescan Projects
 ```
 
-Press `f` to filter the event list by crate name. Press `c` to clear it.
+## Triage
 
-### 2 — Projects
-
-A list of `target/` directories kache has linked artifacts into, with their total disk usage and link status. This gives you a quick view of which projects are using disk space.
-
-Press `r` to refresh the project list (it doesn't auto-refresh because scanning target directories is expensive).
-
-### 3 — Store
-
-A table of all cached crate entries, sortable by name, size, hits, or age. Use this to see what's actually in the cache and identify large or stale entries before running GC.
-
-Press `s` to cycle the sort order (size → hits → age → name). Press `f` to filter by crate name or cache key.
-
-### 4 — Transfer
-
-A log of recent remote uploads and downloads, with transfer rates and artifact sizes. Useful for verifying that the daemon is uploading new artifacts and that remote hits are flowing in correctly.
-
-### 5 — Passthrough
-
-A table of invocations kache passed through instead of caching. Each row shows the time, crate, route (`fallback` if a configured fallback wrapper handled it, else `direct`), exit code, and the reason kache declined to cache it.
-
-## Keyboard shortcuts
-
-```
-q           quit
-Tab         next tab
-1 / 2 / 3 / 4 / 5    switch to tab by number
-↑ / ↓       scroll
-f           filter (Build, Store, and Passthrough tabs)
-s           cycle sort order (Store tab)
-c           clear build event list (Build tab)
-r           refresh project list (Projects tab)
-```
-
-## Quick triage
-
-**High miss rate when the daemon is offline.**
-The remote cache isn't being checked. Start the daemon (`kache daemon start`) and verify it can reach the configured remote. Check `kache daemon log` for errors.
-
-**Store usage is near the maximum.**
-Run `kache gc` to evict the least-recently-used entries, or `kache gc --max-age 7d` to remove anything older than a week. You can also raise `KACHE_MAX_SIZE` if disk space allows.
-
-**Remote is configured but Transfer tab shows no activity.**
-The daemon may not be running, or credentials may be wrong. Check `kache daemon` status and verify the remote config with `kache doctor`.
-
-**A specific crate keeps missing.**
-Run `kache why-miss <crate-name>` to see which input to the cache key changed since the last recorded entry.
+- Daemon offline: run `kache daemon status` and inspect `kache daemon log`.
+- Store near its limit: run `kache gc` or set a larger `cache.local_max_size`.
+- No remote activity: check daemon state, credentials, and `kache doctor`.
+- Unexpected misses: run `kache why-miss <crate>`.

--- a/docs/remote-cache/ci.mdx
+++ b/docs/remote-cache/ci.mdx
@@ -1,169 +1,89 @@
 ---
 title: CI setup
-description: Using kache in GitHub Actions and other CI environments.
+description: Use Kache in GitHub Actions or a shell-based CI job
 ---
-
-# CI setup
 
 ## GitHub Actions
 
-The fastest way to add kache to a GitHub Actions workflow is the official action:
+The official action installs Kache, configures the Rust wrapper, and can persist the local store through GitHub's cache service:
 
 ```yaml title=".github/workflows/ci.yml"
 steps:
   - uses: actions/checkout@v4
   - uses: dtolnay/rust-toolchain@stable
-
   - uses: kunobi-ninja/kache-action@v1
-
-  - run: cargo build --release
+  - run: cargo build --locked
 ```
 
-The action installs kache, sets `RUSTC_WRAPPER=kache`, and persists the local kache store with GitHub's built-in Actions cache by default. No S3 bucket is required.
+See the [kache-action repository](https://github.com/kunobi-ninja/kache-action) for its current input reference and release notes.
 
-<Callout type="info">
-The default GitHub Actions cache backend is the simplest choice for most open-source projects. For private infrastructure, larger caches, or sharing across repositories, use an S3 bucket instead.
-</Callout>
-
-## Using S3 with kache-action
-
-If you have an S3 bucket, pass it to the action:
-
-```yaml
-steps:
-  - uses: actions/checkout@v4
-  - uses: dtolnay/rust-toolchain@stable
-
-  - uses: kunobi-ninja/kache-action@v1
-    with:
-      s3-bucket: my-build-cache
-      s3-region: eu-west-1
-      s3-access-key-id: ${{ secrets.S3_ACCESS_KEY_ID }}
-      s3-secret-access-key: ${{ secrets.S3_SECRET_ACCESS_KEY }}
-
-  - run: cargo build --release
-  - run: cargo test
-```
-
-For S3-compatible stores such as MinIO, Ceph, or R2, also set `s3-endpoint`:
+For S3-compatible storage:
 
 ```yaml
 - uses: kunobi-ninja/kache-action@v1
   with:
     s3-bucket: my-build-cache
-    s3-endpoint: https://minio.internal:9000
+    s3-region: eu-west-1
     s3-access-key-id: ${{ secrets.S3_ACCESS_KEY_ID }}
     s3-secret-access-key: ${{ secrets.S3_SECRET_ACCESS_KEY }}
 ```
 
-With S3 configured, the action starts the kache daemon for warm prefetch, saves a build manifest after the build, pushes new artifacts with `kache sync --push`, writes a job summary, and can post a sticky PR comment with `kache report --format github`.
+Add `s3-endpoint` for R2, Ceph, or MinIO. Prefer workload identity or IAM roles over long-lived access keys when the runner supports them.
 
-Warm prefetch is most useful for ephemeral runners with an empty local store. Long-lived self-hosted runners should measure it separately: when their local store is already warm, speculative planning and remote-key indexing can cost more than exact on-demand remote lookup. Prefer a persistent config file on those runners:
+## Other CI systems
 
-```toml title="~/.config/kache/config.toml"
+Install Kache, then provide wrapper and remote configuration:
+
+```bash
+export RUSTC_WRAPPER=kache
+export KACHE_S3_BUCKET=my-build-cache
+export KACHE_S3_REGION=eu-west-1
+
+kache sync --pull
+cargo build --locked
+kache sync --push
+```
+
+Set credentials through the runner's secret store or standard cloud identity chain. Use `--allow-partial` only when cache failure must not fail the job.
+
+## Ephemeral and persistent runners
+
+Speculative prefetch is intended for empty runners. A persistent self-hosted runner may already have the needed entries locally. Measure both modes and disable speculation when it adds work:
+
+```toml
 [cache]
 prefetch_enabled = false
 ```
 
-The daemon watches the config file and restarts itself when it changes. This retains exact remote hits and uploads without speculative warming. A running daemon cannot see a changed `KACHE_PREFETCH_ENABLED`; stop and start a manually managed daemon from the intended environment. An installed service keeps the environment in its service definition, so a shell export followed by `kache daemon restart` does not apply that export. `kache stats` reports the daemon's effective policy and warns when it differs from the invoking process.
+This keeps exact remote reads and uploads.
 
-Useful action inputs:
+Concurrent jobs may share a persistent local store, but each job should have a distinct `KACHE_RUNTIME_DIR` for sockets, locks, event logs, and session state.
 
-| Input | Default | Description |
-|---|---|---|
-| `version` | latest release | kache version to install |
-| `github-cache` | `true` | Use GitHub Actions cache when S3 is not configured |
-| `s3-bucket` | — | S3 bucket name; enables the S3 backend |
-| `s3-region` | `us-east-1` | S3 region |
-| `s3-prefix` | `artifacts` | S3 key prefix |
-| `s3-endpoint` | — | Custom endpoint for MinIO, Ceph, R2, etc. |
-| `sync` | `false` | With S3, pull the full remote cache during setup |
-| `warm` | `true` | With S3, prefetch likely artifacts from the saved build manifest |
-| `manifest-key` | target triple | Scope saved manifests for different build shapes |
-| `pr-comment` | `true` | Post or update a sticky PR cache summary comment |
-| `max-size` | `50GiB` | Local store cap, mapped to `KACHE_MAX_SIZE` |
+## Progress and reports
 
-## Other CI systems
-
-Outside GitHub Actions, configure kache directly via environment variables:
+Kache is quiet in compiler-wrapper mode by default because Cargo can retain wrapper stderr as compiler diagnostics.
 
 ```yaml
 env:
-  RUSTC_WRAPPER: kache
-  KACHE_S3_BUCKET: my-build-cache
-  KACHE_S3_REGION: us-east-1
-  KACHE_S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-  KACHE_S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+  KACHE_PROGRESS: hits       # hits only
+  # KACHE_PROGRESS: verbose # hits, dups, misses, and long-compile heartbeats
 ```
 
-For AWS with IAM roles (OIDC), skip the access key variables and let kache use the standard credential chain.
+Create a machine-readable summary after the build:
 
-For S3-compatible stores, also set `KACHE_S3_ENDPOINT`. `KACHE_S3_PREFIX` is optional and defaults to `artifacts`.
+```bash
+kache report --format json --output kache-report.json
+kache stats
+```
 
-When no daemon is running in an ephemeral runner, use explicit sync steps:
+## Coverage and uncached steps
+
+Coverage instrumentation uses separate, path-local keys. If you do not want coverage artifacts in Kache:
 
 ```yaml
-- name: Warm cache
-  run: kache sync --pull
-
-- run: cargo build --release
-
-- name: Push new artifacts
-  run: kache sync --push
-  if: always()
-```
-
-The `if: always()` on the push step stores newly built artifacts even when the build fails partway through. Partial cache population still speeds up future runs.
-
-Both sync subcommands require a configured remote. Without one they error with `No remote configured`. By default `kache sync --pull` is filtered to the crates in the current workspace's `Cargo.lock`, so an ephemeral runner only fetches what this build needs. Use `kache sync --pull --all` to pull every artifact in the remote regardless of the local lockfile.
-
-By default, `kache sync` exits non-zero if any transfer or import fails, allowing CI jobs to detect synchronization errors directly from the command exit status. All scheduled transfers continue to drain to completion before exiting. If you want best-effort synchronization where transfer or import failures do not fail the CI step, pass `--allow-partial`.
-
-## CI progress output
-
-kache can print per-crate progress lines to stderr when `KACHE_PROGRESS` is set. It is silent by default — both in CI and locally — to avoid cargo caching the wrapper's stderr as stale compiler diagnostics. Set the variable to opt in:
-
-| Value | Behavior |
-|---|---|
-| unset / anything else | Silent (default) |
-| `1` or `hits` | Print hits only |
-| `verbose` or `all` | Print hits, dups, misses, and in-flight heartbeats |
-
-With `KACHE_PROGRESS=verbose`, lines look like:
-
-```
-[kache] serde: local hit (2ms, 1.2 MB)
-[kache] tokio: local hit (3ms, 4.8 MB)
-[kache] myapp: miss (1.4s, 892 KB)
-[kache] still compiling gkrust — 30s elapsed (typical: 7m51s, ETA 7m21s)
-```
-
-At `hits`/`1` only the `local hit` lines appear; `miss` and `dup` lines show up only under `verbose`/`all`. Result lines use `[kache] <crate>: <label> (<elapsed>[, <size>])`. There is no terminal or CI detection — output depends solely on this variable.
-
-Heartbeat timing is controlled by `KACHE_HEARTBEAT_SECS` / `cache.heartbeat_secs` (30 seconds by default). Structured heartbeat events continue to be written to `events.jsonl` when stderr progress is off.
-
-## Coverage and instrumentation
-
-Coverage tools like `cargo-tarpaulin` and `cargo-llvm-cov` use `-C instrument-coverage`, which changes what kache stores (path remapping is skipped to preserve source mapping for coverage reports). This produces different cache keys from regular builds, and those keys include the build's local path identity, so the coverage cache is isolated automatically — from regular builds and from builds at a different checkout path or tool root.
-
-That said, many teams disable kache for coverage runs entirely to keep things simple:
-
-```yaml
-- name: Test with coverage
-  run: cargo tarpaulin --engine llvm --all-features --workspace --out Json
-  env:
-    RUSTC_WRAPPER: ""   # disable kache for this step
-```
-
-## Disabling kache for specific steps
-
-```yaml
-- name: Some step without caching
-  run: cargo build
+- run: cargo llvm-cov
   env:
     KACHE_DISABLED: "1"
 ```
 
-Only `1` or `true` (case-insensitive) disable kache. Other values — including `0`, `false`, and empty — are ignored, so to re-enable kache in a later step you must unset the variable rather than set it to `0`.
-
-kache still strips the rustc `-C incremental=…` flags when disabled, which avoids APFS-related corruption in git worktrees on macOS — even when caching is off — unless explicit preserve-incremental hybrid mode is enabled.
+Unset `KACHE_DISABLED` to enable caching again. Only `1` and `true` disable it.

--- a/docs/remote-cache/filesystem-setup.mdx
+++ b/docs/remote-cache/filesystem-setup.mdx
@@ -1,15 +1,9 @@
 ---
 title: Filesystem setup
-description: Configure a shared filesystem as the kache remote cache.
+description: Use a mounted directory as the remote cache
 ---
 
-# Filesystem setup
-
-A filesystem remote stores the same versioned cache objects as S3 in a shared
-directory. It is useful when every builder can mount the same NFS, SMB, or other
-shared filesystem and no object-storage service is needed.
-
-## Minimal configuration
+A filesystem remote uses the same logical objects as S3 but stores them below a shared directory.
 
 ```toml title="~/.config/kache/config.toml"
 [cache.remote]
@@ -18,106 +12,47 @@ path = "/mnt/shared-kache"
 prefix = "artifacts"
 ```
 
-Use an absolute `path` so the wrapper, daemon, and `kache sync` resolve the same
-directory regardless of their working directory. Every machine that reads or
-writes the remote must mount that directory and have suitable permissions.
+Use an absolute path mounted consistently on every machine. Keep `cache.local_store` on local storage; the local SQLite store is not designed for cross-machine sharing.
 
-Treat every writer to the shared directory as trusted. A filesystem remote is
-not a security boundary: a peer that can replace cache paths or create symlinks
-can influence what other machines read or overwrite. Use S3 with access controls
-when writers are not mutually trusted.
+## Trust and permissions
 
-<Callout type="info">
-  kache currently compiles the `s3` and `filesystem` remote types. Other
-  OpenDAL services are not included in the binary.
-</Callout>
+Every writer to the mount is trusted. A filesystem remote is not an isolation boundary. Use directory permissions or choose S3 with access policy when clients are not mutually trusted.
+
+Kache validates paths and writes only below the configured root, but this is defense in depth rather than a substitute for mount security.
 
 ## Atomic writes
 
-Writes are staged in a temporary directory and atomically renamed into their
-final location, so readers never observe a partially written pack or manifest.
-By default, the staging directory is `<path>/.kache-tmp`.
+Writes stage under `<path>/.kache-tmp` and then rename into place. Override the directory only when necessary:
 
-Override it only when the default is unsuitable:
-
-```toml title="~/.config/kache/config.toml"
+```toml
 [cache.remote]
 type = "filesystem"
 path = "/mnt/shared-kache"
-prefix = "artifacts"
 atomic_write_dir = "/mnt/shared-kache/.staging"
 ```
 
-<Callout type="warn">
-  `atomic_write_dir` and `path` must be on the same filesystem. The final
-  rename cannot be atomic across filesystems and will fail with a cross-device
-  error. In particular, do not use the machine's `/tmp` unless it is on the
-  same filesystem as the shared cache. kache checks this when it connects and
-  refuses the remote with an explicit message rather than failing every write.
+The staging directory must:
 
-  It must also sit outside the object tree (`<prefix>/v3/...`); otherwise
-  in-progress staging files are listed as if they were cached objects. The
-  default `<path>/.kache-tmp` already satisfies both rules.
-</Callout>
+- be on the same filesystem as `path`
+- sit outside the object subtree `<prefix>/v3/`
 
-<Callout type="info">
-  A shared cache directory that other users can write is a trust boundary. kache
-  verifies that each write resolves inside the configured `path`, so a symlink
-  planted under the cache cannot redirect writes elsewhere, and it rejects keys
-  whose components end in a dot or space (Windows strips those, which would make
-  two distinct keys collide). This is defense in depth: provision the directory
-  with restrictive permissions rather than relying on it.
-</Callout>
+Kache rejects a configuration that cannot provide atomic final renames.
 
-## Directory layout
-
-With the minimal configuration, the shared directory contains:
+## Layout
 
 ```text
 /mnt/shared-kache/
 ├── .kache-tmp/
 └── artifacts/
-    ├── v3/
-    │   ├── manifests/{crate_name}/{cache_key}.json
-    │   └── packs/{crate_name}/{cache_key}.tar.zst
+    ├── v3/manifests/{crate}/{key}.json
+    ├── v3/packs/{crate}/{key}.tar.zst
     └── _manifests/
 ```
 
-`prefix` keeps kache's objects in their own subtree. The logical layout and
-`kache sync` behavior are the same for S3 and filesystem remotes. Filesystem
-prefixes cannot contain `:` so the same config cannot become a Windows drive
-path or alternate data stream.
+Filesystem prefixes cannot contain `:`.
 
-Keep `KACHE_CACHE_DIR` on fast local storage for each machine. Only
-`cache.remote.path` should point at the shared mount; the local store is not
-safe to share between machines.
+## Reclaim remote space
 
-## Reclaiming space on the share
+Local `kache gc` never deletes remote objects. Remote deletion is manual because no protocol coordinates deletion with in-flight readers and writers.
 
-Uploads are safe from any number of machines at once: objects are
-content-addressed and immutable, every write lands via a temp file plus atomic
-rename, and two machines publishing the same key are writing identical bytes.
-Deletion has no such story. Nothing coordinates a delete against another
-machine's in-flight read or upload of the same object, so **removing objects
-from the shared folder is a manual, single-writer operation**.
-
-`kache gc` and the automatic size-pressure eviction apply to a machine's own
-local store only. They never delete from the shared folder — a local eviction
-just means that machine pulls the object again on its next miss.
-
-When the share does need reclaiming, pick one of:
-
-- **A single designated host.** Nominate one machine (or a scheduled job) as
-  the only thing that ever deletes from the share, and run it when the fleet is
-  idle.
-- **Prune by age, offline.** Stop or pause the writers, then delete whole
-  `{cache_key}` pairs — the `.json` manifest and its `.tar.zst` pack — older
-  than your retention window. Deleting a pack while leaving its manifest makes
-  peers fetch a manifest whose pack 404s; they degrade to a compile, but you
-  are paying for a lookup that can never succeed.
-- **Start over.** For a small team, deleting the whole `artifacts/` subtree and
-  letting the next builds repopulate it is often simpler than partial pruning.
-
-Cross-host coordinated deletion is tracked as phase 2 of
-[#414](https://github.com/kunobi-ninja/kache/issues/414). Until it lands, treat
-the share as append-mostly.
+Use one designated deletion job and pause writers when pruning. Delete each manifest and pack pair together. For a small cache, removing the complete `artifacts/` subtree and allowing it to repopulate is safer than an inconsistent partial prune.

--- a/docs/remote-cache/s3-setup.mdx
+++ b/docs/remote-cache/s3-setup.mdx
@@ -1,45 +1,30 @@
 ---
 title: S3 setup
-description: Configure an S3-compatible remote cache and connect kache to it.
+description: Connect Kache to AWS S3 or an S3-compatible service
 ---
 
-# S3 setup
+Kache supports AWS S3, Cloudflare R2, Ceph, MinIO, and other compatible endpoints through its S3 backend.
 
-kache supports AWS S3 and common S3-compatible storage such as Cloudflare R2,
-Ceph, and MinIO. The configuration is the same across providers; adjust the
-endpoint and credentials.
-
-For a shared mounted directory instead, see [Filesystem setup](/docs/remote-cache/filesystem-setup).
-The kache binary currently compiles only these `s3` and `filesystem` remote
-types.
-
-## Minimal configuration
+## Configure the remote
 
 ```toml title="~/.config/kache/config.toml"
 [cache.remote]
 type = "s3"
 bucket = "my-build-cache"
+region = "eu-west-1"
 ```
 
-With just a bucket name and no endpoint, kache uses AWS S3 with the default credential chain (environment variables, `~/.aws/credentials`, IAM role).
+The region defaults to `us-east-1`. Set the actual bucket region for AWS.
 
-<Callout type="warn">
-  If you omit `region`, kache defaults to `us-east-1` rather than your bucket's actual region. Set `region` to your bucket's region for AWS S3, and to whatever value your provider expects (or `auto`) for S3-compatible endpoints.
-</Callout>
-
-## Provider examples
-
-<Tabs items={["AWS S3", "Cloudflare R2", "Ceph / MinIO"]}>
+<Tabs items={["AWS S3", "Cloudflare R2", "Ceph or MinIO"]}>
   <Tab value="AWS S3">
     ```toml
     [cache.remote]
     type = "s3"
     bucket = "my-build-cache"
     region = "eu-west-1"
-    profile = "my-aws-profile"   # omit to use default profile
+    profile = "build-cache"
     ```
-
-    For CI, prefer IAM roles or environment variables over a stored profile.
   </Tab>
   <Tab value="Cloudflare R2">
     ```toml
@@ -49,69 +34,36 @@ With just a bucket name and no endpoint, kache uses AWS S3 with the default cred
     endpoint = "https://<account-id>.r2.cloudflarestorage.com"
     region = "auto"
     ```
-
-    Set credentials via `KACHE_S3_ACCESS_KEY` and `KACHE_S3_SECRET_KEY` or an AWS profile pointing to R2 API tokens.
   </Tab>
-  <Tab value="Ceph / MinIO">
+  <Tab value="Ceph or MinIO">
     ```toml
     [cache.remote]
     type = "s3"
     bucket = "build-cache"
     endpoint = "https://s3.internal.example.com"
-    profile = "ceph"
+    region = "us-east-1"
     ```
 
-    The `profile` field refers to a named profile in `~/.aws/credentials` or `~/.aws/config`. Region is optional for Ceph but you can set it to any non-empty string if your setup requires it.
-
-    kache always uses path-style addressing (`https://endpoint/bucket/key`) for every provider, so self-hosted S3 works without virtual-hosted/bucket-subdomain DNS. This also makes dotted bucket names safe on custom endpoints.
+    Kache uses path-style bucket addressing for custom endpoints.
   </Tab>
 </Tabs>
 
-### macOS and self-hosted LAN endpoints
+## Credentials
 
-macOS 15 and newer protects connections to servers reached directly through a
-local Wi-Fi or Ethernet interface. When kache runs as an installed LaunchAgent,
-allow its **Local Network** prompt; the setting is available later under
-**System Settings > Privacy & Security > Local Network**.
+Kache checks these sources in order:
 
-If only the installed daemon fails with `No route to host (os error 65)` while
-the same endpoint works from `kache daemon run` in a terminal, Local Network
-privacy is the likely cause rather than DNS or S3 credentials. Reinstall the
-service with the current kache binary so its responsible-code metadata is up to
-date. If permission still cannot be granted, use:
+1. `KACHE_S3_ACCESS_KEY` and `KACHE_S3_SECRET_KEY`
+2. standard AWS credential environment variables
+3. the selected shared profile
+4. legacy inline SSO or `credential_process`
+5. environment-based web identity
+6. ECS/task credentials, then EC2 instance credentials
 
-```sh
-kache daemon uninstall
-```
+Both explicit `KACHE_S3_*` credential variables are required. If only one is present, Kache warns and continues down the standard credential chain.
 
-The next terminal build starts the daemon on demand and inherits the terminal's
-Local Network permission. Kache logs a specific hint for this failure shape.
+The configuration fields also have environment overrides:
 
-## Credential resolution order
-
-When kache needs S3 credentials, it checks these sources in order:
-
-1. `KACHE_S3_ACCESS_KEY` + `KACHE_S3_SECRET_KEY` (explicit env var override)
-2. Standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment credentials
-3. The selected shared profile (`KACHE_S3_PROFILE`, `profile`, `AWS_PROFILE`, then `default`)
-4. Legacy inline SSO for that profile
-5. `credential_process` for that profile
-6. Environment-based web identity (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`)
-7. ECS/task credentials, then EC2 instance credentials
-
-For CI, explicit environment credentials or IAM roles are the most common. For
-local setups with multiple AWS accounts, a named profile keeps credentials
-organized.
-
-<Callout type="warn">
-  Both halves of the explicit pair are required. If only `KACHE_S3_ACCESS_KEY` or only `KACHE_S3_SECRET_KEY` is set, kache logs a warning and falls back to the AWS chain rather than erroring — so a missing half surfaces as confusing "wrong credentials" behavior, not a clear failure.
-</Callout>
-
-### Environment overrides
-
-Every remote config field has a matching `KACHE_S3_*` env var, which takes precedence over the config file. This is handy in CI, where setting env vars is easier than shipping a config file:
-
-| Env var | Overrides config field |
+| Environment | TOML field |
 | --- | --- |
 | `KACHE_S3_BUCKET` | `bucket` |
 | `KACHE_S3_ENDPOINT` | `endpoint` |
@@ -119,106 +71,37 @@ Every remote config field has a matching `KACHE_S3_*` env var, which takes prece
 | `KACHE_S3_PREFIX` | `prefix` |
 | `KACHE_S3_PROFILE` | `profile` |
 | `KACHE_S3_USER_AGENT` | `user_agent` |
-| `KACHE_S3_ACCESS_KEY` / `KACHE_S3_SECRET_KEY` | (explicit credentials) |
 
-Existing Kache S3 config keys and defaults remain accepted. A legacy
-`[cache.remote]` table without a `type` field and an environment-only setup
-rooted in `KACHE_S3_BUCKET` still select S3; the other `KACHE_S3_*` overrides
-remain available. `type = "s3"` is the recommended explicit form for new
-config files. The AWS SDK-specific migration boundaries below still apply.
+For a persistent daemon, put remote settings in the config file or service definition. An auto-started daemon does not take per-build remote variables from whichever build happened to start first. `kache doctor` and `kache stats` report mismatches between client and daemon configuration.
 
-<Callout type="warning">
-  **A background daemon does not inherit these.** All remote I/O happens
-  daemon-side, and a daemon started automatically by a build outlives that
-  build and serves every later one on the machine. If it inherited the
-  starting build's environment, its remote would depend on which build won the
-  startup race — the failure this prevents logged 2,330 `no remote configured`
-  errors in six hours on a monorepo whose `KACHE_S3_*` lived in per-checkout
-  `.cargo/config.toml`, then silently began working after an unrelated restart.
+## Compatibility boundaries
 
-  So an auto-started daemon resolves its remote from its watched config file
-  only, and kache prints a warning when a remote is configured *only* in the
-  environment. Env overrides still apply to the wrapper and CLI as documented
-  above, and to a daemon you start yourself:
+The S3 implementation signs with SigV4. It does not currently load SigV4a/Multi-Region Access Point settings, assume-role profiles using `source_profile` or `credential_source`, modern `[sso-session]` profiles, or profile-based web identity. Resolve those credentials before starting Kache or use `credential_process`.
 
-  - **Persistent setup:** put the remote in `[cache.remote]` in the config
-    file. The daemon watches that file and restarts when it changes.
-  - **Env-driven setup (CI, service managers):** start the daemon explicitly
-    from the intended environment with `kache daemon run`, or put the values in
-    the service definition. That placement is deliberate rather than a race, so
-    it is honoured.
+`AWS_ENDPOINT_URL_S3` is accepted when no Kache endpoint is set. An endpoint stored only inside an AWS shared profile is not loaded; copy it to `cache.remote.endpoint` or `KACHE_S3_ENDPOINT`.
 
-  `kache stats` and `kache doctor` report the remote the daemon actually
-  resolved, and warn when it differs from yours.
-</Callout>
+Prefixes are normalized by trimming surrounding separators and collapsing repeated `/`. Backslashes and `.` or `..` segments are rejected. A normalized prefix may point at a different object path from an older non-canonical configuration.
 
-## OpenDAL migration boundaries
+## Object layout and policy
 
-The config-file and `KACHE_S3_*` interfaces are retained. Static shared
-profiles, legacy inline SSO profiles, `credential_process`, environment-based
-web identity, ECS/task credentials, and EC2 instance credentials remain
-available. Web identity uses `cache.remote.region` when choosing its STS
-endpoint.
-
-<Callout type="warn">
-  OpenDAL currently signs with SigV4 only. SigV4a / Multi-Region Access Points,
-  assume-role profiles that rely on `role_arn` with `source_profile` or
-  `credential_source`, and modern profiles that refer to a separate
-  `[sso-session ...]` section are not yet compatible. Profile-based web
-  identity (`role_arn` + `web_identity_token_file` in the profile) is also not
-  loaded; use its standard environment variables instead. Resolve unsupported
-  profile credentials before launching kache (standard AWS credential env vars
-  work), or use `credential_process`. AWS China, ISO, FIPS, and dual-stack
-  endpoints should also set `endpoint` explicitly.
-</Callout>
-
-OpenDAL normalizes object paths, so kache stores objects under a canonical
-prefix. A non-canonical `prefix` is normalized rather than rejected: a leading or
-trailing slash, surrounding whitespace and `//` are collapsed, and kache logs a
-warning when that happens. An empty prefix is valid and stores objects at the
-bucket root.
-
-Normalization changes where objects live. `prefix = "team/"` previously wrote
-`team//v3/...` and now writes `team/v3/...`, so objects written by an older
-kache are no longer found and the remote cache repopulates once. Copy those
-objects first if you want to keep them.
-
-Backslashes and `.` / `..` segments are still rejected: there is no safe
-normalization for them. A rejected prefix does not fail your build — kache logs
-the reason, continues without a remote cache, and reports it in `kache status`.
-
-`AWS_ENDPOINT_URL_S3` remains supported when `endpoint` / `KACHE_S3_ENDPOINT`
-is unset. An `endpoint_url` stored only inside an AWS shared profile is not
-loaded by OpenDAL; copy it to `cache.remote.endpoint` or
-`KACHE_S3_ENDPOINT` during migration.
-
-## S3 bucket layout
-
-Each cached entry is two objects — a packed tarball plus a small JSON manifest used for existence checks and listing:
-
-```
-{prefix}/v3/packs/{crate_name}/{cache_key}.tar.zst      # the packed artifacts (zstd-compressed tar)
-{prefix}/v3/manifests/{crate_name}/{cache_key}.json     # small manifest for existence/listing
+```text
+{prefix}/v3/manifests/{crate}/{key}.json
+{prefix}/v3/packs/{crate}/{key}.tar.zst
+{prefix}/_manifests/...
 ```
 
-The default prefix is `artifacts`. Organizing by crate name makes filtered listing efficient — `kache sync --pull` issues one `ListObjectsV2` per crate against `{prefix}/v3/manifests/{crate_name}/`, so it only enumerates manifests for crates in your `Cargo.lock` rather than scanning the whole `v3/manifests/` tree. Use `kache sync --pull --all` to list everything.
+The default prefix is `artifacts`. Writers need `s3:GetObject`, `s3:PutObject`, and `s3:ListBucket`. Read-only clients need `GetObject` and `ListBucket`. Prefix-scoped policies must include both `v3/` and `_manifests/`.
 
-`kache save-manifest` also writes build manifests under a separate `{prefix}/_manifests/` namespace (and, when a namespace and `Cargo.lock` are present, content-addressed shards under `{prefix}/_manifests/v3/{namespace}/shards/{hash}.json`). Bucket policies that scope by prefix must grant access to `_manifests/` as well as `v3/`.
+Remote packs use zstd; local blobs remain uncompressed. Configure the level with `cache.compression_level` or `KACHE_COMPRESSION_LEVEL`.
 
-## Bucket policies
+## macOS LAN access
 
-kache needs `s3:GetObject`, `s3:PutObject`, and `s3:ListBucket` on the bucket. For read-only CI runners that pull but don't push, `s3:GetObject` and `s3:ListBucket` are sufficient. If you restrict the policy by prefix, cover both `{prefix}/v3/*` and `{prefix}/_manifests/*` (see [S3 bucket layout](#s3-bucket-layout)).
+macOS may request Local Network permission when an installed LaunchAgent reaches a LAN endpoint. If only the service gets `No route to host`, reinstall it with the current binary and check System Settings > Privacy & Security > Local Network.
 
-## Compression
+Verify the result with:
 
-zstd compression applies to the remote `.tar.zst` packs only; the local blob store is kept uncompressed. The default level is `3` — fast to compress and decompress, with reasonable size reduction. Lower levels (1–2) cut compression overhead when network bandwidth matters less than CPU time; higher levels (up to 22) are available but rarely worth it for build artifacts. Values are clamped to the `1`–`22` range.
-
-`KACHE_COMPRESSION_LEVEL` is read when the process that does the compressing starts, so set it on the uploader rather than on a plain `cargo build`:
-
-```sh
-KACHE_COMPRESSION_LEVEL=1 kache sync --push   # fastest, larger packs
+```bash
+kache doctor
+kache daemon status
+kache sync --dry-run
 ```
-
-<Callout>
-  The daemon loads its config once at startup, so changing `KACHE_COMPRESSION_LEVEL` for a single `cargo build` does not reconfigure an already-running daemon. Stop and start a manually managed daemon from the intended environment. For an installed service, put the setting in the watched config or service definition; `kache daemon restart` retains the service environment.
-</Callout>

--- a/docs/remote-cache/sync.mdx
+++ b/docs/remote-cache/sync.mdx
@@ -1,157 +1,44 @@
 ---
 title: Sync
-description: Manually synchronize the local cache with a configured remote using kache sync.
+description: Pull and push cache entries without the daemon
 ---
 
-# Sync
+`kache sync` talks directly to the configured remote. It is useful for explicit CI warm and publish steps.
 
-`kache sync` transfers artifacts between the local store and the configured S3
-or filesystem remote. It talks directly to the remote without requiring the
-daemon, which makes it useful for CI steps that want explicit control over
-cache population timing.
-
-## Basic usage
-
-```sh
-kache sync                 # pull missing artifacts + push new local artifacts
+```bash
+kache sync                 # pull, then push
 kache sync --pull          # download only
 kache sync --push          # upload only
-kache sync --all           # pull all artifacts, ignoring Cargo.lock filtering
-kache sync --workspace     # pull scope = workspace members only (one LIST per member)
-kache sync --allow-partial # exit 0 even if some transfers or imports fail
-kache sync --dry-run       # preview what would transfer, make no changes
+kache sync --dry-run       # show the plan
+kache sync --all           # ignore pull filtering
+kache sync --workspace     # pull discovery for workspace members only
+kache sync --allow-partial # report failures but exit successfully
 ```
 
-## Workspace filtering
+## Filtering
 
-The pull and push directions filter by two different mechanisms:
+Pull and push use different scopes:
 
-- **Pull** filters downloads to every crate listed in the current directory's `Cargo.lock` (all direct and transitive dependencies). This avoids pulling the entire remote on every sync — in a shared cache used by multiple projects, you only download what your project needs.
-- **Push** filters uploads to workspace member packages, derived by running `cargo metadata --no-deps` on the current `Cargo.toml` (or the `--manifest-path` you pass). Non-workspace local artifacts are silently skipped; a push run outside any workspace (no `Cargo.toml`) uploads everything.
+- Pull normally lists crates from `Cargo.lock` in the current directory. With no usable lockfile it falls back to listing the full remote.
+- `--workspace` lists only Cargo workspace members and fails if it cannot resolve the workspace. It conflicts with `--all`.
+- Push uses workspace members from `cargo metadata --no-deps`. `--manifest-path` changes this push-side scope only.
 
-```sh
-# in your project directory (Cargo.lock must exist)
+Narrowing the initial pull does not disable on-demand dependency restores during a later daemon-backed build.
+
+## CI sequence
+
+```bash
 kache sync --pull
-
-# pull everything in the remote regardless of Cargo.lock
-kache sync --pull --all
-```
-
-If kache can't find a `Cargo.lock`, it falls back to pulling everything. The same full-remote fallback applies if `Cargo.lock` is present but yields no package names.
-
-### `--workspace`: scope the pull to workspace members
-
-By default the pull issues one remote LIST per crate in the `Cargo.lock`
-dependency set — often hundreds to thousands of calls. For S3 each call is a
-`ListObjectsV2`; a filesystem remote lists the corresponding manifest
-directory. `--workspace` instead scopes discovery to the **workspace members**
-(the same `cargo metadata --no-deps` set used by the push filter), issuing one
-LIST per member (typically tens). It conflicts with `--all`.
-
-This only narrows the up-front batch pull — dependency artifacts are still
-resolved on demand during the build (the rustc wrapper fetches a local miss
-from the configured remote via the daemon, and the daemon prefetches by build
-intent), so deps are not recompiled. It's most useful when the dependency
-artifacts are already present locally — e.g. a prebuilt `cargo chef` deps image
-whose compiled deps sit in `target/` — where they're local hits that never need
-a remote round-trip.
-
-```sh
-# discovery issues one LIST per workspace member instead of one per dependency
-kache sync --pull --workspace
-```
-
-Unlike the default pull, `--workspace` does **not** fall back to a full-remote scan: if the workspace set can't be resolved (`cargo metadata` failed, or you're not in a Cargo workspace), the command errors rather than silently listing the entire remote.
-
-<Callout type="warn">
-`--manifest-path` controls the **push-side** workspace filter only (which local crates get uploaded). The pull filter always reads `Cargo.lock` from the current working directory and ignores `--manifest-path`, so to pull for a different project, run `kache sync` from that project's directory.
-</Callout>
-
-```sh
-# narrows which local crates get pushed; does NOT change the pull filter
-kache sync --manifest-path /path/to/project/Cargo.toml --push
-```
-
-Workspace filtering shells out to `cargo metadata`. If `cargo` is missing or metadata fails, kache prints a warning and — when `--manifest-path` was given — yields an empty filter that pushes nothing; otherwise it disables push filtering and uploads everything.
-
-## How it fits into a build workflow
-
-In CI, the typical pattern is:
-
-```sh
-# before the build: warm the local cache from the remote
-kache sync --pull
-
-# run the build (kache serves local hits, misses compile normally)
 cargo build --release
-
-# after the build: push newly compiled artifacts to the remote
 kache sync --push
 ```
 
-The `--pull` step fills the local store so that `cargo build` finds local hits instead of remote hits. This is faster because local hits don't involve a daemon RPC round-trip.
+A running daemon already uploads new entries in the background. Use explicit push when the runner may exit before those uploads finish or when the daemon is intentionally absent.
 
-When the daemon is running and remote is configured, it handles uploads automatically in the background after each compilation. Use `kache sync --push` only in workflows where you want an explicit, synchronous upload step — for example, when the daemon isn't running or you want to ensure the cache is populated before the runner terminates.
+## Failure behavior
 
-`kache sync` is safe to run alongside the daemon and alongside other concurrent syncs. Before downloading, it re-checks each entry and skips any that already landed on disk; imports use `INSERT OR REPLACE`; and pushes skip entries that vanished (via GC or purge) mid-run.
+All scheduled operations drain before the command exits. Any transfer or import failure makes the command nonzero unless `--allow-partial` is set.
 
-<Callout type="info">
-`--push` still performs a full, unfiltered LIST of all remote keys to determine
-what is already uploaded — workspace filtering applies to the upload set, not
-to this listing. On a large S3 bucket that LIST is a non-trivial request cost;
-on a filesystem remote it scans the corresponding manifest tree.
-</Callout>
+The legacy `cache.s3_concurrency` / `KACHE_S3_CONCURRENCY` setting controls parallel operations for both S3 and filesystem remotes.
 
-## Remote layout
-
-Each cached entry is stored as two objects under a versioned `v3` layout — a small manifest used for listing and existence checks, and the packed artifact itself:
-
-```text
-{prefix}/v3/manifests/{crate_name}/{cache_key}.json      # manifest (listing / existence)
-{prefix}/v3/packs/{crate_name}/{cache_key}.tar.zst       # packed artifacts
-```
-
-The default prefix is `artifacts`, so `serde` packs live under
-`artifacts/v3/packs/serde/...`. On S3 these are object keys; on a filesystem
-remote they are files below `{path}`. Organizing by crate name keeps filtered
-listing efficient: a workspace-filtered pull scans only the per-crate manifest
-prefix `{prefix}/v3/manifests/{crate_name}/`.
-
-## Dry run
-
-`--dry-run` is useful for understanding what's in the remote cache without transferring anything:
-
-```sh
-kache sync --dry-run
-```
-
-It prints the plan (the count of artifacts to pull and push) followed by one line per artifact showing a truncated cache key and the crate name — for example:
-
-```text
-Plan: pull 2 artifacts, push 1 artifact
-  pull  a1b2c3d4e5f6g7h8... (serde)
-  pull  9i8j7k6l5m4n3o2p... (tokio)
-  push  q1r2s3t4u5v6w7x8... (my-crate)
-```
-
-Sizes are not shown — listing does not fetch object sizes.
-
-## Concurrency
-
-`kache sync` uses up to `s3_concurrency` (a legacy setting name, default 16)
-concurrent remote operations. You can lower it if your S3 provider throttles
-requests or your shared filesystem performs better with less parallelism:
-
-```sh
-KACHE_S3_CONCURRENCY=4 kache sync --push
-```
-
-## Exit status and error handling
-
-By default, `kache sync` exits with a non-zero status code if any transfer (download or upload) or entry import fails. All scheduled operations still drain to completion so you get a full summary of succeeded and failed transfers.
-
-If you are running `kache sync` in a best-effort workflow where partial failure should not fail the job or script, pass the `--allow-partial` flag:
-
-```sh
-kache sync --pull --allow-partial
-```
+Use `--dry-run` to inspect the planned crate names and truncated keys. Object sizes are not available from the listing plan.

--- a/docs/remote-service.mdx
+++ b/docs/remote-service.mdx
@@ -1,81 +1,67 @@
 ---
-title: Remote service
-description: Server-side kache — a remote planner that prefetches artifacts from workspace manifests, dependency history, and build intent.
+title: Remote planner service
+description: Preview service for ranking cache entries to prefetch
 ---
 
-# Remote service
-
 <Callout type="warn">
-**SOON.** Server-side kache is the next milestone. The deployment model, auth integration, and HA behavior are still hardening — treat the planner service and Helm chart as a preview today.
+The planner service and Helm chart are previews. Deployment, authentication, and HA behavior may still change.
 </Callout>
 
-The remote planner service warms the *right* artifacts before rustc asks for them. Where local kache reacts to cargo invoking rustc, the planner anticipates: it draws on build manifests (uploaded by `kache save-manifest`), dependency history, and the client's build intent, then advises clients which artifacts to prefetch from the configured remote at the start of a session.
+The planner ranks likely artifacts before rustc asks for exact keys. It is optional: local caching, exact remote lookup, sync, and client-side fallback planning work without it.
 
-The service lives in [`crates/kache-service`](https://github.com/kunobi-ninja/kache/tree/main/crates/kache-service). It persists planner state in an embedded SurrealDB database and serves three HTTP routes: `POST /v1/prefetch-plan` and `POST /v2/prefetch-plan` (both aliased to the same handler — clients default to `/v2`), plus `GET /healthz` and `GET /readyz` probes. It safely returns a `use_fallback` disposition when the database has no matching candidates — so clients always have a working code path even before the planner has data for them.
+## API and state
 
-## What it does
+The service in [`crates/kache-service`](https://github.com/kunobi-ninja/kache/tree/main/crates/kache-service) exposes:
 
-- **Manifest upload.** Clients call `kache save-manifest` at the end of a build. This uploads a build manifest (and, with `--namespace`, sharded indexes keyed by `Cargo.lock`) to the configured remote — each entry records cache key, crate name, compile time, and artifact size. The planner service consumes that data out of band (it is seeded from a snapshot today; see `KACHE_PLANNER_SEED_STATE_FILE`) — `save-manifest` does not POST to the service.
-- **Prefetch hints.** At the start of a new build session, the client `POST`s a build intent (crate names, namespace, `Cargo.lock` deps) to the planner. The planner replies with a plan: a `disposition` (`Execute` or `UseFallback`) and, when executing, ranked `candidates` (cache key + crate name) likely to be needed.
-- **Use-fallback safety.** If the planner has no service-side state, resolves no candidates, or hits an internal planning error, it returns a `UseFallback` plan rather than an HTTP error. Clients then fall back to filtering remote prefetch by `Cargo.lock` (the same path the daemon uses today without a planner).
+- `POST /v1/prefetch-plan`
+- `POST /v2/prefetch-plan`
+- `GET /healthz`
+- `GET /readyz`
 
-## Build and run
+Both plan versions use the same handler. When no useful candidates exist, the service returns a fallback disposition and the client uses its normal planner.
 
-```sh
-just build-service
-just image-service
-just image-service-release
+Planner state is stored in embedded SurrealDB. `kache save-manifest` writes manifests to the configured remote; it does not post them directly to this service. Current deployments seed or ingest that data separately.
+
+## Run locally
+
+```bash
 cargo run -p kache-service
 ```
 
-For local development, `cargo run -p kache-service` binds `0.0.0.0:8080` by default (override with `--bind` / `KACHE_PLANNER_BIND`) and persists the embedded SurrealDB planner database at `/var/lib/kache/planner.db` (override with `--db-path` / `KACHE_PLANNER_DB_PATH`). Pass `--token` / `KACHE_PLANNER_TOKEN` to enforce bearer auth on the standalone binary, and `KACHE_LOG` (default `kache_service=info`) to filter logs. For a containerized run, the `image-service` recipes produce a `linux/amd64` image (override `PLATFORM` in `docker-bake.hcl` to target other architectures).
+The default bind address is `0.0.0.0:8080` and the default database path is `/var/lib/kache/planner.db`. Override them with `--bind` / `KACHE_PLANNER_BIND` and `--db-path` / `KACHE_PLANNER_DB_PATH`.
 
-## Helm chart
+Set `--token` or `KACHE_PLANNER_TOKEN` to require bearer authentication.
 
-```sh
+## Helm
+
+```bash
 helm upgrade --install kache-service ./charts/kache-service
 ```
 
-The chart in [`charts/kache-service`](https://github.com/kunobi-ninja/kache/tree/main/charts/kache-service) is intentionally small: one `Deployment`, one `Service`, optional `PersistentVolumeClaim`, hardened security defaults (`runAsNonRoot`, UID/GID `65532`, `readOnlyRootFilesystem`, all capabilities dropped — the writable DB path must live on a mounted volume), health probes, optional `kunobi-auth` bearer-token wiring through an existing `Secret`, and optional `kunobi-ha` Lease-based leader election. When `ha.enabled`, it also ships a `ServiceAccount` plus `Role`/`RoleBinding` granting the `coordination.k8s.io` Lease permissions leader election needs (and mounts the service-account token only under HA). It does not bundle ingress or cluster-level policy — bring your own.
+The chart supplies a Deployment, Service, probes, optional persistent volume, optional existing-secret authentication, and optional Lease-based leader election. It does not create ingress.
 
-### Pointing clients at the planner
+Point clients at it:
 
-Clients only consult the planner when `KACHE_PLANNER_ENDPOINT` is set (or `cache.planner.endpoint` in config) — `KACHE_PLANNER_TOKEN` alone does nothing. Point clients at the in-cluster service:
-
-```sh
-KACHE_PLANNER_ENDPOINT=http://<svc>.<ns>.svc.cluster.local:8080
-# optional: KACHE_PLANNER_TIMEOUT_MS to bound the planner round-trip
+```bash
+export KACHE_PLANNER_ENDPOINT=http://kache-service.namespace.svc.cluster.local:8080
+export KACHE_PLANNER_TOKEN=secret-if-required
 ```
 
-### Bearer-token auth
+The equivalent TOML is under `[cache.planner]`.
 
-Auth is enabled by pointing the chart at an existing secret. Clients must send the matching token through `KACHE_PLANNER_TOKEN`. The standalone binary enforces the same check when started with `--token` / `KACHE_PLANNER_TOKEN`; with no token configured, requests are accepted anonymously. A request that lacks valid auth when a token is set gets `401`.
+## Persistence and HA
 
-```yaml title="values.yaml"
-auth:
-  existingSecret: kache-planner-token
-  existingSecretKey: token
-```
-
-### Planner state and persistence
-
-The service stores its embedded planner database at `/var/lib/kache/planner.db` by default (`planner.dbPath`, also `--db-path` / `KACHE_PLANNER_DB_PATH`). The chart default is `persistence.enabled: true` with `type: ephemeral` — an `emptyDir` that does **not** survive pod restarts. Switch `type` to `pvc` for durable planner state:
+The chart defaults to ephemeral `emptyDir` planner storage. Choose `pvc` when state must survive pod replacement:
 
 ```yaml title="values.yaml"
 planner:
-  dbPath: /var/lib/kache/planner.db
   persistence:
     enabled: true
-    type: pvc          # default is `ephemeral` (emptyDir, lost on restart)
-    mountPath: /var/lib/kache
+    type: pvc
     size: 10Gi
 ```
 
-For bootstrap / migration only, the service can still import a legacy JSON planner snapshot on startup via `KACHE_PLANNER_SEED_STATE_FILE`. New installs should ignore this knob.
-
-### High availability
-
-For HA deployments, enable leader election and raise the replica count. `/healthz` always returns `200`, but `/readyz` (and `prefetch-plan`) return `503` until the repository is loaded and leadership is acquired — so followers stay live-but-not-ready until they win the Kubernetes Lease:
+Enable leader election for multiple replicas:
 
 ```yaml title="values.yaml"
 replicaCount: 2
@@ -84,10 +70,4 @@ ha:
   leaseName: kache-service
 ```
 
-The chart's `ha.*` keys map to the binary's `--ha-enabled` / `--ha-namespace` / `--ha-lease-name` flags (`KACHE_HA_ENABLED` / `KACHE_HA_NAMESPACE` / `KACHE_HA_LEASE_NAME`). The namespace resolves from `ha.namespace`, then `POD_NAMESPACE`, then the mounted service-account namespace file — startup fails if none resolve.
-
-When combining HA with PVC-backed planner state, use storage that can be mounted by all scheduled replicas (e.g. ReadWriteMany), or keep `replicaCount: 1`. The Lease itself is fine across replicas — the constraint is the planner DB volume.
-
-## What you get without the service
-
-Local caching, remote sync, and `cargo metadata`-driven prefetch all work without the planner. The planner is purely additive: it raises the hit rate on the *first* build of a new branch or runner where `cargo metadata` alone would underprefetch. If you don't run the service, clients silently behave as they do today.
+Followers remain live but not ready. If replicas share one embedded database, the volume must support their mount pattern; otherwise keep one replica.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+root = Path.cwd()
+docs = root / "docs"
+errors: list[str] = []
+
+pages = sorted(docs.rglob("*.mdx"))
+for page in pages:
+    text = page.read_text()
+    if not text.startswith("---\n") or "\n---\n" not in text[4:]:
+        errors.append(f"{page}: missing MDX front matter")
+
+for data_file in sorted(docs.rglob("*.json")):
+    try:
+        json.loads(data_file.read_text())
+    except json.JSONDecodeError as exc:
+        errors.append(f"{data_file}: invalid JSON: {exc}")
+
+for meta_file in sorted(docs.rglob("meta.json")):
+    meta = json.loads(meta_file.read_text())
+    for entry in meta.get("pages", []):
+        if not isinstance(entry, str):
+            errors.append(f"{meta_file}: non-string page entry {entry!r}")
+            continue
+        candidates = [meta_file.parent / f"{entry}.mdx", meta_file.parent / entry / "meta.json"]
+        if not any(candidate.is_file() for candidate in candidates):
+            errors.append(f"{meta_file}: missing page or section {entry!r}")
+
+link_re = re.compile(r"(?:\]\(|href=\")(/docs(?:/[^)#?\"]*)?)(?:#[^)\"]+)?(?:\)|\")")
+for page in pages:
+    text = page.read_text()
+    for match in link_re.finditer(text):
+        route = match.group(1).removeprefix("/docs").strip("/")
+        candidates = [docs / "index.mdx"] if not route else [docs / f"{route}.mdx", docs / route / "index.mdx"]
+        if not any(candidate.is_file() for candidate in candidates):
+            errors.append(f"{page}: broken internal route {match.group(1)}")
+
+all_prose = "\n".join([root.joinpath("README.md").read_text(), *(p.read_text() for p in pages)])
+for obsolete in ["](/getting-started", "](/daemon", "](/remote-cache", "kache status", "install-shims --dir"]:
+    if obsolete in all_prose:
+        errors.append(f"obsolete documentation spelling remains: {obsolete!r}")
+
+for page in pages:
+    if "/docs/kache/" in page.read_text():
+        errors.append(f"{page}: upstream links must use /docs/...; kunobi-web adds the /kache product slug")
+
+main = root.joinpath("src/main.rs").read_text()
+command_block = main.split("enum Commands {", 1)[1].split("enum DaemonCommands", 1)[0]
+variants = re.findall(r"^    ([A-Z][A-Za-z0-9]+)(?:\s*\{|,)", command_block, re.MULTILINE)
+
+def kebab(name: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", "-", name).lower()
+
+reference = root.joinpath("docs/commands/reference.mdx").read_text()
+for command in map(kebab, variants):
+    if f"`kache {command}`" not in reference:
+        errors.append(f"command reference is missing source command: {command}")
+
+config = root.joinpath("src/config.rs").read_text()
+cache_block = config.split("struct CacheFileConfig {", 1)[1].split("/// Deliberately NOT", 1)[0]
+cache_fields = re.findall(r"pub\(crate\) ([a-z0-9_]+):", cache_block)
+config_doc = root.joinpath("docs/getting-started/configuration.mdx").read_text()
+for field in cache_fields:
+    if f"cache.{field}" not in config_doc:
+        errors.append(f"configuration guide is missing source field: cache.{field}")
+
+for key in ["cc.extra_allowlist_flags", "paths.base_dirs", "workspace.extra_inputs"]:
+    if key not in config_doc:
+        errors.append(f"configuration guide is missing source field: {key}")
+
+expected_default = 'cfg!(target_os = "linux") || cfg!(target_os = "macos")'
+if expected_default not in config:
+    errors.append("cache_executables platform default changed; update the docs and this check")
+if "Linux/macOS: `true`; Windows: `false`" not in config_doc:
+    errors.append("configuration guide does not state the executable-cache platform default")
+
+if errors:
+    print("Documentation checks failed:", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"Documentation checks passed for {len(pages)} MDX pages.")
+PY


### PR DESCRIPTION
## Summary

- rewrite the README and all documentation pages in direct, task-focused language
- align commands, configuration, platform defaults, storage behavior, and remote-cache examples with the current source
- document the nightly real-project benchmark matrix and its evidence rules
- add a practical Kache-versus-sccache comparison page
- route unsupported compilers, backends, and workflows into GitHub feature requests
- validate internal routes and source parity in CI

## Notable corrections

- describe reflink-first restores and the restricted hardlink fallback accurately
- document executable caching defaults on Linux, macOS, and Windows
- cover every current top-level CLI command and cache configuration field
- use upstream /docs/... links expected by the kunobi-web importer
- distinguish scheduled benchmark runs from valid results: a job must succeed and report an ok verdict
- frame sccache as an optional migration fallback instead of a default recommendation

## Validation

- bash scripts/check-docs.sh
- shellcheck scripts/check-docs.sh
- git diff --check origin/main...HEAD
- cargo test -p kache

The package suite passed with 2,208 unit tests plus all integration test binaries.
