### PR TITLE
docs: lead onboarding with kache init

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,24 @@
 
 Kache is a local-first compiler cache for Rust and C/C++. It stores build outputs by content, reuses them across worktrees, and can copy them to S3-compatible or filesystem remotes.
 
-## Try it without changing your setup
-
-Install Kache:
+## Install
 
 ```bash
 cargo install kache
+kache init
 ```
+
+`kache init` sets `rustc-wrapper` in Cargo's config, and on Unix the `[env]` keys that route build-script C and C++ through the cache. Review the proposed changes without applying them:
+
+```bash
+kache init --check
+```
+
+Use `kache init --no-service` if you want persistent Cargo configuration without an OS service.
+
+Then keep running `cargo build`.
+
+## Try it without changing your setup
 
 Run two clean builds from a Rust project:
 
@@ -26,19 +37,7 @@ kache stats
 
 `cargo clean` is only for this demonstration. Kache normally helps when Cargo would otherwise compile an input it has seen before, such as in another worktree or after changing toolchains and changing back.
 
-The commands above do not edit Cargo configuration or install a service. To keep Kache enabled:
-
-```bash
-kache init
-```
-
-Review the proposed changes without applying them:
-
-```bash
-kache init --check
-```
-
-Use `kache init --no-service` if you want persistent Cargo configuration without an OS service.
+This wraps rustc and nothing else. C and C++ compilations still run uncached, so it understates a configured setup.
 
 ## What Kache caches
 
@@ -46,7 +45,7 @@ Use `kache init --no-service` if you want persistent Cargo configuration without
 | --- | --- | --- |
 | Rust libraries and build scripts | Supported | Use `RUSTC_WRAPPER=kache` or `kache init` |
 | Rust executables | Supported on Linux and macOS | Disabled by default on Windows |
-| C and C++ object files | Supported | Use compiler shims or set the compiler launcher |
+| C and C++ object files | Supported | Enabled by `kache init`, compiler shims, or `CC`/`CXX` |
 | Local storage | Built in | Content-addressed store with garbage collection |
 | S3-compatible remote storage | Built in | Includes AWS S3, MinIO, and Cloudflare R2 |
 | Filesystem remote storage | Built in | Useful for shared disks and CI volumes |

--- a/docs/getting-started/c-cpp.mdx
+++ b/docs/getting-started/c-cpp.mdx
@@ -5,6 +5,14 @@ description: Cache supported GCC, Clang, and clang-cl object compilations
 
 Kache caches conservative, single-source C and C++ object compilations. If it cannot prove that an invocation is safe to cache, it runs the real compiler unchanged.
 
+## Cargo build scripts
+
+`RUSTC_WRAPPER` wraps rustc only, so a build script that compiles C through the `cc` crate is not cached until one of the two routes below is in place.
+
+`kache init` sets `HOST_CC` and `HOST_CXX` in Cargo's config (and `CC_KNOWN_WRAPPER_CUSTOM=kache`). It does not set `CC` or `CXX`, so `cargo build --target` keeps the cross compiler the `cc` crate would have found.
+
+PATH shims also cover Cargo's C bits when the crate invokes `cc` or `gcc` from `PATH` without `HOST_CC`.
+
 ## Make, CMake, autotools, PKGBUILD
 
 The Unix path is the same idea as ccache's masquerade method: put a directory of compiler-named symlinks first on `PATH`. `make`, CMake, autotools, and Arch PKGBUILDs that call `gcc` or `clang` by name then go through Kache. There is no `CC=` edit and no shell wrapper.
@@ -43,12 +51,6 @@ This is a native symlink to the `kache` binary. Do not wrap Kache in a shell scr
 Kache is a larger process than ccache. On a tree of many tiny `.c` files, measure both before replacing ccache.
 
 `kache doctor` reports whether a compiler name on `PATH` is a Kache shim. The check is informational, so a Rust-only setup does not fail doctor for skipping it.
-
-## Cargo build scripts
-
-`kache init` sets `HOST_CC` and `HOST_CXX` in Cargo's config (and `CC_KNOWN_WRAPPER_CUSTOM=kache`). It does not set `CC` or `CXX`, so `cargo build --target` keeps the cross compiler the `cc` crate would have found.
-
-PATH shims also cover Cargo's C bits when the crate invokes `cc` or `gcc` from `PATH` without `HOST_CC`.
 
 ## Prefix method
 

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -1,24 +1,9 @@
 ---
 title: Quick start
-description: Try Kache safely, then choose whether to enable it permanently
+description: Enable Kache, then verify the setup
 ---
 
-## Try Kache in one shell
-
-From a Rust project:
-
-```bash
-RUSTC_WRAPPER=kache cargo build
-cargo clean
-KACHE_PROGRESS=hits RUSTC_WRAPPER=kache cargo build
-kache stats
-```
-
-The first build fills the local cache. `cargo clean` makes Cargo request the same outputs again, so the second build can demonstrate restores. Do not add `cargo clean` to a normal build workflow.
-
-This trial does not edit Cargo configuration or install a service.
-
-## Enable Kache permanently
+## Enable Kache
 
 ```bash
 kache init
@@ -44,6 +29,23 @@ export RUSTC_WRAPPER=kache
 [build]
 rustc-wrapper = "kache"
 ```
+
+That covers Rust. Cargo's C and C++ compiles need the `[env]` keys `init` writes, or a shim on `PATH`.
+
+## Try Kache without changing configuration
+
+From a Rust project:
+
+```bash
+RUSTC_WRAPPER=kache cargo build
+cargo clean
+KACHE_PROGRESS=hits RUSTC_WRAPPER=kache cargo build
+kache stats
+```
+
+The first build fills the local cache. `cargo clean` makes Cargo request the same outputs again, so the second build can demonstrate restores. Do not add `cargo clean` to a normal build workflow.
+
+This trial does not edit Cargo configuration or install a service. It also wraps rustc and nothing else, so C and C++ compilations run uncached and the result understates a configured setup.
 
 ## Check the setup
 


### PR DESCRIPTION
The README and quick start opened with the `RUSTC_WRAPPER` trial, so the first thing a reader runs is the configuration that caches least. That route wraps rustc only — `HOST_CC` and `HOST_CXX` stay unset, no shim is on `PATH`, and every C and C++ compilation in the build runs uncached. Anyone benchmarking Kache by following the README is measuring a partial setup without being told so.

## Changes

- README and quick start lead with `kache init`. The trial stays, one section below, and now says what it leaves out.
- `c-cpp.mdx` moves the build-script section above the PATH-shim one. A Cargo user reads it first.
- The "What Kache caches" table said C and C++ needs "compiler shims or the compiler launcher", omitting `kache init` — the route most readers should take.

Text is moved rather than rewritten wherever the original said the right thing. `installation.mdx` is untouched.

## Verification

Every claim checked against the code: `src/cargo_env.rs` for the `[env]` keys and the Unix/Windows split, `src/cli.rs` for the init step order and `--check` / `--no-service` behaviour.

`scripts/check-docs.sh` passes 20 MDX pages. Docs-only, so the CI path filter skips the build matrix.