### PR TITLE
chore(release): prepare 0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3017,11 +3017,11 @@ dependencies = [
 
 [[package]]
 name = "kache-proofs"
-version = "0.0.0"
+version = "0.16.1"
 
 [[package]]
 name = "kache-service"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more, with S3 and shared-filesystem remotes."
 license = "Apache-2.0"
@@ -41,7 +41,7 @@ reqsign-aws-v4 = { version = "=3.3.0", default-features = false }
 reqsign-core = { version = "=3.3.1", default-features = false }
 # Direct dep so OpenDAL/reqwest can use ring without reintroducing aws-lc.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.16.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.16.1", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/charts/kache-service/Chart.yaml
+++ b/charts/kache-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kache-service
 description: Advisory remote planner service for kache
 type: application
-version: 0.16.0
-appVersion: "0.16.0"
+version: 0.16.1
+appVersion: "0.16.1"
 keywords:
   - rust
   - cache

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-proofs/Cargo.toml
+++ b/crates/kache-proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-proofs"
-version = "0.0.0"
+version = "0.16.1"
 publish = false
 edition = "2024"
 description = "Repository-only formal verification harnesses for kache."

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14191,21 +14191,33 @@ mod tests {
             "prefetch dispatch is ok even if downloads fail: {resp:?}"
         );
 
-        // Poll the failure counter; the download runs in the background.
-        let mut failed = false;
-        for _ in 0..100 {
-            if daemon
-                .transfer_counters
-                .downloads_failed
-                .load(Ordering::Relaxed)
-                >= 1
-            {
-                failed = true;
-                break;
+        // The download runs in the background. downloads_failed is bumped
+        // before the TransferEvent is pushed, so waiting on the counter
+        // alone races on Windows. Wait for both, same as
+        // prefetch_import_failure_is_counted_as_failure.
+        let completed = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let failed = daemon
+                    .transfer_counters
+                    .downloads_failed
+                    .load(Ordering::Relaxed);
+                let has_event = daemon
+                    .recent_transfers
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .back()
+                    .is_some();
+                if failed >= 1 && has_event {
+                    break;
+                }
+                tokio::task::yield_now().await;
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-        assert!(failed, "a garbage pack must record a failed download");
+        })
+        .await;
+        assert!(
+            completed.is_ok(),
+            "a garbage pack must record a failed download and a transfer event"
+        );
         assert_v3_transfer_timestamps(&latest_transfer(&daemon));
         // Nothing was imported.
         assert!(!config.store_dir().join(key).join("meta.json").exists());


### PR DESCRIPTION
## Summary

Version bump for the 0.16.1 release. Ships since v0.16.0:

Cacheability, C/C++ units that previously always missed:

- #860 feat(cc): key ring's Darwin debug flag `-gfull` via the resolved probe
- #851 feat(cc): key cc-rs's Apple debug flag `-gdwarf-2` via the resolved probe
- #861 fix(cc): cache zstd builds using `-fmerge-all-constants`
- #845 fix(cc): classify `-fsanitize-undefined-strip-path-components=-1` so aws-lc-sys 0.44 jitterentropy TUs cache (#840)
- #842 fix(cc): cache compiles carrying `-mno-omit-leaf-frame-pointer` (#839)
- #850 fix(cc): cache trivial auto var pattern init

Correctness:

- #834 fix(rustc): key all outcome-affecting lint configuration
- #852 fix(key): accept duplicate native search paths
- #829 fix(key): survive non-UTF-8 environments and multi-byte leak windows
- #841 fix(daemon): treat remote import failures as misses
- #832 fix(service): use indexed identity for planner upserts

Robustness:

- #854 fix(store): use advisory build locks
- #847 fix(daemon): drain accepted handlers on shutdown
- #830 fix: close the remaining majors from the main review (refcounts, purge locking, async flocks, TUI restore)
- #836 chore(deps): refresh OpenDAL and security patches

Also in the tree but not user-visible: docs rewrite (#863), OpenDAL and Lance nightly benchmarks (#864, #859), CODEOWNERS for private-runner workflows (#862), test and CI work (#855, #853, #846, #833, #831).

Patch bump: #860 and #851 are labelled `feat`, but both only add flag keying that turns previously-uncacheable translation units into cacheable ones. No API or behaviour change.

Note: `crates/kache-proofs` moves from `0.0.0` to `0.16.1`. That crate landed in #855 after the last bump, so this is the first time `cargo set-version --workspace` has swept it up. It is `publish = false` and outside the consistency gate, same as `kache-e2e` and `kache-service`, which already track the workspace version.

After merge: tag `v0.16.1` on the merge commit to trigger the release.

## Checklist

- [x] Version bumped in workspace + crates + Helm chart (same shape as #828)
- [x] `just bump 0.16.1` (`cargo set-version --workspace`, lock settled by `cargo check`)
- [x] `scripts/check-version-consistency.sh` passes: kache == kache-core == kache-core dep-pin == 0.16.1
- [x] `cargo check --workspace` clean