### PR TITLE
fix(cache): model frontend job count

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -268,6 +268,9 @@ pub struct RustcArgs {
     /// Unstable `-Z` flags. Can change codegen (e.g. `-Zsanitizer`,
     /// `-Zshare-generics`) and arrive on argv outside RUSTFLAGS.
     pub unstable_flags: Vec<String>,
+    /// Frontend worker counts from `--jobs-frontend`. Stored in argv order
+    /// because repeated occurrences use the last value.
+    pub frontend_jobs: Vec<String>,
     /// Direct rustc `--remap-path-prefix FROM=TO` values in argv order.
     /// The key normalizes known machine-local FROM prefixes while retaining
     /// unrelated FROM values, TO values, and occurrence order.
@@ -389,6 +392,7 @@ impl RustcArgs {
             link_search: Vec::new(),
             link_libs: Vec::new(),
             unstable_flags: Vec::new(),
+            frontend_jobs: Vec::new(),
             remap_path_prefixes: Vec::new(),
             inner_rustc,
             all_args: rustc_args.to_vec(),
@@ -547,6 +551,17 @@ impl RustcArgs {
                 }
                 _ if arg.starts_with("-l") && arg.len() > 2 => {
                     parsed.link_libs.push(arg["-l".len()..].to_string());
+                }
+                "--jobs-frontend" => {
+                    i += 1;
+                    parsed
+                        .frontend_jobs
+                        .push(rustc_args.get(i).cloned().unwrap_or_default());
+                }
+                _ if arg.starts_with("--jobs-frontend=") => {
+                    parsed
+                        .frontend_jobs
+                        .push(arg["--jobs-frontend=".len()..].to_string());
                 }
                 "-Z" => {
                     i += 1;
@@ -1010,6 +1025,7 @@ mod tests {
         link_search: Vec<String>,
         link_libs: Vec<String>,
         unstable_flags: Vec<String>,
+        frontend_jobs: Vec<String>,
         remap_path_prefixes: Vec<String>,
         inner_rustc: Option<PathBuf>,
         all_args: Vec<String>,
@@ -1057,6 +1073,7 @@ mod tests {
             link_search: parsed.link_search.clone(),
             link_libs: parsed.link_libs.clone(),
             unstable_flags: parsed.unstable_flags.clone(),
+            frontend_jobs: parsed.frontend_jobs.clone(),
             remap_path_prefixes: parsed.remap_path_prefixes.clone(),
             inner_rustc: parsed.inner_rustc.clone(),
             all_args: parsed.all_args.clone(),
@@ -1166,6 +1183,25 @@ mod tests {
                 parsed.residual_args
             );
         }
+    }
+
+    #[test]
+    fn frontend_jobs_capture_both_spellings_and_preserve_order() {
+        let parse = |extra: &[&str]| {
+            let mut argv = vec!["rustc".to_string()];
+            argv.extend(extra.iter().map(|s| s.to_string()));
+            RustcArgs::parse(&argv).unwrap()
+        };
+
+        let separated = parse(&["--jobs-frontend", "16"]);
+        let attached = parse(&["--jobs-frontend=16"]);
+        assert_eq!(separated.frontend_jobs, ["16"]);
+        assert_eq!(attached.frontend_jobs, separated.frontend_jobs);
+        assert!(separated.residual_args.is_empty());
+        assert!(attached.residual_args.is_empty());
+
+        let repeated = parse(&["--jobs-frontend=4", "--jobs-frontend", "8"]);
+        assert_eq!(repeated.frontend_jobs, ["4", "8"]);
     }
 
     /// The two sides of the #627 join have to agree: what a producer records

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -1410,6 +1410,14 @@ pub fn compute_cache_key(
         tracing::trace!("[key:{}] unstable:{}", crate_name, z);
     }
 
+    // Parallel frontend compilation changes the compiler execution mode and
+    // can affect emitted artifacts. Preserve occurrence order because rustc
+    // applies repeated values last-wins.
+    for jobs in &args.frontend_jobs {
+        fold_field(&mut hasher, b"frontend_jobs.v1:", jobs.as_bytes());
+        tracing::trace!("[key:{}] frontend_jobs:{}", crate_name, jobs);
+    }
+
     // Residual argv tokens (kunobi-ninja/kache#324): flags kache does not model
     // explicitly still reach rustc and can affect codegen (for example a
     // future flag), yet were previously invisible to the key — the `_ => {}`
@@ -6131,6 +6139,35 @@ mod tests {
         assert_ne!(
             shorthand_then_explicit, explicit_then_shorthand,
             "rustc applies optimization flags last-wins, so opposite orders must not collide"
+        );
+    }
+
+    #[test]
+    fn frontend_jobs_spellings_share_a_key_and_values_remain_ordered() {
+        let _lock = key_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, b"pub fn hello() {}").unwrap();
+
+        let none = key_of_flags(&flag_base(&source, &[]));
+        let separated = key_of_flags(&flag_base(&source, &["--jobs-frontend", "16"]));
+        let attached = key_of_flags(&flag_base(&source, &["--jobs-frontend=16"]));
+        let different = key_of_flags(&flag_base(&source, &["--jobs-frontend=8"]));
+        let order_4_8 = key_of_flags(&flag_base(
+            &source,
+            &["--jobs-frontend=4", "--jobs-frontend=8"],
+        ));
+        let order_8_4 = key_of_flags(&flag_base(
+            &source,
+            &["--jobs-frontend=8", "--jobs-frontend=4"],
+        ));
+
+        assert_ne!(none, attached, "frontend jobs must affect the key");
+        assert_eq!(separated, attached, "both rustc spellings are equivalent");
+        assert_ne!(attached, different, "worker count must affect the key");
+        assert_ne!(
+            order_4_8, order_8_4,
+            "repeated last-wins values must preserve argv order"
         );
     }
 


### PR DESCRIPTION
Handle rustc `--jobs-frontend` as an ordered cache-key input.

- canonicalize attached and separated spellings
- distinguish worker counts
- preserve repeated last-wins order

Validation:
- `just check`
- changed-line mutation test: 8/8 caught