### PR TITLE
test: share process-state lock across env users

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2627,8 +2627,10 @@ pub(crate) use tests::config_path_lock;
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    // Config and compiler tests mutate process-wide env, including PATH. Share
+    // one lock with cache-key tests that read the same state.
+    pub(crate) use crate::test_support::process_state_test_lock as config_path_lock;
     use std::ffi::OsString;
-    use std::sync::{Mutex, OnceLock};
 
     /// kunobi-ninja/kache#319: executables are cached by default only where a
     /// restored binary keeps source-level debugging. Linux embeds DWARF; macOS
@@ -2643,18 +2645,6 @@ pub(crate) mod tests {
             cfg!(target_os = "linux") || cfg!(target_os = "macos"),
             "executables default on for Linux and macOS, off for Windows (see #319)"
         );
-    }
-
-    pub(crate) fn config_path_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        // Poison-tolerant: a test that panics while holding this lock must
-        // not cascade PoisonError panics into every unrelated env-guarded
-        // test behind it (#673). The guarded state is process environment
-        // that the panicking test's drop guards restore on unwind, so the
-        // inner guard is safe to adopt.
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
     }
 
     struct TestEnvGuard {

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -1623,21 +1623,27 @@ mod tests {
     async fn s3_wire_sends_custom_user_agent() {
         let (endpoint, requests) = mock_http_server(vec![http_response("404 Not Found", "")]).await;
 
-        struct ScopedEnvVar(&'static str);
+        struct ScopedEnvVar {
+            key: &'static str,
+            previous: Option<std::ffi::OsString>,
+        }
+
         impl ScopedEnvVar {
             fn set(key: &'static str, val: &str) -> Self {
+                let previous = std::env::var_os(key);
                 unsafe { std::env::set_var(key, val) };
-                Self(key)
-            }
-        }
-        impl Drop for ScopedEnvVar {
-            fn drop(&mut self) {
-                unsafe { std::env::remove_var(self.0) };
+                Self { key, previous }
             }
         }
 
-        let _access = ScopedEnvVar::set("KACHE_S3_ACCESS_KEY", "mock-access-key");
-        let _secret = ScopedEnvVar::set("KACHE_S3_SECRET_KEY", "mock-secret-key");
+        impl Drop for ScopedEnvVar {
+            fn drop(&mut self) {
+                match &self.previous {
+                    Some(previous) => unsafe { std::env::set_var(self.key, previous) },
+                    None => unsafe { std::env::remove_var(self.key) },
+                }
+            }
+        }
 
         let config = S3RemoteConfig {
             bucket: "bucket".to_string(),
@@ -1646,7 +1652,12 @@ mod tests {
             profile: None,
             user_agent: Some("kache-custom-agent/9.9".to_string()),
         };
-        let operator = create_s3_operator(&config, 30).unwrap();
+        let operator = {
+            let _lock = crate::test_support::process_state_test_lock();
+            let _access = ScopedEnvVar::set("KACHE_S3_ACCESS_KEY", "mock-access-key");
+            let _secret = ScopedEnvVar::set("KACHE_S3_SECRET_KEY", "mock-secret-key");
+            create_s3_operator(&config, 30).unwrap()
+        };
         let backend = OpenDalBackend::new(operator, "s3://bucket".to_string());
 
         assert!(

--- a/src/store.rs
+++ b/src/store.rs
@@ -5960,8 +5960,6 @@ mod tests {
         previous: Option<std::ffi::OsString>,
     }
 
-    static ENV_VAR_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     impl EnvVarGuard {
         fn set(key: &'static str, value: &str) -> Self {
             let previous = std::env::var_os(key);
@@ -9295,7 +9293,7 @@ mod tests {
         let blob = store.blob_path(&meta.files[0].hash);
         fs::set_permissions(&blob, fs::Permissions::from_mode(0o000)).unwrap();
 
-        let _env_lock = ENV_VAR_TEST_LOCK.lock().unwrap();
+        let _env_lock = crate::test_support::process_state_test_lock();
         let _verify = EnvVarGuard::set("KACHE_VERIFY_RESTORES", "always");
         let result = store.get("unreadable_key").unwrap();
 
@@ -11789,7 +11787,7 @@ mod tests {
         }
         std::fs::write(&blob, vec![b'X'; meta.files[0].size as usize]).unwrap();
 
-        let _env_lock = ENV_VAR_TEST_LOCK.lock().unwrap();
+        let _env_lock = crate::test_support::process_state_test_lock();
 
         // Guard OFF (default): size matches, content not checked -> still a hit.
         {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -5910,6 +5910,7 @@ mod tests {
     fn adaptive_policy_guard_tracks_kache_semantic_inputs() {
         const ENV_KEY: &str = "KACHE_WRAPPER_POLICY_GUARD_TEST";
 
+        let _lock = crate::test_support::process_state_test_lock();
         let dir = tempfile::tempdir().unwrap();
         let mut config = test_config(dir.path().join("cache"));
         let baseline = adaptive_policy_guard(&config);
@@ -7538,6 +7539,7 @@ mod tests {
     fn stripped_fallback_receives_incremental_disabled_env() {
         use std::os::unix::fs::PermissionsExt;
 
+        let _lock = crate::test_support::process_state_test_lock();
         let dir = tempfile::tempdir().unwrap();
         let fallback = dir.path().join("fallback");
         let env_dump = dir.path().join("incremental-env.txt");
@@ -7755,6 +7757,7 @@ exit 0
     /// output; the scoped guard keeps the process-global var restored.
     #[test]
     fn progress_level_parses_supported_env_values() {
+        let _lock = crate::test_support::process_state_test_lock();
         let _guard = TestEnvGuard::remove("KACHE_PROGRESS");
         assert_eq!(progress_level(), 0);
 
@@ -10015,7 +10018,7 @@ exit 0
     #[test]
     fn event_root_override_reads_kache_event_root_env() {
         // KACHE_EVENT_ROOT, when set and non-empty, overrides the event root.
-        // No other unit test reads this var, so a scoped set/restore is safe.
+        let _lock = crate::test_support::process_state_test_lock();
         let _guard = TestEnvGuard::set("KACHE_EVENT_ROOT", "/some/forest/root");
         assert_eq!(
             event_root_override(),


### PR DESCRIPTION
## What changed

- Reuse one poison-tolerant mutex across config, compiler, cache-key, wrapper, and store tests that change process-wide environment variables.
- Keep the existing `config_path_lock()` API as an alias to that shared lock.
- Restore pre-existing S3 credentials after the wire test creates its client.

The old config-only mutex allowed PATH-changing compiler tests to overlap cache-key tests. That could make a cache-key test fail to spawn `rustc`. Separate or missing locks around other environment tests left the same race open for their variables.

## Validation

- `just pr` (fmt, strict clippy, workspace tests, changed-line mutation gate)
- 11 affected environment, PATH, and cache tests over 25 parallel repetitions
