### PR TITLE
feat(gc): default local_max_size to 5% of the cache disk

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -178,6 +178,11 @@ gitignore = true
 # while the diff mutation lane runs on Ubuntu. macOS tests exercise both SDK
 # discovery and the real flag wrapper. Exclude only the platform wrappers; the
 # extracted flag logic and key folding remain mutation-tested on every host.
+#
+# `cache_fs` also has thin macOS and Windows syscall wrappers which this Ubuntu
+# lane cannot compile. Their sizing and validation rules are extracted into
+# platform-neutral helpers and stay mutation-tested here; hosted platform tests
+# exercise the real wrappers.
 exclude_re = [
     "replace run_config_editor",
     "replace run_monitor",
@@ -221,4 +226,7 @@ exclude_re = [
     "replace run_pull_bench .* with Ok",
     "replace run_sccache_bench .* with Ok",
     "replace run_cold_phase .* with Ok",
+    "src/cache_fs.rs:.*replace probe_windows",
+    "src/cache_fs.rs:.*replace statfs_total_bytes_macos",
+    "src/cache_fs.rs:.*replace volume_total_bytes_windows",
 ]

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -29,7 +29,6 @@ The editor covers common fields and preserves advanced tables it does not expose
 
 ```toml title="~/.config/kache/config.toml"
 [cache]
-local_max_size = "50GiB"
 cache_executables = true
 
 [cache.remote]
@@ -47,7 +46,7 @@ Use `type = "filesystem"` with `path = "/mnt/kache"` for a shared filesystem rem
 | `KACHE_CACHE_DIR` | `cache.local_store` | OS cache directory | Persistent store |
 | `KACHE_RUNTIME_DIR` | `cache.runtime_dir` | local store | Socket, locks, logs, state, and session markers |
 | `KACHE_SOCKET_PATH` | none | `<runtime_dir>/daemon.sock` | Absolute daemon endpoint override |
-| `KACHE_MAX_SIZE` | `cache.local_max_size` | `50GiB` | Registered blob bytes allowed before GC |
+| `KACHE_MAX_SIZE` | `cache.local_max_size` | 5% of the cache disk, floored at 5GiB and capped at 100GiB | Registered blob bytes allowed before GC. An explicit size always wins. `none` is not allowed. |
 | `KACHE_AUTO_GC` | `cache.auto_gc` | `true` | Spawn throttled background GC under size pressure |
 | `KACHE_GC_MAX_AGE_HOURS` | `cache.gc_max_age_hours` | `0` | Automatic age retention; `0` disables it |
 | `KACHE_GC_EVICT_SHARED` | `cache.gc_evict_shared` | `false` | Restore namespace-first GC for entries retained by build outputs |

--- a/src/cache_fs.rs
+++ b/src/cache_fs.rs
@@ -141,10 +141,7 @@ pub fn probe(path: &Path) -> FsProbe {
 /// A zero block size is `None` (the kernel did not report a size), not a
 /// zero-byte disk. Overflow is `None`. Pure so the cases are tested on every
 /// platform, not only the OS whose `statfs` produced the numbers.
-#[cfg_attr(
-    not(any(target_os = "macos", target_os = "linux")),
-    allow(dead_code)
-)]
+#[cfg_attr(not(any(target_os = "macos", target_os = "linux")), allow(dead_code))]
 fn disk_bytes(block_size: u64, blocks: u64) -> Option<u64> {
     if block_size == 0 {
         return None;

--- a/src/cache_fs.rs
+++ b/src/cache_fs.rs
@@ -46,6 +46,10 @@ pub struct FsProbe {
     /// Whether the filesystem is host-local. `None` means "could not tell" and
     /// must not be read as either answer.
     pub is_local: Option<bool>,
+    /// Total bytes of the volume that holds the path. `None` when the probe
+    /// could not measure it. Used for the disk-share store budget, not for
+    /// locality classification.
+    pub total_bytes: Option<u64>,
 }
 
 impl FsProbe {
@@ -145,6 +149,7 @@ fn probe_impl(path: &Path) -> FsProbe {
     FsProbe {
         name: c_str_field_to_string(&stat.f_fstypename),
         is_local: Some(stat.f_flags & (libc::MNT_LOCAL as u32) != 0),
+        total_bytes: statfs_total_bytes(&stat),
     }
 }
 
@@ -175,7 +180,9 @@ fn probe_impl(path: &Path) -> FsProbe {
     // rather than "cleaned up" into a musl build failure.
     #[allow(clippy::unnecessary_cast)]
     let magic = stat.f_type as i64;
-    classify_linux_magic(magic)
+    let mut probe = classify_linux_magic(magic);
+    probe.total_bytes = statfs_total_bytes(&stat);
+    probe
 }
 
 /// Linux superblock magics, from the kernel's `include/uapi/linux/magic.h`.
@@ -233,6 +240,7 @@ fn classify_linux_magic(magic: i64) -> FsProbe {
     let named = |name: &str, is_local: bool| FsProbe {
         name: Some(name.to_string()),
         is_local: Some(is_local),
+        total_bytes: None,
     };
 
     match magic {
@@ -263,6 +271,27 @@ fn classify_linux_magic(magic: i64) -> FsProbe {
         magic::OVERLAYFS => named("overlayfs", true),
         _ => FsProbe::unknown(),
     }
+}
+
+#[cfg(target_os = "macos")]
+fn statfs_total_bytes(stat: &libc::statfs) -> Option<u64> {
+    let bsize = u64::from(stat.f_bsize);
+    if bsize == 0 {
+        return None;
+    }
+    stat.f_blocks.checked_mul(bsize)
+}
+
+#[cfg(target_os = "linux")]
+fn statfs_total_bytes(stat: &libc::statfs) -> Option<u64> {
+    let frag = if stat.f_frsize > 0 {
+        stat.f_frsize
+    } else {
+        stat.f_bsize
+    };
+    let frag = u64::try_from(frag).ok().filter(|&n| n > 0)?;
+    let blocks = u64::try_from(stat.f_blocks).ok()?;
+    blocks.checked_mul(frag)
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -316,6 +345,7 @@ fn probe_impl(path: &Path) -> FsProbe {
         return FsProbe {
             name: Some("a network share (UNC path)".to_string()),
             is_local: Some(false),
+            total_bytes: volume_total_bytes(&target),
         };
     }
 
@@ -359,7 +389,29 @@ fn probe_impl(path: &Path) -> FsProbe {
         String::from_utf16_lossy(&fs_name[..len])
     });
 
-    FsProbe { name, is_local }
+    FsProbe {
+        name,
+        is_local,
+        total_bytes: volume_total_bytes(&target),
+    }
+}
+
+#[cfg(windows)]
+fn volume_total_bytes(path: &Path) -> Option<u64> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
+
+    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    let mut total: u64 = 0;
+    let ok = unsafe {
+        GetDiskFreeSpaceExW(
+            wide.as_ptr(),
+            std::ptr::null_mut(),
+            &mut total,
+            std::ptr::null_mut(),
+        )
+    };
+    (ok != 0 && total > 0).then_some(total)
 }
 
 /// Volume mount root (`C:\`) holding `path`. Mirrors `link::windows_volume_root`
@@ -408,6 +460,7 @@ mod tests {
         let probe = FsProbe {
             name: Some("apfs".to_string()),
             is_local: Some(true),
+            total_bytes: None,
         };
         assert_eq!(classify(&probe), CacheFsVerdict::Local);
     }
@@ -417,6 +470,7 @@ mod tests {
         let probe = FsProbe {
             name: Some("nfs".to_string()),
             is_local: Some(false),
+            total_bytes: None,
         };
         assert_eq!(
             classify(&probe),
@@ -431,6 +485,7 @@ mod tests {
         let probe = FsProbe {
             name: None,
             is_local: Some(false),
+            total_bytes: None,
         };
         let CacheFsVerdict::NotLocal { name } = classify(&probe) else {
             panic!("a non-local filesystem must warn even when unnamed");
@@ -448,6 +503,7 @@ mod tests {
         let named_but_unplaced = FsProbe {
             name: Some("weirdfs".to_string()),
             is_local: None,
+            total_bytes: None,
         };
         assert_eq!(classify(&named_but_unplaced), CacheFsVerdict::Unknown);
     }
@@ -488,6 +544,7 @@ mod tests {
             &FsProbe {
                 name: Some("nfs".to_string()),
                 is_local: Some(false),
+                total_bytes: None,
             },
             dir,
         );
@@ -502,6 +559,7 @@ mod tests {
             FsProbe {
                 name: Some("apfs".to_string()),
                 is_local: Some(true),
+                total_bytes: None,
             },
             FsProbe::unknown(),
         ] {
@@ -511,6 +569,16 @@ mod tests {
                 "must stay silent for {quiet:?}"
             );
         }
+    }
+
+    #[test]
+    fn probe_reports_a_positive_volume_size_for_a_real_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let total = probe(dir.path()).total_bytes;
+        assert!(
+            total.is_some_and(|n| n > 0),
+            "a real directory must yield a volume size, got {total:?}"
+        );
     }
 
     #[test]

--- a/src/cache_fs.rs
+++ b/src/cache_fs.rs
@@ -133,7 +133,15 @@ pub fn advisory_for(probe: &FsProbe, cache_dir: &Path) -> Option<String> {
 /// [`FsProbe::unknown`], which classifies to [`CacheFsVerdict::Unknown`] and
 /// stays silent. This runs at wrapper startup, so it must never fail a build.
 pub fn probe(path: &Path) -> FsProbe {
-    probe_impl(path)
+    #[cfg(target_os = "macos")]
+    let probe = probe_macos(path);
+    #[cfg(target_os = "linux")]
+    let probe = probe_linux(path);
+    #[cfg(windows)]
+    let probe = probe_windows(path);
+    #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+    let probe = probe_unsupported(path);
+    probe
 }
 
 /// Volume size from a `statfs` block size and block count.
@@ -174,14 +182,14 @@ fn win32_succeeded(ok: i32) -> bool {
 // "this filesystem is local" bit (the same one `df -l` filters on), and
 // `f_fstypename` names it. No magic-number table needed.
 #[cfg(target_os = "macos")]
-fn probe_impl(path: &Path) -> FsProbe {
+fn probe_macos(path: &Path) -> FsProbe {
     let Some(stat) = statfs_of(path) else {
         return FsProbe::unknown();
     };
     FsProbe {
         name: c_str_field_to_string(&stat.f_fstypename),
         is_local: Some(stat.f_flags & (libc::MNT_LOCAL as u32) != 0),
-        total_bytes: statfs_total_bytes(&stat),
+        total_bytes: statfs_total_bytes_macos(&stat),
     }
 }
 
@@ -201,7 +209,7 @@ fn c_str_field_to_string(field: &[libc::c_char]) -> Option<String> {
 
 // ── Linux ───────────────────────────────────────────────────────────────────
 #[cfg(target_os = "linux")]
-fn probe_impl(path: &Path) -> FsProbe {
+fn probe_linux(path: &Path) -> FsProbe {
     let Some(stat) = statfs_of(path) else {
         return FsProbe::unknown();
     };
@@ -213,7 +221,7 @@ fn probe_impl(path: &Path) -> FsProbe {
     #[allow(clippy::unnecessary_cast)]
     let magic = stat.f_type as i64;
     let mut probe = classify_linux_magic(magic);
-    probe.total_bytes = statfs_total_bytes(&stat);
+    probe.total_bytes = statfs_total_bytes_linux(&stat);
     probe
 }
 
@@ -306,12 +314,12 @@ fn classify_linux_magic(magic: i64) -> FsProbe {
 }
 
 #[cfg(target_os = "macos")]
-fn statfs_total_bytes(stat: &libc::statfs) -> Option<u64> {
+fn statfs_total_bytes_macos(stat: &libc::statfs) -> Option<u64> {
     disk_bytes(u64::from(stat.f_bsize), stat.f_blocks)
 }
 
 #[cfg(target_os = "linux")]
-fn statfs_total_bytes(stat: &libc::statfs) -> Option<u64> {
+fn statfs_total_bytes_linux(stat: &libc::statfs) -> Option<u64> {
     let frsize = u64::try_from(stat.f_frsize).unwrap_or(0);
     let bsize = u64::try_from(stat.f_bsize).unwrap_or(0);
     disk_bytes(linux_fragment_bytes(frsize, bsize), stat.f_blocks)
@@ -350,7 +358,7 @@ fn nearest_existing(path: &Path) -> Option<std::path::PathBuf> {
 // drive), and a UNC path (`\\server\share`) is remote by construction — it has
 // no drive letter for `GetDriveTypeW` to classify, so it is checked first.
 #[cfg(windows)]
-fn probe_impl(path: &Path) -> FsProbe {
+fn probe_windows(path: &Path) -> FsProbe {
     use std::os::windows::ffi::OsStrExt;
     use windows_sys::Win32::Storage::FileSystem::{GetDriveTypeW, GetVolumeInformationW};
 
@@ -368,7 +376,7 @@ fn probe_impl(path: &Path) -> FsProbe {
         return FsProbe {
             name: Some("a network share (UNC path)".to_string()),
             is_local: Some(false),
-            total_bytes: volume_total_bytes(&target),
+            total_bytes: volume_total_bytes_windows(&target),
         };
     }
 
@@ -415,12 +423,12 @@ fn probe_impl(path: &Path) -> FsProbe {
     FsProbe {
         name,
         is_local,
-        total_bytes: volume_total_bytes(&target),
+        total_bytes: volume_total_bytes_windows(&target),
     }
 }
 
 #[cfg(windows)]
-fn volume_total_bytes(path: &Path) -> Option<u64> {
+fn volume_total_bytes_windows(path: &Path) -> Option<u64> {
     use std::os::windows::ffi::OsStrExt;
     use windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
 
@@ -470,7 +478,7 @@ fn is_unc_path(path: &Path) -> bool {
 
 // ── Unsupported targets ─────────────────────────────────────────────────────
 #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
-fn probe_impl(_path: &Path) -> FsProbe {
+fn probe_unsupported(_path: &Path) -> FsProbe {
     FsProbe::unknown()
 }
 

--- a/src/cache_fs.rs
+++ b/src/cache_fs.rs
@@ -290,8 +290,7 @@ fn statfs_total_bytes(stat: &libc::statfs) -> Option<u64> {
         stat.f_bsize
     };
     let frag = u64::try_from(frag).ok().filter(|&n| n > 0)?;
-    let blocks = u64::try_from(stat.f_blocks).ok()?;
-    blocks.checked_mul(frag)
+    stat.f_blocks.checked_mul(frag)
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]

--- a/src/cache_fs.rs
+++ b/src/cache_fs.rs
@@ -136,6 +136,41 @@ pub fn probe(path: &Path) -> FsProbe {
     probe_impl(path)
 }
 
+/// Volume size from a `statfs` block size and block count.
+///
+/// A zero block size is `None` (the kernel did not report a size), not a
+/// zero-byte disk. Overflow is `None`. Pure so the cases are tested on every
+/// platform, not only the OS whose `statfs` produced the numbers.
+#[cfg_attr(
+    not(any(target_os = "macos", target_os = "linux")),
+    allow(dead_code)
+)]
+fn disk_bytes(block_size: u64, blocks: u64) -> Option<u64> {
+    if block_size == 0 {
+        return None;
+    }
+    block_size.checked_mul(blocks)
+}
+
+/// Linux `statfs` fragment size: `f_frsize` when the kernel reports it, else
+/// `f_bsize`.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn linux_fragment_bytes(frsize: u64, bsize: u64) -> u64 {
+    if frsize > 0 { frsize } else { bsize }
+}
+
+/// Windows `GetDiskFreeSpaceExW` reports success as a nonzero BOOL. A zero
+/// total is treated as a failed probe, not a zero-byte disk.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn accepted_volume_total(ok: bool, total: u64) -> Option<u64> {
+    (ok && total > 0).then_some(total)
+}
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn win32_succeeded(ok: i32) -> bool {
+    ok != 0
+}
+
 // ── macOS ───────────────────────────────────────────────────────────────────
 //
 // `statfs` carries both answers directly: `MNT_LOCAL` is the kernel's own
@@ -275,22 +310,14 @@ fn classify_linux_magic(magic: i64) -> FsProbe {
 
 #[cfg(target_os = "macos")]
 fn statfs_total_bytes(stat: &libc::statfs) -> Option<u64> {
-    let bsize = u64::from(stat.f_bsize);
-    if bsize == 0 {
-        return None;
-    }
-    stat.f_blocks.checked_mul(bsize)
+    disk_bytes(u64::from(stat.f_bsize), stat.f_blocks)
 }
 
 #[cfg(target_os = "linux")]
 fn statfs_total_bytes(stat: &libc::statfs) -> Option<u64> {
-    let frag = if stat.f_frsize > 0 {
-        stat.f_frsize
-    } else {
-        stat.f_bsize
-    };
-    let frag = u64::try_from(frag).ok().filter(|&n| n > 0)?;
-    stat.f_blocks.checked_mul(frag)
+    let frsize = u64::try_from(stat.f_frsize).unwrap_or(0);
+    let bsize = u64::try_from(stat.f_bsize).unwrap_or(0);
+    disk_bytes(linux_fragment_bytes(frsize, bsize), stat.f_blocks)
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -410,7 +437,7 @@ fn volume_total_bytes(path: &Path) -> Option<u64> {
             std::ptr::null_mut(),
         )
     };
-    (ok != 0 && total > 0).then_some(total)
+    accepted_volume_total(win32_succeeded(ok), total)
 }
 
 /// Volume mount root (`C:\`) holding `path`. Mirrors `link::windows_volume_root`

--- a/src/cache_fs.rs
+++ b/src/cache_fs.rs
@@ -598,12 +598,43 @@ mod tests {
     }
 
     #[test]
+    fn disk_bytes_rejects_zero_block_size_and_multiplies() {
+        assert_eq!(disk_bytes(0, 100), None);
+        assert_eq!(disk_bytes(4096, 0), Some(0));
+        assert_eq!(disk_bytes(4096, 2), Some(8192));
+        assert_eq!(disk_bytes(u64::MAX, 2), None);
+    }
+
+    #[test]
+    fn linux_fragment_bytes_prefers_frsize_when_nonzero() {
+        assert_eq!(linux_fragment_bytes(4096, 512), 4096);
+        assert_eq!(linux_fragment_bytes(0, 512), 512);
+        assert_eq!(linux_fragment_bytes(0, 0), 0);
+    }
+
+    #[test]
+    fn accepted_volume_total_requires_success_and_nonzero() {
+        assert_eq!(accepted_volume_total(false, 99), None);
+        assert_eq!(accepted_volume_total(true, 0), None);
+        assert_eq!(accepted_volume_total(true, 1), Some(1));
+        assert_eq!(accepted_volume_total(false, 0), None);
+        assert!(win32_succeeded(1));
+        assert!(!win32_succeeded(0));
+    }
+
+    #[test]
     fn probe_reports_a_positive_volume_size_for_a_real_directory() {
         let dir = tempfile::tempdir().unwrap();
-        let total = probe(dir.path()).total_bytes;
+        let probed = probe(dir.path());
         assert!(
-            total.is_some_and(|n| n > 0),
-            "a real directory must yield a volume size, got {total:?}"
+            probed.total_bytes.is_some_and(|n| n > 1_000_000),
+            "a real directory must yield a volume size, got {:?}",
+            probed.total_bytes
+        );
+        assert_ne!(
+            probed,
+            FsProbe::default(),
+            "a real local probe must not be the empty default"
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -595,7 +595,10 @@ pub(crate) fn render_stats(snap: &StatsSnapshot, config: &Config, hours: u64) ->
     lines.push(format!(
         "Store:      {} / {} ({} entries, {:.0}%)",
         ByteSize(snap.total_size),
-        ByteSize(snap.max_size),
+        crate::config::describe_max_size(
+            snap.max_size,
+            crate::cache_fs::probe(&config.cache_dir).total_bytes,
+        ),
         snap.entry_count,
         store_pct,
     ));
@@ -2987,7 +2990,15 @@ pub fn gc(
     let store = Store::open(config)?;
     let total_size = store.total_size()?;
     let entry_count = store.entry_count()?;
-    println!("Store: {} ({} entries)", ByteSize(total_size), entry_count);
+    println!(
+        "Store: {} / {} ({} entries)",
+        ByteSize(total_size),
+        crate::config::describe_max_size(
+            config.max_size,
+            crate::cache_fs::probe(&config.cache_dir).total_bytes,
+        ),
+        entry_count
+    );
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3096,19 +3096,21 @@ remote_key_cache_refresh_secs = 900
 
     #[test]
     fn disk_share_budget_floors_caps_and_rounds() {
-        const GIB: u64 = 1024 * 1024 * 1024;
-        assert_eq!(disk_share_budget(None), DISK_SHARE_FALLBACK);
-        assert_eq!(disk_share_budget(Some(0)), DISK_SHARE_FALLBACK);
+        const GIB: u64 = 1 << 30;
+        // Independent of DISK_SHARE_* so mutating `*` in those constants
+        // cannot change both sides of the assertion.
+        assert_eq!(disk_share_budget(None), 50 << 30);
+        assert_eq!(disk_share_budget(Some(0)), 50 << 30);
         // 10GiB disk: 5% is 0.5GiB, rounds to 1GiB, then floor 5GiB.
-        assert_eq!(disk_share_budget(Some(10 * GIB)), DISK_SHARE_FLOOR);
+        assert_eq!(disk_share_budget(Some(10 * GIB)), 5 << 30);
         // 200GiB disk: 5% is exactly 10GiB.
         assert_eq!(disk_share_budget(Some(200 * GIB)), 10 * GIB);
         // 256GiB disk: 5% is 12.8GiB, nearest GiB is 13GiB.
         assert_eq!(disk_share_budget(Some(256 * GIB)), 13 * GIB);
         // 4TiB disk: 5% is 204.8GiB, cap 100GiB.
-        assert_eq!(disk_share_budget(Some(4 * 1024 * GIB)), DISK_SHARE_CAP);
+        assert_eq!(disk_share_budget(Some(4 * 1024 * GIB)), 100 << 30);
         // Exactly at the cap: 2000GiB * 5% = 100GiB.
-        assert_eq!(disk_share_budget(Some(2000 * GIB)), DISK_SHARE_CAP);
+        assert_eq!(disk_share_budget(Some(2000 * GIB)), 100 << 30);
     }
 
     #[test]
@@ -3137,6 +3139,11 @@ remote_key_cache_refresh_secs = 900
             describe_max_size(DISK_SHARE_FALLBACK, None).contains("disk size unknown"),
             "{}",
             describe_max_size(DISK_SHARE_FALLBACK, None)
+        );
+        assert!(
+            describe_max_size(DISK_SHARE_FALLBACK, Some(0)).contains("disk size unknown"),
+            "a zero-byte probe is unknown, not 5% of 0: {}",
+            describe_max_size(DISK_SHARE_FALLBACK, Some(0))
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,15 @@ pub const DEFAULT_MIN_STORE_COMPILE_MS: u64 = 0;
 /// would immediately delete previously valid cold entries.
 pub const DEFAULT_GC_MAX_AGE_HOURS: u64 = 0;
 
+/// Disk-share store budget when `KACHE_MAX_SIZE` / `[cache] local_max_size`
+/// are unset. 5% of the volume that holds the store, rounded to the nearest
+/// GiB, then clamped to 5GiB..=100GiB. A failed size probe falls back to
+/// 50GiB so the store stays bounded.
+pub const DISK_SHARE_PERCENT: u64 = 5;
+pub const DISK_SHARE_FLOOR: u64 = 5 * 1024 * 1024 * 1024;
+pub const DISK_SHARE_CAP: u64 = 100 * 1024 * 1024 * 1024;
+pub const DISK_SHARE_FALLBACK: u64 = 50 * 1024 * 1024 * 1024;
+
 /// Remote resilience (kunobi-ninja/kache#327, #564). The daemon-side operation
 /// deadline matches `DEFAULT_PREFETCH_DEADLINE_SECS`: generous enough that no
 /// legitimate background transfer changes behavior while still bounding a
@@ -1081,16 +1090,16 @@ impl Config {
 
         let max_size = env_or_ignored("KACHE_MAX_SIZE", ignore_env)
             .ok()
-            .and_then(|s| parse_size_checked(&s, "KACHE_MAX_SIZE"))
+            .and_then(|s| parse_local_max_size(&s, "KACHE_MAX_SIZE"))
             .or_else(|| {
                 file_config
                     .as_ref()
                     .ok()
                     .and_then(|c| c.cache.as_ref())
                     .and_then(|c| c.local_max_size.as_ref())
-                    .and_then(|s| parse_size_checked(s, "[cache] local_max_size"))
+                    .and_then(|s| parse_local_max_size(s, "[cache] local_max_size"))
             })
-            .unwrap_or(50 * 1024 * 1024 * 1024); // 50 GiB
+            .unwrap_or_else(|| disk_share_budget(crate::cache_fs::probe(&cache_dir).total_bytes));
 
         let cache_executables = env_or_ignored("KACHE_CACHE_EXECUTABLES", ignore_env)
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
@@ -2544,6 +2553,54 @@ pub(crate) fn parse_size(s: &str) -> Option<u64> {
     s.parse::<ByteSize>().ok().map(|b| b.as_u64())
 }
 
+/// Store budget derived from the volume that holds the cache directory.
+///
+/// Pure so tests pin floor / cap / rounding without touching a real disk.
+/// `None` or `0` (probe failed) uses [`DISK_SHARE_FALLBACK`].
+pub(crate) fn disk_share_budget(filesystem_bytes: Option<u64>) -> u64 {
+    let Some(total) = filesystem_bytes.filter(|&n| n > 0) else {
+        return DISK_SHARE_FALLBACK;
+    };
+    let raw = total.saturating_mul(DISK_SHARE_PERCENT) / 100;
+    const GIB: u64 = 1024 * 1024 * 1024;
+    let rounded = raw.saturating_add(GIB / 2) / GIB * GIB;
+    rounded.clamp(DISK_SHARE_FLOOR, DISK_SHARE_CAP)
+}
+
+/// Phrase the effective store limit for stats / gc / doctor.
+///
+/// When the effective cap matches the disk-share default for this volume, say
+/// so. An explicit env/TOML value that happens to equal that number is labelled
+/// the same way; that collision is rare and still names a real bound.
+pub(crate) fn describe_max_size(max_size: u64, filesystem_bytes: Option<u64>) -> String {
+    let derived = disk_share_budget(filesystem_bytes);
+    if max_size != derived {
+        return ByteSize(max_size).to_string();
+    }
+    match filesystem_bytes.filter(|&n| n > 0) {
+        Some(total) => format!(
+            "{} (5% of {}, floor 5GiB, cap 100GiB)",
+            ByteSize(max_size),
+            ByteSize(total)
+        ),
+        None => format!("{} (default; disk size unknown)", ByteSize(max_size)),
+    }
+}
+
+/// Like [`parse_size_checked`], but `"none"` is not a size: unbounded stores
+/// are the thing GC exists to stop, so the value is ignored and the disk-share
+/// default applies.
+fn parse_local_max_size(value: &str, source: &str) -> Option<u64> {
+    if value.trim().eq_ignore_ascii_case("none") {
+        tracing::warn!(
+            "{source}={value:?} is not allowed: the store must stay bounded. \
+             Ignoring it and using the disk-share default"
+        );
+        return None;
+    }
+    parse_size_checked(value, source)
+}
+
 /// Parse a human size string, warning loudly when it is set but malformed.
 ///
 /// A value `ByteSize` can't parse (a typo'd unit like `100 gigs`, digit
@@ -3035,6 +3092,100 @@ remote_key_cache_refresh_secs = 900
             parse_size_checked("2GiB", "KACHE_MAX_SIZE"),
             Some(2 * 1024 * 1024 * 1024)
         );
+    }
+
+    #[test]
+    fn disk_share_budget_floors_caps_and_rounds() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        assert_eq!(disk_share_budget(None), DISK_SHARE_FALLBACK);
+        assert_eq!(disk_share_budget(Some(0)), DISK_SHARE_FALLBACK);
+        // 10GiB disk: 5% is 0.5GiB, rounds to 1GiB, then floor 5GiB.
+        assert_eq!(disk_share_budget(Some(10 * GIB)), DISK_SHARE_FLOOR);
+        // 200GiB disk: 5% is exactly 10GiB.
+        assert_eq!(disk_share_budget(Some(200 * GIB)), 10 * GIB);
+        // 256GiB disk: 5% is 12.8GiB, nearest GiB is 13GiB.
+        assert_eq!(disk_share_budget(Some(256 * GIB)), 13 * GIB);
+        // 4TiB disk: 5% is 204.8GiB, cap 100GiB.
+        assert_eq!(disk_share_budget(Some(4 * 1024 * GIB)), DISK_SHARE_CAP);
+        // Exactly at the cap: 2000GiB * 5% = 100GiB.
+        assert_eq!(disk_share_budget(Some(2000 * GIB)), DISK_SHARE_CAP);
+    }
+
+    #[test]
+    fn parse_local_max_size_rejects_none_without_unbounding() {
+        assert_eq!(parse_local_max_size("none", "KACHE_MAX_SIZE"), None);
+        assert_eq!(parse_local_max_size("None", "[cache] local_max_size"), None);
+        assert_eq!(
+            parse_local_max_size("2GiB", "KACHE_MAX_SIZE"),
+            Some(2 * 1024 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn describe_max_size_names_the_disk_share_when_derived() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        let disk = Some(200 * GIB);
+        let derived = disk_share_budget(disk);
+        let text = describe_max_size(derived, disk);
+        assert!(text.contains("5%"), "{text}");
+        assert!(text.contains(&ByteSize(200 * GIB).to_string()), "{text}");
+        assert_eq!(
+            describe_max_size(2 * GIB, disk),
+            ByteSize(2 * GIB).to_string()
+        );
+        assert!(
+            describe_max_size(DISK_SHARE_FALLBACK, None).contains("disk size unknown"),
+            "{}",
+            describe_max_size(DISK_SHARE_FALLBACK, None)
+        );
+    }
+
+    #[test]
+    fn load_uses_disk_share_budget_when_max_size_is_unset() {
+        let _lock = config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let cfg_path = dir.path().join("config.toml");
+        std::fs::write(&cfg_path, "[cache]\n").unwrap();
+        let cache_dir = dir.path().join("store");
+        std::fs::create_dir(&cache_dir).unwrap();
+        let _cfg = set_kache_config_for_test(&cfg_path);
+        let _cache = set_env_for_test("KACHE_CACHE_DIR", Some(cache_dir.as_os_str()));
+        let _max = set_env_for_test("KACHE_MAX_SIZE", None);
+        let loaded = Config::load().unwrap();
+        let expected = disk_share_budget(crate::cache_fs::probe(&cache_dir).total_bytes);
+        assert_eq!(loaded.max_size, expected);
+    }
+
+    #[test]
+    fn load_explicit_max_size_wins_over_disk_share() {
+        let _lock = config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let cfg_path = dir.path().join("config.toml");
+        std::fs::write(&cfg_path, "[cache]\n").unwrap();
+        let cache_dir = dir.path().join("store");
+        std::fs::create_dir(&cache_dir).unwrap();
+        let _cfg = set_kache_config_for_test(&cfg_path);
+        let _cache = set_env_for_test("KACHE_CACHE_DIR", Some(cache_dir.as_os_str()));
+        let _max = set_env_for_test("KACHE_MAX_SIZE", Some(std::ffi::OsStr::new("2GiB")));
+        let loaded = Config::load().unwrap();
+        assert_eq!(loaded.max_size, 2 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn load_none_max_size_does_not_unbound_the_store() {
+        let _lock = config_path_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let cfg_path = dir.path().join("config.toml");
+        std::fs::write(&cfg_path, "[cache]\nlocal_max_size = \"none\"\n").unwrap();
+        let cache_dir = dir.path().join("store");
+        std::fs::create_dir(&cache_dir).unwrap();
+        let _cfg = set_kache_config_for_test(&cfg_path);
+        let _cache = set_env_for_test("KACHE_CACHE_DIR", Some(cache_dir.as_os_str()));
+        let _max = set_env_for_test("KACHE_MAX_SIZE", None);
+        let loaded = Config::load().unwrap();
+        let expected = disk_share_budget(crate::cache_fs::probe(&cache_dir).total_bytes);
+        assert_eq!(loaded.max_size, expected);
+        assert_ne!(loaded.max_size, 0);
     }
 
     #[test]

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -243,7 +243,7 @@ fn build_fields(file_config: &FileConfig, env: &EnvOverrides) -> Vec<FormField> 
                 .unwrap_or_default(),
             env_var: "KACHE_MAX_SIZE",
             env_value: env_val("KACHE_MAX_SIZE"),
-            default_hint: "(default: 50GiB)",
+            default_hint: "(default: 5% of the cache disk, 5GiB–100GiB)",
             validation_error: None,
             env_locked: env.max_size,
         },

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2911,6 +2911,7 @@ cache_executables = true
 local_only = true
 local_max_size = "{gc_budget}B"
 auto_gc = true
+gc_evict_shared = true
 cache_executables = true
 "#
     );


### PR DESCRIPTION
When `KACHE_MAX_SIZE` and `[cache] local_max_size` are unset, the store budget is 5% of the volume that holds the cache directory, rounded to the nearest GiB, floored at 5GiB and capped at 100GiB.

A failed size probe keeps the previous 50GiB bound so the store is never unbounded. An explicit size still wins. `none` is not a valid size; it is ignored and the disk-share default applies.

`kache stats` and `kache gc` print the derived budget. Volume size comes from the existing `cache_fs` probe (`statfs` / `GetDiskFreeSpaceEx`), not a second syscall.

Does not change wrapper miss logic. Independent of #878 / #880.