### PR TITLE
Accelerate cargo-mutants workflows through Kache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,15 @@
 just pr
 ```
 
-That is `just check` (fmt, clippy `-D warnings`, tests) plus `just mutants-diff` against `origin/main`. Docs-only diffs skip mutants.
+That is `just check` (fmt, clippy `-D warnings`, tests) plus `just mutants-diff` against `origin/main`. Docs-only diffs skip mutants. The PR gate reuses the baseline that `just check` just established; standalone `just mutants-diff` still runs its own baseline.
 
 ```sh
 cargo install --locked cargo-mutants --version 27.1.0
 ```
 
-Do not invoke `cargo mutants` with `RUSTC_WRAPPER=kache`. The Justfile clears it. Hand-running mutants without `just` wraps kache in itself and the unmutated baseline dies.
+Do not invoke `cargo mutants` with `RUSTC_WRAPPER=kache`. Every Just mutation recipe clears it, including when `KACHE_SELF_HOST=1`. Hand-running mutants without `just` wraps kache in itself and the unmutated baseline dies.
+
+On macOS, the mutation recipes default to one cargo-mutants job and two Rust test threads. Set `CARGO_MUTANTS_JOBS` or `RUST_TEST_THREADS` explicitly when the machine can handle more.
 
 Do not open the PR until `just pr` exits 0.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ All common tasks live in the `Justfile` — prefer these over raw `cargo` comman
 
 ```sh
 just check          # fmt + clippy + tests
-just pr             # check + changed-line mutants (run before every PR)
+just pr             # check + bounded changed-line mutants (run before every PR)
 just ci             # mirrors the GitHub Actions verification flow
 just test           # run all tests
 just lint           # clippy with -D warnings
@@ -88,13 +88,13 @@ just mutants-core
 
 Coding agents: read [AGENTS.md](./AGENTS.md) before opening a PR. The usual CI failure is Mutation testing after a push that only ran `just check`.
 
-Run the PR gate before submitting. `just check` is fmt, clippy with `-D warnings`, and tests. CI also mutation-tests every changed Rust line; `just pr` runs that too.
+Run the PR gate before submitting. `just check` is fmt, clippy with `-D warnings`, and tests. CI also mutation-tests every changed Rust line; `just pr` runs that too without repeating the baseline.
 
 ```sh
 just pr
 ```
 
-Install the same cargo-mutants version as CI first (`cargo install --locked cargo-mutants --version 27.1.0`). A docs-only diff skips mutants.
+Install the same cargo-mutants version as CI first (`cargo install --locked cargo-mutants --version 27.1.0`). A docs-only diff skips mutants. On macOS, mutation recipes default to one cargo-mutants job and two Rust test threads; set `CARGO_MUTANTS_JOBS` or `RUST_TEST_THREADS` to override those limits.
 
 Clippy on macOS does not type-check `#[cfg(target_os = "linux")]` functions. Identity conversions (`u64::try_from` on a `u64`) and unused Unix-only test helpers fail on Linux CI under `-D warnings` even when `just lint` is green locally.
 

--- a/Justfile
+++ b/Justfile
@@ -18,7 +18,7 @@ default:
 
 # Run all local quality checks.
 [group('dev')]
-check: fmt-check lint test-resource-guard-check test
+check: fmt-check lint test-resource-guard-check mutation-runner-check test
 
 # What a PR must survive before `gh pr create`: `just check`, then the
 # same changed-line mutants job CI runs. Docs-only diffs skip mutants.
@@ -33,7 +33,9 @@ pr BASE="origin/main": check
     echo "no Rust diff against {{BASE}}; skipping mutants-diff"
     exit 0
   fi
-  just mutants-diff tmp/mutants/pr.diff
+  # `check` just ran the same unmutated tests. Do not pay for that baseline
+  # again before the first changed-line mutant.
+  just mutants-diff tmp/mutants/pr.diff skip
 
 # Mirror the repo CI verification flow.
 [group('dev')]
@@ -88,6 +90,11 @@ test:
 test-resource-guard-check:
   ./scripts/test-with-test-resources.sh
 
+# Verify mutation runs clear self-hosting and remain bounded on macOS.
+[group('dev')]
+mutation-runner-check:
+  ./scripts/test-run-cargo-mutants.sh
+
 # Model-check the bounded planner and artifact-range invariants. Install with:
 # cargo install --locked kani-verifier --version 0.67.0 && cargo kani setup
 [group('dev')]
@@ -118,20 +125,20 @@ fuzz-native-archive SECONDS="600":
 # tool with: cargo install --locked cargo-mutants --version 27.1.0
 [group('dev')]
 mutants-core *ARGS:
-  cargo mutants --package kache-core --all-features --baseline run --timeout 300 --build-timeout 600 --output tmp/mutants/core {{ARGS}}
+  ./scripts/run-cargo-mutants.sh --package kache-core --all-features --baseline run --timeout 300 --build-timeout 600 --output tmp/mutants/core {{ARGS}}
 
 # Mutation-test the complete remote service crate.
 [group('dev')]
 mutants-service *ARGS:
-  cargo mutants --package kache-service --all-features --baseline run --caught --timeout 300 --build-timeout 600 --output tmp/mutants/service {{ARGS}}
+  ./scripts/run-cargo-mutants.sh --package kache-service --all-features --baseline run --caught --timeout 300 --build-timeout 600 --output tmp/mutants/service {{ARGS}}
 
 # Mutation-test changed Rust lines outside the crates covered completely by
 # mutants-core and mutants-service. The proof-only crate runs under Kani, not
 # ordinary tests, so it is deliberately outside mutation discovery. DIFF must
 # describe the current working tree.
 [group('dev')]
-mutants-diff DIFF *ARGS:
-  ./scripts/with-test-resources.sh cargo mutants --workspace --all-features --in-diff "{{DIFF}}" --exclude 'crates/kache-core/**' --exclude 'crates/kache-service/**' --exclude 'crates/kache-proofs/**' --baseline run --timeout 300 --build-timeout 600 --output tmp/mutants/diff {{ARGS}}
+mutants-diff DIFF BASELINE="run" *ARGS:
+  ./scripts/run-cargo-mutants.sh --workspace --all-features --in-diff "{{DIFF}}" --exclude 'crates/kache-core/**' --exclude 'crates/kache-service/**' --exclude 'crates/kache-proofs/**' --baseline "{{BASELINE}}" --timeout 300 --build-timeout 600 --output tmp/mutants/diff {{ARGS}}
 
 # Audit dependencies with cargo-deny (advisories + licenses + bans +
 # sources; config and documented exceptions in `deny.toml`). Runs once

--- a/README.md
+++ b/README.md
@@ -33,9 +33,26 @@ KACHE_PROGRESS=hits RUSTC_WRAPPER=kache cargo build
 kache stats
 ```
 
+For one command, the Cargo proxy sets the wrapper itself:
+
+```bash
+kache cargo -- build
+```
+
 `cargo clean` is only for this demonstration. Kache normally helps when Cargo would otherwise compile an input it has seen before, such as in another worktree or after changing toolchains and changing back.
 
 This wraps rustc only. C and C++ compilations remain uncached.
+
+Cargo subcommands inherit the wrapper too. With cargo-mutants, Kache reuses
+unchanged dependencies and previously seen mutants across scratch directories
+and repeated runs:
+
+```bash
+kache cargo -- mutants
+```
+
+Small or first-time runs may spend more time populating the cache than they
+save. The largest gains come from expensive dependencies and repeated runs.
 
 ## What Kache caches
 

--- a/docs/getting-started/comparison.mdx
+++ b/docs/getting-started/comparison.mdx
@@ -12,7 +12,7 @@ This page describes the current projects; it does not claim that one cache is un
 | Question | Kache | sccache |
 | --- | --- | --- |
 | Primary workflow | Local-first cache with optional explicit remote synchronization | Client-server compiler cache with local and remote storage |
-| Rust setup | `RUSTC_WRAPPER=kache`, `kache init`, or `kache cargo` | `RUSTC_WRAPPER=sccache` |
+| Rust setup | `RUSTC_WRAPPER=kache`, `kache init`, or `kache cargo -- <command>` | `RUSTC_WRAPPER=sccache` |
 | C/C++ setup | PATH compiler-name shims (`kache install-shims`) or `CC="kache cc"` | Prefix wrapper (`sccache gcc`); no ccache-style PATH farm |
 | Remote backends | S3-compatible storage and filesystem paths | S3, Redis, Memcached, GCS, Azure, GitHub Actions, WebDAV, and others listed by sccache |
 | Inspection | `monitor`, `stats`, `why-miss`, `report`, `list`, and `doctor` | `--show-stats`, logs, and server commands |

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -43,9 +43,29 @@ KACHE_PROGRESS=hits RUSTC_WRAPPER=kache cargo build
 kache stats
 ```
 
+For one command, let the Cargo proxy set the wrapper:
+
+```bash
+kache cargo -- build
+```
+
 The first build fills the local cache. `cargo clean` makes Cargo request the same outputs again, so the second build can demonstrate restores. Do not add `cargo clean` to a normal build workflow.
 
 This trial does not edit Cargo configuration or install a service. It wraps rustc only; C and C++ compilations remain uncached.
+
+## Mutation testing
+
+`cargo-mutants` normally builds in copied workspaces with separate target
+directories. Kache normalizes those temporary paths, so unchanged dependencies
+and previously tested mutants can hit across workers and later runs:
+
+```bash
+kache cargo -- mutants
+```
+
+Projects configured by `kache init` can keep using `cargo mutants` directly.
+Small or first-time runs may spend more time populating the cache than they
+save. The largest gains come from expensive dependencies and repeated runs.
 
 ## Check the setup
 

--- a/scripts/run-cargo-mutants.sh
+++ b/scripts/run-cargo-mutants.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Keep mutation testing independent from the Kache version under test. On
+# macOS, bound both cargo-mutants workers and libtest concurrency: process-heavy
+# tests otherwise make the OS assess many short-lived binaries at once.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export RUSTC_WRAPPER=""
+
+if [ "$(uname -s 2>/dev/null || true)" = "Darwin" ]; then
+  export CARGO_MUTANTS_JOBS="${CARGO_MUTANTS_JOBS:-1}"
+  export RUST_TEST_THREADS="${RUST_TEST_THREADS:-2}"
+  printf \
+    'macOS mutation limits: cargo-mutants jobs=%s, Rust test threads=%s\n' \
+    "$CARGO_MUTANTS_JOBS" "$RUST_TEST_THREADS" >&2
+fi
+
+exec "$script_dir/with-test-resources.sh" cargo mutants "$@"

--- a/scripts/test-run-cargo-mutants.sh
+++ b/scripts/test-run-cargo-mutants.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+runner="$script_dir/run-cargo-mutants.sh"
+fake_bin="$(mktemp -d "${TMPDIR:-/tmp}/kache-mutants-test.XXXXXX")"
+trap 'rm -rf "$fake_bin"' EXIT
+
+cat >"$fake_bin/uname" <<'EOF'
+#!/bin/sh
+printf '%s\n' "${FAKE_UNAME:-Darwin}"
+EOF
+
+cat >"$fake_bin/cargo" <<'EOF'
+#!/bin/sh
+printf 'wrapper=%s\n' "${RUSTC_WRAPPER-<unset>}"
+printf 'jobs=%s\n' "${CARGO_MUTANTS_JOBS-<unset>}"
+printf 'threads=%s\n' "${RUST_TEST_THREADS-<unset>}"
+printf 'args='
+printf '<%s>' "$@"
+printf '\n'
+EOF
+
+chmod +x "$fake_bin/uname" "$fake_bin/cargo"
+
+assert_line() {
+  local output="$1"
+  local expected="$2"
+  if ! grep -Fqx "$expected" <<<"$output"; then
+    printf 'missing expected line %q in:\n%s\n' "$expected" "$output" >&2
+    exit 1
+  fi
+}
+
+darwin_output="$(
+  env -u CARGO_MUTANTS_JOBS -u RUST_TEST_THREADS \
+    PATH="$fake_bin:$PATH" FAKE_UNAME=Darwin RUSTC_WRAPPER=kache \
+    "$runner" --list
+)"
+assert_line "$darwin_output" 'wrapper='
+assert_line "$darwin_output" 'jobs=1'
+assert_line "$darwin_output" 'threads=2'
+assert_line "$darwin_output" 'args=<mutants><--list>'
+
+override_output="$(
+  PATH="$fake_bin:$PATH" FAKE_UNAME=Darwin RUSTC_WRAPPER=kache \
+    CARGO_MUTANTS_JOBS=3 RUST_TEST_THREADS=4 "$runner" --check
+)"
+assert_line "$override_output" 'wrapper='
+assert_line "$override_output" 'jobs=3'
+assert_line "$override_output" 'threads=4'
+
+linux_output="$(
+  env -u CARGO_MUTANTS_JOBS \
+    PATH="$fake_bin:$PATH" FAKE_UNAME=Linux RUSTC_WRAPPER=kache \
+    RUST_TEST_THREADS=5 \
+    "$runner" --list
+)"
+assert_line "$linux_output" 'wrapper='
+assert_line "$linux_output" 'jobs=<unset>'
+assert_line "$linux_output" 'threads=5'
+
+echo 'mutation runner: all checks passed'

--- a/src/cargo_proxy.rs
+++ b/src/cargo_proxy.rs
@@ -48,16 +48,18 @@ enum PlanDecision {
     Refused(String),
 }
 
-/// Run Cargo with canonical duplicate `$CARGO_HOME` rustflags collapsed once.
+/// Run Cargo through Kache with canonical duplicate `$CARGO_HOME` rustflags
+/// collapsed once.
 ///
-/// Every ambiguous case fails closed by launching Cargo unchanged. That keeps
-/// this command a conservative convenience rather than a second, incomplete
-/// Cargo config implementation.
+/// Every ambiguous config case fails closed by leaving Cargo's configuration
+/// untouched. That keeps this command a conservative convenience rather than a
+/// second, incomplete Cargo config implementation.
 pub(crate) fn run(cargo_args: Vec<OsString>) -> Result<()> {
     let cwd = std::env::current_dir().context("resolving the Cargo working directory")?;
     let cargo = real_cargo_program()?;
     let mut command = Command::new(&cargo);
     command.args(&cargo_args).current_dir(&cwd);
+    configure_kache_wrapper(&mut command)?;
 
     // Cargo owns freshness before RUSTC_WRAPPER runs. Sharing its intermediate
     // fingerprint directory across worktrees can therefore declare the wrong
@@ -85,7 +87,7 @@ pub(crate) fn run(cargo_args: Vec<OsString>) -> Result<()> {
             if !plan_is_current(&plan) {
                 eprintln!(
                     "kache: Cargo config changed while it was being inspected; \
-                     running Cargo unchanged"
+                     retaining Cargo's configuration"
                 );
             } else {
                 tracing::info!(
@@ -98,7 +100,7 @@ pub(crate) fn run(cargo_args: Vec<OsString>) -> Result<()> {
         PlanDecision::Refused(reason) => {
             eprintln!(
                 "kache: safe Cargo config normalization is unavailable: \
-                 {reason}; running Cargo unchanged"
+                 {reason}; retaining Cargo's configuration"
             );
         }
         PlanDecision::Passthrough => {}
@@ -126,6 +128,17 @@ pub(crate) fn run(cargo_args: Vec<OsString>) -> Result<()> {
     {
         run_cargo_non_unix(command, &cargo)
     }
+}
+
+/// Make `kache cargo -- ...` a complete one-shot setup, including Cargo
+/// subcommands such as `cargo mutants` that launch further Cargo processes.
+/// Those descendants inherit the wrapper and share Kache across their
+/// otherwise-isolated target directories.
+fn configure_kache_wrapper(command: &mut Command) -> Result<()> {
+    let current_exe =
+        std::env::current_exe().context("resolving the Kache executable for the Cargo wrapper")?;
+    command.env("RUSTC_WRAPPER", current_exe);
+    Ok(())
 }
 
 fn real_cargo_program() -> Result<PathBuf> {
@@ -554,6 +567,24 @@ fn revalidate_sources(sources: &[ConfigSource]) -> std::result::Result<(), Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cargo_proxy_forces_the_current_kache_as_rustc_wrapper() {
+        let mut command = Command::new("cargo");
+        command.env("RUSTC_WRAPPER", "another-wrapper");
+
+        configure_kache_wrapper(&mut command).unwrap();
+
+        let wrapper = command
+            .get_envs()
+            .find_map(|(name, value)| (name == "RUSTC_WRAPPER").then_some(value))
+            .flatten();
+        assert_eq!(
+            wrapper,
+            Some(std::env::current_exe().unwrap().as_os_str()),
+            "an explicit `kache cargo` invocation must use this Kache binary"
+        );
+    }
 
     #[test]
     fn command_gate_accepts_only_unambiguous_builtin_build_and_check() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,9 +109,9 @@ pub(crate) struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Run Cargo with canonical duplicate Cargo-home rustflags collapsed once
+    /// Run Cargo through Kache with guarded Cargo configuration normalization
     Cargo {
-        /// Built-in build/check arguments passed verbatim to Cargo (use `--` first)
+        /// Arguments passed verbatim to Cargo (use `--` first)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<std::ffi::OsString>,
     },


### PR DESCRIPTION
## What changed

- Make kache cargo -- <command> set RUSTC_WRAPPER to the current Kache executable. Cargo subcommands and their descendant Cargo processes inherit it.
- Document cargo-mutants reuse across copied workspaces and repeated runs, including the small-project cold-cache tradeoff.
- Bound this repository’s local macOS mutation concurrency and reuse the completed test baseline in just pr.

## Evidence

- A real kache cargo -- mutants run populated an empty Kache store without a caller-provided wrapper.
- Repeated copied-workspace runs produced 23 local hits and reduced warm user CPU from 16.36s to 4.74s in a small fixture. Wall time remained slower for that tiny fixture because hit overhead dominated.
- TMPDIR=/Users/lenij/.cache just pr passed: full tests green; 2 diff mutants tested, 2 caught.