### PR TITLE
feat(rustc): pin native link runtime and admit bundled WASM

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -169,16 +169,17 @@ gitignore = true
 # `run_cold_phase` is the same shape: a full clone/build that this lane cannot
 # drive. The dump it now calls (`write_cache_otlp_or_warn`) stays in scope.
 #
-# macOS SDK discovery is compiled only on macOS, while the diff mutation lane
-# runs on Ubuntu. The macOS unit test exercises both the default SDK and an
-# invalid SDKROOT. Exclude only the platform tool wrappers; the key-folding
-# logic that consumes their identity remains mutation-tested on every host.
+# macOS SDK discovery and `macos_oso_prefix_flag` are compiled only on macOS,
+# while the diff mutation lane runs on Ubuntu. macOS tests exercise both SDK
+# discovery and the real flag wrapper. Exclude only the platform wrappers; the
+# extracted flag logic and key folding remain mutation-tested on every host.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
     "probe_macos",
     "replace sdk_identity_for",
     "xcrun",
+    "replace macos_oso_prefix_flag ->",
     "probe_unsupported",
     "from struct AttrList",
     "regular_output_is_independent_windows",

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -168,10 +168,17 @@ gitignore = true
 # selection, measurement, verdict, artifact, and OTLP helpers remain in scope.
 # `run_cold_phase` is the same shape: a full clone/build that this lane cannot
 # drive. The dump it now calls (`write_cache_otlp_or_warn`) stays in scope.
+#
+# macOS SDK discovery is compiled only on macOS, while the diff mutation lane
+# runs on Ubuntu. The macOS unit test exercises both the default SDK and an
+# invalid SDKROOT. Exclude only the platform tool wrappers; the key-folding
+# logic that consumes their identity remains mutation-tested on every host.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
     "probe_macos",
+    "replace sdk_identity_for",
+    "xcrun",
     "probe_unsupported",
     "from struct AttrList",
     "regular_output_is_independent_windows",

--- a/docs/how-it-works/cache-key.mdx
+++ b/docs/how-it-works/cache-key.mdx
@@ -16,8 +16,13 @@ The exact set depends on the invocation. It can include:
 - code-generation flags, rustflags, and requested emit kinds
 - the contents of `--extern` dependencies
 - compile-time environment values rustc reports
-- native libc identity for host-loaded Linux outputs
+- native libc version and hashed CRT/startup objects for host-loaded Linux outputs
+- macOS SDK identity (version and build) for host-loaded Darwin outputs
 - configured salt, extra inputs, and declared environment inputs
+
+Host-loaded Linux and macOS links pass through if those runtime inputs cannot be resolved, rather than sharing a binary neither host pinned. rustc-bundled self-contained WebAssembly targets (`wasm32-unknown-unknown`, the WASI family, `wasm32v1-none`, `wasm64-unknown-unknown`) are cached; custom target specs, emscripten, and `link-self-contained=no` pass through.
+
+On macOS, a cached debug link gets ld64 `-oso_prefix` for `--out-dir`, so `N_OSO` object paths in the binary are not checkout-local.
 
 Incremental directory names and harmless local path spellings are excluded or normalized.
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -914,6 +914,26 @@ impl RustcArgs {
             .find(|(k, _)| k == key)
             .and_then(|(_, v)| v.as_deref())
     }
+
+    /// Whether this invocation emits debug info.
+    ///
+    /// rustc's default is no debug info, so an absent `-Cdebuginfo` counts as
+    /// off, as do the explicit `0` / `none` spellings. Everything else (`1`,
+    /// `2`, `line-tables-only`, …) produces DWARF. `-g` desugars to
+    /// `-Cdebuginfo=2` at parse time.
+    pub fn debuginfo_enabled(&self) -> bool {
+        match self.get_codegen_opt("debuginfo") {
+            None => false,
+            Some("0") => false,
+            Some("none") => false,
+            Some(_) => true,
+        }
+    }
+
+    /// Whether rustc will invoke the linker for this invocation.
+    pub fn emits_link(&self) -> bool {
+        self.emit.is_empty() || self.emit.iter().any(|kind| kind == "link")
+    }
 }
 
 fn parse_extern(s: &str) -> ExternDep {

--- a/src/args.rs
+++ b/src/args.rs
@@ -1733,6 +1733,26 @@ mod tests {
     }
 
     #[test]
+    fn emits_link_is_false_for_metadata_only() {
+        let mut parsed = RustcArgs::parse(&[
+            "rustc".to_string(),
+            "--crate-name".to_string(),
+            "foo".to_string(),
+            "--crate-type".to_string(),
+            "bin".to_string(),
+            "src/main.rs".to_string(),
+            "--emit".to_string(),
+            "metadata".to_string(),
+        ])
+        .unwrap();
+        assert!(!parsed.emits_link());
+        parsed.emit = vec!["link".to_string()];
+        assert!(parsed.emits_link());
+        parsed.emit.clear();
+        assert!(parsed.emits_link());
+    }
+
+    #[test]
     fn test_parse_codegen_opt_no_value() {
         let (key, value) = parse_codegen_opt("debuginfo");
         assert_eq!(key, "debuginfo");

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -4633,6 +4633,46 @@ mod tests {
     }
 
     #[test]
+    fn crt_fold_requires_linux_os_and_linux_rustc_host() {
+        let args = parsed_linked_bin(None);
+        let a = crt_fold_key(
+            &args,
+            DARWIN_RUSTC_VERSION,
+            true,
+            false,
+            "crt1.o=aaa;libc.so.6=bbb",
+            "",
+            None,
+        )
+        .unwrap();
+        let b = crt_fold_key(
+            &args,
+            DARWIN_RUSTC_VERSION,
+            true,
+            false,
+            "crt1.o=zzz;libc.so.6=yyy",
+            "",
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            a, b,
+            "a Darwin rustc hosted on Linux must not fold Linux CRT objects"
+        );
+    }
+
+    #[test]
+    fn sdk_fold_requires_macos_os_and_darwin_rustc_host() {
+        let args = parsed_linked_bin(None);
+        let a = crt_fold_key(&args, GNU_RUSTC_VERSION, false, true, "", "14.0 (a)", None).unwrap();
+        let b = crt_fold_key(&args, GNU_RUSTC_VERSION, false, true, "", "15.0 (b)", None).unwrap();
+        assert_eq!(
+            a, b,
+            "a GNU rustc hosted on macOS must not fold the Darwin SDK"
+        );
+    }
+
+    #[test]
     fn windows_hosts_do_not_key_linux_crt_or_macos_sdk() {
         let bin = parsed_linked_bin(None);
         assert_eq!(

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, params};
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 /// Bump this when cache key logic changes in a way that could have produced
@@ -225,7 +225,16 @@ use std::path::{Path, PathBuf};
 // was enabled beneath a deny group, or accepted cfg values were tightened.
 // v0.16.0 shipped v27, so the bump also protects mixed fleets from consuming
 // already-persisted false-success entries.
-pub(crate) const CACHE_KEY_VERSION: u32 = 28;
+//
+// v29: native host-loaded links now pin the objects the driver actually
+// places (Linux CRT/startup + libc hashes) and the macOS SDK identity
+// (version + build), failing closed to passthrough when those essentials
+// cannot be resolved. macOS debug links also inject ld64 `-oso_prefix` so
+// `N_OSO` paths are relative to `--out-dir` rather than checkout-local.
+// WASM admission is explicit for rustc-bundled self-contained targets.
+// Shared with the cc recipe, so local and remote Rust/C entries from v28
+// are unreachable; `kache gc --stale-schema` reclaims them.
+pub(crate) const CACHE_KEY_VERSION: u32 = 29;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
 /// Collapse runs of ASCII whitespace into single spaces and trim
@@ -1512,15 +1521,33 @@ pub fn compute_cache_key(
     // sysroot/toolchain, and poisoning those keys with the build host would
     // only destroy valid cross-machine hits without identifying that sysroot.
     // Probe failure is an error, making the wrapper pass through instead of
-    // risking a shared-cache false hit. This conditional component makes old
-    // native-linked keys unreachable while leaving portable rlib keys byte-for-
-    // byte unchanged, so a global CACHE_KEY_VERSION bump is unnecessary.
+    // risking a shared-cache false hit.
     fold_native_host_libc_signature(
         &mut hasher,
         args,
         &rustc_version,
         cfg!(target_os = "linux"),
         probe_linux_libc_signature,
+    )?;
+
+    // Stronger than the version string above: hash the CRT/startup objects and
+    // libc the driver actually places (Linux), and the SDK identity (macOS).
+    // Two hosts with the same `cc --version` / libc version banner and
+    // different object bytes then miss instead of sharing. If none of the
+    // essentials resolve, fail closed — passthrough rather than a key that
+    // claims to have pinned a runtime neither host identified. v29.
+    fold_native_link_runtime_identity(
+        &mut hasher,
+        args,
+        &rustc_version,
+        cfg!(target_os = "linux"),
+        cfg!(target_os = "macos"),
+        crate::native_link_key::probe_linux_crt_objects,
+        |sdkroot| match crate::native_link_key::sdk_identity_for(sdkroot)? {
+            Some(identity) => Ok(identity),
+            None => anyhow::bail!("the macOS SDK could not be identified"),
+        },
+        std::env::var("MACOSX_DEPLOYMENT_TARGET").ok(),
     )?;
 
     // Path remapping status: kache injects multi-prefix
@@ -3894,6 +3921,83 @@ where
     Ok(())
 }
 
+/// Fold hashed CRT/startup/libc objects (Linux) and SDK identity (macOS)
+/// into linked-output keys. Injected probes keep the gating testable without
+/// running host tools.
+fn fold_native_link_runtime_identity<H, Crt, Sdk>(
+    hasher: &mut H,
+    args: &RustcArgs,
+    rustc_version: &str,
+    running_on_linux: bool,
+    running_on_macos: bool,
+    crt_probe: Crt,
+    sdk_probe: Sdk,
+    deployment_target: Option<String>,
+) -> Result<()>
+where
+    H: KeyFold,
+    Crt: FnOnce(&Path) -> Result<BTreeMap<String, String>>,
+    Sdk: FnOnce(Option<String>) -> Result<String>,
+{
+    let emits_link = args.emit.is_empty() || args.emit.iter().any(|kind| kind == "link");
+    if !args.is_executable_output() || !emits_link {
+        return Ok(());
+    }
+    if !running_on_linux && !running_on_macos {
+        return Ok(());
+    }
+    let rustc_version = rustc_version_for_libc(args, rustc_version, get_rustc_version)?;
+    let host = rustc_host_triple(&rustc_version)
+        .context("wrapped rustc -vV output has no host triple; cannot key native link runtime")?;
+    let effective_target = args.target.as_deref().unwrap_or(host);
+    if effective_target != host {
+        return Ok(());
+    }
+
+    if running_on_linux && host.split('-').any(|component| component == "linux") {
+        let driver = resolve_link_driver(args)
+            .context("native Linux link has no cc/linker driver; cannot key CRT objects")?;
+        let objects = crt_probe(&driver).context("determining native Linux CRT/libc identity")?;
+        let encoded = crate::native_link_key::encode_crt_objects(&objects);
+        fold_field(hasher, b"host_crt.v1:", encoded.as_bytes());
+        tracing::trace!(
+            "[key:{}] host_crt={}",
+            args.crate_name.as_deref().unwrap_or("unknown"),
+            encoded.replace('\n', ",")
+        );
+    }
+
+    if running_on_macos && host.split('-').any(|component| component == "darwin") {
+        let identity = sdk_probe(std::env::var("SDKROOT").ok())
+            .context("determining macOS SDK identity for cache key")?;
+        fold_field(hasher, b"host_sdk.v1:", identity.as_bytes());
+        tracing::trace!(
+            "[key:{}] host_sdk={}",
+            args.crate_name.as_deref().unwrap_or("unknown"),
+            identity
+        );
+        if let Some(target) = deployment_target.filter(|value| !value.is_empty()) {
+            fold_field(hasher, b"host_deployment_target.v1:", target.as_bytes());
+            tracing::trace!(
+                "[key:{}] host_deployment_target={}",
+                args.crate_name.as_deref().unwrap_or("unknown"),
+                target
+            );
+        }
+    }
+    Ok(())
+}
+
+fn resolve_link_driver(args: &RustcArgs) -> Option<PathBuf> {
+    let linker = args.get_codegen_opt("linker").unwrap_or("cc");
+    let linker_path = Path::new(linker);
+    if linker_path.is_absolute() {
+        Some(linker_path.to_path_buf())
+    } else {
+        resolve_in_path(linker)
+    }
+}
+
 fn is_libc_version(version: &str) -> bool {
     let mut parts = version.split('.');
     let Some(major) = parts.next() else {
@@ -4034,6 +4138,8 @@ mod tests {
 
     const GNU_RUSTC_VERSION: &str =
         "rustc 1.90.0\nhost: x86_64-unknown-linux-gnu\nrelease: 1.90.0\n";
+    const DARWIN_RUSTC_VERSION: &str =
+        "rustc 1.90.0\nhost: aarch64-apple-darwin\nrelease: 1.90.0\n";
 
     #[test]
     fn source_identity_uses_a_stable_configured_root() {
@@ -4288,6 +4394,262 @@ mod tests {
         assert_eq!(
             rustc_host_triple(&version),
             Some("x86_64-unknown-linux-gnu")
+        );
+    }
+
+    fn parsed_linked_bin(target: Option<&str>) -> RustcArgs {
+        let mut argv = vec![
+            "rustc".to_string(),
+            "--crate-name".to_string(),
+            "probe".to_string(),
+            "--crate-type".to_string(),
+            "bin".to_string(),
+            "src/lib.rs".to_string(),
+            "-Clinker=/abs/cc".to_string(),
+        ];
+        if let Some(target) = target {
+            argv.push("--target".to_string());
+            argv.push(target.to_string());
+        }
+        RustcArgs::parse(&argv).unwrap()
+    }
+
+    fn crt_fold_key(
+        args: &RustcArgs,
+        rustc_version: &str,
+        linux: bool,
+        macos: bool,
+        crt: &str,
+        sdk: &str,
+        deployment_target: Option<&str>,
+    ) -> Result<String> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"base-key");
+        fold_native_link_runtime_identity(
+            &mut hasher,
+            args,
+            rustc_version,
+            linux,
+            macos,
+            |_| {
+                let mut objects = BTreeMap::new();
+                for pair in crt.split(';').filter(|pair| !pair.is_empty()) {
+                    let (name, digest) = pair.split_once('=').unwrap();
+                    objects.insert(name.to_string(), digest.to_string());
+                }
+                Ok(objects)
+            },
+            |_| Ok(sdk.to_string()),
+            deployment_target.map(str::to_string),
+        )?;
+        Ok(hasher.finalize().to_hex().to_string())
+    }
+
+    #[test]
+    fn native_linux_linked_outputs_key_crt_object_hashes() {
+        let args = parsed_linked_bin(None);
+        let old = crt_fold_key(
+            &args,
+            GNU_RUSTC_VERSION,
+            true,
+            false,
+            "crt1.o=aaa;libc.so.6=bbb",
+            "",
+            None,
+        )
+        .unwrap();
+        let new = crt_fold_key(
+            &args,
+            GNU_RUSTC_VERSION,
+            true,
+            false,
+            "crt1.o=aaa;libc.so.6=ccc",
+            "",
+            None,
+        )
+        .unwrap();
+        assert_ne!(old, new, "libc object bytes must re-key the native link");
+    }
+
+    #[test]
+    fn rlibs_and_cross_targets_do_not_key_crt_or_sdk() {
+        let rlib = parsed_crate_type("rlib", None);
+        assert_eq!(
+            crt_fold_key(
+                &rlib,
+                GNU_RUSTC_VERSION,
+                true,
+                true,
+                "crt1.o=aaa;libc.so.6=bbb",
+                "14.0 (a)",
+                Some("11.0"),
+            )
+            .unwrap(),
+            crt_fold_key(
+                &rlib,
+                GNU_RUSTC_VERSION,
+                true,
+                true,
+                "crt1.o=zzz;libc.so.6=yyy",
+                "15.0 (b)",
+                Some("12.0"),
+            )
+            .unwrap(),
+            "portable rlibs must not be tied to CRT/SDK identity"
+        );
+
+        let cross = parsed_linked_bin(Some("aarch64-unknown-linux-gnu"));
+        assert_eq!(
+            crt_fold_key(
+                &cross,
+                GNU_RUSTC_VERSION,
+                true,
+                false,
+                "crt1.o=aaa;libc.so.6=bbb",
+                "",
+                None,
+            )
+            .unwrap(),
+            crt_fold_key(
+                &cross,
+                GNU_RUSTC_VERSION,
+                true,
+                false,
+                "crt1.o=zzz;libc.so.6=yyy",
+                "",
+                None,
+            )
+            .unwrap(),
+            "cross-target output must not be tied to the build host CRT"
+        );
+    }
+
+    #[test]
+    fn native_linux_crt_probe_fails_closed() {
+        let bin = parsed_linked_bin(None);
+        let mut hasher = blake3::Hasher::new();
+        let err = fold_native_link_runtime_identity(
+            &mut hasher,
+            &bin,
+            GNU_RUSTC_VERSION,
+            true,
+            false,
+            |_| anyhow::bail!("no startup object"),
+            |_| unreachable!("linux fold must not probe the macOS SDK"),
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("determining native Linux CRT/libc identity")
+        );
+    }
+
+    #[test]
+    fn native_macos_linked_outputs_key_sdk_identity() {
+        let args = parsed_linked_bin(None);
+        let old = crt_fold_key(
+            &args,
+            DARWIN_RUSTC_VERSION,
+            false,
+            true,
+            "",
+            "14.0 (23A344)",
+            None,
+        )
+        .unwrap();
+        let new = crt_fold_key(
+            &args,
+            DARWIN_RUSTC_VERSION,
+            false,
+            true,
+            "",
+            "15.0 (24A348)",
+            None,
+        )
+        .unwrap();
+        assert_ne!(old, new, "SDK identity must re-key the native macOS link");
+
+        let with_dt = crt_fold_key(
+            &args,
+            DARWIN_RUSTC_VERSION,
+            false,
+            true,
+            "",
+            "14.0 (23A344)",
+            Some("11.0"),
+        )
+        .unwrap();
+        assert_ne!(
+            old, with_dt,
+            "MACOSX_DEPLOYMENT_TARGET must re-key when set"
+        );
+    }
+
+    #[test]
+    fn native_macos_sdk_probe_fails_closed() {
+        let bin = parsed_linked_bin(None);
+        let mut hasher = blake3::Hasher::new();
+        let err = fold_native_link_runtime_identity(
+            &mut hasher,
+            &bin,
+            DARWIN_RUSTC_VERSION,
+            false,
+            true,
+            |_| unreachable!("macOS fold must not probe Linux CRT"),
+            |_| anyhow::bail!("sdk missing"),
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("determining macOS SDK identity for cache key")
+        );
+    }
+
+    #[test]
+    fn metadata_only_outputs_do_not_probe_crt_or_sdk() {
+        let mut metadata = parsed_linked_bin(None);
+        metadata.emit = vec!["metadata".to_string()];
+        let mut hasher = blake3::Hasher::new();
+        fold_native_link_runtime_identity(
+            &mut hasher,
+            &metadata,
+            GNU_RUSTC_VERSION,
+            true,
+            true,
+            |_| panic!("metadata-only output must not probe CRT"),
+            |_| panic!("metadata-only output must not probe SDK"),
+            None,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn windows_hosts_do_not_key_linux_crt_or_macos_sdk() {
+        let bin = parsed_linked_bin(None);
+        assert_eq!(
+            crt_fold_key(
+                &bin,
+                GNU_RUSTC_VERSION,
+                false,
+                false,
+                "crt1.o=aaa;libc.so.6=bbb",
+                "14.0 (a)",
+                Some("11.0"),
+            )
+            .unwrap(),
+            crt_fold_key(
+                &bin,
+                DARWIN_RUSTC_VERSION,
+                false,
+                false,
+                "crt1.o=zzz;libc.so.6=yyy",
+                "15.0 (b)",
+                Some("12.0"),
+            )
+            .unwrap(),
+            "Windows hosts keep the existing linker --version identity only"
         );
     }
 

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -4397,6 +4397,13 @@ mod tests {
         );
     }
 
+    fn dummy_absolute_linker() -> String {
+        std::env::temp_dir()
+            .join("kache-dummy-cc")
+            .to_string_lossy()
+            .into_owned()
+    }
+
     fn parsed_linked_bin(target: Option<&str>) -> RustcArgs {
         let mut argv = vec![
             "rustc".to_string(),
@@ -4405,7 +4412,7 @@ mod tests {
             "--crate-type".to_string(),
             "bin".to_string(),
             "src/lib.rs".to_string(),
-            "-Clinker=/abs/cc".to_string(),
+            format!("-Clinker={}", dummy_absolute_linker()),
         ];
         if let Some(target) = target {
             argv.push("--target".to_string());
@@ -6344,16 +6351,30 @@ mod tests {
             v
         };
 
-        // A resolvable linker (cc exists on dev/CI) folds its version identity;
-        // an unresolvable one folds nothing. The keys must differ.
-        let with_cc = key_of_flags(&bin(&["-Clinker=cc"]));
-        let with_missing = key_of_flags(&bin(&["-Clinker=/nonexistent/kache-linker-xyz"]));
-        assert_ne!(
-            with_cc, with_missing,
-            "linker choice must affect a bin's cache key"
-        );
-        // Deterministic for the same linker.
-        assert_eq!(with_cc, key_of_flags(&bin(&["-Clinker=cc"])));
+        // A resolvable linker (cc on PATH) folds its version and, on Linux,
+        // CRT identity. An unresolvable linker cannot place CRT/startup
+        // objects, so the invocation is uncacheable rather than keyed with
+        // an empty runtime identity.
+        let fh = FileHasher::new();
+        let pn = PathNormalizer::empty();
+        let key = |args: Vec<String>| {
+            let mut parsed = RustcArgs::parse(&args).unwrap();
+            parsed.source_file = None;
+            compute_cache_key(&parsed, &fh, &pn)
+        };
+        let with_cc = key(bin(&["-Clinker=cc"]));
+        let with_missing = key(bin(&["-Clinker=/nonexistent/kache-linker-xyz"]));
+        match (with_cc, with_missing) {
+            (Ok(cc), Ok(missing)) => {
+                assert_ne!(cc, missing, "linker choice must affect a bin's cache key");
+                assert_eq!(cc, key(bin(&["-Clinker=cc"])).unwrap());
+            }
+            (Ok(_), Err(_)) => {}
+            (Err(_), Err(_)) => {}
+            (Err(err), Ok(_)) => {
+                panic!("unresolvable linker produced a key while cc failed: {err:#}")
+            }
+        }
     }
 
     /// A readable `--extern name=path` rlib is content-hashed into the key (not

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -7,6 +7,7 @@
 
 use anyhow::Result;
 use std::borrow::Cow;
+#[cfg(test)]
 use std::path::Path;
 
 use crate::args::RustcArgs;
@@ -316,8 +317,7 @@ fn is_compiler_bundled_wasm_target(target: &str) -> bool {
 }
 
 fn is_custom_target_spec(target: &str) -> bool {
-    let path = Path::new(target);
-    target.ends_with(".json") || target.contains('/') || target.contains('\\') || path.is_file()
+    target.contains('/') || target.contains('\\') || target.ends_with(".json")
 }
 
 fn is_wasm_triple(target: &str) -> bool {
@@ -366,16 +366,22 @@ fn wasm_link_refusal(parsed: &RustcArgs) -> Option<&'static str> {
 /// binary is not checkout-local. An invocation that already carries the flag
 /// keeps the caller's spelling. Passthrough compiles skip injection so the
 /// binary matches an unwrapped rustc.
+#[cfg(target_os = "macos")]
 fn macos_oso_prefix_flag(
     parsed: &RustcArgs,
     all_args: &[String],
     cache_this_compile: bool,
 ) -> Option<String> {
-    macos_oso_prefix_flag_inner(
-        parsed,
-        all_args,
-        cache_this_compile && cfg!(target_os = "macos"),
-    )
+    macos_oso_prefix_flag_inner(parsed, all_args, cache_this_compile)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn macos_oso_prefix_flag(
+    _parsed: &RustcArgs,
+    _all_args: &[String],
+    _cache_this_compile: bool,
+) -> Option<String> {
+    None
 }
 
 fn macos_oso_prefix_flag_inner(
@@ -404,7 +410,7 @@ fn macos_oso_prefix_flag_inner(
         return None;
     }
     let mut prefix = out_dir.display().to_string();
-    if !prefix.ends_with('/') && !prefix.ends_with('\\') {
+    if !prefix.ends_with(['/', '\\']) {
         prefix.push('/');
     }
     Some(format!("-Clink-arg=-Wl,-oso_prefix,{prefix}"))
@@ -893,6 +899,42 @@ mod tests {
         ];
         argv.extend(extra.iter().map(|s| s.to_string()));
         RustcCompiler::new().parse(&argv).unwrap()
+    }
+
+    #[test]
+    fn refuse_reasons_admits_native_host_bins() {
+        let parsed = RustcCompiler::new()
+            .parse(&s(&[
+                "rustc",
+                "--crate-name",
+                "app",
+                "--crate-type",
+                "bin",
+                "--emit",
+                "link",
+                "--target",
+                "x86_64-unknown-linux-gnu",
+                "src/main.rs",
+            ]))
+            .unwrap();
+        assert!(
+            RustcCompiler::new().refuse_reasons(&parsed).is_empty(),
+            "a native GNU bin is not a WASM link: {:?}",
+            RustcCompiler::new().refuse_reasons(&parsed)
+        );
+    }
+
+    #[test]
+    fn refuse_reasons_treats_path_only_wasm_target_as_custom_spec() {
+        let parsed = linked_wasm("/tmp/wasm32-unknown-unknown", &[]);
+        let reasons = RustcCompiler::new().refuse_reasons(&parsed);
+        assert!(
+            reasons.iter().any(|r| matches!(
+                r,
+                RefuseReason::Unsupported(d) if d.contains("custom target spec")
+            )),
+            "a path-shaped wasm target must pass through, got {reasons:?}"
+        );
     }
 
     #[test]

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -384,6 +384,7 @@ fn macos_oso_prefix_flag(
     None
 }
 
+#[cfg(any(test, target_os = "macos"))]
 fn macos_oso_prefix_flag_inner(
     parsed: &RustcArgs,
     all_args: &[String],

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -939,6 +939,14 @@ mod tests {
     }
 
     #[test]
+    fn custom_target_specs_accept_each_supported_path_shape() {
+        assert!(is_custom_target_spec("specs/wasm32-custom"));
+        assert!(is_custom_target_spec(r"specs\wasm32-custom"));
+        assert!(is_custom_target_spec("wasm32-custom.json"));
+        assert!(!is_custom_target_spec("wasm32-unknown-unknown"));
+    }
+
+    #[test]
     fn refuse_reasons_admits_compiler_bundled_wasm_links() {
         for target in COMPILER_BUNDLED_WASM_TARGETS {
             let parsed = linked_wasm(target, &[]);
@@ -1057,6 +1065,44 @@ mod tests {
         assert!(
             macos_oso_prefix_flag_inner(&release, &release.all_args, true).is_none(),
             "no debuginfo means no oso_prefix"
+        );
+
+        let library = RustcCompiler::new()
+            .parse(&s(&[
+                "rustc",
+                "--crate-name",
+                "foo",
+                "--crate-type",
+                "rlib",
+                "-g",
+                "--out-dir",
+                out_dir.to_str().unwrap(),
+                "src/lib.rs",
+            ]))
+            .unwrap();
+        assert!(
+            macos_oso_prefix_flag_inner(&library, &library.all_args, true).is_none(),
+            "non-executable outputs must not receive oso_prefix"
+        );
+
+        let metadata_only = RustcCompiler::new()
+            .parse(&s(&[
+                "rustc",
+                "--crate-name",
+                "foo",
+                "--crate-type",
+                "bin",
+                "-g",
+                "--emit",
+                "metadata",
+                "--out-dir",
+                out_dir.to_str().unwrap(),
+                "src/main.rs",
+            ]))
+            .unwrap();
+        assert!(
+            macos_oso_prefix_flag_inner(&metadata_only, &metadata_only.all_args, true).is_none(),
+            "non-link outputs must not receive oso_prefix"
         );
 
         let relative = debug_bin_args(Path::new("target/debug/deps"), &[]);

--- a/src/compiler/rustc.rs
+++ b/src/compiler/rustc.rs
@@ -6,6 +6,8 @@
 //! callers a stable shape that other compiler adapters can match.
 
 use anyhow::Result;
+use std::borrow::Cow;
+use std::path::Path;
 
 use crate::args::RustcArgs;
 use crate::cache_key::compute_cache_key;
@@ -144,10 +146,22 @@ impl RustcCompiler {
                 crate::cache_key::get_rustc_commit_hash(&parsed.rustc).as_deref(),
             );
         let skip_remap = skip_remap_override.unwrap_or_else(|| parsed.skip_path_remap());
+        // Only the cache miss path injects `-oso_prefix`. A passthrough must
+        // not change the binary relative to an unwrapped rustc. `None` here
+        // is that cache path (`execute` / isolated incremental).
+        let cache_this_compile = skip_remap_override.is_none();
+        let compiler_args = match macos_oso_prefix_flag(parsed, all_args, cache_this_compile) {
+            Some(flag) => {
+                let mut extended = all_args.to_vec();
+                extended.push(flag);
+                Cow::Owned(extended)
+            }
+            None => Cow::Borrowed(all_args),
+        };
         compile::run_rustc(
             &parsed.rustc,
             parsed.inner_rustc.as_deref(),
-            all_args,
+            compiler_args.as_ref(),
             parsed.has_expanded_argfiles(),
             parsed.output.as_deref(),
             parsed.out_dir.as_deref(),
@@ -279,7 +293,121 @@ fn rustc_refuse_reasons(
             "rustc --pretty/--unpretty source dump — not cacheable",
         ));
     }
+    if let Some(reason) = wasm_link_refusal(parsed) {
+        reasons.push(RefuseReason::Unsupported(reason));
+    }
     reasons
+}
+
+/// Built-in WebAssembly targets whose linker and CRT ship in rustc.
+/// Custom target specs never enter this list.
+const COMPILER_BUNDLED_WASM_TARGETS: &[&str] = &[
+    "wasm32-unknown-unknown",
+    "wasm32-wasi",
+    "wasm32-wasip1",
+    "wasm32-wasip1-threads",
+    "wasm32-wasip2",
+    "wasm32v1-none",
+    "wasm64-unknown-unknown",
+];
+
+fn is_compiler_bundled_wasm_target(target: &str) -> bool {
+    COMPILER_BUNDLED_WASM_TARGETS.contains(&target)
+}
+
+fn is_custom_target_spec(target: &str) -> bool {
+    let path = Path::new(target);
+    target.ends_with(".json") || target.contains('/') || target.contains('\\') || path.is_file()
+}
+
+fn is_wasm_triple(target: &str) -> bool {
+    target
+        .split(['-', '.', '/', '\\'])
+        .any(|component| component.starts_with("wasm"))
+}
+
+fn link_self_contained_disabled(parsed: &RustcArgs) -> bool {
+    match parsed.get_codegen_opt("link-self-contained") {
+        None => false,
+        Some("y" | "yes" | "on" | "true") => false,
+        Some(_) => true,
+    }
+}
+
+/// Explicit admission for rustc-bundled self-contained WASM links.
+///
+/// Custom specs, emscripten, and `link-self-contained=no` stay passthrough:
+/// those links depend on an external toolchain or CRT that kache does not
+/// pin. rlibs and metadata-only emits are unaffected.
+fn wasm_link_refusal(parsed: &RustcArgs) -> Option<&'static str> {
+    if !parsed.is_executable_output() || !parsed.emits_link() {
+        return None;
+    }
+    let target = parsed.target.as_deref()?;
+    if is_custom_target_spec(target) && is_wasm_triple(target) {
+        return Some("wasm custom target spec — not yet");
+    }
+    if is_compiler_bundled_wasm_target(target) {
+        if link_self_contained_disabled(parsed) {
+            return Some("wasm link-self-contained disabled — not yet");
+        }
+        return None;
+    }
+    if is_wasm_triple(target) {
+        return Some("wasm target uses an external toolchain — not yet");
+    }
+    None
+}
+
+/// ld64 `-oso_prefix` for a cached macOS debug link.
+///
+/// A `-g` Mach-O records absolute object paths in `N_OSO`. Prefixing the
+/// output directory makes those paths relative to `--out-dir`, so a restored
+/// binary is not checkout-local. An invocation that already carries the flag
+/// keeps the caller's spelling. Passthrough compiles skip injection so the
+/// binary matches an unwrapped rustc.
+fn macos_oso_prefix_flag(
+    parsed: &RustcArgs,
+    all_args: &[String],
+    cache_this_compile: bool,
+) -> Option<String> {
+    macos_oso_prefix_flag_inner(
+        parsed,
+        all_args,
+        cache_this_compile && cfg!(target_os = "macos"),
+    )
+}
+
+fn macos_oso_prefix_flag_inner(
+    parsed: &RustcArgs,
+    all_args: &[String],
+    enabled: bool,
+) -> Option<String> {
+    if !enabled {
+        return None;
+    }
+    if !parsed.debuginfo_enabled() || !parsed.is_executable_output() || !parsed.emits_link() {
+        return None;
+    }
+    if all_args.iter().any(|arg| arg.contains("-oso_prefix,")) {
+        return None;
+    }
+    if parsed
+        .target
+        .as_deref()
+        .is_some_and(|target| !target.contains("-apple-darwin"))
+    {
+        return None;
+    }
+    let out_dir = parsed.out_dir.as_ref()?;
+    if !out_dir.is_absolute() {
+        return None;
+    }
+    let mut prefix = out_dir.display().to_string();
+    if !prefix.ends_with('/') && !prefix.ends_with('\\') {
+        prefix.push('/');
+    }
+    Some(format!("-Clink-arg=-Wl,-oso_prefix,{prefix}"))
 }
 
 #[cfg(test)]
@@ -748,5 +876,153 @@ mod tests {
                 "{t} should be Hardlink strategy"
             );
         }
+    }
+
+    fn linked_wasm(target: &str, extra: &[&str]) -> RustcArgs {
+        let mut argv = vec![
+            "rustc".to_string(),
+            "--crate-name".to_string(),
+            "widget".to_string(),
+            "--crate-type".to_string(),
+            "bin".to_string(),
+            "--emit".to_string(),
+            "link".to_string(),
+            "--target".to_string(),
+            target.to_string(),
+            "src/main.rs".to_string(),
+        ];
+        argv.extend(extra.iter().map(|s| s.to_string()));
+        RustcCompiler::new().parse(&argv).unwrap()
+    }
+
+    #[test]
+    fn refuse_reasons_admits_compiler_bundled_wasm_links() {
+        for target in COMPILER_BUNDLED_WASM_TARGETS {
+            let parsed = linked_wasm(target, &[]);
+            let reasons = RustcCompiler::new().refuse_reasons(&parsed);
+            assert!(
+                reasons.is_empty(),
+                "{target} should use rustc's bundled linker, got {reasons:?}"
+            );
+        }
+
+        let yes = linked_wasm("wasm32-wasip1", &["-Clink-self-contained=yes"]);
+        assert!(RustcCompiler::new().refuse_reasons(&yes).is_empty());
+    }
+
+    #[test]
+    fn refuse_reasons_passthroughs_external_wasm_toolchains() {
+        for target in ["wasm32-unknown-emscripten", "wasm32-wali-linux-musl"] {
+            let parsed = linked_wasm(target, &[]);
+            let reasons = RustcCompiler::new().refuse_reasons(&parsed);
+            assert!(
+                reasons.iter().any(|r| matches!(
+                    r,
+                    RefuseReason::Unsupported(d) if d.contains("external toolchain")
+                )),
+                "{target} should pass through, got {reasons:?}"
+            );
+        }
+
+        let custom = linked_wasm("/tmp/wasm32-unknown-unknown.json", &[]);
+        let reasons = RustcCompiler::new().refuse_reasons(&custom);
+        assert!(
+            reasons.iter().any(|r| matches!(
+                r,
+                RefuseReason::Unsupported(d) if d.contains("custom target spec")
+            )),
+            "custom wasm spec should pass through, got {reasons:?}"
+        );
+
+        let disabled = linked_wasm("wasm32-unknown-unknown", &["-Clink-self-contained=no"]);
+        let reasons = RustcCompiler::new().refuse_reasons(&disabled);
+        assert!(
+            reasons.iter().any(|r| matches!(
+                r,
+                RefuseReason::Unsupported(d) if d.contains("link-self-contained")
+            )),
+            "link-self-contained=no should pass through, got {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn refuse_reasons_does_not_refuse_wasm_rlibs() {
+        let parsed = RustcCompiler::new()
+            .parse(&s(&[
+                "rustc",
+                "--crate-name",
+                "widget",
+                "--crate-type",
+                "rlib",
+                "--target",
+                "wasm32-unknown-emscripten",
+                "src/lib.rs",
+            ]))
+            .unwrap();
+        assert!(RustcCompiler::new().refuse_reasons(&parsed).is_empty());
+    }
+
+    fn debug_bin_args(out_dir: &Path, extra: &[&str]) -> (RustcArgs, Vec<String>) {
+        let mut argv = vec![
+            "rustc".to_string(),
+            "--crate-name".to_string(),
+            "foo".to_string(),
+            "--crate-type".to_string(),
+            "bin".to_string(),
+            "-g".to_string(),
+            "--out-dir".to_string(),
+            out_dir.display().to_string(),
+            "src/main.rs".to_string(),
+        ];
+        argv.extend(extra.iter().map(|s| s.to_string()));
+        let parsed = RustcCompiler::new().parse(&argv).unwrap();
+        (parsed, argv)
+    }
+
+    #[test]
+    fn oso_prefix_is_injected_for_cached_macos_debug_links() {
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join("deps");
+        std::fs::create_dir_all(&out_dir).unwrap();
+
+        let (parsed, argv) = debug_bin_args(&out_dir, &[]);
+        let flag = macos_oso_prefix_flag_inner(&parsed, &argv, true).unwrap();
+        let mut prefix = out_dir.display().to_string();
+        if !prefix.ends_with('/') && !prefix.ends_with('\\') {
+            prefix.push('/');
+        }
+        assert_eq!(flag, format!("-Clink-arg=-Wl,-oso_prefix,{prefix}"));
+
+        let already = debug_bin_args(&out_dir, &["-Clink-arg=-Wl,-oso_prefix,/elsewhere/"]);
+        assert!(macos_oso_prefix_flag_inner(&already.0, &already.1, true).is_none());
+
+        let wasm = debug_bin_args(&out_dir, &["--target", "wasm32-unknown-unknown"]);
+        assert!(macos_oso_prefix_flag_inner(&wasm.0, &wasm.1, true).is_none());
+
+        let release = RustcCompiler::new()
+            .parse(&s(&[
+                "rustc",
+                "--crate-name",
+                "foo",
+                "--crate-type",
+                "bin",
+                "--out-dir",
+                out_dir.to_str().unwrap(),
+                "src/main.rs",
+            ]))
+            .unwrap();
+        assert!(
+            macos_oso_prefix_flag_inner(&release, &release.all_args, true).is_none(),
+            "no debuginfo means no oso_prefix"
+        );
+
+        let relative = debug_bin_args(Path::new("target/debug/deps"), &[]);
+        assert!(macos_oso_prefix_flag_inner(&relative.0, &relative.1, true).is_none());
+
+        let (parsed, argv) = debug_bin_args(&out_dir, &[]);
+        assert!(
+            macos_oso_prefix_flag_inner(&parsed, &argv, false).is_none(),
+            "passthrough must not rewrite the link"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod link;
 mod machine;
 mod miss_chain;
 mod native_archive;
+mod native_link_key;
 mod opcounts;
 mod otel;
 mod path_normalizer;

--- a/src/native_link_key.rs
+++ b/src/native_link_key.rs
@@ -119,10 +119,8 @@ fn print_file_name(driver: &Path, name: &str) -> Option<PathBuf> {
 /// Line Tools vs Xcode spell the same SDK differently and would over-key.
 /// `SDKROOT`, when set, is the SDK that is queried — reporting the default
 /// SDK's version beside another SDK's root would describe an SDK no link used.
+#[cfg(target_os = "macos")]
 pub(crate) fn sdk_identity_for(root: Option<String>) -> Result<Option<String>> {
-    if !cfg!(target_os = "macos") {
-        return Ok(None);
-    }
     let sdk = root.as_deref().unwrap_or("macosx");
     let version = xcrun(&["--sdk", sdk, "--show-sdk-version"])
         .ok_or_else(|| anyhow::anyhow!("xcrun --show-sdk-version failed"))?;
@@ -131,6 +129,12 @@ pub(crate) fn sdk_identity_for(root: Option<String>) -> Result<Option<String>> {
     Ok(Some(format!("{version} ({build})")))
 }
 
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn sdk_identity_for(_root: Option<String>) -> Result<Option<String>> {
+    Ok(None)
+}
+
+#[cfg(target_os = "macos")]
 fn xcrun(arguments: &[&str]) -> Option<String> {
     let output = Command::new("xcrun").args(arguments).output().ok()?;
     output

--- a/src/native_link_key.rs
+++ b/src/native_link_key.rs
@@ -1,0 +1,299 @@
+//! Runtime identity for native rustc links that dep-info does not enumerate.
+//!
+//! A bin/dylib/cdylib/proc-macro on the host is linked against CRT objects,
+//! libc, and (on macOS) an SDK that rustc never lists. Two hosts with the same
+//! `cc --version` banner can still produce incompatible binaries. This module
+//! resolves those inputs so the cache key can pin them, and fails closed when
+//! the essentials cannot be placed — the wrapper then passes through rather
+//! than sharing a binary neither host identified.
+
+use anyhow::{Context, Result, bail};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// What the driver is asked to place, and which of it a key cannot do without.
+///
+/// Chosen with `cfg!` rather than `#[cfg]` so both tables compile everywhere;
+/// a table only one platform builds is a table only that platform's CI can
+/// catch a mistake in.
+#[derive(Clone, Copy)]
+pub(crate) struct FileProbes {
+    /// The object that starts a program. One of these must resolve.
+    startup: &'static [&'static str],
+    /// Names a libc goes by. One must resolve too.
+    libc: &'static [&'static str],
+    /// Constructor/destructor objects. Individually optional.
+    rest: &'static [&'static str],
+}
+
+const LINUX_PROBES: FileProbes = FileProbes {
+    startup: &["Scrt1.o", "crt1.o", "rcrt1.o"],
+    libc: &["libc.so.6", "libc.so", "libc.a"],
+    rest: &[
+        "crti.o",
+        "crtn.o",
+        "crtbegin.o",
+        "crtbeginS.o",
+        "crtbeginT.o",
+        "crtend.o",
+        "crtendS.o",
+    ],
+};
+
+/// Resolve CRT/startup/libc objects through `cc -print-file-name=` and hash
+/// each file that comes back as an absolute path.
+pub(crate) fn probe_linux_crt_objects(driver: &Path) -> Result<BTreeMap<String, String>> {
+    probe_files(LINUX_PROBES, |name| print_file_name(driver, name))
+}
+
+/// Resolve each probe, hash what came back, and insist on the ones a key
+/// cannot describe a link without.
+///
+/// A probe that does not resolve is left out, so a host that resolves a
+/// different set keys differently. That alone is not enough: two hosts
+/// failing the *same* probe would agree on a key without ever pinning what
+/// that probe stood for. Startup and libc therefore have to resolve.
+pub(crate) fn probe_files(
+    probes: FileProbes,
+    place: impl Fn(&str) -> Option<PathBuf>,
+) -> Result<BTreeMap<String, String>> {
+    let mut resolved = BTreeMap::new();
+    for name in probes
+        .startup
+        .iter()
+        .chain(probes.libc)
+        .chain(probes.rest)
+        .copied()
+    {
+        let Some(path) = place(name) else {
+            continue;
+        };
+        let digest = hash_placed(&path)
+            .with_context(|| format!("hashing linker-placed {name} at {}", path.display()))?;
+        resolved.insert(name.to_string(), digest);
+    }
+    for (required, what) in [(probes.startup, "startup object"), (probes.libc, "libc")] {
+        if !required.is_empty() && !required.iter().any(|name| resolved.contains_key(*name)) {
+            bail!("the linker driver resolved no {what}, so its links cannot be identified");
+        }
+    }
+    Ok(resolved)
+}
+
+fn hash_placed(path: &Path) -> Result<String> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("opening {} for hashing", path.display()))?;
+    let mut hasher = blake3::Hasher::new();
+    hasher
+        .update_reader(file)
+        .with_context(|| format!("reading {} for hashing", path.display()))?;
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn print_file_name(driver: &Path, name: &str) -> Option<PathBuf> {
+    let output = Command::new(driver)
+        .arg(format!("-print-file-name={name}"))
+        .env("LC_ALL", "C")
+        .env("LANG", "C")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let reported = String::from_utf8_lossy(&output.stdout);
+    let reported = reported.trim();
+    if reported.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(reported);
+    // The driver echoes the name back when it cannot place it.
+    path.is_absolute()
+        .then_some(path)
+        .filter(|path| path.is_file())
+}
+
+/// Identity of the SDK a macOS link builds against.
+///
+/// Version + build version pin the libraries. The path is not folded: Command
+/// Line Tools vs Xcode spell the same SDK differently and would over-key.
+/// `SDKROOT`, when set, is the SDK that is queried — reporting the default
+/// SDK's version beside another SDK's root would describe an SDK no link used.
+pub(crate) fn sdk_identity_for(root: Option<String>) -> Result<Option<String>> {
+    if !cfg!(target_os = "macos") {
+        return Ok(None);
+    }
+    let sdk = root.as_deref().unwrap_or("macosx");
+    let version = xcrun(&["--sdk", sdk, "--show-sdk-version"])
+        .ok_or_else(|| anyhow::anyhow!("xcrun --show-sdk-version failed"))?;
+    let build = xcrun(&["--sdk", sdk, "--show-sdk-build-version"])
+        .ok_or_else(|| anyhow::anyhow!("xcrun --show-sdk-build-version failed"))?;
+    Ok(Some(format!("{version} ({build})")))
+}
+
+fn xcrun(arguments: &[&str]) -> Option<String> {
+    let output = Command::new("xcrun").args(arguments).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+/// Encode resolved CRT objects as a stable `name=digest` list.
+pub(crate) fn encode_crt_objects(objects: &BTreeMap<String, String>) -> String {
+    let mut encoded = String::new();
+    for (name, digest) in objects {
+        if !encoded.is_empty() {
+            encoded.push('\n');
+        }
+        encoded.push_str(name);
+        encoded.push('=');
+        encoded.push_str(digest);
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn placed(dir: &Path, name: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, name).unwrap();
+        path
+    }
+
+    #[test]
+    fn a_link_is_only_identified_once_its_essentials_resolve() {
+        let directory = tempfile::tempdir().unwrap();
+        let probes = FileProbes {
+            startup: &["Scrt1.o", "crt1.o"],
+            libc: &["libc.so.6", "libc.a"],
+            rest: &["crti.o"],
+        };
+
+        let resolved = probe_files(probes, |name| {
+            matches!(name, "crt1.o" | "libc.a").then(|| placed(directory.path(), name))
+        })
+        .unwrap();
+        assert_eq!(
+            resolved.keys().collect::<Vec<_>>(),
+            ["crt1.o", "libc.a"],
+            "only what resolved belongs in the key"
+        );
+
+        assert!(
+            probe_files(probes, |name| {
+                (name == "crt1.o").then(|| placed(directory.path(), name))
+            })
+            .is_err(),
+            "no libc should refuse"
+        );
+        assert!(
+            probe_files(probes, |name| {
+                (name == "libc.a").then(|| placed(directory.path(), name))
+            })
+            .is_err(),
+            "no startup object should refuse"
+        );
+        assert!(
+            probe_files(probes, |_| None).is_err(),
+            "nothing should refuse"
+        );
+
+        let glibc = probe_files(probes, |name| {
+            matches!(name, "crt1.o" | "libc.so.6").then(|| placed(directory.path(), name))
+        })
+        .unwrap();
+        assert_ne!(glibc, resolved);
+    }
+
+    #[test]
+    fn a_platform_that_places_nothing_is_still_identified() {
+        let probes = FileProbes {
+            startup: &[],
+            libc: &[],
+            rest: &[],
+        };
+        assert!(probe_files(probes, |_| None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn encode_crt_objects_is_sorted_and_stable() {
+        let mut objects = BTreeMap::new();
+        objects.insert("libc.so.6".into(), "bbb".into());
+        objects.insert("crt1.o".into(), "aaa".into());
+        assert_eq!(encode_crt_objects(&objects), "crt1.o=aaa\nlibc.so.6=bbb");
+    }
+
+    #[test]
+    fn linux_probes_require_startup_and_libc() {
+        assert!(!LINUX_PROBES.startup.is_empty());
+        assert!(!LINUX_PROBES.libc.is_empty());
+        if cfg!(target_os = "linux") {
+            assert_eq!(LINUX_PROBES.startup, ["Scrt1.o", "crt1.o", "rcrt1.o"]);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_probe_describes_this_host() {
+        let Ok(driver) = which_cc() else {
+            return;
+        };
+        let Ok(objects) = probe_linux_crt_objects(&driver) else {
+            return;
+        };
+        assert!(
+            LINUX_PROBES
+                .startup
+                .iter()
+                .any(|name| objects.contains_key(*name)),
+            "resolved CRT must pin a startup object: {objects:?}"
+        );
+        assert!(
+            LINUX_PROBES
+                .libc
+                .iter()
+                .any(|name| objects.contains_key(*name)),
+            "resolved CRT must pin a libc: {objects:?}"
+        );
+        assert!(objects.values().all(|d| d.len() == 64));
+    }
+
+    #[cfg(target_os = "linux")]
+    fn which_cc() -> Result<PathBuf> {
+        let path_var = std::env::var_os("PATH").context("PATH unset")?;
+        std::env::split_paths(&path_var)
+            .map(|dir| dir.join("cc"))
+            .find(|p| p.is_file())
+            .context("cc not on PATH")
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn the_sdk_identity_follows_sdkroot() {
+        let Ok(Some(_)) = sdk_identity_for(None) else {
+            return;
+        };
+        let overridden = sdk_identity_for(Some("/nonexistent.sdk".into()));
+        assert!(
+            overridden.is_err(),
+            "an unusable SDKROOT must not report the default SDK: {overridden:?}"
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn sdk_identity_is_none_off_macos() {
+        assert_eq!(sdk_identity_for(None).unwrap(), None);
+        assert_eq!(
+            sdk_identity_for(Some(
+                "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk".into()
+            ))
+            .unwrap(),
+            None
+        );
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -10340,13 +10340,14 @@ mod tests {
 
         // This test proves publication/removal atomicity, not the production
         // five-second fail-fast policy. A two-core hosted Windows runner can
-        // keep eight WAL writers queued past that timeout, so give these test
-        // connections enough time for every logical operation to commit and
-        // reach the invariant checks below.
+        // keep eight WAL writers queued past that timeout. The full Windows
+        // suite has also exhausted 30 seconds under mutation-runner load, so
+        // give these test connections enough time for every logical operation
+        // to commit and reach the invariant checks below.
         let stores: Vec<_> = (0..THREADS)
             .map(|_| {
                 let store = Store::open(&config).unwrap();
-                store.db.busy_timeout(Duration::from_secs(30)).unwrap();
+                store.db.busy_timeout(Duration::from_secs(60)).unwrap();
                 store
             })
             .collect();

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2664,12 +2664,7 @@ fn validate_extra_inputs_dep_info_before_store(
 /// spellings; everything else (`1`, `2`, `line-tables-only`, ...) produces
 /// DWARF worth bundling. `-g` desugars to `-Cdebuginfo=2` at parse time.
 fn rustc_debuginfo_enabled(args: &RustcArgs) -> bool {
-    match args.get_codegen_opt("debuginfo") {
-        None => false,
-        Some("0") => false,
-        Some("none") => false,
-        Some(_) => true,
-    }
+    args.debuginfo_enabled()
 }
 
 /// Store-time gate for [`crate::compiler::Platform::package_debug_bundle`]:


### PR DESCRIPTION
Stacked on #878. This is the `CACHE_KEY_VERSION` bump for the keying wave.

Native host-loaded links used to key `cc --version` and a Linux libc version string. Two hosts with the same banners and different CRT/SDK bits could share an incompatible binary.

This PR:

- hashes the CRT/startup objects and libc the driver actually places on Linux
- folds macOS SDK identity (version + build; `MACOSX_DEPLOYMENT_TARGET` when set)
- fails closed (passthrough) when those essentials cannot be resolved
- injects ld64 `-Wl,-oso_prefix,<outdir>/` on cached macOS debug links so `N_OSO` is not checkout-local
- admits rustc-bundled self-contained WASM (`wasm32-unknown-unknown`, WASI family, `wasm32v1-none`, `wasm64-unknown-unknown`)
- keeps custom target specs, emscripten, and `link-self-contained=no` as passthrough

**`CACHE_KEY_VERSION` 28 → 29.** Local and remote Rust/C entries from the previous schema are unreachable. `kache gc --stale-schema` cleans them.

Windows native links are unchanged (linker `--version` only). C/C++ link mode is still refused.

## Tests

- CRT object hashes re-key a native Linux link; missing startup or libc fails closed
- rlibs and cross targets do not pick up host CRT/SDK
- macOS SDK identity re-keys; unusable `SDKROOT` fails closed
- bundled WASM bins are admitted; emscripten, custom wasm specs, and `link-self-contained=no` pass through
- macOS debug bin argv contains `oso_prefix` when caching; passthrough and wasm do not inject