### PR TITLE
ci: add a per-PR warm-build performance gate

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -174,7 +174,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Set up Node for Kartero
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
 
@@ -374,7 +374,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Set up Node for Kartero
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
 
@@ -618,7 +618,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Set up Node for Kartero
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           "
       - name: Set up Node for Kartero
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
       - name: Export coverage telemetry

--- a/.github/workflows/perf-gate-preflight.yml
+++ b/.github/workflows/perf-gate-preflight.yml
@@ -1,0 +1,90 @@
+name: Perf gate (preflight)
+
+# Untrusted half of the per-PR performance gate. It does exactly one privileged
+# thing: nothing. It runs on a disposable GitHub-hosted runner with a read-only
+# token, records which pull request asked for a measurement, and hands that
+# number to `perf-gate.yml` through an artifact.
+#
+# Why this workflow exists at all: the measurement runs on the self-hosted
+# kunobi ARC runner, and a `pull_request` job from a fork must never reach one.
+# For a `pull_request` event GitHub uses the workflow file AS IT EXISTS IN THE
+# PR, so nothing decided here can be trusted — a fork can rewrite this file.
+# `perf-gate.yml` is therefore triggered by `workflow_run`, which always
+# executes the DEFAULT BRANCH's copy of itself, and it re-derives every fact
+# about the PR from the GitHub API before any privileged job starts. Treat the
+# artifact below as a hint, never as authorization.
+#
+# The eligibility check here is a courtesy: it puts the reason a fork PR gets no
+# perf numbers on the PR itself, instead of leaving the contributor to guess.
+# It never fails the check — an ineligible PR is skipped, not rejected.
+#
+# Docs-only pull requests are filtered out at the trigger. This gate is NOT a
+# required check (see perf-gate.yml), so a never-created run cannot wedge branch
+# protection the way it would for `ci.yml`.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "**.md"
+      - "**.mdx"
+      - "docs/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: Record the perf-gate request
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # The PR number is the whole payload. Everything else — head SHA, base
+      # branch, fork status, draft status — is looked up again from the API by
+      # the trusted half, so there is nothing here worth forging.
+      - name: Record the pull-request number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          mkdir -p perf-gate-request
+          printf '%s\n' "$PR_NUMBER" > perf-gate-request/pr-number.txt
+
+      # Report eligibility to the contributor. The same conditions are enforced
+      # for real, from the API, in perf-gate.yml's `authorize` job.
+      - name: Report eligibility
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          THIS_REPO: ${{ github.repository }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Perf gate"
+            if [ "$HEAD_REPO" != "$THIS_REPO" ]; then
+              echo
+              echo "This pull request comes from a fork (\`$HEAD_REPO\`), so the"
+              echo "performance gate will not run: the benchmark needs a self-hosted"
+              echo "runner, and fork code must not execute on one. A maintainer can"
+              echo "get numbers by pushing the same commits to a branch in"
+              echo "\`$THIS_REPO\`."
+            elif [ "$IS_DRAFT" = "true" ]; then
+              echo
+              echo "This pull request is a draft, so the performance gate is skipped."
+              echo "Mark it ready for review to get numbers."
+            else
+              echo
+              echo "Eligible. The measurement runs in the \`Perf gate\` workflow and"
+              echo "posts its numbers back here as a comment."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: perf-gate-request
+          path: perf-gate-request/
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -1,0 +1,447 @@
+name: Perf gate
+
+# Per-pull-request performance regression gate — the review-time counterpart to
+# the nightly `bench.yml`. Where the nightly measures the giants (Firefox, LLVM,
+# Substrate, SurrealDB, Lance, OpenDAL) for hours and reports absolute numbers,
+# this measures ONE mid-size subject twice — the PR head and its merge base,
+# back to back on the same machine — and reports the delta between them. Nothing
+# is compared against a stored historical figure: numbers from two different
+# runner generations are not comparable, and this repo has no way to pin one.
+#
+# NOT A REQUIRED CHECK. The repo's required contexts are managed outside this
+# file, and nothing here adds itself to them. This workflow reports a
+# `perf-gate/warm` commit status and a PR comment; promoting that status to a
+# blocking context is a separate, deliberate decision for the maintainer once
+# the first few runs have shown what its noise floor actually is.
+#
+# ── Runner topology ─────────────────────────────────────────────────────────
+# The measurement runs on the kunobi self-hosted Linux ARC runner — the
+# `kunobi-runners` gha-runner-scale-set in tenant-int-dev/zur1-builder1,
+# targeted by its INSTALLATION NAME as a single `runs-on` label, not by a
+# `[self-hosted, Linux, X64, …]` label set (see bench.yml's header). Pods are
+# ephemeral with an emptyDir `_work`, so there is no state to isolate and no
+# clone cache between runs, and the image is minimal — the base toolchain is
+# installed below. The two unprivileged jobs (`authorize`, `report`) stay on
+# GitHub-hosted runners so an ineligible PR never claims a self-hosted pod.
+#
+# ── Fork safety ─────────────────────────────────────────────────────────────
+# `workflow_run` is flagged by static analysis because a careless consumer
+# checks out and executes the triggering PR's code with a write-capable token.
+# That is precisely what this workflow is structured to prevent, and it is the
+# only trigger that gives us default-branch code:
+#
+#   1. `perf-gate-preflight.yml` runs on `pull_request`. Its file comes from the
+#      PR, so nothing it says is trusted; all it contributes is a PR number.
+#   2. This workflow is triggered by that run. A `workflow_run` workflow ALWAYS
+#      executes the default branch's copy of itself, so everything below is
+#      code a maintainer reviewed.
+#   3. `authorize` re-derives every fact from the GitHub API and refuses unless
+#      the PR's head repository IS this repository. A fork PR therefore never
+#      reaches step 4, whatever the artifact claimed.
+#   4. Only then does `measure` start on the self-hosted runner, checking out
+#      the head SHA the API confirmed.
+#
+# Same-repo-only is the conservative line: a branch in this repository can only
+# be pushed by someone who already has write access, which is the same trust
+# boundary `ci.yml`'s tag-gated release job relies on. Runner-group policy must
+# enforce that boundary independently — this file is not the only thing standing
+# between a fork and a private runner.
+on:
+  # zizmor: ignore[dangerous-triggers]
+  # Justification: `workflow_run` is the only trigger that guarantees this file
+  # runs from the default branch, which is what makes the fork check below
+  # trustworthy. The usual hazard — checking out and executing the triggering
+  # PR's code with a write-capable token — does not apply: the `authorize` job
+  # refuses anything that is not a same-repository branch, and the only job that
+  # holds write scopes (`report`) never checks out any code. See the header.
+  workflow_run:
+    workflows: ["Perf gate (preflight)"]
+    types: [completed]
+
+concurrency:
+  # One measurement per head branch. Superseding an in-flight run is right here
+  # (the numbers belong to a specific head commit), unlike the nightly bench,
+  # which must never cancel a multi-hour run. The head repository is part of the
+  # key so a fork branch that happens to share a name cannot cancel a real run.
+  group: >-
+    ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{
+    github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  # Selects scenarios/bench-pr-cargo. Kept here so the scenario name appears
+  # once, not in every step that references it.
+  BENCH_PROFILE: pr-cargo
+  BENCH_SCENARIO: bench-pr-cargo
+
+jobs:
+  # ── Trusted validation ──────────────────────────────────────────────────────
+  # Runs from the default branch (see the header) on a disposable runner. This
+  # is the only place that decides whether a self-hosted job may start.
+  authorize:
+    name: Authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # A failed or cancelled preflight, or a preflight that somehow fired on a
+    # non-PR event, produces no measurement.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    permissions:
+      contents: read
+      # Reading an artifact from the triggering run.
+      actions: read
+      pull-requests: read
+    outputs:
+      eligible: ${{ steps.check.outputs.eligible }}
+      pr: ${{ steps.pr.outputs.number }}
+      head_sha: ${{ steps.check.outputs.head_sha }}
+      base_ref: ${{ steps.check.outputs.base_ref }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: perf-gate-request
+          path: request
+          # Cross-run download: the artifact belongs to the preflight run that
+          # triggered this one, not to this run.
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # The artifact came from a workflow file the PR author controls, so treat
+      # its contents as hostile input: keep the digits, drop everything else,
+      # and bound the length. Anything that is not a plausible PR number stops
+      # the run here rather than reaching an API call or a shell.
+      - name: Read the pull-request number
+        id: pr
+        run: |
+          set -euo pipefail
+          raw="$(tr -cd '0-9' < request/pr-number.txt | head -c 9)"
+          if [ -z "$raw" ]; then
+            echo "::error::perf gate: the preflight artifact carried no pull-request number"
+            exit 1
+          fi
+          echo "number=$raw" >> "$GITHUB_OUTPUT"
+
+      # Everything the privileged job acts on is re-derived here, from the API,
+      # by default-branch code. `head.repo.full_name` is the fork check; the
+      # head-SHA comparison ties the PR to the run that actually triggered us,
+      # so a stale or hand-crafted PR number cannot redirect the measurement at
+      # a different commit.
+      - name: Validate the pull request
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.pr.outputs.number }}
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          pr_json="$(gh api "repos/$REPO/pulls/$PR")"
+          head_repo="$(jq -r '.head.repo.full_name // empty' <<<"$pr_json")"
+          head_sha="$(jq -r '.head.sha // empty' <<<"$pr_json")"
+          base_ref="$(jq -r '.base.ref // empty' <<<"$pr_json")"
+          state="$(jq -r '.state // empty' <<<"$pr_json")"
+          draft="$(jq -r '.draft' <<<"$pr_json")"
+
+          skip() {
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::perf gate skipped: $1"
+            { echo "### Perf gate skipped"; echo; echo "$1"; } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
+
+          [ "$head_repo" = "$REPO" ] || skip \
+            "PR #$PR comes from a fork ($head_repo). Fork code is never run on the self-hosted benchmark runner."
+          [ "$head_sha" = "$TRIGGER_SHA" ] || skip \
+            "PR #$PR is now at $head_sha but this run was triggered for $TRIGGER_SHA — a newer push supersedes it."
+          [ "$state" = "open" ] || skip "PR #$PR is $state."
+          [ "$draft" != "true" ] || skip "PR #$PR is a draft."
+          [ -n "$base_ref" ] || skip "PR #$PR has no base branch."
+
+          {
+            echo "eligible=true"
+            echo "head_sha=$head_sha"
+            echo "base_ref=$base_ref"
+          } >> "$GITHUB_OUTPUT"
+
+  # ── The measurement ─────────────────────────────────────────────────────────
+  measure:
+    name: Measure head vs merge base
+    needs: authorize
+    if: needs.authorize.outputs.eligible == 'true'
+    # gha-runner-scale-set: match by the scale-set's installation name (single
+    # label), not a `[self-hosted, …]` set. See the header.
+    runs-on: kunobi-runners
+    # Six builds of the subject (three phases x two commits) plus two builds of
+    # kache itself. Normal runs land well inside this; the cap exists so a stall
+    # is killed in an hour rather than at GitHub's 6h default.
+    timeout-minutes: 100
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        timeout-minutes: 10
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          # The merge base has to be reachable locally, and a shallow checkout
+          # cannot compute one.
+          fetch-depth: 0
+          # Nothing here pushes or fetches after checkout, so leaving a token in
+          # the worktree's git config would be a credential sitting on a
+          # long-lived runner for no reason.
+          persist-credentials: false
+
+      # The ARC image is minimal. This is bench.yml's prerequisite list trimmed
+      # to what `bench-pr-cargo` actually needs: a C toolchain and pkg-config
+      # for the cc-rs build scripts (libgit2-sys, libssh2-sys, libz-sys,
+      # curl-sys), OpenSSL headers for openssl-sys/libgit2, git + curl for the
+      # clone and for mise, and jq for the comparison script. No protoc, no
+      # ninja, no python — nothing in this subject needs them.
+      - name: Install build prerequisites (apt)
+        run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libssl-dev \
+            git curl ca-certificates jq
+
+      # mise installs rust (per rust-toolchain.toml) and just. The SUBJECT pins
+      # its own toolchain through the rust-toolchain.toml the scenario injects,
+      # honoured because RUSTUP_TOOLCHAIN is cleared for the benchmark steps.
+      - name: Install tools via mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          # Pin mise CLI — see ci.yml (v2026.6.10 regression).
+          version: 2026.6.9
+          install_args: --force rust github:casey/just
+          cache: false
+          reshim: false
+
+      # Disk-full mid-build is the worst failure mode on the emptyDir-backed
+      # work volume. Each side needs two debug objdirs plus a store; the base
+      # side's scratch is deleted before the head side starts (see below), so
+      # the floor covers one side plus kache's own target tree with headroom.
+      - name: Free-disk precheck
+        run: |
+          set -euo pipefail
+          avail_gb=$(df -BG --output=avail . | awk 'NR==2 {gsub(/G/,"",$1); print $1}')
+          echo "Free disk: ${avail_gb} GB (need >= 40 GB)"
+          if [ "${avail_gb:-0}" -lt 40 ]; then
+            echo "::error::perf gate: insufficient free disk (${avail_gb} GB < 40 GB)"
+            exit 1
+          fi
+
+      - name: Resolve the merge base
+        id: mergebase
+        env:
+          BASE_REF: ${{ needs.authorize.outputs.base_ref }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          # `origin/<base>` rather than the base branch's tip at PR creation:
+          # the merge base is what this PR is actually a delta against, and it
+          # is the only commit whose numbers are a fair "before". `fetch-depth:
+          # 0` above is what makes the base branch present locally.
+          if ! git rev-parse --verify --quiet "origin/$BASE_REF^{commit}" >/dev/null; then
+            echo "::error::perf gate: origin/$BASE_REF is not present — the checkout was not deep enough"
+            exit 1
+          fi
+          base="$(git merge-base "origin/$BASE_REF" "$HEAD_SHA")"
+          echo "Merge base with origin/$BASE_REF: $base"
+          echo "sha=$base" >> "$GITHUB_OUTPUT"
+
+      # Two kache binaries, ONE measuring instrument.
+      #
+      # `kache-scenario` — the benchmark engine, the scenario TOML it reads, and
+      # the comparison script — is built once, from the PR head, and used for
+      # both sides. If each side ran its own engine, an engine change in the PR
+      # would show up as a subject regression and nobody could tell the two
+      # apart. The consequence to know about: if a PR changes the `kache report
+      # --format json` shape the engine parses, the base binary's report will
+      # fail to parse and this job fails loudly. That is the correct outcome —
+      # such a PR needs its baseline taken by hand.
+      - name: Build kache from the merge base
+        env:
+          MERGE_BASE: ${{ steps.mergebase.outputs.sha }}
+          RUSTC_WRAPPER: ""
+        run: |
+          set -euo pipefail
+          git switch --detach "$MERGE_BASE"
+          cargo build --release -p kache
+          cp target/release/kache "$RUNNER_TEMP/kache-base"
+
+      - name: Build kache and the benchmark engine from the PR head
+        env:
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          RUSTC_WRAPPER: ""
+        run: |
+          set -euo pipefail
+          git switch --detach "$HEAD_SHA"
+          cargo build --release -p kache
+          cargo build --release -p kache-e2e --bin kache-scenario
+          cp target/release/kache "$RUNNER_TEMP/kache-head"
+          cp target/release/kache-scenario "$RUNNER_TEMP/kache-scenario"
+          "$RUNNER_TEMP/kache-base" --version
+          "$RUNNER_TEMP/kache-head" --version
+
+      # The merge base runs FIRST and its scratch is deleted before the head
+      # side starts, so peak disk is one side, not two. Ordering is fixed rather
+      # than randomised: with a fixed order any thermal or cache-warmth drift
+      # biases every PR the same way, which is easier to reason about than a
+      # bias that changes run to run.
+      - name: Benchmark the merge base
+        timeout-minutes: 40
+        env:
+          RUSTC_WRAPPER: ""
+          # The subject pins its own toolchain via the rust-toolchain.toml the
+          # scenario injects; a forced RUSTUP_TOOLCHAIN would override it.
+          RUSTUP_TOOLCHAIN: ""
+        run: |
+          set -euo pipefail
+          "$RUNNER_TEMP/kache-scenario" \
+            --kache "$RUNNER_TEMP/kache-base" \
+            --select suite:bench --select backend:kache \
+            --profile "$BENCH_PROFILE" \
+            --warm-same-tree \
+            --work-dir "tmp/perf-gate/base"
+          cp "tmp/perf-gate/base/$BENCH_SCENARIO.json" "$RUNNER_TEMP/base.json"
+          mkdir -p "$RUNNER_TEMP/logs/base"
+          cp tmp/perf-gate/base/*.log "$RUNNER_TEMP/logs/base/" || true
+          # Free the objdirs, worktrees and store before the head side runs.
+          # `clone-ref` is a SIBLING of the work dir, so it needs its own rm.
+          rm -rf tmp/perf-gate/base tmp/perf-gate/base-clone-ref
+
+      - name: Benchmark the PR head
+        timeout-minutes: 40
+        env:
+          RUSTC_WRAPPER: ""
+          RUSTUP_TOOLCHAIN: ""
+        run: |
+          set -euo pipefail
+          "$RUNNER_TEMP/kache-scenario" \
+            --kache "$RUNNER_TEMP/kache-head" \
+            --select suite:bench --select backend:kache \
+            --profile "$BENCH_PROFILE" \
+            --warm-same-tree \
+            --work-dir "tmp/perf-gate/head"
+          cp "tmp/perf-gate/head/$BENCH_SCENARIO.json" "$RUNNER_TEMP/head.json"
+          mkdir -p "$RUNNER_TEMP/logs/head"
+          cp tmp/perf-gate/head/*.log "$RUNNER_TEMP/logs/head/" || true
+
+      # The threshold and the validity gates live in the script, so `just`
+      # users and CI apply exactly the same rules. Non-zero exit = regression or
+      # invalid measurement; either way the markdown is written first so the
+      # reviewer sees why.
+      - name: Compare and gate
+        id: compare
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/report"
+          status=0
+          ./scripts/perf-gate-compare.sh \
+            "$RUNNER_TEMP/base.json" \
+            "$RUNNER_TEMP/head.json" \
+            "$RUNNER_TEMP/report/perf-gate.md" || status=$?
+          # The script writes the markdown before it decides the exit code, so
+          # the summary is there for both outcomes. Guard anyway: an argument or
+          # environment failure exits before writing anything, and losing the
+          # real exit code to a missing file would be the wrong failure to show.
+          if [ -f "$RUNNER_TEMP/report/perf-gate.md" ]; then
+            cat "$RUNNER_TEMP/report/perf-gate.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit "$status"
+
+      # always(): a failed comparison is exactly when the per-phase reports and
+      # build logs are worth reading.
+      - name: Upload perf-gate artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: perf-gate
+          path: |
+            ${{ runner.temp }}/base.json
+            ${{ runner.temp }}/head.json
+            ${{ runner.temp }}/report/perf-gate.md
+            ${{ runner.temp }}/logs/
+          retention-days: 14
+          if-no-files-found: warn
+
+  # ── Reporting ───────────────────────────────────────────────────────────────
+  # Separate job, and back on a GitHub-hosted runner, so the write-capable token
+  # this needs is never present on the self-hosted runner while third-party
+  # build scripts are executing.
+  report:
+    name: Report
+    needs: [authorize, measure]
+    if: always() && needs.authorize.outputs.eligible == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+      # `perf-gate/warm` on the head commit. Not a required context today; it
+      # exists so making it one later is a branch-protection edit and nothing
+      # else.
+      statuses: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: perf-gate
+          path: perf-gate
+        continue-on-error: true
+
+      - name: Post the numbers
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ needs.authorize.outputs.pr }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          MEASURE_RESULT: ${{ needs.measure.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          body_file="$(mktemp)"
+          # An HTML marker makes the comment sticky: the next run edits this one
+          # instead of adding a new comment to every push.
+          printf '%s\n\n' '<!-- kache-perf-gate -->' > "$body_file"
+          if [ -f perf-gate/report/perf-gate.md ]; then
+            cat perf-gate/report/perf-gate.md >> "$body_file"
+          else
+            {
+              echo "## Perf gate: no numbers"
+              echo
+              echo "The measurement job ended as \`$MEASURE_RESULT\` before it produced a report."
+            } >> "$body_file"
+          fi
+          printf '\n[Run details](%s)\n' "$RUN_URL" >> "$body_file"
+
+          existing="$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
+            --jq 'map(select(.body | startswith("<!-- kache-perf-gate -->"))) | .[0].id // empty' \
+            | head -n 1)"
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -F body=@"$body_file" >/dev/null
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@"$body_file" >/dev/null
+          fi
+
+          if [ "$MEASURE_RESULT" = "success" ]; then
+            state=success
+            description="warm build within budget"
+          else
+            state=failure
+            description="warm build regressed or the run was invalid"
+          fi
+          gh api -X POST "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state="$state" \
+            -f context="perf-gate/warm" \
+            -f description="$description" \
+            -f target_url="$RUN_URL" >/dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 #                    raw coverage data stays under target/llvm-cov-target/
 #                    (already covered by /target above).
 #   tmp/mutants/  — cargo-mutants logs, outcomes, and tested diffs.
+#   tmp/perf-gate/ — per-PR perf-gate scratch: one benchmark work dir per
+#                    side (merge base, PR head). The base side is deleted
+#                    before the head side runs, so peak disk is one side.
 #
 # To recover disk: `rm -rf tmp/` — tools regenerate what they need.
 /tmp/

--- a/Justfile
+++ b/Justfile
@@ -281,6 +281,24 @@ bench-trace PROFILE="" *ARGS:
     ./target/release/kache-scenario --kache ./target/release/kache --select suite:bench --select backend:kache --profile "{{PROFILE}}" --trace-keys {{ARGS}}; \
   fi
 
+# Run ONE side of the per-PR perf gate locally: the mid-size `bench-pr-cargo`
+# scenario with the extra same-worktree warm phase enabled, so the run reports
+# all three numbers the gate compares (cold, warm same-tree, cross-worktree).
+# Minutes, not hours — unlike the nightly giants above.
+#
+# This is one side only. The gate measures the PR head AND its merge base on the
+# same machine and compares them; see .github/workflows/perf-gate.yml. To
+# reproduce that locally, run this once per commit with a different
+# `--work-dir`, then diff the two result JSONs with
+# `scripts/perf-gate-compare.sh`.
+[group('bench')]
+bench-pr *ARGS:
+  cargo build --release -p kache
+  cargo build --release -p kache-e2e --bin kache-scenario
+  ./target/release/kache-scenario --kache ./target/release/kache \
+    --select suite:bench --select backend:kache --profile pr-cargo \
+    --warm-same-tree {{ARGS}}
+
 # Same cold/warm clone benchmark, but with sccache as the compiler cache.
 # Omit PROFILE to list sccache-backed profiles.
 # Use `just bench-sccache firefox` for the Firefox comparison.

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -14,6 +14,15 @@
 //!   off a locally-cached reference clone so re-runs don't pay the
 //!   network cost twice.
 //!
+//! `--warm-same-tree` inserts a third phase between those two:
+//!
+//! - **warm-same-tree**: clone-a rebuilt in place with its objdir wiped and the
+//!   store left warm. Same absolute path, so it measures restore cost with the
+//!   path-portability question held constant — the everyday "I cleaned my
+//!   `target/`" case. Off by default; the nightly scenarios would pay for a
+//!   third full build they do not read. Added for the per-PR perf gate, which
+//!   needs cold, warm, and cross-worktree as three separate numbers.
+//!
 //! The *project-specific* parts — which repo, how to wire kache in, how
 //! to build — live in benchmark scenarios under `scenarios/bench-*`;
 //! this binary is the project-agnostic measurement engine. See
@@ -110,6 +119,10 @@ pub struct BenchRunConfig {
     pub force_setup: bool,
     pub retry: bool,
     pub trace_keys: bool,
+    /// Insert the same-worktree warm phase between `cold` and the cross-clone
+    /// `warm`. Off by default — the nightly scenarios would pay for a third
+    /// full build they do not use. See [`Phase::WarmSameTree`].
+    pub warm_same_tree: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -130,6 +143,9 @@ impl CacheBackend {
 pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     if config.cache_backend == CacheBackend::Sccache && config.trace_keys {
         bail!("--trace-keys is only supported with --cache-backend kache");
+    }
+    if config.cache_backend == CacheBackend::Sccache && config.warm_same_tree {
+        bail!("--warm-same-tree is only supported with --cache-backend kache");
     }
     let cache_tool_arg = match config.cache_backend {
         CacheBackend::Kache => &config.kache,
@@ -252,6 +268,12 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         if config.cache_backend != CacheBackend::Kache {
             bail!("pull scenarios (`ref_next`) are only supported with --cache-backend kache");
         }
+        if config.warm_same_tree {
+            // A pull scenario already rebuilds clone-a a second time, at a
+            // different ref. Adding the same-tree warm phase would silently
+            // change what `pull` measures.
+            bail!("--warm-same-tree is not supported for pull scenarios (`ref_next`)");
+        }
         return run_pull_bench(
             &profile,
             &kache,
@@ -314,7 +336,12 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     // run: on `--retry` cold is restored from a snapshot rather than built, so
     // the delta would not cover the cold pool. Clones already exist at this
     // point; the cache and objdirs do not (cold wipes the cache first).
-    let disk_free_before = if config.retry {
+    //
+    // `--warm-same-tree` also opts out: it wipes and refills clone-a's objdir a
+    // second time, so the volume's free-space delta no longer maps onto the
+    // three-pool (clone-a/obj + clone-b/obj + store) model the estimate checks,
+    // and the comparison would raise a spurious accounting warning.
+    let disk_free_before = if config.retry || config.warm_same_tree {
         None
     } else {
         available_bytes(&work_dir)
@@ -357,13 +384,62 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         )?
     };
 
+    // warm-same-tree (opt-in): rebuild clone-a — the tree cold just built — with
+    // its objdir wiped and the store left warm. Same absolute path, so the
+    // measurement isolates restore cost from the path-portability question the
+    // cross-clone warm phase answers next. It runs BEFORE that phase because
+    // cold's cache snapshot (`cache-after-cold`, used by `--retry`) is already
+    // on disk, and because clone-b must stay untouched until it is built once.
+    //
+    // Anything this rebuild stores (a passthrough that cold did not reach) also
+    // benefits the cross-clone warm phase below; that is the same direction the
+    // cache already works in and is noted in the summary.
+    let warm_same_tree_metrics = if config.warm_same_tree {
+        reset_event_log(&event_log)?;
+        daemon::start(&kache, &cache_dir, &kache_config);
+        let wall_s = build(
+            &profile,
+            &clone_a,
+            Phase::WarmSameTree.name(),
+            &cache_dir,
+            &kache_config,
+            &kache,
+            &work_dir,
+            CacheBackend::Kache,
+            config.trace_keys,
+            &sh,
+        )?;
+        write_cache_otlp_or_warn(
+            &kache,
+            &cache_dir,
+            &kache_config,
+            &work_dir.join("cache-otlp-warm-same-tree"),
+            &profile.name,
+            Phase::WarmSameTree.name(),
+        );
+        daemon::stop(&kache, &cache_dir);
+        let (report, raw) = capture_report(
+            &kache,
+            &cache_dir,
+            &work_dir,
+            Phase::WarmSameTree.name(),
+            &clone_a,
+        )?;
+        let events = read_event_log(&event_log);
+        let (leaks, _) = scan_leak_warnings(
+            &work_dir.join(format!("wrapper-{}.log", Phase::WarmSameTree.name())),
+        );
+        Some(PhaseMetrics::from_report(
+            &report, &raw, wall_s, events, leaks,
+        ))
+    } else {
+        None
+    };
+
     // Reset the event log so warm's report covers only the warm build.
     // Only the observability log is removed — the cache store (`store/`,
     // `index.db`) stays, so warm still hits everything cold populated.
-    if event_log.exists() {
-        std::fs::remove_file(&event_log)
-            .with_context(|| format!("resetting {}", event_log.display()))?;
-    }
+    reset_event_log(&event_log)?;
 
     // warm: same cache, fresh clone at a different path → served from
     // what cold populated. Bring the daemon up first so the restore uses the
@@ -411,6 +487,16 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     } else {
         0.0
     };
+    // Same-tree speedup against the SAME run's cold build — the "did the warm
+    // build actually beat the cold one that seeded it" number a timing gate
+    // needs before it trusts a wall-clock delta. Present only when the phase ran.
+    let warm_same_tree_speedup = warm_same_tree_metrics.as_ref().map(|m| {
+        if m.wall_s > 0 {
+            round2(cold_metrics.wall_s as f64 / m.wall_s as f64)
+        } else {
+            0.0
+        }
+    });
 
     // Cross-clone cache-key stability: for the deterministic correctness
     // signal, see how many crates produced an identical key in both
@@ -423,6 +509,23 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         &warm_metrics,
         profile.checks.assertions.for_phase(Phase::Warm.name()),
     );
+    // The same-tree phase gets its OWN verdict from
+    // `[checks.assert.warm-same-tree]`, kept beside the cross-clone one rather
+    // than folded into it: `verdict` is the shape the nightly telemetry and the
+    // report JSON already publish, and both phases name the same checks. Key
+    // stability is cross-clone by definition, so it is passed as "nothing
+    // compared" — `Verdict::evaluate` skips that check when the denominator is
+    // zero. Both verdicts drive the exit code (see the end of this function).
+    let warm_same_tree_verdict = warm_same_tree_metrics.as_ref().map(|metrics| {
+        Verdict::evaluate(
+            &KeyStability::default(),
+            metrics,
+            profile
+                .checks
+                .assertions
+                .for_phase(Phase::WarmSameTree.name()),
+        )
+    });
     let mut measure_warnings = bench_measure_warnings(
         &warm_metrics,
         speedup,
@@ -490,6 +593,25 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         None
     };
 
+    let mut reports = vec![
+        "report-cold.json".to_string(),
+        "report-cold.md".to_string(),
+        "report-warm.json".to_string(),
+        "report-warm.md".to_string(),
+        "build-cold.log".to_string(),
+        "build-warm.log".to_string(),
+        "wrapper-cold.log".to_string(),
+        "wrapper-warm.log".to_string(),
+    ];
+    if warm_same_tree_metrics.is_some() {
+        reports.extend([
+            "report-warm-same-tree.json".to_string(),
+            "report-warm-same-tree.md".to_string(),
+            "build-warm-same-tree.log".to_string(),
+            "wrapper-warm-same-tree.log".to_string(),
+        ]);
+    }
+
     let result = BenchResult {
         project: profile.name.clone(),
         git_ref: profile.git_ref.clone(),
@@ -498,8 +620,10 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         artifact_dir: run_archive_dir.display().to_string(),
         cache_tool_version: cache_tool_version.clone(),
         cold: cold_metrics,
+        warm_same_tree: warm_same_tree_metrics,
         warm: warm_metrics,
         speedup: round2(speedup),
+        warm_same_tree_speedup,
         cache_size_mb: round1(dir_size_kb(&cache_dir) as f64 / 1024.0),
         cold_objdir_bytes,
         warm_objdir_bytes,
@@ -507,20 +631,10 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         key_stability: stability,
         warm_leak_samples,
         verdict,
+        warm_same_tree_verdict,
         measure_warnings,
         key_diff_top: key_diff_top.clone(),
-        reports: [
-            "report-cold.json",
-            "report-cold.md",
-            "report-warm.json",
-            "report-warm.md",
-            "build-cold.log",
-            "build-warm.log",
-            "wrapper-cold.log",
-            "wrapper-warm.log",
-        ]
-        .map(String::from)
-        .to_vec(),
+        reports,
     };
 
     let out = work_dir.join(format!("{}.json", profile.name));
@@ -550,8 +664,14 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     eprintln!("[bench] summary written to {}", out.display());
 
     // Preserve the existing manual-bench contract: clone-scale correctness
-    // assertions still fail the run, while measurements only warn.
-    if !result.verdict.ok {
+    // assertions still fail the run, while measurements only warn. The
+    // same-tree phase's own verdict is held to the same contract, so a PR gate
+    // reading these numbers cannot be handed a phase that measured nothing.
+    let same_tree_ok = result
+        .warm_same_tree_verdict
+        .as_ref()
+        .is_none_or(|verdict| verdict.ok);
+    if !result.verdict.ok || !same_tree_ok {
         std::process::exit(1);
     }
     Ok(())
@@ -1657,6 +1777,18 @@ fn capture_sccache_report(
     Ok(SccachePhaseMetrics::from_raw(&raw, wall_s))
 }
 
+/// Drop the event log so the next phase's report covers only that phase.
+///
+/// Only the observability log goes; the cache store (`store/`, `index.db`)
+/// stays, so the next build still hits everything its predecessor populated.
+fn reset_event_log(event_log: &Path) -> Result<()> {
+    if event_log.exists() {
+        std::fs::remove_file(event_log)
+            .with_context(|| format!("resetting {}", event_log.display()))?;
+    }
+    Ok(())
+}
+
 /// Parse the raw event log (`events.jsonl`) for one phase.
 ///
 /// `kache report` filters `passthrough` and `skipped` events out of its
@@ -2518,8 +2650,27 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
         "  cold build : {}   (empty cache, baseline)",
         fmt(r.cold.wall_s)
     );
+    // Only when `--warm-same-tree` ran: the plain "cleaned my target/" case,
+    // same absolute path, printed between cold and the cross-clone warm so the
+    // three wall-clocks read in the order they were measured.
+    if let Some(same_tree) = &r.warm_same_tree {
+        eprintln!(
+            "  same-tree  : {}   (clone-a rebuilt, objdir wiped, cache populated by cold)",
+            fmt(same_tree.wall_s)
+        );
+        eprintln!(
+            "               {} hits / {} misses, {:.1}% hit rate, restored {}{}",
+            same_tree.hits,
+            same_tree.misses,
+            same_tree.hit_rate_pct,
+            human_bytes(same_tree.storage.restored_bytes),
+            r.warm_same_tree_speedup
+                .map(|s| format!("   {s:.2}x vs cold"))
+                .unwrap_or_default(),
+        );
+    }
     eprintln!(
-        "  warm build : {}   (cache populated by cold)",
+        "  warm build : {}   (cache populated by cold; DIFFERENT worktree path)",
         fmt(r.warm.wall_s)
     );
     eprintln!("  speedup    : {:.2}x", r.speedup);
@@ -2707,6 +2858,16 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
             eprintln!("    - {issue}");
         }
     }
+    if let Some(same_tree) = &r.warm_same_tree_verdict {
+        if same_tree.ok {
+            eprintln!("  VERDICT (same-tree): ok — the phase validly consumed the cache.");
+        } else {
+            eprintln!("  VERDICT (same-tree): DEGRADED — that phase measured nothing real:");
+            for issue in &same_tree.issues {
+                eprintln!("    - {issue}");
+            }
+        }
+    }
     if !r.measure_warnings.is_empty() {
         eprintln!("  MEASURE WARNINGS:");
         for warning in &r.measure_warnings {
@@ -2771,9 +2932,17 @@ struct BenchResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     cache_tool_version: Option<String>,
     cold: PhaseMetrics,
+    /// The same-worktree warm rebuild, present only under `--warm-same-tree`.
+    /// Absent from every nightly scenario's JSON, so downstream readers must
+    /// treat it as optional.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    warm_same_tree: Option<PhaseMetrics>,
     warm: PhaseMetrics,
     /// Cold wall-clock divided by warm wall-clock.
     speedup: f64,
+    /// Cold wall-clock divided by the same-tree warm wall-clock.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    warm_same_tree_speedup: Option<f64>,
     cache_size_mb: f64,
     /// Apparent bytes of clone-a's objdir after the cold build.
     cold_objdir_bytes: u64,
@@ -2796,6 +2965,10 @@ struct BenchResult {
     warm_leak_samples: Vec<String>,
     /// Whether the run validly exercised kache (drives the exit code).
     verdict: Verdict,
+    /// The same-tree phase's own verdict, from
+    /// `[checks.assert.warm-same-tree]`. Also drives the exit code.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    warm_same_tree_verdict: Option<Verdict>,
     /// Advisory measurement threshold warnings. Never drives exit code.
     measure_warnings: Vec<String>,
     /// Top diverging key-input field across clones, set only when the
@@ -3075,8 +3248,14 @@ struct Verdict {
 
 impl Verdict {
     /// Gate thresholds. A run is degraded if cross-clone key stability
-    /// collapsed (the warm phase measured nothing real) or if most compiles
-    /// never reached the cache.
+    /// collapsed (the warm phase measured nothing real), if most compiles never
+    /// reached the cache, or if the phase reported no hits / restored no bytes.
+    ///
+    /// Applied to one phase's metrics at a time: the cross-clone `warm` phase
+    /// against `[checks.assert.warm]`, and — when `--warm-same-tree` ran — the
+    /// same-tree phase against `[checks.assert.warm-same-tree]`. Pass a default
+    /// [`KeyStability`] for the latter; a zero denominator skips the
+    /// cross-clone-only stability check.
     ///
     /// `max_errors` is intentionally NOT a degradation trigger. kache's
     /// `EventResult::Error` counts only wrapped-compiler non-zero exits — never
@@ -3126,6 +3305,46 @@ impl Verdict {
                     actual: format!("{:.1}", stability.stable_pct),
                     passed: true,
                 });
+            }
+        }
+
+        // Did this phase measure anything at all? A phase that reported zero
+        // hits, or hits that restored no bytes, recompiled the world — its
+        // wall-clock is a build time, not a cache time, and a comparison
+        // against it would be a flattering number rather than a measurement.
+        if let Some(min_hits) = spec.min_hits {
+            let passed = warm.hits >= min_hits;
+            checks.push(AssertionCheck {
+                name: "min_hits",
+                expected: format!(">= {min_hits}"),
+                actual: warm.hits.to_string(),
+                passed,
+            });
+            if !passed {
+                issues.push(format!(
+                    "{} cache hits (need >= {min_hits}) — this phase did not consume \
+                     the cache, so its wall-clock measures a rebuild, not a restore",
+                    warm.hits
+                ));
+            }
+        }
+
+        if let Some(min_restored_bytes) = spec.min_restored_bytes {
+            let restored = warm.storage.restored_bytes;
+            let passed = restored >= min_restored_bytes;
+            checks.push(AssertionCheck {
+                name: "min_restored_bytes",
+                expected: format!(">= {min_restored_bytes}"),
+                actual: restored.to_string(),
+                passed,
+            });
+            if !passed {
+                issues.push(format!(
+                    "{} restored from the store (need >= {}) — the phase reported hits \
+                     but no output files landed in the build tree",
+                    human_bytes(restored),
+                    human_bytes(min_restored_bytes),
+                ));
             }
         }
 
@@ -3333,6 +3552,7 @@ mod tests {
             min_key_stability_pct: Some(50.0),
             max_passthrough_pct: Some(40.0),
             max_errors: Some(0),
+            ..Default::default()
         };
 
         let verdict = Verdict::evaluate(&stability, &warm, Some(&spec));
@@ -3740,6 +3960,7 @@ mod tests {
             min_key_stability_pct: None,
             max_passthrough_pct: None,
             max_errors: Some(0),
+            ..Default::default()
         };
 
         let verdict = Verdict::evaluate(&stability, &warm, Some(&spec));
@@ -3765,6 +3986,7 @@ mod tests {
             min_key_stability_pct: Some(80.0),
             max_passthrough_pct: Some(20.0),
             max_errors: Some(0),
+            ..Default::default()
         };
 
         let verdict = Verdict::evaluate(&stability, &warm, Some(&spec));
@@ -3777,6 +3999,89 @@ mod tests {
             .map(|check| check.name)
             .collect();
         assert_eq!(failed, vec!["min_key_stability_pct", "max_passthrough_pct"]);
+    }
+
+    /// The PR perf gate's core safety property: a phase that recompiled the
+    /// world must be rejected, not reported as a fast build. Zero hits and zero
+    /// restored bytes are the two ways "this measured nothing" shows up.
+    #[test]
+    fn verdict_rejects_a_phase_that_consumed_no_cache() {
+        let spec = ScenarioAssertSpec {
+            min_hits: Some(1),
+            min_restored_bytes: Some(1024),
+            ..Default::default()
+        };
+        let measured_nothing = PhaseMetrics::default();
+
+        // A default `KeyStability` is how the same-tree phase is evaluated:
+        // stability is cross-clone only, so it must stay out of the verdict.
+        let verdict = Verdict::evaluate(&KeyStability::default(), &measured_nothing, Some(&spec));
+
+        assert!(!verdict.ok, "a zero-hit phase must not pass");
+        let failed: Vec<&str> = verdict
+            .checks
+            .iter()
+            .filter(|check| !check.passed)
+            .map(|check| check.name)
+            .collect();
+        assert_eq!(failed, vec!["min_hits", "min_restored_bytes"]);
+        assert!(
+            verdict
+                .checks
+                .iter()
+                .all(|check| check.name != "min_key_stability_pct"),
+            "stability must be skipped when nothing was compared"
+        );
+    }
+
+    /// A phase that hit the cache and pulled real bytes out of it passes both
+    /// validity checks.
+    #[test]
+    fn verdict_accepts_a_phase_that_hit_and_restored() {
+        let spec = ScenarioAssertSpec {
+            min_hits: Some(1),
+            min_restored_bytes: Some(1024),
+            ..Default::default()
+        };
+        let measured = PhaseMetrics {
+            hits: 412,
+            storage: StorageInfo {
+                restored_bytes: 64 * 1024 * 1024,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let verdict = Verdict::evaluate(&KeyStability::default(), &measured, Some(&spec));
+
+        assert!(verdict.ok, "{:?}", verdict.issues);
+        assert_eq!(verdict.checks.len(), 2);
+    }
+
+    /// Hits without bytes is the subtler failure: kache answered every query,
+    /// but nothing landed in the build tree, so the wall-clock is not a restore.
+    #[test]
+    fn verdict_rejects_hits_that_restored_nothing() {
+        let spec = ScenarioAssertSpec {
+            min_hits: Some(1),
+            min_restored_bytes: Some(1024),
+            ..Default::default()
+        };
+        let hollow = PhaseMetrics {
+            hits: 412,
+            ..Default::default()
+        };
+
+        let verdict = Verdict::evaluate(&KeyStability::default(), &hollow, Some(&spec));
+
+        assert!(!verdict.ok);
+        let failed: Vec<&str> = verdict
+            .checks
+            .iter()
+            .filter(|check| !check.passed)
+            .map(|check| check.name)
+            .collect();
+        assert_eq!(failed, vec!["min_restored_bytes"]);
     }
 
     #[test]

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -332,19 +332,13 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
 
     // Snapshot the volume's free space before any build runs, so the real
     // footprint of the cold+warm builds can be measured (free-space delta) and
-    // used to VERIFY the sharing-corrected disk-layout estimate. Only on a full
-    // run: on `--retry` cold is restored from a snapshot rather than built, so
-    // the delta would not cover the cold pool. Clones already exist at this
-    // point; the cache and objdirs do not (cold wipes the cache first).
-    //
-    // `--warm-same-tree` also opts out: it wipes and refills clone-a's objdir a
-    // second time, so the volume's free-space delta no longer maps onto the
-    // three-pool (clone-a/obj + clone-b/obj + store) model the estimate checks,
-    // and the comparison would raise a spurious accounting warning.
-    let disk_free_before = if config.retry || config.warm_same_tree {
-        None
-    } else {
+    // used to VERIFY the sharing-corrected disk-layout estimate. Clones already
+    // exist at this point; the cache and objdirs do not (cold wipes the cache
+    // first). See `measures_disk_footprint` for when the delta is meaningful.
+    let disk_free_before = if measures_disk_footprint(config.retry, config.warm_same_tree) {
         available_bytes(&work_dir)
+    } else {
+        None
     };
 
     if config.cache_backend == CacheBackend::Sccache {
@@ -490,13 +484,9 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     // Same-tree speedup against the SAME run's cold build — the "did the warm
     // build actually beat the cold one that seeded it" number a timing gate
     // needs before it trusts a wall-clock delta. Present only when the phase ran.
-    let warm_same_tree_speedup = warm_same_tree_metrics.as_ref().map(|m| {
-        if m.wall_s > 0 {
-            round2(cold_metrics.wall_s as f64 / m.wall_s as f64)
-        } else {
-            0.0
-        }
-    });
+    let warm_same_tree_speedup = warm_same_tree_metrics
+        .as_ref()
+        .map(|m| phase_speedup(cold_metrics.wall_s, m.wall_s));
 
     // Cross-clone cache-key stability: for the deterministic correctness
     // signal, see how many crates produced an identical key in both
@@ -660,21 +650,56 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     );
 
     archive_run_artifacts(&work_dir, &run_archive_dir)?;
-    print_summary(&result, &run_archive_dir);
+    // A broken stderr must not turn a completed benchmark into a failed one —
+    // the reports are already on disk by this point.
+    let _ = write_summary(&mut std::io::stderr().lock(), &result, &run_archive_dir);
     eprintln!("[bench] summary written to {}", out.display());
 
     // Preserve the existing manual-bench contract: clone-scale correctness
     // assertions still fail the run, while measurements only warn. The
     // same-tree phase's own verdict is held to the same contract, so a PR gate
     // reading these numbers cannot be handed a phase that measured nothing.
-    let same_tree_ok = result
-        .warm_same_tree_verdict
-        .as_ref()
-        .is_none_or(|verdict| verdict.ok);
-    if !result.verdict.ok || !same_tree_ok {
+    if run_is_degraded(&result.verdict, result.warm_same_tree_verdict.as_ref()) {
         std::process::exit(1);
     }
     Ok(())
+}
+
+/// Should this run measure its own disk footprint as the volume's free-space
+/// delta across the build phases?
+///
+/// Only a plain full run can. `--retry` restores cold from a snapshot instead
+/// of building it, so the delta would not cover the cold pool.
+/// `--warm-same-tree` wipes and refills clone-a's objdir a second time, so the
+/// delta no longer maps onto the three-pool (clone-a/obj + clone-b/obj + store)
+/// model the estimate is checked against and the comparison would raise a
+/// spurious accounting warning.
+fn measures_disk_footprint(retry: bool, warm_same_tree: bool) -> bool {
+    !retry && !warm_same_tree
+}
+
+/// Speedup of a warm phase against the cold build that seeded it, rounded for
+/// the report.
+///
+/// Zero when the phase's wall-clock rounded down to zero seconds: the engine
+/// times whole seconds, and dividing by zero yields an infinity that is not a
+/// number any report should carry.
+fn phase_speedup(cold_wall_s: u64, phase_wall_s: u64) -> f64 {
+    if phase_wall_s > 0 {
+        round2(cold_wall_s as f64 / phase_wall_s as f64)
+    } else {
+        0.0
+    }
+}
+
+/// Did any configured assertion say this run is not a valid measurement?
+///
+/// The cross-clone verdict always counts. The same-tree verdict is present only
+/// when `--warm-same-tree` ran, and when it is, it is held to the same
+/// contract: a PR gate reading these numbers must never be handed a phase that
+/// measured nothing.
+fn run_is_degraded(verdict: &Verdict, warm_same_tree_verdict: Option<&Verdict>) -> bool {
+    !verdict.ok || warm_same_tree_verdict.is_some_and(|same_tree| !same_tree.ok)
 }
 
 /// Default scratch dir for a scenario when `--work-dir` is not given:
@@ -2637,28 +2662,41 @@ fn print_sccache_summary(r: &SccacheBenchResult, work_dir: &Path) {
     eprintln!("{bar}");
 }
 
-fn print_summary(r: &BenchResult, work_dir: &Path) {
+/// Render the end-of-run benchmark summary a human reads.
+///
+/// Writes rather than prints so the numbers it reports can be asserted in a
+/// test. That matters for the three wall-clocks at the top: the per-PR perf
+/// gate compares exactly those, and a summary that quietly stopped reporting
+/// one of them would leave the gate reading a blank.
+fn write_summary(
+    out: &mut dyn std::io::Write,
+    r: &BenchResult,
+    work_dir: &Path,
+) -> std::io::Result<()> {
     let bar = "=".repeat(64);
     let fmt = |s: u64| format!("{}m {:02}s", s / 60, s % 60);
-    eprintln!("\n{bar}");
-    eprintln!("  kache benchmark: {} — {}", r.project, r.git_ref);
+    writeln!(out, "\n{bar}")?;
+    writeln!(out, "  kache benchmark: {} — {}", r.project, r.git_ref)?;
     if let Some(version) = &r.cache_tool_version {
-        eprintln!("  cache tool : {version}");
+        writeln!(out, "  cache tool : {version}")?;
     }
-    eprintln!("{bar}");
-    eprintln!(
+    writeln!(out, "{bar}")?;
+    writeln!(
+        out,
         "  cold build : {}   (empty cache, baseline)",
         fmt(r.cold.wall_s)
-    );
+    )?;
     // Only when `--warm-same-tree` ran: the plain "cleaned my target/" case,
     // same absolute path, printed between cold and the cross-clone warm so the
     // three wall-clocks read in the order they were measured.
     if let Some(same_tree) = &r.warm_same_tree {
-        eprintln!(
+        writeln!(
+            out,
             "  same-tree  : {}   (clone-a rebuilt, objdir wiped, cache populated by cold)",
             fmt(same_tree.wall_s)
-        );
-        eprintln!(
+        )?;
+        writeln!(
+            out,
             "               {} hits / {} misses, {:.1}% hit rate, restored {}{}",
             same_tree.hits,
             same_tree.misses,
@@ -2667,17 +2705,19 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
             r.warm_same_tree_speedup
                 .map(|s| format!("   {s:.2}x vs cold"))
                 .unwrap_or_default(),
-        );
+        )?;
     }
-    eprintln!(
+    writeln!(
+        out,
         "  warm build : {}   (cache populated by cold; DIFFERENT worktree path)",
         fmt(r.warm.wall_s)
-    );
-    eprintln!("  speedup    : {:.2}x", r.speedup);
-    eprintln!(
+    )?;
+    writeln!(out, "  speedup    : {:.2}x", r.speedup)?;
+    writeln!(
+        out,
         "  warm cache : {} hits / {} dups / {} misses   {:.1}% hit rate ({:.1}% weighted)",
         r.warm.hits, r.warm.dups, r.warm.misses, r.warm.hit_rate_pct, r.warm.weighted_hit_rate_pct
-    );
+    )?;
     let el = &r.warm.event_log;
     let cacheable = el.hit_bytes.saturating_add(el.miss_bytes);
     let bytes_cov_pct = if cacheable > 0 {
@@ -2685,28 +2725,31 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
     } else {
         0.0
     };
-    eprintln!(
+    writeln!(
+        out,
         "  bytes      : {} cached / {} recompiled   ({:.1}% of cacheable bytes)",
         human_bytes(el.hit_bytes),
         human_bytes(el.miss_bytes),
         bytes_cov_pct,
-    );
-    eprintln!("{bar}");
+    )?;
+    writeln!(out, "{bar}")?;
 
     // ── restore: bytes that flowed cache → warm clone, and how ──
     let st = &r.warm.storage;
-    eprintln!(
+    writeln!(
+        out,
         "  restore    : warm build pulled {} from the cache",
         human_bytes(st.restored_bytes)
-    );
-    eprintln!(
+    )?;
+    writeln!(
+        out,
         "               reflink {} / hardlink {} / copy {}   ({:.1}% zero-copy)",
         human_bytes(st.reflinked_bytes),
         human_bytes(st.hardlinked_bytes),
         human_bytes(st.copied_bytes),
         st.zero_copy_pct,
-    );
-    eprintln!("{bar}");
+    )?;
+    writeln!(out, "{bar}")?;
 
     // ── disk layout: the three pools and what sharing buys ──
     // Apparent = sum of file lengths. The same physical blocks appear in more
@@ -2738,17 +2781,23 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
         .saturating_add(st.blob_bytes);
     let approx_on_disk = sum_apparent.saturating_sub(shared_total);
     let restore_shared = st.reflinked_bytes.saturating_add(st.hardlinked_bytes);
-    eprintln!("  disk layout — three pools, sharing via reflink/hardlink");
-    eprintln!(
+    writeln!(
+        out,
+        "  disk layout — three pools, sharing via reflink/hardlink"
+    )?;
+    writeln!(
+        out,
         "    clone-a/obj   {:>10}   cold-built objdir",
         human_bytes(r.cold_objdir_bytes)
-    );
-    eprintln!(
+    )?;
+    writeln!(
+        out,
         "    clone-b/obj   {:>10}   warm-built; {} shared from cache",
         human_bytes(r.warm_objdir_bytes),
         human_bytes(restore_shared),
-    );
-    eprintln!(
+    )?;
+    writeln!(
+        out,
         "    kache cache   {:>10}   {} blobs; {} shared from build output, {} copied",
         human_bytes(st.blob_bytes),
         st.store_blobs,
@@ -2758,59 +2807,67 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
                 .store_copied_bytes
                 .saturating_add(st.store_copied_bytes)
         ),
-    );
-    eprintln!(
+    )?;
+    writeln!(
+        out,
         "                  {:>10}   ({} dedup vs {} raw)",
         "",
         human_bytes(st.dedup_saved_bytes),
         human_bytes(st.logical_bytes),
-    );
-    eprintln!("                  ──────────");
-    eprintln!(
+    )?;
+    writeln!(out, "                  ──────────")?;
+    writeln!(
+        out,
         "    sum apparent  {:>10}   what 3 independent pools would cost",
         human_bytes(sum_apparent),
-    );
-    eprintln!(
+    )?;
+    writeln!(
+        out,
         "    ≈ on disk    ~{:>10}   zero-copy sharing saves {} ({} restore + {} store)",
         human_bytes(approx_on_disk),
         human_bytes(shared_total),
         human_bytes(restore_shared),
         human_bytes(store_shared),
-    );
+    )?;
     if let Some(measured) = r.disk_measured_bytes {
         // Ground truth: the volume's free-space delta across the two build
         // phases. CoW/dedup/compression-honest and filesystem-agnostic — it
         // VERIFIES the estimate above rather than trusting kache's own tally.
-        eprintln!(
+        writeln!(
+            out,
             "    measured      {:>10}   actual free-space delta (cold+warm builds)",
             human_bytes(measured),
-        );
+        )?;
     }
-    eprintln!("{bar}");
+    writeln!(out, "{bar}")?;
 
     // ── diagnostics: did the run actually exercise kache? ──
-    eprintln!(
+    writeln!(
+        out,
         "  key stability : {:.1}%   ({} of {} crates kept an identical key across clones)",
         r.key_stability.stable_pct, r.key_stability.stable, r.key_stability.compared
-    );
+    )?;
     if let Some(top) = &r.key_diff_top {
-        eprintln!(
+        writeln!(
+            out,
             "  key diff      : top diverging input → {}   (see key-diff.{{json,md}})",
             top
-        );
+        )?;
     }
-    eprintln!(
+    writeln!(
+        out,
         "  kache saw     : {} compiles -> {} cached, {} passed through, {} errored",
         el.total, el.cached, el.passed_through, el.errored
-    );
+    )?;
     if !el.top_passthrough.is_empty() {
         // Decision table, not an error list: `action  category  description`.
         // The header says the build ran normally so the rows don't read as
         // failures. Fixed-width action/category columns align; the variable
         // description trails last.
-        eprintln!(
+        writeln!(
+            out,
             "  passthrough   : top reasons (kache declined to cache; the build ran normally) —"
-        );
+        )?;
         for rc in el.top_passthrough.iter().take(5) {
             // Reason is the kache-emitted `category|detail`; older logs without
             // the `|` fall back to category "—" and the whole string as detail.
@@ -2824,62 +2881,78 @@ fn print_summary(r: &BenchResult, work_dir: &Path) {
                 rc.action.as_str()
             };
             let detail: String = detail.chars().take(64).collect();
-            eprintln!(
+            writeln!(
+                out,
                 "    {:>6}x  {:<8}  {:<14}  {}",
                 rc.count, action, category, detail
-            );
+            )?;
         }
     }
-    eprintln!(
+    writeln!(
+        out,
         "  leak detector : {} firing(s) (kache PathNormalizer; see wrapper-warm.log)",
         r.warm.leak_warnings
-    );
+    )?;
     for sample in r.warm_leak_samples.iter().take(3) {
         let s: String = sample.chars().take(96).collect();
-        eprintln!("    {s}");
+        writeln!(out, "    {s}")?;
     }
 
     if !r.warm.top_misses.is_empty() {
-        eprintln!("{bar}");
-        eprintln!("  costliest warm misses (recompiled despite the cache):");
+        writeln!(out, "{bar}")?;
+        writeln!(
+            out,
+            "  costliest warm misses (recompiled despite the cache):"
+        )?;
         for m in r.warm.top_misses.iter().take(5) {
-            eprintln!("    {:>8}  {}", fmt(m.compile_time_s), m.crate_name);
+            writeln!(out, "    {:>8}  {}", fmt(m.compile_time_s), m.crate_name)?;
         }
     }
 
-    eprintln!("{bar}");
+    writeln!(out, "{bar}")?;
     if r.verdict.ok && r.verdict.checks.is_empty() {
-        eprintln!("  VERDICT: ok — no blocking assertions configured.");
+        writeln!(out, "  VERDICT: ok — no blocking assertions configured.")?;
     } else if r.verdict.ok {
-        eprintln!("  VERDICT: ok — the run validly exercised kache.");
+        writeln!(out, "  VERDICT: ok — the run validly exercised kache.")?;
     } else {
-        eprintln!("  VERDICT: DEGRADED RUN — results are NOT a valid measurement:");
+        writeln!(
+            out,
+            "  VERDICT: DEGRADED RUN — results are NOT a valid measurement:"
+        )?;
         for issue in &r.verdict.issues {
-            eprintln!("    - {issue}");
+            writeln!(out, "    - {issue}")?;
         }
     }
     if let Some(same_tree) = &r.warm_same_tree_verdict {
         if same_tree.ok {
-            eprintln!("  VERDICT (same-tree): ok — the phase validly consumed the cache.");
+            writeln!(
+                out,
+                "  VERDICT (same-tree): ok — the phase validly consumed the cache."
+            )?;
         } else {
-            eprintln!("  VERDICT (same-tree): DEGRADED — that phase measured nothing real:");
+            writeln!(
+                out,
+                "  VERDICT (same-tree): DEGRADED — that phase measured nothing real:"
+            )?;
             for issue in &same_tree.issues {
-                eprintln!("    - {issue}");
+                writeln!(out, "    - {issue}")?;
             }
         }
     }
     if !r.measure_warnings.is_empty() {
-        eprintln!("  MEASURE WARNINGS:");
+        writeln!(out, "  MEASURE WARNINGS:")?;
         for warning in &r.measure_warnings {
-            eprintln!("    - {warning}");
+            writeln!(out, "    - {warning}")?;
         }
     }
-    eprintln!("{bar}");
-    eprintln!(
+    writeln!(out, "{bar}")?;
+    writeln!(
+        out,
         "  detailed reports: {}/{{report,build,wrapper}}-{{cold,warm}}.*",
         work_dir.display()
-    );
-    eprintln!("{bar}");
+    )?;
+    writeln!(out, "{bar}")?;
+    Ok(())
 }
 
 fn print_pull_summary(r: &PullBenchResult, archive_dir: &Path) {
@@ -4018,13 +4091,10 @@ mod tests {
         let verdict = Verdict::evaluate(&KeyStability::default(), &measured_nothing, Some(&spec));
 
         assert!(!verdict.ok, "a zero-hit phase must not pass");
-        let failed: Vec<&str> = verdict
-            .checks
-            .iter()
-            .filter(|check| !check.passed)
-            .map(|check| check.name)
-            .collect();
-        assert_eq!(failed, vec!["min_hits", "min_restored_bytes"]);
+        assert_eq!(
+            failed_check_names(&verdict),
+            vec!["min_hits", "min_restored_bytes"]
+        );
         assert!(
             verdict
                 .checks
@@ -4032,19 +4102,43 @@ mod tests {
                 .all(|check| check.name != "min_key_stability_pct"),
             "stability must be skipped when nothing was compared"
         );
+        // Both failures must be explained. The issue list is what the summary
+        // prints and what a reviewer reads; a verdict that fails without saying
+        // why is barely more useful than one that passes wrongly.
+        assert_eq!(verdict.issues.len(), 2, "{:?}", verdict.issues);
+        assert!(
+            verdict.issues[0].contains("cache hits"),
+            "{:?}",
+            verdict.issues
+        );
+        assert!(
+            verdict.issues[1].contains("restored from the store"),
+            "{:?}",
+            verdict.issues
+        );
     }
 
     /// A phase that hit the cache and pulled real bytes out of it passes both
-    /// validity checks.
+    /// validity checks — at the exact floor and above it. The floors are
+    /// inclusive: `min_hits = N` means N hits is enough.
     #[test]
     fn verdict_accepts_a_phase_that_hit_and_restored() {
         let spec = ScenarioAssertSpec {
-            min_hits: Some(1),
+            min_hits: Some(412),
             min_restored_bytes: Some(1024),
             ..Default::default()
         };
-        let measured = PhaseMetrics {
+        // Exactly at both floors — the boundary an off-by-one moves.
+        let at_the_floor = PhaseMetrics {
             hits: 412,
+            storage: StorageInfo {
+                restored_bytes: 1024,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let comfortably_over = PhaseMetrics {
+            hits: 4_120,
             storage: StorageInfo {
                 restored_bytes: 64 * 1024 * 1024,
                 ..Default::default()
@@ -4052,10 +4146,54 @@ mod tests {
             ..Default::default()
         };
 
-        let verdict = Verdict::evaluate(&KeyStability::default(), &measured, Some(&spec));
+        for measured in [at_the_floor, comfortably_over] {
+            let verdict = Verdict::evaluate(&KeyStability::default(), &measured, Some(&spec));
 
-        assert!(verdict.ok, "{:?}", verdict.issues);
-        assert_eq!(verdict.checks.len(), 2);
+            assert!(verdict.ok, "{:?}", verdict.issues);
+            assert_eq!(verdict.checks.len(), 2);
+            assert!(verdict.checks.iter().all(|check| check.passed));
+            // A passing check must not manufacture an issue. The issue list is
+            // the run's "why this is not a measurement" evidence; noise in it
+            // makes a degraded run indistinguishable from a healthy one.
+            assert!(verdict.issues.is_empty(), "{:?}", verdict.issues);
+        }
+    }
+
+    /// One short of either floor fails. Together with the at-the-floor case
+    /// above this pins both comparisons to `>=` rather than `>`.
+    #[test]
+    fn verdict_rejects_a_phase_one_short_of_either_floor() {
+        let spec = ScenarioAssertSpec {
+            min_hits: Some(412),
+            min_restored_bytes: Some(1024),
+            ..Default::default()
+        };
+
+        let one_hit_short = PhaseMetrics {
+            hits: 411,
+            storage: StorageInfo {
+                restored_bytes: 1024,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let verdict = Verdict::evaluate(&KeyStability::default(), &one_hit_short, Some(&spec));
+        assert!(!verdict.ok);
+        assert_eq!(failed_check_names(&verdict), vec!["min_hits"]);
+        assert_eq!(verdict.issues.len(), 1, "{:?}", verdict.issues);
+
+        let one_byte_short = PhaseMetrics {
+            hits: 412,
+            storage: StorageInfo {
+                restored_bytes: 1023,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let verdict = Verdict::evaluate(&KeyStability::default(), &one_byte_short, Some(&spec));
+        assert!(!verdict.ok);
+        assert_eq!(failed_check_names(&verdict), vec!["min_restored_bytes"]);
+        assert_eq!(verdict.issues.len(), 1, "{:?}", verdict.issues);
     }
 
     /// Hits without bytes is the subtler failure: kache answered every query,
@@ -4075,13 +4213,342 @@ mod tests {
         let verdict = Verdict::evaluate(&KeyStability::default(), &hollow, Some(&spec));
 
         assert!(!verdict.ok);
-        let failed: Vec<&str> = verdict
+        assert_eq!(failed_check_names(&verdict), vec!["min_restored_bytes"]);
+        // Exactly one issue: the hits check passed, so it contributes nothing.
+        assert_eq!(verdict.issues.len(), 1, "{:?}", verdict.issues);
+        assert!(
+            verdict.issues[0].contains("restored from the store"),
+            "{:?}",
+            verdict.issues
+        );
+    }
+
+    fn failed_check_names(verdict: &Verdict) -> Vec<&'static str> {
+        verdict
             .checks
             .iter()
             .filter(|check| !check.passed)
             .map(|check| check.name)
-            .collect();
-        assert_eq!(failed, vec!["min_restored_bytes"]);
+            .collect()
+    }
+
+    fn verdict_with(ok: bool) -> Verdict {
+        Verdict {
+            ok,
+            issues: if ok {
+                Vec::new()
+            } else {
+                vec!["something was wrong".to_string()]
+            },
+            checks: Vec::new(),
+        }
+    }
+
+    /// The exit-code decision, as a truth table. Both verdicts have to hold,
+    /// and a scenario that never ran the same-tree phase has nothing to add.
+    /// This is the last gate between a broken run and a green PR check, so
+    /// every combination is pinned rather than sampled.
+    #[test]
+    fn a_run_is_degraded_when_either_verdict_says_so() {
+        let ok = verdict_with(true);
+        let bad = verdict_with(false);
+
+        assert!(
+            !run_is_degraded(&ok, None),
+            "a passing run without the same-tree phase is not degraded"
+        );
+        assert!(
+            !run_is_degraded(&ok, Some(&ok)),
+            "both verdicts passing is not degraded"
+        );
+        assert!(
+            run_is_degraded(&ok, Some(&bad)),
+            "the same-tree verdict alone must be able to fail the run"
+        );
+        assert!(
+            run_is_degraded(&bad, Some(&ok)),
+            "the cross-clone verdict alone must be able to fail the run"
+        );
+        assert!(run_is_degraded(&bad, None));
+        assert!(run_is_degraded(&bad, Some(&bad)));
+    }
+
+    /// The free-space delta is only meaningful for a plain full run. Both
+    /// opt-outs are independent, so all four combinations are pinned.
+    #[test]
+    fn only_a_plain_full_run_measures_its_disk_footprint() {
+        assert!(measures_disk_footprint(false, false));
+        // --retry restores cold from a snapshot, so the delta misses that pool.
+        assert!(!measures_disk_footprint(true, false));
+        // --warm-same-tree refills clone-a's objdir twice, so the delta no
+        // longer maps onto the three-pool model.
+        assert!(!measures_disk_footprint(false, true));
+        assert!(!measures_disk_footprint(true, true));
+    }
+
+    /// The warm-vs-cold speedup, including the zero-second boundary the
+    /// engine's whole-second timing can actually produce on a small subject.
+    #[test]
+    fn phase_speedup_divides_cold_by_the_phase_and_guards_zero() {
+        // A three-times-faster warm build.
+        assert_eq!(phase_speedup(300, 100), 3.0);
+        // Not a ratio a multiply or a remainder would produce.
+        assert_eq!(phase_speedup(90, 60), 1.5);
+        // Slower than cold is reported as-is; it is the validity gates' job to
+        // reject that, not this helper's to hide it.
+        assert_eq!(phase_speedup(60, 120), 0.5);
+        // Exactly one second is the smallest measurable phase and must still
+        // divide rather than fall into the zero guard.
+        assert_eq!(phase_speedup(42, 1), 42.0);
+        // Zero: dividing would yield infinity, which no report should carry.
+        assert_eq!(phase_speedup(300, 0), 0.0);
+        assert_eq!(phase_speedup(0, 0), 0.0);
+    }
+
+    /// Resetting the log between phases is what keeps each phase's report to
+    /// its own build. A reset that silently did nothing would fold the previous
+    /// phase's events into the next one's counters — and those counters are
+    /// what the validity gates read.
+    #[test]
+    fn reset_event_log_removes_the_log_and_tolerates_its_absence() {
+        let dir = tempfile::tempdir().unwrap();
+        let event_log = dir.path().join("events.jsonl");
+        std::fs::write(&event_log, b"{\"kind\":\"hit\"}\n").unwrap();
+
+        reset_event_log(&event_log).expect("removing an existing log succeeds");
+        assert!(
+            !event_log.exists(),
+            "the event log must be gone after a reset"
+        );
+
+        // Called again — and before the first phase, when no log exists yet.
+        reset_event_log(&event_log).expect("a missing log is not an error");
+        assert!(!event_log.exists());
+    }
+
+    /// `--warm-same-tree` is rejected for the sccache backend and accepted for
+    /// kache. Both halves of the guard matter: rejecting the flag on kache
+    /// would disable the perf gate outright, and accepting it on sccache would
+    /// run a phase that backend has no code path for.
+    #[test]
+    fn warm_same_tree_is_rejected_only_on_the_sccache_backend() {
+        const REJECTION: &str = "--warm-same-tree is only supported with --cache-backend kache";
+        // Non-existent tool paths: the guard under test runs before the binary
+        // is resolved, so every case below stops at resolution with a different
+        // message and nothing touches a clone, a cache, or a compiler.
+        let missing = std::env::temp_dir().join("kache-perf-gate-no-such-binary");
+        let config = |cache_backend, warm_same_tree| BenchRunConfig {
+            kache: missing.clone(),
+            sccache: missing.clone(),
+            cache_backend,
+            scenarios: PathBuf::from("./scenarios"),
+            select: vec!["suite:bench".to_string()],
+            git_ref: None,
+            work_dir: None,
+            skip_clone: false,
+            force_setup: false,
+            retry: false,
+            trace_keys: false,
+            warm_same_tree,
+        };
+
+        let rejected = run_bench(config(CacheBackend::Sccache, true))
+            .expect_err("sccache + --warm-same-tree must be rejected")
+            .to_string();
+        assert!(rejected.contains(REJECTION), "{rejected}");
+
+        // The same flag on the kache backend gets past the guard and fails
+        // later, on the missing binary.
+        let allowed = run_bench(config(CacheBackend::Kache, true))
+            .expect_err("the fake kache binary cannot resolve")
+            .to_string();
+        assert!(!allowed.contains(REJECTION), "{allowed}");
+
+        // ...and so does the sccache backend without the flag.
+        let allowed = run_bench(config(CacheBackend::Sccache, false))
+            .expect_err("the fake sccache binary cannot resolve")
+            .to_string();
+        assert!(!allowed.contains(REJECTION), "{allowed}");
+    }
+
+    fn bench_result_fixture() -> BenchResult {
+        let phase = |wall_s: u64, hits: u64| PhaseMetrics {
+            wall_s,
+            hits,
+            ..Default::default()
+        };
+        BenchResult {
+            project: "bench-pr-cargo".to_string(),
+            git_ref: "797e8a9".to_string(),
+            platform: "linux-x86_64".to_string(),
+            run_id: "20260901T000000Z-kache-1".to_string(),
+            artifact_dir: "tmp/perf-gate/head/runs/x".to_string(),
+            cache_tool_version: Some("kache 0.16.1".to_string()),
+            cold: phase(300, 0),
+            warm_same_tree: Some(phase(100, 412)),
+            warm: phase(120, 400),
+            speedup: 2.5,
+            warm_same_tree_speedup: Some(3.0),
+            cache_size_mb: 1024.0,
+            cold_objdir_bytes: 1 << 30,
+            warm_objdir_bytes: 1 << 30,
+            disk_measured_bytes: None,
+            key_stability: KeyStability::default(),
+            warm_leak_samples: Vec::new(),
+            verdict: verdict_with(true),
+            warm_same_tree_verdict: Some(verdict_with(true)),
+            measure_warnings: Vec::new(),
+            key_diff_top: None,
+            reports: Vec::new(),
+        }
+    }
+
+    /// The summary is the only place a human sees the run's numbers, and the
+    /// perf gate compares exactly the three wall-clocks at the top of it. All
+    /// three must be reported, each labelled for the phase it came from.
+    #[test]
+    fn summary_reports_all_three_phase_wall_clocks() {
+        let text = summary_text(&bench_result_fixture());
+
+        assert!(
+            text.contains("cold build : 5m 00s"),
+            "cold wall-clock missing:\n{text}"
+        );
+        assert!(
+            text.contains("same-tree  : 1m 40s"),
+            "same-tree wall-clock missing:\n{text}"
+        );
+        assert!(
+            text.contains("warm build : 2m 00s"),
+            "cross-clone wall-clock missing:\n{text}"
+        );
+        assert!(
+            text.contains("3.00x vs cold"),
+            "the same-tree speedup is what says the cache helped:\n{text}"
+        );
+        assert!(
+            text.contains("VERDICT: ok"),
+            "the verdict must be stated:\n{text}"
+        );
+        assert!(
+            text.contains("VERDICT (same-tree): ok"),
+            "the same-tree verdict must be stated separately:\n{text}"
+        );
+        assert!(
+            text.contains("/tmp/run"),
+            "the artifact directory must be pointed at:\n{text}"
+        );
+    }
+
+    /// A run without the same-tree phase — every nightly scenario — must not
+    /// grow same-tree lines it has no numbers for.
+    #[test]
+    fn summary_omits_the_same_tree_block_when_the_phase_did_not_run() {
+        let mut result = bench_result_fixture();
+        result.warm_same_tree = None;
+        result.warm_same_tree_speedup = None;
+        result.warm_same_tree_verdict = None;
+
+        let text = summary_text(&result);
+
+        assert!(text.contains("cold build : 5m 00s"), "{text}");
+        assert!(text.contains("warm build : 2m 00s"), "{text}");
+        assert!(!text.contains("same-tree"), "{text}");
+    }
+
+    /// A degraded same-tree phase must say so, and say why. This is the line a
+    /// reviewer reads when the perf gate refuses to report a delta.
+    #[test]
+    fn summary_explains_a_degraded_same_tree_phase() {
+        let mut result = bench_result_fixture();
+        result.warm_same_tree_verdict = Some(Verdict {
+            ok: false,
+            issues: vec!["0 cache hits (need >= 100)".to_string()],
+            checks: Vec::new(),
+        });
+
+        let text = summary_text(&result);
+
+        assert!(text.contains("VERDICT (same-tree): DEGRADED"), "{text}");
+        assert!(text.contains("0 cache hits (need >= 100)"), "{text}");
+    }
+
+    /// The cross-clone verdict has three distinct wordings, and the difference
+    /// between two of them is the whole point: "no blocking assertions
+    /// configured" means the scenario declared no gate, while "validly
+    /// exercised kache" means a gate ran and passed. A reader who cannot tell
+    /// those apart cannot tell an unguarded scenario from a guarded one.
+    #[test]
+    fn summary_distinguishes_an_unguarded_run_from_a_guarded_one() {
+        let passed_check = AssertionCheck {
+            name: "min_hits",
+            expected: ">= 100".to_string(),
+            actual: "412".to_string(),
+            passed: true,
+        };
+
+        let mut unguarded = bench_result_fixture();
+        unguarded.verdict = Verdict {
+            ok: true,
+            issues: Vec::new(),
+            checks: Vec::new(),
+        };
+        let text = summary_text(&unguarded);
+        assert!(
+            text.contains("VERDICT: ok — no blocking assertions configured."),
+            "{text}"
+        );
+
+        let mut guarded = bench_result_fixture();
+        guarded.verdict = Verdict {
+            ok: true,
+            issues: Vec::new(),
+            checks: vec![passed_check],
+        };
+        let text = summary_text(&guarded);
+        assert!(
+            text.contains("VERDICT: ok — the run validly exercised kache."),
+            "{text}"
+        );
+
+        let mut degraded = bench_result_fixture();
+        degraded.verdict = Verdict {
+            ok: false,
+            issues: vec!["cross-clone key stability 3.1%".to_string()],
+            checks: Vec::new(),
+        };
+        let text = summary_text(&degraded);
+        assert!(text.contains("VERDICT: DEGRADED RUN"), "{text}");
+        assert!(text.contains("cross-clone key stability 3.1%"), "{text}");
+    }
+
+    /// The two optional diagnostic sections appear only when they have content.
+    /// An empty "costliest misses" or "measure warnings" heading reads as a
+    /// finding that is not there.
+    #[test]
+    fn summary_shows_optional_sections_only_when_they_have_content() {
+        let quiet = bench_result_fixture();
+        let text = summary_text(&quiet);
+        assert!(!text.contains("costliest warm misses"), "{text}");
+        assert!(!text.contains("MEASURE WARNINGS"), "{text}");
+
+        let mut noisy = bench_result_fixture();
+        noisy.warm.top_misses = vec![MissEntry {
+            crate_name: "libgit2-sys".to_string(),
+            compile_time_s: 71,
+        }];
+        noisy.measure_warnings = vec!["warm hit rate 12.0% below threshold 50.0%".to_string()];
+        let text = summary_text(&noisy);
+        assert!(text.contains("costliest warm misses"), "{text}");
+        assert!(text.contains("libgit2-sys"), "{text}");
+        assert!(text.contains("MEASURE WARNINGS"), "{text}");
+        assert!(text.contains("warm hit rate 12.0%"), "{text}");
+    }
+
+    fn summary_text(result: &BenchResult) -> String {
+        let mut out = Vec::new();
+        write_summary(&mut out, result, Path::new("/tmp/run")).unwrap();
+        String::from_utf8(out).expect("the summary is UTF-8")
     }
 
     #[test]

--- a/crates/kache-e2e/src/phase.rs
+++ b/crates/kache-e2e/src/phase.rs
@@ -9,6 +9,13 @@ use serde::Deserialize;
 #[serde(rename_all = "kebab-case")]
 pub enum Phase {
     Cold,
+    /// Clone benchmarks only: rebuild the SAME worktree `cold` just built, with
+    /// the objdir wiped and the store left warm. This is the plain
+    /// "my `target/` was cleaned" case, with no path change in play — it splits
+    /// restore cost away from the path-portability question the cross-clone
+    /// [`Phase::Warm`] answers. Opt-in (`--warm-same-tree`), so the nightly
+    /// scenarios do not pay for a third full build.
+    WarmSameTree,
     Warm,
     Pull,
     Noop,
@@ -21,6 +28,7 @@ impl Phase {
     pub fn name(self) -> &'static str {
         match self {
             Phase::Cold => "cold",
+            Phase::WarmSameTree => "warm-same-tree",
             Phase::Warm => "warm",
             Phase::Pull => "pull",
             Phase::Noop => "noop",
@@ -53,5 +61,13 @@ mod tests {
         assert!(Phase::Pull.cleans_first());
         // The rebuilt tree must still pass runtime verification.
         assert!(Phase::Pull.runs_verify());
+    }
+
+    #[test]
+    fn warm_same_tree_phase_name_is_artifact_stable() {
+        // The name is the artifact/report suffix the PR perf gate reads
+        // (`report-warm-same-tree.json`) and the `[checks.assert.…]` table key.
+        assert_eq!(Phase::WarmSameTree.name(), "warm-same-tree");
+        assert!(Phase::WarmSameTree.cleans_first());
     }
 }

--- a/crates/kache-e2e/src/runner.rs
+++ b/crates/kache-e2e/src/runner.rs
@@ -818,6 +818,9 @@ fn run_phase(
             .as_ref()
             .map(|spec| apply_metric_assertions(spec, &delta, &phase_misses_by_crate, new_events))
             .unwrap_or_default(),
+        // Clone-benchmark-only phase: `fixture_phases()` never emits it, and
+        // fixtures have no `[assertions.warm-same-tree]` table to apply.
+        Phase::WarmSameTree => Vec::new(),
     };
 
     // Differential check: a cache-hit phase's restored artifact must
@@ -839,7 +842,12 @@ fn run_phase(
                             &bytes,
                         ));
                     }
-                    Phase::Noop | Phase::RelocateNoop | Phase::RelocateModified => {}
+                    // `WarmSameTree` is clone-benchmark-only and never reaches
+                    // the fixture harness; it records no diff baseline either.
+                    Phase::Noop
+                    | Phase::RelocateNoop
+                    | Phase::RelocateModified
+                    | Phase::WarmSameTree => {}
                 },
                 Err(e) => {
                     if matches!(

--- a/crates/kache-e2e/src/scenario.rs
+++ b/crates/kache-e2e/src/scenario.rs
@@ -722,6 +722,50 @@ min_hit_rate_pct = 50.0
         assert_eq!(measure.min_hit_rate_pct, Some(50.0));
     }
 
+    /// The same-worktree warm phase has its OWN gate tables, distinct from the
+    /// cross-clone `warm` ones. Both `for_phase` lookups must return them
+    /// rather than falling through to "no spec configured": a validity gate
+    /// that silently stops binding is a validity gate that no longer runs.
+    #[test]
+    fn warm_same_tree_phase_gates_bind() {
+        let checks: ScenarioChecks = toml::from_str(
+            r#"
+[assert.warm-same-tree]
+max_passthrough_pct = 40.0
+min_hits = 100
+min_restored_bytes = 67108864
+
+[assert.warm]
+min_key_stability_pct = 50.0
+min_hits = 7
+
+[measure.warm-same-tree]
+max_wall_s = 300
+
+[measure.warm]
+max_wall_s = 900
+"#,
+        )
+        .unwrap();
+
+        let assert = checks
+            .assertions
+            .for_phase("warm-same-tree")
+            .expect("warm-same-tree assert gate must bind");
+        assert_eq!(assert.max_passthrough_pct, Some(40.0));
+        assert_eq!(assert.min_hits, Some(100));
+        assert_eq!(assert.min_restored_bytes, Some(67_108_864));
+        // And it is not the cross-clone table: that one declares a different
+        // min_hits and a key-stability floor this phase cannot have.
+        assert_eq!(assert.min_key_stability_pct, None);
+
+        let measure = checks
+            .measure
+            .for_phase("warm-same-tree")
+            .expect("warm-same-tree measure gate must bind");
+        assert_eq!(measure.max_wall_s, Some(300));
+    }
+
     #[test]
     fn scenario_checks_reject_misspelled_fields() {
         for raw in [

--- a/crates/kache-e2e/src/scenario.rs
+++ b/crates/kache-e2e/src/scenario.rs
@@ -213,6 +213,8 @@ pub struct ScenarioChecks {
 #[serde(default, deny_unknown_fields)]
 pub struct PhaseAssertSpecs {
     pub cold: Option<ScenarioAssertSpec>,
+    #[serde(rename = "warm-same-tree")]
+    pub warm_same_tree: Option<ScenarioAssertSpec>,
     pub warm: Option<ScenarioAssertSpec>,
     pub pull: Option<ScenarioAssertSpec>,
     pub noop: Option<ScenarioAssertSpec>,
@@ -227,6 +229,7 @@ impl PhaseAssertSpecs {
     pub fn for_phase(&self, phase: &str) -> Option<&ScenarioAssertSpec> {
         match phase {
             "cold" => self.cold.as_ref(),
+            "warm-same-tree" => self.warm_same_tree.as_ref(),
             "warm" => self.warm.as_ref(),
             "pull" => self.pull.as_ref(),
             "noop" => self.noop.as_ref(),
@@ -245,6 +248,15 @@ pub struct ScenarioAssertSpec {
     pub min_key_stability_pct: Option<f64>,
     pub max_passthrough_pct: Option<f64>,
     pub max_errors: Option<u64>,
+    /// Minimum cache hits the phase must report. Zero hits means the phase
+    /// compiled everything from scratch, so its wall-clock says nothing about
+    /// the cache — the flattering-number failure mode a timing gate has to
+    /// rule out before it trusts a delta.
+    pub min_hits: Option<u64>,
+    /// Minimum bytes the phase must have restored out of the store
+    /// (`storage.restored_bytes`). Hits alone can be satisfied by entries that
+    /// carry no output files; this asserts real artifacts landed in the objdir.
+    pub min_restored_bytes: Option<u64>,
 }
 
 /// Warn-only measurement specs by phase.
@@ -252,6 +264,8 @@ pub struct ScenarioAssertSpec {
 #[serde(default, deny_unknown_fields)]
 pub struct PhaseMeasureSpecs {
     pub cold: Option<MeasureSpec>,
+    #[serde(rename = "warm-same-tree")]
+    pub warm_same_tree: Option<MeasureSpec>,
     pub warm: Option<MeasureSpec>,
     pub pull: Option<MeasureSpec>,
     pub noop: Option<MeasureSpec>,
@@ -266,6 +280,7 @@ impl PhaseMeasureSpecs {
     pub fn for_phase(&self, phase: &str) -> Option<&MeasureSpec> {
         match phase {
             "cold" => self.cold.as_ref(),
+            "warm-same-tree" => self.warm_same_tree.as_ref(),
             "warm" => self.warm.as_ref(),
             "pull" => self.pull.as_ref(),
             "noop" => self.noop.as_ref(),

--- a/crates/kache-e2e/src/scenario_runner.rs
+++ b/crates/kache-e2e/src/scenario_runner.rs
@@ -82,6 +82,12 @@ struct Args {
     /// Enable cache-key trace logging for clone benchmark scenarios.
     #[arg(long)]
     trace_keys: bool,
+
+    /// Add a same-worktree warm rebuild between the cold and cross-clone
+    /// phases (clone-a again, objdir wiped, store left warm). Off by default:
+    /// it costs a third full build, which only the PR perf gate wants.
+    #[arg(long)]
+    warm_same_tree: bool,
 }
 
 pub fn main() -> Result<()> {
@@ -133,6 +139,7 @@ pub fn main() -> Result<()> {
         || args.force_setup
         || args.retry
         || args.trace_keys
+        || args.warm_same_tree
         || args.cache_backend != CacheBackend::Kache;
     if bench_flags && !clone_selected {
         bail!("benchmark options were provided, but no clone scenario was selected");
@@ -163,6 +170,7 @@ pub fn main() -> Result<()> {
             force_setup: args.force_setup,
             retry: args.retry,
             trace_keys: args.trace_keys,
+            warm_same_tree: args.warm_same_tree,
         })?;
     }
 

--- a/crates/kache-e2e/src/scenario_runner.rs
+++ b/crates/kache-e2e/src/scenario_runner.rs
@@ -90,6 +90,26 @@ struct Args {
     warm_same_tree: bool,
 }
 
+impl Args {
+    /// Was any clone-benchmark-only option supplied?
+    ///
+    /// These options mean nothing to a fixture scenario, so passing one without
+    /// selecting a clone scenario is a mistake worth reporting rather than
+    /// silently ignoring — the caller would otherwise believe a flag took
+    /// effect when it did not. Every benchmark option belongs on this list;
+    /// forgetting to add a new one is how a flag becomes silently inert.
+    fn has_bench_options(&self) -> bool {
+        self.git_ref.is_some()
+            || self.work_dir.is_some()
+            || self.skip_clone
+            || self.force_setup
+            || self.retry
+            || self.trace_keys
+            || self.warm_same_tree
+            || self.cache_backend != CacheBackend::Kache
+    }
+}
+
 pub fn main() -> Result<()> {
     let args = Args::parse();
     let mut select = args.select.clone();
@@ -133,14 +153,7 @@ pub fn main() -> Result<()> {
     if args.deny_missing_tools && clone_selected {
         bail!("--deny-missing-tools is only valid for fixture scenarios");
     }
-    let bench_flags = args.git_ref.is_some()
-        || args.work_dir.is_some()
-        || args.skip_clone
-        || args.force_setup
-        || args.retry
-        || args.trace_keys
-        || args.warm_same_tree
-        || args.cache_backend != CacheBackend::Kache;
+    let bench_flags = args.has_bench_options();
     if bench_flags && !clone_selected {
         bail!("benchmark options were provided, but no clone scenario was selected");
     }
@@ -221,6 +234,38 @@ fn profile_hint(name: &str, cache_backend: CacheBackend) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every clone-benchmark option, on its own, must be recognised as one.
+    /// The check is a long disjunction, and a term that stops contributing
+    /// makes its flag silently inert against a fixture selection instead of
+    /// producing the "no clone scenario was selected" error.
+    #[test]
+    fn every_benchmark_option_is_recognised_on_its_own() {
+        let plain = Args::parse_from(["kache-scenario", "--select", "suite:e2e"]);
+        assert!(
+            !plain.has_bench_options(),
+            "a selection with no benchmark option must not look like one"
+        );
+
+        for option in [
+            vec!["--ref", "797e8a9"],
+            vec!["--work-dir", "tmp/bench/x"],
+            vec!["--skip-clone"],
+            vec!["--force-setup"],
+            vec!["--retry"],
+            vec!["--trace-keys"],
+            vec!["--warm-same-tree"],
+            vec!["--cache-backend", "sccache"],
+        ] {
+            let mut argv = vec!["kache-scenario", "--select", "suite:e2e"];
+            argv.extend(option.iter().copied());
+            let args = Args::parse_from(&argv);
+            assert!(
+                args.has_bench_options(),
+                "{option:?} must count as a benchmark option"
+            );
+        }
+    }
 
     #[test]
     fn profile_hint_matches_bench_recipe_arguments() {

--- a/crates/kache-e2e/src/source.rs
+++ b/crates/kache-e2e/src/source.rs
@@ -66,6 +66,13 @@ pub fn clone_ref_path(work_dir: &Path) -> PathBuf {
 
 /// Materialize `clone_a` and `clone_b` at `git_ref` as git worktrees off a
 /// locally-cached shallow reference clone.
+///
+/// `git_ref` is normally a tag or branch, materialized by a `--depth 1
+/// --branch` clone. A full 40-char commit SHA takes the fetch-by-SHA path
+/// instead (`git init` + `fetch --depth 1 origin <sha>`, the same mechanism
+/// [`clone_worktrees_pull`] uses) because `git clone --branch` does not accept
+/// a commit. Short SHAs are not fetchable-by-SHA and are treated as a ref name,
+/// which fails loudly at clone time.
 pub fn clone_worktrees(
     repo: &str,
     git_ref: &str,
@@ -73,7 +80,9 @@ pub fn clone_worktrees(
     clone_a: &Path,
     clone_b: &Path,
 ) -> Result<()> {
-    if clone_ref_at_ref(clone_ref, git_ref)? {
+    if is_full_commit_sha(git_ref) {
+        fetch_commit_into_clone_ref(repo, git_ref, clone_ref)?;
+    } else if clone_ref_at_ref(clone_ref, git_ref)? {
         eprintln!("\n[bench] reusing clone-ref at {git_ref} (no network)");
     } else {
         if clone_ref.exists() {
@@ -126,6 +135,47 @@ pub fn clone_worktrees(
             .arg(d)
             .arg(git_ref))?;
     }
+    Ok(())
+}
+
+/// Is this a full 40-character hex commit SHA — the only form GitHub will
+/// serve to a fetch-by-SHA request?
+fn is_full_commit_sha(git_ref: &str) -> bool {
+    git_ref.len() == 40 && git_ref.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Make `sha` available in `clone_ref` without a checkout, creating the
+/// reference repo if it does not exist yet.
+///
+/// Unlike the tag/branch path this never wipes `clone_ref`: an existing one
+/// already holds the objects, and re-fetching a commit that is already present
+/// is a cheap negotiation rather than a re-download.
+fn fetch_commit_into_clone_ref(repo: &str, sha: &str, clone_ref: &Path) -> Result<()> {
+    if !clone_ref.join(".git").exists() {
+        eprintln!("\n[bench] no clone-ref yet — fetching {repo} @ {sha} (one-time cost)");
+        if let Some(parent) = clone_ref.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        run(Command::new("git").args(["init", "-q"]).arg(clone_ref))?;
+        run(Command::new("git")
+            .arg("-C")
+            .arg(clone_ref)
+            .args(["remote", "add", "origin", repo]))?;
+    } else {
+        eprintln!("\n[bench] clone-ref present — refreshing {sha}");
+        // The pinned repo can change between scenario edits; keep the remote
+        // authoritative rather than trusting whatever a previous run set.
+        run(Command::new("git")
+            .arg("-C")
+            .arg(clone_ref)
+            .args(["remote", "set-url", "origin", repo]))?;
+    }
+    run(Command::new("git")
+        .args(["-c", "core.longpaths=true"])
+        .arg("-C")
+        .arg(clone_ref)
+        .args(["fetch", "--depth", "1", "origin", sha]))?;
     Ok(())
 }
 
@@ -431,6 +481,68 @@ mod tests {
             .success();
         assert!(ok);
         assert_eq!(std::fs::read_to_string(clone_a.join("f")).unwrap(), "b");
+    }
+
+    #[test]
+    fn clone_worktrees_accepts_a_full_commit_sha() {
+        use std::process::Command;
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream = tmp.path().join("upstream");
+        std::fs::create_dir_all(&upstream).unwrap();
+        let git = |args: &[&str], cwd: &std::path::Path| {
+            let ok = Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .status()
+                .unwrap()
+                .success();
+            assert!(ok, "git {args:?} failed");
+        };
+        git(&["init", "-q"], &upstream);
+        git(&["config", "user.email", "t@t"], &upstream);
+        git(&["config", "user.name", "t"], &upstream);
+        std::fs::write(upstream.join("f"), "pinned").unwrap();
+        git(&["add", "."], &upstream);
+        git(&["commit", "-qm", "pinned"], &upstream);
+        let sha = rev_parse(&upstream, "HEAD");
+        // A later commit exists on the branch tip: checking out the pinned SHA
+        // (not the tip) is the whole point of pinning by commit.
+        std::fs::write(upstream.join("f"), "moved on").unwrap();
+        git(&["commit", "-aqm", "moved on"], &upstream);
+
+        let clone_ref = tmp.path().join("ref");
+        let clone_a = tmp.path().join("clone-a");
+        let clone_b = tmp.path().join("clone-b");
+        clone_worktrees(
+            upstream.to_str().unwrap(),
+            &sha,
+            &clone_ref,
+            &clone_a,
+            &clone_b,
+        )
+        .unwrap();
+
+        for clone in [&clone_a, &clone_b] {
+            assert_eq!(
+                std::fs::read_to_string(clone.join("f")).unwrap(),
+                "pinned",
+                "{} must be at the pinned commit, not the branch tip",
+                clone.display()
+            );
+        }
+    }
+
+    #[test]
+    fn full_commit_sha_is_told_apart_from_a_tag() {
+        assert!(is_full_commit_sha(
+            "797e8a9bca276c1c9f9f738d2a20f484fa4eea9d"
+        ));
+        // Short SHAs are not fetchable-by-SHA, so they must NOT take that path.
+        assert!(!is_full_commit_sha("797e8a9"));
+        assert!(!is_full_commit_sha("0.99.0"));
+        assert!(!is_full_commit_sha("FIREFOX_151_0_RELEASE"));
+        // 40 chars, but not hex.
+        assert!(!is_full_commit_sha(&"z".repeat(40)));
     }
 
     fn rev_parse(dir: &std::path::Path, r: &str) -> String {

--- a/docs/benchmarks.mdx
+++ b/docs/benchmarks.mdx
@@ -18,6 +18,22 @@ Jobs upload their reports, Perfetto traces, and logs even when a benchmark fails
 
 A scheduled run is not automatically a valid result. Check that the individual job succeeded and that its benchmark verdict is `ok` before using its timing or hit-rate numbers.
 
+## Per-pull-request perf gate
+
+The nightly matrix reports absolute numbers hours after a change lands. The [Perf gate workflow](https://github.com/kunobi-ninja/kache/actions/workflows/perf-gate.yml) answers a narrower question at review time: is this pull request slower than the commit it is a delta against?
+
+It measures one mid-size subject — `bench-pr-cargo`, the `rust-lang/cargo` tree pinned by commit — in three phases per side:
+
+| phase | store | build tree |
+| --- | --- | --- |
+| cold | empty | fresh |
+| warm | populated by cold | fresh, same path |
+| cross-worktree | populated by cold | fresh, different path |
+
+The pull request head and its merge base are both measured, back to back on the same runner, so the report is a delta rather than a comparison against a stored figure from another machine. A warm build more than 5% slower than the merge base fails the gate. Cold and cross-worktree deltas are reported without failing while their noise floor is still being established. The numbers land as a comment on the pull request.
+
+The gate runs only for branches in this repository: the benchmark needs a self-hosted runner, and fork code never touches one. It is not a required check.
+
 ## Run a scenario
 
 ```bash
@@ -29,6 +45,8 @@ just bench opendal
 just bench llvm
 just bench-retry firefox   # reuse the saved cold state
 just bench-trace firefox   # include key-diff artifacts
+
+just bench-pr              # one side of the per-PR perf gate
 
 just bench-sccache
 just bench-sccache firefox

--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -93,10 +93,27 @@ max_errors = 0
 ```
 
 `checks.assert` drives the bench verdict and exit code; omitted assertion
-fields are not evaluated. `checks.measure` warnings are advisory only.
+fields are not evaluated. The fields are `min_key_stability_pct`,
+`max_passthrough_pct`, `max_errors`, `min_hits`, and `min_restored_bytes`. The
+last two are validity floors: a phase that recompiled everything reports no hits
+and restores no bytes, and without them its wall-clock reads as a flatteringly
+fast build. `checks.measure` warnings are advisory only.
 `{cache}` expands to the selected compiler-cache binary (`kache` by default,
 `sccache` with `--cache-backend sccache`); `{kache}` remains supported for
 older scenarios.
+
+### The same-worktree warm phase
+
+`--warm-same-tree` adds a third phase between `cold` and the cross-clone `warm`:
+clone-a is rebuilt in place with its objdir wiped and the store left warm. Same
+absolute path, so it measures restore cost with the path-portability question
+held constant — the everyday "I cleaned my `target/`" case. Its own gate is
+`[checks.assert.warm-same-tree]`, evaluated separately from `[checks.assert.warm]`
+and folded into the same exit code.
+
+Off by default: it costs a third full build the nightly scenarios do not read.
+`bench-pr-cargo` is the scenario built for it — see the per-PR perf gate in
+`.github/workflows/perf-gate.yml`, and `just bench-pr` to run one side locally.
 
 Every benchmark keeps root-level `report-*`, `build-*`, `wrapper-*`, and result
 JSON files as the latest run for `--retry`, and also archives those artifacts to

--- a/scenarios/bench-pr-cargo/scenario.toml
+++ b/scenarios/bench-pr-cargo/scenario.toml
@@ -1,0 +1,129 @@
+# Per-PR perf-gate benchmark scenario for kache-scenario.
+#
+# The nightly bench giants (Firefox, LLVM, Substrate, SurrealDB, Lance,
+# OpenDAL) take tens of minutes to hours each. A gate that runs on every pull
+# request has to finish in minutes AND still be sensitive enough that a warm
+# regression shows up above noise, so it needs a subject with real dependency
+# depth rather than a toy.
+#
+# Why rust-lang/cargo:
+#   * 550 packages in its lockfile — a deep, wide, realistic Rust graph, not a
+#     handful of leaf crates whose warm phase is dominated by process startup.
+#   * Genuine C content compiled by build scripts through cc-rs: libgit2-sys
+#     (vendored libgit2), libssh2-sys, libz-sys (vendored zlib), curl-sys
+#     (vendored curl when no system libcurl is present) and ring's asm/C. Wiring
+#     CC/CXX through kache below puts those object compiles in the cache too, so
+#     the gate covers both compiler families the way the mixed nightly
+#     scenarios do — the Rust-only scenarios cannot see a cc-path regression.
+#   * Its own build.rs shells out to git and embeds the commit hash, which is
+#     identical in both worktrees — so it does not, by itself, break the
+#     cross-worktree comparison the way a timestamp would.
+#   * Small enough on disk (a shallow clone plus a debug target tree) that two
+#     independent runs — PR head and merge base — fit on one runner.
+#
+# Pinned by COMMIT SHA, not by tag: a tag can be repointed, and a gate whose
+# subject silently changed under it reports a delta that is really a subject
+# change. `clone_worktrees` takes the fetch-by-SHA path for a full 40-char SHA.
+name = "bench-pr-cargo"
+
+# `tier:pr` (not the implicit `tier:nightly`) keeps this out of any
+# tier-selected nightly sweep. The perf-gate workflow selects it by name.
+tags = [
+  "suite:bench",
+  "project:cargo",
+  "backend:kache",
+  "lang:rust",
+  "lang:cc",
+  "tier:pr",
+]
+
+requires = ["cargo", "rustc", "cc"]
+
+# The C halves need a compiler and pkg-config; libgit2/curl want an OpenSSL
+# development package on Linux. The perf-gate workflow installs these (mirroring
+# .github/workflows/bench.yml); the echo documents them for a local run.
+setup = [
+  "echo '[bench] bench-pr-cargo needs: a C compiler, pkg-config, and OpenSSL headers (libgit2-sys/curl-sys). Debian: apt install build-essential pkg-config libssl-dev. macOS: xcode-select --install && brew install openssl@3 pkg-config.'",
+]
+
+# Build the `cargo` binary at the DEV profile, not release. Two reasons:
+#   * Time. The gate runs the subject three times per side and twice per PR
+#     (head + merge base) on one machine. A release build of this graph is the
+#     difference between a gate that lands in minutes and one nobody waits for.
+#   * Sensitivity. Debug artifacts are far larger than release ones, so the warm
+#     phases move many more bytes out of the store — which is exactly the cost a
+#     warm-path regression shows up in.
+# `--locked` pins the resolved graph to the checked-in Cargo.lock, so a crates.io
+# release cannot change what is compiled between the head and base runs.
+#
+# The prefix maps, SOURCE_DATE_EPOCH and KACHE_BASE_DIR are the cross-worktree
+# portability knobs the other cargo-based scenarios use (see bench-opendal /
+# bench-surrealdb): each worktree builds at a different absolute path, and these
+# keep that path out of the cache key and out of the C compilers' output.
+build = """
+repo="$(pwd -P)"
+prefix_map="-ffile-prefix-map=$repo=. -fdebug-prefix-map=$repo=. -fmacro-prefix-map=$repo=."
+export CFLAGS="${CFLAGS:-} $prefix_map"
+export CXXFLAGS="${CXXFLAGS:-} $prefix_map"
+export SOURCE_DATE_EPOCH=1735689600
+export ZERO_AR_DATE=1
+export KACHE_BASE_DIR="$repo"
+
+cargo build --locked
+"""
+
+# Route the build scripts' C/C++ compiles through kache as well as the rustc
+# ones the engine wires via RUSTC_WRAPPER. cc-rs honours a multi-token `CC` on
+# Unix (the e2e-rust-c-ffi fixture relies on the same form); the gate runs on
+# Linux only, so the Windows `check_exe` mangling that fixture documents does
+# not apply here.
+[env]
+CC = "{kache} cc"
+CXX = "{kache} c++"
+
+[source]
+kind = "clone"
+repo = "https://github.com/rust-lang/cargo.git"
+# rust-lang/cargo 0.99.0 — the cargo that ships with Rust 1.98. Bump this
+# together with the injected toolchain pin below, and re-baseline expectations
+# when you do: a subject bump moves every absolute number in the report.
+ref    = "797e8a9bca276c1c9f9f738d2a20f484fa4eea9d"
+objdir = "target"
+
+# cargo ships no rust-toolchain.toml, so rustup would otherwise pick up whatever
+# the host default is — and the gate would compare two runs that could, in
+# principle, use different compilers. Writing one pins the subject's toolchain
+# independently of kache's own `rust-toolchain.toml`. `write` is correct here
+# precisely because the repo does not own this file. 1.98.0 clears cargo
+# 0.99.0's 1.96 MSRV.
+[[file]]
+path = "rust-toolchain.toml"
+content = """
+[toolchain]
+channel = "1.98.0"
+profile = "minimal"
+"""
+
+# Validity floors, not regression bounds. Their job is to make a run that
+# measured NOTHING fail loudly instead of reporting a flatteringly fast warm
+# build: a phase that recompiled the world would report zero hits and restore
+# zero bytes, and its wall-clock would look great next to a cold build.
+#
+# The numbers are deliberately far below what a healthy run produces (~550
+# packages, well over a gigabyte of debug artifacts restored) so an ordinary
+# dependency-graph shift cannot trip them — only a genuinely broken run can.
+[checks.assert.warm-same-tree]
+max_passthrough_pct = 40.0
+max_errors = 0
+min_hits = 100
+min_restored_bytes = 67108864 # 64 MiB
+
+# The cross-worktree phase adds the path-portability check: if the cache key
+# carries an absolute path, this phase misses everything and key stability
+# collapses. Same floors as above.
+[checks.assert.warm]
+min_key_stability_pct = 50.0
+max_passthrough_pct = 40.0
+max_errors = 0
+min_hits = 100
+min_restored_bytes = 67108864 # 64 MiB

--- a/scripts/perf-gate-compare.sh
+++ b/scripts/perf-gate-compare.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Compare two `bench-pr-cargo` runs — the PR head and its merge base, measured
+# back to back on the same machine — and decide whether the head regressed.
+#
+# Usage: scripts/perf-gate-compare.sh <base.json> <head.json> <markdown-out>
+#
+# Both inputs are the result JSON the clone benchmark engine writes
+# (`tmp/bench/<scenario>/<scenario>.json`), produced with `--warm-same-tree` so
+# each side carries three wall-clocks:
+#
+#   cold            empty store, fresh objdir               (baseline)
+#   warm-same-tree  warm store, fresh objdir, SAME path     (the gated number)
+#   warm            warm store, fresh objdir, other path    (cross-worktree)
+#
+# Writes a markdown report to <markdown-out> for the step summary and the PR
+# comment, prints the same table to stdout, and exits non-zero when the gate
+# fails.
+#
+# Exit 0 = within budget.  Exit 1 = regression, or the run did not validly
+#                                  measure anything.
+set -euo pipefail
+
+# ── The threshold ────────────────────────────────────────────────────────────
+# A head warm build slower than the merge base's by more than this fails the
+# gate. 5% sits above the run-to-run noise of a minutes-long build on the ARC
+# runners while still catching the kind of drift that accumulated unnoticed
+# before this gate existed. It is the ONLY blocking number: the cold and
+# cross-worktree deltas are reported so a reviewer sees them, but they do not
+# fail the run until there is enough history to know their noise floor.
+readonly WARM_REGRESSION_LIMIT_PCT=5.0
+
+# The engine times phases to whole seconds. On a warm build this short, a single
+# one-second tick is already worth more than the threshold above, so a "delta"
+# would be reporting quantization rather than performance. The real subject's
+# warm phase runs well past this; tripping it means the subject shrank, the
+# build did nothing, or the scenario is pointed somewhere unexpected.
+readonly MIN_MEASURABLE_WARM_S=30
+
+base_json="${1:?usage: perf-gate-compare.sh <base.json> <head.json> <markdown-out>}"
+head_json="${2:?usage: perf-gate-compare.sh <base.json> <head.json> <markdown-out>}"
+md_out="${3:?usage: perf-gate-compare.sh <base.json> <head.json> <markdown-out>}"
+
+for f in "$base_json" "$head_json"; do
+    [ -f "$f" ] || { echo "::error::perf gate: missing benchmark result $f"; exit 1; }
+done
+command -v jq >/dev/null 2>&1 || { echo "::error::perf gate: jq is required"; exit 1; }
+
+# `// empty` turns a missing field into the empty string rather than the literal
+# "null", so the validity checks below can reject it by name.
+field() { jq -r "${2} // empty" "$1"; }
+
+base_cold="$(field "$base_json" .cold.wall_s)"
+base_warm="$(field "$base_json" .warm_same_tree.wall_s)"
+base_cross="$(field "$base_json" .warm.wall_s)"
+base_hits="$(field "$base_json" .warm_same_tree.hits)"
+base_restored="$(field "$base_json" .warm_same_tree.storage.restored_bytes)"
+base_verdict="$(field "$base_json" .verdict.ok)"
+base_st_verdict="$(field "$base_json" .warm_same_tree_verdict.ok)"
+
+head_cold="$(field "$head_json" .cold.wall_s)"
+head_warm="$(field "$head_json" .warm_same_tree.wall_s)"
+head_cross="$(field "$head_json" .warm.wall_s)"
+head_hits="$(field "$head_json" .warm_same_tree.hits)"
+head_restored="$(field "$head_json" .warm_same_tree.storage.restored_bytes)"
+head_verdict="$(field "$head_json" .verdict.ok)"
+head_st_verdict="$(field "$head_json" .warm_same_tree_verdict.ok)"
+subject_ref="$(field "$head_json" .git_ref)"
+
+# ── Validity gates ───────────────────────────────────────────────────────────
+# A benchmark that measured nothing must fail rather than report a flattering
+# number. The engine already enforces the per-phase floors each scenario
+# declares in `[checks.assert.*]` — cache hits, restored bytes, passthrough
+# share, cross-worktree key stability — and exits non-zero when they trip. What
+# follows re-reads the two that matter most for a TIMING comparison (so a
+# result JSON handed to this script out of band cannot dodge them) and adds the
+# one relation the engine cannot check, because it spans two phases: a warm
+# build that did not beat its own cold build was not served by the cache,
+# whatever its counters say.
+problems=()
+
+check_side() {
+    local side="$1" cold="$2" warm="$3" hits="$4" restored="$5" verdict="$6" st_verdict="$7"
+
+    if [ -z "$warm" ]; then
+        problems+=("$side: no warm-same-tree phase in the result JSON — that run was not invoked with --warm-same-tree")
+        return
+    fi
+    [ "$verdict" = "true" ] ||
+        problems+=("$side: the engine's cross-worktree verdict is not ok")
+    [ "$st_verdict" = "true" ] ||
+        problems+=("$side: the engine's warm-same-tree verdict is not ok")
+    [ "${hits:-0}" -gt 0 ] ||
+        problems+=("$side: the warm build reported 0 cache hits — it recompiled everything, so its wall-clock is not a cache measurement")
+    [ "${restored:-0}" -gt 0 ] ||
+        problems+=("$side: the warm build restored 0 bytes — nothing came out of the store into the build tree")
+    [ "${cold:-0}" -gt 0 ] ||
+        problems+=("$side: cold wall-clock is 0s")
+    [ "${warm:-0}" -ge "$MIN_MEASURABLE_WARM_S" ] ||
+        problems+=("$side: the warm build took ${warm}s, below the ${MIN_MEASURABLE_WARM_S}s floor — at that length a one-second timing tick outstrips the ${WARM_REGRESSION_LIMIT_PCT}% threshold, so any delta would be quantization noise")
+    if [ "${warm:-0}" -gt 0 ] && [ "${cold:-0}" -gt 0 ] && [ "$warm" -ge "$cold" ]; then
+        problems+=("$side: the warm build (${warm}s) did not beat its own cold build (${cold}s) — the cache bought nothing, so a delta against it is meaningless")
+    fi
+}
+
+check_side "merge base" \
+    "$base_cold" "$base_warm" "$base_hits" "$base_restored" "$base_verdict" "$base_st_verdict"
+check_side "PR head" \
+    "$head_cold" "$head_warm" "$head_hits" "$head_restored" "$head_verdict" "$head_st_verdict"
+
+if [ "${#problems[@]}" -gt 0 ]; then
+    {
+        echo "## Perf gate: INVALID MEASUREMENT"
+        echo
+        echo "The benchmark did not validly exercise kache, so no delta is reported."
+        echo
+        for p in "${problems[@]}"; do echo "- $p"; done
+    } | tee "$md_out"
+    for p in "${problems[@]}"; do echo "::error::perf gate: $p"; done
+    exit 1
+fi
+
+# ── Deltas ───────────────────────────────────────────────────────────────────
+# Positive percent means the head is SLOWER than the merge base.
+pct() {
+    awk -v b="$1" -v h="$2" \
+        'BEGIN { if (b + 0 <= 0) print "n/a"; else printf "%+.1f", (h - b) * 100.0 / b }'
+}
+cold_pct="$(pct "$base_cold" "$head_cold")"
+warm_pct="$(pct "$base_warm" "$head_warm")"
+cross_pct="$(pct "$base_cross" "$head_cross")"
+
+regressed="$(awk -v d="$warm_pct" -v lim="$WARM_REGRESSION_LIMIT_PCT" \
+    'BEGIN { print (d != "n/a" && d + 0 > lim + 0) ? "yes" : "no" }')"
+
+if [ "$regressed" = "yes" ]; then
+    headline="## Perf gate: FAIL — warm build ${warm_pct}% (limit +${WARM_REGRESSION_LIMIT_PCT}%)"
+else
+    headline="## Perf gate: pass — warm build ${warm_pct}% (limit +${WARM_REGRESSION_LIMIT_PCT}%)"
+fi
+
+{
+    echo "$headline"
+    echo
+    echo "Subject \`bench-pr-cargo\` @ \`${subject_ref}\`, both sides measured back to back on one runner."
+    echo
+    echo "| phase | merge base | PR head | delta |"
+    echo "| --- | ---: | ---: | ---: |"
+    echo "| cold (empty store) | ${base_cold}s | ${head_cold}s | ${cold_pct}% |"
+    echo "| **warm** (warm store, fresh objdir) | ${base_warm}s | ${head_warm}s | **${warm_pct}%** |"
+    echo "| cross-worktree (warm store, other path) | ${base_cross}s | ${head_cross}s | ${cross_pct}% |"
+    echo
+    echo "Positive means slower. Only the warm row is blocking; cold and cross-worktree"
+    echo "are reported for context while their noise floor is still being established."
+} | tee "$md_out"
+
+if [ "$regressed" = "yes" ]; then
+    echo "::error::perf gate: warm wall-clock regressed ${warm_pct}% (limit +${WARM_REGRESSION_LIMIT_PCT}%)"
+    exit 1
+fi


### PR DESCRIPTION
Kache measures performance nightly, on the giants, on a self-hosted runner — `bench.yml` says outright that it is "intentionally NOT wired into [PR] CI". Nothing catches a warm-build regression at review time.

This adds the review-time counterpart: one mid-size subject, measured twice — the PR head and its merge base, back to back on the same machine — reporting the delta.

**Not a required check.** It reports a `perf-gate/warm` commit status and a PR comment. Promoting that status to blocking is a separate branch-protection decision, once a few runs have shown its noise floor.

## Design

- **Subject** `rust-lang/cargo`, pinned to `797e8a9bca276c1c9f9f738d2a20f484fa4eea9d` (the 0.99.0 tag). 550 lockfile packages and real cc-rs C — libgit2-sys, libssh2-sys, libz-sys, curl-sys, ring — which the pure-Rust nightly subjects cannot exercise. Pinned by SHA, not tag: a repointed tag would read as a fake regression.
- **Head versus merge base on one machine.** Nothing is compared against a stored historical number; figures from two runner generations are not comparable.
- **One measuring instrument.** `kache-scenario` is built once from the PR head and drives both kache binaries, so an engine change in the PR cannot read as a subject regression. Consequence: a PR that changes the `kache report --format json` shape fails loudly against the base binary.
- **Threshold** is one named constant, `WARM_REGRESSION_LIMIT_PCT=5.0`. Cold and cross-worktree report without failing.
- **Validity gates** reuse the engine `[checks.assert.<phase>]` mechanism; `ScenarioAssertSpec` gains `min_hits` and `min_restored_bytes`. The compare script adds what the engine cannot see: warm must beat its own cold, plus a `MIN_MEASURABLE_WARM_S=30` floor below which timing quantization outweighs 5%. A run that measured nothing fails rather than reporting a flattering number.
- **New `Phase::WarmSameTree`**, opt-in via `--warm-same-tree`, so nightly scenarios do not pay for a third build. `just bench-pr` runs one side locally.

## Fork safety

`workflow_run` is the only trigger that guarantees this file executes from the default branch, which is what makes the check below trustworthy.

1. `perf-gate-preflight.yml` runs on `pull_request` and contributes only a PR number. Its file comes from the PR, so nothing it says is trusted.
2. `perf-gate.yml` is triggered by that run, so it always executes `main`s copy of itself.
3. `authorize` sanitises the artifact to digits, re-derives everything from `gh api`, and requires `head.repo.full_name == github.repository`, `head.sha == workflow_run.head_sha`, open, non-draft. Any failure is a clean skip, not a red X.
4. Only then does `measure` start on `kunobi-runners`, checking out the API-confirmed SHA with `persist-credentials: false`.
5. The only write-scoped job (`report`) is GitHub-hosted and checks out no code.

Runner-group policy must enforce the same boundary independently; this file is not the only thing standing between a fork and a private runner.

## Second commit

`just pin-actions-check` already fails on a clean `main`: `actions/setup-node` is SHA-pinned with a trailing `# v6` and pinact now resolves it to `# v6.5.0`. Comment-only, no SHA moves, produced by running the repo own `just pin-actions`. Included here because this branch needs that gate green.

## Validation

Local: fmt-check, clippy `--workspace --all-targets`, `pin-actions-check`, `cargo test -p kache-e2e` (127 passed), `scripts/check-docs.sh`, actionlint 1.7.12 and shellcheck 0.11.0 on both workflows and the compare script.

The engine path was smoke-tested end to end against a throwaway local subject: the third phase produced its own build/wrapper/report artifacts and an isolated event log, 3 hits / 3.4 MB restored, `VERDICT (same-tree): ok`.

**The workflows have never executed.** No `workflow_run` handoff, no cross-run artifact download, no `kunobi-runners` job, and `bench-pr-cargo` has never been built. On the first run a reviewer should confirm:

1. The cross-run artifact download works and the fork / head-SHA checks behave.
2. `bench-pr-cargo` builds on the ARC image. The trimmed apt list is a read of what libgit2-sys/curl-sys/openssl-sys need; curl-sys may differ if the image carries a system libcurl.
3. `CC="{kache} cc"` routes the C halves through kache rather than passing them through — check the passthrough breakdown.
4. `min_hits = 100` and `min_restored_bytes = 64 MiB` sit comfortably below a healthy run, and cross-worktree stability is well above 50%. `cargo` sets `CARGO_RUSTC_CURRENT_DIR` to an absolute path in its own `.cargo/config.toml`; `KACHE_BASE_DIR` should normalise it, and that is the likeliest place cross-worktree stability disappoints.
5. Warm wall clock clears the 30s floor and the job fits the 100-minute cap. The ~25-30 min estimate is unverified; if it lands much above that, shrink the subject before making the status required.
6. `perf-gate/warm` appears and the sticky comment edits rather than duplicating.