### PR TITLE
test: stabilize process and environment-sensitive cases

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10351,7 +10351,17 @@ mod tests {
             .expect("spawn fake daemon");
         let fake_pid = child.id();
 
-        let found = super::find_daemon_pids();
+        // `Command::spawn` returns after fork, before the child necessarily
+        // completes exec and exposes the fake daemon argv to `pgrep -f`.
+        // Poll that transition instead of racing it once.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let found = loop {
+            let found = super::find_daemon_pids();
+            if found.contains(&fake_pid) || Instant::now() >= deadline {
+                break found;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        };
 
         child.kill().expect("kill fake daemon");
         child.wait().expect("reap fake daemon");

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -233,6 +233,8 @@ mod tests {
 
     #[test]
     fn lookup_keys_try_identity_then_legacy() {
+        let _lock = crate::config::config_path_lock();
+        let _guard = set_env("KACHE_MANIFEST_KEY", None);
         let keys = manifest_lookup_keys(Some("id/abcd/x86_64-unknown-linux-gnu/release"));
         assert_eq!(keys[0], "id/abcd/x86_64-unknown-linux-gnu/release");
         assert_eq!(
@@ -244,6 +246,8 @@ mod tests {
 
     #[test]
     fn lookup_keys_dedupe_when_identity_is_the_legacy_triple() {
+        let _lock = crate::config::config_path_lock();
+        let _guard = set_env("KACHE_MANIFEST_KEY", None);
         let legacy = host_target_triple_for(std::env::consts::ARCH, std::env::consts::OS);
         let keys = manifest_lookup_keys(Some(&legacy));
         assert_eq!(keys, vec![legacy]);
@@ -280,6 +284,8 @@ mod tests {
 
     #[test]
     fn lookup_keys_legacy_only_when_identity_is_blank() {
+        let _lock = crate::config::config_path_lock();
+        let _guard = set_env("KACHE_MANIFEST_KEY", None);
         let legacy = host_target_triple_for(std::env::consts::ARCH, std::env::consts::OS);
         assert_eq!(manifest_lookup_keys(None), vec![legacy.clone()]);
         assert_eq!(manifest_lookup_keys(Some("   ")), vec![legacy]);


### PR DESCRIPTION
Two test races were failing checks before feature code was evaluated.

- The daemon PID test now waits for its spawned fixture to complete exec before checking the process list.
- Manifest-key tests now use the shared environment lock and restore `KACHE_MANIFEST_KEY`.

The first race reproduced twice in the local mutation baseline. The second reproduced in Windows CI, which read `only-this` from a neighboring test. Production behavior is unchanged.

Validation:

- `just pr`
- Positive discovery test passed 20 consecutive runs
- Positive and negative PID discovery tests passed together
- Manifest-key group passed 20 repeated parallel runs
- Mutation diff: 0 applicable mutants, 0 survivors, 0 timeouts
