### PR TITLE
feat(ci): publish coverage telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,19 @@ jobs:
               sys.exit(1)
           print(f'OK: >= {threshold}%')
           "
+      - name: Build coverage telemetry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: python3 -B scripts/ci/coverage_otlp.py tmp/llvm-cov/coverage.json tmp/coverage-telemetry
+      - name: Upload coverage telemetry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemetry-otlp-v1-coverage
+          path: |
+            tmp/coverage-telemetry/metrics.otlp.json
+            tmp/coverage-telemetry/schema_version
+          retention-days: 3
+          if-no-files-found: error
       - name: Upload HTML coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # Skip on tag/release runs: the shared release workflow downloads *all*

--- a/Justfile
+++ b/Justfile
@@ -13,11 +13,11 @@ default:
 
 # Run all local quality checks.
 [group('dev')]
-check: fmt-check lint test-resource-guard-check test
+check: fmt-check lint test-resource-guard-check coverage-otlp-test test
 
 # Mirror the repo CI verification flow.
 [group('dev')]
-ci: fmt-check lint image-service-print helm-lint test-resource-guard-check coverage
+ci: fmt-check lint image-service-print helm-lint test-resource-guard-check coverage-otlp-test coverage
 
 # Auto-fix formatting and clippy warnings.
 [group('dev')]
@@ -346,6 +346,11 @@ coverage:
 [group('coverage')]
 coverage-scope-check COVERAGE_JSON="tmp/llvm-cov/coverage.json":
   ./scripts/check-coverage-scope.sh "{{COVERAGE_JSON}}"
+
+# Verify the dependency-free llvm-cov to OTLP converter.
+[group('coverage')]
+coverage-otlp-test:
+  python3 -B -m unittest discover -s scripts/ci -p 'test_*.py'
 
 # Run cargo-llvm-cov and open the HTML report locally.
 [group('coverage')]

--- a/scripts/ci/coverage_otlp.py
+++ b/scripts/ci/coverage_otlp.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Convert cargo-llvm-cov totals into a small OTLP/HTTP JSON artifact."""
+
+import argparse
+import json
+import math
+import time
+from pathlib import Path
+
+
+SCHEMA_VERSION = 1
+
+
+def _gauge(name: str, unit: str, value: int | float, timestamp: str) -> dict:
+    field = "asInt" if isinstance(value, int) else "asDouble"
+    return {
+        "name": name,
+        "unit": unit,
+        "gauge": {
+            "dataPoints": [
+                {
+                    field: value,
+                    "timeUnixNano": timestamp,
+                    "attributes": [],
+                }
+            ]
+        },
+    }
+
+
+def build_request(report: dict, timestamp: str) -> dict:
+    try:
+        lines = report["data"][0]["totals"]["lines"]
+        count = lines["count"]
+        covered = lines["covered"]
+        percent = lines["percent"]
+    except (KeyError, IndexError, TypeError) as error:
+        raise ValueError("llvm-cov report has no line totals") from error
+
+    if (
+        not isinstance(count, int)
+        or isinstance(count, bool)
+        or not isinstance(covered, int)
+        or isinstance(covered, bool)
+        or not isinstance(percent, (int, float))
+        or isinstance(percent, bool)
+        or count < 0
+        or covered < 0
+        or covered > count
+        or not math.isfinite(percent)
+        or not 0 <= percent <= 100
+    ):
+        raise ValueError("llvm-cov line totals are invalid")
+
+    return {
+        "resourceMetrics": [
+            {
+                "resource": {
+                    "attributes": [
+                        {
+                            "key": "kache.telemetry.schema_version",
+                            "value": {"stringValue": str(SCHEMA_VERSION)},
+                        }
+                    ]
+                },
+                "scopeMetrics": [
+                    {
+                        "scope": {"name": "kache.ci.coverage", "version": "1"},
+                        "metrics": [
+                            _gauge("kache.ci.coverage.lines", "%", float(percent), timestamp),
+                            _gauge(
+                                "kache.ci.coverage.lines.covered",
+                                "{line}",
+                                covered,
+                                timestamp,
+                            ),
+                            _gauge(
+                                "kache.ci.coverage.lines.total",
+                                "{line}",
+                                count,
+                                timestamp,
+                            ),
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def write_artifact(report_path: Path, output_dir: Path, timestamp: str) -> None:
+    with report_path.open(encoding="utf-8") as stream:
+        report = json.load(stream)
+    request = build_request(report, timestamp)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "metrics.otlp.json").write_text(
+        json.dumps(request, separators=(",", ":")) + "\n", encoding="utf-8"
+    )
+    (output_dir / "schema_version").write_text(
+        f"{SCHEMA_VERSION}\n", encoding="utf-8"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("report", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--time-unix-nano", default=str(time.time_ns()))
+    args = parser.parse_args()
+    if not args.time_unix_nano.isdigit():
+        parser.error("--time-unix-nano must be an unsigned integer")
+    write_artifact(args.report, args.output_dir, args.time_unix_nano)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test_coverage_otlp.py
+++ b/scripts/ci/test_coverage_otlp.py
@@ -1,0 +1,63 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import coverage_otlp
+
+
+class CoverageOtlpTests(unittest.TestCase):
+    def test_writes_line_percentage_and_counts(self):
+        report = {
+            "data": [
+                {
+                    "totals": {
+                        "lines": {"count": 200, "covered": 178, "percent": 89.0}
+                    }
+                }
+            ]
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            report_path = root / "coverage.json"
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+            output = root / "telemetry"
+
+            coverage_otlp.write_artifact(report_path, output, "123")
+
+            body = json.loads((output / "metrics.otlp.json").read_text())
+            metrics = body["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+            self.assertEqual(
+                [metric["name"] for metric in metrics],
+                [
+                    "kache.ci.coverage.lines",
+                    "kache.ci.coverage.lines.covered",
+                    "kache.ci.coverage.lines.total",
+                ],
+            )
+            self.assertEqual(metrics[0]["gauge"]["dataPoints"][0]["asDouble"], 89.0)
+            self.assertEqual(metrics[1]["gauge"]["dataPoints"][0]["asInt"], 178)
+            self.assertEqual(metrics[2]["gauge"]["dataPoints"][0]["asInt"], 200)
+            self.assertEqual((output / "schema_version").read_text(), "1\n")
+
+    def test_rejects_missing_or_invalid_totals(self):
+        for report in (
+            {},
+            {"data": []},
+            {
+                "data": [
+                    {
+                        "totals": {
+                            "lines": {"count": 10, "covered": 11, "percent": 110.0}
+                        }
+                    }
+                ]
+            },
+        ):
+            with self.subTest(report=report):
+                with self.assertRaises(ValueError):
+                    coverage_otlp.build_request(report, "123")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #867.

- Converts existing cargo-llvm-cov line totals into OTLP JSON.
- Publishes percentage, covered lines, and total lines after trusted `main` pushes only.
- Uses the same short-lived `telemetry-otlp-v1-*` artifact contract consumed by Kartero.
- Adds dependency-free converter tests to `just check` and `just ci`.

Kartero `9ebfe62` adds `ci.yml`, trusted `main` push ingestion, and the coverage allowlist entries.