### PR TITLE
feat(remote): suppress writes from untrusted CI

### DIFF
--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -57,7 +57,7 @@ Use `type = "filesystem"` with `path = "/mnt/kache"` for a shared filesystem rem
 | none | `cache.event_log_keep_lines` | `1000` | Lines retained when the event log rotates |
 | `KACHE_DISABLED` | none | `false` | Pass all compiler work through when set to `1` or `true` |
 | `KACHE_LOCAL_ONLY` | `cache.local_only` | `false` | Ignore all remote and planner configuration while keeping local caching |
-| `KACHE_REMOTE_READONLY` | `cache.remote_readonly` | `false` | Allow remote reads but suppress remote writes |
+| `KACHE_REMOTE_READONLY` | `cache.remote_readonly` | `false` | Allow remote reads but suppress remote writes. Untrusted CI (pull requests, tags, unprotected branches) also forces this on; `=0` does not turn that off. |
 
 On macOS the default store is `~/Library/Caches/kache`; on Linux it is `$XDG_CACHE_HOME/kache` or `~/.cache/kache`; on Windows it is under `%LOCALAPPDATA%`.
 

--- a/docs/remote-cache/ci.mdx
+++ b/docs/remote-cache/ci.mdx
@@ -30,6 +30,26 @@ For S3-compatible storage:
 
 Add `s3-endpoint` for R2, Ceph, or MinIO. Prefer workload identity or IAM roles over long-lived access keys when the runner supports them.
 
+## Who may write
+
+A write credential for an S3 or filesystem remote can overwrite or delete objects.
+
+On GitHub Actions and GitLab CI, Kache suppresses remote writes unless the job is a **push to a protected branch**. Pull requests, merge requests, tags, unprotected branches, `workflow_dispatch`, and scheduled runs are read-only even if the job has a write credential. `KACHE_REMOTE_READONLY=0` does not turn that off.
+
+A laptop or other non-CI process is left as configured, so `kache sync --push` still works locally. Set `KACHE_REMOTE_READONLY=1` (or `cache.remote_readonly`) there when you want reads without writes.
+
+```yaml
+# Optional: make the read-only intent explicit in pull-request jobs.
+env:
+  KACHE_REMOTE_READONLY: "1"
+```
+
+GitHub withholds secrets and OIDC tokens from fork pull-request jobs, so those runs cannot publish unless you also pass a write credential another way. Same-repository pull requests do receive secrets; the CI policy above is what stops them writing.
+
+Pull-request jobs can still restore entries a trusted branch already published.
+
+C and C++ object entries are local-only. A remote pull does not warm them.
+
 ## Other CI systems
 
 Install Kache, then provide wrapper and remote configuration:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4252,6 +4252,19 @@ pub fn doctor(
             detail: remote.describe(),
             fix: None,
         });
+        let writes = if let Some(forced) = crate::policy::forced_remote_readonly() {
+            format!("read-only — {}", forced.reason)
+        } else if cfg.remote_readonly {
+            "read-only (KACHE_REMOTE_READONLY or cache.remote_readonly)".to_string()
+        } else {
+            "read-write".to_string()
+        };
+        checks.push(Check {
+            label: "Remote writes",
+            pass: true,
+            detail: writes,
+            fix: None,
+        });
     } else if let Some(ref cfg) = config
         && cfg.local_only
     {

--- a/src/config.rs
+++ b/src/config.rs
@@ -262,6 +262,10 @@ pub struct Config {
     /// This is useful for environments with GET-only credentials (e.g. fork/PR
     /// CI or shared read-only caches). Set via `KACHE_REMOTE_READONLY=1`/`=true`
     /// or `[cache] remote_readonly`; env wins over the file.
+    ///
+    /// Untrusted CI (pull requests, tags, unprotected branches) also forces
+    /// this on. `KACHE_REMOTE_READONLY=0` does not disable that. See
+    /// [`crate::policy`].
     pub remote_readonly: bool,
     /// Opt-in too-new-input guard (kunobi-ninja/kache#324): when on, an
     /// invocation whose keyed inputs were modified at/after the build started is
@@ -1421,7 +1425,14 @@ impl Config {
         // becomes a clean no-op — no S3 client, no uploads, no remote checks.
         // The planner is suppressed symmetrically in `load_planner_config`.
         let local_only = Self::local_only_enabled(&file_config);
-        let remote_readonly = Self::remote_readonly_enabled(&file_config);
+        let mut remote_readonly = Self::remote_readonly_enabled(&file_config);
+        if let Some(forced) = crate::policy::forced_remote_readonly() {
+            tracing::debug!(
+                reason = %forced.reason,
+                "remote writes suppressed by CI policy"
+            );
+            remote_readonly = true;
+        }
         let modified_input_guard = Self::modified_input_guard_enabled(&file_config);
         let local_hit_daemon = Self::local_hit_daemon_enabled(&file_config);
         let windows_hardlink = Self::windows_hardlink_enabled(&file_config);
@@ -4606,6 +4617,83 @@ exclude = ["src/generated/**", "vendor/problem/**"]
         assert!(
             Config::load_planner_config().is_none(),
             "planner must be suppressed under local-only"
+        );
+    }
+
+    #[test]
+    fn pull_request_ci_forces_remote_readonly() {
+        let _guard = config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("kache/config.toml");
+        let _cfg = set_kache_config_for_test(&config_path);
+        let _gha = NamedEnvGuard::set("GITHUB_ACTIONS", "true");
+        let _event = NamedEnvGuard::set("GITHUB_EVENT_NAME", "pull_request");
+        let _ref_type = NamedEnvGuard::set("GITHUB_REF_TYPE", "branch");
+        let _protected = NamedEnvGuard::set("GITHUB_REF_PROTECTED", "false");
+        let _gitlab = NamedEnvGuard::remove("GITLAB_CI");
+        let _explicit = NamedEnvGuard::remove("KACHE_REMOTE_READONLY");
+
+        let config = Config::load().unwrap();
+        assert!(
+            config.remote_readonly,
+            "untrusted GitHub Actions must suppress remote writes"
+        );
+    }
+
+    #[test]
+    fn remote_readonly_zero_does_not_disable_ci_policy() {
+        let _guard = config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("kache/config.toml");
+        let _cfg = set_kache_config_for_test(&config_path);
+        let _gha = NamedEnvGuard::set("GITHUB_ACTIONS", "true");
+        let _event = NamedEnvGuard::set("GITHUB_EVENT_NAME", "pull_request");
+        let _ref_type = NamedEnvGuard::set("GITHUB_REF_TYPE", "branch");
+        let _protected = NamedEnvGuard::set("GITHUB_REF_PROTECTED", "false");
+        let _gitlab = NamedEnvGuard::remove("GITLAB_CI");
+        let _explicit = NamedEnvGuard::set("KACHE_REMOTE_READONLY", "0");
+
+        let config = Config::load().unwrap();
+        assert!(
+            config.remote_readonly,
+            "KACHE_REMOTE_READONLY=0 must not re-enable writes on a pull request"
+        );
+    }
+
+    #[test]
+    fn protected_branch_push_keeps_configured_writable() {
+        let _guard = config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("kache/config.toml");
+        let _cfg = set_kache_config_for_test(&config_path);
+        let _gha = NamedEnvGuard::set("GITHUB_ACTIONS", "true");
+        let _event = NamedEnvGuard::set("GITHUB_EVENT_NAME", "push");
+        let _ref_type = NamedEnvGuard::set("GITHUB_REF_TYPE", "branch");
+        let _protected = NamedEnvGuard::set("GITHUB_REF_PROTECTED", "true");
+        let _gitlab = NamedEnvGuard::remove("GITLAB_CI");
+        let _explicit = NamedEnvGuard::remove("KACHE_REMOTE_READONLY");
+
+        let config = Config::load().unwrap();
+        assert!(
+            !config.remote_readonly,
+            "a protected-branch push must keep the configured write mode"
+        );
+    }
+
+    #[test]
+    fn local_shell_keeps_configured_writable() {
+        let _guard = config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("kache/config.toml");
+        let _cfg = set_kache_config_for_test(&config_path);
+        let _gha = NamedEnvGuard::remove("GITHUB_ACTIONS");
+        let _gitlab = NamedEnvGuard::remove("GITLAB_CI");
+        let _explicit = NamedEnvGuard::remove("KACHE_REMOTE_READONLY");
+
+        let config = Config::load().unwrap();
+        assert!(
+            !config.remote_readonly,
+            "a local shell must not be forced read-only"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod otel;
 mod path_normalizer;
 mod planner_client;
 mod platform;
+mod policy;
 mod probe;
 mod remote;
 mod remote_backend;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -218,4 +218,33 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn display_env_treats_empty_as_unknown() {
+        assert_eq!(display_env(None), "unknown");
+        assert_eq!(display_env(Some(String::new())), "unknown");
+        assert_eq!(display_env(Some("push".into())), "push");
+    }
+
+    #[test]
+    fn github_empty_event_name_reason_says_unknown() {
+        let vars = github(&[("GITHUB_EVENT_NAME", "")]);
+        let forced = forced_remote_readonly_with(lookup(&vars)).expect("empty event is untrusted");
+        assert!(
+            forced.reason.contains("Actions unknown"),
+            "empty GITHUB_EVENT_NAME must render as unknown, got {}",
+            forced.reason
+        );
+    }
+
+    #[test]
+    fn gitlab_empty_pipeline_source_reason_says_unknown() {
+        let vars = gitlab(&[("CI_PIPELINE_SOURCE", "")]);
+        let forced = forced_remote_readonly_with(lookup(&vars)).expect("empty source is untrusted");
+        assert!(
+            forced.reason.contains("CI unknown"),
+            "empty CI_PIPELINE_SOURCE must render as unknown, got {}",
+            forced.reason
+        );
+    }
 }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,0 +1,221 @@
+//! Effective remote-write permission from the process environment.
+//!
+//! Configured `remote_readonly` still wins when it is on. This module only
+//! *adds* read-only: untrusted CI must not publish, even if the job was given
+//! a write credential. Local shells and non-CI processes are left as
+//! configured so `kache sync --push` from a laptop still works.
+//!
+//! `KACHE_REMOTE_READONLY=0` does not turn this off. There is no override for
+//! untrusted CI; drop the write credential instead.
+
+/// Why remote writes were suppressed by CI context, if they were.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ForcedReadonly {
+    pub reason: String,
+}
+
+/// If this process is untrusted CI, remote writes must be suppressed.
+pub(crate) fn forced_remote_readonly() -> Option<ForcedReadonly> {
+    forced_remote_readonly_with(|name| std::env::var(name).ok())
+}
+
+pub(crate) fn forced_remote_readonly_with(
+    get_env: impl Fn(&str) -> Option<String>,
+) -> Option<ForcedReadonly> {
+    if env_truthy(get_env("GITHUB_ACTIONS")) {
+        return github_forced_readonly(&get_env);
+    }
+    if env_truthy(get_env("GITLAB_CI")) {
+        return gitlab_forced_readonly(&get_env);
+    }
+    None
+}
+
+fn github_forced_readonly(get_env: &impl Fn(&str) -> Option<String>) -> Option<ForcedReadonly> {
+    if is_trusted_github_writer(get_env) {
+        return None;
+    }
+    let event = display_env(get_env("GITHUB_EVENT_NAME"));
+    let ref_type = display_env(get_env("GITHUB_REF_TYPE"));
+    Some(ForcedReadonly {
+        reason: format!("GitHub Actions {event} ({ref_type}) is not a protected-branch push"),
+    })
+}
+
+fn gitlab_forced_readonly(get_env: &impl Fn(&str) -> Option<String>) -> Option<ForcedReadonly> {
+    if is_trusted_gitlab_writer(get_env) {
+        return None;
+    }
+    let source = display_env(get_env("CI_PIPELINE_SOURCE"));
+    Some(ForcedReadonly {
+        reason: format!("GitLab CI {source} is not a protected-branch push"),
+    })
+}
+
+fn is_trusted_github_writer(get_env: &impl Fn(&str) -> Option<String>) -> bool {
+    get_env("GITHUB_EVENT_NAME").as_deref() == Some("push")
+        && get_env("GITHUB_REF_TYPE").as_deref() == Some("branch")
+        && env_truthy(get_env("GITHUB_REF_PROTECTED"))
+}
+
+fn is_trusted_gitlab_writer(get_env: &impl Fn(&str) -> Option<String>) -> bool {
+    get_env("CI_PIPELINE_SOURCE").as_deref() == Some("push")
+        && get_env("CI_COMMIT_TAG").is_none_or(|value| value.is_empty())
+        && get_env("CI_MERGE_REQUEST_IID").is_none_or(|value| value.is_empty())
+        && env_truthy(get_env("CI_COMMIT_REF_PROTECTED"))
+}
+
+fn env_truthy(value: Option<String>) -> bool {
+    value.is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+}
+
+fn display_env(value: Option<String>) -> String {
+    match value {
+        Some(value) if !value.is_empty() => value,
+        _ => "unknown".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn lookup(vars: &HashMap<String, String>) -> impl Fn(&str) -> Option<String> + '_ {
+        |name| vars.get(name).cloned()
+    }
+
+    fn env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    fn github(extra: &[(&str, &str)]) -> HashMap<String, String> {
+        let mut vars = env(&[("GITHUB_ACTIONS", "true")]);
+        vars.extend(env(extra));
+        vars
+    }
+
+    fn gitlab(extra: &[(&str, &str)]) -> HashMap<String, String> {
+        let mut vars = env(&[("GITLAB_CI", "true")]);
+        vars.extend(env(extra));
+        vars
+    }
+
+    #[test]
+    fn local_shell_is_not_forced_readonly() {
+        let vars = HashMap::new();
+        assert_eq!(forced_remote_readonly_with(lookup(&vars)), None);
+    }
+
+    #[test]
+    fn github_protected_branch_push_may_write() {
+        let vars = github(&[
+            ("GITHUB_EVENT_NAME", "push"),
+            ("GITHUB_REF_TYPE", "branch"),
+            ("GITHUB_REF_PROTECTED", "true"),
+        ]);
+        assert_eq!(forced_remote_readonly_with(lookup(&vars)), None);
+    }
+
+    #[test]
+    fn github_pull_request_is_readonly() {
+        let vars = github(&[
+            ("GITHUB_EVENT_NAME", "pull_request"),
+            ("GITHUB_REF_TYPE", "branch"),
+            ("GITHUB_REF_PROTECTED", "false"),
+        ]);
+        let forced = forced_remote_readonly_with(lookup(&vars)).expect("PR is untrusted");
+        assert!(forced.reason.contains("pull_request"), "{}", forced.reason);
+    }
+
+    #[test]
+    fn github_unprotected_push_is_readonly() {
+        let vars = github(&[
+            ("GITHUB_EVENT_NAME", "push"),
+            ("GITHUB_REF_TYPE", "branch"),
+            ("GITHUB_REF_PROTECTED", "false"),
+        ]);
+        assert!(forced_remote_readonly_with(lookup(&vars)).is_some());
+    }
+
+    #[test]
+    fn github_tag_push_is_readonly() {
+        let vars = github(&[
+            ("GITHUB_EVENT_NAME", "push"),
+            ("GITHUB_REF_TYPE", "tag"),
+            ("GITHUB_REF_PROTECTED", "true"),
+        ]);
+        let forced = forced_remote_readonly_with(lookup(&vars)).expect("tags are untrusted");
+        assert!(forced.reason.contains("tag"), "{}", forced.reason);
+    }
+
+    #[test]
+    fn github_workflow_dispatch_is_readonly() {
+        let vars = github(&[
+            ("GITHUB_EVENT_NAME", "workflow_dispatch"),
+            ("GITHUB_REF_TYPE", "branch"),
+            ("GITHUB_REF_PROTECTED", "true"),
+        ]);
+        assert!(forced_remote_readonly_with(lookup(&vars)).is_some());
+    }
+
+    #[test]
+    fn gitlab_protected_push_may_write() {
+        let vars = gitlab(&[
+            ("CI_PIPELINE_SOURCE", "push"),
+            ("CI_COMMIT_REF_PROTECTED", "true"),
+        ]);
+        assert_eq!(forced_remote_readonly_with(lookup(&vars)), None);
+    }
+
+    #[test]
+    fn gitlab_merge_request_is_readonly() {
+        let vars = gitlab(&[
+            ("CI_PIPELINE_SOURCE", "merge_request_event"),
+            ("CI_MERGE_REQUEST_IID", "42"),
+            ("CI_COMMIT_REF_PROTECTED", "false"),
+        ]);
+        let forced = forced_remote_readonly_with(lookup(&vars)).expect("MR is untrusted");
+        assert!(
+            forced.reason.contains("merge_request_event"),
+            "{}",
+            forced.reason
+        );
+    }
+
+    #[test]
+    fn gitlab_tag_pipeline_is_readonly() {
+        let vars = gitlab(&[
+            ("CI_PIPELINE_SOURCE", "push"),
+            ("CI_COMMIT_TAG", "v1.0.0"),
+            ("CI_COMMIT_REF_PROTECTED", "true"),
+        ]);
+        assert!(forced_remote_readonly_with(lookup(&vars)).is_some());
+    }
+
+    #[test]
+    fn gitlab_unprotected_push_is_readonly() {
+        let vars = gitlab(&[
+            ("CI_PIPELINE_SOURCE", "push"),
+            ("CI_COMMIT_REF_PROTECTED", "false"),
+        ]);
+        assert!(forced_remote_readonly_with(lookup(&vars)).is_some());
+    }
+
+    #[test]
+    fn github_actions_truthy_spellings() {
+        for value in ["1", "TRUE", "Yes"] {
+            let vars = env(&[
+                ("GITHUB_ACTIONS", value),
+                ("GITHUB_EVENT_NAME", "pull_request"),
+            ]);
+            assert!(
+                forced_remote_readonly_with(lookup(&vars)).is_some(),
+                "GITHUB_ACTIONS={value} should be detected"
+            );
+        }
+    }
+}

--- a/tests/filesystem_remote_test.rs
+++ b/tests/filesystem_remote_test.rs
@@ -106,7 +106,13 @@ impl Client {
             .env_remove("KACHE_BASE_DIR")
             .env_remove("KACHE_SOCKET_PATH")
             .env_remove("RUSTC_WRAPPER")
-            .env_remove("CARGO_BUILD_RUSTC_WRAPPER");
+            .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+            // These tests publish to a hermetic filesystem remote. CI runners
+            // set GITHUB_ACTIONS/GITLAB_CI, which would force remote_readonly
+            // and skip the upload the suite is proving.
+            .env_remove("GITHUB_ACTIONS")
+            .env_remove("GITLAB_CI")
+            .env_remove("CI");
         cmd
     }
 

--- a/tests/s3_remote_test.rs
+++ b/tests/s3_remote_test.rs
@@ -276,7 +276,10 @@ impl Client {
             .env_remove("KACHE_S3_PROFILE")
             .env_remove("KACHE_SOCKET_PATH")
             .env_remove("RUSTC_WRAPPER")
-            .env_remove("CARGO_BUILD_RUSTC_WRAPPER");
+            .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
+            .env_remove("GITHUB_ACTIONS")
+            .env_remove("GITLAB_CI")
+            .env_remove("CI");
         command
     }
 


### PR DESCRIPTION
## Summary

Remote writes are now suppressed automatically on untrusted CI, even if the job has a write credential.

- **May write:** GitHub Actions or GitLab CI **push to a protected branch**.
- **Read-only:** pull requests, merge requests, tags, unprotected branches, `workflow_dispatch`, scheduled runs.
- **Unchanged:** a local shell keeps the configured mode, so `kache sync --push` from a laptop still works. `KACHE_REMOTE_READONLY=1` remains the local switch.
- `KACHE_REMOTE_READONLY=0` does **not** re-enable writes on untrusted CI.
- `kache doctor` shows a **Remote writes** line with the effective mode and, when CI policy applied, the reason.

Cargo commands are unchanged. This is `Config::load` plus existing `remote_readonly` gating on sync, save-manifest, and wrapper uploads.

## Test plan

- [x] `cargo test --bin kache -- policy:: pull_request_ci_forces_remote_readonly remote_readonly_zero_does_not_disable_ci_policy protected_branch_push_keeps_configured_writable local_shell_keeps_configured_writable`
- [x] `scripts/check-docs.sh`
- [ ] Confirm a GitHub Actions `pull_request` job with S3 write creds does not enqueue uploads
- [ ] Confirm a protected-branch `push` job still uploads
- [ ] `kache doctor` on a PR runner prints read-only with the event name