### PR TITLE
ci: compare the perf gate on millisecond wall clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,6 +592,13 @@ jobs:
       - name: AUR -git pkgver tests
         run: ./scripts/aur/test-vcs-pkgver.sh
 
+      # The perf gate's comparison script sets a commit status on every pull
+      # request from two JSON files. Same fixture-driven shape as the pkgver
+      # tests above: run it on results the engine could have written and check
+      # the exit code and the headline the workflow parses.
+      - name: Perf gate comparison tests
+        run: ./scripts/test-perf-gate-compare.sh
+
   # --- Dependency policy audit ---
   # Runs `cargo deny check` (via `just audit`) on every push and non-docs PR:
   # RustSec advisories PLUS license / bans / sources policy, matching the

--- a/Justfile
+++ b/Justfile
@@ -299,6 +299,15 @@ bench-pr *ARGS:
     --select suite:bench --select backend:kache --profile pr-cargo \
     --warm-same-tree {{ARGS}}
 
+# The comparison script decides the `perf-gate/warm` commit status on every
+# pull request, and the workflow parses its first line into that status. The
+# tests run it on fixture JSON in the engine's shape: threshold, floor, and
+# the validity rejections, each by exit code and headline. Seconds to run.
+# Test scripts/perf-gate-compare.sh on fixture results
+[group('bench')]
+test-perf-gate-compare:
+  @./scripts/test-perf-gate-compare.sh
+
 # Same cold/warm clone benchmark, but with sccache as the compiler cache.
 # Omit PROFILE to list sccache-backed profiles.
 # Use `just bench-sccache firefox` for the Firefox comparison.

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -91,7 +91,7 @@ use std::fs::File;
 use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::assertions::{AssertionCheck, all_passed};
 use crate::bench_profile::BenchProfile;
@@ -391,7 +391,7 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     let warm_same_tree_metrics = if config.warm_same_tree {
         reset_event_log(&event_log)?;
         daemon::start(&kache, &cache_dir, &kache_config);
-        let wall_s = build(
+        let wall_ms = build(
             &profile,
             &clone_a,
             Phase::WarmSameTree.name(),
@@ -424,7 +424,7 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
             &work_dir.join(format!("wrapper-{}.log", Phase::WarmSameTree.name())),
         );
         Some(PhaseMetrics::from_report(
-            &report, &raw, wall_s, events, leaks,
+            &report, &raw, wall_ms, events, leaks,
         ))
     } else {
         None
@@ -440,7 +440,7 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     // async file-hash prefetch path instead of hashing every input inline
     // (cold's daemon was stopped before its report capture).
     daemon::start(&kache, &cache_dir, &kache_config);
-    let warm_s = build(
+    let warm_ms = build(
         &profile,
         &clone_b,
         Phase::Warm.name(),
@@ -476,6 +476,9 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         _ => None,
     };
 
+    // Speedups stay on whole seconds: the nightly JSON and the kartero payload
+    // carry them, and the perf gate reads `wall_ms` directly instead.
+    let warm_s = whole_seconds(warm_ms);
     let speedup = if warm_s > 0 {
         cold_metrics.wall_s as f64 / warm_s as f64
     } else {
@@ -493,7 +496,8 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     // clones. A path leak in the key shows up here as a near-zero rate.
     let stability = key_stability(&cold_raw, &warm_raw);
 
-    let warm_metrics = PhaseMetrics::from_report(&warm, &warm_raw, warm_s, warm_events, warm_leaks);
+    let warm_metrics =
+        PhaseMetrics::from_report(&warm, &warm_raw, warm_ms, warm_events, warm_leaks);
     let verdict = Verdict::evaluate(
         &stability,
         &warm_metrics,
@@ -681,15 +685,60 @@ fn measures_disk_footprint(retry: bool, warm_same_tree: bool) -> bool {
 /// Speedup of a warm phase against the cold build that seeded it, rounded for
 /// the report.
 ///
-/// Zero when the phase's wall-clock rounded down to zero seconds: the engine
-/// times whole seconds, and dividing by zero yields an infinity that is not a
-/// number any report should carry.
+/// Taken on the whole-second `wall_s`, the value the nightly JSON and its
+/// telemetry have always carried; the perf gate does not read speedups, it
+/// compares `wall_ms` directly. Zero when the phase rounded down to zero
+/// seconds: dividing by zero yields an infinity that is not a number any
+/// report should carry.
 fn phase_speedup(cold_wall_s: u64, phase_wall_s: u64) -> f64 {
     if phase_wall_s > 0 {
         round2(cold_wall_s as f64 / phase_wall_s as f64)
     } else {
         0.0
     }
+}
+
+/// The whole-second view of a millisecond wall clock, truncated the way
+/// `Duration::as_secs` truncates. `wall_s` is derived from `wall_ms` through
+/// this, so the nightly JSON and the kartero payload keep the values the
+/// engine recorded back when it timed seconds only.
+fn whole_seconds(wall_ms: u64) -> u64 {
+    wall_ms / 1000
+}
+
+/// A build's elapsed time as the `wall_ms` the phase metrics record.
+/// `as_millis` is `u128`; saturate rather than wrap on a wall clock no build
+/// reaches.
+fn elapsed_ms(elapsed: Duration) -> u64 {
+    u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX)
+}
+
+/// `<m>m <ss>.<t>s` for a summary line, from milliseconds. Tenths are
+/// truncated, not rounded, so the seconds shown agree with the whole-second
+/// `wall_s` next to them in the JSON.
+fn fmt_wall_clock(wall_ms: u64) -> String {
+    let s = whole_seconds(wall_ms);
+    format!("{}m {:02}.{}s", s / 60, s % 60, (wall_ms % 1000) / 100)
+}
+
+/// Deserialize a phase's metrics from a result JSON a previous run wrote.
+///
+/// `wall_ms` arrived after `wall_s`. A `--retry` against a snapshot from an
+/// engine that timed whole seconds only has no milliseconds for cold, so they
+/// are backfilled from the seconds here; a serde default cannot read a sibling
+/// field. The backfilled value is a floor (a recorded 14s was anything up to
+/// 14.999s), which is what a whole-second record can give.
+fn load_saved_phase<T: serde::de::DeserializeOwned>(mut saved: serde_json::Value) -> Result<T> {
+    if let Some(phase) = saved.as_object_mut()
+        && !phase.contains_key("wall_ms")
+        && let Some(wall_s) = phase.get("wall_s").and_then(serde_json::Value::as_u64)
+    {
+        phase.insert(
+            "wall_ms".to_string(),
+            serde_json::Value::from(wall_s.saturating_mul(1000)),
+        );
+    }
+    Ok(serde_json::from_value(saved)?)
 }
 
 /// Did any configured assertion say this run is not a valid measurement?
@@ -1006,8 +1055,13 @@ fn run_setup(
     Ok(())
 }
 
-/// Build the project in `clone` with kache wired in; return wall-clock
-/// seconds.
+/// Build the project in `clone` with kache wired in; return the build's wall
+/// clock in milliseconds.
+///
+/// Milliseconds because the per-PR perf gate compares two of these against a
+/// 5% threshold on a warm build of about 15s: a whole-second tick would be 7%
+/// of that, more than the threshold itself. The timer starts after the objdir
+/// wipe and stops when the build command exits.
 ///
 /// kache writes wrapper-mode diagnostics — in particular
 /// `PathNormalizer`'s residual-path leak detector — directly to
@@ -1133,7 +1187,7 @@ fn build(
             log_path.display()
         );
     }
-    Ok(started.elapsed().as_secs())
+    Ok(elapsed_ms(started.elapsed()))
 }
 
 /// Capture kache's report for the phase that just finished: write the
@@ -1207,7 +1261,7 @@ fn run_cold_phase(
     }
     std::fs::create_dir_all(cache_dir)?;
     daemon::start(kache, cache_dir, kache_config);
-    let cold_s = build(
+    let cold_ms = build(
         profile,
         clone_a,
         Phase::Cold.name(),
@@ -1241,7 +1295,7 @@ fn run_cold_phase(
     source::snapshot_dir(cache_dir, &work_dir.join("cache-after-cold"))?;
 
     Ok((
-        PhaseMetrics::from_report(&cold, &cold_raw, cold_s, cold_events, cold_leaks),
+        PhaseMetrics::from_report(&cold, &cold_raw, cold_ms, cold_events, cold_leaks),
         cold_raw,
     ))
 }
@@ -1275,13 +1329,12 @@ fn retry_load_cold(
 
     let cold_raw: serde_json::Value = read_json(&report_cold)?;
     let prev: serde_json::Value = read_json(&result_json)?;
-    let cold_metrics: PhaseMetrics =
-        serde_json::from_value(prev["cold"].clone()).with_context(|| {
-            format!(
-                "loading previous cold metrics from {}",
-                result_json.display()
-            )
-        })?;
+    let cold_metrics: PhaseMetrics = load_saved_phase(prev["cold"].clone()).with_context(|| {
+        format!(
+            "loading previous cold metrics from {}",
+            result_json.display()
+        )
+    })?;
     Ok((cold_metrics, cold_raw))
 }
 
@@ -1355,7 +1408,7 @@ fn run_pull_bench(
     // the start of every phase (unconditionally), so this is a from-scratch
     // rebuild at ref_next and kache is asked about every TU.
     daemon::start(kache, cache_dir, kache_config);
-    let pull_s = build(
+    let pull_ms = build(
         profile,
         clone_a,
         Phase::Pull.name(),
@@ -1381,7 +1434,8 @@ fn run_pull_bench(
     let pull_events = read_event_log(event_log);
     let (pull_leaks, _pull_leak_samples) =
         scan_leak_warnings(&work_dir.join(format!("wrapper-{}.log", Phase::Pull.name())));
-    let pull_metrics = PhaseMetrics::from_report(&pull, &pull_raw, pull_s, pull_events, pull_leaks);
+    let pull_metrics =
+        PhaseMetrics::from_report(&pull, &pull_raw, pull_ms, pull_events, pull_leaks);
 
     // No cross-clone comparison: an empty KeyStability (compared == 0) makes
     // Verdict skip the key-stability check; the pull scenarios also set no
@@ -1493,7 +1547,7 @@ fn run_sccache_bench(
 
     sccache_start(sccache, cache_dir, clone_b)?;
     sccache_zero_stats(sccache, cache_dir, clone_b)?;
-    let warm_s = build(
+    let warm_ms = build(
         profile,
         clone_b,
         Phase::Warm.name(),
@@ -1511,7 +1565,7 @@ fn run_sccache_bench(
         clone_b,
         work_dir,
         Phase::Warm.name(),
-        warm_s,
+        warm_ms,
     )?;
     sccache_stop(sccache, cache_dir);
     ensure_sccache_cache_location(&warm_metrics, cache_dir, Phase::Warm.name())?;
@@ -1521,6 +1575,8 @@ fn run_sccache_bench(
         (Some(before), Some(after)) => before.checked_sub(after),
         _ => None,
     };
+    // Whole seconds, as for the kache path: the speedup is a nightly value.
+    let warm_s = whole_seconds(warm_ms);
     let speedup = if warm_s > 0 {
         cold_metrics.wall_s as f64 / warm_s as f64
     } else {
@@ -1621,7 +1677,7 @@ fn run_sccache_cold_phase(
     std::fs::create_dir_all(cache_dir)?;
     sccache_start(sccache, cache_dir, clone_a)?;
     sccache_zero_stats(sccache, cache_dir, clone_a)?;
-    let cold_s = build(
+    let cold_ms = build(
         profile,
         clone_a,
         Phase::Cold.name(),
@@ -1639,7 +1695,7 @@ fn run_sccache_cold_phase(
         clone_a,
         work_dir,
         Phase::Cold.name(),
-        cold_s,
+        cold_ms,
     )?;
     sccache_stop(sccache, cache_dir);
 
@@ -1669,7 +1725,7 @@ fn retry_load_sccache_cold(
     source::snapshot_dir(&snapshot, cache_dir)?;
 
     let prev: serde_json::Value = read_json(&result_json)?;
-    serde_json::from_value(prev["cold"].clone()).with_context(|| {
+    load_saved_phase(prev["cold"].clone()).with_context(|| {
         format!(
             "loading previous cold sccache metrics from {}",
             result_json.display()
@@ -1770,7 +1826,7 @@ fn capture_sccache_report(
     base_dir: &Path,
     out_dir: &Path,
     phase: &str,
-    wall_s: u64,
+    wall_ms: u64,
 ) -> Result<SccachePhaseMetrics> {
     let output = sccache_command(sccache, cache_dir, Some(base_dir))
         .args(["--show-stats", "--stats-format", "json"])
@@ -1799,7 +1855,7 @@ fn capture_sccache_report(
             .with_context(|| format!("writing {}", adv_path.display()))?;
     }
 
-    Ok(SccachePhaseMetrics::from_raw(&raw, wall_s))
+    Ok(SccachePhaseMetrics::from_raw(&raw, wall_ms))
 }
 
 /// Drop the event log so the next phase's report covers only that phase.
@@ -2430,7 +2486,9 @@ struct SccacheBenchResult {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct SccachePhaseMetrics {
+    /// Whole seconds, truncated from `wall_ms`; see [`PhaseMetrics::wall_s`].
     wall_s: u64,
+    wall_ms: u64,
     compile_requests: u64,
     requests_executed: u64,
     requests_not_compile: u64,
@@ -2457,7 +2515,7 @@ struct SccachePhaseMetrics {
 }
 
 impl SccachePhaseMetrics {
-    fn from_raw(raw: &serde_json::Value, wall_s: u64) -> Self {
+    fn from_raw(raw: &serde_json::Value, wall_ms: u64) -> Self {
         let stats = &raw["stats"];
         let cache_hits = sum_count_values(&stats["cache_hits"]["counts"]);
         let cache_misses = sum_count_values(&stats["cache_misses"]["counts"]);
@@ -2468,7 +2526,8 @@ impl SccachePhaseMetrics {
             0.0
         };
         SccachePhaseMetrics {
-            wall_s,
+            wall_s: whole_seconds(wall_ms),
+            wall_ms,
             compile_requests: stats["compile_requests"].as_u64().unwrap_or(0),
             requests_executed: stats["requests_executed"].as_u64().unwrap_or(0),
             requests_not_compile: stats["requests_not_compile"].as_u64().unwrap_or(0),
@@ -2665,16 +2724,16 @@ fn print_sccache_summary(r: &SccacheBenchResult, work_dir: &Path) {
 /// Render the end-of-run benchmark summary a human reads.
 ///
 /// Writes rather than prints so the numbers it reports can be asserted in a
-/// test. That matters for the three wall-clocks at the top: the per-PR perf
-/// gate compares exactly those, and a summary that quietly stopped reporting
-/// one of them would leave the gate reading a blank.
+/// test. That matters for the three wall-clocks at the top: they are the
+/// numbers the per-PR perf gate compares (from the result JSON, in
+/// milliseconds), and a summary that quietly stopped reporting one of them
+/// would leave a reviewer without the number the gate acted on.
 fn write_summary(
     out: &mut dyn std::io::Write,
     r: &BenchResult,
     work_dir: &Path,
 ) -> std::io::Result<()> {
     let bar = "=".repeat(64);
-    let fmt = |s: u64| format!("{}m {:02}s", s / 60, s % 60);
     writeln!(out, "\n{bar}")?;
     writeln!(out, "  kache benchmark: {} — {}", r.project, r.git_ref)?;
     if let Some(version) = &r.cache_tool_version {
@@ -2684,7 +2743,7 @@ fn write_summary(
     writeln!(
         out,
         "  cold build : {}   (empty cache, baseline)",
-        fmt(r.cold.wall_s)
+        fmt_wall_clock(r.cold.wall_ms)
     )?;
     // Only when `--warm-same-tree` ran: the plain "cleaned my target/" case,
     // same absolute path, printed between cold and the cross-clone warm so the
@@ -2693,7 +2752,7 @@ fn write_summary(
         writeln!(
             out,
             "  same-tree  : {}   (clone-a rebuilt, objdir wiped, cache populated by cold)",
-            fmt(same_tree.wall_s)
+            fmt_wall_clock(same_tree.wall_ms)
         )?;
         writeln!(
             out,
@@ -2710,7 +2769,7 @@ fn write_summary(
     writeln!(
         out,
         "  warm build : {}   (cache populated by cold; DIFFERENT worktree path)",
-        fmt(r.warm.wall_s)
+        fmt_wall_clock(r.warm.wall_ms)
     )?;
     writeln!(out, "  speedup    : {:.2}x", r.speedup)?;
     writeln!(
@@ -2904,6 +2963,8 @@ fn write_summary(
             out,
             "  costliest warm misses (recompiled despite the cache):"
         )?;
+        // Whole seconds: kache's report carries a miss's compile time as such.
+        let fmt = |s: u64| format!("{}m {:02}s", s / 60, s % 60);
         for m in r.warm.top_misses.iter().take(5) {
             writeln!(out, "    {:>8}  {}", fmt(m.compile_time_s), m.crate_name)?;
         }
@@ -3084,7 +3145,15 @@ struct PullBenchResult {
 /// alone — no cumulative bleed.
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct PhaseMetrics {
+    /// Wall clock in whole seconds, truncated from `wall_ms` the way
+    /// `Duration::as_secs` truncates. The nightly JSON and the kartero payload
+    /// carry this field and keep the values they always had.
     wall_s: u64,
+    /// Wall clock in milliseconds. The per-PR perf gate compares on this
+    /// field: at the ~15s warm build its subject takes on the gate's runner, a
+    /// whole-second tick is 7%, more than the gate's 5% threshold, so `wall_s`
+    /// alone cannot resolve a delta there.
+    wall_ms: u64,
     total_crates: u64,
     hits: u64,
     dups: u64,
@@ -3119,7 +3188,7 @@ impl PhaseMetrics {
     fn from_report(
         report: &report::KacheReport,
         raw: &serde_json::Value,
-        wall_s: u64,
+        wall_ms: u64,
         event_log: EventLogStats,
         leak_warnings: u64,
     ) -> Self {
@@ -3139,7 +3208,8 @@ impl PhaseMetrics {
             })
             .unwrap_or_default();
         PhaseMetrics {
-            wall_s,
+            wall_s: whole_seconds(wall_ms),
+            wall_ms,
             total_crates: s.total_crates,
             hits: s.total_hits(),
             dups: s.dups,
@@ -3968,6 +4038,7 @@ mod tests {
     fn phase_metrics_for_verdict(errors: u64) -> PhaseMetrics {
         PhaseMetrics {
             wall_s: 1,
+            wall_ms: 1_000,
             total_crates: 10,
             hits: 6,
             dups: 0,
@@ -4372,8 +4443,9 @@ mod tests {
     }
 
     fn bench_result_fixture() -> BenchResult {
-        let phase = |wall_s: u64, hits: u64| PhaseMetrics {
-            wall_s,
+        let phase = |wall_ms: u64, hits: u64| PhaseMetrics {
+            wall_s: whole_seconds(wall_ms),
+            wall_ms,
             hits,
             ..Default::default()
         };
@@ -4384,9 +4456,9 @@ mod tests {
             run_id: "20260901T000000Z-kache-1".to_string(),
             artifact_dir: "tmp/perf-gate/head/runs/x".to_string(),
             cache_tool_version: Some("kache 0.16.1".to_string()),
-            cold: phase(300, 0),
-            warm_same_tree: Some(phase(100, 412)),
-            warm: phase(120, 400),
+            cold: phase(300_000, 0),
+            warm_same_tree: Some(phase(100_400, 412)),
+            warm: phase(120_900, 400),
             speedup: 2.5,
             warm_same_tree_speedup: Some(3.0),
             cache_size_mb: 1024.0,
@@ -4411,15 +4483,15 @@ mod tests {
         let text = summary_text(&bench_result_fixture());
 
         assert!(
-            text.contains("cold build : 5m 00s"),
+            text.contains("cold build : 5m 00.0s"),
             "cold wall-clock missing:\n{text}"
         );
         assert!(
-            text.contains("same-tree  : 1m 40s"),
+            text.contains("same-tree  : 1m 40.4s"),
             "same-tree wall-clock missing:\n{text}"
         );
         assert!(
-            text.contains("warm build : 2m 00s"),
+            text.contains("warm build : 2m 00.9s"),
             "cross-clone wall-clock missing:\n{text}"
         );
         assert!(
@@ -4451,8 +4523,8 @@ mod tests {
 
         let text = summary_text(&result);
 
-        assert!(text.contains("cold build : 5m 00s"), "{text}");
-        assert!(text.contains("warm build : 2m 00s"), "{text}");
+        assert!(text.contains("cold build : 5m 00.0s"), "{text}");
+        assert!(text.contains("warm build : 2m 00.9s"), "{text}");
         assert!(!text.contains("same-tree"), "{text}");
     }
 
@@ -4535,12 +4607,15 @@ mod tests {
         let mut noisy = bench_result_fixture();
         noisy.warm.top_misses = vec![MissEntry {
             crate_name: "libgit2-sys".to_string(),
-            compile_time_s: 71,
+            compile_time_s: 125,
         }];
         noisy.measure_warnings = vec!["warm hit rate 12.0% below threshold 50.0%".to_string()];
         let text = summary_text(&noisy);
         assert!(text.contains("costliest warm misses"), "{text}");
-        assert!(text.contains("libgit2-sys"), "{text}");
+        // A miss's compile time is whole seconds from kache's report, shown as
+        // minutes and zero-padded seconds. 125 rather than 71 because
+        // 71 - 60 == 71 % 60, which would let a wrong operator print the same.
+        assert!(text.contains("2m 05s  libgit2-sys"), "{text}");
         assert!(text.contains("MEASURE WARNINGS"), "{text}");
         assert!(text.contains("warm hit rate 12.0%"), "{text}");
     }
@@ -4593,5 +4668,240 @@ mod tests {
             j.get("warm").is_none(),
             "pull result must not carry a warm phase"
         );
+    }
+
+    /// `wall_s` is the truncated whole-second view of `wall_ms`, the same
+    /// rounding `Duration::as_secs` applied when the engine recorded seconds
+    /// only, so the nightly JSON and the kartero payload keep their values.
+    #[test]
+    fn whole_seconds_truncates_like_as_secs() {
+        assert_eq!(whole_seconds(0), 0);
+        assert_eq!(whole_seconds(999), 0);
+        assert_eq!(whole_seconds(1_000), 1);
+        // The first live gate run's warm build: 14.9s is 14s, not 15s.
+        assert_eq!(whole_seconds(14_900), 14);
+        assert_eq!(
+            whole_seconds(14_900),
+            Duration::from_millis(14_900).as_secs()
+        );
+        assert_eq!(whole_seconds(112_400), 112);
+    }
+
+    #[test]
+    fn elapsed_ms_reports_milliseconds_and_saturates() {
+        assert_eq!(elapsed_ms(Duration::from_millis(0)), 0);
+        assert_eq!(elapsed_ms(Duration::from_millis(1_499)), 1_499);
+        assert_eq!(elapsed_ms(Duration::from_micros(1_499_999)), 1_499);
+        assert_eq!(elapsed_ms(Duration::MAX), u64::MAX);
+    }
+
+    /// One decimal, truncated: the tenths must agree with the whole seconds
+    /// `wall_s` carries, so 14.96s reads as 14.9s beside a `wall_s` of 14.
+    #[test]
+    fn fmt_wall_clock_prints_minutes_seconds_and_truncated_tenths() {
+        assert_eq!(fmt_wall_clock(0), "0m 00.0s");
+        assert_eq!(fmt_wall_clock(14_600), "0m 14.6s");
+        assert_eq!(fmt_wall_clock(14_960), "0m 14.9s");
+        assert_eq!(fmt_wall_clock(100_400), "1m 40.4s");
+        assert_eq!(fmt_wall_clock(300_000), "5m 00.0s");
+        assert_eq!(fmt_wall_clock(3_661_050), "61m 01.0s");
+    }
+
+    /// The wall clock enters the metrics once, in milliseconds; the whole
+    /// seconds are derived, never recorded separately.
+    #[test]
+    fn from_report_records_milliseconds_and_derives_whole_seconds() {
+        let raw = serde_json::json!({
+            "schema_version": 1,
+            "summary": {
+                "hit_rate_pct": 100.0,
+                "total_crates": 783,
+                "local_hits": 783,
+                "prefetch_hits": 0,
+                "remote_hits": 0,
+                "dups": 0,
+                "misses": 0,
+                "errors": 0,
+                "weighted_hit_rate_pct": 100.0,
+                "time_saved_ms": 95_500
+            },
+            "top_misses": []
+        });
+        let report: report::KacheReport =
+            serde_json::from_value(raw.clone()).expect("a minimal report parses");
+
+        let metrics = PhaseMetrics::from_report(&report, &raw, 14_600, EventLogStats::default(), 0);
+
+        assert_eq!(metrics.wall_ms, 14_600);
+        assert_eq!(metrics.wall_s, 14);
+        assert_eq!(metrics.hits, 783);
+        assert_eq!(metrics.time_saved_s, 95);
+    }
+
+    #[test]
+    fn sccache_metrics_record_milliseconds_and_derive_whole_seconds() {
+        let raw = serde_json::json!({
+            "stats": {
+                "compile_requests": 10,
+                "cache_hits": { "counts": { "Rust": 8 } },
+                "cache_misses": { "counts": { "Rust": 2 } }
+            }
+        });
+
+        let metrics = SccachePhaseMetrics::from_raw(&raw, 95_400);
+
+        assert_eq!(metrics.wall_ms, 95_400);
+        assert_eq!(metrics.wall_s, 95);
+        assert_eq!(metrics.cache_hits, 8);
+        assert_eq!(metrics.hit_rate_pct, 80.0);
+    }
+
+    /// The result JSON is the perf gate's input: both wall clocks must be
+    /// there, under these names, for every phase the gate reads.
+    #[test]
+    fn result_json_carries_both_wall_clocks_for_every_phase() {
+        let j = serde_json::to_value(bench_result_fixture()).unwrap();
+
+        assert_eq!(j["cold"]["wall_ms"], 300_000);
+        assert_eq!(j["cold"]["wall_s"], 300);
+        assert_eq!(j["warm_same_tree"]["wall_ms"], 100_400);
+        assert_eq!(j["warm_same_tree"]["wall_s"], 100);
+        assert_eq!(j["warm"]["wall_ms"], 120_900);
+        assert_eq!(j["warm"]["wall_s"], 120);
+    }
+
+    /// `--retry` reuses cold from the previous run's JSON. A snapshot written
+    /// before the engine timed milliseconds has only `wall_s`; the milliseconds
+    /// are backfilled from it rather than read as zero, and a snapshot that has
+    /// them keeps its own value.
+    #[test]
+    fn a_saved_phase_without_wall_ms_is_backfilled_from_its_seconds() {
+        let mut saved = serde_json::to_value(PhaseMetrics {
+            wall_s: 14,
+            wall_ms: 14_600,
+            hits: 783,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let current: PhaseMetrics = load_saved_phase(saved.clone()).unwrap();
+        assert_eq!(current.wall_ms, 14_600, "a recorded value is kept as is");
+        assert_eq!(current.wall_s, 14);
+
+        saved.as_object_mut().unwrap().remove("wall_ms");
+        let older: PhaseMetrics = load_saved_phase(saved).unwrap();
+        assert_eq!(older.wall_ms, 14_000, "backfilled from wall_s, as a floor");
+        assert_eq!(older.wall_s, 14);
+        assert_eq!(older.hits, 783);
+    }
+
+    /// `--retry` restores cold from the previous run: the cache snapshot goes
+    /// back into place and cold's metrics come from the result JSON. The JSON
+    /// that matters is one an engine timing whole seconds wrote, since that
+    /// is what the first retry after the millisecond wall clock finds on disk.
+    #[test]
+    fn retry_load_cold_restores_the_snapshot_and_an_older_results_wall_clock() {
+        let dir = tempfile::tempdir().unwrap();
+        let work_dir = dir.path().join("work");
+        let cache_dir = dir.path().join("cache");
+        let kache = dir.path().join("no-such-kache");
+
+        let missing = retry_load_cold("pr-cargo", &kache, &cache_dir, &work_dir)
+            .expect_err("nothing to retry from")
+            .to_string();
+        assert!(
+            missing.contains("--retry: required artifact missing"),
+            "{missing}"
+        );
+
+        let snapshot = work_dir.join("cache-after-cold");
+        std::fs::create_dir_all(&snapshot).unwrap();
+        std::fs::write(snapshot.join("index.db"), b"cold store").unwrap();
+        std::fs::write(
+            work_dir.join("report-cold.json"),
+            r#"{"summary": {"total_crates": 783}}"#,
+        )
+        .unwrap();
+        // Cold as a whole-second engine wrote it: `wall_s` only.
+        let mut previous_cold = serde_json::to_value(PhaseMetrics {
+            wall_s: 112,
+            wall_ms: 0,
+            total_crates: 783,
+            ..Default::default()
+        })
+        .unwrap();
+        previous_cold.as_object_mut().unwrap().remove("wall_ms");
+        std::fs::write(
+            work_dir.join("pr-cargo.json"),
+            serde_json::json!({ "cold": previous_cold }).to_string(),
+        )
+        .unwrap();
+
+        let (cold, cold_raw) = retry_load_cold("pr-cargo", &kache, &cache_dir, &work_dir)
+            .expect("a complete set of artifacts loads");
+
+        assert_eq!(cold.wall_s, 112);
+        assert_eq!(
+            cold.wall_ms, 112_000,
+            "backfilled from the seconds the older engine recorded"
+        );
+        assert_eq!(cold.total_crates, 783);
+        assert_eq!(cold_raw["summary"]["total_crates"], 783);
+        assert_eq!(
+            std::fs::read(cache_dir.join("index.db")).unwrap(),
+            b"cold store",
+            "the cold-state cache is restored into the cache dir"
+        );
+    }
+
+    /// `build` is what the gate times. It must report the build command's own
+    /// wall clock in milliseconds, wipe the objdir before the timer starts,
+    /// and leave the logs the failure path points at.
+    #[cfg(unix)]
+    #[test]
+    fn build_times_the_build_command_in_milliseconds() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile_path = dir.path().join("sleeper.toml");
+        std::fs::write(
+            &profile_path,
+            r#"
+name = "sleeper"
+repo = "https://example.com/sleeper.git"
+ref = "v1"
+objdir = "target"
+build = "sleep 0.2"
+"#,
+        )
+        .unwrap();
+        let profile = BenchProfile::load(&profile_path).unwrap();
+        let clone = dir.path().join("clone");
+        let stale = clone.join("target").join("stale.o");
+        std::fs::create_dir_all(stale.parent().unwrap()).unwrap();
+        std::fs::write(&stale, b"left by a previous phase").unwrap();
+        let work_dir = dir.path().join("work");
+        std::fs::create_dir_all(&work_dir).unwrap();
+        let sh = posix_sh().unwrap();
+
+        let wall_ms = build(
+            &profile,
+            &clone,
+            "cold",
+            &dir.path().join("cache"),
+            &dir.path().join("kache.toml"),
+            &dir.path().join("kache"),
+            &work_dir,
+            CacheBackend::Kache,
+            false,
+            &sh,
+        )
+        .unwrap();
+
+        assert!(
+            (200..60_000).contains(&wall_ms),
+            "a 200ms sleep must time as at least 200ms, got {wall_ms}ms"
+        );
+        assert!(!stale.exists(), "the objdir is wiped before the build");
+        assert!(work_dir.join("build-cold.log").exists());
+        assert!(work_dir.join("wrapper-cold.log").exists());
     }
 }

--- a/docs/benchmarks.mdx
+++ b/docs/benchmarks.mdx
@@ -32,6 +32,10 @@ It measures one mid-size subject — `bench-pr-cargo`, the `rust-lang/cargo` tre
 
 The pull request head and its merge base are both measured, back to back on the same runner, so the report is a delta rather than a comparison against a stored figure from another machine. A warm build more than 5% slower than the merge base fails the gate. Cold and cross-worktree deltas are reported without failing while their noise floor is still being established. The numbers land as a comment on the pull request.
 
+The engine times every phase in milliseconds (`wall_ms` in the result JSON) and the gate takes its delta on that field. The subject's warm build runs about 15 seconds on the gate's runner, where a whole-second tick would already be 7% of the build, more than the threshold. The whole-second `wall_s` next to it is derived from `wall_ms` and keeps its role in the nightly reports and their telemetry.
+
+The gate refuses to compare a warm build shorter than 5 seconds. Below that, 5% of the build is within the fixed cost of spawning the shell, cargo, and its dependency resolution on a shared runner, so a delta would measure the runner rather than kache. The refusal is reported as `INVALID MEASUREMENT`, distinct from a failing delta.
+
 Only the two `kache` binaries come from the pull request. The benchmark engine, the pinned subject, and the threshold all come from the default branch, so both sides are measured with the same instrument. One consequence to expect: a pull request that changes the engine or the scenario is not measured by its own version of them, and those changes take effect for the pull requests that follow.
 
 The gate runs only for branches in this repository: the benchmark needs a self-hosted runner, and fork code never touches one. It is not a required check.

--- a/scripts/perf-gate-compare.sh
+++ b/scripts/perf-gate-compare.sh
@@ -164,8 +164,10 @@ cold_pct="$(pct "$base_cold" "$head_cold")"
 warm_pct="$(pct "$base_warm" "$head_warm")"
 cross_pct="$(pct "$base_cross" "$head_cross")"
 
-regressed="$(awk -v d="$warm_pct" -v lim="$WARM_REGRESSION_LIMIT_PCT" \
-    'BEGIN { print (d != "n/a" && d + 0 > lim + 0) ? "yes" : "no" }')"
+# Decide on the raw milliseconds, not on the one-decimal percent printed
+# above: rounding would let a +5.04% head pass a +5.0% limit.
+regressed="$(awk -v b="$base_warm" -v h="$head_warm" -v lim="$WARM_REGRESSION_LIMIT_PCT" \
+    'BEGIN { print (b + 0 > 0 && (h - b) * 100.0 / b > lim + 0) ? "yes" : "no" }')"
 
 # The workflow's report step parses this first line into the commit status:
 # it strips the leading `## Perf gate: ` and keeps the rest. Keep the grammar.

--- a/scripts/perf-gate-compare.sh
+++ b/scripts/perf-gate-compare.sh
@@ -12,6 +12,10 @@
 #   warm-same-tree  warm store, fresh objdir, SAME path     (the gated number)
 #   warm            warm store, fresh objdir, other path    (cross-worktree)
 #
+# Every phase records its wall-clock twice: `wall_ms`, which this script
+# compares, and `wall_s`, the whole-second view the nightly reports and their
+# telemetry carry.
+#
 # Writes a markdown report to <markdown-out> for the step summary and the PR
 # comment, prints the same table to stdout, and exits non-zero when the gate
 # fails.
@@ -22,19 +26,30 @@ set -euo pipefail
 
 # ── The threshold ────────────────────────────────────────────────────────────
 # A head warm build slower than the merge base's by more than this fails the
-# gate. 5% sits above the run-to-run noise of a minutes-long build on the ARC
-# runners while still catching the kind of drift that accumulated unnoticed
+# gate. 5% sits above the run-to-run noise of a build measured back to back on
+# one runner while still catching the kind of drift that accumulated unnoticed
 # before this gate existed. It is the ONLY blocking number: the cold and
 # cross-worktree deltas are reported so a reviewer sees them, but they do not
 # fail the run until there is enough history to know their noise floor.
 readonly WARM_REGRESSION_LIMIT_PCT=5.0
 
-# The engine times phases to whole seconds. On a warm build this short, a single
-# one-second tick is already worth more than the threshold above, so a "delta"
-# would be reporting quantization rather than performance. The real subject's
-# warm phase runs well past this; tripping it means the subject shrank, the
-# build did nothing, or the scenario is pointed somewhere unexpected.
-readonly MIN_MEASURABLE_WARM_S=30
+# ── The floor ────────────────────────────────────────────────────────────────
+# The gate's first live run measured the subject's warm build at 14-15s. The
+# engine recorded whole seconds then, so one timing tick was 7% of the build,
+# more than the threshold above, and the old 30s floor rightly refused to
+# compare. The engine now records milliseconds, which puts quantization three
+# orders of magnitude below the threshold at that length, so the floor no
+# longer guards against the timer.
+#
+# What it guards against is a build so short that the threshold falls inside
+# the fixed costs that do not scale with the build: spawning the shell and
+# cargo, cargo's own resolve and fingerprint pass, scheduler jitter on a shared
+# runner. Those are tens of milliseconds each. At 5000 ms the threshold is
+# 250 ms, an order of magnitude above them, so a delta at the limit reflects
+# the build changing rather than the runner breathing. The subject sits about
+# three times above this floor; tripping it means the subject shrank, the build
+# did nothing, or the scenario is pointed somewhere unexpected.
+readonly MIN_MEASURABLE_WARM_MS=5000
 
 base_json="${1:?usage: perf-gate-compare.sh <base.json> <head.json> <markdown-out>}"
 head_json="${2:?usage: perf-gate-compare.sh <base.json> <head.json> <markdown-out>}"
@@ -49,22 +64,36 @@ command -v jq >/dev/null 2>&1 || { echo "::error::perf gate: jq is required"; ex
 # "null", so the validity checks below can reject it by name.
 field() { jq -r "${2} // empty" "$1"; }
 
-base_cold="$(field "$base_json" .cold.wall_s)"
-base_warm="$(field "$base_json" .warm_same_tree.wall_s)"
-base_cross="$(field "$base_json" .warm.wall_s)"
+# The same-tree phase is present or it is not: the engine omits the key when
+# the run had no `--warm-same-tree`, and a hand-edited `null` means the same.
+# Testing the value rather than the key keeps both from being misreported as a
+# phase that ran but carries no `wall_ms`.
+has_phase() { jq -r "${2} != null" "$1"; }
+
+base_has_warm="$(has_phase "$base_json" .warm_same_tree)"
+base_cold="$(field "$base_json" .cold.wall_ms)"
+base_warm="$(field "$base_json" .warm_same_tree.wall_ms)"
+base_cross="$(field "$base_json" .warm.wall_ms)"
 base_hits="$(field "$base_json" .warm_same_tree.hits)"
 base_restored="$(field "$base_json" .warm_same_tree.storage.restored_bytes)"
 base_verdict="$(field "$base_json" .verdict.ok)"
 base_st_verdict="$(field "$base_json" .warm_same_tree_verdict.ok)"
 
-head_cold="$(field "$head_json" .cold.wall_s)"
-head_warm="$(field "$head_json" .warm_same_tree.wall_s)"
-head_cross="$(field "$head_json" .warm.wall_s)"
+head_has_warm="$(has_phase "$head_json" .warm_same_tree)"
+head_cold="$(field "$head_json" .cold.wall_ms)"
+head_warm="$(field "$head_json" .warm_same_tree.wall_ms)"
+head_cross="$(field "$head_json" .warm.wall_ms)"
 head_hits="$(field "$head_json" .warm_same_tree.hits)"
 head_restored="$(field "$head_json" .warm_same_tree.storage.restored_bytes)"
 head_verdict="$(field "$head_json" .verdict.ok)"
 head_st_verdict="$(field "$head_json" .warm_same_tree_verdict.ok)"
 subject_ref="$(field "$head_json" .git_ref)"
+
+# Seconds with one decimal for a human, truncated rather than rounded so the
+# figure agrees with the whole-second `wall_s` the same JSON carries.
+secs() {
+    awk -v ms="$1" 'BEGIN { printf "%d.%d", ms / 1000, (ms % 1000) / 100 }'
+}
 
 # ── Validity gates ───────────────────────────────────────────────────────────
 # A benchmark that measured nothing must fail rather than report a flattering
@@ -79,10 +108,14 @@ subject_ref="$(field "$head_json" .git_ref)"
 problems=()
 
 check_side() {
-    local side="$1" cold="$2" warm="$3" hits="$4" restored="$5" verdict="$6" st_verdict="$7"
+    local side="$1" has_warm="$2" cold="$3" warm="$4" cross="$5" hits="$6" restored="$7" verdict="$8" st_verdict="$9"
 
-    if [ -z "$warm" ]; then
+    if [ "$has_warm" != "true" ]; then
         problems+=("$side: no warm-same-tree phase in the result JSON — that run was not invoked with --warm-same-tree")
+        return
+    fi
+    if [ -z "$cold" ] || [ -z "$warm" ] || [ -z "$cross" ]; then
+        problems+=("$side: the result JSON carries no wall_ms — it was written by an engine that timed whole seconds only; rebuild kache-scenario from a current checkout and measure again")
         return
     fi
     [ "$verdict" = "true" ] ||
@@ -93,19 +126,19 @@ check_side() {
         problems+=("$side: the warm build reported 0 cache hits — it recompiled everything, so its wall-clock is not a cache measurement")
     [ "${restored:-0}" -gt 0 ] ||
         problems+=("$side: the warm build restored 0 bytes — nothing came out of the store into the build tree")
-    [ "${cold:-0}" -gt 0 ] ||
-        problems+=("$side: cold wall-clock is 0s")
-    [ "${warm:-0}" -ge "$MIN_MEASURABLE_WARM_S" ] ||
-        problems+=("$side: the warm build took ${warm}s, below the ${MIN_MEASURABLE_WARM_S}s floor — at that length a one-second timing tick outstrips the ${WARM_REGRESSION_LIMIT_PCT}% threshold, so any delta would be quantization noise")
-    if [ "${warm:-0}" -gt 0 ] && [ "${cold:-0}" -gt 0 ] && [ "$warm" -ge "$cold" ]; then
-        problems+=("$side: the warm build (${warm}s) did not beat its own cold build (${cold}s) — the cache bought nothing, so a delta against it is meaningless")
+    [ "$cold" -gt 0 ] ||
+        problems+=("$side: cold wall-clock is 0 ms")
+    [ "$warm" -ge "$MIN_MEASURABLE_WARM_MS" ] ||
+        problems+=("$side: the warm build took ${warm} ms ($(secs "$warm")s), below the ${MIN_MEASURABLE_WARM_MS} ms floor — that short, the ${WARM_REGRESSION_LIMIT_PCT}% threshold sits inside the runner's fixed per-build overhead, so a delta would measure the runner rather than kache")
+    if [ "$warm" -gt 0 ] && [ "$cold" -gt 0 ] && [ "$warm" -ge "$cold" ]; then
+        problems+=("$side: the warm build (${warm} ms) did not beat its own cold build (${cold} ms) — the cache bought nothing, so a delta against it is meaningless")
     fi
 }
 
-check_side "merge base" \
-    "$base_cold" "$base_warm" "$base_hits" "$base_restored" "$base_verdict" "$base_st_verdict"
-check_side "PR head" \
-    "$head_cold" "$head_warm" "$head_hits" "$head_restored" "$head_verdict" "$head_st_verdict"
+check_side "merge base" "$base_has_warm" \
+    "$base_cold" "$base_warm" "$base_cross" "$base_hits" "$base_restored" "$base_verdict" "$base_st_verdict"
+check_side "PR head" "$head_has_warm" \
+    "$head_cold" "$head_warm" "$head_cross" "$head_hits" "$head_restored" "$head_verdict" "$head_st_verdict"
 
 if [ "${#problems[@]}" -gt 0 ]; then
     {
@@ -120,7 +153,9 @@ if [ "${#problems[@]}" -gt 0 ]; then
 fi
 
 # ── Deltas ───────────────────────────────────────────────────────────────────
-# Positive percent means the head is SLOWER than the merge base.
+# Positive percent means the head is SLOWER than the merge base. Computed on
+# milliseconds; the table below shows seconds for reading and repeats the
+# milliseconds so the percent can be checked by hand.
 pct() {
     awk -v b="$1" -v h="$2" \
         'BEGIN { if (b + 0 <= 0) print "n/a"; else printf "%+.1f", (h - b) * 100.0 / b }'
@@ -132,6 +167,8 @@ cross_pct="$(pct "$base_cross" "$head_cross")"
 regressed="$(awk -v d="$warm_pct" -v lim="$WARM_REGRESSION_LIMIT_PCT" \
     'BEGIN { print (d != "n/a" && d + 0 > lim + 0) ? "yes" : "no" }')"
 
+# The workflow's report step parses this first line into the commit status:
+# it strips the leading `## Perf gate: ` and keeps the rest. Keep the grammar.
 if [ "$regressed" = "yes" ]; then
     headline="## Perf gate: FAIL — warm build ${warm_pct}% (limit +${WARM_REGRESSION_LIMIT_PCT}%)"
 else
@@ -145,15 +182,17 @@ fi
     echo
     echo "| phase | merge base | PR head | delta |"
     echo "| --- | ---: | ---: | ---: |"
-    echo "| cold (empty store) | ${base_cold}s | ${head_cold}s | ${cold_pct}% |"
-    echo "| **warm** (warm store, fresh objdir) | ${base_warm}s | ${head_warm}s | **${warm_pct}%** |"
-    echo "| cross-worktree (warm store, other path) | ${base_cross}s | ${head_cross}s | ${cross_pct}% |"
+    echo "| cold (empty store) | $(secs "$base_cold")s | $(secs "$head_cold")s | ${cold_pct}% |"
+    echo "| **warm** (warm store, fresh objdir) | $(secs "$base_warm")s | $(secs "$head_warm")s | **${warm_pct}%** |"
+    echo "| cross-worktree (warm store, other path) | $(secs "$base_cross")s | $(secs "$head_cross")s | ${cross_pct}% |"
     echo
     echo "Positive means slower. Only the warm row is blocking; cold and cross-worktree"
     echo "are reported for context while their noise floor is still being established."
+    echo
+    echo "Milliseconds (merge base / PR head): cold ${base_cold} / ${head_cold}, warm ${base_warm} / ${head_warm}, cross-worktree ${base_cross} / ${head_cross}."
 } | tee "$md_out"
 
 if [ "$regressed" = "yes" ]; then
-    echo "::error::perf gate: warm wall-clock regressed ${warm_pct}% (limit +${WARM_REGRESSION_LIMIT_PCT}%)"
+    echo "::error::perf gate: warm wall-clock regressed ${warm_pct}% (merge base ${base_warm} ms, PR head ${head_warm} ms; limit +${WARM_REGRESSION_LIMIT_PCT}%)"
     exit 1
 fi

--- a/scripts/test-perf-gate-compare.sh
+++ b/scripts/test-perf-gate-compare.sh
@@ -112,6 +112,14 @@ result "$work/head.json" 108100 15345 16200
 run_gate "$work/base.json" "$work/head.json"
 expect_status "+5.1% is a regression" 1
 
+# The decision is taken on the milliseconds, not on the rounded percent the
+# headline prints: +5.04% rounds to +5.0% for display and is still over.
+result "$work/head.json" 108100 15336 16200
+run_gate "$work/base.json" "$work/head.json"
+expect_status "+5.04% is a regression even though it prints as +5.0%" 1
+expect_headline "the headline still shows the rounded delta" \
+    "## Perf gate: FAIL — warm build +5.0% (limit +5.0%)"
+
 # A faster head is never a failure.
 result "$work/head.json" 108100 13000 16200
 run_gate "$work/base.json" "$work/head.json"

--- a/scripts/test-perf-gate-compare.sh
+++ b/scripts/test-perf-gate-compare.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Executable tests for perf-gate-compare.sh.
+#
+# The comparison script decides the `perf-gate/warm` commit status on every
+# pull request, and its first line is parsed by the workflow into that status.
+# It runs on two JSON files, so it can be tested on two JSON files: each case
+# below writes a merge-base and a PR-head result in the shape the benchmark
+# engine emits, runs the script, and checks the exit code, the headline, and
+# the lines a reviewer reads.
+#
+# Usage: scripts/test-perf-gate-compare.sh    (exit 0 = all cases pass)
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$here/perf-gate-compare.sh"
+pass=0
+fail=0
+
+ok() { printf '  ok   %s\n' "$1"; pass=$((pass + 1)); }
+no() { printf '  FAIL %s\n     %s\n' "$1" "$2"; fail=$((fail + 1)); }
+
+# A result JSON as `kache-scenario --warm-same-tree` writes it, reduced to the
+# fields the comparison reads. Each phase carries `wall_ms` and its derived
+# whole-second `wall_s`, exactly as the engine records them.
+#
+#   result <path> <cold_ms> <warm_same_tree_ms> <cross_ms> [hits] [restored_bytes]
+result() {
+    local path="$1" cold="$2" warm="$3" cross="$4" hits="${5:-783}" restored="${6:-2000000000}"
+    cat >"$path" <<EOF
+{
+  "project": "bench-pr-cargo",
+  "git_ref": "797e8a9",
+  "cold": { "wall_s": $((cold / 1000)), "wall_ms": $cold, "hits": 0,
+            "storage": { "restored_bytes": 0 } },
+  "warm_same_tree": { "wall_s": $((warm / 1000)), "wall_ms": $warm, "hits": $hits,
+                      "storage": { "restored_bytes": $restored } },
+  "warm": { "wall_s": $((cross / 1000)), "wall_ms": $cross, "hits": $hits,
+            "storage": { "restored_bytes": $restored } },
+  "verdict": { "ok": true },
+  "warm_same_tree_verdict": { "ok": true }
+}
+EOF
+}
+
+# Run the script on two results; sets $status, $out (stdout+stderr), $md.
+run_gate() {
+    local base="$1" head="$2"
+    md="$(mktemp)"
+    out="$("$script" "$base" "$head" "$md" 2>&1)"
+    status=$?
+}
+
+expect_status() {
+    local name="$1" want="$2"
+    if [ "$status" -eq "$want" ]; then ok "$name"; else no "$name" "exit $status, want $want: $out"; fi
+}
+
+expect_line() {
+    local name="$1" substr="$2"
+    if [[ "$out" == *"$substr"* ]]; then ok "$name"; else no "$name" "output lacked '$substr': $out"; fi
+}
+
+expect_headline() {
+    local name="$1" want="$2" got
+    got="$(head -n 1 "$md")"
+    if [ "$got" = "$want" ]; then ok "$name"; else no "$name" "headline '$got', want '$want'"; fi
+}
+
+echo "perf-gate-compare.sh"
+work="$(mktemp -d)"
+
+# --- the numbers from the gate's first live run ------------------------------
+#
+# 14.6s against 15.1s is +3.4%: a delta whole seconds could never resolve, and
+# one the gate must now report as a pass rather than refuse.
+
+result "$work/base.json" 112400 14600 17000
+result "$work/head.json" 108100 15100 16200
+run_gate "$work/base.json" "$work/head.json"
+expect_status "a +3.4% warm build passes" 0
+expect_headline "pass headline carries the warm delta and the limit" \
+    "## Perf gate: pass — warm build +3.4% (limit +5.0%)"
+expect_line "the table shows seconds with one decimal" "| 14.6s | 15.1s | **+3.4%** |"
+expect_line "the cold row is reported, not gated" "| 112.4s | 108.1s | -3.8% |"
+expect_line "the milliseconds behind the percentages are printed" \
+    "Milliseconds (merge base / PR head): cold 112400 / 108100, warm 14600 / 15100, cross-worktree 17000 / 16200."
+
+# The workflow's report step turns the first line into the commit status
+# description with exactly this sed (see .github/workflows/perf-gate.yml).
+parsed="$(head -n 1 "$md" | sed -e 's/^#\{1,\} *//' -e 's/^Perf gate: *//')"
+if [ "$parsed" = "pass — warm build +3.4% (limit +5.0%)" ]; then
+    ok "the headline parses into the commit-status description the workflow expects"
+else
+    no "the headline parses into the commit-status description the workflow expects" "got '$parsed'"
+fi
+
+# --- the threshold ------------------------------------------------------------
+
+result "$work/head.json" 108100 16000 16200
+run_gate "$work/base.json" "$work/head.json"
+expect_status "a +9.6% warm build fails" 1
+expect_headline "FAIL headline carries the warm delta and the limit" \
+    "## Perf gate: FAIL — warm build +9.6% (limit +5.0%)"
+expect_line "the failure is annotated with the milliseconds it was decided on" \
+    "::error::perf gate: warm wall-clock regressed +9.6% (merge base 14600 ms, PR head 16000 ms; limit +5.0%)"
+
+# Exactly the limit is within budget; the first tenth past it is not.
+result "$work/head.json" 108100 15330 16200
+run_gate "$work/base.json" "$work/head.json"
+expect_status "+5.0% is within budget" 0
+result "$work/head.json" 108100 15345 16200
+run_gate "$work/base.json" "$work/head.json"
+expect_status "+5.1% is a regression" 1
+
+# A faster head is never a failure.
+result "$work/head.json" 108100 13000 16200
+run_gate "$work/base.json" "$work/head.json"
+expect_status "a faster warm build passes" 0
+expect_headline "a speed-up is reported with its sign" \
+    "## Perf gate: pass — warm build -11.0% (limit +5.0%)"
+
+# --- the floor ------------------------------------------------------------------
+
+result "$work/base.json" 20000 4900 6000
+result "$work/head.json" 20000 4900 6000
+run_gate "$work/base.json" "$work/head.json"
+expect_status "a warm build under the floor is not compared" 1
+expect_headline "an uncompared run says so in the headline" "## Perf gate: INVALID MEASUREMENT"
+expect_line "the floor message names both figures in milliseconds" \
+    "the warm build took 4900 ms (4.9s), below the 5000 ms floor"
+
+result "$work/base.json" 20000 5000 6000
+result "$work/head.json" 20000 5000 6000
+run_gate "$work/base.json" "$work/head.json"
+expect_status "a warm build exactly at the floor is compared" 0
+
+# --- runs that measured nothing ------------------------------------------------
+
+result "$work/base.json" 20000 20000 6000
+result "$work/head.json" 20000 15000 6000
+run_gate "$work/base.json" "$work/head.json"
+expect_status "a warm build that did not beat its cold build is rejected" 1
+expect_line "the rejection names the side and both builds" \
+    "merge base: the warm build (20000 ms) did not beat its own cold build (20000 ms)"
+
+result "$work/base.json" 112400 14600 17000 0 0
+result "$work/head.json" 108100 15100 16200
+run_gate "$work/base.json" "$work/head.json"
+expect_status "zero hits is rejected" 1
+expect_line "zero hits is named" "merge base: the warm build reported 0 cache hits"
+expect_line "zero restored bytes is named" "merge base: the warm build restored 0 bytes"
+
+# A result written by an engine that recorded whole seconds only. It has the
+# phase, but no milliseconds to compare on.
+result "$work/base.json" 112400 14600 17000
+result "$work/head.json" 108100 15100 16200
+jq 'del(.cold.wall_ms, .warm_same_tree.wall_ms, .warm.wall_ms)' "$work/head.json" >"$work/old.json"
+run_gate "$work/base.json" "$work/old.json"
+expect_status "a result without wall_ms is rejected" 1
+expect_line "the missing field is named" "PR head: the result JSON carries no wall_ms"
+
+jq 'del(.warm_same_tree, .warm_same_tree_verdict)' "$work/head.json" >"$work/nophase.json"
+run_gate "$work/base.json" "$work/nophase.json"
+expect_status "a result without the same-tree phase is rejected" 1
+expect_line "the missing phase is named" "PR head: no warm-same-tree phase in the result JSON"
+
+# The same phase, present as a literal null rather than absent. Not a shape the
+# engine writes, but the diagnosis must still be "no phase", not "no wall_ms".
+jq '.warm_same_tree = null | .warm_same_tree_verdict = null' "$work/head.json" >"$work/nullphase.json"
+run_gate "$work/base.json" "$work/nullphase.json"
+expect_status "a null same-tree phase is rejected" 1
+expect_line "a null phase is reported as missing, not as lacking wall_ms" "PR head: no warm-same-tree phase in the result JSON"
+
+run_gate "$work/base.json" "$work/does-not-exist.json"
+expect_status "a missing input is an error" 1
+expect_line "the missing input is named" "missing benchmark result"
+
+rm -rf "$work"
+echo
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Follow-up to #907. The gate now measures with one instrument, and on its first complete live run it reported `INVALID MEASUREMENT`, correctly: the subject's warm build takes 14 s on the ARC runner, the engine recorded whole seconds, and at that length one timing tick is 7% against a 5% threshold. As configured the gate could never produce a delta.

## What changed

- The bench engine records `wall_ms` beside `wall_s` for every phase. `wall_s` is derived from it by truncation, exactly what `as_secs` gave before, so the nightly JSON values, the speedup figures and the kartero payload are unchanged; the field is only added. A cold snapshot saved by an older engine loads with `wall_ms` defaulted from its `wall_s`.
- `scripts/perf-gate-compare.sh` compares on milliseconds. The floor becomes 5000 ms: at millisecond resolution the concern is no longer quantization but scheduler jitter, and 5% of five seconds is well above it. The headline keeps the grammar the workflow parses; the comment table shows seconds to one decimal and repeats the milliseconds so the percent can be checked by hand.
- The regression decision is taken on the raw milliseconds, not on the rounded percent the headline prints. Before this, a head that was +5.04% slower passed a +5.0% limit.
- `docs/benchmarks.mdx` describes the new floor.

## Verification

- `scripts/test-perf-gate-compare.sh`: 32 cases, including the +5.04% boundary, the exact-limit pass, the floor message, and a null phase.
- kache-e2e unit tests cover the `wall_ms` plumbing, the `wall_s` derivation, and the summary and verdict paths.
- `mise exec -- just pr` on this head: fmt, clippy `-D warnings`, full workspace tests, changed-line mutants: 21 mutants tested, 14 caught, 7 unviable, 0 missed, 0 timed out.

## What a reviewer should still watch

- The first live run after this merges is the first real pass/fail verdict on a pull request. The two figures to check are the warm milliseconds on both sides and that the headline reads as a pass or a fail rather than an invalid measurement.
- The sccache and pull summaries still print whole seconds; only the kache summary prints tenths. Cosmetic, left for a follow-up.
