### PR TITLE
fix(store): read the executable bit from the compiler output, not the staged blob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,9 +652,9 @@ jobs:
   # unobservable in CI: the store's reflink ingest creates its staging temp with
   # `File::create` (umask mode, no +x), so a mode-losing ingest looks perfectly
   # healthy here and only breaks on btrfs / XFS-with-reflink / ZFS >= 2.2 /
-  # bcachefs / APFS. #648 fixed the restore half of that and #822 silently
-  # reverted it through the ingest half; both shipped green. This lane exists so
-  # a third round can't.
+  # bcachefs. macOS clonefile preserves mode, so APFS is not in that set.
+  # #648 fixed the restore half of that and #822 silently reverted it through
+  # the ingest half; both shipped green. This lane exists so a third round can't.
   cow-filesystem:
     name: CoW filesystem (btrfs)
     runs-on: ubuntu-latest
@@ -707,8 +707,8 @@ jobs:
           RUSTC_WRAPPER: ""
         run: |
           set -euo pipefail
-          cargo test --test custom_harness_test
-          cargo test --bins -- store:: link:: wrapper::tests::materialize_cached_artifact
+          cargo test -p kache --test custom_harness_test
+          cargo test -p kache --bins -- store:: link:: wrapper::tests::materialize_cached_artifact
       - name: Report mount usage
         if: always()
         run: df -h /mnt/cow || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,6 +646,73 @@ jobs:
       - name: Build flake checks
         run: nix flake check --keep-going --print-build-logs
 
+  # --- Copy-on-write filesystem coverage ---
+  # Every hosted runner is ext4, where `try_reflink` always fails and the
+  # `fs::copy` fallback preserves permissions. That makes an entire class of bug
+  # unobservable in CI: the store's reflink ingest creates its staging temp with
+  # `File::create` (umask mode, no +x), so a mode-losing ingest looks perfectly
+  # healthy here and only breaks on btrfs / XFS-with-reflink / ZFS >= 2.2 /
+  # bcachefs / APFS. #648 fixed the restore half of that and #822 silently
+  # reverted it through the ingest half; both shipped green. This lane exists so
+  # a third round can't.
+  cow-filesystem:
+    name: CoW filesystem (btrfs)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          # Pin mise CLI — see the `check` job's note (v2026.6.10 regression).
+          version: 2026.6.9
+          install_args: rust
+          cache: false
+      - name: Mount a loopback btrfs volume
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y btrfs-progs
+          # Sparse: the image only occupies what the tests actually write.
+          truncate -s 20G "$RUNNER_TEMP/cow.img"
+          mkfs.btrfs -q "$RUNNER_TEMP/cow.img"
+          sudo mkdir -p /mnt/cow
+          sudo mount -o loop "$RUNNER_TEMP/cow.img" /mnt/cow
+          sudo chown "$(id -u):$(id -g)" /mnt/cow
+          mkdir -p /mnt/cow/scratch /mnt/cow/tmp
+      # A mount that silently cannot clone makes this whole job a slower
+      # duplicate of the ext4 lanes — the exact blind spot it is here to close.
+      # `--reflink=always` fails rather than falling back to a copy, so this
+      # proves FICLONE works before any test relies on it.
+      - name: Prove reflink works on the mount
+        run: |
+          set -euo pipefail
+          head -c 1M /dev/urandom > /mnt/cow/probe-src
+          cp --reflink=always /mnt/cow/probe-src /mnt/cow/probe-dst
+          rm -f /mnt/cow/probe-src /mnt/cow/probe-dst
+      # `KACHE_TEST_SCRATCH_DIR` moves the integration fixtures' cache and target
+      # dirs onto btrfs; `TMPDIR` does the same for `tempfile::tempdir()`, which
+      # is where the store and link unit tests do their ingest. The build tree
+      # itself stays on the runner disk — it is the artifacts under test that
+      # need the CoW filesystem, not the compile.
+      #
+      # No kache-action here: this lane must exercise the wrapper built from
+      # this PR, not a released one, and dogfooding would put a second store in
+      # play.
+      - name: Run the filesystem-sensitive suites on btrfs
+        env:
+          KACHE_TEST_SCRATCH_DIR: /mnt/cow/scratch
+          TMPDIR: /mnt/cow/tmp
+          RUSTC_WRAPPER: ""
+        run: |
+          set -euo pipefail
+          cargo test --test custom_harness_test
+          cargo test --bins -- store:: link:: wrapper::tests::materialize_cached_artifact
+      - name: Report mount usage
+        if: always()
+        run: df -h /mnt/cow || true
+
   # --- E2E smoke test ---
   # Builds kache, configures as RUSTC_WRAPPER, cold-builds a fixture project,
   # cleans, warm-builds, and verifies cache hits work end-to-end.
@@ -1124,7 +1191,16 @@ jobs:
     # the full validation suite — `version-consistency` rejects a tag that
     # disagrees with the manifest BEFORE any binary builds; `e2e` includes the
     # (blocking) Windows arm, so a tag won't release unless Windows e2e is green.
-    needs: [check, nix-package, e2e, test-macos, test-windows, version-consistency]
+    needs:
+      [
+        check,
+        cow-filesystem,
+        nix-package,
+        e2e,
+        test-macos,
+        test-windows,
+        version-consistency,
+      ]
     # IN-ORG MIRROR of zondax/_workflows@7f61511 (v11) — a byte-identical import.
     # The macOS legs run on the self-hosted signing runners, whose runner group
     # restricts which workflows may use it. GitHub matches that allowlist against

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -82,7 +82,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           ./scripts/require-ci-green.sh "$(git rev-parse HEAD)" \
-            "Check (Linux)" "Nix package" \
+            "Check (Linux)" "Nix package" "CoW filesystem (btrfs)" \
             "E2E smoke (Linux)" "E2E smoke (macOS)" "E2E smoke (Windows)" \
             "Test (macOS)" "Test (Windows)"
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -47,6 +47,73 @@ fn set_blob_readonly_checked(blob: &Path) -> std::io::Result<()> {
     fs::set_permissions(blob, perms)
 }
 
+#[cfg(test)]
+thread_local! {
+    /// Test-only ingest override: reproduce, on any filesystem, what a Linux
+    /// CoW reflink does to a staged snapshot — independent bytes at the
+    /// *umask*, not at the source's mode.
+    ///
+    /// CI runs on ext4, where `try_reflink` always fails and the `fs::copy`
+    /// fallback carries the permission bits over. That is the blind spot #822
+    /// shipped through: a mode-losing ingest is simply unobservable there, so
+    /// the regression only ever appeared on a developer's btrfs/ZFS box.
+    /// Forcing the emulation makes the contract testable everywhere.
+    ///
+    /// Thread-local rather than a process-wide flag (`link.rs`'s
+    /// `WINDOWS_HARDLINK_RESTORE` is the latter, but it is a real feature
+    /// switch): `cargo test` runs store tests in parallel, and one test's
+    /// emulation must not leak into another's put.
+    static FORCE_MODE_DROPPING_INGEST: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+}
+
+/// Enable [`FORCE_MODE_DROPPING_INGEST`] for the duration of the guard.
+#[cfg(test)]
+struct ModeDroppingIngest;
+
+#[cfg(test)]
+impl ModeDroppingIngest {
+    fn enable() -> Self {
+        FORCE_MODE_DROPPING_INGEST.with(|forced| forced.set(true));
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for ModeDroppingIngest {
+    fn drop(&mut self) {
+        FORCE_MODE_DROPPING_INGEST.with(|forced| forced.set(false));
+    }
+}
+
+/// Stage `source` at `tmp` the way a Linux CoW reflink would, reporting whether
+/// the emulation was active at all. See [`FORCE_MODE_DROPPING_INGEST`].
+#[cfg(test)]
+fn emulate_cow_reflink_ingest(source: &Path, tmp: &Path) -> Result<bool> {
+    if !FORCE_MODE_DROPPING_INGEST.with(std::cell::Cell::get) {
+        return Ok(false);
+    }
+    fs::copy(source, tmp)
+        .with_context(|| format!("emulating a reflink ingest of {}", source.display()))?;
+    // `try_reflink` on Linux opens the destination with `File::create` before
+    // the FICLONE ioctl, so the snapshot lands at `0o666 & !umask` whatever the
+    // source was. The exact value varies with the umask; the only property that
+    // matters here is that it carries no `+x`.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(tmp, fs::Permissions::from_mode(0o644))
+            .with_context(|| format!("resetting the emulated staging mode on {}", tmp.display()))?;
+    }
+    Ok(true)
+}
+
+#[cfg(not(test))]
+#[inline(always)]
+fn emulate_cow_reflink_ingest(_source: &Path, _tmp: &Path) -> Result<bool> {
+    Ok(false)
+}
+
 /// Is `name` exactly a content-blob filename: 64 lowercase hex chars (a
 /// blake3 digest)? Used by the orphan sweep so it only ever unlinks files
 /// that look like a blob — never an in-progress temp (`.{hash}.{pid}.{n}.tmp`)
@@ -1852,13 +1919,29 @@ impl Store {
         let mut put_result = StorePutResult::default();
         let mut total_size = 0u64;
         for (source_path, store_name) in output_files {
-            // Eligibility decision only; the staged snapshot's own metadata
-            // is authoritative for what gets recorded below.
-            let source_executable = fs::metadata(source_path)
+            // The mode is read from the compiler's output, never from the
+            // staging snapshot taken below. That snapshot is authoritative for
+            // *bytes* — hashing it rather than the live output is the whole
+            // point of #822 — but it is not authoritative for permissions:
+            // `stage_blob_from_source` prefers `try_reflink`, whose Linux
+            // implementation creates the temp with `File::create` before the
+            // FICLONE ioctl, so a 0o755 binary reads back at the umask on every
+            // CoW filesystem (btrfs, XFS-with-reflink, ZFS >= 2.2, bcachefs).
+            // `fs::copy` and macOS `clonefile` happen to preserve it, which is
+            // why ext4 CI and macOS did not notice #822 undoing #648's restore
+            // fix: recorded `executable: false`, a `harness = false` test binary
+            // classifies as `Other("rustc:unknown")`, restores via `Hardlink`
+            // with no 0o755, and cargo fails the run with "Permission denied
+            // (os error 13)".
+            //
+            // A failed stat is an error rather than a silent `false`, because
+            // `false` is precisely the wrong value this guards against — and
+            // staging opens the same path one line below regardless.
+            let executable = fs::metadata(source_path)
                 .map(|meta| is_executable(&meta))
-                .unwrap_or(false);
+                .with_context(|| format!("stating compiler output for {store_name}"))?;
             let use_source_hardlink =
-                source_hardlink_allowed(allow_source_hardlinks, store_name, source_executable);
+                source_hardlink_allowed(allow_source_hardlinks, store_name, executable);
 
             let (staged, ingest) = self.stage_blob_from_source(source_path, use_source_hardlink)?;
             let staged_meta = match fs::metadata(&staged) {
@@ -1870,7 +1953,6 @@ impl Store {
                 }
             };
             let size = staged_meta.len();
-            let executable = is_executable(&staged_meta);
             if size == 0 && !zero_byte_is_valid_output(store_name, crate_types) {
                 Self::discard_staged_blob(&staged);
                 anyhow::bail!("refusing to cache zero-byte artifact: {}", store_name);
@@ -2909,6 +2991,15 @@ impl Store {
     /// reflink and hardlink ingests can only write to a destination that does
     /// not exist yet, so pre-creating it would cost a full byte copy per
     /// artifact on every filesystem.
+    ///
+    /// **The snapshot's bytes are faithful; its mode is not.** Only the hardlink
+    /// ingest shares the source's inode, and only `fs::copy` promises to carry
+    /// the permission bits over. [`crate::link::try_reflink`] on Linux creates
+    /// the destination with `File::create` before the FICLONE ioctl, so a
+    /// reflinked snapshot of a 0o755 binary lands at the umask instead — which
+    /// is how #822 silently reverted #648. Anything permission-shaped
+    /// (`CachedFile::executable`) must be read from the source, never from
+    /// here.
     fn stage_blob_from_source(
         &self,
         source: &Path,
@@ -2925,7 +3016,11 @@ impl Store {
             .with_context(|| format!("reserving a staging name in {}", dir.display()))?;
 
         let stage = |tmp: &Path, allow_hardlink: bool| -> Result<(StoreIngest, bool)> {
-            let ingest = if crate::link::try_reflink(source, tmp).is_ok() {
+            // Short-circuit: the real reflink is only attempted when no test
+            // emulation claimed the staging slot.
+            let ingest = if emulate_cow_reflink_ingest(source, tmp)?
+                || crate::link::try_reflink(source, tmp).is_ok()
+            {
                 StoreIngest::Reflink
             } else if allow_hardlink
                 && fs::symlink_metadata(source).is_ok_and(|m| m.file_type().is_file())
@@ -4898,6 +4993,107 @@ mod tests {
             "independent ingest must never share the compiler output inode"
         );
         assert!(blob_meta.permissions().readonly());
+    }
+
+    /// #648 made restore honour the mode bit recorded at insert time, because a
+    /// `[[test]] harness = false` target supplies its own `main` and is compiled
+    /// with neither `--test` nor `--crate-type` — nothing in the rustc argv says
+    /// "executable", so the recorded bit is the only signal. #822 then began
+    /// reading that bit off the *staging snapshot* rather than the compiler's
+    /// output, and a reflinked snapshot is created at the umask: on every CoW
+    /// filesystem the entry recorded `executable: false`, restore fell back to
+    /// `Hardlink`, and cargo failed the run with "Permission denied (os error
+    /// 13)".
+    ///
+    /// The emulation is what makes this reachable on ext4. Without it the copy
+    /// fallback preserves the mode, the assertion holds for free, and the test
+    /// would only fail on the filesystems CI never runs on.
+    #[cfg(unix)]
+    #[test]
+    fn put_records_the_executable_bit_from_the_compiler_output_not_the_staging_snapshot() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let output = dir.path().join("harness-a1b2c3d4e5f60718");
+        fs::write(&output, b"\x7fELF harness=false test binary").unwrap();
+        fs::set_permissions(&output, fs::Permissions::from_mode(0o755)).unwrap();
+
+        {
+            let _forced = ModeDroppingIngest::enable();
+            store
+                .put_with_compile_time_independent(
+                    "harness-entry",
+                    "harness",
+                    &[],
+                    &[],
+                    "x86_64-unknown-linux-gnu",
+                    "",
+                    &[(output.clone(), "harness-a1b2c3d4e5f60718".to_string())],
+                    "",
+                    "",
+                    1,
+                )
+                .unwrap();
+        }
+
+        let meta = store.get("harness-entry").unwrap().unwrap();
+        // Proves the emulation actually dropped the bit, so the assertion below
+        // cannot pass because the snapshot happened to keep it.
+        let blob_mode = fs::metadata(store.blob_path(&meta.files[0].hash))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            blob_mode & 0o111,
+            0,
+            "emulated reflink ingest should have staged without the bit, got {blob_mode:o}"
+        );
+        assert!(
+            meta.files[0].executable,
+            "the recorded mode must come from the compiler's 0o755 output, \
+             not from the staging snapshot"
+        );
+    }
+
+    /// The converse, under the same emulation: reading the mode from the source
+    /// must not degenerate into recording every artifact executable.
+    #[cfg(unix)]
+    #[test]
+    fn put_records_no_executable_bit_for_a_non_executable_output() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let store = Store::open(&config).unwrap();
+        let output = dir.path().join("libfoo.rlib");
+        fs::write(&output, b"rlib bytes").unwrap();
+        fs::set_permissions(&output, fs::Permissions::from_mode(0o644)).unwrap();
+
+        {
+            let _forced = ModeDroppingIngest::enable();
+            store
+                .put_with_compile_time_independent(
+                    "rlib-entry",
+                    "foo",
+                    &["lib".to_string()],
+                    &[],
+                    "x86_64-unknown-linux-gnu",
+                    "",
+                    &[(output.clone(), "libfoo.rlib".to_string())],
+                    "",
+                    "",
+                    1,
+                )
+                .unwrap();
+        }
+
+        let meta = store.get("rlib-entry").unwrap().unwrap();
+        assert!(
+            !meta.files[0].executable,
+            "a 0o644 compiler output must not be recorded executable"
+        );
     }
 
     /// A mutable-kind blob must never share an inode with the build's output:

--- a/src/store.rs
+++ b/src/store.rs
@@ -47,7 +47,7 @@ fn set_blob_readonly_checked(blob: &Path) -> std::io::Result<()> {
     fs::set_permissions(blob, perms)
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 thread_local! {
     /// Test-only ingest override: reproduce, on any filesystem, what a Linux
     /// CoW reflink does to a staged snapshot — independent bytes at the
@@ -63,15 +63,18 @@ thread_local! {
     /// `WINDOWS_HARDLINK_RESTORE` is the latter, but it is a real feature
     /// switch): `cargo test` runs store tests in parallel, and one test's
     /// emulation must not leak into another's put.
+    ///
+    /// Unix-only: the tests that construct [`ModeDroppingIngest`] are
+    /// `#[cfg(unix)]`, and Windows test builds fail `-D dead-code` otherwise.
     static FORCE_MODE_DROPPING_INGEST: std::cell::Cell<bool> =
         const { std::cell::Cell::new(false) };
 }
 
 /// Enable [`FORCE_MODE_DROPPING_INGEST`] for the duration of the guard.
-#[cfg(test)]
+#[cfg(all(test, unix))]
 struct ModeDroppingIngest;
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 impl ModeDroppingIngest {
     fn enable() -> Self {
         FORCE_MODE_DROPPING_INGEST.with(|forced| forced.set(true));
@@ -79,7 +82,7 @@ impl ModeDroppingIngest {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 impl Drop for ModeDroppingIngest {
     fn drop(&mut self) {
         FORCE_MODE_DROPPING_INGEST.with(|forced| forced.set(false));
@@ -88,7 +91,7 @@ impl Drop for ModeDroppingIngest {
 
 /// Stage `source` at `tmp` the way a Linux CoW reflink would, reporting whether
 /// the emulation was active at all. See [`FORCE_MODE_DROPPING_INGEST`].
-#[cfg(test)]
+#[cfg(all(test, unix))]
 fn emulate_cow_reflink_ingest(source: &Path, tmp: &Path) -> Result<bool> {
     if !FORCE_MODE_DROPPING_INGEST.with(std::cell::Cell::get) {
         return Ok(false);
@@ -99,16 +102,13 @@ fn emulate_cow_reflink_ingest(source: &Path, tmp: &Path) -> Result<bool> {
     // the FICLONE ioctl, so the snapshot lands at `0o666 & !umask` whatever the
     // source was. The exact value varies with the umask; the only property that
     // matters here is that it carries no `+x`.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(tmp, fs::Permissions::from_mode(0o644))
-            .with_context(|| format!("resetting the emulated staging mode on {}", tmp.display()))?;
-    }
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(tmp, fs::Permissions::from_mode(0o644))
+        .with_context(|| format!("resetting the emulated staging mode on {}", tmp.display()))?;
     Ok(true)
 }
 
-#[cfg(not(test))]
+#[cfg(not(all(test, unix)))]
 #[inline(always)]
 fn emulate_cow_reflink_ingest(_source: &Path, _tmp: &Path) -> Result<bool> {
     Ok(false)

--- a/src/store.rs
+++ b/src/store.rs
@@ -5096,6 +5096,29 @@ mod tests {
         );
     }
 
+    /// cargo-mutants replacing `Drop` with `()` left the thread-local on.
+    /// The put tests never insert again after the guard, so they could not
+    /// see the leak.
+    #[cfg(unix)]
+    #[test]
+    fn mode_dropping_ingest_guard_clears_on_drop() {
+        assert!(
+            !FORCE_MODE_DROPPING_INGEST.with(std::cell::Cell::get),
+            "ingest emulation must start off"
+        );
+        {
+            let _forced = ModeDroppingIngest::enable();
+            assert!(
+                FORCE_MODE_DROPPING_INGEST.with(std::cell::Cell::get),
+                "enable must turn ingest emulation on"
+            );
+        }
+        assert!(
+            !FORCE_MODE_DROPPING_INGEST.with(std::cell::Cell::get),
+            "Drop must turn ingest emulation off so a later put on this thread is not forced"
+        );
+    }
+
     /// A mutable-kind blob must never share an inode with the build's output:
     /// mutating the output post-put (codesigning, stripping) must not be able
     /// to reach the content-addressed blob. Deterministic on every

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -108,11 +108,21 @@ pub fn isolated_config_path(cache_dir: &Path) -> PathBuf {
 /// they leave behind. Anchoring here keeps such tests on whatever filesystem
 /// the developer or CI actually builds on, and `cargo clean` reclaims it.
 ///
+/// `KACHE_TEST_SCRATCH_DIR` overrides it. The developer's filesystem is
+/// whatever it is, but CI's is ext4 — where `try_reflink` always fails and the
+/// `fs::copy` fallback preserves permissions, hiding every mode-losing
+/// reflink path (that is how #822 reverted #648 unnoticed). The
+/// `cow-filesystem` job points this at a loopback btrfs mount so those paths
+/// actually run.
+///
 /// Only the tests that materialize artifacts need this, and each integration
 /// test binary compiles this module separately, so the rest see it as dead.
 #[allow(dead_code)]
 pub fn scratch_dir() -> PathBuf {
-    let dir = bootstrap_target_dir().with_file_name("kache-test-scratch");
+    let dir = match std::env::var_os("KACHE_TEST_SCRATCH_DIR") {
+        Some(dir) => PathBuf::from(dir),
+        None => bootstrap_target_dir().with_file_name("kache-test-scratch"),
+    };
     std::fs::create_dir_all(&dir).expect("creating scratch dir");
     dir
 }


### PR DESCRIPTION
## Summary

Maintainer-owned adoption of #871 from @glebpom, pinned at contributor head [`407deec99e6eb9cf417c4040b18f3b2c08e51f24`](https://github.com/nervix-io/kache/commit/407deec99e6eb9cf417c4040b18f3b2c08e51f24).

`#822` started recording `CachedFile.executable` from the staging snapshot. Linux `try_reflink` creates that snapshot with `File::create` before `FICLONE`, so a 0o755 binary is stored `executable: false` on btrfs / XFS-with-reflink / ZFS ≥ 2.2 / bcachefs. Restore then takes `Other("rustc:unknown")`'s `Hardlink` path and never applies 0o755 — the `#648` failure again. This reads the mode from the compiler output and adds a btrfs CI lane so the next regression cannot hide on ext4.

This replacement is maintainer-opened so we do not approve fork CI on a workflow change.

## Provenance and attribution

| Source commit | Imported commit | Original author | Disposition |
| --- | --- | --- | --- |
| `407deec99e6eb9cf417c4040b18f3b2c08e51f24` | `539916092c9065dce26102ef2e98677533bf33b9` | Gleb Pomykalov `<glebpom@gmail.com>` | Cherry-picked with `-x`; logical patch identical (matching patch-ids). Source OID and signature not retained because `main` is linear. |

Maintainer work is separate:

- `0584b5924aadeddfe07d57a8d6272c10c10376ed` pins the CoW job to `-p kache` and drops APFS from the affected-filesystem list (`clonefile` preserves mode).

## Review

- Safety: store and tests are ordinary Rust. The CoW job is GitHub-hosted `ubuntu-latest` with `sudo` only to mount a loopback btrfs volume; no secrets, no self-hosted runners, no trigger/permission/environment change. `publish-crates.yaml` only adds the job name to `require-ci-green` (release-only). CODEOWNERS still applies to `.github/workflows/`. Original fork CI was not approved.
- Purpose: **ACCOMPLISHES** — ingest records the source mode bit; restore already honours it.
- Tests: **COVERED** — two unit tests force a mode-dropping ingest so ext4 cannot hide the bug; `custom_harness_test` plus `KACHE_TEST_SCRATCH_DIR` is the real CoW path.
- Docs: **NOT REQUIRED** — no user-facing enumeration this change falsifies. Existing 0.16 CoW-store entries that already recorded `executable: false` stay wrong until rebuilt; call that out in the next release notes.

## Validation

- Static combined-diff and provenance review: clean.
- `git diff --check origin/main..HEAD`: clean.
- Both local commits carry valid maintainer signatures; imported author identity is preserved.
- Contributor code and tests were not executed on a maintainer machine.
- Fresh full hosted CI against current `main`: pending this replacement PR.

## Test plan

- [ ] Required Linux, macOS, Windows, Nix, E2E, and mutation checks pass on the exact replacement head.
- [ ] New `CoW filesystem (btrfs)` job is green (not a required check today; it does gate tag releases and crates publish).
- [x] Contributor and maintainer changes remain separate and attributable.
- [x] No public documentation claim becomes stale.
