### PR TITLE
fix(bench): repair Firefox and Lance scenarios

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,1 @@
-# Byte-exact checkouts on every platform. kache's fixtures are applied
-# verbatim against pinned upstream sources: the bench scenarios carry
-# `git apply` patches (scenarios/*/patches/) whose context lines must match
-# LF upstream trees byte-for-byte, and scenario TOML payloads are written
-# into checkouts as-is. Git for Windows defaults to core.autocrlf=true,
-# which CRLF-ifies all of these at checkout and broke the Windows Firefox
-# bench at patch-apply time. Disabling text normalization repo-wide (the
-# same policy the Firefox repo uses) removes the whole class.
-* -text
+**/*.patch whitespace=-blank-at-eol

--- a/crates/kache-e2e/src/bench_profile.rs
+++ b/crates/kache-e2e/src/bench_profile.rs
@@ -1000,6 +1000,8 @@ diff --git a/hello.txt b/hello.txt
         assert!(moz.contains("mk_add_options \"export RUSTC_WRAPPER=/k\""));
         assert!(moz.contains("mk_add_options \"export CARGO_INCREMENTAL=0\""));
         assert!(moz.contains("mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-kache-bench"));
+        assert!(moz.contains("ac_add_options --host=\"$rust_target\""));
+        assert!(moz.contains("ac_add_options --target=\"$rust_target\""));
         assert!(
             !moz.contains("{kache}") && !moz.contains("{objdir}"),
             "placeholders must be interpolated"
@@ -1011,6 +1013,38 @@ diff --git a/hello.txt b/hello.txt
         assert!(moz.contains("mk_add_options \"export MOZ_BUILD_DATE=20260101000000\""));
         assert!(moz.contains("export KACHE_PATH_ONLY_ENV_VARS=BUILDCONFIG_RS,"));
         assert!(moz.ends_with('\n'), "mozconfig is newline-terminated");
+    }
+
+    #[test]
+    fn shipped_firefox_windows_profile_uses_only_the_upstream_cbindgen_fix() {
+        let p = BenchProfile::load(&repo_profile("firefox-windows"))
+            .expect("firefox-windows.toml loads");
+        assert_eq!(p.name, "bench-firefox-windows");
+        let patches = p
+            .files
+            .iter()
+            .filter(|file| file.mode == FileMode::Patch)
+            .collect::<Vec<_>>();
+        assert_eq!(patches.len(), 1);
+        assert!(
+            patches[0]
+                .content_file
+                .as_deref()
+                .expect("patch file")
+                .ends_with("firefox-cbindgen-visibility.patch")
+        );
+        let mozconfig = p
+            .files
+            .iter()
+            .find(|file| file.path == "mozconfig")
+            .expect("mozconfig entry");
+        assert!(
+            !mozconfig
+                .content
+                .as_deref()
+                .expect("inline mozconfig")
+                .contains("KACHE_PATH_ONLY_ENV_VARS")
+        );
     }
 
     /// The shipped Substrate scenario wires kache via `RUSTC_WRAPPER` only
@@ -1035,9 +1069,9 @@ diff --git a/hello.txt b/hello.txt
         );
     }
 
-    /// The shipped Lance scenario wires kache via `RUSTC_WRAPPER` only
-    /// (no file injection, no CC/CXX — optional fp16 kernels stay off),
-    /// honours the tree's rust-toolchain.toml, and builds the `lance` crate.
+    /// The shipped Lance scenario wires kache via `RUSTC_WRAPPER`, exposes the
+    /// system protobuf includes to prost-build, honours the tree's
+    /// rust-toolchain.toml, and builds the `lance` crate.
     #[test]
     fn shipped_lance_profile_is_rustc_wrapper_only() {
         let p = BenchProfile::load(&repo_profile("lance")).expect("lance.toml loads");
@@ -1045,7 +1079,24 @@ diff --git a/hello.txt b/hello.txt
         assert_eq!(p.objdir, "target");
         assert_eq!(p.repo, "https://github.com/lance-format/lance.git");
         assert_eq!(p.git_ref, "v10.0.0");
-        assert!(p.files.is_empty(), "lance uses RUSTC_WRAPPER only");
+        assert_eq!(p.files.len(), 3);
+        for file in &p.files {
+            assert_eq!(file.mode, FileMode::Write);
+            assert!(file.path.starts_with("protos/google/protobuf/"));
+        }
+        let well_known_types = p
+            .files
+            .iter()
+            .map(|file| file.path.as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            well_known_types,
+            std::collections::BTreeSet::from([
+                "protos/google/protobuf/any.proto",
+                "protos/google/protobuf/empty.proto",
+                "protos/google/protobuf/timestamp.proto",
+            ])
+        );
         assert!(
             p.env.is_empty(),
             "no extra env — CARGO_INCREMENTAL is an engine baseline, not a profile var"

--- a/scenarios/bench-firefox-pull/scenario.toml
+++ b/scenarios/bench-firefox-pull/scenario.toml
@@ -38,6 +38,9 @@ content = """
 ac_add_options --enable-optimize
 ac_add_options --disable-debug
 ac_add_options --disable-tests
+rust_target="$(rustc -vV | sed -n 's/^host: //p')"
+ac_add_options --host="$rust_target"
+ac_add_options --target="$rust_target"
 ac_add_options --with-compiler-wrapper={kache}
 mk_add_options "export RUSTC_WRAPPER={kache}"
 mk_add_options "export KACHE_CACHE_EXECUTABLES=1"

--- a/scenarios/bench-firefox-sccache/scenario.toml
+++ b/scenarios/bench-firefox-sccache/scenario.toml
@@ -22,6 +22,9 @@ content = """
 ac_add_options --enable-optimize
 ac_add_options --disable-debug
 ac_add_options --disable-tests
+rust_target="$(rustc -vV | sed -n 's/^host: //p')"
+ac_add_options --host="$rust_target"
+ac_add_options --target="$rust_target"
 
 # Use Firefox's native sccache integration for C/C++ and rustc.
 ac_add_options --with-ccache={cache}
@@ -48,6 +51,11 @@ content_file = "patches/firefox-mozbuild-path-clean.patch"
 path         = "gfx/wr/webrender/build.rs"
 mode         = "patch"
 content_file = "patches/firefox-generated-source-relative.patch"
+
+[[file]]
+path         = "gfx/wr/webrender/src/texture_cache.rs"
+mode         = "patch"
+content_file = "../bench-firefox/patches/firefox-cbindgen-visibility.patch"
 
 [checks.measure.warm]
 min_hit_rate_pct = 50.0

--- a/scenarios/bench-firefox-windows/scenario.toml
+++ b/scenarios/bench-firefox-windows/scenario.toml
@@ -88,32 +88,22 @@ mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/{objdir}
 
 # Cross-clone cache-key portability. KACHE_BASE_DIR rewrites paths under it to a
 # stable sentinel in the cache key; @TOPSRCDIR@ expands per worktree so each
-# normalizes its OWN objdir path. (Windows path shapes mean convergence is
-# best-effort here — see the relaxed warm assertion below.)
+# normalizes its own objdir path.
 mk_add_options "export KACHE_BASE_DIR=@TOPSRCDIR@"
 
 # Pin the Firefox build ID so buildid.cpp / application.ini.h are byte-identical
 # across worktrees built minutes apart.
 mk_add_options "export MOZ_BUILD_DATE=20260101000000"
 
-# Opt path-only env vars into kache key normalization (the OUT_DIR contract).
-mk_add_options "export KACHE_PATH_ONLY_ENV_VARS=BUILDCONFIG_RS,MOZ_TOPOBJDIR,MOZ_TOPSRCDIR,CONVERSIONS_FILE,GLEAN_METRICS_FILE,BINDINGS,TYPENUM_BUILD_CONSTS,TYPENUM_BUILD_OP,TYPENUM_BUILD_GENERIC_CONSTS"
 """
 
-# Shared cross-clone convergence patches — reused from bench-firefox (resolved
-# relative to this scenario dir). mozbuild path-clean + generated-source-relative
-# make the cascade-root rlibs byte-identical across checkouts. These are
-# text/`git apply` patches; if Windows checkout line endings reject them, the
-# run fails loudly at apply time (a known thing to shake out on first real run).
+# Mozilla's upstream cbindgen fix for Firefox 151 (Bug 2046162). Without it,
+# cbindgen emits `BudgetType_VALUES[COUNT]`, which clang-cl rejects because
+# COUNT is an associated Rust constant and is not in the C++ scope.
 [[file]]
-path         = "build/rust/mozbuild/generate_buildconfig.py"
+path         = "gfx/wr/webrender/src/texture_cache.rs"
 mode         = "patch"
-content_file = "../bench-firefox/patches/firefox-mozbuild-path-clean.patch"
-
-[[file]]
-path         = "gfx/wr/webrender/build.rs"
-mode         = "patch"
-content_file = "../bench-firefox/patches/firefox-generated-source-relative.patch"
+content_file = "../bench-firefox/patches/firefox-cbindgen-visibility.patch"
 
 # v1 gates. min_key_stability_pct is relaxed (cross-path convergence on Windows
 # is unsolved); max_passthrough_pct + max_errors are the meaningful gates that

--- a/scenarios/bench-firefox/patches/firefox-cbindgen-visibility.patch
+++ b/scenarios/bench-firefox/patches/firefox-cbindgen-visibility.patch
@@ -1,0 +1,25 @@
+diff --git a/gfx/wr/webrender/src/texture_cache.rs b/gfx/wr/webrender/src/texture_cache.rs
+index e14c26bd3190..77e1f3a312ac 100644
+--- a/gfx/wr/webrender/src/texture_cache.rs
++++ b/gfx/wr/webrender/src/texture_cache.rs
+@@ -273,9 +273,9 @@ enum BudgetType {
+ }
+ 
+ impl BudgetType {
+-    pub const COUNT: usize = 7;
++    const COUNT: usize = 7;
+ 
+-    pub const VALUES: [BudgetType; BudgetType::COUNT] = [
++    const VALUES: [BudgetType; BudgetType::COUNT] = [
+         BudgetType::SharedColor8Linear,
+         BudgetType::SharedColor8Nearest,
+         BudgetType::SharedColor8Glyphs,
+@@ -285,7 +285,7 @@ impl BudgetType {
+         BudgetType::Standalone,
+     ];
+ 
+-    pub const PRESSURE_COUNTERS: [usize; BudgetType::COUNT] = [
++    const PRESSURE_COUNTERS: [usize; BudgetType::COUNT] = [
+         profiler::ATLAS_COLOR8_LINEAR_PRESSURE,
+         profiler::ATLAS_COLOR8_NEAREST_PRESSURE,
+         profiler::ATLAS_COLOR8_GLYPHS_PRESSURE,

--- a/scenarios/bench-firefox/scenario.toml
+++ b/scenarios/bench-firefox/scenario.toml
@@ -39,6 +39,14 @@ ac_add_options --enable-optimize
 ac_add_options --disable-debug
 ac_add_options --disable-tests
 
+# GNU config identifies Linux as x86_64-pc-linux-gnu. Modern rustc exposes
+# several Linux GNU targets (plain, ASan, MSan, TSan), so Firefox cannot infer
+# which Rust target matches that alias. Use rustc's exact native triple for
+# both configure dimensions.
+rust_target="$(rustc -vV | sed -n 's/^host: //p')"
+ac_add_options --host="$rust_target"
+ac_add_options --target="$rust_target"
+
 # Prepend kache as the C/C++ compiler launcher. Firefox keeps
 # selecting its own bootstrapped clang; kache wraps each -c step.
 #
@@ -123,6 +131,14 @@ content_file = "patches/firefox-mozbuild-path-clean.patch"
 path         = "gfx/wr/webrender/build.rs"
 mode         = "patch"
 content_file = "patches/firefox-generated-source-relative.patch"
+
+# Firefox 151 retained public associated constants on a private enum. cbindgen
+# emits those constants without their enum qualifier, producing invalid C++.
+# This is Mozilla's upstream fix (Bug 2046162, c4aab1ba6aadd6985fcd271679d2118f094ec876).
+[[file]]
+path         = "gfx/wr/webrender/src/texture_cache.rs"
+mode         = "patch"
+content_file = "patches/firefox-cbindgen-visibility.patch"
 
 [checks.assert.warm]
 min_key_stability_pct = 50.0

--- a/scenarios/bench-lance/scenario.toml
+++ b/scenarios/bench-lance/scenario.toml
@@ -41,6 +41,42 @@ repo = "https://github.com/lance-format/lance.git"
 ref    = "v10.0.0"
 objdir = "target"
 
+# Lance v10 invokes protoc with only its local proto directory but imports
+# three well-known types. Supply their schemas inside the include tree Lance
+# already passes to protoc.
+[[file]]
+path = "protos/google/protobuf/empty.proto"
+mode = "write"
+content = '''
+syntax = "proto3";
+package google.protobuf;
+message Empty {}
+'''
+
+[[file]]
+path = "protos/google/protobuf/any.proto"
+mode = "write"
+content = '''
+syntax = "proto3";
+package google.protobuf;
+message Any {
+  string type_url = 1;
+  bytes value = 2;
+}
+'''
+
+[[file]]
+path = "protos/google/protobuf/timestamp.proto"
+mode = "write"
+content = '''
+syntax = "proto3";
+package google.protobuf;
+message Timestamp {
+  int64 seconds = 1;
+  int32 nanos = 2;
+}
+'''
+
 [checks.assert.warm]
 min_key_stability_pct = 50.0
 max_passthrough_pct = 40.0


### PR DESCRIPTION
Fixes the benchmark failures seen in recent nightly runs.

- Pass Firefox the exact native Rust host/target triple so modern sanitizer targets do not make Mozilla target detection ambiguous.
- Apply Mozilla Bug 2046162 upstream cbindgen visibility fix to Firefox 151.
- Keep the Windows benchmark off the experimental cross-clone source rewrites that alter bindgen inputs.
- Supply the Empty, Any, and Timestamp well-known protobuf schemas inside Lance v10 local proto include tree.
- Add profile regression tests.

Validation: just check; the Firefox patch applies cleanly to its pinned upstream ref; protoc accepts all Lance v10 well-known imports; lance-encoding, lance-file, lance-table, and lance-index build together with the injected schemas.