### PR TITLE
test(store): give concurrent shared-blob puts a 30s busy timeout

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -9587,13 +9587,23 @@ mod tests {
 
         let content = b"identical artifact content shared across all entries";
 
+        // Same Windows-runner caveat as test_concurrent_put_remove_never_dangles:
+        // this proves refcount consistency, not the production five-second
+        // fail-fast. Eight WAL writers on a two-core hosted Windows runner
+        // queue past 5s and surface SQLITE_BUSY (v0.16.1 tag CI).
+        let stores: Vec<_> = (0..N)
+            .map(|_| {
+                let store = Store::open(&config).unwrap();
+                store.db.busy_timeout(Duration::from_secs(30)).unwrap();
+                store
+            })
+            .collect();
+
         let mut handles = Vec::new();
-        for i in 0..N {
-            let config = test_config(dir.path());
+        for (i, store) in stores.into_iter().enumerate() {
             let src = dir.path().join(format!("art-{i}.rlib"));
             std::fs::write(&src, content).unwrap();
             handles.push(std::thread::spawn(move || {
-                let store = Store::open(&config).unwrap();
                 store
                     .put(
                         &format!("key{i}"),


### PR DESCRIPTION
## Value
- Unblocks the **v0.16.1 GitHub Release**: tag CI died on Windows `SQLITE_BUSY` in `test_concurrent_puts_sharing_blob_are_consistent` (2070 passed, 1 failed), so `release` was skipped.
- Same Windows-runner caveat already handled in `test_concurrent_put_remove_never_dangles`.

## Technical
- Pre-open N store connections and set `busy_timeout` to 30s before the racing `put`s, matching the sibling test.
- Production `busy_timeout` stays 5s (fail-fast for wrapper storms).
- Does not retag `v0.16.1`. After merge, cut **v0.16.2**.

Failed run: https://github.com/kunobi-ninja/kache/actions/runs/33109479923