### PR TITLE
docs: add AGENTS.md so PRs run just pr before push

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ Include before/after numbers for performance changes. -->
 
 ## Checklist
 
-- [ ] `just check` passes locally (fmt + clippy + tests)
+- [ ] `just pr` passes locally (fmt + clippy + tests + changed-line mutants)
 - [ ] New behaviour is covered by tests where it makes sense
 - [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
 - [ ] User-visible changes (CLI, config, output) are reflected in the README or relevant docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent notes
+
+`just check` is not the merge gate. CI mutation-tests changed Rust lines in the kache binary. A PR that only ran `cargo test` on the new tests will go red on Mutation testing. That is the usual failure.
+
+## Before `gh pr create`
+
+```sh
+just pr
+```
+
+That is `just check` (fmt, clippy `-D warnings`, tests) plus `just mutants-diff` against `origin/main`. Docs-only diffs skip mutants.
+
+```sh
+cargo install --locked cargo-mutants --version 27.1.0
+```
+
+Do not invoke `cargo mutants` with `RUSTC_WRAPPER=kache`. The Justfile clears it. Hand-running mutants without `just` wraps kache in itself and the unmutated baseline dies.
+
+Do not open the PR until `just pr` exits 0.
+
+## How mutants die here
+
+Prefer tests and deleting dead branches over skip annotations.
+
+- `if !s.is_empty() { print!("{s}") }` — printing `""` is a no-op, so `delete !` is missed. Call a helper that already has empty vs nonempty tests (`replay_cached_diagnostics`).
+- `a && b` / `a || b` — one test where the left is false, one where the right is false.
+- Named size constants built with `*` (`5 * 1024 * 1024 * 1024`) — do not `assert_eq!` against that same constant. Use an independent literal (`5 << 30`).
+- `u64::try_from` on a value that is already `u64` — Linux clippy `-D warnings`. macOS clippy does not type-check `#[cfg(target_os = "linux")]`.
+- Unix-only test helpers under `-D warnings` on Windows are unused. Mark them `#[cfg(unix)]`.
+- macOS-only helpers Linux never calls: `#[cfg(any(test, target_os = "macos"))]`.
+- `Drop` / file locks — a second process must acquire after the first drops.
+- New event-log fields — grep `event.schema` in the same commit and bump the tests.
+
+## PRs
+
+Every PR targets `main`. Do not stack PRs on each other's branches. After one merges, rebase the others onto `main`.
+
+Work in a git worktree. Do not mix unrelated dirty-tree WIP into the PR.
+
+People keep running `cargo`. There is no `kache build`. Caching is `kache init` / `RUSTC_WRAPPER`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,8 @@ cargo install --locked cargo-mutants --version 27.1.0
 just mutants-core
 ```
 
+Coding agents: read [AGENTS.md](./AGENTS.md) before opening a PR. The usual CI failure is Mutation testing after a push that only ran `just check`.
+
 Run the PR gate before submitting. `just check` is fmt, clippy with `-D warnings`, and tests. CI also mutation-tests every changed Rust line; `just pr` runs that too.
 
 ```sh
@@ -109,7 +111,7 @@ Clippy on macOS does not type-check `#[cfg(target_os = "linux")]` functions. Ide
 - Keep PRs small and focused on a single change
 - Add tests for new functionality
 - Don't bundle unrelated refactors with feature work
-- CI must pass before merge (fmt, clippy, tests, coverage threshold)
+- CI must pass before merge (fmt, clippy, tests, coverage, changed-line mutants)
 
 ## Branching and releases
 


### PR DESCRIPTION
Coding agents were opening PRs after `just check` / targeted `cargo test`. CI then failed on Mutation testing.

Adds `AGENTS.md` (what agents actually read): `just pr` is the gate, how to kill the mutants we keep missing, PRs target `main`. CONTRIBUTING points at it. The PR template checkbox is `just pr`, not `just check`.