### PR TITLE
docs: tighten the onboarding wording from #900

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,13 @@ Kache is a local-first compiler cache for Rust and C/C++. It stores build output
 
 ```bash
 cargo install kache
-kache init
+kache init --check   # print the proposed changes
+kache init           # apply them
 ```
 
-`kache init` sets `rustc-wrapper` in Cargo's config, and on Unix the `[env]` keys that route build-script C and C++ through the cache. Review the proposed changes without applying them:
+`kache init` sets `rustc-wrapper` in Cargo's config. On Unix it also adds the `[env]` keys for build-script C and C++. Use `kache init --no-service` if you want persistent Cargo configuration without an OS service.
 
-```bash
-kache init --check
-```
-
-Use `kache init --no-service` if you want persistent Cargo configuration without an OS service.
-
-Then keep running `cargo build`.
+Your Cargo commands do not change.
 
 ## Try it without changing your setup
 
@@ -37,7 +32,7 @@ kache stats
 
 `cargo clean` is only for this demonstration. Kache normally helps when Cargo would otherwise compile an input it has seen before, such as in another worktree or after changing toolchains and changing back.
 
-This wraps rustc and nothing else. C and C++ compilations still run uncached, so it understates a configured setup.
+This wraps rustc only. C and C++ compilations remain uncached.
 
 ## What Kache caches
 
@@ -45,7 +40,7 @@ This wraps rustc and nothing else. C and C++ compilations still run uncached, so
 | --- | --- | --- |
 | Rust libraries and build scripts | Supported | Use `RUSTC_WRAPPER=kache` or `kache init` |
 | Rust executables | Supported on Linux and macOS | Disabled by default on Windows |
-| C and C++ object files | Supported | Enabled by `kache init`, compiler shims, or `CC`/`CXX` |
+| C and C++ object files | Supported | Build scripts via `kache init`; other builds via shims or `CC`/`CXX` |
 | Local storage | Built in | Content-addressed store with garbage collection |
 | S3-compatible remote storage | Built in | Includes AWS S3, MinIO, and Cloudflare R2 |
 | Filesystem remote storage | Built in | Useful for shared disks and CI volumes |

--- a/docs/getting-started/c-cpp.mdx
+++ b/docs/getting-started/c-cpp.mdx
@@ -7,7 +7,7 @@ Kache caches conservative, single-source C and C++ object compilations. If it ca
 
 ## Cargo build scripts
 
-`RUSTC_WRAPPER` wraps rustc only, so a build script that compiles C through the `cc` crate is not cached until one of the two routes below is in place.
+`RUSTC_WRAPPER` wraps rustc only. To cache the objects a build script compiles through the `cc` crate, run `kache init` or put a shim on `PATH`.
 
 `kache init` sets `HOST_CC` and `HOST_CXX` in Cargo's config (and `CC_KNOWN_WRAPPER_CUSTOM=kache`). It does not set `CC` or `CXX`, so `cargo build --target` keeps the cross compiler the `cc` crate would have found.
 

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -30,7 +30,7 @@ export RUSTC_WRAPPER=kache
 rustc-wrapper = "kache"
 ```
 
-That covers Rust. Cargo's C and C++ compiles need the `[env]` keys `init` writes, or a shim on `PATH`.
+For Cargo build scripts that compile C or C++, add the `[env]` keys `kache init` writes, or put a shim on `PATH`.
 
 ## Try Kache without changing configuration
 
@@ -45,7 +45,7 @@ kache stats
 
 The first build fills the local cache. `cargo clean` makes Cargo request the same outputs again, so the second build can demonstrate restores. Do not add `cargo clean` to a normal build workflow.
 
-This trial does not edit Cargo configuration or install a service. It also wraps rustc and nothing else, so C and C++ compilations run uncached and the result understates a configured setup.
+This trial does not edit Cargo configuration or install a service. It wraps rustc only; C and C++ compilations remain uncached.
 
 ## Check the setup
 


### PR DESCRIPTION
Follow-up to #900. A review pass over the text that PR added found one usability problem, one overclaim, and some wording that reads worse than the prose around it.

## Ordering

The README told the reader to run `kache init`, then explained `kache init --check` underneath it. By the time you learn how to preview the changes you have already applied them. Preview now comes first, in the same block:

```bash
cargo install kache
kache init --check   # print the proposed changes
kache init           # apply them
```

## Overclaim in the table

"C and C++ object files — Enabled by `kache init`" is too broad. `init` sets `HOST_CC` / `HOST_CXX`, which covers Cargo build scripts; it offers to create the compiler-name shims but does not put them on `PATH`. A Make or CMake build still needs the shim directory in `PATH`, or `CC`/`CXX`. The row now says so.

## Wording

- "understates a configured setup" appeared in both the README and the quick start. The pronoun had no clear antecedent, and the sentence before it already stated the limitation. Both places now state it once: "C and C++ compilations remain uncached."
- "until one of the two routes below is in place" described the page instead of the configuration. It names `kache init` and PATH shims.
- Split the `kache init` sentence that carried the Cargo-config and Unix `[env]` effects together.
- Dropped "Then keep running `cargo build`" and "That covers Rust".

Net -5 lines. `scripts/check-docs.sh` passes 20 MDX pages. Docs-only, so the CI path filter skips the build matrix.

## Not changed

The quick start still shows `kache init` before listing `--check` among its variants. That ordering predates #900 and fixing it would widen this diff; worth a separate look.