### PR TITLE
ci: make rust-toolchain.toml the toolchain CI actually uses

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing to kache! This document covers the d
 ### Prerequisites
 
 - [mise](https://mise.jdx.dev/) (recommended)
-- Rust **1.95+**
+- Rust, at the version pinned in `rust-toolchain.toml` (rustup and `mise install` both read it)
 - `just`
 
 ### Clone and build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,9 @@ jobs:
           # job below — see that job for the rationale.
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      # mise installs everything in mise.toml: rust (with rustfmt +
-      # clippy via the rust tool-options block), just, helm, sccache,
-      # cargo-llvm-cov.
+      # mise installs everything in mise.toml (just, helm, sccache,
+      # cargo-llvm-cov) plus rust, which it reads from rust-toolchain.toml:
+      # channel, rustfmt and clippy.
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           # Pin the mise CLI. v2026.6.10 (2026-06-14) regressed binary
@@ -1060,8 +1060,9 @@ jobs:
           reshim: false
       # mise installs the toolchain via rustup under RUSTUP_HOME, but on a
       # runner with a pre-existing rustup it leaves no cargo proxy on PATH —
-      # so the stale system Rust (Homebrew 1.94) would win. Prepend the
-      # toolchain's own bin dir (the real 1.95 binaries) to PATH instead.
+      # so the stale system Rust (Homebrew) would win. Prepend the pinned
+      # toolchain's own bin dir (the rust-toolchain.toml binaries) to PATH
+      # instead.
       - name: Put the Rust toolchain first on PATH
         run: |
           bin_dir=$(echo "$RUSTUP_HOME"/toolchains/*/bin)

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -3,7 +3,7 @@ title: Installation
 description: Install Kache from a release, package manager, crates.io, or Nix
 ---
 
-Kache requires Rust 1.95 when built from source. Release binaries have no Rust runtime dependency.
+Building from a git checkout uses the toolchain pinned in `rust-toolchain.toml`, which rustup installs on first use. `cargo install` builds with your own toolchain and needs Rust 1.95 or newer, the crate's `rust-version`. Release binaries have no Rust runtime dependency.
 
 ## Recommended methods
 

--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779992051,
-        "narHash": "sha256-4YWGv/0NkAdtTW1MXfaLYpfC9BhpCy9k1pWkR0xI9uw=",
+        "lastModified": 1788248235,
+        "narHash": "sha256-siCQqLbY7AbZ9V3oyc65K8bhNr7QgZTXoqLTws3pv0s=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e93ad0df1073b2c969a8f0c1f10b84e870469d40",
+        "rev": "6a84c41e705533dcc5569ac0731f18406b4cdf86",
         "type": "github"
       },
       "original": {

--- a/mise.toml
+++ b/mise.toml
@@ -1,14 +1,15 @@
 [settings]
-# Read rust version from rust-toolchain.toml (single source of truth
-# for both rustup and mise).
+# rust (channel, components, profile) comes from rust-toolchain.toml, the one
+# pin that rustup, mise, and the Nix flake all read. Do not add a [tools].rust
+# entry below: it would take precedence over the file. That is how CI drifted
+# to `latest` while plain rustup gave contributors the pinned channel.
 idiomatic_version_file_enable_tools = ["rust"]
 
 [tools]
-rust = { version = "latest", components = "rustfmt,clippy" }
 "github:casey/just" = "1.43.1"
 # Versions are pinned (not `latest`) so a tool release can't break CI with no
-# code change. Bump deliberately. (rust is intentionally left to
-# rust-toolchain.toml via idiomatic_version_file_enable_tools above.)
+# code change. Bump deliberately. (rust is pinned in rust-toolchain.toml, read
+# via idiomatic_version_file_enable_tools above.)
 helm = "4.2.0"
 # Drives the out-of-tree CMake e2e scenario (e2e-cmake-out-of-tree, #394) so it
 # runs on the Linux/macOS gate instead of skipping. The scenario itself is

--- a/packaging/docker/e2e.Dockerfile
+++ b/packaging/docker/e2e.Dockerfile
@@ -11,14 +11,16 @@
 # copied back to the host. (`just e2e-docker` wires this up; `rsync` syncs
 # the source in, excluding .git/target/tmp.)
 #
-# Rust pin matches docker/service.Dockerfile. build-essential gives
+# The Rust tag matches rust-toolchain.toml (and docker/service.Dockerfile), so
+# the toolchain the copied tree asks for is already in the image and rustup does
+# not download it on every run. build-essential gives
 # cc/c++/make for the gnu C fixtures; clang adds the clang / clang-cl
 # (`--driver-mode=cl`) path the Firefox-flag fixture (issue #411) exercises;
 # cmake + ninja-build drive the CMake out-of-tree fixtures (e2e-cmake-out-of-tree,
 # e2e-cmake-file-macro-oot) — the LLVM-bench build-system shape. Without these,
 # `requires = ["cmake"]` fixtures SKIP silently in the container instead of
 # running the path-normalization checks they exist to guard.
-FROM rust:1.95-bookworm
+FROM rust:1.98-bookworm
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential clang make cmake ninja-build rsync ca-certificates \

--- a/packaging/docker/service.Dockerfile
+++ b/packaging/docker/service.Dockerfile
@@ -1,4 +1,7 @@
-FROM rust:1.95-bookworm AS builder
+# Keep the tag in step with rust-toolchain.toml. The tree is copied in with
+# that file, so a base image on another version makes rustup download the
+# pinned toolchain on every build instead of using the one in the image.
+FROM rust:1.98-bookworm AS builder
 
 WORKDIR /app
 RUN apt-get update \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,9 @@
+# The one Rust pin. rustup reads it directly, mise reads it through
+# `idiomatic_version_file_enable_tools` in mise.toml, and the Nix flake reads it
+# with `fromRustupToolchainFile`, so CI and contributors build with the same
+# compiler. The channel is an exact version: a point release must not move CI
+# without a commit here.
 [toolchain]
-channel = "1.95"
+channel = "1.98.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
`rust-toolchain.toml` pinned channel 1.95. `mise.toml` set `rust = latest`, and mise gives its own `[tools]` entry precedence over the idiomatic file, despite the comment beside it saying the file was the source of truth. CI installs Rust through mise, so CI has been testing whichever stable was newest (1.98.0 today), while plain rustup gave contributors 1.95, whose clippy rejects main:

- `src/remote_backend.rs:212` nonminimal_bool
- `src/tui.rs:697` collapsible_match
- `src/wrapper.rs:4881` collapsible_if

A new stable release could have reddened CI on any day, and nobody had chosen the version CI tests.

## What changed

- `rust-toolchain.toml` is the only pin, at the exact version CI has been running: `1.98.0`. Exact, so a point release cannot move CI without a commit here.
- `mise.toml` drops its `rust` entry. The comment now says why it must not come back.
- The Docker images under `packaging/docker/` and the docs that named 1.95 follow the file. `flake.lock` advances rust-overlay so the Nix package can resolve 1.98.0 through `fromRustupToolchainFile`.
- The `ci.yml` comments that described the old arrangement are corrected. The lane that installs 1.93.0 on purpose is unchanged.

`cargo install kache` still builds with the user's own toolchain and needs the crate's `rust-version`, 1.95; the installation page now says both things.

## Verification

- `mise ls --current rust` reports `rust-toolchain.toml` as the source and `1.98.0`; `mise exec -- rustc --version` prints 1.98.0.
- `mise exec -- just pr` on this head: fmt, clippy `-D warnings`, full workspace tests. No Rust diff, so the mutants step was skipped.

## What a reviewer should still watch

- The Nix package job is the first evaluation of the advanced rust-overlay pin.
- The macOS and Windows self-hosted lanes install through mise-action too; their logs should now show 1.98.0.
