### PR TITLE
feat(init): set HOST_CC and HOST_CXX, not CC

### DIFF
--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -97,7 +97,7 @@ kache init --no-service
 kache init --yes
 ```
 
-`--check` reports proposed changes without writing. `--no-service` skips login-service installation.
+`--check` reports proposed changes without writing. `--no-service` skips login-service installation. Besides `rustc-wrapper`, init adds `HOST_CC` / `HOST_CXX` / `CC_KNOWN_WRAPPER_CUSTOM` under Cargo `[env]` when those keys are absent. It never sets `CC` or `CXX`.
 
 ## `kache doctor`
 

--- a/docs/getting-started/c-cpp.mdx
+++ b/docs/getting-started/c-cpp.mdx
@@ -7,6 +7,8 @@ Kache caches conservative, single-source C and C++ object compilations. If it ca
 
 ## Set up the wrapper
 
+For Cargo build scripts, `kache init` sets `HOST_CC` and `HOST_CXX` in Cargo's config (and `CC_KNOWN_WRAPPER_CUSTOM=kache`). It does not set `CC` or `CXX`, so `cargo build --target` keeps the cross compiler the `cc` crate would have found.
+
 For build systems that honor `CC` and `CXX`:
 
 ```bash

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -24,7 +24,7 @@ This trial does not edit Cargo configuration or install a service.
 kache init
 ```
 
-`init` configures Cargo, installs the daemon as a login service, and starts it. It is safe to run again when repairing a setup.
+`init` configures Cargo (`rustc-wrapper` and, when unset, `HOST_CC` / `HOST_CXX` for build-script C), installs the daemon as a login service, and starts it. It does not set `CC` or `CXX`. It is safe to run again when repairing a setup.
 
 Useful variants:
 

--- a/src/cargo_env.rs
+++ b/src/cargo_env.rs
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     fn apply_inserts_under_existing_env_table() {
-        let existing = "[env]\nRUST_BACKTRACE = \"1\"\n";
+        let existing = "# keep me first\n[env]\nRUST_BACKTRACE = \"1\"\n";
         let additions = [CargoEnvAssignment {
             name: "CC_KNOWN_WRAPPER_CUSTOM",
             value: "kache",
@@ -193,6 +193,39 @@ mod tests {
         assert!(out.contains("RUST_BACKTRACE = \"1\""));
         assert!(out.contains("CC_KNOWN_WRAPPER_CUSTOM = \"kache\""));
         assert_eq!(out.matches("[env]").count(), 1);
+        let preamble = out.split("[env]").next().expect("env table");
+        assert!(
+            preamble.contains("# keep me first"),
+            "comment before [env] must stay before it"
+        );
+        assert!(
+            !preamble.contains("CC_KNOWN_WRAPPER_CUSTOM"),
+            "keys must be inserted under [env], not after the first line: {out}"
+        );
+    }
+
+    #[test]
+    fn apply_puts_a_blank_line_before_a_new_env_table() {
+        let existing = "[build]\nrustc-wrapper = \"kache\"";
+        let additions = [CargoEnvAssignment {
+            name: "CC_KNOWN_WRAPPER_CUSTOM",
+            value: "kache",
+        }];
+        let out = apply_cargo_env_edit(existing, &additions);
+        assert!(
+            out.contains(
+                "[build]\nrustc-wrapper = \"kache\"\n\n[env]\nCC_KNOWN_WRAPPER_CUSTOM = \"kache\"\n"
+            ),
+            "expected a blank line between [build] and a newly created [env], got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn missing_assignments_from_absent_file_are_all_desired() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let missing = missing_assignments_from_path(&path).unwrap();
+        assert_eq!(missing, desired_assignments());
     }
 
     #[cfg(unix)]

--- a/src/cargo_env.rs
+++ b/src/cargo_env.rs
@@ -233,8 +233,7 @@ mod tests {
         }];
         let out = apply_cargo_env_edit("", &additions);
         assert_eq!(
-            out,
-            "[env]\nCC_KNOWN_WRAPPER_CUSTOM = \"kache\"\n",
+            out, "[env]\nCC_KNOWN_WRAPPER_CUSTOM = \"kache\"\n",
             "an empty config must not grow leading blank lines:\n{out}"
         );
     }

--- a/src/cargo_env.rs
+++ b/src/cargo_env.rs
@@ -1,0 +1,216 @@
+//! Cargo `[env]` keys `kache init` may add for host C/C++ wrapping.
+//!
+//! Cargo has no `CC_WRAPPER`. Setting `CC` / `CXX` makes `cargo build --target`
+//! use the host shim as the cross compiler. `HOST_CC` / `HOST_CXX` are what the
+//! `cc` crate consults for host compiles only.
+//!
+//! Existing `[env]` keys are never overwritten. Cargo itself also leaves a
+//! variable already present in the process environment alone unless `force` is
+//! set; we never set `force`.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+/// One `[env]` assignment `kache init` is willing to add.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CargoEnvAssignment {
+    pub name: &'static str,
+    pub value: &'static str,
+}
+
+/// Keys init may add. Unix gets host compiler wrappers; Windows only tells the
+/// `cc` crate that `kache` is a known wrapper, because choosing clang-cl vs
+/// MSVC is the user's call.
+pub(crate) fn desired_assignments() -> &'static [CargoEnvAssignment] {
+    #[cfg(unix)]
+    {
+        &[
+            CargoEnvAssignment {
+                name: "HOST_CC",
+                value: "kache cc",
+            },
+            CargoEnvAssignment {
+                name: "HOST_CXX",
+                value: "kache c++",
+            },
+            CargoEnvAssignment {
+                name: "CC_KNOWN_WRAPPER_CUSTOM",
+                value: "kache",
+            },
+        ]
+    }
+    #[cfg(windows)]
+    {
+        &[CargoEnvAssignment {
+            name: "CC_KNOWN_WRAPPER_CUSTOM",
+            value: "kache",
+        }]
+    }
+}
+
+/// Assignments not already present in `content`. A key with any value, including
+/// a different one, is left alone.
+pub(crate) fn missing_assignments(content: &str) -> Result<Vec<CargoEnvAssignment>> {
+    let parsed: toml::Value = if content.trim().is_empty() {
+        toml::Value::Table(toml::map::Map::new())
+    } else {
+        toml::from_str(content).context("parsing cargo config")?
+    };
+    let env_table = parsed.get("env");
+    Ok(desired_assignments()
+        .iter()
+        .copied()
+        .filter(|assignment| {
+            env_table
+                .and_then(|table| table.get(assignment.name))
+                .is_none()
+        })
+        .collect())
+}
+
+pub(crate) fn missing_assignments_from_path(path: &Path) -> Result<Vec<CargoEnvAssignment>> {
+    if !path.exists() {
+        return Ok(desired_assignments().to_vec());
+    }
+    let content =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    missing_assignments(&content)
+}
+
+/// Insert missing keys under `[env]`, creating the table if needed. Never
+/// writes `CC` or `CXX`.
+pub(crate) fn apply_cargo_env_edit(existing: &str, additions: &[CargoEnvAssignment]) -> String {
+    if additions.is_empty() {
+        return existing.to_string();
+    }
+
+    let mut block = String::new();
+    for assignment in additions {
+        block.push_str(&format!("{} = \"{}\"\n", assignment.name, assignment.value));
+    }
+
+    if cargo_config_has_env_table(existing) {
+        let mut out = String::with_capacity(existing.len() + block.len());
+        let mut inserted = false;
+        for line in existing.lines() {
+            out.push_str(line);
+            out.push('\n');
+            if !inserted && is_env_table_header(line) {
+                out.push_str(&block);
+                inserted = true;
+            }
+        }
+        if !inserted {
+            if !out.ends_with('\n') {
+                out.push('\n');
+            }
+            out.push_str("\n[env]\n");
+            out.push_str(&block);
+        }
+        return out;
+    }
+
+    let mut out = existing.to_string();
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    out.push_str("[env]\n");
+    out.push_str(&block);
+    out
+}
+
+fn cargo_config_has_env_table(content: &str) -> bool {
+    content.lines().any(is_env_table_header)
+}
+
+fn is_env_table_header(line: &str) -> bool {
+    matches!(line.trim(), "[env]" | "[env]\r")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_content_needs_every_desired_key() {
+        let missing = missing_assignments("").unwrap();
+        assert_eq!(missing, desired_assignments());
+    }
+
+    #[test]
+    fn existing_key_is_not_replaced() {
+        let content = "[env]\nHOST_CC = \"gcc\"\nCC_KNOWN_WRAPPER_CUSTOM = \"kache\"\n";
+        let missing = missing_assignments(content).unwrap();
+        assert!(
+            !missing.iter().any(|a| a.name == "HOST_CC"),
+            "user HOST_CC must win, got {missing:?}"
+        );
+        assert!(
+            !missing.iter().any(|a| a.name == "CC_KNOWN_WRAPPER_CUSTOM"),
+            "matching CC_KNOWN_WRAPPER_CUSTOM must not be re-added"
+        );
+    }
+
+    #[test]
+    fn apply_never_writes_cc_or_cxx() {
+        let out = apply_cargo_env_edit("", desired_assignments());
+        for line in out.lines() {
+            let trimmed = line.trim();
+            assert!(
+                !trimmed.starts_with("CC ") && !trimmed.starts_with("CC=") && trimmed != "CC",
+                "must not set CC: {trimmed}"
+            );
+            assert!(
+                !trimmed.starts_with("CXX ") && !trimmed.starts_with("CXX="),
+                "must not set CXX: {trimmed}"
+            );
+        }
+        assert!(out.contains("[env]"));
+        assert!(out.contains("CC_KNOWN_WRAPPER_CUSTOM = \"kache\""));
+    }
+
+    #[test]
+    fn apply_appends_env_table_after_build() {
+        let existing = "[build]\nrustc-wrapper = \"kache\"\n";
+        let out = apply_cargo_env_edit(existing, desired_assignments());
+        assert!(out.contains("[build]"));
+        assert!(out.contains("rustc-wrapper = \"kache\""));
+        assert!(out.contains("[env]"));
+        assert!(out.contains("CC_KNOWN_WRAPPER_CUSTOM = \"kache\""));
+    }
+
+    #[test]
+    fn apply_inserts_under_existing_env_table() {
+        let existing = "[env]\nRUST_BACKTRACE = \"1\"\n";
+        let additions = [CargoEnvAssignment {
+            name: "CC_KNOWN_WRAPPER_CUSTOM",
+            value: "kache",
+        }];
+        let out = apply_cargo_env_edit(existing, &additions);
+        assert!(out.contains("RUST_BACKTRACE = \"1\""));
+        assert!(out.contains("CC_KNOWN_WRAPPER_CUSTOM = \"kache\""));
+        assert_eq!(out.matches("[env]").count(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_assignments_include_host_compilers() {
+        let names: Vec<_> = desired_assignments().iter().map(|a| a.name).collect();
+        assert!(names.contains(&"HOST_CC"));
+        assert!(names.contains(&"HOST_CXX"));
+        let out = apply_cargo_env_edit("", desired_assignments());
+        assert!(out.contains("HOST_CC = \"kache cc\""));
+        assert!(out.contains("HOST_CXX = \"kache c++\""));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_assignments_do_not_pick_a_c_compiler() {
+        let names: Vec<_> = desired_assignments().iter().map(|a| a.name).collect();
+        assert!(!names.contains(&"HOST_CC"));
+        assert!(!names.contains(&"HOST_CXX"));
+    }
+}

--- a/src/cargo_env.rs
+++ b/src/cargo_env.rs
@@ -101,9 +101,6 @@ pub(crate) fn apply_cargo_env_edit(existing: &str, additions: &[CargoEnvAssignme
             }
         }
         if !inserted {
-            if !out.ends_with('\n') {
-                out.push('\n');
-            }
             out.push_str("\n[env]\n");
             out.push_str(&block);
         }
@@ -226,6 +223,20 @@ mod tests {
         let path = dir.path().join("config.toml");
         let missing = missing_assignments_from_path(&path).unwrap();
         assert_eq!(missing, desired_assignments());
+    }
+
+    #[test]
+    fn apply_to_empty_file_starts_at_env_table() {
+        let additions = [CargoEnvAssignment {
+            name: "CC_KNOWN_WRAPPER_CUSTOM",
+            value: "kache",
+        }];
+        let out = apply_cargo_env_edit("", &additions);
+        assert_eq!(
+            out,
+            "[env]\nCC_KNOWN_WRAPPER_CUSTOM = \"kache\"\n",
+            "an empty config must not grow leading blank lines:\n{out}"
+        );
     }
 
     #[cfg(unix)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7436,6 +7436,14 @@ mod tests {
     }
 
     #[test]
+    fn dry_run_never_writes_an_init_edit() {
+        assert!(should_write_init_step(false, true));
+        assert!(!should_write_init_step(true, true));
+        assert!(!should_write_init_step(false, false));
+        assert!(!should_write_init_step(true, false));
+    }
+
+    #[test]
     fn test_cargo_wrapper_edit_create() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
@@ -10801,6 +10809,12 @@ pub(crate) fn apply_cargo_wrapper_edit(existing: &str, plan: &CargoWrapperPlan) 
     }
 }
 
+/// Whether an init file-edit step should write. Dry-run (`check`) never
+/// writes, even if the operator would have accepted the prompt.
+fn should_write_init_step(check: bool, accepted: bool) -> bool {
+    !check && accepted
+}
+
 fn prompt_yes_no(question: &str, default_yes: bool, auto_yes: bool) -> Result<bool> {
     use std::io::{BufRead, Write};
 
@@ -10911,7 +10925,7 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
                 CargoWrapperPlan::AlreadySet => unreachable!(),
             };
             println!("  \x1b[33m→\x1b[0m {summary}");
-            if !check && prompt_yes_no(&question, true, yes)? {
+            if should_write_init_step(check, prompt_yes_no(&question, true, yes)?) {
                 if let Some(parent) = cargo_path.parent() {
                     std::fs::create_dir_all(parent)
                         .with_context(|| format!("creating {}", parent.display()))?;
@@ -10957,13 +10971,14 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
             "  \x1b[33m→\x1b[0m set {names} in {} (does not set CC or CXX)",
             crate::wrapper_config::display_path(&cargo_path)
         );
-        if !check
-            && prompt_yes_no(
+        if should_write_init_step(
+            check,
+            prompt_yes_no(
                 "Set host C compiler wrappers for Cargo build scripts?",
                 true,
                 yes,
-            )?
-        {
+            )?,
+        ) {
             if let Some(parent) = cargo_path.parent() {
                 std::fs::create_dir_all(parent)
                     .with_context(|| format!("creating {}", parent.display()))?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10709,6 +10709,8 @@ mod tests {
 // Interactive setup that resolves the common doctor issues:
 //   1. Writes `build.rustc-wrapper = "kache"` to $CARGO_HOME/config.toml
 //      (fallback to ~/.cargo/config.toml)
+//   1b. Adds HOST_CC / HOST_CXX / CC_KNOWN_WRAPPER_CUSTOM under `[env]`
+//       when those keys are absent. Never sets CC or CXX.
 //   2. Installs the daemon as a login service (launchd/systemd)
 //   3. Starts the daemon
 //
@@ -10933,6 +10935,54 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
                     .with_context(|| format!("writing {}", cargo_path.display()))?;
                 println!("    \x1b[32m✓\x1b[0m wrote {}", cargo_path.display());
             }
+        }
+    }
+
+    // ── Step 1b: cargo [env] host C wrappers ─────────────────────
+    // HOST_CC/HOST_CXX wrap host compiles from the `cc` crate without replacing
+    // `cargo build --target`'s cross compiler. CC/CXX are never set here.
+    let env_missing = crate::cargo_env::missing_assignments_from_path(&cargo_path)?;
+    if env_missing.is_empty() {
+        println!(
+            "  \x1b[32m✓\x1b[0m cargo [env] host C wrappers already set in {}",
+            crate::wrapper_config::display_path(&cargo_path)
+        );
+    } else {
+        let names = env_missing
+            .iter()
+            .map(|assignment| assignment.name)
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!(
+            "  \x1b[33m→\x1b[0m set {names} in {} (does not set CC or CXX)",
+            crate::wrapper_config::display_path(&cargo_path)
+        );
+        if !check
+            && prompt_yes_no(
+                "Set host C compiler wrappers for Cargo build scripts?",
+                true,
+                yes,
+            )?
+        {
+            if let Some(parent) = cargo_path.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("creating {}", parent.display()))?;
+            }
+            if cargo_path.exists()
+                && let Some(backup_path) = backup_path_for(&cargo_path)
+            {
+                std::fs::copy(&cargo_path, &backup_path)
+                    .with_context(|| format!("writing backup to {}", backup_path.display()))?;
+                println!(
+                    "    \x1b[32m✓\x1b[0m backup saved to {}",
+                    backup_path.display()
+                );
+            }
+            let existing = std::fs::read_to_string(&cargo_path).unwrap_or_default();
+            let new = crate::cargo_env::apply_cargo_env_edit(&existing, &env_missing);
+            std::fs::write(&cargo_path, new)
+                .with_context(|| format!("writing {}", cargo_path.display()))?;
+            println!("    \x1b[32m✓\x1b[0m wrote {}", cargo_path.display());
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod atomic;
 mod build_intent;
 mod cache_fs;
 mod cache_key;
+mod cargo_env;
 mod cargo_proxy;
 mod checked_regions;
 mod cli;


### PR DESCRIPTION
## Summary

`kache init` now configures host C wrapping for Cargo build scripts without changing `CC`/`CXX`.

- Unix: adds `HOST_CC = "kache cc"` and `HOST_CXX = "kache c++"` under Cargo `[env]` when those keys are missing.
- Every platform: adds `CC_KNOWN_WRAPPER_CUSTOM = "kache"` when missing.
- Existing `[env]` keys are never overwritten. Cargo also leaves a variable already in the process environment alone (we do not set `force`).
- `CC` and `CXX` are never written, so `cargo build --target` keeps the cross compiler the `cc` crate would have found.
- Windows does not pick clang-cl vs MSVC; it only sets `CC_KNOWN_WRAPPER_CUSTOM`.
- You still run `cargo build`. This is cargo config, not a kache-prefixed command.

## Test plan

- [x] `cargo test --bin kache -- cargo_env::`
- [x] `scripts/check-docs.sh`
- [ ] `kache init --check` on a machine with no `[env]` keys shows HOST_CC / HOST_CXX
- [ ] `kache init --yes --no-service` then `cargo build --target <triple>` still uses the target compiler for `cc` crate compiles