### PR TITLE
ci: build Kache with stable Kache cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,15 +99,25 @@ jobs:
       # KACHE_RUNTIME_DIR into the job env, and the test suite is not yet
       # hermetic against it (integration tests read events.jsonl from the
       # cache dir; daemon unit tests would share one runtime dir).
-      - uses: kunobi-ninja/kache-action@49398d37113c616fdb61be434cb497e3c2c8f3e6 # v1
+      # Use the latest stable release to accelerate ordinary verification.
+      # E2E, mutation, Kani, and platform jobs below still build this commit
+      # directly. Add `[no-kache]` to a PR title to diagnose cache-related CI.
+      - id: stable_kache
+        if: github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[no-kache]')
+        uses: kunobi-ninja/kache-action@49398d37113c616fdb61be434cb497e3c2c8f3e6 # v1
         with:
           github-cache: "true"
           cache-executables: "false"
+          # The old key contains no compiler outputs because Justfile disabled
+          # the wrapper. Start a new immutable Actions cache with real entries.
+          cache-key-prefix: kache-self-build
       - name: Clean bootstrap cache artifacts
         run: cargo clean
       - name: Run repo verification
         # kache-action exports the installed release version; self-checks must
         # compile with Cargo.toml's version from this PR.
+        env:
+          KACHE_SELF_HOST: ${{ steps.stable_kache.outcome == 'success' && '1' || '0' }}
         run: env -u KACHE_VERSION ./scripts/with-test-resources.sh just ci
         timeout-minutes: 30
       - name: Check crates.io package metadata

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,10 @@
-# Don't use kache to build kache (bootstrapping problem).
-export RUSTC_WRAPPER := ""
+# Build kache directly by default. CI may opt into using a released kache as
+# the wrapper; independent bare-build lanes still validate the current source.
+export RUSTC_WRAPPER := if env_var_or_default("KACHE_SELF_HOST", "") == "1" {
+  env_var_or_default("RUSTC_WRAPPER", "")
+} else {
+  ""
+}
 
 # On Windows, `just` runs each recipe line via `sh`, which Git for Windows
 # provides but does not put on PATH — so recipes (e.g. `just bench`) fail with


### PR DESCRIPTION
## What changed

- Keep the stable Kache action as the compiler wrapper for Linux `just ci`.
- Skip Kache when a PR title contains `[no-kache]`.
- Rotate the immutable Actions cache prefix so it starts with real compiler artifacts.
- Keep E2E, mutation, Kani, macOS, and Windows as independent bare-build checks.

## Validation

- Workflow YAML and Justfile parse successfully.
- The opt-in preserves `RUSTC_WRAPPER`; the opt-out clears it.
- Stable Kache 0.16.0 compiled current `kache-core` 0.16.1; a clean repeat completed from cache in 0.14 seconds.
- `cargo test --locked -p kache-core --lib`: 33 passed.