### PR TITLE
ci: run nightly benchmarks at 03:37 Zurich time

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,8 +24,9 @@ name: Bench
 # is minimal, so the base build toolchain is installed below.
 on:
   schedule:
-    # ~04:37 UTC nightly. Off the top-of-hour to dodge GitHub's cron congestion.
-    - cron: "37 4 * * *"
+    # 03:37 Zurich time nightly. Keeping :37 avoids top-of-hour cron congestion.
+    - cron: "37 3 * * *"
+      timezone: "Europe/Zurich"
   workflow_dispatch:
     inputs:
       scenario:


### PR DESCRIPTION
Run the benchmark workflow at 03:37 Europe/Zurich throughout the year.

The previous 04:37 UTC schedule fired at 06:37 during CEST and 05:37 during CET. The timezone-aware schedule also handles daylight-saving changes.

Validation:
- `git diff --check`
- parsed `.github/workflows/bench.yml` with Ruby YAML