### PR TITLE
fix(store): read the executable bit from the compiler output, not the staged blob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,6 +633,73 @@ jobs:
       - name: Build flake checks
         run: nix flake check --keep-going --print-build-logs
 
+  # --- Copy-on-write filesystem coverage ---
+  # Every hosted runner is ext4, where `try_reflink` always fails and the
+  # `fs::copy` fallback preserves permissions. That makes an entire class of bug
+  # unobservable in CI: the store's reflink ingest creates its staging temp with
+  # `File::create` (umask mode, no +x), so a mode-losing ingest looks perfectly
+  # healthy here and only breaks on btrfs / XFS-with-reflink / ZFS >= 2.2 /
+  # bcachefs / APFS. #648 fixed the restore half of that and #822 silently
+  # reverted it through the ingest half; both shipped green. This lane exists so
+  # a third round can't.
+  cow-filesystem:
+    name: CoW filesystem (btrfs)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          # Pin mise CLI — see the `check` job's note (v2026.6.10 regression).
+          version: 2026.6.9
+          install_args: rust
+          cache: false
+      - name: Mount a loopback btrfs volume
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y btrfs-progs
+          # Sparse: the image only occupies what the tests actually write.
+          truncate -s 20G "$RUNNER_TEMP/cow.img"
+          mkfs.btrfs -q "$RUNNER_TEMP/cow.img"
+          sudo mkdir -p /mnt/cow
+          sudo mount -o loop "$RUNNER_TEMP/cow.img" /mnt/cow
+          sudo chown "$(id -u):$(id -g)" /mnt/cow
+          mkdir -p /mnt/cow/scratch /mnt/cow/tmp
+      # A mount that silently cannot clone makes this whole job a slower
+      # duplicate of the ext4 lanes — the exact blind spot it is here to close.
+      # `--reflink=always` fails rather than falling back to a copy, so this
+      # proves FICLONE works before any test relies on it.
+      - name: Prove reflink works on the mount
+        run: |
+          set -euo pipefail
+          head -c 1M /dev/urandom > /mnt/cow/probe-src
+          cp --reflink=always /mnt/cow/probe-src /mnt/cow/probe-dst
+          rm -f /mnt/cow/probe-src /mnt/cow/probe-dst
+      # `KACHE_TEST_SCRATCH_DIR` moves the integration fixtures' cache and target
+      # dirs onto btrfs; `TMPDIR` does the same for `tempfile::tempdir()`, which
+      # is where the store and link unit tests do their ingest. The build tree
+      # itself stays on the runner disk — it is the artifacts under test that
+      # need the CoW filesystem, not the compile.
+      #
+      # No kache-action here: this lane must exercise the wrapper built from
+      # this PR, not a released one, and dogfooding would put a second store in
+      # play.
+      - name: Run the filesystem-sensitive suites on btrfs
+        env:
+          KACHE_TEST_SCRATCH_DIR: /mnt/cow/scratch
+          TMPDIR: /mnt/cow/tmp
+          RUSTC_WRAPPER: ""
+        run: |
+          set -euo pipefail
+          cargo test --test custom_harness_test
+          cargo test --bins -- store:: link:: wrapper::tests::materialize_cached_artifact
+      - name: Report mount usage
+        if: always()
+        run: df -h /mnt/cow || true
+
   # --- E2E smoke test ---
   # Builds kache, configures as RUSTC_WRAPPER, cold-builds a fixture project,
   # cleans, warm-builds, and verifies cache hits work end-to-end.
@@ -1111,7 +1178,16 @@ jobs:
     # the full validation suite — `version-consistency` rejects a tag that
     # disagrees with the manifest BEFORE any binary builds; `e2e` includes the
     # (blocking) Windows arm, so a tag won't release unless Windows e2e is green.
-    needs: [check, nix-package, e2e, test-macos, test-windows, version-consistency]
+    needs:
+      [
+        check,
+        cow-filesystem,
+        nix-package,
+        e2e,
+        test-macos,
+        test-windows,
+        version-consistency,
+      ]
     # IN-ORG MIRROR of zondax/_workflows@7f61511 (v11) — a byte-identical import.
     # The macOS legs run on the self-hosted signing runners, whose runner group
     # restricts which workflows may use it. GitHub matches that allowlist against

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -82,7 +82,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           ./scripts/require-ci-green.sh "$(git rev-parse HEAD)" \
-            "Check (Linux)" "Nix package" \
+            "Check (Linux)" "Nix package" "CoW filesystem (btrfs)" \
             "E2E smoke (Linux)" "E2E smoke (macOS)" "E2E smoke (Windows)" \
             "Test (macOS)" "Test (Windows)"
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -47,6 +47,73 @@ fn set_blob_readonly_checked(blob: &Path) -> std::io::Result<()> {
     fs::set_permissions(blob, perms)
 }
 
+#[cfg(test)]
+thread_local! {
+    /// Test-only ingest override: reproduce, on any filesystem, what a Linux
+    /// CoW reflink does to a staged snapshot — independent bytes at the
+    /// *umask*, not at the source's mode.
+    ///
+    /// CI runs on ext4, where `try_reflink` always fails and the `fs::copy`
+    /// fallback carries the permission bits over. That is the blind spot #822
+    /// shipped through: a mode-losing ingest is simply unobservable there, so
+    /// the regression only ever appeared on a developer's btrfs/ZFS box.
+    /// Forcing the emulation makes the contract testable everywhere.
+    ///
+    /// Thread-local rather than a process-wide flag (`link.rs`'s
+    /// `WINDOWS_HARDLINK_RESTORE` is the latter, but it is a real feature
+    /// switch): `cargo test` runs store tests in parallel, and one test's
+    /// emulation must not leak into another's put.
+    static FORCE_MODE_DROPPING_INGEST: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+}
+
+/// Enable [`FORCE_MODE_DROPPING_INGEST`] for the duration of the guard.
+#[cfg(test)]
+struct ModeDroppingIngest;
+
+#[cfg(test)]
+impl ModeDroppingIngest {
+    fn enable() -> Self {
+        FORCE_MODE_DROPPING_INGEST.with(|forced| forced.set(true));
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for ModeDroppingIngest {
+    fn drop(&mut self) {
+        FORCE_MODE_DROPPING_INGEST.with(|forced| forced.set(false));
+    }
+}
+
+/// Stage `source` at `tmp` the way a Linux CoW reflink would, reporting whether
+/// the emulation was active at all. See [`FORCE_MODE_DROPPING_INGEST`].
+#[cfg(test)]
+fn emulate_cow_reflink_ingest(source: &Path, tmp: &Path) -> Result<bool> {
+    if !FORCE_MODE_DROPPING_INGEST.with(std::cell::Cell::get) {
+        return Ok(false);
+    }
+    fs::copy(source, tmp)
+        .with_context(|| format!("emulating a reflink ingest of {}", source.display()))?;
+    // `try_reflink` on Linux opens the destination with `File::create` before
+    // the FICLONE ioctl, so the snapshot lands at `0o666 & !umask` whatever the
+    // source was. The exact value varies with the umask; the only property that
+    // matters here is that it carries no `+x`.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(tmp, fs::Permissions::from_mode(0o644))
+            .with_context(|| format!("resetting the emulated staging mode on {}", tmp.display()))?;
+    }
+    Ok(true)
+}
+
+#[cfg(not(test))]
+#[inline(always)]
+fn emulate_cow_reflink_ingest(_source: &Path, _tmp: &Path) -> Result<bool> {
+    Ok(false)
+}
+
 /// Is `name` exactly a content-blob filename: 64 lowercase hex chars (a
 /// blake3 digest)? Used by the orphan sweep so it only ever unlinks files
 /// that look like a blob — never an in-progress temp (`.{hash}.{pid}.{n}.tmp`)
@@ -1805,13 +1872,29 @@ impl Store {
         let mut put_result = StorePutResult::default();
         let mut total_size = 0u64;
         for (source_path, store_name) in output_files {
-            // Eligibility decision only; the staged snapshot's own metadata
-            // is authoritative for what gets recorded below.
-            let source_executable = fs::metadata(source_path)
+            // The mode is read from the compiler's output, never from the
+            // staging snapshot taken below. That snapshot is authoritative for
+            // *bytes* — hashing it rather than the live output is the whole
+            // point of #822 — but it is not authoritative for permissions:
+            // `stage_blob_from_source` prefers `try_reflink`, whose Linux
+            // implementation creates the temp with `File::create` before the
+            // FICLONE ioctl, so a 0o755 binary reads back at the umask on every
+            // CoW filesystem (btrfs, XFS-with-reflink, ZFS >= 2.2, bcachefs).
+            // `fs::copy` and macOS `clonefile` happen to preserve it, which is
+            // why ext4 CI and macOS did not notice #822 undoing #648's restore
+            // fix: recorded `executable: false`, a `harness = false` test binary
+            // classifies as `Other("rustc:unknown")`, restores via `Hardlink`
+            // with no 0o755, and cargo fails the run with "Permission denied
+            // (os error 13)".
+            //
+            // A failed stat is an error rather than a silent `false`, because
+            // `false` is precisely the wrong value this guards against — and
+            // staging opens the same path one line below regardless.
+            let executable = fs::metadata(source_path)
                 .map(|meta| is_executable(&meta))
-                .unwrap_or(false);
+                .with_context(|| format!("stating compiler output for {store_name}"))?;
             let use_source_hardlink =
-                source_hardlink_allowed(allow_source_hardlinks, store_name, source_executable);
+                source_hardlink_allowed(allow_source_hardlinks, store_name, executable);
 
             let (staged, ingest) = self.stage_blob_from_source(source_path, use_source_hardlink)?;
             let staged_meta = match fs::metadata(&staged) {
@@ -1823,7 +1906,6 @@ impl Store {
                 }
             };
             let size = staged_meta.len();
-            let executable = is_executable(&staged_meta);
             if size == 0 && !zero_byte_is_valid_output(store_name, crate_types) {
                 Self::discard_staged_blob(&staged);
                 anyhow::bail!("refusing to cache zero-byte artifact: {}", store_name);
@@ -2862,6 +2944,15 @@ impl Store {
     /// reflink and hardlink ingests can only write to a destination that does
     /// not exist yet, so pre-creating it would cost a full byte copy per
     /// artifact on every filesystem.
+    ///
+    /// **The snapshot's bytes are faithful; its mode is not.** Only the hardlink
+    /// ingest shares the source's inode, and only `fs::copy` promises to carry
+    /// the permission bits over. [`crate::link::try_reflink`] on Linux creates
+    /// the destination with `File::create` before the FICLONE ioctl, so a
+    /// reflinked snapshot of a 0o755 binary lands at the umask instead — which
+    /// is how #822 silently reverted #648. Anything permission-shaped
+    /// (`CachedFile::executable`) must be read from the source, never from
+    /// here.
     fn stage_blob_from_source(
         &self,
         source: &Path,
@@ -2878,7 +2969,11 @@ impl Store {
             .with_context(|| format!("reserving a staging name in {}", dir.display()))?;
 
         let stage = |tmp: &Path, allow_hardlink: bool| -> Result<(StoreIngest, bool)> {
-            let ingest = if crate::link::try_reflink(source, tmp).is_ok() {
+            // Short-circuit: the real reflink is only attempted when no test
+            // emulation claimed the staging slot.
+            let ingest = if emulate_cow_reflink_ingest(source, tmp)?
+                || crate::link::try_reflink(source, tmp).is_ok()
+            {
                 StoreIngest::Reflink
             } else if allow_hardlink
                 && fs::symlink_metadata(source).is_ok_and(|m| m.file_type().is_file())
@@ -4711,6 +4806,107 @@ mod tests {
             "independent ingest must never share the compiler output inode"
         );
         assert!(blob_meta.permissions().readonly());
+    }
+
+    /// #648 made restore honour the mode bit recorded at insert time, because a
+    /// `[[test]] harness = false` target supplies its own `main` and is compiled
+    /// with neither `--test` nor `--crate-type` — nothing in the rustc argv says
+    /// "executable", so the recorded bit is the only signal. #822 then began
+    /// reading that bit off the *staging snapshot* rather than the compiler's
+    /// output, and a reflinked snapshot is created at the umask: on every CoW
+    /// filesystem the entry recorded `executable: false`, restore fell back to
+    /// `Hardlink`, and cargo failed the run with "Permission denied (os error
+    /// 13)".
+    ///
+    /// The emulation is what makes this reachable on ext4. Without it the copy
+    /// fallback preserves the mode, the assertion holds for free, and the test
+    /// would only fail on the filesystems CI never runs on.
+    #[cfg(unix)]
+    #[test]
+    fn put_records_the_executable_bit_from_the_compiler_output_not_the_staging_snapshot() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let output = dir.path().join("harness-a1b2c3d4e5f60718");
+        fs::write(&output, b"\x7fELF harness=false test binary").unwrap();
+        fs::set_permissions(&output, fs::Permissions::from_mode(0o755)).unwrap();
+
+        {
+            let _forced = ModeDroppingIngest::enable();
+            store
+                .put_with_compile_time_independent(
+                    "harness-entry",
+                    "harness",
+                    &[],
+                    &[],
+                    "x86_64-unknown-linux-gnu",
+                    "",
+                    &[(output.clone(), "harness-a1b2c3d4e5f60718".to_string())],
+                    "",
+                    "",
+                    1,
+                )
+                .unwrap();
+        }
+
+        let meta = store.get("harness-entry").unwrap().unwrap();
+        // Proves the emulation actually dropped the bit, so the assertion below
+        // cannot pass because the snapshot happened to keep it.
+        let blob_mode = fs::metadata(store.blob_path(&meta.files[0].hash))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            blob_mode & 0o111,
+            0,
+            "emulated reflink ingest should have staged without the bit, got {blob_mode:o}"
+        );
+        assert!(
+            meta.files[0].executable,
+            "the recorded mode must come from the compiler's 0o755 output, \
+             not from the staging snapshot"
+        );
+    }
+
+    /// The converse, under the same emulation: reading the mode from the source
+    /// must not degenerate into recording every artifact executable.
+    #[cfg(unix)]
+    #[test]
+    fn put_records_no_executable_bit_for_a_non_executable_output() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let output = dir.path().join("libfoo.rlib");
+        fs::write(&output, b"rlib bytes").unwrap();
+        fs::set_permissions(&output, fs::Permissions::from_mode(0o644)).unwrap();
+
+        {
+            let _forced = ModeDroppingIngest::enable();
+            store
+                .put_with_compile_time_independent(
+                    "rlib-entry",
+                    "foo",
+                    &["lib".to_string()],
+                    &[],
+                    "x86_64-unknown-linux-gnu",
+                    "",
+                    &[(output.clone(), "libfoo.rlib".to_string())],
+                    "",
+                    "",
+                    1,
+                )
+                .unwrap();
+        }
+
+        let meta = store.get("rlib-entry").unwrap().unwrap();
+        assert!(
+            !meta.files[0].executable,
+            "a 0o644 compiler output must not be recorded executable"
+        );
     }
 
     /// A mutable-kind blob must never share an inode with the build's output:

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -108,11 +108,21 @@ pub fn isolated_config_path(cache_dir: &Path) -> PathBuf {
 /// they leave behind. Anchoring here keeps such tests on whatever filesystem
 /// the developer or CI actually builds on, and `cargo clean` reclaims it.
 ///
+/// `KACHE_TEST_SCRATCH_DIR` overrides it. The developer's filesystem is
+/// whatever it is, but CI's is ext4 — where `try_reflink` always fails and the
+/// `fs::copy` fallback preserves permissions, hiding every mode-losing
+/// reflink path (that is how #822 reverted #648 unnoticed). The
+/// `cow-filesystem` job points this at a loopback btrfs mount so those paths
+/// actually run.
+///
 /// Only the tests that materialize artifacts need this, and each integration
 /// test binary compiles this module separately, so the rest see it as dead.
 #[allow(dead_code)]
 pub fn scratch_dir() -> PathBuf {
-    let dir = bootstrap_target_dir().with_file_name("kache-test-scratch");
+    let dir = match std::env::var_os("KACHE_TEST_SCRATCH_DIR") {
+        Some(dir) => PathBuf::from(dir),
+        None => bootstrap_target_dir().with_file_name("kache-test-scratch"),
+    };
     std::fs::create_dir_all(&dir).expect("creating scratch dir");
     dir
 }


### PR DESCRIPTION
#648 taught restore to honour the mode bit recorded at insert time, because a
`[[test]] harness = false` target supplies its own `main` and is compiled with
neither `--test` nor `--crate-type` — nothing in the rustc argv says
"executable", so the recorded bit is the only signal.

#822 then moved that read from the compiler's output to the staging snapshot:

    -  let executable = is_executable(&metadata);      // the compiler's output
    +  let executable = is_executable(&staged_meta);   // the staging temp

`stage_blob_from_source` prefers `try_reflink`, whose Linux implementation
creates the destination with `File::create` before the FICLONE ioctl. The
snapshot therefore lands at `0o666 & !umask` whatever the source was, so on
every CoW filesystem (btrfs, XFS-with-reflink, ZFS >= 2.2, bcachefs) a 0o755
binary is recorded `executable: false`. Restore then falls back to
`Other("rustc:unknown")`'s `Hardlink` strategy, never applies 0o755, and cargo
fails the run with "Permission denied (os error 13)" — the exact failure #648
fixed.

`fs::copy` and macOS `clonefile` both preserve the mode, which is why ext4 CI
and macOS saw nothing. In a 0.16 store on ZFS the harness-shaped entries
(`crate_types: []`, extensionless ELF output) split 144 executable / 237 not,
nondeterministically: FICLONE fails for blocks not yet written out, and the copy
fallback then preserves the bit by accident.

The snapshot is authoritative for *bytes* — hashing it rather than the live
output is the whole point of #822 — but never for permissions, and
`CachedFile::executable` already documents itself as "whether the source file
had the executable bit set at store time". A failed stat becomes an error rather
than a silent `false`, which is precisely the wrong value; staging opens the same
path a line later regardless, so only the message changes.

Two layers of coverage, because CI could observe none of this:

  - A `#[cfg(test)]` thread-local makes staging emulate a Linux reflink (copy,
    then chmod 0o644) on any filesystem. Without it ext4 only ever exercises the
    mode-preserving copy fallback, and the new tests hold for free.
  - A `cow-filesystem` job runs the filesystem-sensitive suites on a loopback
    btrfs mount, gated on a `cp --reflink=always` probe so a mount that cannot
    clone fails the job instead of silently becoming a second ext4 lane.
    `scratch_dir()` honours `KACHE_TEST_SCRATCH_DIR` to get there.

`custom_harness_test` reproduces the reported failure on ZFS without this fix
and passes with it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
