### PR TITLE
feat(telemetry): dump cache counters as OTLP JSON for Kartero

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -166,6 +166,8 @@ gitignore = true
 # Linux/macOS/Windows E2E smoke lanes exercise those entry points instead.
 # Keep only the whole-body replacements out of this lane: their parsing,
 # selection, measurement, verdict, artifact, and OTLP helpers remain in scope.
+# `run_cold_phase` is the same shape: a full clone/build that this lane cannot
+# drive. The dump it now calls (`write_cache_otlp_or_warn`) stays in scope.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -204,4 +206,5 @@ exclude_re = [
     "replace run_bench .* with Ok",
     "replace run_pull_bench .* with Ok",
     "replace run_sccache_bench .* with Ok",
+    "replace run_cold_phase .* with Ok",
 ]

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -322,6 +322,30 @@ jobs:
           retention-days: 3
           if-no-files-found: error
 
+      # Daemon/store counters (`kache.cache.*`), not the bench gauges above.
+      # Separate artifacts so Kartero imports them as different payloads.
+      # Do not validate with @kunobi/kartero@0.3.0: that CLI's published
+      # allowlist does not include kache.cache.* yet.
+      - name: Upload cache telemetry (cold)
+        if: always()
+        timeout-minutes: 10
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemetry-otlp-v1-cache-${{ matrix.name }}-cold
+          path: tmp/bench/${{ matrix.dir }}/cache-otlp-cold/
+          retention-days: 3
+          if-no-files-found: warn
+
+      - name: Upload cache telemetry (warm)
+        if: always()
+        timeout-minutes: 10
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemetry-otlp-v1-cache-${{ matrix.name }}-warm
+          path: tmp/bench/${{ matrix.dir }}/cache-otlp-warm/
+          retention-days: 3
+          if-no-files-found: warn
+
   # Firefox compile-cache bench on the self-hosted Windows runner (clang-cl +
   # MSVC under MozillaBuild). Separate from the `bench` matrix above: that runs
   # on the ephemeral Linux ARC (`kunobi-runners`); this needs the persistent
@@ -549,6 +573,26 @@ jobs:
             ${{ runner.temp }}/f/bench-firefox-windows.json
           retention-days: 3
           if-no-files-found: error
+
+      - name: Upload cache telemetry (cold)
+        if: always()
+        timeout-minutes: 10
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemetry-otlp-v1-cache-firefox-windows-cold
+          path: ${{ runner.temp }}/f/cache-otlp-cold/
+          retention-days: 3
+          if-no-files-found: warn
+
+      - name: Upload cache telemetry (warm)
+        if: always()
+        timeout-minutes: 10
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemetry-otlp-v1-cache-firefox-windows-warm
+          path: ${{ runner.temp }}/f/cache-otlp-warm/
+          retention-days: 3
+          if-no-files-found: warn
 
   # Firefox DAILY-PULL (temporal, #477) compile-cache bench on the self-hosted
   # Windows runner — the axis that matches the reported issue (clang-cl on
@@ -793,3 +837,23 @@ jobs:
             ${{ runner.temp }}/b/bench-firefox-pull-windows.json
           retention-days: 3
           if-no-files-found: error
+
+      - name: Upload cache telemetry (cold)
+        if: always()
+        timeout-minutes: 10
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemetry-otlp-v1-cache-firefox-pull-windows-cold
+          path: ${{ runner.temp }}/b/cache-otlp-cold/
+          retention-days: 3
+          if-no-files-found: warn
+
+      - name: Upload cache telemetry (pull)
+        if: always()
+        timeout-minutes: 10
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemetry-otlp-v1-cache-firefox-pull-windows-pull
+          path: ${{ runner.temp }}/b/cache-otlp-pull/
+          retention-days: 3
+          if-no-files-found: warn

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -672,7 +672,7 @@ fn write_cache_otlp_or_warn(
     dest: &Path,
     scenario: &str,
     phase: &str,
-) {
+) -> bool {
     let status = Command::new(kache)
         .args(["telemetry", "write"])
         .arg(dest)
@@ -687,12 +687,15 @@ fn write_cache_otlp_or_warn(
                 "[bench] cache otlp written to {}",
                 dest.join("metrics.otlp.json").display()
             );
+            true
         }
         Ok(code) => {
             eprintln!("[bench] warning: kache telemetry write exited {code}");
+            false
         }
         Err(err) => {
             eprintln!("[bench] warning: kache telemetry write failed: {err}");
+            false
         }
     }
 }
@@ -3191,6 +3194,95 @@ mod tests {
         assert!(is_run_artifact("schema_version"));
         assert!(is_run_artifact("bench-firefox.json"));
         assert!(!is_run_artifact("kache.log"));
+    }
+
+    #[test]
+    fn write_cache_otlp_or_warn_runs_telemetry_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("invoked.txt");
+        let kache = fake_kache_that_records(dir.path(), &marker, 0);
+        let dest = dir.path().join("cache-otlp-warm");
+        assert!(write_cache_otlp_or_warn(
+            &kache,
+            dir.path(),
+            &dir.path().join("kache.toml"),
+            &dest,
+            "bench-firefox",
+            "warm",
+        ));
+        let invoked = std::fs::read_to_string(&marker).unwrap();
+        assert!(
+            invoked.contains("telemetry"),
+            "expected telemetry subcommand, got {invoked:?}"
+        );
+        assert!(
+            invoked.contains("write"),
+            "expected write subcommand, got {invoked:?}"
+        );
+        assert!(
+            invoked.contains("bench-firefox") && invoked.contains("warm"),
+            "expected scenario and phase, got {invoked:?}"
+        );
+    }
+
+    #[test]
+    fn write_cache_otlp_or_warn_is_false_when_kache_exits_nonzero() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("invoked.txt");
+        let kache = fake_kache_that_records(dir.path(), &marker, 1);
+        assert!(!write_cache_otlp_or_warn(
+            &kache,
+            dir.path(),
+            &dir.path().join("kache.toml"),
+            &dir.path().join("cache-otlp-cold"),
+            "bench-firefox",
+            "cold",
+        ));
+        assert!(marker.is_file());
+    }
+
+    #[test]
+    fn write_cache_otlp_or_warn_is_false_when_kache_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!write_cache_otlp_or_warn(
+            &dir.path().join("no-such-kache"),
+            dir.path(),
+            &dir.path().join("kache.toml"),
+            &dir.path().join("cache-otlp-pull"),
+            "bench-firefox",
+            "pull",
+        ));
+    }
+
+    fn fake_kache_that_records(dir: &Path, marker: &Path, exit: i32) -> PathBuf {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let path = dir.join("fake-kache");
+            std::fs::write(
+                &path,
+                format!(
+                    "#!/bin/sh\nprintf '%s\\n' \"$0\" \"$@\" > '{}'\nexit {exit}\n",
+                    marker.display()
+                ),
+            )
+            .unwrap();
+            std::fs::set_permissions(&path, PermissionsExt::from_mode(0o755)).unwrap();
+            path
+        }
+        #[cfg(windows)]
+        {
+            let path = dir.join("fake-kache.cmd");
+            std::fs::write(
+                &path,
+                format!(
+                    "@echo off\r\necho %* > \"{}\"\r\nexit /b {exit}\r\n",
+                    marker.display()
+                ),
+            )
+            .unwrap();
+            path
+        }
     }
 
     #[test]

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -52,8 +52,9 @@
 //!
 //! Each run prints a summary block and writes `tmp/bench/<scenario>/<scenario>.json`
 //! plus per-phase reports (`report-<phase>.*`), build logs
-//! (`build-<phase>.log`), wrapper logs (`wrapper-<phase>.log`), and OTLP
-//! gauges (`metrics.otlp.json`) for kartero to pull from CI.
+//! (`build-<phase>.log`), wrapper logs (`wrapper-<phase>.log`), OTLP
+//! gauges (`metrics.otlp.json`, `kache.bench.*`), and cache counters
+//! (`cache-otlp-<phase>/metrics.otlp.json`, `kache.cache.*`) for kartero.
 //! By default each scenario writes under its own `./tmp/bench/<scenario>` (so
 //! scenarios coexist); a `work_dir` lock prevents two runs from sharing one
 //! scratch dir. Concurrent runs on one host make the wall-clock numbers
@@ -381,6 +382,14 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         config.trace_keys,
         &sh,
     )?;
+    write_cache_otlp_or_warn(
+        &kache,
+        &cache_dir,
+        &kache_config,
+        &work_dir.join("cache-otlp-warm"),
+        &profile.name,
+        "warm",
+    );
     daemon::stop(&kache, &cache_dir);
     let (warm, warm_raw) =
         capture_report(&kache, &cache_dir, &work_dir, Phase::Warm.name(), &clone_b)?;
@@ -650,6 +659,42 @@ fn write_otlp_or_warn(work_dir: &Path, run: crate::bench_otlp::OtlpRun) {
         "[bench] otlp written to {}",
         work_dir.join(crate::bench_otlp::METRICS_FILE).display()
     );
+}
+
+/// Snapshot daemon/store counters into `cache-otlp-<phase>/` for Kartero.
+/// Separate from the bench gauges (`kache.bench.*`) so the two signals never
+/// share a metric name. Call while the phase's daemon is still up. Failures
+/// warn; a multi-hour bench must still upload reports.
+fn write_cache_otlp_or_warn(
+    kache: &Path,
+    cache_dir: &Path,
+    kache_config: &Path,
+    dest: &Path,
+    scenario: &str,
+    phase: &str,
+) {
+    let status = Command::new(kache)
+        .args(["telemetry", "write"])
+        .arg(dest)
+        .args(["--scenario", scenario, "--phase", phase])
+        .env("KACHE_CACHE_DIR", cache_dir)
+        .env("KACHE_CONFIG", kache_config)
+        .env("RUSTC_WRAPPER", "")
+        .status();
+    match status {
+        Ok(code) if code.success() => {
+            eprintln!(
+                "[bench] cache otlp written to {}",
+                dest.join("metrics.otlp.json").display()
+            );
+        }
+        Ok(code) => {
+            eprintln!("[bench] warning: kache telemetry write exited {code}");
+        }
+        Err(err) => {
+            eprintln!("[bench] warning: kache telemetry write failed: {err}");
+        }
+    }
 }
 
 /// Take an exclusive advisory lock on the work dir so two bench runs can't
@@ -1026,6 +1071,15 @@ fn run_cold_phase(
         trace_keys,
         sh,
     )?;
+    // Dump before stop: process-lifetime counters die with the daemon.
+    write_cache_otlp_or_warn(
+        kache,
+        cache_dir,
+        kache_config,
+        &work_dir.join("cache-otlp-cold"),
+        &profile.name,
+        "cold",
+    );
     daemon::stop(kache, cache_dir);
     let (cold, cold_raw) = capture_report(kache, cache_dir, work_dir, Phase::Cold.name(), clone_a)?;
     // Read the raw event log *before* the caller's reset — it carries the
@@ -1165,6 +1219,14 @@ fn run_pull_bench(
         trace_keys,
         sh,
     )?;
+    write_cache_otlp_or_warn(
+        kache,
+        cache_dir,
+        kache_config,
+        &work_dir.join("cache-otlp-pull"),
+        &profile.name,
+        "pull",
+    );
     daemon::stop(kache, cache_dir);
 
     let (pull, pull_raw) = capture_report(kache, cache_dir, work_dir, Phase::Pull.name(), clone_a)?;

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -21,6 +21,7 @@ Run `kache <command> --help` for the exact syntax in your installed version.
 | `daemon` | Inspect and manage the background daemon |
 | `monitor` | Open the live dashboard |
 | `stats` | Print a non-interactive summary |
+| `telemetry` | Write cache counters as OTLP JSON for Kartero |
 | `why-miss` | Explain a crate's recent key change |
 | `report` | Produce text, Markdown, JSON, or trace output |
 | `config` | Open the configuration editor |
@@ -184,6 +185,15 @@ kache stats --since 1h
 ```
 
 The default window is 24 hours.
+
+## `kache telemetry`
+
+```bash
+kache telemetry write ./cache-otlp
+kache telemetry write ./cache-otlp --scenario bench-firefox --phase warm
+```
+
+Writes `metrics.otlp.json` and `schema_version` for Kartero. Metric names are `kache.cache.*` / `kache.prefetch.*` (scope `kache.cache`), never `kache.bench.*`. `--scenario` must match `kache.bench.project`. `--phase` is `cold`, `warm`, or `pull` so dumps from the same scenario do not collide. The rustc wrapper does not write these files.
 
 ## `kache why-miss`
 

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -208,6 +208,21 @@ prefetch_enabled = false
 
 Exact remote lookup and background upload continue to work.
 
+## Telemetry
+
+Kache does not push metrics to a collector. It writes OTLP JSON files that Kartero imports from CI artifacts, the same way nightly benches already work.
+
+Two signals, never mixed:
+
+- `kache.bench.*` — one-shot bench gauges (duration, speedup, verdict) from `kache-scenario`
+- `kache.cache.*` — cache counters (uploads, prefetch, store size) from `kache telemetry write`
+
+```bash
+kache telemetry write ./cache-otlp --scenario bench-firefox --phase warm
+```
+
+That writes `metrics.otlp.json` and `schema_version` in the directory. `--scenario` must match `kache.bench.project`. `--phase` distinguishes cold from warm: the bench stops the daemon between phases, so counters are per daemon lifetime. The rustc wrapper does not write these files. The planner service still exposes Prometheus `/metrics` for cluster scrape.
+
 ## Daemon, events, and diagnostics
 
 | Environment | TOML key | Default | Purpose |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -361,6 +361,111 @@ pub(crate) fn snapshot_from_direct_reads(
     }
 }
 
+/// Write cache counters as OTLP JSON for Kartero (`metrics.otlp.json` +
+/// `schema_version`). Uses the running daemon when reachable; otherwise the
+/// local store. Does not auto-start a daemon, so a finished bench dumps what
+/// is already on disk instead of an empty new process.
+pub fn telemetry_write(
+    config: &Config,
+    dir: &std::path::Path,
+    scenario: Option<&str>,
+    phase: Option<&str>,
+) -> Result<()> {
+    let snap = match daemon::send_stats_request_options(config, false, false, None, Some(24)) {
+        Ok(resp) => StatsSnapshot {
+            total_size: resp.total_size,
+            max_size: resp.max_size,
+            entry_count: resp.entry_count,
+            entries: resp.entries.unwrap_or_default(),
+            event_stats: resp.events,
+            daemon_connected: true,
+            daemon_version: resp.version,
+            daemon_build_epoch: resp.build_epoch,
+            pending_uploads: resp.pending_uploads,
+            active_downloads: resp.active_downloads,
+            s3_concurrency_total: resp.s3_concurrency_total,
+            s3_concurrency_used: resp.s3_concurrency_used,
+            uploads_completed: resp.uploads_completed,
+            uploads_failed: resp.uploads_failed,
+            uploads_skipped: resp.uploads_skipped,
+            uploads_suppressed: resp.uploads_suppressed,
+            downloads_completed: resp.downloads_completed,
+            downloads_failed: resp.downloads_failed,
+            downloads_suppressed: resp.downloads_suppressed,
+            remote_check_roundtrips: resp.remote_check_roundtrips,
+            negative_hits: resp.negative_hits,
+            negative_entries: resp.negative_entries,
+            remote_degraded: resp.remote_degraded,
+            bytes_uploaded: resp.bytes_uploaded,
+            bytes_downloaded: resp.bytes_downloaded,
+            recent_transfers: resp.recent_transfers,
+            blob_stats: resp.blob_stats,
+            recent_summaries: resp.recent_summaries,
+            prefetch: resp.prefetch,
+            in_flight: resp.in_flight,
+            daemon_effective_config: resp.effective_config,
+        },
+        Err(_) => snapshot_from_direct_reads(config, false, "size", Some(24), false),
+    };
+    crate::otel::write_otlp(
+        dir,
+        &otel_snapshot_from_stats(config, &snap),
+        crate::VERSION,
+        scenario,
+        phase,
+    )?;
+    eprintln!(
+        "wrote {} and {}",
+        dir.join(crate::otel::METRICS_FILE).display(),
+        dir.join(crate::otel::SCHEMA_VERSION_FILE).display()
+    );
+    Ok(())
+}
+
+fn otel_snapshot_from_stats(config: &Config, snap: &StatsSnapshot) -> crate::otel::OtelSnapshot {
+    crate::otel::OtelSnapshot {
+        remote_kind: config
+            .remote
+            .as_ref()
+            .map(|remote| remote.backend_kind())
+            .unwrap_or("none"),
+        store_max: snap.max_size,
+        store_size: Some(snap.total_size),
+        store_entries: Some(snap.entry_count as u64),
+        pending_uploads: Some(snap.pending_uploads as u64),
+        active_downloads: Some(snap.active_downloads as u64),
+        s3_concurrency_total: snap.s3_concurrency_total as u64,
+        s3_concurrency_used: snap.s3_concurrency_used as u64,
+        uploads_completed: snap.uploads_completed,
+        uploads_failed: snap.uploads_failed,
+        uploads_skipped: snap.uploads_skipped,
+        uploads_suppressed: snap.uploads_suppressed,
+        downloads_completed: snap.downloads_completed,
+        downloads_failed: snap.downloads_failed,
+        downloads_suppressed: snap.downloads_suppressed,
+        bytes_uploaded: snap.bytes_uploaded,
+        bytes_downloaded: snap.bytes_downloaded,
+        remote_check_roundtrips: snap.remote_check_roundtrips,
+        negative_hits: snap.negative_hits,
+        negative_entries: snap.negative_entries,
+        remote_degraded: snap.remote_degraded,
+        prefetch_downloads: snap.prefetch.downloads_completed,
+        prefetch_bytes: snap.prefetch.bytes_downloaded,
+        prefetch_keys_used: snap.prefetch.keys_used,
+        prefetch_keys_cancelled: snap.prefetch.keys_cancelled,
+        prefetch_keys_over_budget: snap.prefetch.keys_over_budget,
+        prefetch_plans_advisory: snap.prefetch.plans_advisory,
+        prefetch_plans_fallback: snap.prefetch.plans_fallback,
+        prefetch_list_requests: snap.prefetch.list_requests_total,
+        prefetch_list_failures: snap.prefetch.list_failures_total,
+        prefetch_pack_requests: snap.prefetch.pack_requests_total,
+        prefetch_v3_requests: snap.prefetch.v3_requests_total,
+        prefetch_cancelled: snap.prefetch.cancelled,
+        prefetch_last_plan_candidates: snap.prefetch.last_plan_candidates,
+        prefetch_last_plan_wall_ms: snap.prefetch.last_plan_wall_ms,
+    }
+}
+
 // ── kache stats ────────────────────────────────────────────────────────────
 
 fn cloned_targets_line(disk: &crate::machine::DiskView) -> Option<String> {
@@ -8034,6 +8139,50 @@ mod tests {
                 .filter(|m| m.contains("likely source code"))
                 .count(),
             1
+        );
+    }
+
+    #[test]
+    fn telemetry_write_emits_cache_scope_not_bench() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = save_manifest_config(dir.path().join("cache"), None);
+        let out = dir.path().join("otlp");
+        telemetry_write(&config, &out, Some("bench-firefox"), Some("warm"))
+            .expect("telemetry write");
+        let body = std::fs::read_to_string(out.join("metrics.otlp.json")).unwrap();
+        assert!(
+            body.contains("\"kache.cache\""),
+            "cache OTLP must use the kache.cache scope"
+        );
+        assert!(
+            body.contains("\"kache.cache.scenario\""),
+            "bench dumps must name the scenario"
+        );
+        assert!(
+            body.contains("bench-firefox"),
+            "scenario value must match kache.bench.project"
+        );
+        assert!(
+            body.contains("\"kache.cache.phase\""),
+            "bench dumps must name the phase"
+        );
+        assert!(
+            body.contains("warm"),
+            "phase value must match the bench phase"
+        );
+        assert!(
+            !body.contains("kache.bench."),
+            "cache dump must not mix bench gauges"
+        );
+        assert!(
+            !body.contains("\"sum\""),
+            "Kartero drops non-gauge series; cache dump must be gauges"
+        );
+        assert_eq!(
+            std::fs::read_to_string(out.join("schema_version"))
+                .unwrap()
+                .trim(),
+            "1"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod machine;
 mod miss_chain;
 mod native_archive;
 mod opcounts;
+mod otel;
 mod path_normalizer;
 mod planner_client;
 mod platform;
@@ -270,6 +271,12 @@ enum Commands {
         since: String,
     },
 
+    /// Write cache counters as OTLP JSON for Kartero to import later
+    Telemetry {
+        #[command(subcommand)]
+        command: TelemetryCommands,
+    },
+
     /// Diagnose why a specific crate missed the cache
     WhyMiss {
         /// Crate name to investigate
@@ -339,6 +346,21 @@ enum DaemonCommands {
     Uninstall,
     /// Stream daemon logs
     Log,
+}
+
+#[derive(Subcommand)]
+enum TelemetryCommands {
+    /// Snapshot live cache counters into `metrics.otlp.json` + `schema_version`
+    Write {
+        /// Directory to write. Created if missing.
+        dir: PathBuf,
+        /// Bench scenario this dump belongs to (same string as `kache.bench.project`).
+        #[arg(long)]
+        scenario: Option<String>,
+        /// Bench phase this dump belongs to (`cold`, `warm`, `pull`).
+        #[arg(long)]
+        phase: Option<String>,
+    },
 }
 
 fn command_supports_json(command: &Option<Commands>) -> bool {
@@ -750,6 +772,14 @@ fn main() -> Result<()> {
             let hours = parse_duration_hours(&since);
             cli::stats(&config, &config_provenance, hours, json)
         }
+        Some(Commands::Telemetry {
+            command:
+                TelemetryCommands::Write {
+                    dir,
+                    scenario,
+                    phase,
+                },
+        }) => cli::telemetry_write(&config, &dir, scenario.as_deref(), phase.as_deref()),
         Some(Commands::WhyMiss { crate_name }) => cli::why_miss(&config, &crate_name, json),
         Some(Commands::Monitor { since }) => {
             if json {
@@ -1139,6 +1169,13 @@ mod tests {
         assert!(!command_supports_json(&Some(Commands::Config)));
         assert!(!command_supports_json(&Some(Commands::Monitor {
             since: None
+        })));
+        assert!(!command_supports_json(&Some(Commands::Telemetry {
+            command: TelemetryCommands::Write {
+                dir: PathBuf::from("/tmp"),
+                scenario: None,
+                phase: None,
+            },
         })));
         assert!(!command_supports_json(&None));
 

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -1,0 +1,538 @@
+//! OTLP JSON snapshot of live cache counters, for Kartero to pick up later.
+//!
+//! Same on-disk contract as the bench emitter (`metrics.otlp.json` +
+//! `schema_version`): the file is already an OTLP/HTTP
+//! `ExportMetricsServiceRequest` body. There is no collector POST from kache
+//! itself — CI uploads the files and Kartero imports them.
+//!
+//! Metric names live under `kache.cache.*` / `kache.prefetch.*` (scope
+//! `kache.cache`). Bench gauges stay in `kache.bench.*` and must not be mixed
+//! into this payload. Kartero drops non-gauge series, so this dump is a
+//! point-in-time gauge snapshot of daemon/store totals, not cumulative sums.
+
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Major schema version in the sidecar file and as a resource attribute.
+pub(crate) const SCHEMA_VERSION: u32 = 1;
+
+pub(crate) const METRICS_FILE: &str = "metrics.otlp.json";
+pub(crate) const SCHEMA_VERSION_FILE: &str = "schema_version";
+
+const SCOPE_NAME: &str = "kache.cache";
+const DEFAULT_SERVICE_NAME: &str = "kache";
+
+/// Cheap snapshot of process-lifetime daemon counters plus store gauges.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OtelSnapshot {
+    pub remote_kind: &'static str,
+    pub store_max: u64,
+    pub store_size: Option<u64>,
+    pub store_entries: Option<u64>,
+    pub pending_uploads: Option<u64>,
+    pub active_downloads: Option<u64>,
+    pub s3_concurrency_total: u64,
+    pub s3_concurrency_used: u64,
+    pub uploads_completed: u64,
+    pub uploads_failed: u64,
+    pub uploads_skipped: u64,
+    pub uploads_suppressed: u64,
+    pub downloads_completed: u64,
+    pub downloads_failed: u64,
+    pub downloads_suppressed: u64,
+    pub bytes_uploaded: u64,
+    pub bytes_downloaded: u64,
+    pub remote_check_roundtrips: u64,
+    pub negative_hits: u64,
+    pub negative_entries: u64,
+    pub remote_degraded: bool,
+    pub prefetch_downloads: u64,
+    pub prefetch_bytes: u64,
+    pub prefetch_keys_used: u64,
+    pub prefetch_keys_cancelled: u64,
+    pub prefetch_keys_over_budget: u64,
+    pub prefetch_plans_advisory: u64,
+    pub prefetch_plans_fallback: u64,
+    pub prefetch_list_requests: u64,
+    pub prefetch_list_failures: u64,
+    pub prefetch_pack_requests: u64,
+    pub prefetch_v3_requests: u64,
+    pub prefetch_cancelled: bool,
+    pub prefetch_last_plan_candidates: u64,
+    pub prefetch_last_plan_wall_ms: u64,
+}
+
+pub(crate) fn write_otlp(
+    dir: &Path,
+    snap: &OtelSnapshot,
+    service_version: &str,
+    scenario: Option<&str>,
+    phase: Option<&str>,
+) -> Result<()> {
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("creating telemetry dir {}", dir.display()))?;
+    let body = serialize_metrics(
+        snap,
+        DEFAULT_SERVICE_NAME,
+        service_version,
+        &unix_nano_now(),
+        scenario,
+        phase,
+    );
+    let metrics_path = dir.join(METRICS_FILE);
+    std::fs::write(
+        &metrics_path,
+        serde_json::to_string(&body).context("serializing OTLP metrics")? + "\n",
+    )
+    .with_context(|| format!("writing {}", metrics_path.display()))?;
+    std::fs::write(dir.join(SCHEMA_VERSION_FILE), format!("{SCHEMA_VERSION}\n"))
+        .with_context(|| format!("writing {}", dir.join(SCHEMA_VERSION_FILE).display()))?;
+    Ok(())
+}
+
+pub(crate) fn serialize_metrics(
+    snap: &OtelSnapshot,
+    service_name: &str,
+    service_version: &str,
+    time_unix_nano: &str,
+    scenario: Option<&str>,
+    phase: Option<&str>,
+) -> Value {
+    let mut resource = vec![
+        str_attr("service.name", service_name),
+        str_attr("service.version", service_version),
+        str_attr(
+            "kache.telemetry.schema_version",
+            &SCHEMA_VERSION.to_string(),
+        ),
+        str_attr("kache.cache.remote", snap.remote_kind),
+    ];
+    // Same string as `kache.bench.project` so a SigNoz query can join
+    // daemon counters to the bench that produced them.
+    if let Some(scenario) = scenario.filter(|s| !s.is_empty()) {
+        resource.push(str_attr("kache.cache.scenario", scenario));
+    }
+    // Benches stop the daemon between phases, so counters are per daemon
+    // lifetime. Tag the phase so cold and warm dumps do not collide.
+    if let Some(phase) = phase.filter(|s| !s.is_empty()) {
+        resource.push(str_attr("kache.cache.phase", phase));
+    }
+    json!({
+        "resourceMetrics": [{
+            "resource": {
+                "attributes": resource
+            },
+            "scopeMetrics": [{
+                "scope": {
+                    "name": SCOPE_NAME,
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+                "metrics": metrics_for(snap, time_unix_nano),
+            }]
+        }]
+    })
+}
+
+fn metrics_for(snap: &OtelSnapshot, now: &str) -> Vec<Value> {
+    let mut metrics = Vec::new();
+
+    if let Some(size) = snap.store_size {
+        metrics.push(gauge(
+            "kache.cache.store.size",
+            "By",
+            vec![as_int(size, now, &[])],
+        ));
+    }
+    if let Some(entries) = snap.store_entries {
+        metrics.push(gauge(
+            "kache.cache.store.entries",
+            "{entry}",
+            vec![as_int(entries, now, &[])],
+        ));
+    }
+    metrics.push(gauge(
+        "kache.cache.store.max",
+        "By",
+        vec![as_int(snap.store_max, now, &[])],
+    ));
+    if let Some(pending) = snap.pending_uploads {
+        metrics.push(gauge(
+            "kache.cache.uploads.pending",
+            "{upload}",
+            vec![as_int(pending, now, &[])],
+        ));
+    }
+    if let Some(active) = snap.active_downloads {
+        metrics.push(gauge(
+            "kache.cache.downloads.active",
+            "{download}",
+            vec![as_int(active, now, &[])],
+        ));
+    }
+    metrics.push(gauge(
+        "kache.cache.s3.concurrency",
+        "{permit}",
+        vec![
+            as_int(
+                snap.s3_concurrency_used,
+                now,
+                &[str_attr("kache.cache.limit", "used")],
+            ),
+            as_int(
+                snap.s3_concurrency_total,
+                now,
+                &[str_attr("kache.cache.limit", "total")],
+            ),
+        ],
+    ));
+    metrics.push(gauge(
+        "kache.cache.remote.degraded",
+        "1",
+        vec![as_int(u64::from(snap.remote_degraded), now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.cache.negative_entries",
+        "{entry}",
+        vec![as_int(snap.negative_entries, now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.cancelled",
+        "1",
+        vec![as_int(u64::from(snap.prefetch_cancelled), now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.last_plan.candidates",
+        "{candidate}",
+        vec![as_int(snap.prefetch_last_plan_candidates, now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.last_plan.wall",
+        "ms",
+        vec![as_int(snap.prefetch_last_plan_wall_ms, now, &[])],
+    ));
+
+    metrics.push(gauge(
+        "kache.cache.uploads",
+        "{upload}",
+        vec![
+            as_int(snap.uploads_completed, now, &result_attr("completed")),
+            as_int(snap.uploads_failed, now, &result_attr("failed")),
+            as_int(snap.uploads_skipped, now, &result_attr("skipped")),
+            as_int(snap.uploads_suppressed, now, &result_attr("suppressed")),
+        ],
+    ));
+    metrics.push(gauge(
+        "kache.cache.downloads",
+        "{download}",
+        vec![
+            as_int(snap.downloads_completed, now, &result_attr("completed")),
+            as_int(snap.downloads_failed, now, &result_attr("failed")),
+            as_int(snap.downloads_suppressed, now, &result_attr("suppressed")),
+        ],
+    ));
+    metrics.push(gauge(
+        "kache.cache.bytes",
+        "By",
+        vec![
+            as_int(
+                snap.bytes_uploaded,
+                now,
+                &[str_attr("kache.cache.direction", "upload")],
+            ),
+            as_int(
+                snap.bytes_downloaded,
+                now,
+                &[str_attr("kache.cache.direction", "download")],
+            ),
+        ],
+    ));
+    metrics.push(gauge(
+        "kache.cache.remote_checks",
+        "{check}",
+        vec![as_int(snap.remote_check_roundtrips, now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.cache.negative_hits",
+        "{hit}",
+        vec![as_int(snap.negative_hits, now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.downloads",
+        "{download}",
+        vec![as_int(snap.prefetch_downloads, now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.bytes",
+        "By",
+        vec![as_int(snap.prefetch_bytes, now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.keys_used",
+        "{key}",
+        vec![as_int(snap.prefetch_keys_used, now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.keys_cancelled",
+        "{key}",
+        vec![as_int(snap.prefetch_keys_cancelled, now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.keys_over_budget",
+        "{key}",
+        vec![as_int(snap.prefetch_keys_over_budget, now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.plans",
+        "{plan}",
+        vec![
+            as_int(
+                snap.prefetch_plans_advisory,
+                now,
+                &[str_attr("kache.prefetch.kind", "advisory")],
+            ),
+            as_int(
+                snap.prefetch_plans_fallback,
+                now,
+                &[str_attr("kache.prefetch.kind", "fallback")],
+            ),
+        ],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.list.requests",
+        "{request}",
+        vec![as_int(snap.prefetch_list_requests, now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.list.failures",
+        "{request}",
+        vec![as_int(snap.prefetch_list_failures, now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.pack.requests",
+        "{request}",
+        vec![as_int(snap.prefetch_pack_requests, now, &[])],
+    ));
+    metrics.push(gauge(
+        "kache.prefetch.v3.requests",
+        "{request}",
+        vec![as_int(snap.prefetch_v3_requests, now, &[])],
+    ));
+    metrics
+}
+
+fn result_attr(result: &str) -> Vec<Value> {
+    vec![str_attr("kache.cache.result", result)]
+}
+
+fn unix_nano_now() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        .to_string()
+}
+
+fn str_attr(key: &str, value: &str) -> Value {
+    json!({"key": key, "value": {"stringValue": value}})
+}
+
+fn as_int(value: u64, time_unix_nano: &str, attributes: &[Value]) -> Value {
+    json!({
+        "asInt": value.to_string(),
+        "timeUnixNano": time_unix_nano,
+        "attributes": attributes,
+    })
+}
+
+fn gauge(name: &str, unit: &str, data_points: Vec<Value>) -> Value {
+    json!({
+        "name": name,
+        "unit": unit,
+        "gauge": { "dataPoints": data_points }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    fn sample_snap() -> OtelSnapshot {
+        OtelSnapshot {
+            remote_kind: "s3",
+            store_max: 50 * 1024 * 1024 * 1024,
+            store_size: Some(1234),
+            store_entries: Some(9),
+            pending_uploads: Some(2),
+            active_downloads: Some(1),
+            s3_concurrency_total: 16,
+            s3_concurrency_used: 3,
+            uploads_completed: 10,
+            uploads_failed: 1,
+            uploads_skipped: 2,
+            uploads_suppressed: 0,
+            downloads_completed: 8,
+            downloads_failed: 0,
+            downloads_suppressed: 1,
+            bytes_uploaded: 100,
+            bytes_downloaded: 200,
+            remote_check_roundtrips: 5,
+            negative_hits: 4,
+            negative_entries: 3,
+            remote_degraded: false,
+            prefetch_downloads: 7,
+            prefetch_bytes: 70,
+            prefetch_keys_used: 6,
+            prefetch_keys_cancelled: 1,
+            prefetch_keys_over_budget: 0,
+            prefetch_plans_advisory: 2,
+            prefetch_plans_fallback: 1,
+            prefetch_list_requests: 3,
+            prefetch_list_failures: 0,
+            prefetch_pack_requests: 1,
+            prefetch_v3_requests: 4,
+            prefetch_cancelled: false,
+            prefetch_last_plan_candidates: 12,
+            prefetch_last_plan_wall_ms: 40,
+        }
+    }
+
+    fn metric<'a>(body: &'a Value, name: &str) -> &'a Value {
+        body["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["name"] == name)
+            .unwrap_or_else(|| panic!("missing metric {name}"))
+    }
+
+    fn all_attr_keys(body: &Value) -> BTreeSet<String> {
+        let mut keys = BTreeSet::new();
+        for attr in body["resourceMetrics"][0]["resource"]["attributes"]
+            .as_array()
+            .unwrap()
+        {
+            keys.insert(attr["key"].as_str().unwrap().to_string());
+        }
+        for m in body["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+            .as_array()
+            .unwrap()
+        {
+            let points = m["gauge"]["dataPoints"].as_array().unwrap();
+            for point in points {
+                for attr in point["attributes"].as_array().unwrap() {
+                    keys.insert(attr["key"].as_str().unwrap().to_string());
+                }
+            }
+        }
+        keys
+    }
+
+    #[test]
+    fn attribute_set_is_the_allowlist() {
+        let body = serialize_metrics(
+            &sample_snap(),
+            "kache",
+            "0.16.0",
+            "1700000000000000000",
+            None,
+            None,
+        );
+        let expected: BTreeSet<_> = [
+            "service.name",
+            "service.version",
+            "kache.telemetry.schema_version",
+            "kache.cache.remote",
+            "kache.cache.result",
+            "kache.cache.direction",
+            "kache.cache.limit",
+            "kache.prefetch.kind",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+        assert_eq!(all_attr_keys(&body), expected);
+        let dumped = body.to_string();
+        assert!(!dumped.contains("kache.bench."));
+        assert!(!dumped.contains("run_id"));
+        assert!(!dumped.contains("cicd."));
+        assert!(!dumped.contains("cache_key"));
+        assert!(!dumped.contains("\"sum\""));
+    }
+
+    #[test]
+    fn scope_is_cache_not_bench() {
+        let body = serialize_metrics(&sample_snap(), "kache", "0.16.0", "1", None, None);
+        assert_eq!(
+            body["resourceMetrics"][0]["scopeMetrics"][0]["scope"]["name"],
+            SCOPE_NAME
+        );
+    }
+
+    #[test]
+    fn counters_are_int_gauges() {
+        let body = serialize_metrics(
+            &sample_snap(),
+            "kache",
+            "0.16.0",
+            "1700000000000000000",
+            None,
+            None,
+        );
+        let uploads = metric(&body, "kache.cache.uploads");
+        assert!(uploads.get("sum").is_none());
+        assert_eq!(uploads["gauge"]["dataPoints"][0]["asInt"], "10");
+        assert_eq!(
+            uploads["gauge"]["dataPoints"][0]["attributes"][0]["value"]["stringValue"],
+            "completed"
+        );
+    }
+
+    #[test]
+    fn write_otlp_emits_kartero_sidecars() {
+        let dir = tempfile::tempdir().unwrap();
+        write_otlp(dir.path(), &sample_snap(), "0.16.0", None, None).unwrap();
+        let metrics = dir.path().join(METRICS_FILE);
+        let version = dir.path().join(SCHEMA_VERSION_FILE);
+        assert!(metrics.is_file());
+        assert_eq!(std::fs::read_to_string(version).unwrap().trim(), "1");
+        let body: Value = serde_json::from_str(&std::fs::read_to_string(metrics).unwrap()).unwrap();
+        assert_eq!(
+            body["resourceMetrics"][0]["scopeMetrics"][0]["scope"]["name"],
+            "kache.cache"
+        );
+    }
+
+    #[test]
+    fn scenario_is_the_join_key_to_the_bench() {
+        let body = serialize_metrics(
+            &sample_snap(),
+            "kache",
+            "0.16.0",
+            "1",
+            Some("bench-firefox"),
+            Some("warm"),
+        );
+        assert!(all_attr_keys(&body).contains("kache.cache.scenario"));
+        assert!(all_attr_keys(&body).contains("kache.cache.phase"));
+        let attrs = body["resourceMetrics"][0]["resource"]["attributes"]
+            .as_array()
+            .unwrap();
+        let scenario = attrs
+            .iter()
+            .find(|a| a["key"] == "kache.cache.scenario")
+            .unwrap();
+        assert_eq!(scenario["value"]["stringValue"], "bench-firefox");
+        let phase = attrs
+            .iter()
+            .find(|a| a["key"] == "kache.cache.phase")
+            .unwrap();
+        assert_eq!(phase["value"]["stringValue"], "warm");
+        assert!(
+            !body.to_string().contains("kache.bench."),
+            "join key must not pull bench metric names onto the cache dump"
+        );
+    }
+}

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -503,6 +503,14 @@ mod tests {
             body["resourceMetrics"][0]["scopeMetrics"][0]["scope"]["name"],
             "kache.cache"
         );
+        let ts = body["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0]["gauge"]["dataPoints"]
+            [0]["timeUnixNano"]
+            .as_str()
+            .expect("timeUnixNano is a string");
+        assert!(
+            ts.parse::<u128>().expect("unix nano") > 0,
+            "dump timestamp must be a positive integer, got {ts:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Nightly benches already publish `kache.bench.*` (duration, speedup, verdict). After a run we still cannot see how the daemon behaved: uploads, prefetch, store size. This PR writes those counters to the same Kartero transport — a UTF-8 `metrics.otlp.json` plus `schema_version` in a GitHub artifact.

## What lands

- `kache telemetry write <dir> [--scenario NAME] [--phase NAME]`
- Scope `kache.cache`, names `kache.cache.*` / `kache.prefetch.*`. No `kache.bench.*` in this payload.
- Gauges only. Kartero drops sums, and a bench dump is a point-in-time snapshot anyway.
- Join: `kache.cache.scenario` == `kache.bench.project`. Phase (`cold` / `warm` / `pull`) is a resource attribute because the bench stops the daemon between phases, so counters are per daemon lifetime.
- CI uploads `telemetry-otlp-v1-cache-<scenario>-<phase>`. `if-no-files-found: warn`. Not validated with `@kunobi/kartero@0.3.0` — that CLI's published allowlist does not include these names yet.
- rustc-wrapper is unchanged and does not talk to the network.

Companion: https://github.com/kunobi-ninja/kartero/pull/7. Without that Helm deploy, Kartero will drop every `kache.cache.*` series.

## How to read it

In SigNoz, group `kache.bench.*` by `kache.bench.project` and `kache.cache.*` by `kache.cache.scenario` (same string: `bench-firefox`, …). Split cache dumps by `kache.cache.phase`.

## Validation

- `bash scripts/check-docs.sh`
- `cargo test --bin kache -- otel:: telemetry_write_emits json_support_is_limited`
- `cargo clippy --bin kache -- -D warnings`
- `cargo test -p kache-e2e --lib write_otlp_or_warn_writes`