### PR TITLE
feat(prefetch): prefer identity manifests and drop guppy

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -183,6 +183,11 @@ gitignore = true
 # lane cannot compile. Their sizing and validation rules are extracted into
 # platform-neutral helpers and stay mutation-tested here; hosted platform tests
 # exercise the real wrappers.
+ #
+# The service repository has no identity-manifest store yet, so its
+# `identity_candidates` implementation returns `Ok(Vec::new())`. Replacing that
+# with `Ok(vec![])` is the same value. The daemon and core planner identity paths
+# remain in scope and are exercised with populated manifests.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -229,4 +234,5 @@ exclude_re = [
     "src/cache_fs.rs:.*replace probe_windows",
     "src/cache_fs.rs:.*replace statfs_total_bytes_macos",
     "src/cache_fs.rs:.*replace volume_total_bytes_windows",
+    "SurrealPlannerRepository>::identity_candidates .* with Ok\\(vec!\\[\\]\\)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,39 +656,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
 
 [[package]]
-name = "camino"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,16 +674,6 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
-]
-
-[[package]]
-name = "cfg-expr"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
-dependencies = [
- "smallvec",
- "target-lexicon",
 ]
 
 [[package]]
@@ -1200,12 +1157,6 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
-name = "debug-ignore"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
 
 [[package]]
 name = "defmt"
@@ -1708,12 +1659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
 name = "flatbuffers"
 version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,12 +1689,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -2041,39 +1980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
-name = "guppy"
-version = "0.17.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb611f63088c20f3f7252d896f0beaa176a9628da8c21cdf258fe9ae179bebda"
-dependencies = [
- "ahash 0.8.12",
- "camino",
- "cargo_metadata",
- "cfg-if",
- "debug-ignore",
- "fixedbitset 0.5.7",
- "guppy-workspace-hack",
- "indexmap 2.14.0",
- "itertools 0.14.0",
- "nested",
- "once_cell",
- "pathdiff",
- "petgraph",
- "semver",
- "serde",
- "serde_json",
- "smallvec",
- "static_assertions",
- "target-spec",
-]
-
-[[package]]
-name = "guppy-workspace-hack"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
-
-[[package]]
 name = "h2"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,22 +2057,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -2177,7 +2074,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -2957,7 +2854,6 @@ dependencies = [
  "filetime",
  "futures",
  "glob",
- "guppy",
  "home",
  "interprocess",
  "kache-core",
@@ -3448,12 +3344,6 @@ dependencies = [
  "num-traits",
  "rand 0.8.6",
 ]
-
-[[package]]
-name = "nested"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -3971,15 +3861,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-dependencies = [
- "camino",
-]
-
-[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4063,17 +3944,6 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset 0.5.7",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -6368,23 +6238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-lexicon"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
-
-[[package]]
-name = "target-spec"
-version = "3.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00e973676af5497c2a69cc9787e2205c00f3b6f4f70e7d7b0112e28aa84b501"
-dependencies = [
- "cfg-expr",
- "guppy-workspace-hack",
- "target-lexicon",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6459,7 +6312,7 @@ dependencies = [
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset 0.4.2",
+ "fixedbitset",
  "hex",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ home = "0.5.12"
 tar = "0.4"
 futures = "0.3"
 glob = "0.3"
-guppy = "0.17"
 libc = "0.2"
 tempfile = "3"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider"] }

--- a/crates/kache-core/src/lib.rs
+++ b/crates/kache-core/src/lib.rs
@@ -15,6 +15,10 @@ pub struct BuildIntent {
     pub namespace: Option<String>,
     #[serde(default)]
     pub cargo_lock_deps: Vec<(String, String)>,
+    /// Rank-0 prefetch key: lock digest + target + profile. Absent on older
+    /// clients and when no lockfile was visible at session start.
+    #[serde(default)]
+    pub identity_key: Option<String>,
 }
 
 /// Which source produced a candidate, i.e. how much to trust it
@@ -27,6 +31,8 @@ pub struct BuildIntent {
 #[cfg_attr(kani, derive(kani::Arbitrary))]
 #[serde(rename_all = "snake_case")]
 pub enum CandidateSource {
+    /// Recorded action list for this lockfile + target + profile.
+    Manifest,
     /// Exact lockfile-shard match: this build's dependency set produced it.
     Shard,
     /// This machine built this crate before.
@@ -44,10 +50,11 @@ impl CandidateSource {
     /// probabilities and must not be presented as any.
     pub fn confidence_rank(self) -> u8 {
         match self {
-            CandidateSource::Shard => 0,
-            CandidateSource::History => 1,
-            CandidateSource::KeyCache => 2,
-            CandidateSource::Unknown => 3,
+            CandidateSource::Manifest => 0,
+            CandidateSource::Shard => 1,
+            CandidateSource::History => 2,
+            CandidateSource::KeyCache => 3,
+            CandidateSource::Unknown => 4,
         }
     }
 }
@@ -146,12 +153,13 @@ impl Default for PlanLimits {
 
 /// Urgency bucket width, in dependency-order positions (#617).
 ///
-/// Demand order is bucketed rather than used exactly because it comes from a
-/// guppy graph traversal, which only approximates when cargo will actually ask
-/// (cargo reorders for parallelism, build scripts, proc macros, features).
-/// Treating position 40 and 45 as meaningfully different is false precision;
-/// 40 versus 400 is real. Roughly the prefetch concurrency, so one window is
-/// about one wave of downloads.
+/// Demand order is bucketed rather than used exactly because crate-name order
+/// from a lockfile (or a previous graph walk) only approximates when cargo
+/// will actually ask (cargo reorders for parallelism, build scripts, proc
+/// macros, features). Treating position 40 and 45 as meaningfully different
+/// is false precision; 40 versus 400 is real. Roughly the prefetch
+/// concurrency, so one window is about one wave of downloads. Identity
+/// manifests stamp demand_index from last-compile order when they have it.
 #[cfg(feature = "planning")]
 const URGENCY_BUCKET: u32 = 16;
 
@@ -213,6 +221,7 @@ fn cap_to(items: &mut Vec<PrefetchCandidate>, limit: usize) -> usize {
 /// had nothing more to offer (#616).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct PlanComposition {
+    pub from_identity: usize,
     pub from_shards: usize,
     pub from_history: usize,
     pub from_key_cache: usize,
@@ -242,6 +251,10 @@ pub trait PlannerDataSource {
     async fn history_candidates(&self, crate_names: &[String]) -> Result<Vec<PrefetchCandidate>>;
 
     async fn key_cache_keys_for_crate(&self, crate_name: &str) -> Result<Vec<String>>;
+
+    /// Rank-0: recorded actions for this lock+target+profile. A miss is
+    /// `Ok(vec![])`, not fatal — shards and history still run.
+    async fn identity_candidates(&self, identity_key: &str) -> Result<Vec<PrefetchCandidate>>;
 }
 
 #[cfg(feature = "planning")]
@@ -278,12 +291,40 @@ where
     let mut composition = PlanComposition::default();
 
     // Sources are merged in descending order of confidence, each one filling
-    // only the crates the ones before it left unresolved. Shard lookups used
-    // to RETURN as soon as they produced anything (kunobi-ninja/kache#614),
-    // but a shard hit is exact per bucket: one dependency bump invalidates one
-    // of `NUM_SHARDS` buckets while the rest still match, so a single matching
-    // shard was enough to short-circuit history and key-cache recovery for
-    // every crate in every bucket that missed.
+    // only the crates the ones before it left unresolved.
+    if let Some(identity_key) = intent
+        .identity_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+    {
+        match source.identity_candidates(identity_key).await {
+            Ok(identity_candidates) => {
+                for (index, candidate) in identity_candidates.into_iter().enumerate() {
+                    resolved_crates.insert(candidate.crate_name.clone());
+                    if seen.insert(candidate.cache_key.clone()) {
+                        let mut candidate = candidate.with_source(CandidateSource::Manifest);
+                        if candidate.demand_index.is_none() {
+                            candidate.demand_index = u32::try_from(index).ok();
+                        }
+                        candidates.push(candidate);
+                    }
+                }
+                composition.from_identity = candidates.len();
+            }
+            Err(_) => {
+                // Not fatal: shards and history still run.
+            }
+        }
+    }
+    let identity_resolved = resolved_crates.clone();
+
+    // Shard lookups used to RETURN as soon as they produced anything
+    // (kunobi-ninja/kache#614), but a shard hit is exact per bucket: one
+    // dependency bump invalidates one of `NUM_SHARDS` buckets while the rest
+    // still match, so a single matching shard was enough to short-circuit
+    // history and key-cache recovery for every crate in every bucket that
+    // missed.
     if let Some(namespace) = intent.namespace.as_deref()
         && !intent.cargo_lock_deps.is_empty()
     {
@@ -293,8 +334,12 @@ where
             .await
         {
             for candidate in order_candidates_by_crate_order(shard_candidates, intent) {
+                if identity_resolved.contains(&candidate.crate_name) {
+                    continue;
+                }
                 resolved_crates.insert(candidate.crate_name.clone());
                 if seen.insert(candidate.cache_key.clone()) {
+                    composition.from_shards += 1;
                     candidates.push(candidate.with_source(CandidateSource::Shard));
                 }
             }
@@ -308,8 +353,6 @@ where
             .cloned()
             .collect()
     };
-
-    composition.from_shards = candidates.len();
 
     let history_query = unresolved(&resolved_crates);
     if !history_query.is_empty() {
@@ -387,8 +430,11 @@ where
 
     // Stamp demand position so the daemon can rank without the intent: it only
     // receives the plan, and `PrefetchRequest::from_plan` drops everything else.
+    // Identity manifests already carry last-compile order; leave those alone.
     for candidate in &mut candidates {
-        candidate.demand_index = demand_index.get(&candidate.crate_name).copied();
+        if candidate.demand_index.is_none() {
+            candidate.demand_index = demand_index.get(&candidate.crate_name).copied();
+        }
     }
 
     // Dispatch order (#617). Stable, so equal keys keep the confidence-merge
@@ -589,6 +635,7 @@ mod tests {
     #[cfg(feature = "planning")]
     #[derive(Default)]
     struct FakePlannerDataSource {
+        identity_candidates: Vec<PrefetchCandidate>,
         shard_candidates: Vec<PrefetchCandidate>,
         shard_error: bool,
         history_candidates: Vec<PrefetchCandidate>,
@@ -632,6 +679,10 @@ mod tests {
         async fn key_cache_keys_for_crate(&self, crate_name: &str) -> Result<Vec<String>> {
             Ok(self.key_cache.get(crate_name).cloned().unwrap_or_default())
         }
+
+        async fn identity_candidates(&self, _identity_key: &str) -> Result<Vec<PrefetchCandidate>> {
+            Ok(self.identity_candidates.clone())
+        }
     }
 
     #[test]
@@ -640,6 +691,7 @@ mod tests {
             crate_names: vec!["serde".into(), "tokio".into()],
             namespace: Some("x86_64/hash/release".into()),
             cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+            identity_key: None,
         };
 
         let json = serde_json::to_string(&intent).unwrap();
@@ -653,6 +705,7 @@ mod tests {
         assert_eq!(parsed.crate_names, vec!["serde"]);
         assert!(parsed.namespace.is_none());
         assert!(parsed.cargo_lock_deps.is_empty());
+        assert!(parsed.identity_key.is_none());
     }
 
     #[test]
@@ -703,6 +756,7 @@ mod tests {
             crate_names: vec!["serde".into()],
             namespace: Some("linux/hash/release".into()),
             cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+            identity_key: None,
         };
 
         let plan = build_prefetch_plan(&source, &intent, "fallback")
@@ -713,6 +767,34 @@ mod tests {
         assert_eq!(plan.planner.as_deref(), Some("fallback"));
         assert_eq!(plan.candidates.len(), 1);
         assert_eq!(plan.candidates[0].cache_key, "from-shard");
+    }
+
+    #[cfg(feature = "planning")]
+    #[tokio::test]
+    async fn test_build_prefetch_plan_prefers_identity_manifest_over_shards() {
+        let source = FakePlannerDataSource {
+            identity_candidates: vec![PrefetchCandidate::new(
+                "from-identity".into(),
+                "serde".into(),
+            )],
+            shard_candidates: vec![PrefetchCandidate::new("from-shard".into(), "serde".into())],
+            ..Default::default()
+        };
+        let intent = BuildIntent {
+            crate_names: vec!["serde".into()],
+            namespace: Some("linux/hash/release".into()),
+            cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+            identity_key: Some("id/abcd/x86_64-unknown-linux-gnu/release".into()),
+        };
+
+        let plan = build_prefetch_plan(&source, &intent, "fallback")
+            .await
+            .unwrap();
+
+        assert_eq!(plan.candidates.len(), 1);
+        assert_eq!(plan.candidates[0].cache_key, "from-identity");
+        assert_eq!(plan.candidates[0].source, CandidateSource::Manifest);
+        assert_eq!(plan.candidates[0].demand_index, Some(0));
     }
 
     #[cfg(feature = "planning")]
@@ -732,6 +814,7 @@ mod tests {
             crate_names: vec!["serde".into(), "tokio".into()],
             namespace: Some("linux/hash/debug".into()),
             cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+            identity_key: None,
         };
 
         let plan = build_prefetch_plan(&source, &intent, "fallback")
@@ -759,6 +842,7 @@ mod tests {
             crate_names: vec!["dep".into(), "middle".into(), "app".into()],
             namespace: Some("linux/hash/debug".into()),
             cargo_lock_deps: vec![("dep".into(), "1.0.0".into())],
+            identity_key: None,
         };
 
         let plan = build_prefetch_plan(&source, &intent, "fallback")
@@ -798,6 +882,7 @@ mod tests {
             crate_names: vec!["dep".into(), "middle".into(), "app".into()],
             namespace: Some("linux/hash/debug".into()),
             cargo_lock_deps: vec![("dep".into(), "1.0.0".into())],
+            identity_key: None,
         };
 
         let plan = build_prefetch_plan(&source, &intent, "fallback")
@@ -838,6 +923,7 @@ mod tests {
             crate_names: vec!["serde".into()],
             namespace: Some("linux/hash/debug".into()),
             cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+            identity_key: None,
         };
 
         let plan = build_prefetch_plan(&source, &intent, "fallback")
@@ -867,6 +953,7 @@ mod tests {
             crate_names: vec!["dep".into(), "middle".into(), "app".into()],
             namespace: None,
             cargo_lock_deps: vec![],
+            identity_key: None,
         };
 
         let plan = build_prefetch_plan(&source, &intent, "fallback")
@@ -981,6 +1068,9 @@ mod tests {
     #[test]
     fn test_confidence_rank_orders_sources() {
         assert!(
+            CandidateSource::Manifest.confidence_rank() < CandidateSource::Shard.confidence_rank()
+        );
+        assert!(
             CandidateSource::Shard.confidence_rank() < CandidateSource::History.confidence_rank()
         );
         assert!(
@@ -1037,8 +1127,9 @@ mod tests {
         );
     }
 
-    /// Positions inside one bucket are treated as equally urgent: guppy order
-    /// only approximates demand time, so finer distinctions are false precision.
+    /// Positions inside one bucket are treated as equally urgent: lockfile
+    /// order only approximates demand time, so finer distinctions are false
+    /// precision.
     #[cfg(feature = "planning")]
     #[test]
     fn test_dispatch_order_buckets_nearby_positions_together() {

--- a/crates/kache-core/src/lib.rs
+++ b/crates/kache-core/src/lib.rs
@@ -759,14 +759,16 @@ mod tests {
             identity_key: None,
         };
 
-        let plan = build_prefetch_plan(&source, &intent, "fallback")
-            .await
-            .unwrap();
+        let (plan, composition) =
+            build_prefetch_plan_with_limits(&source, &intent, "fallback", PlanLimits::default())
+                .await
+                .unwrap();
 
         assert_eq!(plan.disposition, PrefetchDisposition::Execute);
         assert_eq!(plan.planner.as_deref(), Some("fallback"));
         assert_eq!(plan.candidates.len(), 1);
         assert_eq!(plan.candidates[0].cache_key, "from-shard");
+        assert_eq!(composition.from_shards, 1);
     }
 
     #[cfg(feature = "planning")]

--- a/crates/kache-service/src/lib.rs
+++ b/crates/kache-service/src/lib.rs
@@ -830,6 +830,7 @@ mod tests {
                             crate_names: vec!["serde".to_string()],
                             namespace: Some("linux/hash/debug".to_string()),
                             cargo_lock_deps: vec![("serde".to_string(), "1.0.0".to_string())],
+                            identity_key: None,
                         })
                         .unwrap(),
                     ))
@@ -883,6 +884,7 @@ mod tests {
                             crate_names: vec!["serde".to_string()],
                             namespace: None,
                             cargo_lock_deps: vec![],
+                            identity_key: None,
                         })
                         .unwrap(),
                     ))
@@ -923,6 +925,7 @@ mod tests {
                             crate_names: vec!["serde".to_string()],
                             namespace: None,
                             cargo_lock_deps: vec![],
+                            identity_key: None,
                         })
                         .unwrap(),
                     ))

--- a/crates/kache-service/src/state.rs
+++ b/crates/kache-service/src/state.rs
@@ -303,6 +303,13 @@ ORDER BY last_seen_at DESC;
             .take("cache_key")
             .context("decoding crate cache keys")
     }
+
+    async fn identity_candidates(&self, _identity_key: &str) -> Result<Vec<PrefetchCandidate>> {
+        // Identity manifests live on the object store the daemon reads, not in
+        // the planner's Surreal projections. An empty list lets shards/history
+        // fill the plan; the daemon fallback still fetches the object.
+        Ok(Vec::new())
+    }
 }
 
 fn dep_key(name: &str, version: &str) -> String {

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -150,7 +150,11 @@ kache save-manifest --manifest-key x86_64-linux-release
 kache save-manifest --namespace x86_64-unknown-linux-gnu/rustc-hash/release
 ```
 
-The default manifest key is the host target triple. A namespace plus `Cargo.lock` also publishes content-addressed shards.
+Without `--manifest-key`, Kache publishes an identity key
+(`id/<lock-digest>/<target>/<profile>` when `Cargo.lock` and a profile are
+known) and the host target triple so older prefetch still finds the file.
+`KACHE_MANIFEST_KEY` or `--manifest-key` writes a single key. A namespace plus
+`Cargo.lock` also publishes content-addressed shards.
 
 ## `kache daemon`
 

--- a/docs/how-it-works/architecture.mdx
+++ b/docs/how-it-works/architecture.mdx
@@ -65,6 +65,10 @@ C/C++ caching is separate. Kache must be invoked as the compiler wrapper (`kache
 
 ## Planner
 
-Without a planner service, the daemon can prefetch from manifests, Cargo metadata, remote indexes, and local history. With `cache.planner.endpoint` or `KACHE_PLANNER_ENDPOINT`, it first asks the preview planner for ranked candidates. A fallback response returns the client to its local planning path.
+Without a planner service, the daemon prefetches from a ranked list: the identity
+manifest for this lockfile + target + profile, then lockfile shards, then local
+history, then crate-name guesses. With `cache.planner.endpoint` or
+`KACHE_PLANNER_ENDPOINT`, it first asks the preview planner for ranked
+candidates. A fallback response returns the client to its local planning path.
 
 The planner does not affect local correctness or exact-key lookup. See [Remote service](/docs/remote-service).

--- a/notes/design/prefetch-budgets-and-ranking.md
+++ b/notes/design/prefetch-budgets-and-ranking.md
@@ -79,7 +79,7 @@ Admission and dispatch are separate concerns and should not share one comparator
 - **Admission** decides what is worth spending a finite budget on: confidence-weighted value
   density.
 - **Dispatch** decides what starts first: coarse urgency windows, value descending inside a
-  window. Coarse because guppy position is a weak proxy for demand time, so treating position
+  window. Coarse because lockfile/crate-name position is a weak proxy for demand time, so treating position
   40 versus 45 as meaningful is false precision while 40 versus 400 is real.
 
 The weights are guardrail constants, not measured probabilities, and they should be versioned

--- a/src/build_intent.rs
+++ b/src/build_intent.rs
@@ -301,6 +301,16 @@ mod tests {
     }
 
     #[test]
+    fn discover_entrypoint_never_returns_an_empty_default_intent() {
+        let intent = discover(None).expect("the Kache workspace should be discoverable");
+        assert!(
+            intent.crate_names.iter().any(|name| name == "kache"),
+            "expected the current workspace packages, got {:?}",
+            intent.crate_names
+        );
+    }
+
+    #[test]
     fn discover_omits_unrelated_workspace_members_absent_from_the_lock() {
         let ws = scaffold_workspace();
         let root = ws.path();

--- a/src/build_intent.rs
+++ b/src/build_intent.rs
@@ -1,18 +1,18 @@
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use crate::args::RustcArgs;
-use guppy::graph::{DependencyDirection, PackageGraph};
+use crate::identity;
 use kache_core::BuildIntent;
 
-struct MetadataDiscovery {
+struct WorkspaceDiscovery {
     crate_names: Vec<String>,
     workspace_root: Option<PathBuf>,
+    lock_path: Option<PathBuf>,
 }
 
 pub fn discover(args: Option<&RustcArgs>) -> Option<BuildIntent> {
-    let metadata = discover_metadata(args)?;
-    let crate_names = metadata.crate_names;
+    let discovery = discover_workspace(args)?;
+    let crate_names = discovery.crate_names;
     if crate_names.is_empty() {
         return None;
     }
@@ -22,20 +22,31 @@ pub fn discover(args: Option<&RustcArgs>) -> Option<BuildIntent> {
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
 
-    let lock_path = metadata
-        .workspace_root
-        .as_deref()
-        .map(|root| root.join("Cargo.lock"))
-        .unwrap_or_else(|| PathBuf::from("Cargo.lock"));
+    let lock_path = discovery.lock_path.clone().unwrap_or_else(|| {
+        discovery
+            .workspace_root
+            .as_deref()
+            .map(|root| root.join("Cargo.lock"))
+            .unwrap_or_else(|| PathBuf::from("Cargo.lock"))
+    });
     let cargo_lock_deps = namespace
         .as_ref()
         .and_then(|_| load_cargo_lock_deps(&lock_path))
         .unwrap_or_default();
 
+    let identity_key = args.and_then(|args| {
+        identity::identity_key(
+            &lock_path,
+            &identity::target_from_rustc_args(args),
+            &identity::profile_from_rustc_args(args),
+        )
+    });
+
     Some(BuildIntent {
         crate_names,
         namespace,
         cargo_lock_deps,
+        identity_key,
     })
 }
 
@@ -64,7 +75,18 @@ fn load_cargo_lock_deps(lock_path: &Path) -> Option<Vec<(String, String)>> {
         .ok()
 }
 
-fn discover_metadata(args: Option<&RustcArgs>) -> Option<MetadataDiscovery> {
+fn discover_workspace(args: Option<&RustcArgs>) -> Option<WorkspaceDiscovery> {
+    let lock_path = find_lock_path(args);
+    if let Some(lock_path) = lock_path.as_ref() {
+        let crate_names = crate_names_from_lock(lock_path)?;
+        let workspace_root = lock_path.parent().map(Path::to_path_buf);
+        return Some(WorkspaceDiscovery {
+            crate_names,
+            workspace_root,
+            lock_path: Some(lock_path.clone()),
+        });
+    }
+
     for manifest_path in candidate_manifest_paths(args) {
         if let Some(discovery) = run_cargo_metadata(Some(&manifest_path)) {
             return Some(discovery);
@@ -72,6 +94,57 @@ fn discover_metadata(args: Option<&RustcArgs>) -> Option<MetadataDiscovery> {
     }
 
     run_cargo_metadata(None)
+}
+
+fn crate_names_from_lock(lock_path: &Path) -> Option<Vec<String>> {
+    let deps = load_cargo_lock_deps(lock_path)?;
+    let mut names = Vec::new();
+    for (name, _) in deps {
+        if !names.contains(&name) {
+            names.push(name);
+        }
+    }
+    if names.is_empty() { None } else { Some(names) }
+}
+
+fn find_lock_path(args: Option<&RustcArgs>) -> Option<PathBuf> {
+    for start in candidate_roots(args) {
+        for ancestor in start.ancestors() {
+            let lock = ancestor.join("Cargo.lock");
+            if lock.is_file() {
+                return Some(lock);
+            }
+        }
+    }
+    None
+}
+
+fn candidate_roots(args: Option<&RustcArgs>) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(args) = args {
+        if let Some(root) = args.workspace_root() {
+            push_unique(&mut roots, root);
+        }
+        if let Some(out_dir) = args.out_dir.as_deref()
+            && let Some(manifest) = manifest_from_target_out_dir(out_dir)
+            && let Some(parent) = manifest.parent()
+        {
+            push_unique(&mut roots, parent.to_path_buf());
+        }
+    }
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        push_unique(&mut roots, PathBuf::from(manifest_dir));
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        push_unique(&mut roots, cwd);
+    }
+    roots
+}
+
+fn push_unique(roots: &mut Vec<PathBuf>, path: PathBuf) {
+    if !roots.iter().any(|existing| existing == &path) {
+        roots.push(path);
+    }
 }
 
 fn candidate_manifest_paths(args: Option<&RustcArgs>) -> Vec<PathBuf> {
@@ -103,10 +176,10 @@ fn manifest_from_target_out_dir(out_dir: &Path) -> Option<PathBuf> {
     None
 }
 
-fn run_cargo_metadata(manifest_path: Option<&Path>) -> Option<MetadataDiscovery> {
+fn run_cargo_metadata(manifest_path: Option<&Path>) -> Option<WorkspaceDiscovery> {
     let mut command = std::process::Command::new("cargo");
     command
-        .args(["metadata", "--format-version", "1"])
+        .args(["metadata", "--format-version", "1", "--no-deps"])
         .env_remove("RUSTC_WRAPPER")
         .env_remove("RUSTC_WORKSPACE_WRAPPER")
         .stdout(std::process::Stdio::piped())
@@ -122,123 +195,53 @@ fn run_cargo_metadata(manifest_path: Option<&Path>) -> Option<MetadataDiscovery>
         return None;
     }
 
-    parse_metadata_graph(&output.stdout, manifest_path)
+    parse_metadata_packages(&output.stdout)
 }
 
-fn parse_metadata_graph(
-    metadata_json: &[u8],
-    manifest_path: Option<&Path>,
-) -> Option<MetadataDiscovery> {
-    let graph = PackageGraph::from_json(std::str::from_utf8(metadata_json).ok()?).ok()?;
-    let crate_names = graph_crate_order(&graph, manifest_path)?;
-    let workspace_root = Some(graph.workspace().root().as_std_path().to_path_buf());
-
-    Some(MetadataDiscovery {
+fn parse_metadata_packages(metadata_json: &[u8]) -> Option<WorkspaceDiscovery> {
+    let metadata: serde_json::Value = serde_json::from_slice(metadata_json).ok()?;
+    let workspace_root = metadata
+        .get("workspace_root")
+        .and_then(serde_json::Value::as_str)
+        .map(PathBuf::from);
+    let crate_names = metadata
+        .get("packages")
+        .and_then(serde_json::Value::as_array)
+        .map(|packages| {
+            let mut names = Vec::new();
+            for package in packages {
+                if let Some(name) = package.get("name").and_then(serde_json::Value::as_str)
+                    && !names.iter().any(|existing| existing == name)
+                {
+                    names.push(name.to_string());
+                }
+            }
+            names
+        })
+        .unwrap_or_default();
+    if crate_names.is_empty() {
+        return None;
+    }
+    let lock_path = workspace_root.as_ref().map(|root| root.join("Cargo.lock"));
+    Some(WorkspaceDiscovery {
         crate_names,
         workspace_root,
+        lock_path,
     })
-}
-
-fn graph_crate_order(graph: &PackageGraph, manifest_path: Option<&Path>) -> Option<Vec<String>> {
-    let package_ids = if let Some(manifest_path) = manifest_path
-        && let Some(package) = graph
-            .packages()
-            .find(|package| paths_match(package.manifest_path().as_std_path(), manifest_path))
-    {
-        vec![package.id().clone()]
-    } else {
-        graph
-            .workspace()
-            .iter()
-            .map(|package| package.id().clone())
-            .collect::<Vec<_>>()
-    };
-
-    let package_set = graph.query_forward(package_ids.iter()).ok()?.resolve();
-    let mut seen = HashSet::new();
-    let mut ordered = Vec::new();
-
-    for package in package_set.packages(DependencyDirection::Reverse) {
-        let name = package.name().to_string();
-        if seen.insert(name.clone()) {
-            ordered.push(name);
-        }
-    }
-
-    Some(ordered)
-}
-
-fn paths_match(left: &Path, right: &Path) -> bool {
-    if left == right {
-        return true;
-    }
-
-    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
-        (Ok(left), Ok(right)) => left == right,
-        _ => false,
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_run_cargo_metadata_uses_guppy_graph_and_workspace_root() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path();
-
-        std::fs::write(
-            root.join("Cargo.toml"),
-            r#"[workspace]
-members = ["app", "dep", "unrelated"]
-resolver = "2"
-"#,
-        )
-        .unwrap();
-
-        std::fs::create_dir_all(root.join("app/src")).unwrap();
-        std::fs::write(
-            root.join("app/Cargo.toml"),
-            r#"[package]
-name = "app"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-dep = { path = "../dep" }
-"#,
-        )
-        .unwrap();
-        std::fs::write(root.join("app/src/lib.rs"), "").unwrap();
-
-        std::fs::create_dir_all(root.join("dep/src")).unwrap();
-        std::fs::write(
-            root.join("dep/Cargo.toml"),
-            r#"[package]
-name = "dep"
-version = "0.1.0"
-edition = "2021"
-"#,
-        )
-        .unwrap();
-        std::fs::write(root.join("dep/src/lib.rs"), "").unwrap();
-
-        std::fs::create_dir_all(root.join("unrelated/src")).unwrap();
-        std::fs::write(
-            root.join("unrelated/Cargo.toml"),
-            r#"[package]
-name = "unrelated"
-version = "0.1.0"
-edition = "2021"
-"#,
-        )
-        .unwrap();
-        std::fs::write(root.join("unrelated/src/lib.rs"), "").unwrap();
-
-        let discovery = run_cargo_metadata(Some(&root.join("app/Cargo.toml"))).unwrap();
-        assert_eq!(discovery.crate_names, vec!["dep", "app"]);
-        assert_eq!(discovery.workspace_root.as_deref(), Some(root));
+    fn write_lock(root: &Path, packages: &[(&str, &str)]) {
+        let mut body = String::from("version = 3\n");
+        for (name, version) in packages {
+            body.push_str(&format!(
+                "\n[[package]]\nname = \"{name}\"\nversion = \"{version}\"\n"
+            ));
+        }
+        std::fs::write(root.join("Cargo.lock"), body).unwrap();
     }
 
     #[test]
@@ -253,65 +256,18 @@ edition = "2021"
 
     #[test]
     fn test_manifest_from_target_out_dir_without_target_is_none() {
-        // No `target` component in the path -> nothing to anchor on.
         assert!(manifest_from_target_out_dir(Path::new("/repo/src/deps")).is_none());
     }
 
     #[test]
     fn test_manifest_from_target_out_dir_picks_nearest_target() {
-        // `ancestors()` walks from the leaf upward, so the *deepest* `target`
-        // wins when the path is nested (e.g. a workspace target inside a repo
-        // that itself sits under another `target`).
         let manifest =
             manifest_from_target_out_dir(Path::new("/work/target/x/inner/target/release/deps"))
                 .unwrap();
         assert_eq!(manifest, Path::new("/work/target/x/inner/Cargo.toml"));
     }
 
-    #[test]
-    fn test_paths_match_identical_paths() {
-        assert!(paths_match(
-            Path::new("/some/where/Cargo.toml"),
-            Path::new("/some/where/Cargo.toml"),
-        ));
-    }
-
-    #[test]
-    fn test_paths_match_distinct_nonexistent_paths_do_not_match() {
-        // Different paths that can't be canonicalized fall through to false.
-        assert!(!paths_match(
-            Path::new("/nonexistent/a/Cargo.toml"),
-            Path::new("/nonexistent/b/Cargo.toml"),
-        ));
-    }
-
-    // Unix-only: creating a symlink on Windows needs Developer Mode / admin
-    // privileges, which CI runners lack. The canonicalization logic under test
-    // is platform-shared and covered here on Linux/macOS.
-    #[cfg(unix)]
-    #[test]
-    fn test_paths_match_canonicalizes_equivalent_paths() {
-        // A symlink and its target canonicalize to the same real path.
-        let dir = tempfile::tempdir().unwrap();
-        let real = dir.path().join("Cargo.toml");
-        std::fs::write(&real, "").unwrap();
-        let link = dir.path().join("link.toml");
-        std::os::unix::fs::symlink(&real, &link).unwrap();
-        assert!(paths_match(&link, &real));
-    }
-
-    #[test]
-    fn test_parse_metadata_graph_rejects_invalid_json() {
-        assert!(parse_metadata_graph(b"not json at all", None).is_none());
-    }
-
-    #[test]
-    fn test_parse_metadata_graph_rejects_invalid_utf8() {
-        assert!(parse_metadata_graph(&[0xff, 0xfe, 0x00], None).is_none());
-    }
-
-    /// Build a minimal two-member cargo workspace under a temp dir and return
-    /// its root. `app` depends on `dep`.
+    /// Build a two-member cargo workspace under a temp dir and return its root.
     fn scaffold_workspace() -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
@@ -339,13 +295,10 @@ edition = "2021"
     }
 
     #[test]
-    fn discover_builds_intent_from_out_dir_args() {
-        // `discover` resolves the manifest from a rustc --out-dir that sits under
-        // a `target/` tree (candidate_manifest_paths -> manifest_from_target_out_dir),
-        // runs cargo metadata, and returns the workspace crate order. Covers
-        // discover + discover_metadata + candidate_manifest_paths end-to-end.
+    fn discover_builds_intent_from_lockfile_without_cargo_metadata() {
         let ws = scaffold_workspace();
         let root = ws.path();
+        write_lock(root, &[("app", "0.1.0"), ("dep", "0.1.0")]);
         let out_dir = root.join("target/debug/deps");
         std::fs::create_dir_all(&out_dir).unwrap();
 
@@ -357,24 +310,56 @@ edition = "2021"
         .unwrap();
 
         let intent = discover(Some(&args)).expect("discover should resolve the workspace");
-        // dep is a dependency of app, so reverse topo order lists dep before app.
         assert!(intent.crate_names.contains(&"app".to_string()));
         assert!(intent.crate_names.contains(&"dep".to_string()));
-        // No KACHE_NAMESPACE set in the common case -> no namespace, no lock deps.
         assert!(intent.namespace.is_none());
+        let key = intent
+            .identity_key
+            .expect("lockfile yields an identity key");
+        assert!(key.starts_with("id/"), "{key}");
+        assert!(key.ends_with("/debug"), "{key}");
     }
 
     #[test]
-    fn run_cargo_metadata_workspace_manifest_lists_all_members() {
-        // Passing the workspace's *virtual* root manifest (no [package]) means no
-        // single package matches, so graph_crate_order falls to the workspace-iter
-        // branch and returns every member. Covers that else branch.
+    fn discover_omits_unrelated_workspace_members_absent_from_the_lock() {
         let ws = scaffold_workspace();
-        let discovery = run_cargo_metadata(Some(&ws.path().join("Cargo.toml")))
-            .expect("metadata for workspace");
-        let mut names = discovery.crate_names.clone();
-        names.sort();
-        assert_eq!(names, vec!["app", "dep"]);
+        let root = ws.path();
+        std::fs::create_dir_all(root.join("unrelated/src")).unwrap();
+        std::fs::write(
+            root.join("unrelated/Cargo.toml"),
+            "[package]\nname = \"unrelated\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("unrelated/src/lib.rs"), "").unwrap();
+        write_lock(root, &[("app", "0.1.0"), ("dep", "0.1.0")]);
+
+        let out_dir = root.join("target/debug/deps");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        let args = RustcArgs::parse(&[
+            "rustc".to_string(),
+            "--out-dir".to_string(),
+            out_dir.to_string_lossy().into_owned(),
+        ])
+        .unwrap();
+
+        let intent = discover(Some(&args)).unwrap();
+        assert!(!intent.crate_names.contains(&"unrelated".to_string()));
+    }
+
+    #[test]
+    fn parse_metadata_packages_reads_workspace_root_and_names() {
+        let json = br#"{
+            "workspace_root": "/ws",
+            "packages": [{"name": "app"}, {"name": "dep"}, {"name": "app"}]
+        }"#;
+        let discovery = parse_metadata_packages(json).unwrap();
+        assert_eq!(discovery.crate_names, vec!["app", "dep"]);
+        assert_eq!(discovery.workspace_root.as_deref(), Some(Path::new("/ws")));
+    }
+
+    #[test]
+    fn parse_metadata_packages_rejects_invalid_json() {
+        assert!(parse_metadata_packages(b"not json at all").is_none());
     }
 
     #[test]
@@ -392,8 +377,22 @@ edition = "2021"
 
     #[test]
     fn load_cargo_lock_deps_returns_none_for_missing_lockfile() {
-        // A missing Cargo.lock surfaces the parse-error -> debug-log -> None arm.
         assert!(load_cargo_lock_deps(Path::new("/nonexistent/Cargo.lock")).is_none());
+    }
+
+    #[test]
+    fn crate_names_from_lock_dedupes_and_rejects_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        write_lock(
+            dir.path(),
+            &[("serde", "1.0.0"), ("serde", "1.0.1"), ("tokio", "1.0.0")],
+        );
+        let names = crate_names_from_lock(&dir.path().join("Cargo.lock")).unwrap();
+        assert_eq!(names, vec!["serde", "tokio"]);
+
+        let empty = tempfile::tempdir().unwrap();
+        write_lock(empty.path(), &[]);
+        assert!(crate_names_from_lock(&empty.path().join("Cargo.lock")).is_none());
     }
 
     #[test]
@@ -402,12 +401,17 @@ edition = "2021"
             crate_names: vec!["serde".into(), "tokio".into()],
             namespace: Some("x86_64/hash/release".into()),
             cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+            identity_key: Some("id/abcd/x86_64-unknown-linux-gnu/release".into()),
         };
 
         let req = into_build_started_request(intent, 42, "sess-test".into());
         assert_eq!(req.intent.crate_names, vec!["serde", "tokio"]);
         assert_eq!(req.intent.namespace.as_deref(), Some("x86_64/hash/release"));
         assert_eq!(req.intent.cargo_lock_deps.len(), 1);
+        assert_eq!(
+            req.intent.identity_key.as_deref(),
+            Some("id/abcd/x86_64-unknown-linux-gnu/release")
+        );
         assert_eq!(req.client_epoch, 42);
     }
 }

--- a/src/build_intent.rs
+++ b/src/build_intent.rs
@@ -11,7 +11,17 @@ struct WorkspaceDiscovery {
 }
 
 pub fn discover(args: Option<&RustcArgs>) -> Option<BuildIntent> {
-    let discovery = discover_workspace(args)?;
+    let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR").map(PathBuf::from);
+    let cwd = std::env::current_dir().ok();
+    discover_with_context(args, manifest_dir.as_deref(), cwd.as_deref())
+}
+
+fn discover_with_context(
+    args: Option<&RustcArgs>,
+    manifest_dir: Option<&Path>,
+    cwd: Option<&Path>,
+) -> Option<BuildIntent> {
+    let discovery = discover_workspace(args, manifest_dir, cwd)?;
     let crate_names = discovery.crate_names;
     if crate_names.is_empty() {
         return None;
@@ -75,8 +85,12 @@ fn load_cargo_lock_deps(lock_path: &Path) -> Option<Vec<(String, String)>> {
         .ok()
 }
 
-fn discover_workspace(args: Option<&RustcArgs>) -> Option<WorkspaceDiscovery> {
-    let lock_path = find_lock_path(args);
+fn discover_workspace(
+    args: Option<&RustcArgs>,
+    manifest_dir: Option<&Path>,
+    cwd: Option<&Path>,
+) -> Option<WorkspaceDiscovery> {
+    let lock_path = find_lock_path(args, manifest_dir, cwd);
     if let Some(lock_path) = lock_path.as_ref() {
         let crate_names = crate_names_from_lock(lock_path)?;
         let workspace_root = lock_path.parent().map(Path::to_path_buf);
@@ -87,7 +101,7 @@ fn discover_workspace(args: Option<&RustcArgs>) -> Option<WorkspaceDiscovery> {
         });
     }
 
-    for manifest_path in candidate_manifest_paths(args) {
+    for manifest_path in candidate_manifest_paths(args, manifest_dir, cwd) {
         if let Some(discovery) = run_cargo_metadata(Some(&manifest_path)) {
             return Some(discovery);
         }
@@ -107,8 +121,12 @@ fn crate_names_from_lock(lock_path: &Path) -> Option<Vec<String>> {
     if names.is_empty() { None } else { Some(names) }
 }
 
-fn find_lock_path(args: Option<&RustcArgs>) -> Option<PathBuf> {
-    for start in candidate_roots(args) {
+fn find_lock_path(
+    args: Option<&RustcArgs>,
+    manifest_dir: Option<&Path>,
+    cwd: Option<&Path>,
+) -> Option<PathBuf> {
+    for start in candidate_roots(args, manifest_dir, cwd) {
         for ancestor in start.ancestors() {
             let lock = ancestor.join("Cargo.lock");
             if lock.is_file() {
@@ -119,24 +137,22 @@ fn find_lock_path(args: Option<&RustcArgs>) -> Option<PathBuf> {
     None
 }
 
-fn candidate_roots(args: Option<&RustcArgs>) -> Vec<PathBuf> {
+fn candidate_roots(
+    args: Option<&RustcArgs>,
+    manifest_dir: Option<&Path>,
+    cwd: Option<&Path>,
+) -> Vec<PathBuf> {
     let mut roots = Vec::new();
-    if let Some(args) = args {
-        if let Some(root) = args.workspace_root() {
-            push_unique(&mut roots, root);
-        }
-        if let Some(out_dir) = args.out_dir.as_deref()
-            && let Some(manifest) = manifest_from_target_out_dir(out_dir)
-            && let Some(parent) = manifest.parent()
-        {
-            push_unique(&mut roots, parent.to_path_buf());
-        }
+    if let (Some(args), Some(cwd)) = (args, cwd)
+        && let Some(root) = args.verified_workspace_root(cwd)
+    {
+        push_unique(&mut roots, root);
     }
-    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
-        push_unique(&mut roots, PathBuf::from(manifest_dir));
+    if let Some(manifest_dir) = manifest_dir {
+        push_unique(&mut roots, manifest_dir.to_path_buf());
     }
-    if let Ok(cwd) = std::env::current_dir() {
-        push_unique(&mut roots, cwd);
+    if let Some(cwd) = cwd {
+        push_unique(&mut roots, cwd.to_path_buf());
     }
     roots
 }
@@ -147,33 +163,19 @@ fn push_unique(roots: &mut Vec<PathBuf>, path: PathBuf) {
     }
 }
 
-fn candidate_manifest_paths(args: Option<&RustcArgs>) -> Vec<PathBuf> {
+fn candidate_manifest_paths(
+    args: Option<&RustcArgs>,
+    manifest_dir: Option<&Path>,
+    cwd: Option<&Path>,
+) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
-
-    if let Some(out_dir) = args.and_then(|a| a.out_dir.as_deref())
-        && let Some(path) = manifest_from_target_out_dir(out_dir)
-        && path.is_file()
-    {
-        candidates.push(path);
-    }
-
-    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
-        let path = PathBuf::from(manifest_dir).join("Cargo.toml");
+    for root in candidate_roots(args, manifest_dir, cwd) {
+        let path = root.join("Cargo.toml");
         if path.is_file() && !candidates.iter().any(|existing| existing == &path) {
             candidates.push(path);
         }
     }
-
     candidates
-}
-
-fn manifest_from_target_out_dir(out_dir: &Path) -> Option<PathBuf> {
-    for ancestor in out_dir.ancestors() {
-        if ancestor.file_name().and_then(|name| name.to_str()) == Some("target") {
-            return ancestor.parent().map(|root| root.join("Cargo.toml"));
-        }
-    }
-    None
 }
 
 fn run_cargo_metadata(manifest_path: Option<&Path>) -> Option<WorkspaceDiscovery> {
@@ -244,29 +246,6 @@ mod tests {
         std::fs::write(root.join("Cargo.lock"), body).unwrap();
     }
 
-    #[test]
-    fn test_manifest_from_target_out_dir_uses_target_parent() {
-        let manifest = manifest_from_target_out_dir(Path::new(
-            "/repo/apps/tauri/src-tauri/target/release/deps",
-        ))
-        .unwrap();
-
-        assert_eq!(manifest, Path::new("/repo/apps/tauri/src-tauri/Cargo.toml"));
-    }
-
-    #[test]
-    fn test_manifest_from_target_out_dir_without_target_is_none() {
-        assert!(manifest_from_target_out_dir(Path::new("/repo/src/deps")).is_none());
-    }
-
-    #[test]
-    fn test_manifest_from_target_out_dir_picks_nearest_target() {
-        let manifest =
-            manifest_from_target_out_dir(Path::new("/work/target/x/inner/target/release/deps"))
-                .unwrap();
-        assert_eq!(manifest, Path::new("/work/target/x/inner/Cargo.toml"));
-    }
-
     /// Build a two-member cargo workspace under a temp dir and return its root.
     fn scaffold_workspace() -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();
@@ -309,7 +288,8 @@ mod tests {
         ])
         .unwrap();
 
-        let intent = discover(Some(&args)).expect("discover should resolve the workspace");
+        let intent = discover_with_context(Some(&args), Some(root), Some(root))
+            .expect("discover should resolve the workspace");
         assert!(intent.crate_names.contains(&"app".to_string()));
         assert!(intent.crate_names.contains(&"dep".to_string()));
         assert!(intent.namespace.is_none());
@@ -342,7 +322,7 @@ mod tests {
         ])
         .unwrap();
 
-        let intent = discover(Some(&args)).unwrap();
+        let intent = discover_with_context(Some(&args), Some(root), Some(root)).unwrap();
         assert!(!intent.crate_names.contains(&"unrelated".to_string()));
     }
 
@@ -378,6 +358,82 @@ mod tests {
     #[test]
     fn load_cargo_lock_deps_returns_none_for_missing_lockfile() {
         assert!(load_cargo_lock_deps(Path::new("/nonexistent/Cargo.lock")).is_none());
+    }
+
+    fn rustc_args_for_out_dir(out_dir: &Path) -> RustcArgs {
+        RustcArgs::parse(&[
+            "rustc".to_string(),
+            "--out-dir".to_string(),
+            out_dir.to_string_lossy().into_owned(),
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn find_lock_path_walks_from_out_dir_to_the_workspace_lock() {
+        let ws = scaffold_workspace();
+        write_lock(ws.path(), &[("app", "0.1.0")]);
+        let out_dir = ws.path().join("target/debug/deps");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        let found = find_lock_path(
+            Some(&rustc_args_for_out_dir(&out_dir)),
+            Some(ws.path()),
+            Some(ws.path()),
+        )
+        .unwrap();
+        assert_eq!(found, ws.path().join("Cargo.lock"));
+    }
+
+    #[test]
+    fn candidate_roots_are_nonempty_and_push_unique_dedupes() {
+        let ws = scaffold_workspace();
+        let out_dir = ws.path().join("target/debug/deps");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        let roots = candidate_roots(
+            Some(&rustc_args_for_out_dir(&out_dir)),
+            Some(ws.path()),
+            Some(ws.path()),
+        );
+        assert!(
+            roots.iter().any(|root| root == ws.path()),
+            "expected workspace root in {roots:?}"
+        );
+
+        let mut paths = vec![PathBuf::from("/a")];
+        push_unique(&mut paths, PathBuf::from("/a"));
+        push_unique(&mut paths, PathBuf::from("/b"));
+        assert_eq!(paths, vec![PathBuf::from("/a"), PathBuf::from("/b")]);
+    }
+
+    #[test]
+    fn external_target_directory_cannot_supply_the_workspace_lock() {
+        let ws = scaffold_workspace();
+        write_lock(ws.path(), &[("app", "0.1.0"), ("dep", "0.1.0")]);
+        let member = ws.path().join("app");
+
+        let external = tempfile::tempdir().unwrap();
+        std::fs::write(external.path().join("Cargo.toml"), "[workspace]\n").unwrap();
+        write_lock(external.path(), &[("wrong", "9.9.9")]);
+        let out_dir = external.path().join("target/debug/deps");
+        std::fs::create_dir_all(&out_dir).unwrap();
+
+        let found = find_lock_path(
+            Some(&rustc_args_for_out_dir(&out_dir)),
+            Some(&member),
+            Some(&member),
+        )
+        .unwrap();
+        assert_eq!(found, ws.path().join("Cargo.lock"));
+    }
+
+    #[test]
+    fn cargo_metadata_discovers_a_workspace_without_a_lockfile() {
+        let ws = scaffold_workspace();
+        let discovery = run_cargo_metadata(Some(&ws.path().join("Cargo.toml")))
+            .expect("metadata should resolve the workspace");
+        assert!(discovery.crate_names.contains(&"app".to_string()));
+        assert!(discovery.crate_names.contains(&"dep".to_string()));
+        assert_eq!(discovery.workspace_root.as_deref(), Some(ws.path()));
     }
 
     #[test]

--- a/src/build_intent.rs
+++ b/src/build_intent.rs
@@ -277,16 +277,18 @@ mod tests {
     fn candidate_manifests_keep_each_distinct_existing_manifest() {
         let first = tempfile::tempdir().unwrap();
         let second = tempfile::tempdir().unwrap();
+        let missing = tempfile::tempdir().unwrap();
         std::fs::write(first.path().join("Cargo.toml"), "[workspace]\n").unwrap();
         std::fs::write(second.path().join("Cargo.toml"), "[workspace]\n").unwrap();
 
         assert_eq!(
-            candidate_manifest_paths(None, Some(first.path()), Some(second.path())),
+            candidate_manifest_paths(None, Some(first.path()), Some(second.path()),),
             vec![
                 first.path().join("Cargo.toml"),
                 second.path().join("Cargo.toml")
             ]
         );
+        assert!(candidate_manifest_paths(None, Some(missing.path()), None).is_empty());
     }
 
     #[test]

--- a/src/build_intent.rs
+++ b/src/build_intent.rs
@@ -274,6 +274,22 @@ mod tests {
     }
 
     #[test]
+    fn candidate_manifests_keep_each_distinct_existing_manifest() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        std::fs::write(first.path().join("Cargo.toml"), "[workspace]\n").unwrap();
+        std::fs::write(second.path().join("Cargo.toml"), "[workspace]\n").unwrap();
+
+        assert_eq!(
+            candidate_manifest_paths(None, Some(first.path()), Some(second.path())),
+            vec![
+                first.path().join("Cargo.toml"),
+                second.path().join("Cargo.toml")
+            ]
+        );
+    }
+
+    #[test]
     fn discover_builds_intent_from_lockfile_without_cargo_metadata() {
         let ws = scaffold_workspace();
         let root = ws.path();

--- a/src/cargo_proxy.rs
+++ b/src/cargo_proxy.rs
@@ -118,10 +118,6 @@ pub(crate) fn run(cargo_args: Vec<OsString>) -> Result<()> {
         }
     }
 
-    if let Some(config) = publish_config_after_cargo() {
-        return run_cargo_and_publish(command, &cargo, config);
-    }
-
     #[cfg(unix)]
     {
         exec_cargo_unix(command, &cargo)
@@ -130,28 +126,6 @@ pub(crate) fn run(cargo_args: Vec<OsString>) -> Result<()> {
     {
         run_cargo_non_unix(command, &cargo)
     }
-}
-
-fn publish_config_after_cargo() -> Option<crate::config::Config> {
-    let config = crate::config::Config::load().ok()?;
-    (config.remote.is_some() && !config.remote_readonly).then_some(config)
-}
-
-fn run_cargo_and_publish(
-    mut command: Command,
-    cargo: &Path,
-    config: crate::config::Config,
-) -> Result<()> {
-    let status = command
-        .status()
-        .with_context(|| format!("running Cargo program {cargo:?}"))?;
-    if status.success() {
-        let namespace = std::env::var("KACHE_NAMESPACE").ok();
-        if let Err(error) = crate::cli::save_manifest_auto(&config, None, namespace.as_deref()) {
-            tracing::debug!("identity manifest auto-publish after cargo failed: {error:#}");
-        }
-    }
-    std::process::exit(status.code().unwrap_or(1));
 }
 
 fn real_cargo_program() -> Result<PathBuf> {

--- a/src/cargo_proxy.rs
+++ b/src/cargo_proxy.rs
@@ -118,6 +118,10 @@ pub(crate) fn run(cargo_args: Vec<OsString>) -> Result<()> {
         }
     }
 
+    if let Some(config) = publish_config_after_cargo() {
+        return run_cargo_and_publish(command, &cargo, config);
+    }
+
     #[cfg(unix)]
     {
         exec_cargo_unix(command, &cargo)
@@ -126,6 +130,28 @@ pub(crate) fn run(cargo_args: Vec<OsString>) -> Result<()> {
     {
         run_cargo_non_unix(command, &cargo)
     }
+}
+
+fn publish_config_after_cargo() -> Option<crate::config::Config> {
+    let config = crate::config::Config::load().ok()?;
+    (config.remote.is_some() && !config.remote_readonly).then_some(config)
+}
+
+fn run_cargo_and_publish(
+    mut command: Command,
+    cargo: &Path,
+    config: crate::config::Config,
+) -> Result<()> {
+    let status = command
+        .status()
+        .with_context(|| format!("running Cargo program {cargo:?}"))?;
+    if status.success() {
+        let namespace = std::env::var("KACHE_NAMESPACE").ok();
+        if let Err(error) = crate::cli::save_manifest_auto(&config, None, namespace.as_deref()) {
+            tracing::debug!("identity manifest auto-publish after cargo failed: {error:#}");
+        }
+    }
+    std::process::exit(status.code().unwrap_or(1));
 }
 
 fn real_cargo_program() -> Result<PathBuf> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5323,6 +5323,23 @@ pub fn save_manifest(
     manifest_key: Option<&str>,
     namespace: Option<&str>,
 ) -> Result<()> {
+    save_manifest_impl(config, manifest_key, namespace, true)
+}
+
+pub(crate) fn save_manifest_auto(
+    config: &Config,
+    manifest_key: Option<&str>,
+    namespace: Option<&str>,
+) -> Result<()> {
+    save_manifest_impl(config, manifest_key, namespace, false)
+}
+
+fn save_manifest_impl(
+    config: &Config,
+    manifest_key: Option<&str>,
+    namespace: Option<&str>,
+    announce: bool,
+) -> Result<()> {
     if config.remote_readonly {
         tracing::debug!("skipping manifest save (read-only mode)");
         return Ok(());
@@ -5337,13 +5354,18 @@ pub fn save_manifest(
     let entries = manifest_entries_from_events(&events);
 
     if entries.is_empty() {
-        eprintln!("No build events found, skipping manifest save");
+        if announce {
+            eprintln!("No build events found, skipping manifest save");
+        }
         return Ok(());
     }
 
-    let key = manifest_key
-        .map(String::from)
-        .unwrap_or_else(default_manifest_key);
+    let keys = match manifest_key {
+        Some(key) => vec![key.to_string()],
+        None => {
+            crate::identity::manifest_publish_keys(std::path::Path::new("Cargo.lock"), None, None)
+        }
+    };
     let env_namespace = std::env::var("KACHE_NAMESPACE")
         .ok()
         .map(|value| value.trim().to_string())
@@ -5361,20 +5383,34 @@ pub fn save_manifest(
 
     let pool_idle_secs = config.s3_pool_idle_secs;
     let entry_count = entries.len();
+    let published = keys.clone();
     rt.block_on(async {
         let backend = crate::remote_backend::create_backend(remote, pool_idle_secs).await?;
-        upload_manifest_and_shards(
-            &backend,
-            remote,
-            &key,
-            effective_namespace.as_deref(),
-            std::path::Path::new("Cargo.lock"),
-            entries,
-        )
-        .await
+        for (index, key) in keys.iter().enumerate() {
+            let shard_namespace = if index == 0 {
+                effective_namespace.as_deref()
+            } else {
+                None
+            };
+            upload_manifest_and_shards(
+                &backend,
+                remote,
+                key,
+                shard_namespace,
+                std::path::Path::new("Cargo.lock"),
+                entries.clone(),
+            )
+            .await?;
+        }
+        Ok::<(), anyhow::Error>(())
     })?;
 
-    eprintln!("Saved manifest: {entry_count} entries for '{key}'");
+    if announce {
+        eprintln!(
+            "Saved manifest: {entry_count} entries for '{}'",
+            published.join("', '")
+        );
+    }
     Ok(())
 }
 
@@ -5388,6 +5424,7 @@ fn manifest_entries_from_events(
     events: &[crate::events::BuildEvent],
 ) -> Vec<crate::remote::ManifestEntry> {
     let mut by_key = std::collections::HashMap::<String, crate::remote::ManifestEntry>::new();
+    let mut order = Vec::new();
     for e in events {
         if e.cache_key.is_empty() {
             continue;
@@ -5410,16 +5447,19 @@ fn manifest_entries_from_events(
             },
             artifact_size: e.size,
         };
-        by_key
-            .entry(e.cache_key.clone())
-            .and_modify(|existing| {
-                if entry.compile_time_ms > existing.compile_time_ms {
-                    *existing = entry.clone();
-                }
-            })
-            .or_insert(entry);
+        if let Some(existing) = by_key.get_mut(&e.cache_key) {
+            if entry.compile_time_ms > existing.compile_time_ms {
+                *existing = entry;
+            }
+        } else {
+            order.push(e.cache_key.clone());
+            by_key.insert(e.cache_key.clone(), entry);
+        }
     }
-    by_key.into_values().collect()
+    order
+        .into_iter()
+        .filter_map(|key| by_key.remove(&key))
+        .collect()
 }
 
 /// Upload the monolithic build manifest and, when a namespace is given and a
@@ -5535,20 +5575,6 @@ async fn upload_shards(
     }
 
     Ok(uploaded)
-}
-
-/// Default manifest key: host target triple at runtime.
-pub(crate) fn default_manifest_key() -> String {
-    default_manifest_key_for(std::env::consts::ARCH, std::env::consts::OS)
-}
-
-fn default_manifest_key_for(arch: &str, os: &str) -> String {
-    match os {
-        "linux" => format!("{arch}-unknown-linux-gnu"),
-        "macos" => format!("{arch}-apple-darwin"),
-        "windows" => format!("{arch}-pc-windows-msvc"),
-        _ => format!("{arch}-unknown-{os}"),
-    }
 }
 
 /// Build a workspace crate name filter from Cargo.toml metadata.
@@ -7611,40 +7637,6 @@ mod tests {
         assert!(
             err.to_string().contains("parsing"),
             "expected a parse-context error, got: {err}"
-        );
-    }
-
-    #[test]
-    fn test_default_manifest_key_matches_host_triple_shape() {
-        let key = default_manifest_key();
-        assert!(key.starts_with(std::env::consts::ARCH), "got {key}");
-        let expected_vendor_os = match std::env::consts::OS {
-            "linux" => "-unknown-linux-gnu",
-            "macos" => "-apple-darwin",
-            "windows" => "-pc-windows-msvc",
-            other => return assert!(key.contains(other)),
-        };
-        assert!(key.ends_with(expected_vendor_os), "got {key}");
-    }
-
-    #[test]
-    fn test_default_manifest_key_for_all_os_arms() {
-        // OS mapper -> linux, macOS, Windows, and fallback triples.
-        assert_eq!(
-            default_manifest_key_for("x86_64", "linux"),
-            "x86_64-unknown-linux-gnu"
-        );
-        assert_eq!(
-            default_manifest_key_for("aarch64", "macos"),
-            "aarch64-apple-darwin"
-        );
-        assert_eq!(
-            default_manifest_key_for("x86_64", "windows"),
-            "x86_64-pc-windows-msvc"
-        );
-        assert_eq!(
-            default_manifest_key_for("riscv64", "freebsd"),
-            "riscv64-unknown-freebsd"
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5323,22 +5323,41 @@ pub fn save_manifest(
     manifest_key: Option<&str>,
     namespace: Option<&str>,
 ) -> Result<()> {
-    save_manifest_impl(config, manifest_key, namespace, true)
+    save_manifest_impl(config, manifest_key, namespace, None, true, true)
 }
 
-pub(crate) fn save_manifest_auto(
+pub(crate) fn save_manifest_auto_for_session(
     config: &Config,
-    manifest_key: Option<&str>,
-    namespace: Option<&str>,
+    manifest_key: &str,
+    session_id: &str,
 ) -> Result<()> {
-    save_manifest_impl(config, manifest_key, namespace, false)
+    // The daemon does not own the calling workspace's Cargo.lock or namespace.
+    // Publish the exact session manifest only; explicit save-manifest calls own
+    // shard publication because they run from the workspace.
+    save_manifest_impl(
+        config,
+        Some(manifest_key),
+        None,
+        Some(session_id),
+        false,
+        false,
+    )
+}
+
+/// Shards are content-addressed under the first published key only. Later
+/// keys (legacy host triple, extra aliases) get the JSON manifest without
+/// duplicating shard objects.
+fn shard_namespace_for_publish_key(index: usize, namespace: Option<&str>) -> Option<&str> {
+    if index == 0 { namespace } else { None }
 }
 
 fn save_manifest_impl(
     config: &Config,
     manifest_key: Option<&str>,
     namespace: Option<&str>,
+    session_id: Option<&str>,
     announce: bool,
+    allow_env_namespace: bool,
 ) -> Result<()> {
     if config.remote_readonly {
         tracing::debug!("skipping manifest save (read-only mode)");
@@ -5351,7 +5370,7 @@ fn save_manifest_impl(
         .ok_or_else(|| anyhow::anyhow!("No remote configured"))?;
 
     let events = crate::events::read_events(&config.event_log_path())?;
-    let entries = manifest_entries_from_events(&events);
+    let entries = manifest_entries_from_events(&events, session_id);
 
     if entries.is_empty() {
         if announce {
@@ -5366,8 +5385,9 @@ fn save_manifest_impl(
             crate::identity::manifest_publish_keys(std::path::Path::new("Cargo.lock"), None, None)
         }
     };
-    let env_namespace = std::env::var("KACHE_NAMESPACE")
-        .ok()
+    let env_namespace = allow_env_namespace
+        .then(|| std::env::var("KACHE_NAMESPACE").ok())
+        .flatten()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
     let effective_namespace = namespace
@@ -5387,11 +5407,8 @@ fn save_manifest_impl(
     rt.block_on(async {
         let backend = crate::remote_backend::create_backend(remote, pool_idle_secs).await?;
         for (index, key) in keys.iter().enumerate() {
-            let shard_namespace = if index == 0 {
-                effective_namespace.as_deref()
-            } else {
-                None
-            };
+            let shard_namespace =
+                shard_namespace_for_publish_key(index, effective_namespace.as_deref());
             upload_manifest_and_shards(
                 &backend,
                 remote,
@@ -5422,10 +5439,14 @@ fn save_manifest_impl(
 /// flags). Pure — extracted so the dedup logic is unit-testable without S3.
 fn manifest_entries_from_events(
     events: &[crate::events::BuildEvent],
+    session_id: Option<&str>,
 ) -> Vec<crate::remote::ManifestEntry> {
     let mut by_key = std::collections::HashMap::<String, crate::remote::ManifestEntry>::new();
     let mut order = Vec::new();
     for e in events {
+        if session_id.is_some_and(|session_id| e.session_id != session_id) {
+            continue;
+        }
         if e.cache_key.is_empty() {
             continue;
         }
@@ -9194,6 +9215,25 @@ mod tests {
     }
 
     #[test]
+    fn automatic_manifest_save_without_remote_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = save_manifest_config(dir.path().to_path_buf(), None);
+        let err = save_manifest_auto_for_session(&config, "key", "session")
+            .expect_err("no remote -> error");
+        assert!(
+            err.to_string().contains("No remote configured"),
+            "got {err}"
+        );
+    }
+
+    #[test]
+    fn only_the_primary_manifest_key_publishes_shards() {
+        assert_eq!(shard_namespace_for_publish_key(0, Some("ns")), Some("ns"));
+        assert_eq!(shard_namespace_for_publish_key(1, Some("ns")), None);
+        assert_eq!(shard_namespace_for_publish_key(0, None), None);
+    }
+
+    #[test]
     fn save_manifest_with_no_events_returns_ok_before_touching_remote() {
         // A remote is configured, but the event log is empty, so save_manifest
         // returns Ok early ("No build events found") without creating a remote
@@ -9296,7 +9336,7 @@ mod tests {
             build_event("skip", EventResult::Skipped, 5, 0, 0, "k-s"),
         ];
 
-        let mut entries = manifest_entries_from_events(&events);
+        let mut entries = manifest_entries_from_events(&events, None);
         entries.sort_by(|a, b| a.crate_name.cmp(&b.crate_name));
 
         assert_eq!(entries.len(), 2, "only the two cacheable keys survive");
@@ -9306,11 +9346,39 @@ mod tests {
     }
 
     #[test]
+    fn manifest_entry_ties_keep_the_first_observation() {
+        use crate::events::EventResult;
+        let events = vec![
+            build_event("first", EventResult::Miss, 100, 0, 10, "same-key"),
+            build_event("second", EventResult::Miss, 100, 0, 20, "same-key"),
+        ];
+
+        let entries = manifest_entries_from_events(&events, None);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].crate_name, "first");
+        assert_eq!(entries[0].artifact_size, 10);
+    }
+
+    #[test]
+    fn automatic_manifest_entries_are_scoped_to_the_build_session() {
+        use crate::events::EventResult;
+        let mut current = build_event("current", EventResult::Miss, 100, 0, 10, "current-key");
+        current.session_id = "current-session".into();
+        let mut other = build_event("other", EventResult::Miss, 200, 0, 20, "other-key");
+        other.session_id = "other-session".into();
+
+        let entries = manifest_entries_from_events(&[other, current], Some("current-session"));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].crate_name, "current");
+        assert_eq!(entries[0].cache_key, "current-key");
+    }
+
+    #[test]
     fn manifest_entries_from_events_falls_back_to_elapsed_when_no_compile_time() {
         use crate::events::EventResult;
         // compile_time_ms == 0 -> the entry's compile_time_ms uses elapsed_ms.
         let events = vec![build_event("x", EventResult::Miss, 0, 77, 1, "k")];
-        let entries = manifest_entries_from_events(&events);
+        let entries = manifest_entries_from_events(&events, None);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].compile_time_ms, 77);
     }
@@ -9332,7 +9400,7 @@ mod tests {
             build_event("error", EventResult::Error, 99, 99, 99, "k-error"),
         ];
 
-        let mut entries = manifest_entries_from_events(&events);
+        let mut entries = manifest_entries_from_events(&events, None);
         entries.sort_by(|a, b| a.crate_name.cmp(&b.crate_name));
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].crate_name, "prefetch");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -981,8 +981,10 @@ impl PackPrefetchContext {
 
     fn from_intent(intent: &kache_core::BuildIntent) -> Option<Self> {
         let namespace = intent.namespace.as_deref()?;
-        let manifest_key = std::env::var("KACHE_MANIFEST_KEY")
-            .unwrap_or_else(|_| crate::cli::default_manifest_key());
+        let manifest_key = crate::identity::manifest_lookup_keys(intent.identity_key.as_deref())
+            .into_iter()
+            .next()
+            .unwrap_or_else(crate::identity::host_target_triple);
         Self::from_deps(manifest_key, namespace, &intent.cargo_lock_deps).ok()
     }
 }
@@ -1837,6 +1839,8 @@ pub(crate) struct ActivePlan {
     /// Cumulative LIST counters at install time, for per-session deltas.
     pub list_requests_at_install: u64,
     pub list_duration_ms_at_install: u64,
+    /// Rank-0 identity key for this session, if the wrapper sent one.
+    pub identity_key: Option<String>,
 }
 
 impl ActivePlan {
@@ -1863,6 +1867,7 @@ impl ActivePlan {
             last_activity_ms: now,
             list_requests_at_install,
             list_duration_ms_at_install,
+            identity_key: None,
         }
     }
 
@@ -2422,6 +2427,70 @@ impl Daemon {
                     &remote.prefix,
                     namespace,
                     shard_hash,
+                ),
+            )
+            .await;
+        drop(semaphore);
+        match &result {
+            Ok(_) => breaker.success(),
+            Err(error) => {
+                let class = classify_remote_error(error);
+                breaker.failure(class, &format!("{error:#}"));
+            }
+        }
+        result
+    }
+
+    /// Breaker/deadline/semaphore-aware identity-manifest fetch for the
+    /// fallback planner. Missing objects are `Ok(None)`.
+    pub(crate) async fn download_planner_manifest(
+        &self,
+        manifest_key: &str,
+    ) -> Result<Option<crate::remote::BuildManifest>> {
+        let remote = self
+            .config
+            .remote
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("no remote configured"))?;
+        let deadline = RemoteDeadline::from_secs(self.config.remote_restore_timeout_secs);
+        let breaker = self
+            .remote_breaker
+            .try_acquire(RemoteOperation::ManifestGet)
+            .ok_or_else(|| anyhow::anyhow!("remote read breaker open"))?;
+        let backend = match deadline
+            .run("planner backend initialization", self.get_remote_backend())
+            .await
+        {
+            Ok(backend) => backend,
+            Err(error) => {
+                let class = classify_remote_error(&error);
+                breaker.failure(class, &format!("{error:#}"));
+                return Err(error);
+            }
+        };
+        let semaphore = match deadline
+            .run("planner manifest queue", async {
+                self.s3_semaphore
+                    .acquire()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("remote semaphore closed"))
+            })
+            .await
+        {
+            Ok(permit) => permit,
+            Err(error) => {
+                let class = classify_remote_error(&error);
+                breaker.failure(class, &format!("{error:#}"));
+                return Err(error);
+            }
+        };
+        let result = deadline
+            .run(
+                "planner manifest GET",
+                crate::remote::try_download_manifest(
+                    backend.as_ref(),
+                    &remote.prefix,
+                    manifest_key,
                 ),
             )
             .await;
@@ -4881,9 +4950,10 @@ impl Daemon {
         plan_id: &str,
         plan_source: &'static str,
         candidates: impl Iterator<Item = String>,
+        identity_key: Option<String>,
     ) {
         let _ = self.prefetch_cancel.send(false);
-        let plan = ActivePlan::new(
+        let mut plan = ActivePlan::new(
             session_id.to_string(),
             plan_id.to_string(),
             plan_source,
@@ -4895,6 +4965,7 @@ impl Daemon {
                 .list_duration_ms_total
                 .load(Ordering::Relaxed),
         );
+        plan.identity_key = identity_key;
         let prev = {
             let mut slot = self.active_plan.lock().unwrap_or_else(|p| p.into_inner());
             slot.replace(plan)
@@ -4960,6 +5031,37 @@ impl Daemon {
         if let Err(e) = crate::events::log_summary(&path, &event) {
             tracing::debug!("failed to write build summary: {e}");
         }
+        self.maybe_publish_identity_manifest(plan.identity_key.as_deref());
+    }
+
+    /// Best-effort rank-0 publish when a session ends. Failures must not
+    /// affect the daemon: the next `save-manifest` still writes the same
+    /// events.
+    fn maybe_publish_identity_manifest(&self, identity_key: Option<&str>) {
+        let Some(identity_key) = identity_key
+            .map(str::trim)
+            .filter(|key| !key.is_empty())
+            .map(str::to_string)
+        else {
+            return;
+        };
+        if self.config.remote.is_none() || self.config.remote_readonly {
+            return;
+        }
+        let config = self.config.clone();
+        let namespace = std::env::var("KACHE_NAMESPACE").ok();
+        let publish = move || {
+            if let Err(error) =
+                crate::cli::save_manifest_auto(&config, Some(&identity_key), namespace.as_deref())
+            {
+                tracing::debug!("identity manifest auto-publish failed: {error:#}");
+            }
+        };
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn_blocking(publish);
+        } else {
+            publish();
+        }
     }
 
     pub async fn handle_build_started(self: &Arc<Self>, req: &BuildStartedRequest) -> Response {
@@ -5009,6 +5111,7 @@ impl Daemon {
                             plan_id.as_deref().unwrap_or(""),
                             "advisory",
                             prefetch_req.keys.iter().map(|(k, _)| k.clone()),
+                            req.intent.identity_key.clone(),
                         );
                         let resp = self
                             .handle_prefetch_with_context(
@@ -5095,6 +5198,7 @@ impl Daemon {
             "",
             "fallback",
             prefetch_req.keys.iter().map(|(k, _)| k.clone()),
+            req.intent.identity_key.clone(),
         );
         self.handle_prefetch_with_context(&prefetch_req, pack_context, plan_started_at)
             .await
@@ -6378,12 +6482,11 @@ async fn populate_key_cache(daemon: &Daemon) -> Result<usize> {
     Ok(count)
 }
 
-/// Download the build manifest from S3 and prefetch expensive crates.
-/// Runs once on daemon startup — filters by cost-benefit (skip cheap crates).
+/// Download recorded actions, then lockfile shards if those were missing.
 ///
-/// If `KACHE_NAMESPACE` is set and Cargo.lock is available, uses shard-based prefetch:
-/// computes shard hashes from Cargo.lock deps, downloads matching shards in parallel,
-/// and collects cache keys from them. Otherwise falls back to the monolithic build manifest.
+/// Rank 0 is the identity manifest (lock + target + profile), with the
+/// legacy host-triple key as a fallback. Rank 1 is content-addressed
+/// shards for a cold first run of this command.
 async fn manifest_prefetch(
     daemon: &Arc<Daemon>,
     namespace: Option<&str>,
@@ -6409,7 +6512,15 @@ async fn manifest_prefetch(
         }
     };
 
-    // Try shard-based prefetch first if namespace is available.
+    let identity = crate::identity::profile_from_env().and_then(|profile| {
+        crate::identity::identity_key(lock_path, &crate::identity::host_target_triple(), &profile)
+    });
+    let from_identity =
+        identity_manifest_prefetch(daemon, backend.as_ref(), remote, identity.as_deref()).await;
+    if from_identity > 0 {
+        return from_identity;
+    }
+
     if let Some(namespace) = namespace {
         if lock_path.exists() {
             match shard_prefetch(daemon, backend, &remote.prefix, namespace, lock_path).await {
@@ -6418,19 +6529,15 @@ async fn manifest_prefetch(
                     return n;
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        "shard prefetch failed, falling back to monolithic build manifest: {e}"
-                    );
+                    tracing::warn!("shard prefetch failed: {e}");
                 }
             }
         } else {
-            tracing::info!(
-                "KACHE_NAMESPACE set but no Cargo.lock found, falling back to monolithic build manifest"
-            );
+            tracing::info!("KACHE_NAMESPACE set but no Cargo.lock found");
         }
     }
 
-    monolithic_manifest_prefetch(daemon, backend.as_ref(), remote).await
+    0
 }
 
 /// Shard-based prefetch: compute shard hashes from Cargo.lock, download matching shards
@@ -6541,8 +6648,10 @@ async fn shard_prefetch_for_deps(
         keys: prefetch_keys,
         warm_all: false,
     };
-    let manifest_key =
-        std::env::var("KACHE_MANIFEST_KEY").unwrap_or_else(|_| crate::cli::default_manifest_key());
+    let manifest_key = crate::identity::manifest_lookup_keys(None)
+        .into_iter()
+        .next()
+        .unwrap_or_else(crate::identity::host_target_triple);
     let pack_context = PackPrefetchContext::from_deps(manifest_key, namespace, deps).ok();
     let resp = daemon
         .handle_prefetch_with_context(&req, pack_context, plan_started_at)
@@ -6556,65 +6665,46 @@ async fn shard_prefetch_for_deps(
     Ok(count)
 }
 
-/// Monolithic build-manifest prefetch: download the manifest and filter by compile cost.
-async fn monolithic_manifest_prefetch(
+/// Rank-0 prefetch: identity key, then the legacy host triple.
+async fn identity_manifest_prefetch(
     daemon: &Arc<Daemon>,
     backend: &dyn crate::remote_backend::RemoteBackend,
     remote: &crate::config::RemoteConfig,
+    identity_key: Option<&str>,
 ) -> usize {
-    let manifest_key =
-        std::env::var("KACHE_MANIFEST_KEY").unwrap_or_else(|_| crate::cli::default_manifest_key());
+    let mut manifest = None;
+    let mut manifest_key = String::new();
+    for key in crate::identity::manifest_lookup_keys(identity_key) {
+        match crate::remote::try_download_manifest(backend, &remote.prefix, &key).await {
+            Ok(Some(found)) => {
+                manifest_key = key;
+                manifest = Some(found);
+                break;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::debug!("manifest prefetch '{key}': {e:#}");
+            }
+        }
+    }
+    let Some(manifest) = manifest else {
+        tracing::info!("manifest prefetch: no identity or legacy manifest, skipping");
+        return 0;
+    };
 
+    identity_manifest_prefetch_from(daemon, remote, manifest_key, manifest).await
+}
+
+async fn identity_manifest_prefetch_from(
+    daemon: &Arc<Daemon>,
+    _remote: &crate::config::RemoteConfig,
+    manifest_key: String,
+    manifest: crate::remote::BuildManifest,
+) -> usize {
     let min_compile_ms: u64 = std::env::var("KACHE_MIN_COMPILE_MS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(1000);
-
-    let Some(breaker) = daemon
-        .remote_breaker
-        .try_acquire(RemoteOperation::ManifestGet)
-    else {
-        tracing::debug!("manifest prefetch suppressed by read breaker");
-        return 0;
-    };
-    let deadline = RemoteDeadline::from_secs(daemon.config.remote_restore_timeout_secs);
-    let semaphore = match deadline
-        .run("manifest GET queue", async {
-            daemon
-                .s3_semaphore
-                .acquire()
-                .await
-                .map_err(|_| anyhow::anyhow!("remote semaphore closed"))
-        })
-        .await
-    {
-        Ok(permit) => permit,
-        Err(error) => {
-            let class = classify_remote_error(&error);
-            breaker.failure(class, &format!("{error:#}"));
-            tracing::warn!("manifest prefetch queue failed: {error:#}");
-            return 0;
-        }
-    };
-    let manifest_result = deadline
-        .run(
-            "manifest GET",
-            crate::remote::download_manifest(backend, &remote.prefix, &manifest_key),
-        )
-        .await;
-    drop(semaphore);
-    let manifest = match manifest_result {
-        Ok(manifest) => {
-            breaker.success();
-            manifest
-        }
-        Err(e) => {
-            let class = classify_remote_error(&e);
-            breaker.failure(class, &format!("{e:#}"));
-            tracing::info!("manifest prefetch: no manifest for '{manifest_key}' ({e}), skipping");
-            return 0;
-        }
-    };
 
     // Cost-benefit filter: skip crates cheaper to recompile than download
     let mut worth_prefetching: Vec<_> = manifest
@@ -6628,7 +6718,7 @@ async fn monolithic_manifest_prefetch(
 
     let skipped = manifest.entries.len() - worth_prefetching.len();
     tracing::info!(
-        "manifest prefetch: {} entries, prefetching {} (skipped {} cheap crates < {}ms)",
+        "manifest prefetch '{manifest_key}': {} entries, prefetching {} (skipped {} cheap crates < {}ms)",
         manifest.entries.len(),
         worth_prefetching.len(),
         skipped,
@@ -12306,6 +12396,7 @@ mod tests {
                     crate_names: vec!["serde".into()],
                     namespace: Some("ns".into()),
                     cargo_lock_deps: vec![],
+                    identity_key: None,
                 },
                 client_epoch: 0,
                 session_id: String::new(),
@@ -12715,7 +12806,7 @@ mod tests {
     fn test_build_manifest_object_key() -> String {
         format!(
             "prefix/_manifests/{}.json",
-            crate::cli::default_manifest_key()
+            crate::identity::host_target_triple()
         )
     }
 
@@ -13106,6 +13197,7 @@ mod tests {
                 crate_names: vec!["serde".into(), "tokio".into()],
                 namespace: None,
                 cargo_lock_deps: vec![],
+                identity_key: None,
             },
             client_epoch: 0,
             session_id: String::new(),
@@ -13319,6 +13411,7 @@ mod tests {
             crate_names: vec!["serde".into()],
             namespace: Some("linux/toolchain/release".into()),
             cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+            identity_key: None,
         };
         let context = PackPrefetchContext::from_intent(&intent)
             .expect("a namespaced lockfile intent must enable catalog discovery");
@@ -13419,7 +13512,7 @@ mod tests {
         assert!(daemon.remote_backend.set(backend.clone()).is_ok());
         let deps = vec![("serde".to_string(), "1.0.0".to_string())];
         let context = PackPrefetchContext::from_deps(
-            crate::cli::default_manifest_key(),
+            crate::identity::host_target_triple(),
             "linux/toolchain/release",
             &deps,
         )
@@ -13509,7 +13602,7 @@ mod tests {
         config.remote = Some(test_remote_config());
         let inner = test_remote_backend();
         let context = PackPrefetchContext::from_deps(
-            crate::cli::default_manifest_key(),
+            crate::identity::host_target_triple(),
             "linux/toolchain/release",
             &[("serde".to_string(), "1.0.0".to_string())],
         )
@@ -13575,7 +13668,7 @@ mod tests {
         let inner = test_remote_backend();
         let deps = vec![("serde".to_string(), "1.0.0".to_string())];
         let context = PackPrefetchContext::from_deps(
-            crate::cli::default_manifest_key(),
+            crate::identity::host_target_triple(),
             "linux/toolchain/release",
             &deps,
         )
@@ -13685,7 +13778,7 @@ mod tests {
         assert!(daemon.remote_backend.set(backend.clone()).is_ok());
         let deps = vec![("serde".to_string(), "1.0.0".to_string())];
         let context = PackPrefetchContext::from_deps(
-            crate::cli::default_manifest_key(),
+            crate::identity::host_target_triple(),
             "linux/toolchain/release",
             &deps,
         )
@@ -13750,7 +13843,7 @@ mod tests {
         let daemon = Arc::new(Daemon::new(config));
         assert!(daemon.remote_backend.set(backend.clone()).is_ok());
         let context = PackPrefetchContext::from_deps(
-            crate::cli::default_manifest_key(),
+            crate::identity::host_target_triple(),
             "linux/toolchain/release",
             &[("serde".to_string(), "1.0.0".to_string())],
         )
@@ -13846,7 +13939,7 @@ mod tests {
         assert!(daemon.remote_backend.set(backend.clone()).is_ok());
         let deps = vec![("serde".to_string(), "1.0.0".to_string())];
         let context = PackPrefetchContext::from_deps(
-            crate::cli::default_manifest_key(),
+            crate::identity::host_target_triple(),
             "linux/toolchain/release",
             &deps,
         )
@@ -14408,6 +14501,7 @@ mod tests {
             "test-plan",
             "test",
             std::iter::once(key.clone()),
+            None,
         );
 
         let response = daemon
@@ -14527,7 +14621,7 @@ mod tests {
     #[tokio::test]
     async fn test_monolithic_manifest_prefetch_downloads_and_filters() {
         // Serve a build manifest whose single entry is below the prefetch cost
-        // threshold, so monolithic_manifest_prefetch downloads + parses it, then
+        // threshold, so identity_manifest_prefetch downloads + parses it, then
         // skips the cheap crate (no prefetch queued). Covers download_manifest +
         // the cost-benefit filter path.
         let dir = tempfile::tempdir().unwrap();
@@ -14538,7 +14632,7 @@ mod tests {
         let manifest = crate::remote::BuildManifest {
             version: 3,
             created: "2025-01-01T00:00:00Z".to_string(),
-            manifest_key: crate::cli::default_manifest_key(),
+            manifest_key: crate::identity::host_target_triple(),
             entries: vec![crate::remote::ManifestEntry {
                 cache_key: "cheapkey".to_string(),
                 crate_name: "cheap".to_string(),
@@ -14552,13 +14646,13 @@ mod tests {
         let daemon = Arc::new(Daemon::new(config));
 
         // Should complete without panicking and without queuing the cheap crate.
-        monolithic_manifest_prefetch(&daemon, client.as_ref(), &remote).await;
+        identity_manifest_prefetch(&daemon, client.as_ref(), &remote, None).await;
     }
 
     #[tokio::test]
     async fn test_manifest_prefetch_skips_when_no_manifest() {
-        // The mock 404s the manifest GET, so download_manifest errors and
-        // monolithic_manifest_prefetch logs + returns early. Covers the
+        // The mock 404s the manifest GET, so identity lookup finds nothing
+        // and shard fallback has no lockfile. Covers the
         // "no manifest, skipping" arm (daemon.rs 2957-2960).
         let dir = tempfile::tempdir().unwrap();
         let mut config = test_config(dir.path());
@@ -14586,7 +14680,7 @@ mod tests {
         let manifest = crate::remote::BuildManifest {
             version: 3,
             created: "2025-01-01T00:00:00Z".to_string(),
-            manifest_key: crate::cli::default_manifest_key(),
+            manifest_key: crate::identity::host_target_triple(),
             entries: vec![crate::remote::ManifestEntry {
                 cache_key: key.clone(),
                 crate_name: "expensive".to_string(),
@@ -16474,6 +16568,7 @@ mod tests {
                 crate_names: vec!["serde".into(), "tokio".into(), "anyhow".into()],
                 namespace: Some("x86_64/hash/release".into()),
                 cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+                identity_key: None,
             },
             client_epoch: 0,
             session_id: String::new(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1820,7 +1820,7 @@ const RECENT_TRANSFERS_CAP: usize = 50;
 pub(crate) struct ActivePlan {
     pub session_id: String,
     pub plan_id: String,
-    /// `advisory` | `fallback`.
+    /// `none` while only tracking a session, then `advisory` or `fallback`.
     pub plan_source: &'static str,
     pub candidates: HashSet<String>,
     /// Distinct keys demanded via RemoteCheck while this plan was active —
@@ -4953,11 +4953,12 @@ impl Daemon {
         identity_key: Option<String>,
     ) {
         let _ = self.prefetch_cancel.send(false);
+        let candidates: HashSet<String> = candidates.collect();
         let mut plan = ActivePlan::new(
             session_id.to_string(),
             plan_id.to_string(),
             plan_source,
-            candidates.collect(),
+            candidates,
             self.prefetch_stats
                 .list_requests_total
                 .load(Ordering::Relaxed),
@@ -4968,7 +4969,58 @@ impl Daemon {
         plan.identity_key = identity_key;
         let prev = {
             let mut slot = self.active_plan.lock().unwrap_or_else(|p| p.into_inner());
+            if let Some(existing) = slot.as_mut()
+                && existing.session_id == session_id
+            {
+                existing.plan_id = plan.plan_id;
+                existing.plan_source = plan.plan_source;
+                existing.candidates = plan.candidates;
+                existing.cancelled = false;
+                existing.last_activity_ms = plan.last_activity_ms;
+                if plan.identity_key.is_some() {
+                    existing.identity_key = plan.identity_key;
+                }
+                return;
+            }
             slot.replace(plan)
+        };
+        if let Some(prev) = prev {
+            self.emit_plan_summary(prev, "superseded");
+        }
+    }
+
+    /// Start tracking a build even when planning produces no candidates. The
+    /// session still owns the exact identity needed to publish its completed
+    /// events for the next cold build.
+    fn ensure_active_session(&self, req: &BuildStartedRequest) {
+        if req.session_id.trim().is_empty() {
+            return;
+        }
+        let mut plan = ActivePlan::new(
+            req.session_id.clone(),
+            String::new(),
+            "none",
+            HashSet::new(),
+            self.prefetch_stats
+                .list_requests_total
+                .load(Ordering::Relaxed),
+            self.prefetch_stats
+                .list_duration_ms_total
+                .load(Ordering::Relaxed),
+        );
+        plan.identity_key = req.intent.identity_key.clone();
+        let prev = {
+            let mut slot = self.active_plan.lock().unwrap_or_else(|p| p.into_inner());
+            match slot.as_mut() {
+                Some(existing) if existing.session_id == req.session_id => {
+                    if plan.identity_key.is_some() {
+                        existing.identity_key = plan.identity_key;
+                    }
+                    existing.last_activity_ms = epoch_ms();
+                    return;
+                }
+                _ => slot.replace(plan),
+            }
         };
         if let Some(prev) = prev {
             self.emit_plan_summary(prev, "superseded");
@@ -5001,7 +5053,7 @@ impl Daemon {
         let event = crate::events::BuildSummaryEvent {
             ts: chrono::Utc::now(),
             schema: 1,
-            session_id: plan.session_id,
+            session_id: plan.session_id.clone(),
             root: String::new(),
             plan_source: plan.plan_source.to_string(),
             plan_id: plan.plan_id,
@@ -5031,13 +5083,16 @@ impl Daemon {
         if let Err(e) = crate::events::log_summary(&path, &event) {
             tracing::debug!("failed to write build summary: {e}");
         }
-        self.maybe_publish_identity_manifest(plan.identity_key.as_deref());
+        self.maybe_publish_identity_manifest(
+            plan.identity_key.as_deref(),
+            plan.session_id.as_str(),
+        );
     }
 
     /// Best-effort rank-0 publish when a session ends. Failures must not
     /// affect the daemon: the next `save-manifest` still writes the same
     /// events.
-    fn maybe_publish_identity_manifest(&self, identity_key: Option<&str>) {
+    fn maybe_publish_identity_manifest(&self, identity_key: Option<&str>, session_id: &str) {
         let Some(identity_key) = identity_key
             .map(str::trim)
             .filter(|key| !key.is_empty())
@@ -5045,14 +5100,17 @@ impl Daemon {
         else {
             return;
         };
+        let session_id = session_id.trim().to_string();
+        if session_id.is_empty() {
+            return;
+        }
         if self.config.remote.is_none() || self.config.remote_readonly {
             return;
         }
         let config = self.config.clone();
-        let namespace = std::env::var("KACHE_NAMESPACE").ok();
         let publish = move || {
             if let Err(error) =
-                crate::cli::save_manifest_auto(&config, Some(&identity_key), namespace.as_deref())
+                crate::cli::save_manifest_auto_for_session(&config, &identity_key, &session_id)
             {
                 tracing::debug!("identity manifest auto-publish failed: {error:#}");
             }
@@ -5070,26 +5128,10 @@ impl Daemon {
         let Some(_remote) = &self.config.remote else {
             return Response::err("no remote configured");
         };
+        self.ensure_active_session(req);
         if speculative_prefetch_disabled(self.config.prefetch_enabled) {
             tracing::debug!("build-started: speculative prefetch disabled");
             return Response::ok();
-        }
-
-        // A new session supersedes the previous plan even when THIS build ends
-        // up with no plan (DoNothing, empty candidates, planning failure) —
-        // otherwise the old plan would keep absorbing the new build's demands,
-        // never go inactive, and never finalize (cross-family review finding).
-        {
-            let prev = {
-                let mut slot = self.active_plan.lock().unwrap_or_else(|p| p.into_inner());
-                match slot.as_ref() {
-                    Some(p) if p.session_id != req.session_id => slot.take(),
-                    _ => None,
-                }
-            };
-            if let Some(prev) = prev {
-                self.emit_plan_summary(prev, "superseded");
-            }
         }
 
         match crate::planner_client::resolve_prefetch_plan(&req.intent).await {
@@ -6515,8 +6557,7 @@ async fn manifest_prefetch(
     let identity = crate::identity::profile_from_env().and_then(|profile| {
         crate::identity::identity_key(lock_path, &crate::identity::host_target_triple(), &profile)
     });
-    let from_identity =
-        identity_manifest_prefetch(daemon, backend.as_ref(), remote, identity.as_deref()).await;
+    let from_identity = identity_manifest_prefetch(daemon, identity.as_deref()).await;
     if from_identity > 0 {
         return from_identity;
     }
@@ -6666,16 +6707,11 @@ async fn shard_prefetch_for_deps(
 }
 
 /// Rank-0 prefetch: identity key, then the legacy host triple.
-async fn identity_manifest_prefetch(
-    daemon: &Arc<Daemon>,
-    backend: &dyn crate::remote_backend::RemoteBackend,
-    remote: &crate::config::RemoteConfig,
-    identity_key: Option<&str>,
-) -> usize {
+async fn identity_manifest_prefetch(daemon: &Arc<Daemon>, identity_key: Option<&str>) -> usize {
     let mut manifest = None;
     let mut manifest_key = String::new();
     for key in crate::identity::manifest_lookup_keys(identity_key) {
-        match crate::remote::try_download_manifest(backend, &remote.prefix, &key).await {
+        match daemon.download_planner_manifest(&key).await {
             Ok(Some(found)) => {
                 manifest_key = key;
                 manifest = Some(found);
@@ -6692,12 +6728,11 @@ async fn identity_manifest_prefetch(
         return 0;
     };
 
-    identity_manifest_prefetch_from(daemon, remote, manifest_key, manifest).await
+    identity_manifest_prefetch_from(daemon, manifest_key, manifest).await
 }
 
 async fn identity_manifest_prefetch_from(
     daemon: &Arc<Daemon>,
-    _remote: &crate::config::RemoteConfig,
     manifest_key: String,
     manifest: crate::remote::BuildManifest,
 ) -> usize {
@@ -8879,6 +8914,38 @@ mod tests {
         assert!(plan.cancelled);
         // ...and never again for the same plan.
         assert!(!plan.record_demand("k10"));
+    }
+
+    #[test]
+    fn planned_candidates_upgrade_the_tracked_session_in_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let summary_path = config.summary_log_path();
+        let daemon = Daemon::new(config);
+        let req = BuildStartedRequest {
+            intent: kache_core::BuildIntent {
+                identity_key: Some("id/session".into()),
+                ..Default::default()
+            },
+            client_epoch: 0,
+            session_id: "session".into(),
+        };
+        daemon.ensure_active_session(&req);
+        daemon.install_plan(
+            "session",
+            "plan",
+            "fallback",
+            ["key".to_string()].into_iter(),
+            req.intent.identity_key.clone(),
+        );
+
+        let plan = daemon.active_plan.lock().unwrap();
+        let plan = plan.as_ref().unwrap();
+        assert_eq!(plan.plan_id, "plan");
+        assert_eq!(plan.plan_source, "fallback");
+        assert_eq!(plan.identity_key.as_deref(), Some("id/session"));
+        assert_eq!(plan.candidates, HashSet::from(["key".to_string()]));
+        assert!(!summary_path.exists());
     }
 
     // Tests use the same cross-platform transport as production. On Unix
@@ -13197,16 +13264,21 @@ mod tests {
                 crate_names: vec!["serde".into(), "tokio".into()],
                 namespace: None,
                 cargo_lock_deps: vec![],
-                identity_key: None,
+                identity_key: Some("id/cold-build".into()),
             },
             client_epoch: 0,
-            session_id: String::new(),
+            session_id: "cold-session".into(),
         };
         let resp = daemon.handle_build_started(&req).await;
         assert!(
             resp.ok,
             "fallback with nothing to prefetch should be ok: {resp:?}"
         );
+        let plan = daemon.active_plan.lock().unwrap();
+        let plan = plan.as_ref().expect("cold build session must be tracked");
+        assert_eq!(plan.session_id, "cold-session");
+        assert_eq!(plan.identity_key.as_deref(), Some("id/cold-build"));
+        assert!(plan.candidates.is_empty());
     }
 
     #[tokio::test]
@@ -14644,9 +14716,10 @@ mod tests {
         let client = test_remote_backend();
         put_test_object(&client, &test_build_manifest_object_key(), &body).await;
         let daemon = Arc::new(Daemon::new(config));
+        assert!(daemon.remote_backend.set(client).is_ok());
 
         // Should complete without panicking and without queuing the cheap crate.
-        identity_manifest_prefetch(&daemon, client.as_ref(), &remote, None).await;
+        identity_manifest_prefetch(&daemon, None).await;
     }
 
     #[tokio::test]
@@ -16785,7 +16858,12 @@ mod tests {
             .await;
 
         assert!(resp.ok);
-        assert!(daemon.active_plan.lock().unwrap().is_none());
+        let plan = daemon.active_plan.lock().unwrap();
+        let plan = plan
+            .as_ref()
+            .expect("disabled prefetch must still track the build session");
+        assert_eq!(plan.session_id, "disabled-prefetch");
+        assert!(plan.candidates.is_empty());
         assert_eq!(
             daemon.prefetch_stats.plans_advisory.load(Ordering::Relaxed),
             0

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2244,6 +2244,23 @@ impl GcRunReport {
     }
 }
 
+fn identity_publish_context(
+    identity_key: Option<&str>,
+    session_id: &str,
+    remote_configured: bool,
+    remote_readonly: bool,
+) -> Option<(String, String)> {
+    if !remote_configured || remote_readonly {
+        return None;
+    }
+    let identity_key = identity_key?.trim();
+    let session_id = session_id.trim();
+    if identity_key.is_empty() || session_id.is_empty() {
+        return None;
+    }
+    Some((identity_key.to_string(), session_id.to_string()))
+}
+
 impl Daemon {
     #[cfg(test)]
     pub fn new(config: Config) -> Self {
@@ -2590,6 +2607,17 @@ impl Daemon {
                 crate::remote_backend::create_backend(remote, self.config.s3_pool_idle_secs).await
             })
             .await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_remote_backend_for_test(
+        &self,
+        backend: Arc<dyn crate::remote_backend::RemoteBackend>,
+    ) {
+        assert!(
+            self.remote_backend.set(backend).is_ok(),
+            "test remote backend must be set only once"
+        );
     }
 
     /// Dispatch a parsed request to the appropriate handler (sync-only requests).
@@ -5083,7 +5111,7 @@ impl Daemon {
         if let Err(e) = crate::events::log_summary(&path, &event) {
             tracing::debug!("failed to write build summary: {e}");
         }
-        self.maybe_publish_identity_manifest(
+        let _ = self.maybe_publish_identity_manifest(
             plan.identity_key.as_deref(),
             plan.session_id.as_str(),
         );
@@ -5092,21 +5120,19 @@ impl Daemon {
     /// Best-effort rank-0 publish when a session ends. Failures must not
     /// affect the daemon: the next `save-manifest` still writes the same
     /// events.
-    fn maybe_publish_identity_manifest(&self, identity_key: Option<&str>, session_id: &str) {
-        let Some(identity_key) = identity_key
-            .map(str::trim)
-            .filter(|key| !key.is_empty())
-            .map(str::to_string)
-        else {
-            return;
+    fn maybe_publish_identity_manifest(
+        &self,
+        identity_key: Option<&str>,
+        session_id: &str,
+    ) -> bool {
+        let Some((identity_key, session_id)) = identity_publish_context(
+            identity_key,
+            session_id,
+            self.config.remote.is_some(),
+            self.config.remote_readonly,
+        ) else {
+            return false;
         };
-        let session_id = session_id.trim().to_string();
-        if session_id.is_empty() {
-            return;
-        }
-        if self.config.remote.is_none() || self.config.remote_readonly {
-            return;
-        }
         let config = self.config.clone();
         let publish = move || {
             if let Err(error) =
@@ -5120,6 +5146,7 @@ impl Daemon {
         } else {
             publish();
         }
+        true
     }
 
     pub async fn handle_build_started(self: &Arc<Self>, req: &BuildStartedRequest) -> Response {
@@ -6558,7 +6585,7 @@ async fn manifest_prefetch(
         crate::identity::identity_key(lock_path, &crate::identity::host_target_triple(), &profile)
     });
     let from_identity = identity_manifest_prefetch(daemon, identity.as_deref()).await;
-    if from_identity > 0 {
+    if identity_prefetch_satisfied(from_identity) {
         return from_identity;
     }
 
@@ -6579,6 +6606,10 @@ async fn manifest_prefetch(
     }
 
     0
+}
+
+fn identity_prefetch_satisfied(count: usize) -> bool {
+    count > 0
 }
 
 /// Shard-based prefetch: compute shard hashes from Cargo.lock, download matching shards
@@ -8602,6 +8633,56 @@ mod tests {
     use std::sync::mpsc;
 
     #[test]
+    fn identity_publish_context_requires_both_nonempty_values() {
+        assert_eq!(identity_publish_context(None, "session", true, false), None);
+        assert_eq!(
+            identity_publish_context(Some(""), "session", true, false),
+            None
+        );
+        assert_eq!(
+            identity_publish_context(Some("   "), "session", true, false),
+            None
+        );
+        assert_eq!(
+            identity_publish_context(Some("identity"), "", true, false),
+            None
+        );
+        assert_eq!(
+            identity_publish_context(Some("identity"), "   ", true, false),
+            None
+        );
+        assert_eq!(
+            identity_publish_context(Some("identity"), "session", false, false),
+            None
+        );
+        assert_eq!(
+            identity_publish_context(Some("identity"), "session", true, true),
+            None
+        );
+        assert_eq!(
+            identity_publish_context(Some("  identity  "), "  session  ", true, false),
+            Some(("identity".to_string(), "session".to_string()))
+        );
+    }
+
+    #[test]
+    fn identity_prefetch_only_short_circuits_after_queuing_work() {
+        assert!(!identity_prefetch_satisfied(0));
+        assert!(identity_prefetch_satisfied(1));
+    }
+
+    #[test]
+    fn automatic_identity_publish_reports_when_work_was_attempted() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.remote = Some(test_remote_config());
+        let daemon = Daemon::new(config);
+
+        assert!(!daemon.maybe_publish_identity_manifest(None, "session"));
+        assert!(daemon.maybe_publish_identity_manifest(Some("id/test"), "session"));
+    }
+
+    #[test]
     fn target_registration_debounce_expires_at_the_boundary() {
         let last = Instant::now();
         assert!(target_registration_is_recent(
@@ -8946,6 +9027,45 @@ mod tests {
         assert_eq!(plan.identity_key.as_deref(), Some("id/session"));
         assert_eq!(plan.candidates, HashSet::from(["key".to_string()]));
         assert!(!summary_path.exists());
+    }
+
+    #[test]
+    fn active_session_updates_in_place_and_summarizes_on_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let summary_path = config.summary_log_path();
+        let daemon = Daemon::new(config);
+        let request = |session: &str, identity: &str| BuildStartedRequest {
+            intent: kache_core::BuildIntent {
+                identity_key: Some(identity.to_string()),
+                ..Default::default()
+            },
+            client_epoch: 0,
+            session_id: session.to_string(),
+        };
+
+        daemon.ensure_active_session(&request("session-a", "id/a"));
+        daemon.ensure_active_session(&request("session-a", "id/a-updated"));
+        {
+            let plan = daemon.active_plan.lock().unwrap();
+            let plan = plan.as_ref().unwrap();
+            assert_eq!(plan.session_id, "session-a");
+            assert_eq!(plan.identity_key.as_deref(), Some("id/a-updated"));
+        }
+        assert!(!summary_path.exists());
+
+        daemon.ensure_active_session(&request("session-b", "id/b"));
+        {
+            let plan = daemon.active_plan.lock().unwrap();
+            let plan = plan.as_ref().unwrap();
+            assert_eq!(plan.session_id, "session-b");
+            assert_eq!(plan.identity_key.as_deref(), Some("id/b"));
+        }
+        let summaries = crate::events::read_summaries(&summary_path).unwrap();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].session_id, "session-a");
+        assert_eq!(summaries[0].closure_reason, "superseded");
+        assert_eq!(summaries[0].plan_source, "none");
     }
 
     // Tests use the same cross-platform transport as production. On Unix
@@ -14719,7 +14839,7 @@ mod tests {
         assert!(daemon.remote_backend.set(client).is_ok());
 
         // Should complete without panicking and without queuing the cheap crate.
-        identity_manifest_prefetch(&daemon, None).await;
+        assert_eq!(identity_manifest_prefetch(&daemon, None).await, 0);
     }
 
     #[tokio::test]

--- a/src/fallback_planner.rs
+++ b/src/fallback_planner.rs
@@ -54,6 +54,20 @@ struct LocalPlannerSource<'a> {
     daemon: &'a Arc<Daemon>,
 }
 
+fn manifest_entry_candidate(
+    entry: crate::remote::ManifestEntry,
+    index: usize,
+) -> PrefetchCandidate {
+    PrefetchCandidate {
+        cache_key: entry.cache_key,
+        crate_name: entry.crate_name,
+        compile_time_ms: (entry.compile_time_ms > 0).then_some(entry.compile_time_ms),
+        size_bytes: (entry.artifact_size > 0).then_some(entry.artifact_size),
+        source: kache_core::CandidateSource::Manifest,
+        demand_index: u32::try_from(index).ok(),
+    }
+}
+
 #[async_trait]
 impl PlannerDataSource for LocalPlannerSource<'_> {
     async fn shard_candidates(
@@ -154,16 +168,7 @@ impl PlannerDataSource for LocalPlannerSource<'_> {
                     );
                     for (index, entry) in manifest.entries.into_iter().enumerate() {
                         if seen.insert(entry.cache_key.clone()) {
-                            candidates.push(PrefetchCandidate {
-                                cache_key: entry.cache_key,
-                                crate_name: entry.crate_name,
-                                compile_time_ms: (entry.compile_time_ms > 0)
-                                    .then_some(entry.compile_time_ms),
-                                size_bytes: (entry.artifact_size > 0)
-                                    .then_some(entry.artifact_size),
-                                source: kache_core::CandidateSource::Manifest,
-                                demand_index: u32::try_from(index).ok(),
-                            });
+                            candidates.push(manifest_entry_candidate(entry, index));
                         }
                     }
                     break;
@@ -179,6 +184,38 @@ impl PlannerDataSource for LocalPlannerSource<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn manifest_entry_zero_measurements_remain_unknown() {
+        let candidate = manifest_entry_candidate(
+            crate::remote::ManifestEntry {
+                cache_key: "key".into(),
+                crate_name: "crate".into(),
+                compile_time_ms: 0,
+                artifact_size: 0,
+            },
+            7,
+        );
+        assert_eq!(candidate.compile_time_ms, None);
+        assert_eq!(candidate.size_bytes, None);
+        assert_eq!(candidate.demand_index, Some(7));
+    }
+
+    #[test]
+    fn manifest_entry_positive_measurements_are_preserved() {
+        let candidate = manifest_entry_candidate(
+            crate::remote::ManifestEntry {
+                cache_key: "key".into(),
+                crate_name: "crate".into(),
+                compile_time_ms: 12,
+                artifact_size: 34,
+            },
+            0,
+        );
+        assert_eq!(candidate.compile_time_ms, Some(12));
+        assert_eq!(candidate.size_bytes, Some(34));
+        assert_eq!(candidate.demand_index, Some(0));
+    }
 
     /// Composition is reported only when a cap actually dropped something
     /// (#616): always logging would drown the interesting case, never logging

--- a/src/fallback_planner.rs
+++ b/src/fallback_planner.rs
@@ -247,6 +247,33 @@ mod tests {
     };
     use crate::store::Store;
 
+    struct EnvRestore {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    fn set_env(key: &'static str, value: Option<&str>) -> EnvRestore {
+        let previous = std::env::var_os(key);
+        unsafe {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+        EnvRestore { key, previous }
+    }
+
     fn test_config(
         cache_dir: std::path::PathBuf,
         remote: Option<crate::config::RemoteConfig>,
@@ -359,6 +386,42 @@ mod tests {
             err.to_string().contains("no remote configured"),
             "got: {err}"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(clippy::await_holding_lock)]
+    async fn identity_candidates_return_entries_from_the_first_manifest() {
+        let _lock = crate::config::config_path_lock();
+        let _manifest_key = set_env("KACHE_MANIFEST_KEY", None);
+        let dir = tempfile::tempdir().unwrap();
+        let remote = crate::config::RemoteConfig::test_s3("bucket", "prefix");
+        let config = test_config(dir.path().join("cache"), Some(remote));
+        let backend: Arc<dyn crate::remote_backend::RemoteBackend> =
+            Arc::new(crate::remote_backend::memory_backend());
+        let manifest = crate::remote::BuildManifest {
+            version: 3,
+            created: "2026-08-30T00:00:00Z".into(),
+            manifest_key: "id/test".into(),
+            entries: vec![crate::remote::ManifestEntry {
+                cache_key: "cache-key".into(),
+                crate_name: "serde".into(),
+                compile_time_ms: 1200,
+                artifact_size: 4096,
+            }],
+        };
+        crate::remote::upload_manifest(backend.as_ref(), "prefix", "id/test", &manifest)
+            .await
+            .unwrap();
+        let daemon = Arc::new(Daemon::new(config));
+        daemon.set_remote_backend_for_test(backend);
+        let source = LocalPlannerSource { daemon: &daemon };
+
+        let candidates = source.identity_candidates("id/test").await.unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].cache_key, "cache-key");
+        assert_eq!(candidates[0].crate_name, "serde");
+        assert_eq!(candidates[0].compile_time_ms, Some(1200));
+        assert_eq!(candidates[0].size_bytes, Some(4096));
     }
 
     #[tokio::test]

--- a/src/fallback_planner.rs
+++ b/src/fallback_planner.rs
@@ -25,6 +25,7 @@ pub async fn build_prefetch_plan(
     if should_report_composition(&composition) {
         tracing::info!(
             candidates = plan.candidates.len(),
+            from_identity = composition.from_identity,
             from_shards = composition.from_shards,
             from_history = composition.from_history,
             from_key_cache = composition.from_key_cache,
@@ -139,6 +140,39 @@ impl PlannerDataSource for LocalPlannerSource<'_> {
             );
         }
         Ok(keys)
+    }
+
+    async fn identity_candidates(&self, identity_key: &str) -> Result<Vec<PrefetchCandidate>> {
+        let mut candidates = Vec::new();
+        let mut seen = HashSet::new();
+        for key in crate::identity::manifest_lookup_keys(Some(identity_key)) {
+            match self.daemon.download_planner_manifest(&key).await {
+                Ok(Some(manifest)) => {
+                    tracing::info!(
+                        "fallback planner: identity manifest '{key}' has {} entries",
+                        manifest.entries.len()
+                    );
+                    for (index, entry) in manifest.entries.into_iter().enumerate() {
+                        if seen.insert(entry.cache_key.clone()) {
+                            candidates.push(PrefetchCandidate {
+                                cache_key: entry.cache_key,
+                                crate_name: entry.crate_name,
+                                compile_time_ms: (entry.compile_time_ms > 0)
+                                    .then_some(entry.compile_time_ms),
+                                size_bytes: (entry.artifact_size > 0)
+                                    .then_some(entry.artifact_size),
+                                source: kache_core::CandidateSource::Manifest,
+                                demand_index: u32::try_from(index).ok(),
+                            });
+                        }
+                    }
+                    break;
+                }
+                Ok(None) => {}
+                Err(e) => tracing::debug!("fallback planner: identity manifest '{key}': {e}"),
+            }
+        }
+        Ok(candidates)
     }
 }
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,0 +1,447 @@
+//! Build-identity keys for rank-0 prefetch manifests.
+//!
+//! A recorded action list is only useful when the next build shares the
+//! lockfile, target, and Cargo profile. The host OS triple is not that, but
+//! older remotes still publish under it, so lookup tries the identity key
+//! first and the legacy triple second.
+
+use std::path::{Component, Path};
+
+use crate::args::RustcArgs;
+
+/// Object-key prefix that distinguishes identity manifests from host triples.
+pub const IDENTITY_KEY_PREFIX: &str = "id/";
+
+/// Hex characters of the lockfile digest embedded in the identity key.
+const LOCK_DIGEST_HEX: usize = 16;
+
+/// Content hash of `Cargo.lock`, truncated for object keys.
+pub fn lockfile_digest(path: &Path) -> Option<String> {
+    let bytes = std::fs::read(path).ok()?;
+    if bytes.is_empty() {
+        return None;
+    }
+    let hex = blake3::hash(&bytes).to_hex();
+    Some(hex[..LOCK_DIGEST_HEX].to_string())
+}
+
+/// Host target triple used as the pre-identity default manifest key.
+pub fn host_target_triple() -> String {
+    host_target_triple_for(std::env::consts::ARCH, std::env::consts::OS)
+}
+
+pub(crate) fn host_target_triple_for(arch: &str, os: &str) -> String {
+    match os {
+        "linux" => format!("{arch}-unknown-linux-gnu"),
+        "macos" => format!("{arch}-apple-darwin"),
+        "windows" => format!("{arch}-pc-windows-msvc"),
+        _ => format!("{arch}-unknown-{os}"),
+    }
+}
+
+fn sanitize_key_component(value: &str) -> String {
+    value.replace(['/', '\\'], "_")
+}
+
+/// `id/{lock16}/{target}/{profile}` when the lockfile can be read.
+pub fn identity_key(lock_path: &Path, target: &str, profile: &str) -> Option<String> {
+    let digest = lockfile_digest(lock_path)?;
+    let target = sanitize_key_component(target);
+    let profile = sanitize_key_component(profile);
+    if target.is_empty() || profile.is_empty() {
+        return None;
+    }
+    Some(format!("{IDENTITY_KEY_PREFIX}{digest}/{target}/{profile}"))
+}
+
+/// Cargo profile directory under `target/` (`debug`, `release`, …).
+pub fn profile_from_rustc_args(args: &RustcArgs) -> String {
+    if let (Some(out_dir), Some(target_dir)) = (args.out_dir.as_deref(), args.target_dir())
+        && let Some(profile) = profile_between(&target_dir, out_dir, args.target.is_some())
+    {
+        return profile;
+    }
+    profile_from_env().unwrap_or_else(|| "unknown".to_string())
+}
+
+pub fn profile_from_env() -> Option<String> {
+    for var in ["KACHE_PROFILE", "PROFILE"] {
+        if let Ok(value) = std::env::var(var) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn profile_between(target_dir: &Path, out_dir: &Path, is_cross: bool) -> Option<String> {
+    let rel = out_dir.strip_prefix(target_dir).ok()?;
+    let mut names = rel.components().filter_map(|component| match component {
+        Component::Normal(name) => name.to_str(),
+        _ => None,
+    });
+    if is_cross {
+        names.next()?;
+    }
+    names.next().map(str::to_string)
+}
+
+/// rustc `--target`, else the host triple.
+pub fn target_from_rustc_args(args: &RustcArgs) -> String {
+    args.target
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(host_target_triple)
+}
+
+pub fn explicit_manifest_key() -> Option<String> {
+    std::env::var("KACHE_MANIFEST_KEY")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// Keys to fetch, most specific first. `KACHE_MANIFEST_KEY` wins alone.
+pub fn manifest_lookup_keys(identity: Option<&str>) -> Vec<String> {
+    if let Some(explicit) = explicit_manifest_key() {
+        return vec![explicit];
+    }
+    let mut keys = Vec::new();
+    if let Some(identity) = identity.map(str::trim).filter(|value| !value.is_empty()) {
+        keys.push(identity.to_string());
+    }
+    let legacy = host_target_triple();
+    if !keys.iter().any(|key| key == &legacy) {
+        keys.push(legacy);
+    }
+    keys
+}
+
+/// Keys to publish. Explicit env/flag is a single key; otherwise identity
+/// (when lock + profile are known) plus the legacy host triple so older
+/// prefetch still finds this build.
+pub fn manifest_publish_keys(
+    lock_path: &Path,
+    target: Option<&str>,
+    profile: Option<&str>,
+) -> Vec<String> {
+    if let Some(explicit) = explicit_manifest_key() {
+        return vec![explicit];
+    }
+    let mut keys = Vec::new();
+    let target = target
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(host_target_triple);
+    if let Some(profile) = profile
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(profile_from_env)
+        && let Some(identity) = identity_key(lock_path, &target, &profile)
+    {
+        keys.push(identity);
+    }
+    let legacy = host_target_triple();
+    if !keys.iter().any(|key| key == &legacy) {
+        keys.push(legacy);
+    }
+    keys
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn lockfile_digest_is_stable_and_absent_for_missing_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        std::fs::write(&lock, "version = 3\n").unwrap();
+        let first = lockfile_digest(&lock).unwrap();
+        let second = lockfile_digest(&lock).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.len(), LOCK_DIGEST_HEX);
+        assert!(lockfile_digest(&dir.path().join("missing.lock")).is_none());
+    }
+
+    #[test]
+    fn identity_key_embeds_lock_target_and_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        std::fs::write(&lock, "version = 3\n").unwrap();
+        let key = identity_key(&lock, "x86_64-unknown-linux-gnu", "release").unwrap();
+        assert!(key.starts_with(IDENTITY_KEY_PREFIX), "{key}");
+        assert!(key.contains("/x86_64-unknown-linux-gnu/release"), "{key}");
+        assert!(!key.contains('\\'), "{key}");
+    }
+
+    #[test]
+    fn identity_key_sanitizes_path_separators() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        std::fs::write(&lock, "version = 3\n").unwrap();
+        let key = identity_key(&lock, "thumbv7em-none-eabihf", "custom/profile").unwrap();
+        assert!(key.ends_with("/custom_profile"), "{key}");
+        assert!(!key.contains("custom/profile"), "{key}");
+    }
+
+    #[test]
+    fn host_target_triple_for_known_oses() {
+        assert_eq!(
+            host_target_triple_for("x86_64", "linux"),
+            "x86_64-unknown-linux-gnu"
+        );
+        assert_eq!(
+            host_target_triple_for("aarch64", "macos"),
+            "aarch64-apple-darwin"
+        );
+        assert_eq!(
+            host_target_triple_for("x86_64", "windows"),
+            "x86_64-pc-windows-msvc"
+        );
+        assert_eq!(
+            host_target_triple_for("riscv64", "freebsd"),
+            "riscv64-unknown-freebsd"
+        );
+    }
+
+    #[test]
+    fn profile_between_reads_cargo_layout() {
+        let target = PathBuf::from("/ws/target");
+        assert_eq!(
+            profile_between(&target, Path::new("/ws/target/debug/deps"), false).as_deref(),
+            Some("debug")
+        );
+        assert_eq!(
+            profile_between(
+                &target,
+                Path::new("/ws/target/x86_64-unknown-linux-gnu/release/deps"),
+                true
+            )
+            .as_deref(),
+            Some("release")
+        );
+        assert!(profile_between(&target, Path::new("/elsewhere/debug/deps"), false).is_none());
+    }
+
+    #[test]
+    fn lookup_keys_try_identity_then_legacy() {
+        let keys = manifest_lookup_keys(Some("id/abcd/x86_64-unknown-linux-gnu/release"));
+        assert_eq!(keys[0], "id/abcd/x86_64-unknown-linux-gnu/release");
+        assert_eq!(
+            keys[1],
+            host_target_triple_for(std::env::consts::ARCH, std::env::consts::OS)
+        );
+        assert_eq!(keys.len(), 2);
+    }
+
+    #[test]
+    fn lookup_keys_dedupe_when_identity_is_the_legacy_triple() {
+        let legacy = host_target_triple_for(std::env::consts::ARCH, std::env::consts::OS);
+        let keys = manifest_lookup_keys(Some(&legacy));
+        assert_eq!(keys, vec![legacy]);
+    }
+
+    #[test]
+    fn host_target_triple_matches_consts() {
+        let got = host_target_triple();
+        assert_eq!(
+            got,
+            host_target_triple_for(std::env::consts::ARCH, std::env::consts::OS)
+        );
+        assert!(!got.is_empty());
+        assert_ne!(got, "xyzzy");
+    }
+
+    #[test]
+    fn lockfile_digest_rejects_empty_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        std::fs::write(&lock, "").unwrap();
+        assert!(lockfile_digest(&lock).is_none());
+        assert!(identity_key(&lock, "x86_64-unknown-linux-gnu", "debug").is_none());
+    }
+
+    #[test]
+    fn identity_key_rejects_empty_target_or_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        std::fs::write(&lock, "version = 3\n").unwrap();
+        assert!(identity_key(&lock, "", "release").is_none());
+        assert!(identity_key(&lock, "x86_64-unknown-linux-gnu", "").is_none());
+    }
+
+    #[test]
+    fn lookup_keys_legacy_only_when_identity_is_blank() {
+        let legacy = host_target_triple_for(std::env::consts::ARCH, std::env::consts::OS);
+        assert_eq!(manifest_lookup_keys(None), vec![legacy.clone()]);
+        assert_eq!(manifest_lookup_keys(Some("   ")), vec![legacy]);
+    }
+
+    struct EnvRestore {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            unsafe {
+                match self.previous.as_ref() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    fn set_env(key: &'static str, value: Option<&str>) -> EnvRestore {
+        let previous = std::env::var_os(key);
+        unsafe {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+        EnvRestore { key, previous }
+    }
+
+    #[test]
+    fn explicit_manifest_key_trims_and_ignores_blank() {
+        let _lock = crate::config::config_path_lock();
+        let _guard = set_env("KACHE_MANIFEST_KEY", None);
+        assert!(explicit_manifest_key().is_none());
+        let _set = set_env("KACHE_MANIFEST_KEY", Some("  mine  "));
+        assert_eq!(explicit_manifest_key().as_deref(), Some("mine"));
+        drop(_set);
+        let _blank = set_env("KACHE_MANIFEST_KEY", Some("   "));
+        assert!(explicit_manifest_key().is_none());
+    }
+
+    #[test]
+    fn lookup_keys_explicit_env_wins_alone() {
+        let _lock = crate::config::config_path_lock();
+        let _guard = set_env("KACHE_MANIFEST_KEY", Some("only-this"));
+        assert_eq!(
+            manifest_lookup_keys(Some("id/abcd/x86_64-unknown-linux-gnu/release")),
+            vec!["only-this".to_string()]
+        );
+    }
+
+    #[test]
+    fn publish_keys_identity_then_legacy() {
+        let _lock = crate::config::config_path_lock();
+        let _clear_key = set_env("KACHE_MANIFEST_KEY", None);
+        let _clear_profile = set_env("KACHE_PROFILE", None);
+        let _clear_cargo_profile = set_env("PROFILE", None);
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        std::fs::write(&lock, "version = 3\n").unwrap();
+        let keys = manifest_publish_keys(&lock, Some("x86_64-unknown-linux-gnu"), Some("release"));
+        assert_eq!(
+            keys[0],
+            identity_key(&lock, "x86_64-unknown-linux-gnu", "release").unwrap()
+        );
+        assert_eq!(
+            keys[1],
+            host_target_triple_for(std::env::consts::ARCH, std::env::consts::OS)
+        );
+        assert_eq!(keys.len(), 2);
+    }
+
+    #[test]
+    fn publish_keys_explicit_env_wins_alone() {
+        let _lock = crate::config::config_path_lock();
+        let _guard = set_env("KACHE_MANIFEST_KEY", Some("forced"));
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        std::fs::write(&lock, "version = 3\n").unwrap();
+        assert_eq!(
+            manifest_publish_keys(&lock, Some("x86_64-unknown-linux-gnu"), Some("release")),
+            vec!["forced".to_string()]
+        );
+    }
+
+    #[test]
+    fn publish_keys_skip_identity_without_profile() {
+        let _lock = crate::config::config_path_lock();
+        let _clear_key = set_env("KACHE_MANIFEST_KEY", None);
+        let _clear_profile = set_env("KACHE_PROFILE", None);
+        let _clear_cargo_profile = set_env("PROFILE", None);
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        std::fs::write(&lock, "version = 3\n").unwrap();
+        let keys = manifest_publish_keys(&lock, Some("x86_64-unknown-linux-gnu"), None);
+        assert_eq!(
+            keys,
+            vec![host_target_triple_for(
+                std::env::consts::ARCH,
+                std::env::consts::OS
+            )]
+        );
+    }
+
+    #[test]
+    fn profile_from_env_prefers_kache_profile() {
+        let _lock = crate::config::config_path_lock();
+        let _clear_kache = set_env("KACHE_PROFILE", Some("  bench  "));
+        let _clear_cargo = set_env("PROFILE", Some("release"));
+        assert_eq!(profile_from_env().as_deref(), Some("bench"));
+        drop(_clear_kache);
+        let _blank = set_env("KACHE_PROFILE", Some("  "));
+        assert_eq!(profile_from_env().as_deref(), Some("release"));
+        drop(_blank);
+        drop(_clear_cargo);
+        let _none_kache = set_env("KACHE_PROFILE", None);
+        let _none_cargo = set_env("PROFILE", None);
+        assert!(profile_from_env().is_none());
+    }
+
+    #[test]
+    fn target_from_rustc_args_prefers_explicit_target() {
+        let args = crate::args::RustcArgs::parse(&[
+            "rustc".to_string(),
+            "--target".to_string(),
+            "wasm32-unknown-unknown".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(target_from_rustc_args(&args), "wasm32-unknown-unknown");
+        let host = crate::args::RustcArgs::parse(&[
+            "rustc".to_string(),
+            "--edition".to_string(),
+            "2021".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(
+            target_from_rustc_args(&host),
+            host_target_triple_for(std::env::consts::ARCH, std::env::consts::OS)
+        );
+    }
+
+    #[test]
+    fn profile_from_rustc_args_reads_out_dir() {
+        let _lock = crate::config::config_path_lock();
+        let _clear_kache = set_env("KACHE_PROFILE", None);
+        let _clear_cargo = set_env("PROFILE", None);
+        let args = crate::args::RustcArgs::parse(&[
+            "rustc".to_string(),
+            "--out-dir".to_string(),
+            "/ws/target/release/deps".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(profile_from_rustc_args(&args), "release");
+        let unknown = crate::args::RustcArgs::parse(&[
+            "rustc".to_string(),
+            "--edition".to_string(),
+            "2021".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(profile_from_rustc_args(&unknown), "unknown");
+    }
+}

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -388,6 +388,22 @@ mod tests {
     }
 
     #[test]
+    fn publish_keys_use_host_target_when_explicit_target_is_blank() {
+        let _lock = crate::config::config_path_lock();
+        let _clear_key = set_env("KACHE_MANIFEST_KEY", None);
+        let _clear_profile = set_env("KACHE_PROFILE", None);
+        let _clear_cargo_profile = set_env("PROFILE", None);
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("Cargo.lock");
+        std::fs::write(&lock, "version = 3\n").unwrap();
+
+        assert_eq!(
+            manifest_publish_keys(&lock, Some("   "), Some("release")),
+            manifest_publish_keys(&lock, None, Some("release"))
+        );
+    }
+
+    #[test]
     fn profile_from_env_prefers_kache_profile() {
         let _lock = crate::config::config_path_lock();
         let _clear_kache = set_env("KACHE_PROFILE", Some("  bench  "));

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod eviction;
 mod extra_inputs;
 mod fallback_planner;
 mod heartbeat;
+mod identity;
 mod incremental_policy;
 mod link;
 mod machine;
@@ -245,7 +246,7 @@ enum Commands {
 
     /// Save a build manifest for future prefetch warming
     SaveManifest {
-        /// Override manifest key (default: host target triple)
+        /// Override manifest key (default: identity key plus host triple)
         #[arg(long)]
         manifest_key: Option<String>,
         /// Shard namespace: target/rustc_hash/profile. If set and Cargo.lock exists,

--- a/src/planner_client.rs
+++ b/src/planner_client.rs
@@ -162,6 +162,7 @@ mod tests {
             crate_names: vec!["serde".into()],
             namespace: Some("ns".into()),
             cargo_lock_deps: vec![("serde".into(), "1.0.0".into())],
+            identity_key: None,
         };
 
         let plan = resolve_prefetch_plan_with_config(&config, &req)
@@ -190,6 +191,7 @@ mod tests {
             crate_names: vec!["serde".into()],
             namespace: None,
             cargo_lock_deps: vec![],
+            identity_key: None,
         };
 
         let err = resolve_prefetch_plan_with_config(&config, &req)
@@ -217,6 +219,7 @@ mod tests {
             crate_names: vec!["serde".into()],
             namespace: None,
             cargo_lock_deps: vec![],
+            identity_key: None,
         };
 
         let plan = resolve_prefetch_plan_with_config(&config, &req)

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -98,21 +98,24 @@ pub struct Shard {
 /// is missing or under-reported.
 const MAX_METADATA_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
 
-pub async fn download_manifest(
+pub async fn try_download_manifest(
     backend: &dyn RemoteBackend,
     prefix: &str,
     manifest_key: &str,
-) -> Result<BuildManifest> {
+) -> Result<Option<BuildManifest>> {
     let object_key =
         crate::config::join_remote_key(prefix, &format!("{MANIFEST_PREFIX}/{manifest_key}.json"));
 
-    let fetched = backend
+    let Some(fetched) = backend
         .get(&object_key, Some(MAX_METADATA_BYTES))
         .await
         .context("downloading manifest")?
-        .with_context(|| format!("manifest not found: {}", backend.describe(&object_key)))?;
+    else {
+        return Ok(None);
+    };
 
-    serde_json::from_slice(&fetched.body).context("parsing manifest JSON")
+    let manifest = serde_json::from_slice(&fetched.body).context("parsing manifest JSON")?;
+    Ok(Some(manifest))
 }
 
 pub async fn upload_manifest(
@@ -292,9 +295,10 @@ mod tests {
             .await
             .unwrap();
 
-        let got = download_manifest(&backend, "prefix", "key")
+        let got = try_download_manifest(&backend, "prefix", "key")
             .await
-            .expect("download should succeed");
+            .expect("download should succeed")
+            .expect("manifest present");
         assert_eq!(got.entries.len(), 1);
         assert_eq!(got.entries[0].crate_name, "serde");
     }


### PR DESCRIPTION
## Summary

Prefetch now has one ranked pipeline instead of a guppy graph walk plus a separate host-triple manifest.

- Session start reads `Cargo.lock` for crate names (and `--no-deps` metadata only if there is no lock). The `guppy` crate is gone.
- Candidates are merged in confidence order: identity manifest (`id/<lock-digest>/<target>/<profile>`) → lockfile shards → local history → crate-name key-cache.
- `save-manifest` writes the identity key and the legacy host triple unless `--manifest-key` / `KACHE_MANIFEST_KEY` is set. A successful `kache cargo` and an ended daemon session publish the same list.

Exact-key lookup and OpenDAL are unchanged. `prefetch_enabled=false` still turns speculation off.

## Test plan

- [x] `cargo test -p kache-core --lib`
- [x] Focused `kache` unit tests: `build_intent`, `identity`, `save-manifest` defaults, daemon prefetch / `BuildStarted`
- [ ] `just check` (fmt + clippy + full test suite) — run in CI
- [x] `cargo tree -p kache -i guppy` fails (crate no longer in the binary graph)