### PR TITLE
feat(cc): publish C/C++ objects to the remote

### DIFF
--- a/docs/getting-started/c-cpp.mdx
+++ b/docs/getting-started/c-cpp.mdx
@@ -92,7 +92,7 @@ GCC and Clang entries can be reused across worktrees when source and build paths
 KACHE_BASE_DIR="$PWD" cmake --build build
 ```
 
-clang-cl debug objects remain machine-local because CodeView records paths that clang-cl does not remap.
+A configured remote publishes GCC and Clang objects the same way it publishes Rust entries. clang-cl debug objects stay on the machine because CodeView records paths that clang-cl does not remap.
 
 ## Passthroughs
 
@@ -104,8 +104,6 @@ Kache currently passes through:
 - precompiled headers and modules
 - coverage and split-DWARF builds
 - flags it has not classified
-
-C/C++ entries are local-only. Remote sync currently handles Rust entries.
 
 Inspect passthrough reasons in the monitor or logs:
 

--- a/docs/how-it-works/architecture.mdx
+++ b/docs/how-it-works/architecture.mdx
@@ -61,7 +61,7 @@ See [Daemon overview](/docs/daemon/overview) and [Lifecycle](/docs/daemon/lifecy
 
 As `RUSTC_WRAPPER`, Kache sees rustc and workspace-wrapper invocations. It does not wrap Cargo itself or arbitrary tools. Rust link work driven by rustc can be cached when the artifact policy allows it; an independently invoked linker is outside this path.
 
-C/C++ caching is separate. Kache must be invoked as the compiler wrapper (`kache cc`) or through a compiler-name shim on `PATH` (`kache install-shims`), and currently caches supported object compilations locally. See [C and C++](/docs/getting-started/c-cpp).
+C/C++ caching is separate. Kache must be invoked as the compiler wrapper (`kache cc`) or through a compiler-name shim on `PATH` (`kache install-shims`). Supported object compilations use the same local store and remote pipeline as rustc. clang-cl debug objects stay machine-local. See [C and C++](/docs/getting-started/c-cpp).
 
 ## Planner
 

--- a/docs/remote-cache/ci.mdx
+++ b/docs/remote-cache/ci.mdx
@@ -48,7 +48,7 @@ GitHub withholds secrets and OIDC tokens from fork pull-request jobs, so those r
 
 Pull-request jobs can still restore entries a trusted branch already published.
 
-C and C++ object entries are local-only. A remote pull does not warm them.
+C and C++ objects publish through the same remote as Rust. A daemon-backed compile restores them on miss; `kache sync --pull --all` also warms them in the local store. clang-cl debug objects stay on the machine and are not published.
 
 ## Other CI systems
 

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1038,6 +1038,12 @@ impl CcArgs {
         cc_target_arch(self)
     }
 
+    /// True when this clang-cl compile requests debug info that CodeView
+    /// records with un-remapped paths. Those objects stay in the local store.
+    pub fn embeds_codeview_debug(&self) -> bool {
+        cl_debug_present(self)
+    }
+
     /// The subset of `rest` that identifies the *compile configuration*
     /// — per-translation-unit noise removed: source files, the `-o`
     /// output path, and (under the Gnu dialect only) dependency-file
@@ -6533,9 +6539,17 @@ mod tests {
                 cl_debug_path_inputs(&p).is_some(),
                 "{flag}: cl_debug_path_inputs must recognise a debug compile"
             );
+            assert!(
+                p.embeds_codeview_debug(),
+                "{flag}: clang-cl debug objects stay machine-local"
+            );
         }
         // gcc debug never goes through the cl path-fold path.
         let gnu = CcArgs::parse(&s(&["gcc", "-c", "a.c", "-g2"])).unwrap();
+        assert!(
+            !gnu.embeds_codeview_debug(),
+            "GCC debug objects may publish to a remote"
+        );
         assert_eq!(
             cl_debug_path_inputs(&gnu),
             None,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12368,6 +12368,28 @@ mod tests {
             .unwrap();
     }
 
+    fn seed_cc_store_entry(config: &Config, cache_key: &str, crate_name: &str, dir: &Path) {
+        let store = Store::open(config).unwrap();
+        let src = dir.join(format!("{cache_key}-src"));
+        std::fs::create_dir_all(&src).unwrap();
+        let artifact = src.join("foo.o");
+        std::fs::write(&artifact, b"cc object bytes").unwrap();
+        store
+            .put_with_compile_time_independent(
+                cache_key,
+                crate_name,
+                &[],
+                &[],
+                "x86_64-unknown-linux-gnu",
+                "",
+                &[(artifact, "foo.o".to_string())],
+                "",
+                "",
+                0,
+            )
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn test_socket_stats_roundtrip_with_populated_store() {
         // A populated store exercises the daemon's stats aggregation + entry
@@ -16554,6 +16576,44 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), server)
             .await
             .expect("the upload request must reach the live daemon")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_send_upload_job_client_roundtrip_for_cc_object() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let key = test_cache_key("cc-object-upload");
+        seed_cc_store_entry(&config, &key, "foo.c", dir.path());
+        let socket_path = config.socket_path();
+        std::fs::create_dir_all(socket_path.parent().unwrap()).unwrap();
+
+        let listener = bind_listener(&socket_path);
+        let daemon = Arc::new(Daemon::new(config.clone()));
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<UploadJob>();
+        daemon.set_upload_tx(tx);
+        let server = tokio::spawn(async move {
+            let stream = listener.accept().await.expect("accept");
+            let _ =
+                handle_connection(stream, &daemon, &AtomicBool::new(false), &Notify::new()).await;
+        });
+
+        let cfg = config.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            send_upload_job(&cfg, &key, Path::new("/tmp/test"), "foo.c")
+        })
+        .await
+        .unwrap();
+        assert!(
+            result.is_ok(),
+            "a C object upload job should send to a live daemon: {result:?}"
+        );
+        let jobs = load_upload_jobs(&config).unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].crate_name, "foo.c");
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("the cc upload request must reach the live daemon")
             .unwrap();
     }
 

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -1433,6 +1433,34 @@ mod tests {
         (tmp, store, entry_dir)
     }
 
+    fn populated_cc_entry(
+        cache_key: &str,
+        crate_name: &str,
+    ) -> (tempfile::TempDir, Store, std::path::PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(&min_config(tmp.path().join("cache"))).unwrap();
+        let source_dir = tmp.path().join("source");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source_file = source_dir.join("foo.o");
+        std::fs::write(&source_file, b"cc object bytes").unwrap();
+        store
+            .put_with_compile_time_independent(
+                cache_key,
+                crate_name,
+                &[],
+                &[],
+                "x86_64-unknown-linux-gnu",
+                "",
+                &[(source_file, "foo.o".to_string())],
+                "",
+                "",
+                0,
+            )
+            .unwrap();
+        let entry_dir = store.entry_dir(cache_key);
+        (tmp, store, entry_dir)
+    }
+
     #[tokio::test]
     async fn exists_entry_reports_present_and_missing_objects() {
         let remote = test_remote();
@@ -1516,6 +1544,36 @@ mod tests {
         assert_eq!(manifest.cache_key, "key123");
         assert_eq!(manifest.crate_name, "foo");
         assert_eq!(manifest.file_count, 1);
+    }
+
+    #[tokio::test]
+    async fn cc_object_pack_round_trips_through_v3() {
+        let cache_key = "c".repeat(64);
+        let (_tmp, store, entry_dir) = populated_cc_entry(&cache_key, "foo.c");
+        let remote = test_remote();
+        let backend = memory_backend();
+        let layout = RemoteLayout::new(&backend, &remote);
+
+        layout
+            .upload_entry(&cache_key, "foo.c", &entry_dir, &store.blobs_dir(), 3)
+            .await
+            .expect("cc object upload should reuse the v3 pack layout");
+
+        let dest = _tmp.path().join("restored");
+        layout
+            .download_entry(&cache_key, "foo.c", &dest, &store.blobs_dir())
+            .await
+            .expect("cc object download should extract the same pack");
+        assert_eq!(
+            std::fs::read(dest.join("foo.o")).unwrap(),
+            b"cc object bytes"
+        );
+        assert!(
+            backend
+                .head(&v3_manifest_key(&remote.prefix, &cache_key, "foo.c"))
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -504,6 +504,32 @@ fn store_admits_compile(config: &Config, compile_time_ms: u64, publishes_to_remo
         || compile_time_ms >= config.min_store_compile_ms
 }
 
+/// GCC/Clang objects (and clang-cl without CodeView debug) use the rustc
+/// remote pipeline. clang-cl debug objects embed un-remapped paths.
+fn cc_publishes_to_remote(parsed: &crate::compiler::cc::CcArgs) -> bool {
+    !parsed.embeds_codeview_debug()
+}
+
+fn cc_should_enqueue_upload(config: &Config, publishes_to_remote: bool) -> bool {
+    publishes_to_remote && config.remote.is_some()
+}
+
+fn maybe_enqueue_cc_upload(
+    config: &Config,
+    store: &Store,
+    cache_key: &str,
+    crate_name: &str,
+    publishes_to_remote: bool,
+) {
+    if !cc_should_enqueue_upload(config, publishes_to_remote) {
+        return;
+    }
+    let entry_dir = store.entry_dir(cache_key);
+    if let Err(e) = crate::daemon::send_upload_job(config, cache_key, &entry_dir, crate_name) {
+        tracing::warn!("failed to send upload job to daemon: {e}");
+    }
+}
+
 fn should_store_cc_result(exit_code: i32, has_artifacts: bool) -> bool {
     exit_code == 0 && has_artifacts
 }
@@ -808,6 +834,22 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         }
     }
 
+    if let Some(exit) = cc_try_remote_hit(
+        config,
+        &store,
+        &compiler,
+        &parsed,
+        &file_hasher,
+        &cache_key,
+        &crate_name,
+        &event_root,
+        start,
+        key_ms,
+        lookup_ms,
+    )? {
+        return Ok(exit);
+    }
+
     // ── Cache miss — compile, then store ─────────────────────────
     // Key generation and lookup can take long enough for another process to
     // create an output. Recheck at the last possible wrapper boundary and run
@@ -860,9 +902,8 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
     if store_candidate {
         compiler.commit_preprocess_memo(&file_hasher);
     }
-    // The CC path has no remote upload pipeline, so remote configuration must
-    // not bypass its local-store admission threshold.
-    let admitted = store_admits_compile(config, compile_time_ms, false);
+    let publishes_to_remote = cc_publishes_to_remote(&parsed);
+    let admitted = store_admits_compile(config, compile_time_ms, publishes_to_remote);
     let store_decision = cc_store_decision(store_candidate, admitted);
     if store_decision.admission_skipped {
         tracing::debug!(
@@ -898,6 +939,13 @@ pub fn run_cc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
                     // Store grew — throttled size check + detached background GC if over
                     // budget (kunobi-ninja/kache#497). Never blocks the compile path.
                     maybe_spawn_auto_gc(config, &store);
+                    maybe_enqueue_cc_upload(
+                        config,
+                        &store,
+                        &cache_key,
+                        &crate_name,
+                        publishes_to_remote,
+                    );
                 }
                 Err(e) => {
                     store_error = store_error_for_event(&e);
@@ -1342,6 +1390,98 @@ fn restore_cc_from_cache(
         )?);
     }
     publish_prepared_cc_artifacts(prepared)
+}
+
+/// After a local miss, ask the daemon for an exact remote entry.
+/// Returns `Some(exit)` when the hit was restored (or the restore fell through
+/// to passthrough). `None` means continue to compile.
+fn cc_try_remote_hit(
+    config: &Config,
+    store: &Store,
+    compiler: &CcCompiler,
+    parsed: &crate::compiler::cc::CcArgs,
+    file_hasher: &crate::cache_key::FileHasher<'_>,
+    cache_key: &str,
+    crate_name: &str,
+    event_root: &str,
+    start: std::time::Instant,
+    key_ms: u64,
+    lookup_ms: u64,
+) -> Result<Option<i32>> {
+    if !cc_should_enqueue_upload(config, cc_publishes_to_remote(parsed)) {
+        return Ok(None);
+    }
+    let entry_dir = store.entry_dir(cache_key);
+    let Some(result) = crate::daemon::send_remote_check(config, cache_key, &entry_dir, crate_name)
+    else {
+        return Ok(None);
+    };
+    if !result.found {
+        return Ok(None);
+    }
+    let Ok(Some(meta)) = store.get(cache_key) else {
+        return Ok(None);
+    };
+    let event_result = if result.prefetched {
+        tracing::debug!(
+            "cc prefetch cache hit for {} ({})",
+            crate_name,
+            &cache_key[..16]
+        );
+        EventResult::PrefetchHit
+    } else {
+        tracing::debug!(
+            "cc remote cache hit for {} ({})",
+            crate_name,
+            &cache_key[..16]
+        );
+        EventResult::RemoteHit
+    };
+    let restore_start = std::time::Instant::now();
+    if let Err(e) = restore_cc_from_cache(store, parsed, &meta) {
+        if e.downcast_ref::<PartialCcRestore>().is_some() {
+            return Err(e);
+        }
+        tracing::warn!(
+            "restoring cc remote cache hit for {} failed: {} — recompiling",
+            crate_name,
+            e
+        );
+        return Ok(Some(cc_passthrough_with_event(
+            config,
+            parsed,
+            crate_name,
+            event_root,
+            start,
+            format!("restore failed: {e}"),
+        )?));
+    }
+    let restore_ms = restore_start.elapsed().as_millis() as u64;
+    let elapsed = start.elapsed().as_millis() as u64;
+    let size: u64 = meta.files.iter().map(|f| f.size).sum();
+    log_event(
+        config,
+        event_root,
+        crate_name,
+        event_result,
+        elapsed,
+        meta.compile_time_ms,
+        size,
+        cache_key,
+        key_ms,
+        lookup_ms,
+        restore_ms,
+        0,
+    );
+    print_progress(crate_name, event_result, elapsed, size);
+    if !meta.stdout.is_empty() {
+        print!("{}", meta.stdout);
+    }
+    if !meta.stderr.is_empty() {
+        eprint!("{}", meta.stderr);
+    }
+    compiler.commit_preprocess_memo(file_hasher);
+    Ok(Some(0))
 }
 
 /// Run kache in RUSTC_WRAPPER mode.
@@ -7425,6 +7565,182 @@ exit 0
                 "exit={exit_code}, artifacts={has_artifacts}"
             );
         }
+    }
+
+    fn parse_cc(args: &[&str]) -> crate::compiler::cc::CcArgs {
+        crate::compiler::cc::CcArgs::parse(&s(args)).unwrap()
+    }
+
+    fn spool_intent_count(config: &Config) -> usize {
+        let dir = config.upload_spool_dir();
+        match std::fs::read_dir(&dir) {
+            Ok(entries) => entries.filter_map(Result::ok).count(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => 0,
+            Err(error) => panic!("reading upload spool {}: {error}", dir.display()),
+        }
+    }
+
+    fn seed_cc_object_entry(store: &Store, cache_key: &str, dir: &Path) {
+        let object = dir.join("foo.o");
+        std::fs::write(&object, b"object bytes").unwrap();
+        store
+            .put_with_compile_time_independent(
+                cache_key,
+                "foo.c",
+                &[],
+                &[],
+                "x86_64-unknown-linux-gnu",
+                "",
+                &[(object, "foo.o".to_string())],
+                "",
+                "",
+                12,
+            )
+            .unwrap();
+    }
+
+    /// Keep auto-start from `send_upload_job` off the developer's daemon.
+    /// Persist uses the test `Config`; daemon spawn reloads `KACHE_CONFIG`.
+    fn isolate_daemon_autostart(dir: &Path) -> (TestEnvGuard, TestEnvGuard) {
+        let config_path = dir.join("isolated-kache.toml");
+        let cache_dir = dir.join("isolated-cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        let store = toml::Value::String(cache_dir.to_string_lossy().into_owned());
+        std::fs::write(
+            &config_path,
+            format!(
+                "[cache]\n\
+                 local_only = true\n\
+                 ignore_env = true\n\
+                 local_store = {store}\n\
+                 runtime_dir = {store}\n\
+                 daemon_idle_timeout_secs = 1\n"
+            ),
+        )
+        .unwrap();
+        (
+            TestEnvGuard::set(
+                "KACHE_CONFIG",
+                config_path.to_str().expect("utf-8 isolated config path"),
+            ),
+            TestEnvGuard::set(
+                "KACHE_CACHE_DIR",
+                cache_dir.to_str().expect("utf-8 isolated cache path"),
+            ),
+        )
+    }
+
+    #[test]
+    fn clang_cl_debug_does_not_bypass_local_admission() {
+        let mut config = test_config(PathBuf::from("cache"));
+        config.min_store_compile_ms = 1_000;
+        config.remote = Some(crate::config::RemoteConfig::test_s3("bucket", "artifacts"));
+
+        let cl_debug = parse_cc(&["clang-cl", "-c", "foo.c", "-Fofoo.obj", "/Z7"]);
+        assert!(
+            !store_admits_compile(&config, 1, cc_publishes_to_remote(&cl_debug)),
+            "clang-cl debug must keep the local cheap-compile threshold"
+        );
+
+        let gnu = parse_cc(&["gcc", "-c", "foo.c", "-o", "foo.o"]);
+        assert!(
+            store_admits_compile(&config, 1, cc_publishes_to_remote(&gnu)),
+            "publishable cc compiles must store so they can upload"
+        );
+    }
+
+    #[test]
+    fn cc_remote_publication_skips_clang_cl_debug_only() {
+        let gnu = parse_cc(&["gcc", "-c", "foo.c", "-o", "foo.o"]);
+        let gnu_debug = parse_cc(&["gcc", "-c", "foo.c", "-o", "foo.o", "-g2"]);
+        let cl = parse_cc(&["clang-cl", "-c", "foo.c", "-Fofoo.obj"]);
+        let cl_debug = parse_cc(&["clang-cl", "-c", "foo.c", "-Fofoo.obj", "/Z7"]);
+        let cl_g = parse_cc(&["clang-cl", "-c", "foo.c", "-Fofoo.obj", "-g"]);
+
+        assert!(cc_publishes_to_remote(&gnu));
+        assert!(cc_publishes_to_remote(&gnu_debug));
+        assert!(cc_publishes_to_remote(&cl));
+        assert!(!cc_publishes_to_remote(&cl_debug));
+        assert!(!cc_publishes_to_remote(&cl_g));
+    }
+
+    #[test]
+    fn cc_upload_enqueue_requires_a_configured_remote_and_publication() {
+        let mut config = test_config(PathBuf::from("cache"));
+        assert!(!cc_should_enqueue_upload(&config, true));
+        assert!(!cc_should_enqueue_upload(&config, false));
+
+        config.remote = Some(crate::config::RemoteConfig::test_s3("bucket", "artifacts"));
+        assert!(cc_should_enqueue_upload(&config, true));
+        assert!(!cc_should_enqueue_upload(&config, false));
+
+        config.remote_readonly = true;
+        assert!(
+            cc_should_enqueue_upload(&config, true),
+            "readonly is enforced inside send_upload_job, matching rustc"
+        );
+    }
+
+    #[test]
+    fn cc_store_enqueues_an_upload_intent_when_a_writable_remote_is_configured() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path().join("cache"));
+        config.remote = Some(crate::config::RemoteConfig::test_s3("bucket", "artifacts"));
+        let store = Store::open(&config).unwrap();
+        let key = blake3::hash(b"cc-upload-intent").to_hex().to_string();
+        seed_cc_object_entry(&store, &key, dir.path());
+
+        let _lock = crate::config::config_path_lock();
+        let _isolated = isolate_daemon_autostart(dir.path());
+        maybe_enqueue_cc_upload(&config, &store, &key, "foo.c", true);
+
+        assert_eq!(spool_intent_count(&config), 1);
+        assert!(
+            config
+                .upload_spool_dir()
+                .join(format!("{key}.json"))
+                .is_file()
+        );
+    }
+
+    #[test]
+    fn clang_cl_debug_store_does_not_enqueue_an_upload_intent() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path().join("cache"));
+        config.remote = Some(crate::config::RemoteConfig::test_s3("bucket", "artifacts"));
+        let store = Store::open(&config).unwrap();
+        let key = blake3::hash(b"cc-cl-debug-no-upload").to_hex().to_string();
+        seed_cc_object_entry(&store, &key, dir.path());
+
+        let _lock = crate::config::config_path_lock();
+        let _isolated = isolate_daemon_autostart(dir.path());
+        maybe_enqueue_cc_upload(&config, &store, &key, "foo.c", false);
+
+        assert_eq!(spool_intent_count(&config), 0);
+    }
+
+    #[test]
+    fn cc_store_does_not_enqueue_when_remote_is_readonly_or_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = blake3::hash(b"cc-no-upload-gates").to_hex().to_string();
+
+        let mut readonly = test_config(dir.path().join("readonly"));
+        readonly.remote = Some(crate::config::RemoteConfig::test_s3("bucket", "artifacts"));
+        readonly.remote_readonly = true;
+        let readonly_store = Store::open(&readonly).unwrap();
+        seed_cc_object_entry(&readonly_store, &key, dir.path());
+
+        let local = test_config(dir.path().join("local"));
+        let local_store = Store::open(&local).unwrap();
+        seed_cc_object_entry(&local_store, &key, dir.path());
+
+        let _lock = crate::config::config_path_lock();
+        let _isolated = isolate_daemon_autostart(dir.path());
+        maybe_enqueue_cc_upload(&readonly, &readonly_store, &key, "foo.c", true);
+        maybe_enqueue_cc_upload(&local, &local_store, &key, "foo.c", true);
+
+        assert_eq!(spool_intent_count(&readonly), 0);
+        assert_eq!(spool_intent_count(&local), 0);
     }
 
     #[test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1474,12 +1474,7 @@ fn cc_try_remote_hit(
         0,
     );
     print_progress(crate_name, event_result, elapsed, size);
-    if !meta.stdout.is_empty() {
-        print!("{}", meta.stdout);
-    }
-    if !meta.stderr.is_empty() {
-        eprint!("{}", meta.stderr);
-    }
+    replay_cached_diagnostics(&meta, std::io::stdout(), std::io::stderr());
     compiler.commit_preprocess_memo(file_hasher);
     Ok(Some(0))
 }
@@ -4822,8 +4817,12 @@ fn clean_incremental_dir(config: &Config, args: &RustcArgs) {
 mod tests {
     use super::*;
     use crate::cache_key::FileHasher;
+    use crate::transport::{ListenerOptions, socket_name};
     use std::ffi::OsString;
+    use std::io::{Read, Write};
     use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     struct TestEnvGuard {
         key: &'static str,
@@ -7630,6 +7629,119 @@ exit 0
         )
     }
 
+    /// Answers `RemoteCheck` with a fixed `found` flag. `send_remote_check`
+    /// probes reachability before the real request, so the accept loop must
+    /// survive empty connections.
+    struct RemoteCheckReplyDaemon {
+        stop: Arc<AtomicBool>,
+        requests: Arc<AtomicUsize>,
+        handle: Option<std::thread::JoinHandle<()>>,
+        socket_path: PathBuf,
+    }
+
+    impl RemoteCheckReplyDaemon {
+        fn spawn(socket_path: PathBuf, found: bool) -> Self {
+            if let Some(parent) = socket_path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            let name = socket_name(&socket_path).expect("fake remote-check socket name");
+            let listener = ListenerOptions::new()
+                .name(name)
+                .create_sync()
+                .expect("bind fake remote-check daemon");
+            let stop = Arc::new(AtomicBool::new(false));
+            let requests = Arc::new(AtomicUsize::new(0));
+            let stop_thread = Arc::clone(&stop);
+            let requests_thread = Arc::clone(&requests);
+            let handle = std::thread::spawn(move || {
+                use crate::transport::prelude::*;
+                while !stop_thread.load(Ordering::SeqCst) {
+                    let mut stream = match listener.accept() {
+                        Ok(stream) => stream,
+                        Err(_) => break,
+                    };
+                    if stop_thread.load(Ordering::SeqCst) {
+                        break;
+                    }
+                    let mut buf = Vec::new();
+                    let mut chunk = [0u8; 1024];
+                    loop {
+                        match stream.read(&mut chunk) {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                buf.extend_from_slice(&chunk[..n]);
+                                if buf.contains(&b'\n') {
+                                    break;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    if buf.is_empty() {
+                        continue;
+                    }
+                    requests_thread.fetch_add(1, Ordering::SeqCst);
+                    let body = format!("{}\n", serde_json::json!({ "ok": true, "found": found }));
+                    let _ = stream.write_all(body.as_bytes());
+                }
+            });
+            Self {
+                stop,
+                requests,
+                handle: Some(handle),
+                socket_path,
+            }
+        }
+
+        fn request_count(&self) -> usize {
+            self.requests.load(Ordering::SeqCst)
+        }
+    }
+
+    impl Drop for RemoteCheckReplyDaemon {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::SeqCst);
+            let _ = crate::transport::is_reachable(&self.socket_path);
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    fn wait_until_reachable(path: &Path) {
+        let start = std::time::Instant::now();
+        while !crate::transport::is_reachable(path) {
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(2),
+                "fake remote-check daemon did not become reachable at {}",
+                path.display()
+            );
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+    }
+
+    fn try_cc_remote_hit(
+        config: &Config,
+        store: &Store,
+        parsed: &crate::compiler::cc::CcArgs,
+        cache_key: &str,
+    ) -> Option<i32> {
+        cc_try_remote_hit(
+            config,
+            store,
+            &CcCompiler::new(),
+            parsed,
+            &FileHasher::new(),
+            cache_key,
+            "foo.c",
+            "foo.c",
+            std::time::Instant::now(),
+            0,
+            0,
+        )
+        .unwrap()
+    }
+
     #[test]
     fn clang_cl_debug_does_not_bypass_local_admission() {
         let mut config = test_config(PathBuf::from("cache"));
@@ -7678,6 +7790,63 @@ exit 0
         assert!(
             cc_should_enqueue_upload(&config, true),
             "readonly is enforced inside send_upload_job, matching rustc"
+        );
+    }
+
+    #[test]
+    fn cc_try_remote_hit_skips_the_daemon_when_enqueue_is_false() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+        let store = Store::open(&config).unwrap();
+        let key = blake3::hash(b"cc-remote-skip-enqueue").to_hex().to_string();
+        seed_cc_object_entry(&store, &key, dir.path());
+
+        let output = dir.path().join("restored.o");
+        let output_arg = output.to_string_lossy().into_owned();
+        let parsed = parse_cc(&["gcc", "-c", "foo.c", "-o", &output_arg]);
+
+        let daemon = RemoteCheckReplyDaemon::spawn(config.socket_path(), true);
+        wait_until_reachable(&config.socket_path());
+        let requests_before = daemon.request_count();
+
+        assert!(try_cc_remote_hit(&config, &store, &parsed, &key).is_none());
+        assert_eq!(
+            daemon.request_count(),
+            requests_before,
+            "enqueue=false must not send RemoteCheck"
+        );
+        assert!(
+            !output.exists(),
+            "skipping the daemon must not restore a local store entry"
+        );
+    }
+
+    #[test]
+    fn cc_try_remote_hit_does_not_restore_on_a_remote_miss() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path().join("cache"));
+        config.remote = Some(crate::config::RemoteConfig::test_s3("bucket", "artifacts"));
+        let store = Store::open(&config).unwrap();
+        let key = blake3::hash(b"cc-remote-miss-no-restore")
+            .to_hex()
+            .to_string();
+        seed_cc_object_entry(&store, &key, dir.path());
+
+        let output = dir.path().join("restored.o");
+        let output_arg = output.to_string_lossy().into_owned();
+        let parsed = parse_cc(&["gcc", "-c", "foo.c", "-o", &output_arg]);
+
+        let daemon = RemoteCheckReplyDaemon::spawn(config.socket_path(), false);
+        wait_until_reachable(&config.socket_path());
+
+        assert!(try_cc_remote_hit(&config, &store, &parsed, &key).is_none());
+        assert!(
+            daemon.request_count() >= 1,
+            "a configured remote must still ask the daemon"
+        );
+        assert!(
+            !output.exists(),
+            "found=false must not restore even when the local store already has the entry"
         );
     }
 

--- a/tests/filesystem_remote_test.rs
+++ b/tests/filesystem_remote_test.rs
@@ -25,6 +25,14 @@ fn rustc_path() -> String {
     std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string())
 }
 
+fn cc_available() -> bool {
+    std::process::Command::new("cc")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
 fn toml_path(path: &Path) -> String {
     toml::Value::String(path.to_string_lossy().into_owned()).to_string()
 }
@@ -208,6 +216,20 @@ impl Client {
             output.status.success(),
             "kache rustc failed.\nstderr: {}",
             String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    fn compile_cc_checkout(&self, checkout: &Path, source: &str, output: &str) {
+        let result = self.run_within_at(
+            Some(checkout),
+            &["cc", "-c", source, "-o", output, "-O0", "-g0"],
+            Duration::from_secs(90),
+        );
+        assert!(
+            result.status.success(),
+            "kache cc failed.\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&result.stdout),
+            String::from_utf8_lossy(&result.stderr),
         );
     }
 
@@ -503,6 +525,75 @@ fn daemon_upload_reaches_an_independent_client_through_one_folder() {
         std::fs::read(out_a.path().join("libfsremote.rlib")).unwrap(),
         std::fs::read(out_b.path().join("libfsremote.rlib")).unwrap(),
         "the remotely restored artifact must match the producer byte-for-byte"
+    );
+    beta.stop_daemon_and_wait();
+}
+
+/// C object compiles use the same v3 pack layout and daemon upload/check
+/// path as rustc. Two clients sharing a folder get a remote hit without
+/// an explicit sync.
+#[test]
+fn daemon_upload_reaches_an_independent_client_for_a_c_object() {
+    if !cc_available() {
+        eprintln!("skipping: no working `cc` on PATH");
+        return;
+    }
+    build_kache();
+
+    let shared = TempDir::new().unwrap();
+    let producer_source = TempDir::new().unwrap();
+    let consumer_source = TempDir::new().unwrap();
+    let source = "int answer(void) { return 42; }\n";
+    std::fs::write(producer_source.path().join("foo.c"), source).unwrap();
+    std::fs::write(consumer_source.path().join("foo.c"), source).unwrap();
+
+    let alpha = Client::new(shared.path());
+    alpha.start_daemon();
+    alpha.compile_cc_checkout(producer_source.path(), "foo.c", "foo.o");
+    let alpha_report = alpha.report();
+    let alpha_event = crate_event(&alpha_report, "foo.c");
+    assert!(
+        alpha_event["result"] == "miss" || alpha_event["result"] == "dup",
+        "client A's first C compile must be a real compile: {alpha_report}"
+    );
+    assert_eq!(
+        alpha_event["compiler_runs"], 1,
+        "the producer must compile instead of restoring: {alpha_report}"
+    );
+    let cache_key = alpha_event["cache_key"]
+        .as_str()
+        .expect("producer event should include its cache key")
+        .to_owned();
+
+    wait_for_remote_entry(shared.path(), "foo.c", &cache_key);
+    alpha.stop_daemon_and_wait();
+
+    let beta = Client::new(shared.path());
+    beta.start_daemon();
+    beta.compile_cc_checkout(consumer_source.path(), "foo.c", "foo.o");
+    let beta_report = beta.report();
+    let beta_event = crate_event(&beta_report, "foo.c");
+
+    assert_eq!(
+        beta_event["result"], "remote_hit",
+        "client B must pull A's C object from the shared folder on miss: {beta_report}"
+    );
+    assert_eq!(
+        beta_event["compiler_runs"], 0,
+        "client B must restore without running cc: {beta_report}"
+    );
+    assert_eq!(
+        beta_event["cache_key"], cache_key,
+        "producer and consumer C checkouts must resolve to the same key"
+    );
+    assert!(
+        consumer_source.path().join("foo.o").is_file(),
+        "client B must end up with the object materialized"
+    );
+    assert_eq!(
+        std::fs::read(producer_source.path().join("foo.o")).unwrap(),
+        std::fs::read(consumer_source.path().join("foo.o")).unwrap(),
+        "the remotely restored object must match the producer byte-for-byte"
     );
     beta.stop_daemon_and_wait();
 }


### PR DESCRIPTION
Successful C/C++ object stores now use rustc's daemon upload path, and a local miss asks the daemon for an exact remote restore. The v3 pack layout is unchanged: `meta.json` plus the object and optional `.d`.

**Guardrails**
- `remote_readonly` still skips persist inside `send_upload_job`.
- clang-cl debug objects stay machine-local. CodeView paths are not remapped, so those compiles keep the cheap-compile threshold and are never uploaded, even with a writable remote.
- GCC/Clang objects (and clang-cl without debug) publish when a remote is configured.

**Tests**
- Wrapper: writable remote enqueues an upload intent; clang-cl debug does not; readonly / no remote do not.
- Daemon: C object fixture round-trips through `send_upload_job`.
- Remote layout: `.o` pack upload/download.
- Filesystem remote: two isolated clients share a folder; producer miss uploads, consumer gets `remote_hit` without `kache sync`.

`CACHE_KEY_VERSION` is unchanged.