### PR TITLE
feat(cc): default shim farm and Makefile/PKGBUILD docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,9 @@ assets = [
     ["target/release/kache", "usr/bin/kache", "755"],
     ["README.md", "usr/share/doc/kache/README", "644"],
 ]
+# postinst runs `kache install-shims --force /usr/lib/kache` so the farm
+# matches SHIM_NAMES in this binary. prerm removes those six links.
+maintainer-scripts = "packaging/debian/"
 
 [profile.release]
 lto = "fat"

--- a/README.md
+++ b/README.md
@@ -73,16 +73,16 @@ See the [CI guide](https://kunobi.ninja/docs/kache/remote-cache/ci) for GitHub A
 
 ## C and C++
 
-Create compiler-name shims, then put their directory first in `PATH`:
+On Unix, install compiler-name shims and put that directory first in `PATH`. Make, CMake, autotools, and Arch PKGBUILDs that call `gcc` by name then go through Kache. No `CC=` edit and no shell wrapper.
 
 ```bash
-kache install-shims ~/.local/lib/kache/shims
+kache install-shims
 export PATH="$HOME/.local/lib/kache/shims:$PATH"
-cmake -S . -B build
-cmake --build build
 ```
 
-Kache inspects the real compiler invocation. Unsupported or unsafe invocations pass through to the compiler instead of being cached.
+APT and AUR packages install `/usr/lib/kache`. Nix puts the same farm in `$out/lib/kache`. `kache init` can create the user farm; it does not change `PATH`. For `makepkg`, put the same assignment in `~/.makepkg.conf`. Wrap extra names already on `PATH` with `kache install-shims --from-path`.
+
+Kache inspects the real compiler invocation. Unsupported or unsafe invocations pass through. See [C and C++](https://kunobi.ninja/docs/kache/getting-started/c-cpp).
 
 ## Storage and remotes
 
@@ -109,6 +109,7 @@ Credentials come from the standard AWS environment variables or credential chain
 kache monitor                 # live build and cache activity
 kache stats                   # non-interactive summary
 kache doctor                  # setup and integrity checks
+kache install-shims           # Unix compiler-name PATH farm
 kache why-miss <crate>        # explain the latest miss
 kache list                    # inspect cached entries
 kache gc                      # enforce cache limits
@@ -122,6 +123,7 @@ Run `kache help <command>` for exact flags. The [command reference](https://kuno
 
 - [Install Kache](https://kunobi.ninja/docs/kache/getting-started/installation)
 - [Quick start](https://kunobi.ninja/docs/kache/getting-started/quick-start)
+- [C and C++](https://kunobi.ninja/docs/kache/getting-started/c-cpp)
 - [Configuration](https://kunobi.ninja/docs/kache/getting-started/configuration)
 - [How cache keys work](https://kunobi.ninja/docs/kache/how-it-works/cache-key)
 - [Daemon lifecycle](https://kunobi.ninja/docs/kache/daemon/lifecycle)

--- a/aur/kache-bin/PKGBUILD
+++ b/aur/kache-bin/PKGBUILD
@@ -31,4 +31,12 @@ package() {
   install -Dm0644 kache.zsh    "$pkgdir/usr/share/zsh/site-functions/_kache"
   install -Dm0644 kache.fish   "$pkgdir/usr/share/fish/vendor_completions.d/kache.fish"
   install -Dm0644 kache.elvish "$pkgdir/usr/share/elvish/lib/kache.elv"
+
+  # Compiler-name farm (ccache's /usr/lib/ccache). Keep in sync with
+  # compiler::shim::SHIM_NAMES. Symlink target is the installed path, not
+  # the extracted srcdir binary.
+  install -d "$pkgdir/usr/lib/kache"
+  for name in cc c++ gcc g++ clang clang++; do
+    ln -s /usr/bin/kache "$pkgdir/usr/lib/kache/$name"
+  done
 }

--- a/aur/kache-git/PKGBUILD
+++ b/aur/kache-git/PKGBUILD
@@ -47,5 +47,12 @@ package() {
   install -Dm0644 kache.fish   "$pkgdir/usr/share/fish/vendor_completions.d/kache.fish"
   install -Dm0644 kache.elvish "$pkgdir/usr/share/elvish/lib/kache.elv"
 
+  # Compiler-name farm (ccache's /usr/lib/ccache). Keep in sync with
+  # compiler::shim::SHIM_NAMES.
+  install -d "$pkgdir/usr/lib/kache"
+  for name in cc c++ gcc g++ clang clang++; do
+    ln -s /usr/bin/kache "$pkgdir/usr/lib/kache/$name"
+  done
+
   install -Dm0644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }

--- a/crates/kache-e2e/src/fixture.rs
+++ b/crates/kache-e2e/src/fixture.rs
@@ -116,6 +116,12 @@ pub struct Fixture {
     #[serde(default)]
     pub requires: Vec<String>,
 
+    /// When true, the harness runs `kache install-shims` into the fixture
+    /// cache dir, prepends that directory to `PATH`, and drops `CC`/`CXX`.
+    /// Make then finds `cc` as kache (ccache's masquerade method). Unix only.
+    #[serde(default)]
+    pub compiler_shims: bool,
+
     /// Operating systems this fixture supports, by `std::env::consts::OS`
     /// value (`"linux"`, `"macos"`, `"windows"`). Empty (default) = all.
     /// When non-empty and the current OS isn't listed, the harness SKIPS the

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -32,9 +32,8 @@ use crate::scenario::MeasureSpec;
 use crate::source;
 
 /// Install PATH compiler-name shims for a masquerade fixture, or refuse on
-/// Windows (no symlink farm). Split by cfg so Windows does not see a `mut`
-/// that is never assigned (`unused_mut` under `-D warnings`).
-#[cfg(unix)]
+/// Windows (no symlink farm). One function on every OS so Linux mutation
+/// testing does not "miss" a `cfg(not(unix))` helper it never compiles.
 fn maybe_apply_compiler_shims(
     fixture: &Fixture,
     kache_path: &Path,
@@ -43,53 +42,49 @@ fn maybe_apply_compiler_shims(
     if !fixture.compiler_shims {
         return Ok(None);
     }
-    let shim_dir = cache_dir.join("compiler-shims");
-    let output = Command::new(kache_path)
-        .arg("install-shims")
-        .arg("--force")
-        .arg(&shim_dir)
-        .output()
-        .with_context(|| {
-            format!(
-                "running `{} install-shims --force {}`",
-                kache_path.display(),
-                shim_dir.display()
-            )
-        })?;
-    if !output.status.success() {
-        anyhow::bail!(
-            "kache install-shims failed with {}: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-    let mut path = shim_dir.into_os_string();
-    path.push(":");
-    if let Some(orig) = std::env::var_os("PATH") {
-        path.push(orig);
-    }
-    let mut owned = fixture.clone();
-    owned
-        .env
-        .insert("PATH".into(), path.to_string_lossy().into_owned());
-    owned.env.remove("CC");
-    owned.env.remove("CXX");
-    Ok(Some(owned))
-}
-
-#[cfg(not(unix))]
-fn maybe_apply_compiler_shims(
-    fixture: &Fixture,
-    _kache_path: &Path,
-    _cache_dir: &Path,
-) -> Result<Option<Fixture>> {
-    if fixture.compiler_shims {
+    #[cfg(not(unix))]
+    {
+        let _ = (kache_path, cache_dir);
         anyhow::bail!(
             "fixture `{}` sets compiler_shims, which is Unix-only",
             fixture.name
         );
     }
-    Ok(None)
+    #[cfg(unix)]
+    {
+        let shim_dir = cache_dir.join("compiler-shims");
+        let output = Command::new(kache_path)
+            .arg("install-shims")
+            .arg("--force")
+            .arg(&shim_dir)
+            .output()
+            .with_context(|| {
+                format!(
+                    "running `{} install-shims --force {}`",
+                    kache_path.display(),
+                    shim_dir.display()
+                )
+            })?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "kache install-shims failed with {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        let mut path = shim_dir.into_os_string();
+        path.push(":");
+        if let Some(orig) = std::env::var_os("PATH") {
+            path.push(orig);
+        }
+        let mut owned = fixture.clone();
+        owned
+            .env
+            .insert("PATH".into(), path.to_string_lossy().into_owned());
+        owned.env.remove("CC");
+        owned.env.remove("CXX");
+        Ok(Some(owned))
+    }
 }
 
 /// Run every phase against `fixture` and return the aggregated result.
@@ -1562,5 +1557,93 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("main.c"), "int main(){}").unwrap();
         assert!(inspect_restored_depinfo(dir.path()).is_none());
+    }
+
+    fn dummy_shim_fixture(compiler_shims: bool) -> crate::fixture::Fixture {
+        crate::fixture::Fixture {
+            name: "shim-test".into(),
+            source: None,
+            env: std::collections::HashMap::from([("CC".into(), "cc".into())]),
+            commands: crate::fixture::Commands {
+                build: "true".into(),
+                clean: "true".into(),
+            },
+            verify: None,
+            assertions: Default::default(),
+            tags: Vec::new(),
+            checks: Default::default(),
+            diff: None,
+            modify: None,
+            negative_control_exempt: false,
+            check_depinfo: false,
+            requires: Vec::new(),
+            compiler_shims,
+            os: Vec::new(),
+            windows: None,
+            dir: PathBuf::new(),
+        }
+    }
+
+    #[test]
+    fn compiler_shims_off_does_not_rewrite_the_fixture() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fixture = dummy_shim_fixture(false);
+        let out = super::maybe_apply_compiler_shims(&fixture, Path::new("/no-kache"), tmp.path())
+            .expect("off must succeed without running kache");
+        assert!(out.is_none(), "must not rewrite a non-shim fixture");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compiler_shims_on_fails_when_kache_cannot_run() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fixture = dummy_shim_fixture(true);
+        let err = super::maybe_apply_compiler_shims(
+            &fixture,
+            Path::new("/no-such-kache-binary"),
+            tmp.path(),
+        )
+        .expect_err("a missing kache must not look like a successful shim install");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("install-shims") || msg.contains("No such") || msg.contains("not found"),
+            "{msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compiler_shims_on_prepends_path_and_drops_cc() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let kache = tmp.path().join("kache");
+        std::fs::write(&kache, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&kache, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let fixture = dummy_shim_fixture(true);
+        let out = super::maybe_apply_compiler_shims(&fixture, &kache, tmp.path())
+            .expect("a succeeding kache must yield a rewritten fixture")
+            .expect("compiler_shims must produce a fixture, not None");
+        let path = out.env.get("PATH").expect("PATH must be set");
+        assert!(
+            path.contains("compiler-shims"),
+            "shim dir must be on PATH: {path}"
+        );
+        assert!(
+            !out.env.contains_key("CC"),
+            "CC must be dropped so Make uses PATH"
+        );
+        assert!(!out.env.contains_key("CXX"));
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn compiler_shims_on_windows_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fixture = dummy_shim_fixture(true);
+        let err = super::maybe_apply_compiler_shims(&fixture, Path::new("kache"), tmp.path())
+            .expect_err("Windows has no symlink farm");
+        assert!(format!("{err:#}").contains("Unix-only"));
     }
 }

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -31,6 +31,67 @@ use crate::result::{FixtureResult, Measurement, PhaseResult, VerifyResult, fixtu
 use crate::scenario::MeasureSpec;
 use crate::source;
 
+/// Install PATH compiler-name shims for a masquerade fixture, or refuse on
+/// Windows (no symlink farm). Split by cfg so Windows does not see a `mut`
+/// that is never assigned (`unused_mut` under `-D warnings`).
+#[cfg(unix)]
+fn maybe_apply_compiler_shims(
+    fixture: &Fixture,
+    kache_path: &Path,
+    cache_dir: &Path,
+) -> Result<Option<Fixture>> {
+    if !fixture.compiler_shims {
+        return Ok(None);
+    }
+    let shim_dir = cache_dir.join("compiler-shims");
+    let output = Command::new(kache_path)
+        .arg("install-shims")
+        .arg("--force")
+        .arg(&shim_dir)
+        .output()
+        .with_context(|| {
+            format!(
+                "running `{} install-shims --force {}`",
+                kache_path.display(),
+                shim_dir.display()
+            )
+        })?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "kache install-shims failed with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let mut path = shim_dir.into_os_string();
+    path.push(":");
+    if let Some(orig) = std::env::var_os("PATH") {
+        path.push(orig);
+    }
+    let mut owned = fixture.clone();
+    owned
+        .env
+        .insert("PATH".into(), path.to_string_lossy().into_owned());
+    owned.env.remove("CC");
+    owned.env.remove("CXX");
+    Ok(Some(owned))
+}
+
+#[cfg(not(unix))]
+fn maybe_apply_compiler_shims(
+    fixture: &Fixture,
+    _kache_path: &Path,
+    _cache_dir: &Path,
+) -> Result<Option<Fixture>> {
+    if fixture.compiler_shims {
+        anyhow::bail!(
+            "fixture `{}` sets compiler_shims, which is Unix-only",
+            fixture.name
+        );
+    }
+    Ok(None)
+}
+
 /// Run every phase against `fixture` and return the aggregated result.
 ///
 /// The runner owns the cache dir lifecycle: a fresh `TempDir` is created
@@ -40,49 +101,7 @@ use crate::source;
 /// before `TempDir` removes the files underneath it.
 pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult> {
     let cache_dir = TempDir::new().context("creating per-fixture cache dir")?;
-    let mut fixture_owned: Option<Fixture> = None;
-    if fixture.compiler_shims {
-        #[cfg(not(unix))]
-        anyhow::bail!(
-            "fixture `{}` sets compiler_shims, which is Unix-only",
-            fixture.name
-        );
-        #[cfg(unix)]
-        {
-            let shim_dir = cache_dir.path().join("compiler-shims");
-            let output = Command::new(kache_path)
-                .arg("install-shims")
-                .arg("--force")
-                .arg(&shim_dir)
-                .output()
-                .with_context(|| {
-                    format!(
-                        "running `{} install-shims --force {}`",
-                        kache_path.display(),
-                        shim_dir.display()
-                    )
-                })?;
-            if !output.status.success() {
-                anyhow::bail!(
-                    "kache install-shims failed with {}: {}",
-                    output.status,
-                    String::from_utf8_lossy(&output.stderr)
-                );
-            }
-            let mut path = shim_dir.into_os_string();
-            path.push(":");
-            if let Some(orig) = std::env::var_os("PATH") {
-                path.push(orig);
-            }
-            let mut owned = fixture.clone();
-            owned
-                .env
-                .insert("PATH".into(), path.to_string_lossy().into_owned());
-            owned.env.remove("CC");
-            owned.env.remove("CXX");
-            fixture_owned = Some(owned);
-        }
-    }
+    let fixture_owned = maybe_apply_compiler_shims(fixture, kache_path, cache_dir.path())?;
     let fixture = fixture_owned.as_ref().unwrap_or(fixture);
     eprintln!(
         "--- {} (cache: {})",

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -40,6 +40,50 @@ use crate::source;
 /// before `TempDir` removes the files underneath it.
 pub fn run_fixture(fixture: &Fixture, kache_path: &Path) -> Result<FixtureResult> {
     let cache_dir = TempDir::new().context("creating per-fixture cache dir")?;
+    let mut fixture_owned: Option<Fixture> = None;
+    if fixture.compiler_shims {
+        #[cfg(not(unix))]
+        anyhow::bail!(
+            "fixture `{}` sets compiler_shims, which is Unix-only",
+            fixture.name
+        );
+        #[cfg(unix)]
+        {
+            let shim_dir = cache_dir.path().join("compiler-shims");
+            let output = Command::new(kache_path)
+                .arg("install-shims")
+                .arg("--force")
+                .arg(&shim_dir)
+                .output()
+                .with_context(|| {
+                    format!(
+                        "running `{} install-shims --force {}`",
+                        kache_path.display(),
+                        shim_dir.display()
+                    )
+                })?;
+            if !output.status.success() {
+                anyhow::bail!(
+                    "kache install-shims failed with {}: {}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            let mut path = shim_dir.into_os_string();
+            path.push(":");
+            if let Some(orig) = std::env::var_os("PATH") {
+                path.push(orig);
+            }
+            let mut owned = fixture.clone();
+            owned
+                .env
+                .insert("PATH".into(), path.to_string_lossy().into_owned());
+            owned.env.remove("CC");
+            owned.env.remove("CXX");
+            fixture_owned = Some(owned);
+        }
+    }
+    let fixture = fixture_owned.as_ref().unwrap_or(fixture);
     eprintln!(
         "--- {} (cache: {})",
         fixture.name,

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -14,7 +14,7 @@ Run `kache <command> --help` for the exact syntax in your installed version.
 | `gc` | Evict local entries |
 | `purge` | Remove local cache entries |
 | `clean` | Remove Cargo target directories below cwd or from the local tracked-root registry |
-| `init` | Configure Cargo and optionally install the daemon service |
+| `init` | Configure Cargo, optional C/C++ shims, and the daemon service |
 | `doctor` | Diagnose setup and store integrity |
 | `sync` | Pull from and push to a remote |
 | `save-manifest` | Publish build metadata for later prefetch |
@@ -233,11 +233,12 @@ This command can open even when the current config file is invalid. See [Configu
 ## `kache install-shims`
 
 ```bash
-kache install-shims ~/.local/lib/kache/shims
+kache install-shims
+kache install-shims --from-path
 kache install-shims --force ~/.local/lib/kache/shims
 ```
 
-This Unix command creates `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++` symlinks to Kache. Put the directory before the real compilers in `PATH`.
+Unix only. Creates `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++` symlinks to Kache. With no directory argument the farm is `~/.local/lib/kache/shims`. `--from-path` also wraps compiler names already on `PATH` (`gcc-13`, target-prefixed drivers). Put the directory before the real compilers in `PATH`. See [C and C++](/docs/getting-started/c-cpp).
 
 ## `kache completions`
 

--- a/docs/getting-started/c-cpp.mdx
+++ b/docs/getting-started/c-cpp.mdx
@@ -5,37 +5,70 @@ description: Cache supported GCC, Clang, and clang-cl object compilations
 
 Kache caches conservative, single-source C and C++ object compilations. If it cannot prove that an invocation is safe to cache, it runs the real compiler unchanged.
 
-## Set up the wrapper
+## Make, CMake, autotools, PKGBUILD
 
-For Cargo build scripts, `kache init` sets `HOST_CC` and `HOST_CXX` in Cargo's config (and `CC_KNOWN_WRAPPER_CUSTOM=kache`). It does not set `CC` or `CXX`, so `cargo build --target` keeps the cross compiler the `cc` crate would have found.
+The Unix path is the same idea as ccache's masquerade method: put a directory of compiler-named symlinks first on `PATH`. `make`, CMake, autotools, and Arch PKGBUILDs that call `gcc` or `clang` by name then go through Kache. There is no `CC=` edit and no shell wrapper.
 
-For build systems that honor `CC` and `CXX`:
+```bash
+kache install-shims
+export PATH="$HOME/.local/lib/kache/shims:$PATH"
+```
+
+`kache init` can create that directory. It does not edit your shell rc or `PATH`. Add the `export` to the shell you build from, or for `makepkg`:
+
+```bash
+# ~/.makepkg.conf
+PATH="$HOME/.local/lib/kache/shims:$PATH"
+```
+
+The APT and AUR packages also install `/usr/lib/kache` with the same symlinks:
+
+```bash
+export PATH="/usr/lib/kache:$PATH"
+```
+
+`kache install-shims` creates `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++`. Keep the real compilers later in `PATH`; Kache skips any entry that resolves back to itself.
+
+Versioned and target-prefixed names (`gcc-13`, `x86_64-pc-linux-gnu-gcc`) work if you create them by hand or scan `PATH`:
+
+```bash
+kache install-shims --from-path
+kache install-shims --force ~/.local/lib/kache/shims
+```
+
+Omitting the directory uses `~/.local/lib/kache/shims`. `--from-path` adds a symlink for every compiler-shaped name already on `PATH` that is not Kache itself.
+
+This is a native symlink to the `kache` binary. Do not wrap Kache in a shell script; that would spawn a shell per compile.
+
+Kache is a larger process than ccache. On a tree of many tiny `.c` files, measure both before replacing ccache.
+
+`kache doctor` reports whether a compiler name on `PATH` is a Kache shim. The check is informational, so a Rust-only setup does not fail doctor for skipping it.
+
+## Cargo build scripts
+
+`kache init` sets `HOST_CC` and `HOST_CXX` in Cargo's config (and `CC_KNOWN_WRAPPER_CUSTOM=kache`). It does not set `CC` or `CXX`, so `cargo build --target` keeps the cross compiler the `cc` crate would have found.
+
+PATH shims also cover Cargo's C bits when the crate invokes `cc` or `gcc` from `PATH` without `HOST_CC`.
+
+## Prefix method
+
+For a single project that honors `CC` and `CXX`:
 
 ```bash
 export CC="kache cc"
 export CXX="kache c++"
-```
-
-The Rust `cc` crate also needs to know that `kache` is a wrapper:
-
-```bash
 export CC_KNOWN_WRAPPER_CUSTOM=kache
 ```
 
-For build systems that call compiler names directly, install shims on Unix:
-
-```bash
-kache install-shims ~/.local/lib/kache/shims
-export PATH="$HOME/.local/lib/kache/shims:$PATH"
-```
-
-Kache creates `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++` symlinks. Keep the real compilers later in `PATH`; Kache skips paths that resolve back to itself.
+The `cc` crate needs `CC_KNOWN_WRAPPER_CUSTOM` so it keeps the real compiler argument. PATH shims do not need that variable, because the compiler name stays `gcc`.
 
 For clang-cl driver mode:
 
 ```powershell
 $env:CC = "kache clang-cl"
 ```
+
+Windows has no `install-shims` generator yet. Use `CC`/`CXX`, or copy `kache.exe` to `gcc.exe` and put that directory first on `PATH`.
 
 ## Cached invocations
 

--- a/docs/getting-started/comparison.mdx
+++ b/docs/getting-started/comparison.mdx
@@ -13,7 +13,7 @@ This page describes the current projects; it does not claim that one cache is un
 | --- | --- | --- |
 | Primary workflow | Local-first cache with optional explicit remote synchronization | Client-server compiler cache with local and remote storage |
 | Rust setup | `RUSTC_WRAPPER=kache`, `kache init`, or `kache cargo` | `RUSTC_WRAPPER=sccache` |
-| C/C++ setup | Compiler-name shims or build-system launcher configuration | Compiler wrapper or build-system launcher configuration |
+| C/C++ setup | PATH compiler-name shims (`kache install-shims`) or `CC="kache cc"` | Prefix wrapper (`sccache gcc`); no ccache-style PATH farm |
 | Remote backends | S3-compatible storage and filesystem paths | S3, Redis, Memcached, GCS, Azure, GitHub Actions, WebDAV, and others listed by sccache |
 | Inspection | `monitor`, `stats`, `why-miss`, `report`, `list`, and `doctor` | `--show-stats`, logs, and server commands |
 | Remote transfer | On-demand restore plus `sync`, manifests, and prefetch | Remote access is part of normal server operation |
@@ -27,6 +27,7 @@ This page describes the current projects; it does not claim that one cache is un
 - You want to inspect individual events and ask why a compile missed.
 - You want explicit pull, push, manifest, and prefetch controls for CI.
 - Caching eligible Rust executable and linker outputs matters to your workload.
+- You want one `PATH` change to cache Make/CMake/PKGBUILD object compiles without wrapping `CC` in a shell.
 
 ## Where Kache may not fit yet
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -60,6 +60,8 @@ Release candidates do not resolve as `latest`. Request their full `x.y.z-rc.n` v
     ```
 
     Replace `stable` with `unstable` to receive prereleases as well as stable releases.
+
+    The package also installs compiler-name shims in `/usr/lib/kache`. Prepend that directory to `PATH` to cache Make and CMake object compiles. See [C and C++](/docs/getting-started/c-cpp).
   </Tab>
   <Tab value="Windows">
     ```powershell
@@ -79,6 +81,8 @@ Release candidates do not resolve as `latest`. Request their full `x.y.z-rc.n` v
     ```
 
     `kache-bin` is the official prebuilt package. `kache-git` builds the current main branch; the community `kache` package builds a release from source.
+
+    Both official packages install compiler-name shims in `/usr/lib/kache`. For `makepkg`, put `PATH="/usr/lib/kache:$PATH"` in `~/.makepkg.conf`.
   </Tab>
 </Tabs>
 

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -24,7 +24,7 @@ This trial does not edit Cargo configuration or install a service.
 kache init
 ```
 
-`init` configures Cargo (`rustc-wrapper` and, when unset, `HOST_CC` / `HOST_CXX` for build-script C), installs the daemon as a login service, and starts it. It does not set `CC` or `CXX`. It is safe to run again when repairing a setup.
+`init` configures Cargo (`rustc-wrapper` and, when unset, `HOST_CC` / `HOST_CXX` for build-script C), offers Unix compiler-name shims for Make/CMake/PKGBUILD, installs the daemon as a login service, and starts it. It does not set `CC` or `CXX`, and it does not edit `PATH`. After the shims exist, prepend their directory yourself. See [C and C++](/docs/getting-started/c-cpp). It is safe to run again when repairing a setup.
 
 Useful variants:
 
@@ -52,7 +52,7 @@ kache doctor
 kache monitor
 ```
 
-`doctor` checks wrapper configuration, conflicting wrappers, config parsing, and daemon access. `monitor` shows hits, misses, passthroughs, store use, and remote transfers.
+`doctor` checks wrapper configuration, conflicting wrappers, config parsing, daemon access, and (informational) whether a C/C++ compiler on `PATH` is a Kache shim. `monitor` shows hits, misses, passthroughs, store use, and remote transfers.
 
 For a non-interactive check:
 

--- a/docs/how-it-works/architecture.mdx
+++ b/docs/how-it-works/architecture.mdx
@@ -61,7 +61,7 @@ See [Daemon overview](/docs/daemon/overview) and [Lifecycle](/docs/daemon/lifecy
 
 As `RUSTC_WRAPPER`, Kache sees rustc and workspace-wrapper invocations. It does not wrap Cargo itself or arbitrary tools. Rust link work driven by rustc can be cached when the artifact policy allows it; an independently invoked linker is outside this path.
 
-C/C++ caching is separate. Kache must be invoked as the compiler wrapper or through a compiler-name shim, and currently caches supported object compilations locally.
+C/C++ caching is separate. Kache must be invoked as the compiler wrapper (`kache cc`) or through a compiler-name shim on `PATH` (`kache install-shims`), and currently caches supported object compilations locally. See [C and C++](/docs/getting-started/c-cpp).
 
 ## Planner
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -67,7 +67,7 @@ Benchmark numbers count only when the individual job succeeds and its self-check
     Enable Kache for a project or across Cargo builds.
   </Card>
   <Card title="C and C++" href="/docs/getting-started/c-cpp">
-    Set up compiler shims and check what is cached.
+    PATH shims for Make and PKGBUILD, and what is cached.
   </Card>
   <Card title="Remote cache" href="/docs/remote-cache/s3-setup">
     Share entries through S3-compatible or filesystem storage.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -76,6 +76,13 @@ buildRustPackage {
   # Avoid bootstrapping loop: don't let kache wrap itself during build
   env.RUSTC_WRAPPER = "";
 
+  postInstall = lib.optionalString stdenv.hostPlatform.isUnix ''
+    mkdir -p $out/lib/kache
+    for name in cc c++ gcc g++ clang clang++; do
+      ln -s $out/bin/kache $out/lib/kache/$name
+    done
+  '';
+
   # reqwest (rustls) loads system CA certs when building a client, even for the
   # plain-HTTP localhost planner tests. The sandbox has no trust store, so point
   # it at the cacert bundle to keep client construction from failing.

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Recreate the compiler-name farm from the installed binary so the
+# names cannot drift from compiler::shim::SHIM_NAMES.
+case "$1" in
+configure)
+  kache install-shims --force /usr/lib/kache >/dev/null
+  ;;
+esac
+
+exit 0

--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+# Remove only the canonical farm. Extra names a local admin added with
+# `kache install-shims --from-path /usr/lib/kache` are left in place.
+case "$1" in
+remove|deconfigure)
+  if [ -d /usr/lib/kache ]; then
+    for name in cc c++ gcc g++ clang clang++; do
+      path="/usr/lib/kache/$name"
+      if [ -L "$path" ]; then
+        rm -f "$path"
+      fi
+    done
+    rmdir /usr/lib/kache 2>/dev/null || true
+  fi
+  ;;
+esac
+
+exit 0

--- a/scenarios/COVERAGE.md
+++ b/scenarios/COVERAGE.md
@@ -2,7 +2,7 @@
 
 A map of kache's user-facing features to the e2e scenarios that exercise them,
 and the gaps where a feature has no end-to-end scenario. The functional suite
-(`just e2e`, `suite:e2e`) currently has **43 scenarios** (the `bench-*` cases are
+(`just e2e`, `suite:e2e`) currently has **44 scenarios** (the `bench-*` cases are
 load benchmarks, not feature tests).
 
 This was produced by a cross-family audit (Claude + codex, independent passes):
@@ -32,6 +32,7 @@ came from the second pass.
 | Bypass rules (`[cache].bypass_env` / `_argv` / `_crates`, #222) | `e2e-bypass-rules` |
 | Fallback wrapper (`KACHE_FALLBACK`, #109) | `e2e-rust-fallback`, `e2e-rust-sccache` |
 | C / C++ object + depfile caching, header invalidation | `e2e-c-hello`, `e2e-cpp-hello`, `e2e-c-depinfo` |
+| C compiler-name shims on PATH (no `CC=`) | `e2e-c-shims` |
 | Flag modeling (gcc / clang / clang-cl) | `e2e-cc-bench-flags`, `e2e-cc-bench-flags-gnu`, `e2e-cc-cl-debug`, `e2e-cc-cl-xclang-deps` |
 | Realistic flag-soup canaries | `e2e-cc-flag-soup`, `e2e-rust-flag-soup`, `e2e-cmake-ninja-flagset` |
 | `__FILE__` / out-of-tree base-dir handling (#410) | `e2e-cc-file-macro-oot`, `e2e-cmake-file-macro-oot` |

--- a/scenarios/e2e-c-shims/scenario.toml
+++ b/scenarios/e2e-c-shims/scenario.toml
@@ -1,0 +1,56 @@
+# Same C project as e2e-c-hello, intercepted by PATH compiler-name shims
+# instead of `CC="$KACHE cc"`. Make uses `CC ?= cc`, so with CC unset it
+# execs `cc` from PATH. The harness installs shims and prepends them.
+#
+# Unix only (`install-shims` creates symlinks). Windows stays on the
+# prefix method in e2e-c-hello.
+
+name = "e2e-c-shims"
+tags = ["suite:e2e", "lang:cc"]
+compiler_shims = true
+os = ["linux", "macos"]
+
+[source]
+kind = "fixture"
+path = "../e2e-c-hello/source"
+
+[commands]
+build = "make"
+clean = "make clean"
+
+[verify]
+run = "./build/foo"
+expected_stdout_contains = ["hello from bar"]
+
+[diff]
+artifacts = ["build/foo.o"]
+
+[modify]
+file = "src/bar.h"
+find = "hello from bar"
+replace = "edited greeting"
+
+[assertions.cold]
+min_entries_after = 1
+max_compiler_runs = 1
+max_preprocessor_runs = 1
+max_probe_runs = 1
+
+[assertions.warm]
+min_hits = 1
+max_compiler_runs = 0
+max_preprocessor_runs = 0
+max_probe_runs = 0
+
+[assertions.noop]
+should_not_recompile = false
+
+[assertions.relocate]
+min_hits = 1
+max_compiler_runs = 0
+max_preprocessor_runs = 1
+
+[assertions.relocate-modified]
+min_misses = 1
+max_compiler_runs = 1
+max_preprocessor_runs = 1

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3852,11 +3852,13 @@ const DAEMON_CHECK_LABELS: [&str; 5] = [
 ];
 
 /// Whether a failing doctor check is informational rather than an issue:
-/// daemon checks when no remote/planner needs a daemon (#443), and the
-/// compiler probe when there is no `cc` at all to diagnose (#626).
+/// daemon checks when no remote/planner needs a daemon (#443), the
+/// compiler probe when there is no `cc` at all to diagnose (#626), and
+/// C/C++ shims (PATH masquerade is opt-in).
 fn doctor_check_is_optional(label: &str, daemon_optional: bool, probe_no_compiler: bool) -> bool {
     (daemon_optional && DAEMON_CHECK_LABELS.contains(&label))
         || (label == "Compiler probe" && probe_no_compiler)
+        || label == "C/C++ shims"
 }
 
 /// The daemon footnote prints when at least one daemon check failed but was
@@ -4508,6 +4510,16 @@ pub fn doctor(
             fix: Some("kache daemon install  (re-registers against current binary)".into()),
         });
     }
+
+    // Informational: rust-only setups skip the farm, so a miss here is not
+    // an issue. Failures tell Make/PKGBUILD users why gcc is not kache.
+    let shim_status = crate::compiler::shim::live_shim_path_status();
+    checks.push(Check {
+        label: "C/C++ shims",
+        pass: shim_status.on_path,
+        detail: shim_status.detail,
+        fix: shim_status.fix,
+    });
 
     // Compiler probe (#626): reported from the live toolchain, bypassing the
     // probe cache, so a stale stored "unresolved" record can't mask a fixed
@@ -6225,8 +6237,12 @@ mod tests {
         assert!(!doctor_check_is_optional("Binary", true, true));
         assert!(!doctor_check_is_optional("Daemon version", false, true));
         assert!(!doctor_check_is_optional("Compiler probe", true, false));
-        // Non-daemon, non-probe labels are never optional.
+        // Non-daemon, non-probe labels are never optional, except C/C++
+        // shims: PATH masquerade is opt-in and rust-only setups must not
+        // fail doctor for skipping it.
         assert!(!doctor_check_is_optional("Remote", true, true));
+        assert!(doctor_check_is_optional("C/C++ shims", false, false));
+        assert!(doctor_check_is_optional("C/C++ shims", true, true));
     }
 
     #[test]
@@ -10732,6 +10748,8 @@ mod tests {
 //      (fallback to ~/.cargo/config.toml)
 //   1b. Adds HOST_CC / HOST_CXX / CC_KNOWN_WRAPPER_CUSTOM under `[env]`
 //       when those keys are absent. Never sets CC or CXX.
+//   1c. Unix: offers compiler-name shims in ~/.local/lib/kache/shims.
+//       Does not edit PATH or shell rc.
 //   2. Installs the daemon as a login service (launchd/systemd)
 //   3. Starts the daemon
 //
@@ -11014,6 +11032,35 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
         }
     }
 
+    // ── Step 1c: C/C++ compiler-name shims (Unix) ───────────────
+    // Creates ~/.local/lib/kache/shims. Does not edit shell rc or PATH.
+    #[cfg(unix)]
+    {
+        let shim_dir = crate::compiler::shim::default_shim_dir();
+        if shim_dir_is_ready(&shim_dir) {
+            println!(
+                "  \x1b[32m✓\x1b[0m C/C++ shims already in {}",
+                shim_dir.display()
+            );
+            println!("    export PATH=\"{}:$PATH\"", shim_dir.display());
+        } else {
+            println!(
+                "  \x1b[33m→\x1b[0m install C/C++ compiler shims in {}",
+                shim_dir.display()
+            );
+            if should_write_init_step(
+                check,
+                prompt_yes_no(
+                    "Install C/C++ compiler shims for Make, CMake, and PKGBUILD?",
+                    true,
+                    yes,
+                )?,
+            ) {
+                install_shims(&shim_dir, false)?;
+            }
+        }
+    }
+
     // ── Step 2: daemon service ───────────────────────────────────
     let service_path = crate::service::service_file_path();
     let service_installed = service_path.as_ref().is_some_and(|p| p.exists());
@@ -11115,12 +11162,25 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
     }
 }
 
+/// True when `dir` already holds the canonical compiler-name farm pointing
+/// at this kache binary. Used by `kache init` so a second run is a no-op.
+#[cfg(unix)]
+fn shim_dir_is_ready(dir: &std::path::Path) -> bool {
+    let Ok(exe) = std::env::current_exe() else {
+        return false;
+    };
+    let exe = std::fs::canonicalize(&exe).unwrap_or(exe);
+    crate::compiler::shim::SHIM_NAMES.iter().all(|name| {
+        let link = dir.join(name);
+        std::fs::canonicalize(&link).is_ok_and(|real| real == exe)
+    })
+}
+
 /// Populate `dir` with compiler-name symlinks pointing at this kache binary
 /// (kunobi-ninja/kache#310).
 ///
 /// Prepending the result to `PATH` routes every build's compiler calls through
 /// kache with no `CC`/`CXX` edits and no per-project build-system changes.
-///
 ///
 /// Unix-only: it creates symlinks, and the Windows `.exe` shim story differs
 /// (kunobi-ninja/kache#310). The unsupported message lives in the command
@@ -11128,6 +11188,15 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
 /// same-named ones the mutation lane cannot tell apart.
 #[cfg(unix)]
 pub(crate) fn install_shims(dir: &std::path::Path, force: bool) -> anyhow::Result<()> {
+    install_shims_named(dir, force, &[])
+}
+
+#[cfg(unix)]
+pub(crate) fn install_shims_named(
+    dir: &std::path::Path,
+    force: bool,
+    extra_names: &[String],
+) -> anyhow::Result<()> {
     let exe = std::env::current_exe().context("locating the kache binary")?;
     // Resolve so the shims survive kache being invoked through its own
     // symlink, and so `resolve_real_compiler`'s identity check (which
@@ -11136,13 +11205,26 @@ pub(crate) fn install_shims(dir: &std::path::Path, force: bool) -> anyhow::Resul
     std::fs::create_dir_all(dir)
         .with_context(|| format!("creating shim directory {}", dir.display()))?;
 
+    let mut names: Vec<String> = crate::compiler::shim::SHIM_NAMES
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    for extra in extra_names {
+        if !crate::compiler::shim::invoked_as_compiler(extra) {
+            anyhow::bail!("`{extra}` is not a compiler name kache can wrap");
+        }
+        if !names.iter().any(|n| n == extra) {
+            names.push(extra.clone());
+        }
+    }
+
     let mut created = Vec::new();
     let mut skipped = Vec::new();
-    for name in crate::compiler::shim::SHIM_NAMES {
+    for name in &names {
         let link = dir.join(name);
         match std::fs::symlink_metadata(&link) {
             Ok(_) if !force => {
-                skipped.push((*name).to_string());
+                skipped.push(name.clone());
                 continue;
             }
             Ok(_) => std::fs::remove_file(&link)
@@ -11154,7 +11236,7 @@ pub(crate) fn install_shims(dir: &std::path::Path, force: bool) -> anyhow::Resul
         }
         std::os::unix::fs::symlink(&exe, &link)
             .with_context(|| format!("creating shim {}", link.display()))?;
-        created.push((*name).to_string());
+        created.push(name.clone());
     }
 
     println!(
@@ -11183,6 +11265,18 @@ pub(crate) fn install_shims(dir: &std::path::Path, force: bool) -> anyhow::Resul
         "The directory must come BEFORE the real toolchain on PATH, and the real \
          compilers must remain on PATH behind it — kache runs them."
     );
+    println!(
+        "Make, CMake, autotools, and Arch PKGBUILDs that invoke gcc/cc/clang \
+         from PATH then go through kache. No CC/CXX edit and no shell wrapper."
+    );
+    if dir == crate::compiler::shim::system_shim_dir() {
+        println!("For makepkg, put PATH=\"/usr/lib/kache:$PATH\" in ~/.makepkg.conf.");
+    } else {
+        println!(
+            "For makepkg, put PATH=\"{}:$PATH\" in ~/.makepkg.conf.",
+            dir.display()
+        );
+    }
     Ok(())
 }
 
@@ -11194,6 +11288,34 @@ mod shim_install_tests {
 
     fn is_symlink(path: &std::path::Path) -> bool {
         std::fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink())
+    }
+
+    #[test]
+    fn extra_compiler_name_is_installed_next_to_the_canonical_farm() {
+        let dir = tempfile::tempdir().unwrap();
+        let shims = dir.path().join("shims");
+        super::install_shims_named(&shims, false, &["gcc-13".into()]).unwrap();
+
+        let exe = std::fs::canonicalize(std::env::current_exe().unwrap()).unwrap();
+        let link = shims.join("gcc-13");
+        assert!(is_symlink(&link));
+        assert_eq!(std::fs::read_link(&link).unwrap(), exe);
+        for name in SHIM_NAMES {
+            assert!(
+                is_symlink(&shims.join(name)),
+                "{name} must still be installed"
+            );
+        }
+    }
+
+    #[test]
+    fn extra_name_that_is_not_a_compiler_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let shims = dir.path().join("shims");
+        let err = super::install_shims_named(&shims, false, &["gcc-ar".into()]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("gcc-ar"), "{msg}");
+        assert!(msg.contains("not a compiler name"), "{msg}");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11269,14 +11269,10 @@ pub(crate) fn install_shims_named(
         "Make, CMake, autotools, and Arch PKGBUILDs that invoke gcc/cc/clang \
          from PATH then go through kache. No CC/CXX edit and no shell wrapper."
     );
-    if dir == crate::compiler::shim::system_shim_dir() {
-        println!("For makepkg, put PATH=\"/usr/lib/kache:$PATH\" in ~/.makepkg.conf.");
-    } else {
-        println!(
-            "For makepkg, put PATH=\"{}:$PATH\" in ~/.makepkg.conf.",
-            dir.display()
-        );
-    }
+    println!(
+        "For makepkg, put PATH=\"{}:$PATH\" in ~/.makepkg.conf.",
+        dir.display()
+    );
     Ok(())
 }
 
@@ -11306,6 +11302,39 @@ mod shim_install_tests {
                 "{name} must still be installed"
             );
         }
+    }
+
+    #[test]
+    fn empty_dir_is_not_ready() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            !super::shim_dir_is_ready(dir.path()),
+            "an empty directory must not count as an installed farm"
+        );
+    }
+
+    #[test]
+    fn install_makes_the_dir_ready_and_a_wrong_target_does_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let shims = dir.path().join("shims");
+        install_shims(&shims, false).unwrap();
+        assert!(
+            super::shim_dir_is_ready(&shims),
+            "the installer must produce a farm that init treats as already done"
+        );
+
+        let other = dir.path().join("other");
+        std::fs::create_dir_all(&other).unwrap();
+        let not_kache = other.join("not-kache");
+        std::fs::write(&not_kache, b"#!/bin/sh\n").unwrap();
+        for name in SHIM_NAMES {
+            std::fs::remove_file(shims.join(name)).unwrap();
+            std::os::unix::fs::symlink(not_kache.as_path(), shims.join(name)).unwrap();
+        }
+        assert!(
+            !super::shim_dir_is_ready(&shims),
+            "links that do not resolve to this kache must not look ready"
+        );
     }
 
     #[test]

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1908,6 +1908,7 @@ mod tests {
 /// compiler at `argv[1]`, fall through to CLI mode, and fail parsing `foo.c`
 /// as a subcommand.
 pub(crate) mod shim {
+    use std::collections::BTreeSet;
     use std::path::{Path, PathBuf};
 
     /// The compiler names a generated shim directory populates. Deliberately
@@ -1972,6 +1973,164 @@ pub(crate) mod shim {
             name,
             &dirs,
             self_exe.as_deref(),
+            &|candidate| super::is_executable(candidate),
+            &|path| std::fs::canonicalize(path).ok(),
+        )
+    }
+
+    /// User-level farm created by `kache install-shims` with no directory argument.
+    pub(crate) fn default_shim_dir() -> PathBuf {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".local/lib/kache/shims")
+    }
+
+    /// Distro-package farm (`pacman -S kache-bin`, the kache `.deb`).
+    pub(crate) fn system_shim_dir() -> PathBuf {
+        PathBuf::from("/usr/lib/kache")
+    }
+
+    /// Compiler names already on PATH that are not in [`SHIM_NAMES`].
+    ///
+    /// `kache install-shims --from-path` uses this so versioned and
+    /// target-prefixed drivers (`gcc-13`, `x86_64-pc-linux-gnu-gcc`) get a
+    /// symlink without a second hardcoded list. Entries that resolve to kache
+    /// itself are skipped, otherwise a re-run would treat the farm as compilers.
+    pub(crate) fn extra_compiler_names(
+        path_dirs: &[PathBuf],
+        self_exe: Option<&Path>,
+        is_candidate: &dyn Fn(&Path) -> bool,
+        resolve: &dyn Fn(&Path) -> Option<PathBuf>,
+    ) -> Vec<String> {
+        let self_real = self_exe.and_then(resolve);
+        let mut names = BTreeSet::new();
+        for dir in path_dirs {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !is_candidate(&path) {
+                    continue;
+                }
+                if let (Some(real), Some(mine)) = (resolve(&path), self_real.as_deref())
+                    && real == mine
+                {
+                    continue;
+                }
+                let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+                if SHIM_NAMES.contains(&name) {
+                    continue;
+                }
+                if invoked_as_compiler(name) {
+                    names.insert(name.to_string());
+                }
+            }
+        }
+        names.into_iter().collect()
+    }
+
+    /// Live wiring for [`extra_compiler_names`].
+    #[cfg_attr(not(unix), allow(dead_code))]
+    pub(crate) fn extra_compiler_names_from_env() -> Vec<String> {
+        let path = std::env::var_os("PATH").unwrap_or_default();
+        let dirs: Vec<PathBuf> = std::env::split_paths(&path).collect();
+        let self_exe = std::env::current_exe().ok();
+        extra_compiler_names(
+            &dirs,
+            self_exe.as_deref(),
+            &|candidate| super::is_executable(candidate),
+            &|path| std::fs::canonicalize(path).ok(),
+        )
+    }
+
+    /// Whether a compiler-name shim is the first `gcc`/`cc`/… on PATH.
+    pub(crate) struct ShimPathStatus {
+        pub on_path: bool,
+        pub detail: String,
+        pub fix: Option<String>,
+    }
+
+    fn dir_holds_kache_shims(
+        dir: &Path,
+        self_real: Option<&Path>,
+        resolve: &dyn Fn(&Path) -> Option<PathBuf>,
+    ) -> bool {
+        let Some(mine) = self_real else {
+            return false;
+        };
+        SHIM_NAMES
+            .iter()
+            .any(|name| resolve(&dir.join(name)).is_some_and(|real| real == mine))
+    }
+
+    /// `on_path` is true when the first PATH hit for any canonical compiler
+    /// name resolves to this kache binary. Otherwise, report a farm that exists
+    /// but is not first on PATH, or that nothing is installed.
+    pub(crate) fn shim_path_status(
+        path_dirs: &[PathBuf],
+        self_exe: Option<&Path>,
+        installed_dirs: &[PathBuf],
+        is_candidate: &dyn Fn(&Path) -> bool,
+        resolve: &dyn Fn(&Path) -> Option<PathBuf>,
+    ) -> ShimPathStatus {
+        let self_real = self_exe.and_then(resolve);
+        for name in SHIM_NAMES {
+            for dir in path_dirs {
+                let candidate = dir.join(name);
+                if !is_candidate(&candidate) {
+                    continue;
+                }
+                if let (Some(real), Some(mine)) = (resolve(&candidate), self_real.as_deref())
+                    && real == mine
+                {
+                    return ShimPathStatus {
+                        on_path: true,
+                        detail: format!("{name} on PATH is a kache shim ({})", dir.display()),
+                        fix: None,
+                    };
+                }
+                // First hit for this name is some other binary. Try the next name.
+                break;
+            }
+        }
+
+        let installed = installed_dirs
+            .iter()
+            .find(|dir| dir_holds_kache_shims(dir, self_real.as_deref(), resolve));
+        if let Some(dir) = installed {
+            return ShimPathStatus {
+                on_path: false,
+                detail: format!("installed at {}, not first on PATH", dir.display()),
+                fix: Some(format!("export PATH=\"{}:$PATH\"", dir.display())),
+            };
+        }
+
+        let default = default_shim_dir();
+        ShimPathStatus {
+            on_path: false,
+            detail: "not installed".into(),
+            fix: Some(format!(
+                "kache install-shims && export PATH=\"{}:$PATH\"",
+                default.display()
+            )),
+        }
+    }
+
+    /// Live wiring for [`shim_path_status`].
+    pub(crate) fn live_shim_path_status() -> ShimPathStatus {
+        let path = std::env::var_os("PATH").unwrap_or_default();
+        let dirs: Vec<PathBuf> = std::env::split_paths(&path).collect();
+        let self_exe = std::env::current_exe().ok();
+        let default = default_shim_dir();
+        let system = system_shim_dir();
+        let installed = [default, system];
+        shim_path_status(
+            &dirs,
+            self_exe.as_deref(),
+            &installed,
             &|candidate| super::is_executable(candidate),
             &|path| std::fs::canonicalize(path).ok(),
         )
@@ -2189,5 +2348,114 @@ mod shim_tests {
         assert!(wrapper_args(&["kache".into(), "gcc".into(), "a.c".into()]).is_none());
         assert!(wrapper_args(&["kache".into(), "stats".into()]).is_none());
         assert!(wrapper_args(&[]).is_none());
+    }
+
+    #[test]
+    fn shim_path_status_passes_when_the_first_gcc_is_kache() {
+        let kache = PathBuf::from("/opt/kache/bin/kache");
+        let shims = PathBuf::from("/shims");
+        let real = PathBuf::from("/usr/bin");
+        let resolve = |path: &Path| -> Option<PathBuf> {
+            if path.starts_with("/shims") {
+                Some(kache.clone())
+            } else {
+                Some(path.to_path_buf())
+            }
+        };
+        let status = shim_path_status(&[shims, real], Some(&kache), &[], &|_| true, &resolve);
+        assert!(status.on_path, "{}", status.detail);
+        assert!(status.detail.contains("/shims"), "{}", status.detail);
+        assert!(status.fix.is_none());
+    }
+
+    #[test]
+    fn shim_path_status_reports_installed_farm_that_is_not_on_path() {
+        let kache = PathBuf::from("/opt/kache/bin/kache");
+        let farm = PathBuf::from("/home/user/.local/lib/kache/shims");
+        let real = PathBuf::from("/usr/bin");
+        let resolve = |path: &Path| -> Option<PathBuf> {
+            if path.starts_with(&farm) {
+                Some(kache.clone())
+            } else {
+                Some(path.to_path_buf())
+            }
+        };
+        let status = shim_path_status(
+            &[real],
+            Some(&kache),
+            std::slice::from_ref(&farm),
+            &|_| true,
+            &resolve,
+        );
+        assert!(!status.on_path);
+        assert!(
+            status.detail.contains("not first on PATH"),
+            "{}",
+            status.detail
+        );
+        assert_eq!(
+            status.fix.as_deref(),
+            Some("export PATH=\"/home/user/.local/lib/kache/shims:$PATH\"")
+        );
+    }
+
+    #[test]
+    fn shim_path_status_reports_missing_farm() {
+        let kache = PathBuf::from("/opt/kache/bin/kache");
+        let status = shim_path_status(
+            &[PathBuf::from("/usr/bin")],
+            Some(&kache),
+            &[],
+            &|_| true,
+            &|path| Some(path.to_path_buf()),
+        );
+        assert!(!status.on_path);
+        assert_eq!(status.detail, "not installed");
+        let fix = status.fix.expect("missing farm must say how to install");
+        assert!(fix.contains("kache install-shims"), "{fix}");
+        assert!(fix.contains("export PATH="), "{fix}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extra_names_on_path_include_versioned_compilers_not_the_farm() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _lock = crate::config::tests::config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let shim_dir = dir.path().join("shims");
+        let real_dir = dir.path().join("real");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+        std::fs::create_dir_all(&real_dir).unwrap();
+
+        let exe = std::env::current_exe().unwrap();
+        std::os::unix::fs::symlink(&exe, shim_dir.join("gcc")).unwrap();
+
+        let gcc13 = real_dir.join("gcc-13");
+        std::fs::write(&gcc13, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&gcc13, std::fs::Permissions::from_mode(0o755)).unwrap();
+        // Canonical names are already in SHIM_NAMES; --from-path must not
+        // re-list them just because a real gcc sits later on PATH.
+        let gcc = real_dir.join("gcc");
+        std::fs::write(&gcc, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&gcc, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let _path = PathForTest(std::env::var_os("PATH"));
+        unsafe {
+            std::env::set_var(
+                "PATH",
+                format!("{}:{}", shim_dir.display(), real_dir.display()),
+            )
+        };
+
+        let extra = extra_compiler_names_from_env();
+        assert!(
+            extra.iter().any(|n| n == "gcc-13"),
+            "versioned compiler must be wrapped, got {extra:?}"
+        );
+        assert!(
+            !extra.iter().any(|n| n == "gcc"),
+            "canonical names belong to SHIM_NAMES, got {extra:?}"
+        );
     }
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -2418,6 +2418,36 @@ mod shim_tests {
 
     #[cfg(unix)]
     #[test]
+    fn default_and_system_shim_dirs_are_the_documented_locations() {
+        let home = default_shim_dir();
+        assert!(
+            home.ends_with(".local/lib/kache/shims"),
+            "user farm must be ~/.local/lib/kache/shims, got {}",
+            home.display()
+        );
+        assert_eq!(system_shim_dir(), PathBuf::from("/usr/lib/kache"));
+    }
+
+    #[test]
+    fn a_path_that_does_not_hold_kache_is_not_an_installed_farm() {
+        let kache = PathBuf::from("/opt/kache/bin/kache");
+        let decoy = PathBuf::from("/opt/other/shims");
+        let status = shim_path_status(
+            &[PathBuf::from("/usr/bin")],
+            Some(&kache),
+            std::slice::from_ref(&decoy),
+            &|_| true,
+            &|path| Some(path.to_path_buf()),
+        );
+        assert!(!status.on_path);
+        assert_eq!(
+            status.detail, "not installed",
+            "a decoy directory must not count as the kache farm: {}",
+            status.detail
+        );
+    }
+
+    #[test]
     fn extra_names_on_path_include_versioned_compilers_not_the_farm() {
         use std::os::unix::fs::PermissionsExt;
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -2416,7 +2416,6 @@ mod shim_tests {
         assert!(fix.contains("export PATH="), "{fix}");
     }
 
-    #[cfg(unix)]
     #[test]
     fn default_and_system_shim_dirs_are_the_documented_locations() {
         let home = default_shim_dir();
@@ -2447,6 +2446,7 @@ mod shim_tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn extra_names_on_path_include_versioned_compilers_not_the_farm() {
         use std::os::unix::fs::PermissionsExt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,12 +314,17 @@ enum Commands {
     /// Create compiler-name symlinks pointing at kache, for transparent
     /// interception by prepending the directory to PATH
     InstallShims {
-        /// Directory to populate (created if missing)
-        dir: PathBuf,
+        /// Directory to populate. Defaults to ~/.local/lib/kache/shims
+        #[arg(value_name = "DIR")]
+        dir: Option<PathBuf>,
 
         /// Replace existing entries instead of refusing
         #[arg(long)]
         force: bool,
+
+        /// Also wrap compiler names already on PATH (gcc-13, target triplets)
+        #[arg(long)]
+        from_path: bool,
     },
 
     /// Generate shell completion scripts
@@ -796,7 +801,19 @@ fn main() -> Result<()> {
             tui::run_monitor(&config, hours)
         }
         #[cfg(unix)]
-        Some(Commands::InstallShims { dir, force }) => cli::install_shims(&dir, force),
+        Some(Commands::InstallShims {
+            dir,
+            force,
+            from_path,
+        }) => {
+            let dir = dir.unwrap_or_else(compiler::shim::default_shim_dir);
+            let extra = if from_path {
+                compiler::shim::extra_compiler_names_from_env()
+            } else {
+                Vec::new()
+            };
+            cli::install_shims_named(&dir, force, &extra)
+        }
         // Unix-only (symlinks); the Windows `.exe` shim story differs (#310).
         #[cfg(not(unix))]
         Some(Commands::InstallShims { .. }) => Err(anyhow::anyhow!(


### PR DESCRIPTION
## Summary

Follow-up to #310 / #796. The argv0 intercept already existed, but the documented path was still `CC="kache cc"` plus a directory argument to `install-shims`. That is not ccache's masquerade method, which is what Make and Arch PKGBUILD users actually want: one `PATH` change, no `CC=`, no bash wrapper.

This makes that path the default:

- `kache install-shims` with no directory uses `~/.local/lib/kache/shims`
- `--from-path` also wraps compiler names already on `PATH` (`gcc-13`, target triplets)
- `kache init` offers to create the farm and does not edit `PATH` or shell rc
- `kache doctor` reports whether `gcc`/`cc` on `PATH` is a kache shim (informational, so rust-only setups still pass)
- APT/AUR install `/usr/lib/kache`; Nix installs `$out/lib/kache`

Docs (C/C++, README, install, quick start, comparison, command reference) now lead with Make/CMake/PKGBUILD + `PATH`, including `~/.makepkg.conf`.

```bash
kache install-shims
export PATH="$HOME/.local/lib/kache/shims:$PATH"
```

After an APT/AUR install:

```bash
export PATH="/usr/lib/kache:$PATH"
```

## Test plan

- [x] `just check` (fmt, clippy `-D warnings`, workspace tests)
- [x] shim unit tests: PATH identity skip, installed-but-not-first, missing farm, `--from-path` extra names, rejected `gcc-ar`
- [x] `e2e-c-shims`: Make with `CC` unset, `cc` found on PATH through the shim farm; cold miss, warm hit, relocate hit

```bash
cargo test --bin kache -- shim_path_status extra_names extra_compiler_name extra_name_that doctor_check_optionality installs_a_symlink
./target/debug/kache-scenario --kache ./target/debug/kache --scenarios ./scenarios --select name:e2e-c-shims
```

## Checklist

- [x] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [x] User-visible changes (CLI, config, output) are reflected in the README or relevant docs