### PR TITLE
test: isolate throwaway Git repositories from signing

### DIFF
--- a/crates/kache-e2e/src/source.rs
+++ b/crates/kache-e2e/src/source.rs
@@ -446,6 +446,7 @@ mod tests {
         git(&["init", "-q"], &upstream);
         git(&["config", "user.email", "t@t"], &upstream);
         git(&["config", "user.name", "t"], &upstream);
+        git(&["config", "--local", "commit.gpgSign", "false"], &upstream);
         std::fs::write(upstream.join("f"), "a").unwrap();
         git(&["add", "."], &upstream);
         git(&["commit", "-qm", "a"], &upstream);
@@ -501,6 +502,7 @@ mod tests {
         git(&["init", "-q"], &upstream);
         git(&["config", "user.email", "t@t"], &upstream);
         git(&["config", "user.name", "t"], &upstream);
+        git(&["config", "--local", "commit.gpgSign", "false"], &upstream);
         std::fs::write(upstream.join("f"), "pinned").unwrap();
         git(&["add", "."], &upstream);
         git(&["commit", "-qm", "pinned"], &upstream);

--- a/scripts/aur/test-vcs-pkgver.sh
+++ b/scripts/aur/test-vcs-pkgver.sh
@@ -27,6 +27,8 @@ make_repo() {
   git -C "$root" init -q -b main
   git -C "$root" config user.email t@example.com
   git -C "$root" config user.name t
+  git -C "$root" config --local commit.gpgSign false
+  git -C "$root" config --local tag.gpgSign false
   for i in $(seq 1 "$commits"); do
     echo "$i" >"$root/f"
     git -C "$root" add f


### PR DESCRIPTION
Two kache-e2e tests build a throwaway upstream repository and commit into it, and `scripts/aur/test-vcs-pkgver.sh` builds one and tags it. A maintainer whose global Git config requires signed commits or tags inherits that requirement inside those repositories, so the suite depends on a signing agent that is either absent or, when tests commit in parallel, refuses the burst of requests. Locally that looked like `clone_worktrees_pull_makes_both_commits_checkoutable` and `clone_worktrees_accepts_a_full_commit_sha` failing with `Signing ... failed: agent refused operation`, and `just test-aur-pkgver` failing 3 of 8 cases.

Each throwaway repository now sets `commit.gpgSign false` (and `tag.gpgSign false` where a tag is made) with `--local`, right after `git init`. The writes land in the temporary repository's own `.git/config`; user and global configuration are untouched. Four added lines, no behaviour change outside test fixtures.

## Verification

- With a global config that requires signed commits, without any override in the environment: `cargo test -p kache-e2e clone_worktrees` passes both tests, and `just test-aur-pkgver` reports 8 passed, 0 failed (5/3 before).
- `mise exec -- just pr` on this head: fmt, clippy `-D warnings`, full workspace tests; cargo-mutants found no mutants in the changed lines.

The packaging move in #906 relocated the AUR scripts' inputs; the paths here are current.

## What a reviewer should still watch

CI runners never had signing configured, so this changes local runs only. Nothing platform-specific.
