### PR TITLE
feat(bench): publish OTLP telemetry artifacts

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -159,6 +159,13 @@ gitignore = true
 # EOF has no payload for the required non-empty, non-zero-length entry set.
 # Exact-limit and first-real-overshoot tests retain coverage of every reachable
 # boundary on the corresponding decode/build paths.
+#
+# The benchmark entry points orchestrate real repository clones, compilers,
+# cache daemons, and multi-gigabyte scenarios. Their whole-body `Ok(())`
+# replacement cannot be observed by the hermetic `cargo test` process. The
+# Linux/macOS/Windows E2E smoke lanes exercise those entry points instead.
+# Keep only the whole-body replacements out of this lane: their parsing,
+# selection, measurement, verdict, artifact, and OTLP helpers remain in scope.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -194,4 +201,7 @@ exclude_re = [
     "src/remote_pack.rs:351:20: replace > with (>=|==) in encode_catalog",
     "src/remote_pack.rs:309:20: replace < with <= in decode_pack",
     "src/remote_pack.rs:324:22: replace > with >= in decode_pack",
+    "replace run_bench .* with Ok",
+    "replace run_pull_bench .* with Ok",
+    "replace run_sccache_bench .* with Ok",
 ]

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -274,6 +274,22 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
+      # Short-lived OTLP JSON for kartero. Separate name and retention from
+      # the diagnostic bundle above: kartero pulls `telemetry-otlp-v1*` and
+      # nothing else. The suffix is required because upload-artifact v4
+      # rejects two jobs in one run sharing an identical artifact name.
+      - name: Upload telemetry
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemetry-otlp-v1-${{ matrix.name }}
+          path: |
+            tmp/bench/${{ matrix.dir }}/metrics.otlp.json
+            tmp/bench/${{ matrix.dir }}/schema_version
+            tmp/bench/${{ matrix.dir }}/${{ matrix.dir }}.json
+          retention-days: 3
+          if-no-files-found: warn
+
   # Firefox compile-cache bench on the self-hosted Windows runner (clang-cl +
   # MSVC under MozillaBuild). Separate from the `bench` matrix above: that runs
   # on the ephemeral Linux ARC (`kunobi-runners`); this needs the persistent
@@ -461,6 +477,18 @@ jobs:
             ${{ runner.temp }}/f/*.log
             ${{ runner.temp }}/f/*.txt
           retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload telemetry
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemetry-otlp-v1-firefox-windows
+          path: |
+            ${{ runner.temp }}/f/metrics.otlp.json
+            ${{ runner.temp }}/f/schema_version
+            ${{ runner.temp }}/f/bench-firefox-windows.json
+          retention-days: 3
           if-no-files-found: warn
 
   # Firefox DAILY-PULL (temporal, #477) compile-cache bench on the self-hosted
@@ -666,4 +694,16 @@ jobs:
             ${{ runner.temp }}/b/*.log
             ${{ runner.temp }}/b/*.txt
           retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload telemetry
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemetry-otlp-v1-firefox-pull-windows
+          path: |
+            ${{ runner.temp }}/b/metrics.otlp.json
+            ${{ runner.temp }}/b/schema_version
+            ${{ runner.temp }}/b/bench-firefox-pull-windows.json
+          retention-days: 3
           if-no-files-found: warn

--- a/crates/kache-e2e/src/bench_otlp.rs
+++ b/crates/kache-e2e/src/bench_otlp.rs
@@ -1,0 +1,558 @@
+//! OTLP JSON gauges for one completed bench run.
+//!
+//! Built with `serde_json` next to the human-readable report. There is no
+//! OpenTelemetry SDK: the file is already the body of an OTLP/HTTP
+//! `ExportMetricsServiceRequest`, so a later collector can POST it as-is
+//! after adding the CI envelope.
+//!
+//! Mapping is the §10 table in kartero's 2026-08-27 artifact-transport spec.
+//! Gauges only. `run_id` is never emitted. `cicd.*` / `vcs.*` are not
+//! asserted here.
+
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Major schema version carried in the artifact name (`telemetry-otlp-v1`)
+/// and as a resource attribute. A breaking change gets a new number and a
+/// new artifact name.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// OTLP metrics request body, one signal, one request.
+pub const METRICS_FILE: &str = "metrics.otlp.json";
+
+/// Sidecar so a collector can reject an unknown major version without
+/// parsing the request body.
+pub const SCHEMA_VERSION_FILE: &str = "schema_version";
+
+const SCOPE_NAME: &str = "kache.bench";
+
+/// One completed bench, already reduced to the fields OTLP is allowed to
+/// carry. Callers map `BenchResult` / `PullBenchResult` / `SccacheBenchResult`
+/// into this; the writer does not know those types.
+pub struct OtlpRun {
+    pub project: String,
+    pub git_ref: String,
+    pub cache_tool: &'static str,
+    pub time_unix_nano: String,
+    pub verdict_ok: bool,
+    pub speedup: Option<f64>,
+    pub cache_size_bytes: u64,
+    pub key_stability_pct: Option<f64>,
+    pub disk_measured_bytes: Option<u64>,
+    pub phases: Vec<OtlpPhase>,
+}
+
+pub struct OtlpPhase {
+    pub name: &'static str,
+    pub wall_s: u64,
+    pub time_saved_s: Option<u64>,
+    pub hits: u64,
+    pub dups: Option<u64>,
+    pub misses: u64,
+    pub errors: Option<u64>,
+    pub total: Option<u64>,
+    pub hit_rate_pct: f64,
+    pub weighted_hit_rate_pct: Option<f64>,
+    pub leak_warnings: Option<u64>,
+    pub objdir_bytes: u64,
+}
+
+impl OtlpRun {
+    pub fn now_unix_nano() -> String {
+        let d = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default();
+        d.as_nanos().to_string()
+    }
+
+    /// `cache_size_mb` on the report is KiB/1024 rounded to 1 decimal — MiB,
+    /// not SI MB. Convert through 1024² so the metric unit can be `By`.
+    pub fn bytes_from_mib(mib: f64) -> u64 {
+        (mib * 1024.0 * 1024.0).round() as u64
+    }
+}
+
+pub fn write_otlp(work_dir: &Path, run: &OtlpRun) -> Result<()> {
+    let body = serialize_metrics(run);
+    let metrics_path = work_dir.join(METRICS_FILE);
+    std::fs::write(
+        &metrics_path,
+        serde_json::to_string(&body).context("serializing OTLP metrics")? + "\n",
+    )
+    .with_context(|| format!("writing {}", metrics_path.display()))?;
+    let version_path = work_dir.join(SCHEMA_VERSION_FILE);
+    std::fs::write(&version_path, format!("{SCHEMA_VERSION}\n"))
+        .with_context(|| format!("writing {}", version_path.display()))?;
+    Ok(())
+}
+
+pub fn serialize_metrics(run: &OtlpRun) -> Value {
+    json!({
+        "resourceMetrics": [{
+            "resource": {
+                "attributes": [
+                    str_attr("kache.telemetry.schema_version", &SCHEMA_VERSION.to_string()),
+                    str_attr("kache.bench.git_ref", &run.git_ref),
+                ]
+            },
+            "scopeMetrics": [{
+                "scope": {
+                    "name": SCOPE_NAME,
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+                "metrics": metrics_for(run),
+            }]
+        }]
+    })
+}
+
+fn metrics_for(run: &OtlpRun) -> Vec<Value> {
+    let mut metrics = Vec::new();
+
+    let mut duration_points = Vec::new();
+    let mut saved_points = Vec::new();
+    let mut unit_points = Vec::new();
+    let mut hit_rate_points = Vec::new();
+    let mut weighted_points = Vec::new();
+    let mut leak_points = Vec::new();
+    let mut objdir_points = Vec::new();
+
+    for phase in &run.phases {
+        let phase_attrs = common_attrs(run, Some(phase.name));
+        duration_points.push(as_double(
+            phase.wall_s as f64,
+            &run.time_unix_nano,
+            &phase_attrs,
+        ));
+        if let Some(saved) = phase.time_saved_s {
+            saved_points.push(as_double(saved as f64, &run.time_unix_nano, &phase_attrs));
+        }
+        push_unit_points(&mut unit_points, run, phase);
+        hit_rate_points.push(as_double(
+            phase.hit_rate_pct,
+            &run.time_unix_nano,
+            &phase_attrs,
+        ));
+        if let Some(weighted) = phase.weighted_hit_rate_pct {
+            weighted_points.push(as_double(weighted, &run.time_unix_nano, &phase_attrs));
+        }
+        if let Some(leaks) = phase.leak_warnings {
+            leak_points.push(as_int(leaks, &run.time_unix_nano, &phase_attrs));
+        }
+        objdir_points.push(as_int(
+            phase.objdir_bytes,
+            &run.time_unix_nano,
+            &phase_attrs,
+        ));
+    }
+
+    metrics.push(gauge("kache.bench.build.duration", "s", duration_points));
+    if !saved_points.is_empty() {
+        metrics.push(gauge("kache.bench.compile.time_saved", "s", saved_points));
+    }
+    if !unit_points.is_empty() {
+        metrics.push(gauge("kache.bench.compile.units", "{unit}", unit_points));
+    }
+    metrics.push(gauge("kache.bench.cache.hit_rate", "%", hit_rate_points));
+    if !weighted_points.is_empty() {
+        metrics.push(gauge(
+            "kache.bench.cache.weighted_hit_rate",
+            "%",
+            weighted_points,
+        ));
+    }
+    if !leak_points.is_empty() {
+        metrics.push(gauge("kache.bench.leak_warnings", "{warning}", leak_points));
+    }
+
+    let run_attrs = common_attrs(run, None);
+    if let Some(speedup) = run.speedup {
+        metrics.push(gauge(
+            "kache.bench.speedup",
+            "1",
+            vec![as_double(speedup, &run.time_unix_nano, &run_attrs)],
+        ));
+    }
+    metrics.push(gauge(
+        "kache.bench.cache.size",
+        "By",
+        vec![as_int(
+            run.cache_size_bytes,
+            &run.time_unix_nano,
+            &run_attrs,
+        )],
+    ));
+    metrics.push(gauge("kache.bench.objdir.size", "By", objdir_points));
+    if let Some(disk) = run.disk_measured_bytes {
+        metrics.push(gauge(
+            "kache.bench.disk.consumed",
+            "By",
+            vec![as_int(disk, &run.time_unix_nano, &run_attrs)],
+        ));
+    }
+    if let Some(stable) = run.key_stability_pct {
+        metrics.push(gauge(
+            "kache.bench.key_stability",
+            "%",
+            vec![as_double(stable, &run.time_unix_nano, &run_attrs)],
+        ));
+    }
+    metrics.push(gauge(
+        "kache.bench.verdict.ok",
+        "1",
+        vec![as_int(
+            u64::from(run.verdict_ok),
+            &run.time_unix_nano,
+            &run_attrs,
+        )],
+    ));
+    metrics
+}
+
+fn push_unit_points(out: &mut Vec<Value>, run: &OtlpRun, phase: &OtlpPhase) {
+    let push = |out: &mut Vec<Value>, result: &str, value: u64| {
+        let attrs = unit_attrs(run, phase.name, result);
+        out.push(as_int(value, &run.time_unix_nano, &attrs));
+    };
+    push(out, "hit", phase.hits);
+    if let Some(dups) = phase.dups {
+        push(out, "dup", dups);
+    }
+    push(out, "miss", phase.misses);
+    if let Some(errors) = phase.errors {
+        push(out, "error", errors);
+    }
+    if let Some(total) = phase.total {
+        push(out, "total", total);
+    }
+}
+
+fn common_attrs(run: &OtlpRun, phase: Option<&str>) -> Vec<Value> {
+    let mut attrs = vec![
+        str_attr("kache.bench.project", &run.project),
+        str_attr("kache.bench.cache_tool", run.cache_tool),
+    ];
+    if let Some(phase) = phase {
+        attrs.push(str_attr("kache.bench.phase", phase));
+    }
+    attrs
+}
+
+fn unit_attrs(run: &OtlpRun, phase: &str, result: &str) -> Vec<Value> {
+    let mut attrs = common_attrs(run, Some(phase));
+    attrs.push(str_attr("kache.bench.result", result));
+    attrs
+}
+
+fn gauge(name: &str, unit: &str, data_points: Vec<Value>) -> Value {
+    json!({
+        "name": name,
+        "unit": unit,
+        "gauge": { "dataPoints": data_points }
+    })
+}
+
+fn str_attr(key: &str, value: &str) -> Value {
+    json!({"key": key, "value": {"stringValue": value}})
+}
+
+fn as_double(value: f64, time_unix_nano: &str, attributes: &[Value]) -> Value {
+    json!({
+        "asDouble": value,
+        "timeUnixNano": time_unix_nano,
+        "attributes": attributes,
+    })
+}
+
+fn as_int(value: u64, time_unix_nano: &str, attributes: &[Value]) -> Value {
+    json!({
+        "asInt": value.to_string(),
+        "timeUnixNano": time_unix_nano,
+        "attributes": attributes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn kache_run() -> OtlpRun {
+        OtlpRun {
+            project: "bench-firefox".into(),
+            git_ref: "FIREFOX_140_0_RELEASE".into(),
+            cache_tool: "kache",
+            time_unix_nano: "1700000000000000000".into(),
+            verdict_ok: true,
+            speedup: Some(4.2),
+            cache_size_bytes: 12 * 1024 * 1024,
+            key_stability_pct: Some(96.9),
+            disk_measured_bytes: Some(3_000_000_000),
+            phases: vec![
+                OtlpPhase {
+                    name: "cold",
+                    wall_s: 400,
+                    time_saved_s: Some(0),
+                    hits: 0,
+                    dups: Some(0),
+                    misses: 500,
+                    errors: Some(3),
+                    total: Some(503),
+                    hit_rate_pct: 0.0,
+                    weighted_hit_rate_pct: Some(0.0),
+                    leak_warnings: Some(0),
+                    objdir_bytes: 8_000_000_000,
+                },
+                OtlpPhase {
+                    name: "warm",
+                    wall_s: 95,
+                    time_saved_s: Some(280),
+                    hits: 480,
+                    dups: Some(10),
+                    misses: 10,
+                    errors: Some(0),
+                    total: Some(500),
+                    hit_rate_pct: 96.0,
+                    weighted_hit_rate_pct: Some(97.5),
+                    leak_warnings: Some(2),
+                    objdir_bytes: 8_100_000_000,
+                },
+            ],
+        }
+    }
+
+    fn names(body: &Value) -> Vec<&str> {
+        body["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| m["name"].as_str().unwrap())
+            .collect()
+    }
+
+    fn metric<'a>(body: &'a Value, name: &str) -> &'a Value {
+        body["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["name"] == name)
+            .unwrap_or_else(|| panic!("missing metric {name}"))
+    }
+
+    fn attr_map(point: &Value) -> std::collections::BTreeMap<String, String> {
+        point["attributes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|a| {
+                (
+                    a["key"].as_str().unwrap().to_string(),
+                    a["value"]["stringValue"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect()
+    }
+
+    fn all_attr_keys(body: &Value) -> std::collections::BTreeSet<String> {
+        let mut keys = std::collections::BTreeSet::new();
+        for attr in body["resourceMetrics"][0]["resource"]["attributes"]
+            .as_array()
+            .unwrap()
+        {
+            keys.insert(attr["key"].as_str().unwrap().to_string());
+        }
+        for metric in body["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+            .as_array()
+            .unwrap()
+        {
+            for point in metric["gauge"]["dataPoints"].as_array().unwrap() {
+                for attr in point["attributes"].as_array().unwrap() {
+                    keys.insert(attr["key"].as_str().unwrap().to_string());
+                }
+            }
+        }
+        keys
+    }
+
+    #[test]
+    fn time_unix_nano_is_a_decimal_string() {
+        let body = serialize_metrics(&kache_run());
+        let point = &metric(&body, "kache.bench.speedup")["gauge"]["dataPoints"][0];
+        assert!(point["timeUnixNano"].is_string());
+        assert_eq!(point["timeUnixNano"], "1700000000000000000");
+        assert!(point.get("asDouble").is_some());
+    }
+
+    #[test]
+    fn integer_counts_use_as_int_string() {
+        let body = serialize_metrics(&kache_run());
+        let point = &metric(&body, "kache.bench.cache.size")["gauge"]["dataPoints"][0];
+        assert_eq!(point["asInt"], "12582912");
+        assert!(point.get("asDouble").is_none());
+    }
+
+    #[test]
+    fn cache_size_is_bytes_not_megabytes() {
+        assert_eq!(OtlpRun::bytes_from_mib(1.5), 1_572_864);
+    }
+
+    #[test]
+    fn run_id_platform_and_cicd_are_absent() {
+        let body = serialize_metrics(&kache_run());
+        let dumped = body.to_string();
+        assert!(!dumped.contains("run_id"));
+        assert!(!dumped.contains("run-1"));
+        assert!(!dumped.contains("cicd."));
+        assert!(!dumped.contains("vcs."));
+        assert!(!dumped.contains("macos"));
+        let keys = all_attr_keys(&body);
+        for forbidden in [
+            "kache.bench.run_id",
+            "kache.bench.platform",
+            "cicd.pipeline.name",
+            "vcs.repository.url.full",
+        ] {
+            assert!(!keys.contains(forbidden), "{forbidden} must not be emitted");
+        }
+    }
+
+    #[test]
+    fn attribute_set_is_the_allowlist() {
+        let body = serialize_metrics(&kache_run());
+        let keys = all_attr_keys(&body);
+        let expected: std::collections::BTreeSet<_> = [
+            "kache.telemetry.schema_version",
+            "kache.bench.git_ref",
+            "kache.bench.project",
+            "kache.bench.cache_tool",
+            "kache.bench.phase",
+            "kache.bench.result",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+        assert_eq!(keys, expected);
+    }
+
+    #[test]
+    fn compile_units_carry_result_and_phase() {
+        let body = serialize_metrics(&kache_run());
+        let points = metric(&body, "kache.bench.compile.units")["gauge"]["dataPoints"]
+            .as_array()
+            .unwrap();
+        let results: Vec<_> = points
+            .iter()
+            .map(|p| {
+                let attrs = attr_map(p);
+                (
+                    attrs["kache.bench.phase"].clone(),
+                    attrs["kache.bench.result"].clone(),
+                    p["asInt"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect();
+        assert!(results.contains(&("warm".into(), "hit".into(), "480".into())));
+        assert!(results.contains(&("warm".into(), "dup".into(), "10".into())));
+        assert!(results.contains(&("cold".into(), "error".into(), "3".into())));
+        assert!(results.contains(&("warm".into(), "total".into(), "500".into())));
+    }
+
+    #[test]
+    fn pull_phase_is_a_dimension_not_a_new_metric() {
+        let mut run = kache_run();
+        run.speedup = None;
+        run.key_stability_pct = None;
+        run.phases = vec![OtlpPhase {
+            name: "pull",
+            wall_s: 120,
+            time_saved_s: Some(40),
+            hits: 100,
+            dups: Some(0),
+            misses: 20,
+            errors: Some(0),
+            total: Some(120),
+            hit_rate_pct: 83.3,
+            weighted_hit_rate_pct: Some(80.0),
+            leak_warnings: Some(0),
+            objdir_bytes: 1,
+        }];
+        let body = serialize_metrics(&run);
+        let duration = &metric(&body, "kache.bench.build.duration")["gauge"]["dataPoints"][0];
+        assert_eq!(attr_map(duration)["kache.bench.phase"], "pull");
+        assert!(!names(&body).contains(&"kache.bench.speedup"));
+        assert!(!names(&body).contains(&"kache.bench.key_stability"));
+    }
+
+    #[test]
+    fn sccache_omits_kache_only_gauges() {
+        let run = OtlpRun {
+            project: "bench-firefox-sccache".into(),
+            git_ref: "FIREFOX_140_0_RELEASE".into(),
+            cache_tool: "sccache",
+            time_unix_nano: "1".into(),
+            verdict_ok: true,
+            speedup: Some(1.1),
+            cache_size_bytes: 100,
+            key_stability_pct: None,
+            disk_measured_bytes: None,
+            phases: vec![OtlpPhase {
+                name: "warm",
+                wall_s: 10,
+                time_saved_s: None,
+                hits: 4,
+                dups: None,
+                misses: 1,
+                errors: None,
+                total: Some(5),
+                hit_rate_pct: 80.0,
+                weighted_hit_rate_pct: None,
+                leak_warnings: None,
+                objdir_bytes: 9,
+            }],
+        };
+        let body = serialize_metrics(&run);
+        let listed = names(&body);
+        assert!(!listed.contains(&"kache.bench.compile.time_saved"));
+        assert!(!listed.contains(&"kache.bench.cache.weighted_hit_rate"));
+        assert!(!listed.contains(&"kache.bench.leak_warnings"));
+        assert!(!listed.contains(&"kache.bench.key_stability"));
+        assert!(!listed.contains(&"kache.bench.disk.consumed"));
+        let units = metric(&body, "kache.bench.compile.units")["gauge"]["dataPoints"]
+            .as_array()
+            .unwrap();
+        let results: Vec<_> = units
+            .iter()
+            .map(|p| attr_map(p)["kache.bench.result"].clone())
+            .collect();
+        assert_eq!(results, vec!["hit", "miss", "total"]);
+    }
+
+    #[test]
+    fn degraded_run_still_emits_with_verdict_zero() {
+        let mut run = kache_run();
+        run.verdict_ok = false;
+        let body = serialize_metrics(&run);
+        let point = &metric(&body, "kache.bench.verdict.ok")["gauge"]["dataPoints"][0];
+        assert_eq!(point["asInt"], "0");
+        assert!(names(&body).contains(&"kache.bench.cache.hit_rate"));
+    }
+
+    #[test]
+    fn write_otlp_emits_both_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write_otlp(dir.path(), &kache_run()).unwrap();
+        let body: Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join(METRICS_FILE)).unwrap())
+                .unwrap();
+        assert_eq!(
+            body["resourceMetrics"][0]["resource"]["attributes"][0]["value"]["stringValue"],
+            "1"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join(SCHEMA_VERSION_FILE)).unwrap(),
+            "1\n"
+        );
+    }
+}

--- a/crates/kache-e2e/src/bench_otlp.rs
+++ b/crates/kache-e2e/src/bench_otlp.rs
@@ -386,6 +386,13 @@ mod tests {
     }
 
     #[test]
+    fn current_time_unix_nano_is_nonzero_decimal() {
+        let timestamp = OtlpRun::now_unix_nano();
+        let nanos = timestamp.parse::<u128>().unwrap();
+        assert!(nanos > 1_000_000_000_000_000_000);
+    }
+
+    #[test]
     fn integer_counts_use_as_int_string() {
         let body = serialize_metrics(&kache_run());
         let point = &metric(&body, "kache.bench.cache.size")["gauge"]["dataPoints"][0];

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -3132,6 +3132,32 @@ mod tests {
     }
 
     #[test]
+    fn write_otlp_or_warn_writes_artifact_pair() {
+        let dir = tempfile::tempdir().unwrap();
+        write_otlp_or_warn(
+            dir.path(),
+            crate::bench_otlp::OtlpRun {
+                project: "bench-test".into(),
+                git_ref: "main".into(),
+                cache_tool: "kache",
+                time_unix_nano: "1".into(),
+                verdict_ok: true,
+                speedup: None,
+                cache_size_bytes: 0,
+                key_stability_pct: None,
+                disk_measured_bytes: None,
+                phases: Vec::new(),
+            },
+        );
+        assert!(dir.path().join(crate::bench_otlp::METRICS_FILE).is_file());
+        assert!(
+            dir.path()
+                .join(crate::bench_otlp::SCHEMA_VERSION_FILE)
+                .is_file()
+        );
+    }
+
+    #[test]
     fn wrapped_compile_failures_do_not_degrade_the_run() {
         let stability = KeyStability {
             stable_pct: 96.9,

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -52,7 +52,8 @@
 //!
 //! Each run prints a summary block and writes `tmp/bench/<scenario>/<scenario>.json`
 //! plus per-phase reports (`report-<phase>.*`), build logs
-//! (`build-<phase>.log`), and wrapper logs (`wrapper-<phase>.log`).
+//! (`build-<phase>.log`), wrapper logs (`wrapper-<phase>.log`), and OTLP
+//! gauges (`metrics.otlp.json`) for kartero to pull from CI.
 //! By default each scenario writes under its own `./tmp/bench/<scenario>` (so
 //! scenarios coexist); a `work_dir` lock prevents two runs from sharing one
 //! scratch dir. Concurrent runs on one host make the wall-clock numbers
@@ -516,6 +517,24 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     let out = work_dir.join(format!("{}.json", profile.name));
     std::fs::write(&out, serde_json::to_string_pretty(&result)? + "\n")
         .with_context(|| format!("writing {}", out.display()))?;
+    write_otlp_or_warn(
+        &work_dir,
+        crate::bench_otlp::OtlpRun {
+            project: result.project.clone(),
+            git_ref: result.git_ref.clone(),
+            cache_tool: "kache",
+            time_unix_nano: crate::bench_otlp::OtlpRun::now_unix_nano(),
+            verdict_ok: result.verdict.ok,
+            speedup: Some(result.speedup),
+            cache_size_bytes: crate::bench_otlp::OtlpRun::bytes_from_mib(result.cache_size_mb),
+            key_stability_pct: Some(result.key_stability.stable_pct),
+            disk_measured_bytes: result.disk_measured_bytes,
+            phases: vec![
+                otlp_phase("cold", &result.cold, result.cold_objdir_bytes),
+                otlp_phase("warm", &result.warm, result.warm_objdir_bytes),
+            ],
+        },
+    );
 
     archive_run_artifacts(&work_dir, &run_archive_dir)?;
     print_summary(&result, &run_archive_dir);
@@ -576,6 +595,61 @@ fn is_run_artifact(name: &str) -> bool {
         || name.starts_with("trace-")
         || name.starts_with("key-diff.")
         || (name.starts_with("bench-") && name.ends_with(".json"))
+        || name == crate::bench_otlp::METRICS_FILE
+        || name == crate::bench_otlp::SCHEMA_VERSION_FILE
+}
+
+fn otlp_phase(
+    name: &'static str,
+    metrics: &PhaseMetrics,
+    objdir_bytes: u64,
+) -> crate::bench_otlp::OtlpPhase {
+    crate::bench_otlp::OtlpPhase {
+        name,
+        wall_s: metrics.wall_s,
+        time_saved_s: Some(metrics.time_saved_s),
+        hits: metrics.hits,
+        dups: Some(metrics.dups),
+        misses: metrics.misses,
+        errors: Some(metrics.errors),
+        total: Some(metrics.total_crates),
+        hit_rate_pct: metrics.hit_rate_pct,
+        weighted_hit_rate_pct: Some(metrics.weighted_hit_rate_pct),
+        leak_warnings: Some(metrics.leak_warnings),
+        objdir_bytes,
+    }
+}
+
+fn otlp_sccache_phase(
+    name: &'static str,
+    metrics: &SccachePhaseMetrics,
+    objdir_bytes: u64,
+) -> crate::bench_otlp::OtlpPhase {
+    crate::bench_otlp::OtlpPhase {
+        name,
+        wall_s: metrics.wall_s,
+        time_saved_s: None,
+        hits: metrics.cache_hits,
+        dups: None,
+        misses: metrics.cache_misses,
+        errors: None,
+        total: Some(metrics.compile_requests),
+        hit_rate_pct: metrics.hit_rate_pct,
+        weighted_hit_rate_pct: None,
+        leak_warnings: None,
+        objdir_bytes,
+    }
+}
+
+fn write_otlp_or_warn(work_dir: &Path, run: crate::bench_otlp::OtlpRun) {
+    if let Err(err) = crate::bench_otlp::write_otlp(work_dir, &run) {
+        eprintln!("[bench] warning: failed to write OTLP telemetry: {err:#}");
+        return;
+    }
+    eprintln!(
+        "[bench] otlp written to {}",
+        work_dir.join(crate::bench_otlp::METRICS_FILE).display()
+    );
 }
 
 /// Take an exclusive advisory lock on the work dir so two bench runs can't
@@ -1155,6 +1229,24 @@ fn run_pull_bench(
     let out = work_dir.join(format!("{}.json", profile.name));
     std::fs::write(&out, serde_json::to_string_pretty(&result)? + "\n")
         .with_context(|| format!("writing {}", out.display()))?;
+    write_otlp_or_warn(
+        work_dir,
+        crate::bench_otlp::OtlpRun {
+            project: result.project.clone(),
+            git_ref: result.git_ref.clone(),
+            cache_tool: "kache",
+            time_unix_nano: crate::bench_otlp::OtlpRun::now_unix_nano(),
+            verdict_ok: result.verdict.ok,
+            speedup: None,
+            cache_size_bytes: crate::bench_otlp::OtlpRun::bytes_from_mib(result.cache_size_mb),
+            key_stability_pct: None,
+            disk_measured_bytes: None,
+            phases: vec![
+                otlp_phase("cold", &result.cold, result.cold_objdir_bytes),
+                otlp_phase("pull", &result.pull, result.pull_objdir_bytes),
+            ],
+        },
+    );
     archive_run_artifacts(work_dir, run_archive_dir)?;
     print_pull_summary(&result, run_archive_dir);
     eprintln!("[bench] summary written to {}", out.display());
@@ -1279,6 +1371,24 @@ fn run_sccache_bench(
     let out = work_dir.join(format!("{}.json", profile.name));
     std::fs::write(&out, serde_json::to_string_pretty(&result)? + "\n")
         .with_context(|| format!("writing {}", out.display()))?;
+    write_otlp_or_warn(
+        work_dir,
+        crate::bench_otlp::OtlpRun {
+            project: result.project.clone(),
+            git_ref: result.git_ref.clone(),
+            cache_tool: "sccache",
+            time_unix_nano: crate::bench_otlp::OtlpRun::now_unix_nano(),
+            verdict_ok: true,
+            speedup: Some(result.speedup),
+            cache_size_bytes: result.cache_dir_bytes,
+            key_stability_pct: None,
+            disk_measured_bytes: result.disk_measured_bytes,
+            phases: vec![
+                otlp_sccache_phase("cold", &result.cold, result.cold_objdir_bytes),
+                otlp_sccache_phase("warm", &result.warm, result.warm_objdir_bytes),
+            ],
+        },
+    );
 
     archive_run_artifacts(work_dir, run_archive_dir)?;
     print_sccache_summary(&result, run_archive_dir);
@@ -3013,6 +3123,14 @@ mod tests {
     /// feature probes that rustc rejected — kache `EventResult::Error`) must
     /// NOT degrade the run: those are not kache cache faults. Regression guard
     /// for kunobi-ninja/kache (SurrealDB bench surfaced one such probe).
+    #[test]
+    fn run_archive_keeps_otlp_sidecars() {
+        assert!(is_run_artifact("metrics.otlp.json"));
+        assert!(is_run_artifact("schema_version"));
+        assert!(is_run_artifact("bench-firefox.json"));
+        assert!(!is_run_artifact("kache.log"));
+    }
+
     #[test]
     fn wrapped_compile_failures_do_not_degrade_the_run() {
         let stability = KeyStability {

--- a/crates/kache-e2e/src/lib.rs
+++ b/crates/kache-e2e/src/lib.rs
@@ -12,6 +12,7 @@
 //! owns the lifecycle; the TOML owns what the fixture is and what it expects.
 
 pub mod assertions;
+mod bench_otlp;
 pub mod bench_profile;
 pub mod bench_runner;
 pub mod daemon;


### PR DESCRIPTION
Kache benches now write an OTLP/HTTP metrics request beside each human-readable report. The workflow uploads it as a separate `telemetry-otlp-v1-*` artifact with three-day retention for Kartero.

- Covers Kache cold/warm, daily-pull, and sccache runs.
- Uses Gauges with bounded attributes and no OpenTelemetry SDK dependency.
- Keeps diagnostic reports on their existing 30-day retention.

Validation:

- `cargo test -p kache-e2e --lib --locked`
- `cargo clippy -p kache-e2e --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`