### PR TITLE
feat(wrapper): compile-and-compare verify on hits

### DIFF
--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -120,6 +120,13 @@ bypass_env = ["SPECIAL_BUILD=1"]
 | `KACHE_PATH_ONLY_ENV_VARS` | `cache.path_only_env_vars` | `[]` | Path locator variables eligible for safe normalization |
 | `KACHE_KEY_ENV_VARS` | `cache.key_env_vars` | `[]` | Environment read by proc macros but not reported by rustc |
 | `KACHE_VERIFY_RESTORES` | none | `off` | Re-hash `sampled` or `always` before restoring |
+| `KACHE_VERIFY` | none | `off` | Recompile each rustc cache hit and compare it to the restored files |
+
+`KACHE_VERIFY` is qualification for cache-key changes. Set it to `1` or `true` to recompile every rustc cache hit into a staging directory and diff those artifacts against the files just restored. Leave it unset (or `0` / `false`) in ordinary builds: each hit pays a full compile. There is no `kache build` command for this.
+
+Path and debug-info bytes that differ only as embedded absolute paths are reported as `path-debug` and do not fail the build. Remaining byte differences are `content`. In both cases the restored files stay in place so the build continues; the wrapper records the class on the hit event as `verify_compare` (and in tracing when logging is on).
+
+`KACHE_VERIFY_RESTORES` still only re-hashes stored blobs before restore. It does not recompile.
 
 Use a key salt when an unobserved toolchain component changes output:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9255,6 +9255,7 @@ mod tests {
             passthrough_reason: String::new(),
             store_error: String::new(),
             lookup_rejection: String::new(),
+            verify_compare: String::new(),
             fallback: false,
             exit_code: None,
             key_fields: Default::default(),

--- a/src/events.rs
+++ b/src/events.rs
@@ -39,7 +39,8 @@ pub struct BuildEvent {
     /// 12 = per-extern artifact digests (#609),
     /// 13 = store-failure reason (#629),
     /// 14 = compilation-unit identity, own and per-extern (#627),
-    /// 15 = same-key lookup rejection reason (#655).
+    /// 15 = same-key lookup rejection reason (#655),
+    /// 16 = compile-and-compare verify on hits (`verify_compare`).
     #[serde(default)]
     pub schema: u32,
     /// Build session this event belongs to (kunobi-ninja/kache#583 P0.5).
@@ -147,6 +148,14 @@ pub struct BuildEvent {
     /// `why-miss` to misdiagnose the event as a cold miss or key mismatch.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub lookup_rejection: String,
+    /// Compile-and-compare qualification (`KACHE_VERIFY`) on a cache hit.
+    ///
+    /// Empty when the flag is off. `ok` when the restored artifacts match a
+    /// fresh compile. `path-debug: …` for embedded absolute-path / debug-info
+    /// differences. `content: …` for remaining byte faults. The hit is still
+    /// served (fail-open); this field is the record.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub verify_compare: String,
     /// Whether a configured fallback wrapper handled the passthrough.
     #[serde(default, skip_serializing_if = "is_false")]
     pub fallback: bool,
@@ -1260,6 +1269,7 @@ impl BuildEvent {
             passthrough_reason: String::new(),
             store_error: String::new(),
             lookup_rejection: String::new(),
+            verify_compare: String::new(),
             fallback: false,
             exit_code: None,
             key_fields: Default::default(),
@@ -1333,6 +1343,7 @@ mod tests {
             passthrough_reason: String::new(),
             store_error: String::new(),
             lookup_rejection: String::new(),
+            verify_compare: String::new(),
             fallback: false,
             exit_code: None,
             key_fields: Default::default(),
@@ -1369,6 +1380,24 @@ mod tests {
         value.as_object_mut().unwrap().remove("lookup_rejection");
         let legacy: BuildEvent = serde_json::from_value(value).unwrap();
         assert!(legacy.lookup_rejection.is_empty());
+    }
+
+    #[test]
+    fn verify_compare_round_trips_and_defaults_for_older_events() {
+        let mut event = BuildEvent::new_for_test("foo", EventResult::LocalHit);
+        event.verify_compare = "content: libfoo.rlib (byte mismatch)".to_string();
+
+        let mut value = serde_json::to_value(&event).unwrap();
+        assert_eq!(
+            value["verify_compare"],
+            "content: libfoo.rlib (byte mismatch)"
+        );
+        let round_trip: BuildEvent = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(round_trip.verify_compare, event.verify_compare);
+
+        value.as_object_mut().unwrap().remove("verify_compare");
+        let legacy: BuildEvent = serde_json::from_value(value).unwrap();
+        assert!(legacy.verify_compare.is_empty());
     }
 
     fn test_heartbeat(crate_name: &str, elapsed_s: u64) -> HeartbeatEvent {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ mod store;
 mod test_support;
 mod transport;
 mod tui;
+mod verify_compare;
 mod wrapper;
 mod wrapper_config;
 

--- a/src/opcounts.rs
+++ b/src/opcounts.rs
@@ -13,16 +13,51 @@
 //! reliability as a correctness assertion. Wall-clock budgets cannot do
 //! that across the self-hosted / GitHub-hosted runner mix.
 
+use std::cell::Cell;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
 static COMPILER_RUNS: AtomicU32 = AtomicU32::new(0);
 static PREPROCESSOR_RUNS: AtomicU32 = AtomicU32::new(0);
 static PROBE_RUNS: AtomicU32 = AtomicU32::new(0);
 
+thread_local! {
+    static SUSPEND_SPAWN_COUNTS: Cell<u32> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+thread_local! {
+    static SKIPPED_COMPILER_RUNS: Cell<u32> = const { Cell::new(0) };
+}
+
+/// Run `f` without counting compiler/preprocessor/probe spawns toward this
+/// process's event. Compile-and-compare qualification still spawns rustc on
+/// a hit; the hit event must keep `compiler_runs = 0` so warm-cache
+/// assertions stay meaningful.
+pub fn suspend_spawn_counts<T>(f: impl FnOnce() -> T) -> T {
+    SUSPEND_SPAWN_COUNTS.with(|depth| depth.set(depth.get() + 1));
+    struct Restore;
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            SUSPEND_SPAWN_COUNTS.with(|depth| depth.set(depth.get().saturating_sub(1)));
+        }
+    }
+    let _restore = Restore;
+    f()
+}
+
+fn spawn_counts_suspended() -> bool {
+    SUSPEND_SPAWN_COUNTS.with(|depth| depth.get() > 0)
+}
+
 /// Record that kache spawned the underlying compiler — `rustc`, or a
 /// C-family `cc -c` compile. A cache hit must record zero of these; a
 /// miss records one.
 pub fn record_compiler_run() {
+    if spawn_counts_suspended() {
+        #[cfg(test)]
+        SKIPPED_COMPILER_RUNS.with(|count| count.set(count.get() + 1));
+        return;
+    }
     COMPILER_RUNS.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -30,6 +65,9 @@ pub fn record_compiler_run() {
 /// done once per C/C++ compile to derive the cache key. Always zero for
 /// rustc, which has no separate preprocess step.
 pub fn record_preprocessor_run() {
+    if spawn_counts_suspended() {
+        return;
+    }
     PREPROCESSOR_RUNS.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -48,6 +86,9 @@ pub fn preprocessor_runs() -> u32 {
 /// a build records one of these the first time it sees a compiler and
 /// zero thereafter; a fully warm probe cache records zero.
 pub fn record_probe_run() {
+    if spawn_counts_suspended() {
+        return;
+    }
     PROBE_RUNS.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -184,6 +225,42 @@ mod tests {
         let before = probe_runs();
         record_probe_run();
         assert!(probe_runs() > before);
+    }
+
+    #[test]
+    fn suspend_spawn_counts_skips_compiler_run_on_this_thread() {
+        let skipped_before = SKIPPED_COMPILER_RUNS.with(|count| count.get());
+        assert!(
+            !SUSPEND_SPAWN_COUNTS.with(|depth| depth.get() > 0),
+            "this test thread must start unsuspended"
+        );
+        suspend_spawn_counts(|| {
+            assert!(SUSPEND_SPAWN_COUNTS.with(|depth| depth.get() > 0));
+            record_compiler_run();
+            suspend_spawn_counts(|| {
+                assert!(SUSPEND_SPAWN_COUNTS.with(|depth| depth.get() >= 2));
+            });
+        });
+        assert!(SUSPEND_SPAWN_COUNTS.with(|depth| depth.get() == 0));
+        let skipped = SKIPPED_COMPILER_RUNS.with(|count| count.get());
+        assert_eq!(skipped, skipped_before + 1);
+        record_compiler_run();
+        assert_eq!(
+            SKIPPED_COMPILER_RUNS.with(|count| count.get()),
+            skipped,
+            "an unsuspended compiler run must not count as skipped"
+        );
+    }
+
+    #[test]
+    fn suspend_spawn_counts_restores_after_panic() {
+        let _ = std::panic::catch_unwind(|| {
+            suspend_spawn_counts(|| panic!("qualification compile failed"));
+        });
+        assert!(
+            SUSPEND_SPAWN_COUNTS.with(|depth| depth.get() == 0),
+            "panic inside suspend must not leave spawn counts suppressed"
+        );
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -3159,6 +3159,7 @@ mod tests {
             passthrough_reason: String::new(),
             store_error: String::new(),
             lookup_rejection: String::new(),
+            verify_compare: String::new(),
             fallback: false,
             exit_code: None,
             key_fields: Default::default(),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2743,6 +2743,7 @@ mod tests {
             passthrough_reason: "linker invocation".to_string(),
             store_error: String::new(),
             lookup_rejection: String::new(),
+            verify_compare: String::new(),
             fallback: false,
             exit_code: Some(0),
             key_fields: Default::default(),

--- a/src/verify_compare.rs
+++ b/src/verify_compare.rs
@@ -241,62 +241,59 @@ pub(crate) fn classify_bytes(name: &str, restored: &[u8], compiled: &[u8]) -> Ar
 /// True when `left` and `right` differ only in embedded absolute-path /
 /// debug-path strings (including kache remap sentinels).
 pub(crate) fn bytes_equal_ignoring_embedded_paths(left: &[u8], right: &[u8]) -> bool {
-    let mut i = 0;
-    let mut j = 0;
-    while i < left.len() && j < right.len() {
-        if left[i] == right[j] {
-            i += 1;
-            j += 1;
-            continue;
-        }
-        let Some((next_i, next_j)) = skip_divergent_paths(left, i, right, j) else {
+    let mut left = left;
+    let mut right = right;
+    loop {
+        let mismatch = left
+            .iter()
+            .zip(right)
+            .position(|(left_byte, right_byte)| left_byte != right_byte);
+        let Some(mismatch) = mismatch else {
+            let common = left.len().min(right.len());
+            return remaining_is_path(left, common) && remaining_is_path(right, common);
+        };
+        let Some((_, left_end)) = path_span_covering(left, mismatch) else {
             return false;
         };
-        if next_i <= i || next_j <= j {
+        let Some(left_end) = std::num::NonZeroUsize::new(left_end) else {
             return false;
-        }
-        i = next_i;
-        j = next_j;
+        };
+        let Some((_, right_end)) = path_span_covering(right, mismatch) else {
+            return false;
+        };
+        let Some(right_end) = std::num::NonZeroUsize::new(right_end) else {
+            return false;
+        };
+        left = &left[left_end.get()..];
+        right = &right[right_end.get()..];
     }
-    remaining_is_path(left, i) && remaining_is_path(right, j)
 }
 
 fn remaining_is_path(bytes: &[u8], index: usize) -> bool {
-    if index >= bytes.len() {
-        return true;
-    }
-    path_span_covering(bytes, index).is_some_and(|(_, end)| end == bytes.len())
-}
-
-fn skip_divergent_paths(left: &[u8], i: usize, right: &[u8], j: usize) -> Option<(usize, usize)> {
-    let (_, left_end) = path_span_covering(left, i)?;
-    let (_, right_end) = path_span_covering(right, j)?;
-    if left_end <= i || right_end <= j {
-        return None;
-    }
-    Some((left_end, right_end))
+    let Some(remaining) = bytes.get(index..) else {
+        return false;
+    };
+    remaining.is_empty()
+        || path_span_covering(bytes, index).is_some_and(|(_, end)| end == bytes.len())
 }
 
 fn path_span_covering(bytes: &[u8], mismatch: usize) -> Option<(usize, usize)> {
     let start = find_path_start(bytes, mismatch)?;
-    let mut end = mismatch.max(start);
-    while end < bytes.len() && is_path_byte(bytes[end]) {
-        end += 1;
-    }
-    if end <= start {
-        return None;
-    }
+    let path_len = bytes[mismatch..]
+        .iter()
+        .take_while(|byte| is_path_byte(**byte))
+        .count();
+    let end = mismatch.checked_add(path_len)?;
+    (end > mismatch).then_some(())?;
     looks_like_path(&bytes[start..end]).then_some((start, end))
 }
 
 fn find_path_start(bytes: &[u8], mismatch: usize) -> Option<usize> {
-    if bytes.is_empty() || mismatch >= bytes.len() {
-        return None;
-    }
-    let mut start = mismatch;
-    while start > 0 && is_path_byte(bytes[start - 1]) {
-        start -= 1;
-    }
+    let prefix = bytes.get(..=mismatch)?;
+    let start = prefix
+        .iter()
+        .rposition(|byte| !is_path_byte(*byte))
+        .map_or(0, |index| index.saturating_add(1));
     (start..=mismatch).find(|&index| is_path_start(bytes, index))
 }
 
@@ -307,7 +304,9 @@ fn is_path_start(bytes: &[u8], index: usize) -> bool {
     match byte {
         b'/' | b'\\' | b'<' => true,
         b'_' => bytes[index..].starts_with(b"__kache"),
-        b'A'..=b'Z' | b'a'..=b'z' => bytes.get(index + 1).copied() == Some(b':'),
+        b'A'..=b'Z' | b'a'..=b'z' => {
+            matches!(bytes.get(index..), Some([_, b':', ..]))
+        }
         _ => false,
     }
 }
@@ -559,6 +558,62 @@ mod tests {
     }
 
     #[test]
+    fn embedded_path_comparison_covers_equal_exhausted_and_non_path_boundaries() {
+        assert!(bytes_equal_ignoring_embedded_paths(b"", b""));
+        assert!(bytes_equal_ignoring_embedded_paths(b"same", b"same"));
+        assert!(bytes_equal_ignoring_embedded_paths(
+            b"prefix",
+            b"prefix/tmp/file"
+        ));
+        assert!(bytes_equal_ignoring_embedded_paths(
+            b"prefix/tmp/file",
+            b"prefix"
+        ));
+        assert!(!bytes_equal_ignoring_embedded_paths(b"prefix", b"prefix!"));
+        assert!(!bytes_equal_ignoring_embedded_paths(b"prefix!", b"prefix"));
+        assert!(!bytes_equal_ignoring_embedded_paths(b"left", b"right"));
+    }
+
+    #[test]
+    fn embedded_path_helpers_reject_out_of_range_and_partial_spans() {
+        let bytes = b"xx/abc.rs";
+        assert_eq!(find_path_start(bytes, 5), Some(2));
+        assert_eq!(path_span_covering(bytes, 5), Some((2, bytes.len())));
+        assert_eq!(path_span_covering(b"/a\0", 2), None);
+        assert_eq!(find_path_start(b"", 0), None);
+        assert_eq!(find_path_start(b"abc", 3), None);
+
+        assert!(remaining_is_path(b"", 0));
+        assert!(remaining_is_path(b"abc", 3));
+        assert!(!remaining_is_path(b"abc", 4));
+        assert!(remaining_is_path(b"/tmp/file", 0));
+        assert!(!remaining_is_path(b"/tmp/file\0", 0));
+        assert!(!remaining_is_path(b"plain", 0));
+    }
+
+    #[test]
+    fn path_start_and_shape_detection_cover_each_supported_form() {
+        assert!(is_path_start(b"/tmp", 0));
+        assert!(is_path_start(b"\\tmp", 0));
+        assert!(is_path_start(b"<WORKSPACE>", 0));
+        assert!(is_path_start(b"__kache_root__", 0));
+        assert!(is_path_start(b"C:\\tmp", 0));
+        assert!(is_path_start(b"z:/tmp", 0));
+        assert!(!is_path_start(b"_other", 0));
+        assert!(!is_path_start(b"C/tmp", 0));
+        assert!(!is_path_start(b"9:\\tmp", 0));
+        assert!(!is_path_start(b"abc", 3));
+
+        assert!(!looks_like_path(b""));
+        assert!(!looks_like_path(b"/"));
+        assert!(!looks_like_path(b"plain"));
+        assert!(!looks_like_path(b"C:plain"));
+        assert!(looks_like_path(b"/tmp"));
+        assert!(looks_like_path(b"C:\\tmp"));
+        assert!(looks_like_path(b"<WORKSPACE>"));
+    }
+
+    #[test]
     fn depinfo_path_rewrite_is_path_debug() {
         let restored = b"__kache_root__/debug/deps/libfoo.rlib: /Users/alice/src/lib.rs\n";
         let compiled = b"/tmp/kache-verify-1/libfoo.rlib: /Users/bob/src/lib.rs\n";
@@ -603,15 +658,39 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let restored = dir.path().join("out/libfoo.rlib");
         let compiled = dir.path().join("stage/libfoo.rlib");
+        let nested_restored = dir.path().join("out/libbar.rlib");
+        let nested_compiled = dir.path().join("stage/libbar.rlib");
         std::fs::create_dir_all(restored.parent().unwrap()).unwrap();
         std::fs::create_dir_all(compiled.parent().unwrap()).unwrap();
         std::fs::write(&restored, b"same").unwrap();
         std::fs::write(&compiled, b"same").unwrap();
-        let restored_list = vec![("libfoo.rlib".to_string(), restored)];
+        std::fs::write(&nested_restored, b"cached").unwrap();
+        std::fs::write(&nested_compiled, b"fresh!").unwrap();
+        let restored_list = vec![
+            ("libfoo.rlib".to_string(), restored),
+            ("nested/libbar.rlib".to_string(), nested_restored),
+        ];
         let mut compiled_by_name = BTreeMap::new();
         compiled_by_name.insert("libfoo.rlib".to_string(), compiled);
+        compiled_by_name.insert("libbar.rlib".to_string(), nested_compiled);
         let report = compare_named_artifacts(&restored_list, &compiled_by_name);
-        assert_eq!(report.worst(), DivergenceClass::Match);
+        assert_eq!(report.artifacts.len(), 2);
+        assert_eq!(report.artifacts[0].class, DivergenceClass::Match);
+        assert_eq!(report.artifacts[1].name, "nested/libbar.rlib");
+        assert_eq!(report.artifacts[1].class, DivergenceClass::Content);
+        assert_eq!(report.worst(), DivergenceClass::Content);
+    }
+
+    #[test]
+    fn named_compare_reports_missing_recompile_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let restored = dir.path().join("libfoo.rlib");
+        std::fs::write(&restored, b"cached").unwrap();
+        let report =
+            compare_named_artifacts(&[("libfoo.rlib".to_string(), restored)], &BTreeMap::new());
+        assert_eq!(report.artifacts.len(), 1);
+        assert_eq!(report.artifacts[0].class, DivergenceClass::Content);
+        assert_eq!(report.artifacts[0].detail, "missing from recompile");
     }
 
     #[test]

--- a/src/verify_compare.rs
+++ b/src/verify_compare.rs
@@ -283,8 +283,8 @@ fn path_span_covering(bytes: &[u8], mismatch: usize) -> Option<(usize, usize)> {
         .iter()
         .take_while(|byte| is_path_byte(**byte))
         .count();
-    let end = mismatch.checked_add(path_len)?;
-    (end > mismatch).then_some(())?;
+    let path_len = std::num::NonZeroUsize::new(path_len)?;
+    let end = mismatch.checked_add(path_len.get())?;
     looks_like_path(&bytes[start..end]).then_some((start, end))
 }
 

--- a/src/verify_compare.rs
+++ b/src/verify_compare.rs
@@ -1,0 +1,712 @@
+//! Compile-and-compare qualification for cache hits (`KACHE_VERIFY`).
+//!
+//! When enabled, a hit still restores as usual, then the wrapper recompiles
+//! into a staging directory and diffs those artifacts against the restored
+//! files. This checks identity with a fresh compile, which is a different
+//! question from [`crate::store::verify_restores_mode`] (blob re-hash before
+//! restore).
+//!
+//! Off by default. Each hit pays a full compile, so this is a qualification
+//! mode for cache-key changes, not a daily setting. There is no separate
+//! `kache build` command for it.
+//!
+//! Policy is fail-open: restored files stay in place so the build continues.
+//! Divergences are classified and recorded on the hit event.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Named outcome of comparing one restored artifact to a fresh compile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DivergenceClass {
+    /// Byte-identical.
+    Match,
+    /// Bytes differ, but only in embedded absolute paths / debug-info path
+    /// strings. Not treated as a poisoned cache entry.
+    PathDebug,
+    /// Remaining byte differences after ignoring embedded paths, or the
+    /// recompile did not produce the artifact.
+    Content,
+}
+
+impl DivergenceClass {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Match => "ok",
+            Self::PathDebug => "path-debug",
+            Self::Content => "content",
+        }
+    }
+}
+
+/// One artifact's compare result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ArtifactDivergence {
+    pub name: String,
+    pub class: DivergenceClass,
+    pub detail: &'static str,
+}
+
+/// Compare result for a set of artifacts.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct CompareReport {
+    pub artifacts: Vec<ArtifactDivergence>,
+}
+
+impl CompareReport {
+    /// Strongest divergence in the set. `content` wins over `path-debug`.
+    pub(crate) fn worst(&self) -> DivergenceClass {
+        if self
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.class == DivergenceClass::Content)
+        {
+            DivergenceClass::Content
+        } else if self
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.class == DivergenceClass::PathDebug)
+        {
+            DivergenceClass::PathDebug
+        } else {
+            DivergenceClass::Match
+        }
+    }
+
+    /// Single-line summary for the hit event's `verify_compare` field.
+    pub(crate) fn event_summary(&self) -> String {
+        let mut path_debug = Vec::new();
+        let mut content = Vec::new();
+        for artifact in &self.artifacts {
+            match artifact.class {
+                DivergenceClass::Match => {}
+                DivergenceClass::PathDebug => path_debug.push(format_named(artifact)),
+                DivergenceClass::Content => content.push(format_named(artifact)),
+            }
+        }
+        if content.is_empty() && path_debug.is_empty() {
+            return DivergenceClass::Match.as_str().to_string();
+        }
+        let mut parts = Vec::new();
+        if !content.is_empty() {
+            parts.push(format!(
+                "{}: {}",
+                DivergenceClass::Content.as_str(),
+                content.join(", ")
+            ));
+        }
+        if !path_debug.is_empty() {
+            parts.push(format!(
+                "{}: {}",
+                DivergenceClass::PathDebug.as_str(),
+                path_debug.join(", ")
+            ));
+        }
+        parts.join("; ")
+    }
+}
+
+fn format_named(artifact: &ArtifactDivergence) -> String {
+    if artifact.detail.is_empty() {
+        artifact.name.clone()
+    } else {
+        format!("{} ({})", artifact.name, artifact.detail)
+    }
+}
+
+thread_local! {
+    static LAST_REPORT: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Stash a verify summary for the hit event that the wrapper is about to log.
+pub(crate) fn record_report(summary: String) {
+    let _ = LAST_REPORT.try_with(|stash| *stash.borrow_mut() = Some(summary));
+}
+
+/// Take the stashed summary. Empty when verify did not run for this compile.
+pub(crate) fn take_last_report() -> String {
+    LAST_REPORT
+        .try_with(|stash| stash.borrow_mut().take().unwrap_or_default())
+        .unwrap_or_default()
+}
+
+/// `KACHE_VERIFY=1` / `true` enables compile-and-compare. Unset, `0`, `false`,
+/// and any other spelling leave it off. Read per call so tests can toggle it.
+pub(crate) fn enabled() -> bool {
+    parse_enabled(std::env::var("KACHE_VERIFY").ok().as_deref())
+}
+
+pub(crate) fn parse_enabled(value: Option<&str>) -> bool {
+    matches!(
+        value.map(str::trim),
+        Some(v) if v == "1" || v.eq_ignore_ascii_case("true")
+    )
+}
+
+/// Compare two isolated artifact trees by relative file name.
+///
+/// Files that exist only in `compiled` are ignored (a recompile may write
+/// extra sidecars). Files that exist only in `restored` are `content`
+/// (missing from recompile). Tests use this so they do not have to spawn
+/// rustc or cargo.
+#[cfg(test)]
+pub(crate) fn compare_artifact_trees(restored: &Path, compiled: &Path) -> CompareReport {
+    let restored_files = collect_relative_files(restored);
+    let compiled_files = collect_relative_files(compiled);
+    let mut artifacts = Vec::with_capacity(restored_files.len());
+    for (name, restored_path) in &restored_files {
+        match compiled_files.get(name) {
+            Some(compiled_path) => {
+                artifacts.push(compare_paths(name, restored_path, Some(compiled_path)))
+            }
+            None => artifacts.push(ArtifactDivergence {
+                name: name.clone(),
+                class: DivergenceClass::Content,
+                detail: "missing from recompile",
+            }),
+        }
+    }
+    CompareReport { artifacts }
+}
+
+/// Compare restored files to the matching recompile outputs, by cache-entry
+/// artifact name.
+pub(crate) fn compare_named_artifacts(
+    restored: &[(String, PathBuf)],
+    compiled_by_name: &BTreeMap<String, PathBuf>,
+) -> CompareReport {
+    let mut artifacts = Vec::with_capacity(restored.len());
+    for (name, restored_path) in restored {
+        let compiled_path = compiled_by_name.get(name).or_else(|| {
+            let file_name = Path::new(name).file_name()?.to_string_lossy().into_owned();
+            compiled_by_name.get(&file_name)
+        });
+        artifacts.push(compare_paths(
+            name,
+            restored_path,
+            compiled_path.map(PathBuf::as_path),
+        ));
+    }
+    CompareReport { artifacts }
+}
+
+fn compare_paths(name: &str, restored: &Path, compiled: Option<&Path>) -> ArtifactDivergence {
+    let Ok(restored_bytes) = std::fs::read(restored) else {
+        return ArtifactDivergence {
+            name: name.to_string(),
+            class: DivergenceClass::Content,
+            detail: "unreadable restored file",
+        };
+    };
+    let Some(compiled) = compiled else {
+        return ArtifactDivergence {
+            name: name.to_string(),
+            class: DivergenceClass::Content,
+            detail: "missing from recompile",
+        };
+    };
+    let Ok(compiled_bytes) = std::fs::read(compiled) else {
+        return ArtifactDivergence {
+            name: name.to_string(),
+            class: DivergenceClass::Content,
+            detail: "missing from recompile",
+        };
+    };
+    classify_bytes(name, &restored_bytes, &compiled_bytes)
+}
+
+pub(crate) fn classify_bytes(name: &str, restored: &[u8], compiled: &[u8]) -> ArtifactDivergence {
+    if restored == compiled {
+        return ArtifactDivergence {
+            name: name.to_string(),
+            class: DivergenceClass::Match,
+            detail: "",
+        };
+    }
+    if bytes_equal_ignoring_embedded_paths(restored, compiled) {
+        return ArtifactDivergence {
+            name: name.to_string(),
+            class: DivergenceClass::PathDebug,
+            detail: "",
+        };
+    }
+    ArtifactDivergence {
+        name: name.to_string(),
+        class: DivergenceClass::Content,
+        detail: "byte mismatch",
+    }
+}
+
+/// True when `left` and `right` differ only in embedded absolute-path /
+/// debug-path strings (including kache remap sentinels).
+pub(crate) fn bytes_equal_ignoring_embedded_paths(left: &[u8], right: &[u8]) -> bool {
+    let mut i = 0;
+    let mut j = 0;
+    while i < left.len() && j < right.len() {
+        if left[i] == right[j] {
+            i += 1;
+            j += 1;
+            continue;
+        }
+        let Some((next_i, next_j)) = skip_divergent_paths(left, i, right, j) else {
+            return false;
+        };
+        if next_i <= i || next_j <= j {
+            return false;
+        }
+        i = next_i;
+        j = next_j;
+    }
+    remaining_is_path(left, i) && remaining_is_path(right, j)
+}
+
+fn remaining_is_path(bytes: &[u8], index: usize) -> bool {
+    if index >= bytes.len() {
+        return true;
+    }
+    path_span_covering(bytes, index).is_some_and(|(_, end)| end == bytes.len())
+}
+
+fn skip_divergent_paths(left: &[u8], i: usize, right: &[u8], j: usize) -> Option<(usize, usize)> {
+    let (_, left_end) = path_span_covering(left, i)?;
+    let (_, right_end) = path_span_covering(right, j)?;
+    if left_end <= i || right_end <= j {
+        return None;
+    }
+    Some((left_end, right_end))
+}
+
+fn path_span_covering(bytes: &[u8], mismatch: usize) -> Option<(usize, usize)> {
+    let start = find_path_start(bytes, mismatch)?;
+    let mut end = mismatch.max(start);
+    while end < bytes.len() && is_path_byte(bytes[end]) {
+        end += 1;
+    }
+    if end <= start {
+        return None;
+    }
+    looks_like_path(&bytes[start..end]).then_some((start, end))
+}
+
+fn find_path_start(bytes: &[u8], mismatch: usize) -> Option<usize> {
+    if bytes.is_empty() || mismatch >= bytes.len() {
+        return None;
+    }
+    let mut start = mismatch;
+    while start > 0 && is_path_byte(bytes[start - 1]) {
+        start -= 1;
+    }
+    (start..=mismatch).find(|&index| is_path_start(bytes, index))
+}
+
+fn is_path_start(bytes: &[u8], index: usize) -> bool {
+    let Some(byte) = bytes.get(index).copied() else {
+        return false;
+    };
+    match byte {
+        b'/' | b'\\' | b'<' => true,
+        b'_' => bytes[index..].starts_with(b"__kache"),
+        b'A'..=b'Z' | b'a'..=b'z' => bytes.get(index + 1).copied() == Some(b':'),
+        _ => false,
+    }
+}
+
+fn is_path_byte(byte: u8) -> bool {
+    matches!(
+        byte,
+        b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'/'
+            | b'\\'
+            | b'.'
+            | b'_'
+            | b'-'
+            | b'~'
+            | b'+'
+            | b'%'
+            | b':'
+            | b'@'
+            | b'='
+            | b'$'
+            | b'{'
+            | b'}'
+            | b'['
+            | b']'
+            | b'<'
+            | b'>'
+    )
+}
+
+fn looks_like_path(bytes: &[u8]) -> bool {
+    bytes.len() >= 2
+        && is_path_start(bytes, 0)
+        && bytes.iter().any(|byte| matches!(byte, b'/' | b'\\' | b'>'))
+}
+
+#[cfg(test)]
+fn collect_relative_files(root: &Path) -> BTreeMap<String, PathBuf> {
+    let mut files = BTreeMap::new();
+    collect_relative_files_into(root, root, &mut files);
+    files
+}
+
+#[cfg(test)]
+fn collect_relative_files_into(root: &Path, dir: &Path, files: &mut BTreeMap<String, PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            collect_relative_files_into(root, &path, files);
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let Ok(relative) = path.strip_prefix(root) else {
+            continue;
+        };
+        if relative.as_os_str().is_empty() {
+            continue;
+        }
+        files.insert(relative_name(relative), path);
+    }
+}
+
+#[cfg(test)]
+fn relative_name(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::process_state_test_lock;
+
+    fn write_tree(root: &Path, files: &[(&str, &[u8])]) {
+        for (name, bytes) in files {
+            let path = root.join(name);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(path, bytes).unwrap();
+        }
+    }
+
+    #[test]
+    fn parse_enabled_accepts_only_boolean_on_spellings() {
+        assert!(!parse_enabled(None));
+        assert!(!parse_enabled(Some("")));
+        assert!(!parse_enabled(Some("0")));
+        assert!(!parse_enabled(Some("false")));
+        assert!(!parse_enabled(Some("FALSE")));
+        assert!(!parse_enabled(Some("off")));
+        assert!(!parse_enabled(Some("always")));
+        assert!(!parse_enabled(Some("sampled")));
+        assert!(parse_enabled(Some("1")));
+        assert!(parse_enabled(Some("true")));
+        assert!(parse_enabled(Some("TRUE")));
+        assert!(parse_enabled(Some(" True ")));
+    }
+
+    #[test]
+    fn enabled_reads_kache_verify_env() {
+        let _lock = process_state_test_lock();
+        let previous = std::env::var_os("KACHE_VERIFY");
+        // SAFETY: `_lock` serializes process-global env mutation in this crate's tests.
+        unsafe { std::env::remove_var("KACHE_VERIFY") };
+        assert!(!enabled());
+        unsafe { std::env::set_var("KACHE_VERIFY", "1") };
+        assert!(enabled());
+        unsafe { std::env::set_var("KACHE_VERIFY", "false") };
+        assert!(!enabled());
+        match previous {
+            Some(value) => unsafe { std::env::set_var("KACHE_VERIFY", value) },
+            None => unsafe { std::env::remove_var("KACHE_VERIFY") },
+        }
+    }
+
+    #[test]
+    fn matching_trees_compare_clean() {
+        let dir = tempfile::tempdir().unwrap();
+        let restored = dir.path().join("restored");
+        let compiled = dir.path().join("compiled");
+        write_tree(
+            &restored,
+            &[("libfoo.rlib", b"rlib-bytes"), ("foo.d", b"foo: src.rs\n")],
+        );
+        write_tree(
+            &compiled,
+            &[("libfoo.rlib", b"rlib-bytes"), ("foo.d", b"foo: src.rs\n")],
+        );
+
+        let report = compare_artifact_trees(&restored, &compiled);
+        assert_eq!(report.worst(), DivergenceClass::Match);
+        assert_eq!(report.event_summary(), "ok");
+        assert!(
+            report
+                .artifacts
+                .iter()
+                .all(|artifact| artifact.class == DivergenceClass::Match)
+        );
+    }
+
+    #[test]
+    fn extra_compiled_sidecar_is_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let restored = dir.path().join("restored");
+        let compiled = dir.path().join("compiled");
+        write_tree(&restored, &[("libfoo.rlib", b"rlib-bytes")]);
+        write_tree(
+            &compiled,
+            &[("libfoo.rlib", b"rlib-bytes"), ("libfoo.rmeta", b"extra")],
+        );
+
+        let report = compare_artifact_trees(&restored, &compiled);
+        assert_eq!(report.worst(), DivergenceClass::Match);
+        assert_eq!(report.artifacts.len(), 1);
+    }
+
+    #[test]
+    fn planted_content_divergence_is_named() {
+        let dir = tempfile::tempdir().unwrap();
+        let restored = dir.path().join("restored");
+        let compiled = dir.path().join("compiled");
+        write_tree(&restored, &[("libfoo.rlib", b"the-cached-artifact")]);
+        write_tree(&compiled, &[("libfoo.rlib", b"the-fresh-artifact!!")]);
+
+        let report = compare_artifact_trees(&restored, &compiled);
+        assert_eq!(report.worst(), DivergenceClass::Content);
+        assert_eq!(report.artifacts[0].name, "libfoo.rlib");
+        assert_eq!(report.artifacts[0].class, DivergenceClass::Content);
+        assert!(
+            report.event_summary().starts_with("content: libfoo.rlib"),
+            "{}",
+            report.event_summary()
+        );
+    }
+
+    #[test]
+    fn missing_recompile_output_is_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let restored = dir.path().join("restored");
+        let compiled = dir.path().join("compiled");
+        write_tree(&restored, &[("libfoo.rlib", b"bytes")]);
+        std::fs::create_dir_all(&compiled).unwrap();
+
+        let report = compare_artifact_trees(&restored, &compiled);
+        assert_eq!(report.worst(), DivergenceClass::Content);
+        assert_eq!(report.artifacts[0].detail, "missing from recompile");
+    }
+
+    #[test]
+    fn embedded_absolute_paths_are_path_debug() {
+        let dir = tempfile::tempdir().unwrap();
+        let restored = dir.path().join("restored");
+        let compiled = dir.path().join("compiled");
+        let cached = b"meta\0/Users/alice/proj/src/lib.rs\0payload";
+        let fresh = b"meta\0/Users/bob/proj/src/lib.rs\0payload";
+        write_tree(&restored, &[("libfoo.rmeta", cached)]);
+        write_tree(&compiled, &[("libfoo.rmeta", fresh)]);
+
+        let report = compare_artifact_trees(&restored, &compiled);
+        assert_eq!(report.worst(), DivergenceClass::PathDebug);
+        assert_eq!(report.artifacts[0].class, DivergenceClass::PathDebug);
+        assert_eq!(report.event_summary(), "path-debug: libfoo.rmeta");
+    }
+
+    #[test]
+    fn path_length_change_is_still_path_debug() {
+        let left = b"DWARF\0/Users/alice/very/long/src/lib.rs\0code";
+        let right = b"DWARF\0/tmp/x/src/lib.rs\0code";
+        assert!(bytes_equal_ignoring_embedded_paths(left, right));
+        let classified = classify_bytes("libfoo.rlib", left, right);
+        assert_eq!(classified.class, DivergenceClass::PathDebug);
+    }
+
+    #[test]
+    fn remap_sentinel_versus_absolute_path_is_path_debug() {
+        let left = b"x<WORKSPACE>/src/lib.rs\0y";
+        let right = b"x/home/dev/crate/src/lib.rs\0y";
+        assert!(bytes_equal_ignoring_embedded_paths(left, right));
+    }
+
+    #[test]
+    fn windows_drive_paths_are_path_debug() {
+        let left = b"objC:\\Users\\alice\\src\\lib.rs\0tail";
+        let right = b"objC:\\Users\\bob\\src\\lib.rs\0tail";
+        assert!(bytes_equal_ignoring_embedded_paths(left, right));
+    }
+
+    #[test]
+    fn path_debug_plus_payload_change_is_content() {
+        let left = b"meta\0/Users/alice/src/lib.rs\0PAYLOAD";
+        let right = b"meta\0/Users/bob/src/lib.rs\0PAYLOAX";
+        assert!(!bytes_equal_ignoring_embedded_paths(left, right));
+        assert_eq!(
+            classify_bytes("libfoo.rlib", left, right).class,
+            DivergenceClass::Content
+        );
+    }
+
+    #[test]
+    fn depinfo_path_rewrite_is_path_debug() {
+        let restored = b"__kache_root__/debug/deps/libfoo.rlib: /Users/alice/src/lib.rs\n";
+        let compiled = b"/tmp/kache-verify-1/libfoo.rlib: /Users/bob/src/lib.rs\n";
+        assert_eq!(
+            classify_bytes("foo.d", restored, compiled).class,
+            DivergenceClass::PathDebug
+        );
+    }
+
+    #[test]
+    fn mixed_classes_put_content_first_in_summary() {
+        let dir = tempfile::tempdir().unwrap();
+        let restored = dir.path().join("restored");
+        let compiled = dir.path().join("compiled");
+        write_tree(
+            &restored,
+            &[
+                ("libfoo.rlib", b"cached"),
+                ("foo.d", b"foo: /Users/alice/src.rs\n"),
+            ],
+        );
+        write_tree(
+            &compiled,
+            &[
+                ("libfoo.rlib", b"fresh!"),
+                ("foo.d", b"foo: /tmp/staging/src.rs\n"),
+            ],
+        );
+        let report = compare_artifact_trees(&restored, &compiled);
+        assert_eq!(report.worst(), DivergenceClass::Content);
+        let summary = report.event_summary();
+        assert!(summary.contains("content: libfoo.rlib"), "{summary}");
+        assert!(summary.contains("path-debug: foo.d"), "{summary}");
+        assert!(
+            summary.find("content").unwrap() < summary.find("path-debug").unwrap(),
+            "{summary}"
+        );
+    }
+
+    #[test]
+    fn named_compare_pairs_restored_files_to_recompile_outputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let restored = dir.path().join("out/libfoo.rlib");
+        let compiled = dir.path().join("stage/libfoo.rlib");
+        std::fs::create_dir_all(restored.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(compiled.parent().unwrap()).unwrap();
+        std::fs::write(&restored, b"same").unwrap();
+        std::fs::write(&compiled, b"same").unwrap();
+        let restored_list = vec![("libfoo.rlib".to_string(), restored)];
+        let mut compiled_by_name = BTreeMap::new();
+        compiled_by_name.insert("libfoo.rlib".to_string(), compiled);
+        let report = compare_named_artifacts(&restored_list, &compiled_by_name);
+        assert_eq!(report.worst(), DivergenceClass::Match);
+    }
+
+    #[test]
+    fn record_and_take_report_round_trips() {
+        let _ = take_last_report();
+        record_report("content: libfoo.rlib".to_string());
+        assert_eq!(take_last_report(), "content: libfoo.rlib");
+        assert!(take_last_report().is_empty());
+    }
+
+    fn rustc_available() -> bool {
+        std::process::Command::new("rustc")
+            .arg("--version")
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
+
+    fn rustc_emit_lib(out_dir: &Path, src: &Path) {
+        let status = std::process::Command::new("rustc")
+            .args([
+                "--crate-name",
+                "foo",
+                "--crate-type",
+                "lib",
+                "--emit",
+                "link,metadata",
+                "--out-dir",
+            ])
+            .arg(out_dir)
+            .arg(src)
+            .status()
+            .unwrap();
+        assert!(
+            status.success(),
+            "rustc failed writing to {}",
+            out_dir.display()
+        );
+    }
+
+    #[test]
+    fn matching_rustc_recompile_compares_clean() {
+        if !rustc_available() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("lib.rs");
+        std::fs::write(&src, "pub fn f() -> u8 { 1 }\n").unwrap();
+        let restored = dir.path().join("restored");
+        let compiled = dir.path().join("compiled");
+        std::fs::create_dir_all(&restored).unwrap();
+        std::fs::create_dir_all(&compiled).unwrap();
+        rustc_emit_lib(&restored, &src);
+        rustc_emit_lib(&compiled, &src);
+        let report = compare_artifact_trees(&restored, &compiled);
+        assert_eq!(
+            report.worst(),
+            DivergenceClass::Match,
+            "{}",
+            report.event_summary()
+        );
+    }
+
+    #[test]
+    fn planted_byte_in_rustc_rlib_is_content() {
+        if !rustc_available() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("lib.rs");
+        std::fs::write(&src, "pub fn f() -> u8 { 1 }\n").unwrap();
+        let restored = dir.path().join("restored");
+        let compiled = dir.path().join("compiled");
+        std::fs::create_dir_all(&restored).unwrap();
+        std::fs::create_dir_all(&compiled).unwrap();
+        rustc_emit_lib(&restored, &src);
+        rustc_emit_lib(&compiled, &src);
+        let rlib = std::fs::read_dir(&restored)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .find(|path| path.extension().and_then(|ext| ext.to_str()) == Some("rlib"))
+            .expect("rustc emitted an rlib");
+        let mut bytes = std::fs::read(&rlib).unwrap();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xFF;
+        std::fs::write(&rlib, bytes).unwrap();
+        let report = compare_artifact_trees(&restored, &compiled);
+        assert_eq!(report.worst(), DivergenceClass::Content);
+        assert!(
+            report
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.class == DivergenceClass::Content
+                    && artifact.name.ends_with(".rlib")),
+            "{report:?}"
+        );
+    }
+}

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3537,13 +3537,7 @@ fn run_verify_recompile(
     let staged_args = retarget_rustc_args_for_staging(args, staging.path());
     let result = crate::opcounts::suspend_spawn_counts(|| compiler.execute(&staged_args))
         .context("running KACHE_VERIFY recompile")?;
-    if result.exit_code != 0 {
-        anyhow::bail!(
-            "rustc exited {}{}",
-            result.exit_code,
-            verify_recompile_stderr_hint(&result.stderr)
-        );
-    }
+    verify_recompile_exit_status(result.exit_code, &result.stderr)?;
     let mut compiled_by_name = std::collections::BTreeMap::new();
     for artifact in result.artifacts.outputs() {
         compiled_by_name.insert(artifact.store_name.clone(), artifact.path.clone());
@@ -3563,6 +3557,16 @@ fn run_verify_recompile(
         restored,
         &compiled_by_name,
     ))
+}
+
+fn verify_recompile_exit_status(exit_code: i32, stderr: &str) -> Result<()> {
+    if exit_code == 0 {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "rustc exited {exit_code}{}",
+        verify_recompile_stderr_hint(stderr)
+    )
 }
 
 fn verify_recompile_stderr_hint(stderr: &str) -> String {
@@ -3599,42 +3603,39 @@ fn retarget_rustc_args_for_staging(args: &RustcArgs, staging: &Path) -> RustcArg
 fn rewrite_output_argv(argv: &[String], staging: &Path) -> Vec<String> {
     let staging_s = staging.display().to_string();
     let mut out = Vec::with_capacity(argv.len());
-    let mut i = 0;
-    while i < argv.len() {
-        let arg = &argv[i];
-        if arg == "--out-dir" {
-            out.push(arg.clone());
-            if i + 1 < argv.len() {
-                out.push(staging_s.clone());
-                i += 2;
-                continue;
+    let mut args = argv.iter();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--out-dir" => {
+                out.push(arg.clone());
+                if args.next().is_some() {
+                    out.push(staging_s.clone());
+                }
             }
-        } else if arg.starts_with("--out-dir=") {
-            out.push(format!("--out-dir={staging_s}"));
-            i += 1;
-            continue;
-        } else if arg == "-o" {
-            out.push(arg.clone());
-            if let Some(next) = argv.get(i + 1) {
-                let name = Path::new(next).file_name().unwrap_or_default();
-                out.push(staging.join(name).to_string_lossy().into_owned());
-                i += 2;
-                continue;
+            "-o" => {
+                out.push(arg.clone());
+                if let Some(next) = args.next() {
+                    let name = Path::new(next).file_name().unwrap_or_default();
+                    out.push(staging.join(name).to_string_lossy().into_owned());
+                }
             }
-        } else if arg == "--emit" {
-            out.push(arg.clone());
-            if let Some(next) = argv.get(i + 1) {
-                out.push(rewrite_emit_value(next, staging));
-                i += 2;
-                continue;
+            "--emit" => {
+                out.push(arg.clone());
+                if let Some(next) = args.next() {
+                    out.push(rewrite_emit_value(next, staging));
+                }
             }
-        } else if let Some(value) = arg.strip_prefix("--emit=") {
-            out.push(format!("--emit={}", rewrite_emit_value(value, staging)));
-            i += 1;
-            continue;
+            _ if arg.starts_with("--out-dir=") => {
+                out.push(format!("--out-dir={staging_s}"));
+            }
+            _ => {
+                if let Some(value) = arg.strip_prefix("--emit=") {
+                    out.push(format!("--emit={}", rewrite_emit_value(value, staging)));
+                } else {
+                    out.push(arg.clone());
+                }
+            }
         }
-        out.push(arg.clone());
-        i += 1;
     }
     out
 }
@@ -9535,6 +9536,77 @@ exit 0
     }
 
     #[test]
+    fn verify_recompile_exit_status_reports_the_first_plain_stderr_line() {
+        assert!(verify_recompile_exit_status(0, "error: ignored on success").is_ok());
+
+        let error = verify_recompile_exit_status(
+            2,
+            "\n{\"message\":\"json diagnostic\"}\n  error: compile failed  \n",
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "rustc exited 2 (error: compile failed)");
+        assert_eq!(verify_recompile_stderr_hint(""), "");
+        assert_eq!(
+            verify_recompile_stderr_hint("\n{\"message\":\"json only\"}\n"),
+            ""
+        );
+        assert_eq!(
+            verify_recompile_stderr_hint("\n warning: plain diagnostic \n"),
+            " (warning: plain diagnostic)"
+        );
+    }
+
+    #[test]
+    fn rewrite_output_argv_rewrites_separate_values_without_shifting_other_args() {
+        let staging = Path::new("/tmp/stage");
+        let rewritten = rewrite_output_argv(
+            &[
+                "rustc".into(),
+                "--out-dir".into(),
+                "/old/deps".into(),
+                "-o".into(),
+                "/old/deps/libfoo.rlib".into(),
+                "--emit".into(),
+                "metadata,dep-info=/old/deps/foo.d".into(),
+                "--cfg".into(),
+                "feature=\"x\"".into(),
+            ],
+            staging,
+        );
+        assert_eq!(
+            rewritten,
+            vec![
+                "rustc".to_string(),
+                "--out-dir".to_string(),
+                staging.display().to_string(),
+                "-o".to_string(),
+                staging.join("libfoo.rlib").display().to_string(),
+                "--emit".to_string(),
+                format!("metadata,dep-info={}", staging.join("foo.d").display()),
+                "--cfg".to_string(),
+                "feature=\"x\"".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn rewrite_output_argv_preserves_dangling_flags_and_empty_emit_paths() {
+        let staging = Path::new("/tmp/stage");
+        for flag in ["--out-dir", "-o", "--emit"] {
+            let argv = vec!["rustc".to_string(), flag.to_string()];
+            assert_eq!(rewrite_output_argv(&argv, staging), argv);
+        }
+        assert_eq!(
+            rewrite_emit_value("metadata,dep-info=", staging),
+            "metadata,dep-info="
+        );
+        assert_eq!(
+            rewrite_emit_value("dep-info=/old/foo.d", staging),
+            format!("dep-info={}", staging.join("foo.d").display())
+        );
+    }
+
+    #[test]
     fn rewrite_output_argv_handles_attached_out_dir_and_emit() {
         let staging = Path::new("/tmp/stage");
         let rewritten = rewrite_output_argv(
@@ -9551,8 +9623,11 @@ exit 0
             rewritten,
             vec![
                 "rustc".to_string(),
-                "--out-dir=/tmp/stage".to_string(),
-                "--emit=metadata,dep-info=/tmp/stage/foo.d".to_string(),
+                format!("--out-dir={}", staging.display()),
+                format!(
+                    "--emit=metadata,dep-info={}",
+                    staging.join("foo.d").display()
+                ),
                 "-C".to_string(),
                 "extra-filename=-abc".to_string(),
             ]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3470,6 +3470,189 @@ fn replay_cached_diagnostics(
     replay_diagnostics(&meta.stdout, &meta.stderr, out, err);
 }
 
+/// When `KACHE_VERIFY` is on, recompile into a staging directory and compare
+/// those artifacts to the files just restored.
+///
+/// Fail-open: never fails the restore, never overwrites restored outputs, and
+/// never prints the qualification rustc's diagnostics onto the hit's
+/// stdout/stderr (cargo fingerprints those streams).
+fn maybe_verify_restored_hit(
+    compiler: &RustcCompiler,
+    args: &RustcArgs,
+    restored: &[(String, PathBuf)],
+) {
+    if !crate::verify_compare::enabled() {
+        return;
+    }
+    let crate_name = args.crate_name.as_deref().unwrap_or("unknown");
+    match run_verify_recompile(compiler, args, restored) {
+        Ok(report) => {
+            let summary = report.event_summary();
+            match report.worst() {
+                crate::verify_compare::DivergenceClass::Match => {
+                    tracing::info!(
+                        crate_name,
+                        summary = %summary,
+                        "KACHE_VERIFY: restored artifacts match a fresh compile"
+                    );
+                }
+                crate::verify_compare::DivergenceClass::PathDebug => {
+                    tracing::warn!(
+                        crate_name,
+                        summary = %summary,
+                        "KACHE_VERIFY: path/debug divergence versus a fresh compile"
+                    );
+                }
+                crate::verify_compare::DivergenceClass::Content => {
+                    tracing::error!(
+                        crate_name,
+                        summary = %summary,
+                        "KACHE_VERIFY: content mismatch versus a fresh compile; serving the restored hit"
+                    );
+                }
+            }
+            crate::verify_compare::record_report(summary);
+        }
+        Err(error) => {
+            let summary = format!("recompile-failed: {error:#}");
+            tracing::error!(
+                crate_name,
+                error = %error,
+                "KACHE_VERIFY: recompile failed; serving the restored hit"
+            );
+            crate::verify_compare::record_report(summary);
+        }
+    }
+}
+
+fn run_verify_recompile(
+    compiler: &RustcCompiler,
+    args: &RustcArgs,
+    restored: &[(String, PathBuf)],
+) -> Result<crate::verify_compare::CompareReport> {
+    let staging = tempfile::Builder::new()
+        .prefix("kache-verify-")
+        .tempdir()
+        .context("creating KACHE_VERIFY staging directory")?;
+    let staged_args = retarget_rustc_args_for_staging(args, staging.path());
+    let result = crate::opcounts::suspend_spawn_counts(|| compiler.execute(&staged_args))
+        .context("running KACHE_VERIFY recompile")?;
+    if result.exit_code != 0 {
+        anyhow::bail!(
+            "rustc exited {}{}",
+            result.exit_code,
+            verify_recompile_stderr_hint(&result.stderr)
+        );
+    }
+    let mut compiled_by_name = std::collections::BTreeMap::new();
+    for artifact in result.artifacts.outputs() {
+        compiled_by_name.insert(artifact.store_name.clone(), artifact.path.clone());
+        if let Some(file_name) = artifact.path.file_name() {
+            compiled_by_name
+                .entry(file_name.to_string_lossy().into_owned())
+                .or_insert_with(|| artifact.path.clone());
+        }
+    }
+    for (name, _) in restored {
+        let staged = staging.path().join(name);
+        if staged.is_file() {
+            compiled_by_name.entry(name.clone()).or_insert(staged);
+        }
+    }
+    Ok(crate::verify_compare::compare_named_artifacts(
+        restored,
+        &compiled_by_name,
+    ))
+}
+
+fn verify_recompile_stderr_hint(stderr: &str) -> String {
+    let line = stderr
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with('{'))
+        .unwrap_or("");
+    if line.is_empty() {
+        String::new()
+    } else {
+        format!(" ({line})")
+    }
+}
+
+/// Point this invocation's output flags at `staging` without changing the
+/// frozen path-normalization root, so the qualification compile writes a
+/// private tree and does not pre-clean restored artifacts.
+fn retarget_rustc_args_for_staging(args: &RustcArgs, staging: &Path) -> RustcArgs {
+    let mut staged = args.clone();
+    staged.all_args = rewrite_output_argv(&args.all_args, staging);
+    staged.out_dir = args.out_dir.as_ref().map(|_| staging.to_path_buf());
+    if let Some(output) = &args.output {
+        let name = output.file_name().unwrap_or_default();
+        staged.output = Some(staging.join(name));
+    }
+    if let Some(dep) = &args.dep_info_output {
+        let name = dep.file_name().unwrap_or_default();
+        staged.dep_info_output = Some(staging.join(name));
+    }
+    staged
+}
+
+fn rewrite_output_argv(argv: &[String], staging: &Path) -> Vec<String> {
+    let staging_s = staging.display().to_string();
+    let mut out = Vec::with_capacity(argv.len());
+    let mut i = 0;
+    while i < argv.len() {
+        let arg = &argv[i];
+        if arg == "--out-dir" {
+            out.push(arg.clone());
+            if i + 1 < argv.len() {
+                out.push(staging_s.clone());
+                i += 2;
+                continue;
+            }
+        } else if arg.starts_with("--out-dir=") {
+            out.push(format!("--out-dir={staging_s}"));
+            i += 1;
+            continue;
+        } else if arg == "-o" {
+            out.push(arg.clone());
+            if let Some(next) = argv.get(i + 1) {
+                let name = Path::new(next).file_name().unwrap_or_default();
+                out.push(staging.join(name).to_string_lossy().into_owned());
+                i += 2;
+                continue;
+            }
+        } else if arg == "--emit" {
+            out.push(arg.clone());
+            if let Some(next) = argv.get(i + 1) {
+                out.push(rewrite_emit_value(next, staging));
+                i += 2;
+                continue;
+            }
+        } else if let Some(value) = arg.strip_prefix("--emit=") {
+            out.push(format!("--emit={}", rewrite_emit_value(value, staging)));
+            i += 1;
+            continue;
+        }
+        out.push(arg.clone());
+        i += 1;
+    }
+    out
+}
+
+fn rewrite_emit_value(value: &str, staging: &Path) -> String {
+    value
+        .split(',')
+        .map(|part| match part.split_once('=') {
+            Some((kind, path)) if !path.is_empty() => {
+                let name = Path::new(path).file_name().unwrap_or_default();
+                format!("{kind}={}", staging.join(name).display())
+            }
+            _ => part.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
 fn restore_from_cache(
     config: &Config,
     compiler: &RustcCompiler,
@@ -3666,6 +3849,7 @@ fn restore_from_cache(
     // Artifacts that came back as verbatim blob copies, each paired with the
     // digest the entry already recorded for it (kunobi-ninja/kache#540).
     let mut exact_restores: Vec<(crate::cache_key::FileFingerprint, &str)> = Vec::new();
+    let mut restored_paths: Vec<(String, PathBuf)> = Vec::with_capacity(meta.files.len());
 
     for cached_file in &meta.files {
         // Defense-in-depth trust-boundary check (kunobi-ninja/kache#211):
@@ -3712,9 +3896,12 @@ fn restore_from_cache(
         if let RestoredBytes::ExactBlobCopy(fingerprint) = restored {
             exact_restores.push((fingerprint, &cached_file.hash));
         }
+        restored_paths.push((cached_file.name.clone(), target_path));
     }
 
     blobs.record_known_file_hashes(&exact_restores);
+
+    maybe_verify_restored_hit(compiler, args, &restored_paths);
 
     Ok(())
 }
@@ -4452,7 +4639,7 @@ fn log_event_details(
         compile_time_ms,
         size,
         cache_key: cache_key.to_string(),
-        schema: 15,
+        schema: 16,
         session_id,
         key_ms,
         key_hash_hits: key_hash_stats.cache_hits,
@@ -4478,6 +4665,7 @@ fn log_event_details(
         passthrough_reason,
         store_error,
         lookup_rejection,
+        verify_compare: crate::verify_compare::take_last_report(),
         fallback,
         exit_code,
         key_fields,
@@ -9213,6 +9401,180 @@ exit 0
         .to_string();
 
         assert!(err.contains("no output path"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn retarget_rustc_args_rewrites_out_dir_output_and_emit_paths() {
+        let staging = PathBuf::from("/tmp/kache-verify-stage");
+        let args = rustc_args(&[
+            "rustc",
+            "src/lib.rs",
+            "--crate-name",
+            "foo",
+            "--out-dir",
+            "/orig/target/debug/deps",
+            "-o",
+            "/orig/target/debug/deps/libfoo.rlib",
+            "--emit",
+            "dep-info=/orig/target/debug/deps/foo.d,link",
+        ]);
+        let original_root = args.path_normalization_root().map(Path::to_path_buf);
+        let staged = retarget_rustc_args_for_staging(&args, &staging);
+        assert_eq!(staged.out_dir.as_deref(), Some(staging.as_path()));
+        assert_eq!(
+            staged.output.as_deref(),
+            Some(staging.join("libfoo.rlib").as_path())
+        );
+        assert_eq!(
+            staged.dep_info_output.as_deref(),
+            Some(staging.join("foo.d").as_path())
+        );
+        assert_eq!(
+            staged.path_normalization_root(),
+            original_root.as_deref(),
+            "qualification compile must keep the frozen remap root"
+        );
+        assert!(
+            staged
+                .all_args
+                .iter()
+                .any(|arg| arg == staging.to_str().unwrap()),
+            "argv --out-dir value must move to staging: {:?}",
+            staged.all_args
+        );
+        assert!(
+            staged
+                .all_args
+                .iter()
+                .any(|arg| arg.contains("dep-info=") && arg.contains("foo.d")),
+            "explicit dep-info emit path must move to staging: {:?}",
+            staged.all_args
+        );
+        assert!(
+            !staged
+                .all_args
+                .iter()
+                .any(|arg| arg.contains("/orig/target")),
+            "original output paths must not remain in argv: {:?}",
+            staged.all_args
+        );
+    }
+
+    #[test]
+    fn rewrite_output_argv_handles_attached_out_dir_and_emit() {
+        let staging = Path::new("/tmp/stage");
+        let rewritten = rewrite_output_argv(
+            &[
+                "rustc".into(),
+                "--out-dir=/old/deps".into(),
+                "--emit=metadata,dep-info=/old/foo.d".into(),
+                "-C".into(),
+                "extra-filename=-abc".into(),
+            ],
+            staging,
+        );
+        assert_eq!(
+            rewritten,
+            vec![
+                "rustc".to_string(),
+                "--out-dir=/tmp/stage".to_string(),
+                "--emit=metadata,dep-info=/tmp/stage/foo.d".to_string(),
+                "-C".to_string(),
+                "extra-filename=-abc".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn restore_from_cache_with_verify_on_is_fail_open_when_recompile_fails() {
+        let _lock = crate::test_support::process_state_test_lock();
+        let _verify = TestEnvGuard::set("KACHE_VERIFY", "1");
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+        let store = Store::open(&config).unwrap();
+        let out_dir = dir.path().join("target/debug/deps");
+        let content = b"restored-bytes";
+        let source = dir.path().join("source.rlib");
+        std::fs::write(&source, content).unwrap();
+        let hash = crate::cache_key::hash_file(&source).unwrap();
+        create_blob(&store, &hash, content);
+
+        let args = rustc_args(&[
+            "/no-such-rustc-kache-verify",
+            "src/lib.rs",
+            "--crate-name",
+            "foo",
+            "--emit",
+            "link",
+            "--out-dir",
+            &out_dir.to_string_lossy(),
+        ]);
+        let mut file = cached_file("libfoo.rlib", &hash);
+        file.size = content.len() as u64;
+        let meta = entry_meta("verify-fail-open", vec![file], &["link"]);
+
+        restore_from_cache(
+            &config,
+            &RustcCompiler::new(),
+            &BlobSource::Store(&store),
+            &args,
+            &meta,
+            None,
+        )
+        .expect("qualification recompile failure must not fail the restore");
+
+        assert_eq!(std::fs::read(out_dir.join("libfoo.rlib")).unwrap(), content);
+        let summary = crate::verify_compare::take_last_report();
+        assert!(
+            summary.starts_with("recompile-failed:"),
+            "expected a recompile-failed note, got {summary:?}"
+        );
+    }
+
+    #[test]
+    fn restore_from_cache_skips_verify_when_flag_off() {
+        let _lock = crate::test_support::process_state_test_lock();
+        let _verify = TestEnvGuard::remove("KACHE_VERIFY");
+        let _ = crate::verify_compare::take_last_report();
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+        let store = Store::open(&config).unwrap();
+        let out_dir = dir.path().join("target/debug/deps");
+        let content = b"off-path-bytes";
+        let source = dir.path().join("source.rlib");
+        std::fs::write(&source, content).unwrap();
+        let hash = crate::cache_key::hash_file(&source).unwrap();
+        create_blob(&store, &hash, content);
+
+        let args = rustc_args(&[
+            "rustc",
+            "src/lib.rs",
+            "--crate-name",
+            "foo",
+            "--emit",
+            "link",
+            "--out-dir",
+            &out_dir.to_string_lossy(),
+        ]);
+        let mut file = cached_file("libfoo.rlib", &hash);
+        file.size = content.len() as u64;
+        let meta = entry_meta("verify-off", vec![file], &["link"]);
+
+        restore_from_cache(
+            &config,
+            &RustcCompiler::new(),
+            &BlobSource::Store(&store),
+            &args,
+            &meta,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(out_dir.join("libfoo.rlib")).unwrap(), content);
+        assert!(
+            crate::verify_compare::take_last_report().is_empty(),
+            "flag off must not stash a verify_compare note"
+        );
     }
 
     #[test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -8461,6 +8461,7 @@ exit 0
     /// because reports rely on these schema-9 fields.
     #[test]
     fn log_event_with_store_stats_persists_timing_hash_and_store_fields() {
+        let _ = crate::verify_compare::take_last_report();
         let dir = tempfile::tempdir().unwrap();
         let config = test_config(dir.path().join("cache"));
         let store_put = StorePutResult {
@@ -8501,7 +8502,7 @@ exit 0
         assert_eq!(event.compile_time_ms, 20);
         assert_eq!(event.size, 30);
         assert_eq!(event.cache_key, "cache-key");
-        assert_eq!(event.schema, 15);
+        assert_eq!(event.schema, 16);
         assert_eq!(event.key_ms, 40);
         assert_eq!(event.key_hash_hits, 4);
         assert_eq!(event.key_hash_misses, 5);
@@ -8515,6 +8516,10 @@ exit 0
         assert!(
             event.store_error.is_empty(),
             "a successful store records no failure reason"
+        );
+        assert!(
+            event.verify_compare.is_empty(),
+            "verify off must not invent a verify_compare class"
         );
     }
 
@@ -8551,6 +8556,7 @@ exit 0
     /// (kunobi-ninja/kache#629).
     #[test]
     fn log_event_with_store_outcome_persists_the_store_failure_reason() {
+        let _ = crate::verify_compare::take_last_report();
         let dir = tempfile::tempdir().unwrap();
         let config = test_config(dir.path().join("cache"));
 
@@ -8583,10 +8589,15 @@ exit 0
             event.store_error,
             "refusing to cache zero-byte artifact: libfoo.rlib"
         );
+        assert!(
+            event.verify_compare.is_empty(),
+            "a store-failure miss must not invent a verify_compare class"
+        );
     }
 
     #[test]
     fn log_event_persists_same_key_lookup_rejection() {
+        let _ = crate::verify_compare::take_last_report();
         let dir = tempfile::tempdir().unwrap();
         let config = test_config(dir.path().join("cache"));
 
@@ -8617,18 +8628,77 @@ exit 0
         let event = &events[0];
         assert_eq!(event.result, EventResult::Miss);
         assert_eq!(event.cache_key, "same-key");
-        assert_eq!(event.schema, 15);
+        assert_eq!(event.schema, 16);
         assert_eq!(
             event.lookup_rejection,
             "matching entry lacks dep-info required by this invocation"
         );
         assert!(event.store_error.is_empty());
+        assert!(
+            event.verify_compare.is_empty(),
+            "lookup rejection must not invent a verify_compare class"
+        );
+    }
+
+    /// Schema 16 writes `verify_compare` from the hit-qualification stash.
+    /// Empty when verify did not run; the class string when it did.
+    #[test]
+    fn log_event_persists_verify_compare_class_on_hit() {
+        let _ = crate::verify_compare::take_last_report();
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+
+        log_event(
+            &config,
+            "/repo",
+            "foo",
+            EventResult::LocalHit,
+            1,
+            20,
+            30,
+            "hit-key",
+            0,
+            0,
+            0,
+            0,
+        );
+        let events = crate::events::read_events(&config.event_log_path()).unwrap();
+        assert_eq!(events[0].schema, 16);
+        assert_eq!(events[0].result, EventResult::LocalHit);
+        assert!(
+            events[0].verify_compare.is_empty(),
+            "no qualification run must leave verify_compare empty"
+        );
+
+        crate::verify_compare::record_report("content: libfoo.rlib (byte mismatch)".to_string());
+        log_event(
+            &config,
+            "/repo",
+            "foo",
+            EventResult::LocalHit,
+            2,
+            20,
+            30,
+            "hit-key",
+            0,
+            0,
+            1,
+            0,
+        );
+        let events = crate::events::read_events(&config.event_log_path()).unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[1].schema, 16);
+        assert_eq!(
+            events[1].verify_compare,
+            "content: libfoo.rlib (byte mismatch)"
+        );
     }
 
     /// Passthrough events intentionally omit cache timings but preserve the
     /// structured reason, fallback marker, and compiler exit code.
     #[test]
     fn log_passthrough_event_persists_reason_fallback_and_exit_code() {
+        let _ = crate::verify_compare::take_last_report();
         let dir = tempfile::tempdir().unwrap();
         let config = test_config(dir.path().join("cache"));
         let output = PassthroughOutput {
@@ -8657,6 +8727,10 @@ exit 0
         assert!(event.fallback);
         assert_eq!(event.exit_code, Some(42));
         assert_eq!(event.cache_key, "");
+        assert!(
+            event.verify_compare.is_empty(),
+            "passthrough must not invent a verify_compare class"
+        );
     }
 
     /// The emit gate must reject a missing requested output kind, while


### PR DESCRIPTION
## Summary

Adds `KACHE_VERIFY` (`1` / `true`; unset / `0` / `false` off) so a rustc cache hit still restores, then recompiles into a staging directory and diffs those artifacts against the restored files.

This is qualification for cache-key changes. Default off. Each enabled hit pays a full compile. There is no `kache build` command for this.

Compared: restored outputs vs a fresh rustc compile of the same invocation, with `--out-dir` / `-o` / explicit `--emit=…=path` rewritten to a temp staging tree so restored files are not overwritten. Embedded absolute paths and debug-info path bytes are `path-debug`. Remaining byte differences, or a missing recompile output, are `content`. Both stay fail-open: the restored files stay in place so the build continues, and the class is recorded on the hit event as `verify_compare` (and in tracing when logging is on). Qualification rustc diagnostics are not printed on the hit's stdout/stderr.

`KACHE_VERIFY_RESTORES` is unchanged. It only re-hashes stored blobs before restore.

C/C++ hits are not covered. `restore_cc_from_cache` is a different shape; rustc-only in this PR.

Env-only: no `config.rs` field, so this does not collide with #882.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --bin kache -- -D warnings`
- [x] `cargo clippy --bin kache --tests -- -D warnings`
- [x] `cargo test --bin kache -- verify_compare opcounts::tests::suspend restore_from_cache retarget_rustc rewrite_output_argv verify_compare_round`
- [x] Flag off: existing restore tests still pass; restore does not stash a `verify_compare` note
- [x] Flag on: two identical temp artifact trees compare as `ok`; a planted rlib byte flip is `content`; embedded path / dep-info / remap-sentinel diffs are `path-debug`
- [x] Flag on with a missing rustc: restore still succeeds (fail-open) and records `recompile-failed:`
- [ ] Full `just check` not run locally

## Checklist

- [ ] `just check` passes locally (fmt + clippy + tests)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [x] User-visible changes are reflected in `docs/getting-started/configuration.mdx` next to `KACHE_VERIFY_RESTORES`