### PR TITLE
test: pin kache runtime state for spawned children

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,13 @@ jobs:
           cache: false
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       # Held at a pre-runtime-dir revision: newer kache-action exports
-      # KACHE_RUNTIME_DIR into the job env, and the test suite is not yet
-      # hermetic against it (integration tests read events.jsonl from the
-      # cache dir; daemon unit tests would share one runtime dir).
+      # KACHE_RUNTIME_DIR into the job env. The integration tests now pin
+      # KACHE_RUNTIME_DIR to their own cache dir and clear KACHE_SOCKET_PATH,
+      # KACHE_EVENT_ROOT, and KACHE_ACTIVE for every child they spawn
+      # (tests/common/mod.rs, hermetic_command), so events.jsonl and the
+      # daemon socket land where the tests look. In-process unit tests that
+      # call Config::load still see the job env, so the pin stays until they
+      # are checked.
       # Use the latest stable release to accelerate ordinary verification.
       # E2E, mutation, Kani, and platform jobs below still build this commit
       # directly. Add `[no-kache]` to a PR title to diagnose cache-related CI.

--- a/tests/adaptive_incremental_test.rs
+++ b/tests/adaptive_incremental_test.rs
@@ -12,6 +12,12 @@ use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+// Only the env plumbing is shared; this file drives the Cargo-built binary,
+// so the bootstrap helpers in `common` stay unused here.
+#[allow(dead_code)]
+mod common;
+use common::hermetic_command;
+
 fn kache_binary() -> &'static str {
     env!("CARGO_BIN_EXE_kache")
 }
@@ -38,25 +44,26 @@ fn build_variant(
     filetime::set_file_mtime(&source, FileTime::from_unix_time(source_mtime, 0)).unwrap();
 
     let event_count = fixture_events(cache_dir).len();
-    let output = Command::new("cargo")
-        .args(["build", "--offline", "--quiet", "--lib"])
-        .current_dir(project)
-        .env("RUSTC_WRAPPER", kache_binary())
-        .env("CARGO_TARGET_DIR", target_dir)
-        .env("CARGO_INCREMENTAL", "1")
-        .env("KACHE_CACHE_DIR", cache_dir)
-        .env("KACHE_CONFIG", project.join("missing-kache.toml"))
-        .env("KACHE_ADAPTIVE_INCREMENTAL", "1")
-        .env("KACHE_FALLBACK", fallback)
-        .env("FALLBACK_MARKER", project.join("fallback-used"))
-        .env("KACHE_LOG", "kache=debug")
-        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
-        .env_remove("RUSTC_WORKSPACE_WRAPPER")
-        .env_remove("KACHE_CLEAN_INCREMENTAL")
-        .env_remove("KACHE_DISABLED")
-        .env_remove("KACHE_PRESERVE_INCREMENTAL")
-        .output()
-        .expect("failed to build adaptive fixture");
+    let output = hermetic_command(
+        "cargo",
+        cache_dir,
+        Some(&project.join("missing-kache.toml")),
+    )
+    .args(["build", "--offline", "--quiet", "--lib"])
+    .current_dir(project)
+    .env("RUSTC_WRAPPER", kache_binary())
+    .env("CARGO_TARGET_DIR", target_dir)
+    .env("CARGO_INCREMENTAL", "1")
+    .env("KACHE_ADAPTIVE_INCREMENTAL", "1")
+    .env("KACHE_FALLBACK", fallback)
+    .env("FALLBACK_MARKER", project.join("fallback-used"))
+    .env("KACHE_LOG", "kache=debug")
+    .env_remove("RUSTC_WORKSPACE_WRAPPER")
+    .env_remove("KACHE_CLEAN_INCREMENTAL")
+    .env_remove("KACHE_DISABLED")
+    .env_remove("KACHE_PRESERVE_INCREMENTAL")
+    .output()
+    .expect("failed to build adaptive fixture");
     assert!(
         output.status.success(),
         "fixture build failed for variant {answer}\nstdout:\n{}\nstderr:\n{}",
@@ -290,24 +297,25 @@ fn user_facing_executable_without_fallback_uses_default_immediate_adaptive_lane(
         "fn main() { print!(\"adaptive executable\"); }\n",
     )
     .unwrap();
-    let output = Command::new("cargo")
-        .args(["build", "--offline", "--quiet", "--bin", "adaptive-fixture"])
-        .current_dir(project.path())
-        .env("RUSTC_WRAPPER", kache_binary())
-        .env("CARGO_TARGET_DIR", &target)
-        .env("CARGO_INCREMENTAL", "1")
-        .env("KACHE_CACHE_DIR", cache.path())
-        .env("KACHE_CONFIG", project.path().join("missing-kache.toml"))
-        .env("KACHE_CACHE_EXECUTABLES", "0")
-        .env_remove("KACHE_FALLBACK")
-        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
-        .env_remove("RUSTC_WORKSPACE_WRAPPER")
-        .env_remove("KACHE_ADAPTIVE_INCREMENTAL")
-        .env_remove("KACHE_CLEAN_INCREMENTAL")
-        .env_remove("KACHE_DISABLED")
-        .env_remove("KACHE_PRESERVE_INCREMENTAL")
-        .output()
-        .expect("failed to build adaptive executable fixture");
+    let output = hermetic_command(
+        "cargo",
+        cache.path(),
+        Some(&project.path().join("missing-kache.toml")),
+    )
+    .args(["build", "--offline", "--quiet", "--bin", "adaptive-fixture"])
+    .current_dir(project.path())
+    .env("RUSTC_WRAPPER", kache_binary())
+    .env("CARGO_TARGET_DIR", &target)
+    .env("CARGO_INCREMENTAL", "1")
+    .env("KACHE_CACHE_EXECUTABLES", "0")
+    .env_remove("KACHE_FALLBACK")
+    .env_remove("RUSTC_WORKSPACE_WRAPPER")
+    .env_remove("KACHE_ADAPTIVE_INCREMENTAL")
+    .env_remove("KACHE_CLEAN_INCREMENTAL")
+    .env_remove("KACHE_DISABLED")
+    .env_remove("KACHE_PRESERVE_INCREMENTAL")
+    .output()
+    .expect("failed to build adaptive executable fixture");
     assert!(
         output.status.success(),
         "adaptive executable build failed\nstdout:\n{}\nstderr:\n{}",
@@ -375,25 +383,26 @@ fn user_facing_executable_preserves_configured_fallback_contract() {
     )
     .unwrap();
 
-    let output = Command::new("cargo")
-        .args(["build", "--offline", "--quiet", "--bin", "adaptive-fixture"])
-        .current_dir(project.path())
-        .env("RUSTC_WRAPPER", kache_binary())
-        .env("CARGO_TARGET_DIR", &target)
-        .env("CARGO_INCREMENTAL", "1")
-        .env("KACHE_CACHE_DIR", cache.path())
-        .env("KACHE_CONFIG", project.path().join("missing-kache.toml"))
-        .env("KACHE_CACHE_EXECUTABLES", "0")
-        .env("KACHE_FALLBACK", &fallback)
-        .env("FALLBACK_MARKER", &fallback_marker)
-        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
-        .env_remove("RUSTC_WORKSPACE_WRAPPER")
-        .env_remove("KACHE_ADAPTIVE_INCREMENTAL")
-        .env_remove("KACHE_CLEAN_INCREMENTAL")
-        .env_remove("KACHE_DISABLED")
-        .env_remove("KACHE_PRESERVE_INCREMENTAL")
-        .output()
-        .expect("failed to build fallback executable fixture");
+    let output = hermetic_command(
+        "cargo",
+        cache.path(),
+        Some(&project.path().join("missing-kache.toml")),
+    )
+    .args(["build", "--offline", "--quiet", "--bin", "adaptive-fixture"])
+    .current_dir(project.path())
+    .env("RUSTC_WRAPPER", kache_binary())
+    .env("CARGO_TARGET_DIR", &target)
+    .env("CARGO_INCREMENTAL", "1")
+    .env("KACHE_CACHE_EXECUTABLES", "0")
+    .env("KACHE_FALLBACK", &fallback)
+    .env("FALLBACK_MARKER", &fallback_marker)
+    .env_remove("RUSTC_WORKSPACE_WRAPPER")
+    .env_remove("KACHE_ADAPTIVE_INCREMENTAL")
+    .env_remove("KACHE_CLEAN_INCREMENTAL")
+    .env_remove("KACHE_DISABLED")
+    .env_remove("KACHE_PRESERVE_INCREMENTAL")
+    .output()
+    .expect("failed to build fallback executable fixture");
     assert!(
         output.status.success(),
         "fallback executable build failed\nstdout:\n{}\nstderr:\n{}",
@@ -464,7 +473,11 @@ exit 0
     fs::set_permissions(&fake_rustc, fs::Permissions::from_mode(0o755)).unwrap();
 
     let wrapper = |argv_dump: &Path| {
-        let mut command = Command::new(kache_binary());
+        let mut command = hermetic_command(
+            kache_binary(),
+            cache.path(),
+            Some(&project.path().join("missing-kache.toml")),
+        );
         command
             .arg(&fake_rustc)
             .args(["--crate-name", "adaptive_fixture", "--crate-type", "bin"])
@@ -482,11 +495,8 @@ exit 0
             .env("CONTENDER_FILE", &contender)
             .env("CARGO_PRIMARY_PACKAGE", "1")
             .env("CARGO_INCREMENTAL", "1")
-            .env("KACHE_CACHE_DIR", cache.path())
-            .env("KACHE_CONFIG", project.path().join("missing-kache.toml"))
             .env("KACHE_CACHE_EXECUTABLES", "0")
             .env("KACHE_LOG", "kache=warn")
-            .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
             .env_remove("RUSTC_WORKSPACE_WRAPPER")
             .env_remove("KACHE_ADAPTIVE_INCREMENTAL")
             .env_remove("KACHE_CLEAN_INCREMENTAL")

--- a/tests/cargo_proxy_test.rs
+++ b/tests/cargo_proxy_test.rs
@@ -11,19 +11,26 @@ use std::process::{Command, Output};
 
 const KACHE_BIN: &str = env!("CARGO_BIN_EXE_kache");
 
-fn cargo_env(command: &mut Command, home: &Path, cache: &Path, target: &Path) {
+// Only the env plumbing is shared; this file drives the Cargo-built binary,
+// so the bootstrap helpers in `common` stay unused here.
+#[allow(dead_code)]
+mod common;
+use common::hermetic_command;
+
+/// `kache cargo` wired to a throwaway HOME, cache, and target directory.
+fn proxied_cargo(home: &Path, cache: &Path, target: &Path) -> Command {
+    let mut command = hermetic_command(KACHE_BIN, cache, Some(&cache.join("config.toml")));
     command
         .env("HOME", home)
         .env("CARGO_HOME", home.join(".cargo"))
         .env("CARGO_TARGET_DIR", target)
         .env("CARGO_INCREMENTAL", "0")
         .env("RUSTC_WRAPPER", KACHE_BIN)
-        .env("KACHE_CACHE_DIR", cache)
-        .env("KACHE_CONFIG", cache.join("config.toml"))
         .env("KACHE_LOG", "off")
         .env_remove("RUSTFLAGS")
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .env_remove("CARGO_BUILD_RUSTFLAGS");
+    command
 }
 
 #[test]
@@ -49,11 +56,10 @@ fn canonical_cargo_home_alias_keeps_existing_cargo_unit_fresh() {
     )
     .unwrap();
 
-    let mut cold = Command::new(KACHE_BIN);
+    let mut cold = proxied_cargo(&home, &cache, &cold_target);
     cold.args(["cargo", "--", "check", "--quiet"])
         .current_dir(&project)
         .env("KACHE_REAL_CARGO", env!("CARGO"));
-    cargo_env(&mut cold, &home, &cache, &cold_target);
     let cold = cold.output().unwrap();
     assert!(
         cold.status.success(),
@@ -63,12 +69,11 @@ fn canonical_cargo_home_alias_keeps_existing_cargo_unit_fresh() {
 
     std::os::unix::fs::symlink(&cargo_home, home.join("work/.cargo")).unwrap();
 
-    let mut warm = Command::new(KACHE_BIN);
+    let mut warm = proxied_cargo(&home, &cache, &cold_target);
     warm.args(["cargo", "--", "check", "--verbose", "--color=never"])
         .current_dir(&project)
         .env("KACHE_REAL_CARGO", env!("CARGO"))
         .env("CARGO_TERM_COLOR", "always");
-    cargo_env(&mut warm, &home, &cache, &cold_target);
     let warm = warm.output().unwrap();
     assert!(
         warm.status.success(),
@@ -124,12 +129,11 @@ fn explicit_rustflags_keep_their_cargo_precedence() {
     .unwrap();
     std::os::unix::fs::symlink(&cargo_home, home.join("work/.cargo")).unwrap();
 
-    let mut command = Command::new(KACHE_BIN);
+    let mut command = proxied_cargo(&home, &cache, &target);
     command
         .args(["cargo", "--", "check", "--quiet"])
         .current_dir(&project)
         .env("KACHE_REAL_CARGO", env!("CARGO"));
-    cargo_env(&mut command, &home, &cache, &target);
     command.env("RUSTFLAGS", "--cfg from_env");
     let output = command.output().unwrap();
     assert!(
@@ -253,13 +257,12 @@ fn write_shared_target_project(root: &Path, value: &str) {
 }
 
 fn proxied_shared_target_build(project: &Path, home: &Path, cache: &Path, target: &Path) -> Output {
-    let mut command = Command::new(KACHE_BIN);
+    let mut command = proxied_cargo(home, cache, target);
     command
         .args(["cargo", "--", "build", "--quiet"])
         .current_dir(project)
         .env("KACHE_REAL_CARGO", env!("CARGO"))
         .env("KACHE_CACHE_EXECUTABLES", "1");
-    cargo_env(&mut command, home, cache, target);
     command.output().unwrap()
 }
 

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -13,6 +13,12 @@ use predicates::prelude::PredicateBooleanExt;
 use std::path::Path;
 use tempfile::TempDir;
 
+// Only the env plumbing is shared; this file drives the Cargo-built binary,
+// so the bootstrap helpers in `common` stay unused here.
+#[allow(dead_code)]
+mod common;
+use common::hermetic_command;
+
 /// Path to the binary under test. Cargo sets `CARGO_BIN_EXE_kache` to the
 /// artifact it built for this integration test — under `cargo llvm-cov` that
 /// is the instrumented binary, so spawning it counts toward coverage.
@@ -22,19 +28,18 @@ const KACHE_BIN: &str = env!("CARGO_BIN_EXE_kache");
 /// config path, and HOME/CARGO_HOME so nothing touches the developer's real
 /// setup and no background daemon is contacted.
 fn kache(home: &Path, cache_dir: &Path) -> Command {
-    let mut cmd = Command::new(KACHE_BIN);
-    cmd.env("KACHE_CACHE_DIR", cache_dir)
-        .env("KACHE_CONFIG", cache_dir.join("config.toml"))
-        .env("KACHE_LOG", "off")
+    let mut cmd = Command::from(hermetic_command(
+        KACHE_BIN,
+        cache_dir,
+        Some(&cache_dir.join("config.toml")),
+    ));
+    cmd.env("KACHE_LOG", "off")
         .env("HOME", home)
         .env("CARGO_HOME", home.join(".cargo"))
         // Daemons spawned during tests must self-exit quickly instead of
         // lingering indefinitely — otherwise, under `just coverage`,
         // they pile up and CPU-starve the rest of the suite.
-        .env("KACHE_DAEMON_IDLE_TIMEOUT", "3")
-        // Never let a real wrapper config leak into the spawned process.
-        .env_remove("RUSTC_WRAPPER")
-        .env_remove("CARGO_BUILD_RUSTC_WRAPPER");
+        .env("KACHE_DAEMON_IDLE_TIMEOUT", "3");
     cmd
 }
 
@@ -64,21 +69,23 @@ impl Env {
     /// Run `cargo build --lib` for `project` through the kache rustc wrapper,
     /// wired to this env's isolated cache/config/HOME. Returns the build output.
     fn wrapper_build(&self, project: &Path, target_dir: &Path) -> std::process::Output {
-        std::process::Command::new(env!("CARGO"))
-            .args(["build", "--lib"])
-            .current_dir(project)
-            .env("RUSTC_WRAPPER", KACHE_BIN)
-            .env("KACHE_CACHE_DIR", &self.cache)
-            .env("KACHE_CONFIG", self.cache.join("config.toml"))
-            .env("KACHE_LOG", "off")
-            .env("HOME", &self.home)
-            // Short idle timeout so the build-spawned daemon doesn't linger and
-            // pile up across tests (see kache() for rationale).
-            .env("KACHE_DAEMON_IDLE_TIMEOUT", "3")
-            .env("CARGO_TARGET_DIR", target_dir)
-            .env("CARGO_INCREMENTAL", "0")
-            .output()
-            .expect("run cargo build with kache wrapper")
+        hermetic_command(
+            env!("CARGO"),
+            &self.cache,
+            Some(&self.cache.join("config.toml")),
+        )
+        .args(["build", "--lib"])
+        .current_dir(project)
+        .env("RUSTC_WRAPPER", KACHE_BIN)
+        .env("KACHE_LOG", "off")
+        .env("HOME", &self.home)
+        // Short idle timeout so the build-spawned daemon doesn't linger and
+        // pile up across tests (see kache() for rationale).
+        .env("KACHE_DAEMON_IDLE_TIMEOUT", "3")
+        .env("CARGO_TARGET_DIR", target_dir)
+        .env("CARGO_INCREMENTAL", "0")
+        .output()
+        .expect("run cargo build with kache wrapper")
     }
 }
 
@@ -896,12 +903,10 @@ fn doctor_reports_reachable_daemon_version() {
     let e = env();
     let project = scaffold_lib("kachedoc", "pub fn d() -> u8 { 1 }\n");
     let target_dir = project.path().join("target");
-    let build = std::process::Command::new(env!("CARGO"))
+    let build = hermetic_command(env!("CARGO"), &e.cache, Some(&e.cache.join("config.toml")))
         .args(["build", "--lib"])
         .current_dir(project.path())
         .env("RUSTC_WRAPPER", KACHE_BIN)
-        .env("KACHE_CACHE_DIR", &e.cache)
-        .env("KACHE_CONFIG", e.cache.join("config.toml"))
         .env("KACHE_LOG", "off")
         .env("HOME", &e.home)
         .env("KACHE_DAEMON_IDLE_TIMEOUT", "30") // keep the daemon alive for doctor
@@ -1631,15 +1636,13 @@ fn workspace_wrapper_via_cargo_build_env_and_path() {
         new_path.push(p);
     }
 
-    let build = std::process::Command::new(env!("CARGO"))
+    let build = hermetic_command(env!("CARGO"), &e.cache, Some(&e.cache.join("config.toml")))
         .args(["build", "--lib"])
         .current_dir(project.path())
         .env("PATH", new_path)
         .env("RUSTC_WRAPPER", KACHE_BIN)
         .env("CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER", "mydriver")
         .env_remove("RUSTC_WORKSPACE_WRAPPER")
-        .env("KACHE_CACHE_DIR", &e.cache)
-        .env("KACHE_CONFIG", e.cache.join("config.toml"))
         .env("KACHE_LOG", "off")
         .env("HOME", &e.home)
         .env("KACHE_DAEMON_IDLE_TIMEOUT", "3")
@@ -1683,15 +1686,13 @@ fn workspace_wrapper_via_cargo_config_and_path() {
         new_path.push(p);
     }
 
-    let build = std::process::Command::new(env!("CARGO"))
+    let build = hermetic_command(env!("CARGO"), &e.cache, Some(&e.cache.join("config.toml")))
         .args(["build", "--lib"])
         .current_dir(project.path())
         .env("PATH", new_path)
         .env("RUSTC_WRAPPER", KACHE_BIN)
         .env_remove("RUSTC_WORKSPACE_WRAPPER")
         .env_remove("CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER")
-        .env("KACHE_CACHE_DIR", &e.cache)
-        .env("KACHE_CONFIG", e.cache.join("config.toml"))
         .env("KACHE_LOG", "off")
         .env("HOME", &e.home)
         .env("KACHE_DAEMON_IDLE_TIMEOUT", "3")

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,7 +17,9 @@
 //! already gitignored, and concurrent suites reuse the same build instead of
 //! each doing their own (cargo's build-dir lock serializes them).
 
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::OnceLock;
 
 /// `<target>/kache-test-bootstrap`, derived from the running test binary at
@@ -96,6 +98,43 @@ fn bootstrap_kache() -> Result<PathBuf, String> {
 /// Keeps tests off the developer's real `~/.config/kache/config.toml`.
 pub fn isolated_config_path(cache_dir: &Path) -> PathBuf {
     cache_dir.join("config.toml")
+}
+
+/// A child `cargo` or `kache` whose Kache state is pinned to `cache_dir`.
+///
+/// Tests read `events.jsonl` and reach the daemon socket under the cache dir
+/// they created, and Kache resolves both under its runtime dir. The parent
+/// environment can point that elsewhere: kache-action exports
+/// `KACHE_RUNTIME_DIR`, a build that runs the suite through the wrapper leaves
+/// `KACHE_ACTIVE`, `KACHE_SOCKET_PATH`, and `KACHE_EVENT_ROOT` behind, and a
+/// developer dogfooding Kache has `RUSTC_WRAPPER` configured. All of those
+/// are pinned or cleared here, before the caller adds its own wrapper and
+/// overrides; a later `env` call on the same key wins.
+///
+/// `config` pins `KACHE_CONFIG`. `None` unsets it so the child discovers its
+/// configuration the way a real build would.
+///
+/// Not every test binary spawns children, so the rest see it as dead.
+#[allow(dead_code)]
+pub fn hermetic_command(
+    program: impl AsRef<OsStr>,
+    cache_dir: &Path,
+    config: Option<&Path>,
+) -> Command {
+    let mut command = Command::new(program);
+    command
+        .env("KACHE_CACHE_DIR", cache_dir)
+        .env("KACHE_RUNTIME_DIR", cache_dir)
+        .env_remove("KACHE_SOCKET_PATH")
+        .env_remove("KACHE_EVENT_ROOT")
+        .env_remove("KACHE_ACTIVE")
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("CARGO_BUILD_RUSTC_WRAPPER");
+    match config {
+        Some(path) => command.env("KACHE_CONFIG", path),
+        None => command.env_remove("KACHE_CONFIG"),
+    };
+    command
 }
 
 /// A scratch directory on the *repository's* filesystem, for tests whose

--- a/tests/custom_harness_test.rs
+++ b/tests/custom_harness_test.rs
@@ -34,7 +34,7 @@ use std::path::Path;
 use tempfile::TempDir;
 
 mod common;
-use common::{build_kache, isolated_config_path, kache_binary, scratch_dir};
+use common::{build_kache, hermetic_command, isolated_config_path, kache_binary, scratch_dir};
 
 fn copy_dir(src: &Path, dst: &Path) {
     std::fs::create_dir_all(dst).unwrap();
@@ -58,12 +58,10 @@ fn copy_fixture() -> TempDir {
 
 /// Runs `cargo test --test harness` through the kache wrapper.
 fn cargo_test(project: &Path, cache_dir: &Path, target_dir: &Path) -> std::process::Output {
-    std::process::Command::new("cargo")
+    hermetic_command("cargo", cache_dir, Some(&isolated_config_path(cache_dir)))
         .args(["test", "--test", "harness"])
         .current_dir(project)
         .env("RUSTC_WRAPPER", kache_binary())
-        .env("KACHE_CACHE_DIR", cache_dir)
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
         .env("CARGO_TARGET_DIR", target_dir)
         .env("CARGO_INCREMENTAL", "0")
         .output()
@@ -71,12 +69,14 @@ fn cargo_test(project: &Path, cache_dir: &Path, target_dir: &Path) -> std::proce
 }
 
 fn kache_report(cache_dir: &Path) -> serde_json::Value {
-    let output = std::process::Command::new(kache_binary())
-        .args(["report", "--format", "json", "--since", "1h"])
-        .env("KACHE_CACHE_DIR", cache_dir)
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
-        .output()
-        .expect("failed to run kache report");
+    let output = hermetic_command(
+        kache_binary(),
+        cache_dir,
+        Some(&isolated_config_path(cache_dir)),
+    )
+    .args(["report", "--format", "json", "--since", "1h"])
+    .output()
+    .expect("failed to run kache report");
 
     assert!(
         output.status.success(),

--- a/tests/extra_inputs_warm_target_test.rs
+++ b/tests/extra_inputs_warm_target_test.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 mod common;
-use common::{build_kache, isolated_config_path, kache_binary};
+use common::{build_kache, hermetic_command, isolated_config_path, kache_binary};
 
 const INPUT_PATH_ENV: &str = "KACHE_TEST_DECLARED_INPUT";
 const ACTIVATE_CONFIG_ENV: &str = "KACHE_TEST_ACTIVATE_CONFIG";
@@ -155,7 +155,7 @@ fn cargo_build_with_env(
     input_reader: &Path,
     extra_env: &[(&str, &str)],
 ) -> Output {
-    let mut command = Command::new("cargo");
+    let mut command = hermetic_command("cargo", cache_dir, Some(&isolated_config_path(cache_dir)));
     command
         .args([
             "build",
@@ -169,9 +169,7 @@ fn cargo_build_with_env(
         .env("CARGO_TARGET_DIR", target_dir)
         .env("CARGO_INCREMENTAL", "0")
         .env("CARGO_TERM_COLOR", "never")
-        .env("KACHE_CACHE_DIR", cache_dir)
         .env("KACHE_CACHE_EXECUTABLES", "1")
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
         .env("KACHE_LOG", "kache=debug")
         .env(INPUT_PATH_ENV, input)
         .env(
@@ -179,7 +177,6 @@ fn cargo_build_with_env(
             format!("--extern=input_reader={}", input_reader.display()),
         )
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
-        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
         .env_remove("RUSTC_WORKSPACE_WRAPPER")
         .env_remove("KACHE_DISABLED");
     for (name, value) in extra_env {
@@ -256,22 +253,21 @@ fn run_daemon_command(cache_dir: &Path, subcommand: &str) -> Output {
     let stderr_path = cache_dir.join(format!("daemon-{subcommand}.stderr"));
     let stdout = std::fs::File::create(&stdout_path).unwrap();
     let stderr = std::fs::File::create(&stderr_path).unwrap();
-    let mut child = Command::new(kache_binary())
-        .args(["daemon", subcommand])
-        .env("KACHE_CACHE_DIR", cache_dir)
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
-        .env("KACHE_LOCAL_HIT_DAEMON", "1")
-        .env("KACHE_DAEMON_IDLE_TIMEOUT", "60")
-        .env("KACHE_LOG", "off")
-        .env_remove("KACHE_SOCKET_PATH")
-        .env_remove("RUSTC_WRAPPER")
-        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
-        .env_remove("RUSTC_WORKSPACE_WRAPPER")
-        .stdin(std::process::Stdio::null())
-        .stdout(stdout)
-        .stderr(stderr)
-        .spawn()
-        .unwrap();
+    let mut child = hermetic_command(
+        kache_binary(),
+        cache_dir,
+        Some(&isolated_config_path(cache_dir)),
+    )
+    .args(["daemon", subcommand])
+    .env("KACHE_LOCAL_HIT_DAEMON", "1")
+    .env("KACHE_DAEMON_IDLE_TIMEOUT", "60")
+    .env("KACHE_LOG", "off")
+    .env_remove("RUSTC_WORKSPACE_WRAPPER")
+    .stdin(std::process::Stdio::null())
+    .stdout(stdout)
+    .stderr(stderr)
+    .spawn()
+    .unwrap();
     let deadline = Instant::now() + Duration::from_secs(60);
     let status = loop {
         if let Some(status) = child.try_wait().unwrap() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,21 +3,23 @@ use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 mod common;
-use common::{build_kache, isolated_config_path, kache_binary};
+use common::{build_kache, hermetic_command, isolated_config_path, kache_binary};
 
 fn run_kache_cc(project: &Path, cache_dir: &Path, args: &[&str]) {
     run_kache_cc_from(project, cache_dir, args);
 }
 
 fn run_kache_cc_from(cwd: &Path, cache_dir: &Path, args: &[&str]) {
-    let output = std::process::Command::new(kache_binary())
-        .args(args)
-        .current_dir(cwd)
-        .env("KACHE_CACHE_DIR", cache_dir)
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
-        .env("KACHE_LOG", "kache=debug")
-        .output()
-        .expect("failed to run kache cc");
+    let output = hermetic_command(
+        kache_binary(),
+        cache_dir,
+        Some(&isolated_config_path(cache_dir)),
+    )
+    .args(args)
+    .current_dir(cwd)
+    .env("KACHE_LOG", "kache=debug")
+    .output()
+    .expect("failed to run kache cc");
 
     assert!(
         output.status.success(),
@@ -28,12 +30,10 @@ fn run_kache_cc_from(cwd: &Path, cache_dir: &Path, args: &[&str]) {
 }
 
 fn run_cargo_build_with_kache(project: &Path, cache_dir: &Path, target_dir: &Path) {
-    let output = std::process::Command::new("cargo")
+    let output = hermetic_command("cargo", cache_dir, Some(&isolated_config_path(cache_dir)))
         .args(["build", "--lib"])
         .current_dir(project)
         .env("RUSTC_WRAPPER", kache_binary())
-        .env("KACHE_CACHE_DIR", cache_dir)
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
         .env("CARGO_TARGET_DIR", target_dir)
         .env("CARGO_INCREMENTAL", "0")
         .env("KACHE_LOG", "kache=debug")
@@ -49,12 +49,10 @@ fn run_cargo_build_with_kache(project: &Path, cache_dir: &Path, target_dir: &Pat
 }
 
 fn run_cargo_test_with_kache(project: &Path, cache_dir: &Path, target_dir: &Path, package: &str) {
-    let output = std::process::Command::new("cargo")
+    let output = hermetic_command("cargo", cache_dir, Some(&isolated_config_path(cache_dir)))
         .args(["test", "-q", "-p", package])
         .current_dir(project)
         .env("RUSTC_WRAPPER", kache_binary())
-        .env("KACHE_CACHE_DIR", cache_dir)
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
         .env("CARGO_TARGET_DIR", target_dir)
         .env("CARGO_INCREMENTAL", "0")
         .env("KACHE_LOG", "kache=debug")
@@ -70,12 +68,14 @@ fn run_cargo_test_with_kache(project: &Path, cache_dir: &Path, target_dir: &Path
 }
 
 fn kache_report(cache_dir: &Path) -> serde_json::Value {
-    let output = std::process::Command::new(kache_binary())
-        .args(["report", "--format", "json", "--since", "1h"])
-        .env("KACHE_CACHE_DIR", cache_dir)
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
-        .output()
-        .expect("failed to run kache report");
+    let output = hermetic_command(
+        kache_binary(),
+        cache_dir,
+        Some(&isolated_config_path(cache_dir)),
+    )
+    .args(["report", "--format", "json", "--since", "1h"])
+    .output()
+    .expect("failed to run kache report");
 
     assert!(
         output.status.success(),
@@ -87,14 +87,16 @@ fn kache_report(cache_dir: &Path) -> serde_json::Value {
 }
 
 fn kache_perfetto_report(cache_dir: &Path, root: &Path) -> serde_json::Value {
-    let output = std::process::Command::new(kache_binary())
-        .arg("report")
-        .args(["--format", "perfetto", "--since", "1h", "--root"])
-        .arg(root)
-        .env("KACHE_CACHE_DIR", cache_dir)
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
-        .output()
-        .expect("failed to run kache perfetto report");
+    let output = hermetic_command(
+        kache_binary(),
+        cache_dir,
+        Some(&isolated_config_path(cache_dir)),
+    )
+    .arg("report")
+    .args(["--format", "perfetto", "--since", "1h", "--root"])
+    .arg(root)
+    .output()
+    .expect("failed to run kache perfetto report");
 
     assert!(
         output.status.success(),
@@ -269,13 +271,15 @@ fn test_cli_list_empty() {
     build_kache();
     let cache_dir = TempDir::new().unwrap();
 
-    Command::new(kache_binary())
-        .arg("list")
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("No cached entries"));
+    Command::from(hermetic_command(
+        kache_binary(),
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    ))
+    .arg("list")
+    .assert()
+    .success()
+    .stdout(predicates::str::contains("No cached entries"));
 }
 
 #[test]
@@ -283,13 +287,15 @@ fn test_cli_purge_empty() {
     build_kache();
     let cache_dir = TempDir::new().unwrap();
 
-    Command::new(kache_binary())
-        .arg("purge")
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("Cleared"));
+    Command::from(hermetic_command(
+        kache_binary(),
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    ))
+    .arg("purge")
+    .assert()
+    .success()
+    .stdout(predicates::str::contains("Cleared"));
 }
 
 #[test]
@@ -301,16 +307,18 @@ fn test_disabled_passthrough() {
     let target_dir = TempDir::new().unwrap();
 
     // Build with kache disabled — should work just like normal cargo
-    let status = std::process::Command::new("cargo")
-        .args(["build"])
-        .current_dir(&test_project)
-        .env("RUSTC_WRAPPER", kache_binary())
-        .env("KACHE_DISABLED", "1")
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .env("CARGO_TARGET_DIR", target_dir.path())
-        .status()
-        .expect("failed to run cargo build with kache disabled");
+    let status = hermetic_command(
+        "cargo",
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    )
+    .args(["build"])
+    .current_dir(&test_project)
+    .env("RUSTC_WRAPPER", kache_binary())
+    .env("KACHE_DISABLED", "1")
+    .env("CARGO_TARGET_DIR", target_dir.path())
+    .status()
+    .expect("failed to run cargo build with kache disabled");
 
     assert!(
         status.success(),
@@ -327,17 +335,19 @@ fn test_wrapper_hello_world() {
     let target_dir = TempDir::new().unwrap();
 
     // First build (should be all cache misses)
-    let status = std::process::Command::new("cargo")
-        .args(["build"])
-        .current_dir(&test_project)
-        .env("RUSTC_WRAPPER", kache_binary())
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .env("KACHE_EVENT_ROOT", &test_project)
-        .env("CARGO_TARGET_DIR", target_dir.path())
-        .env("KACHE_LOG", "kache=debug")
-        .status()
-        .expect("failed to run cargo build with kache");
+    let status = hermetic_command(
+        "cargo",
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    )
+    .args(["build"])
+    .current_dir(&test_project)
+    .env("RUSTC_WRAPPER", kache_binary())
+    .env("KACHE_EVENT_ROOT", &test_project)
+    .env("CARGO_TARGET_DIR", target_dir.path())
+    .env("KACHE_LOG", "kache=debug")
+    .status()
+    .expect("failed to run cargo build with kache");
 
     assert!(status.success(), "first build with kache should succeed");
 
@@ -368,17 +378,19 @@ fn test_wrapper_hello_world() {
         .env("CARGO_TARGET_DIR", target_dir.path())
         .status();
 
-    let status = std::process::Command::new("cargo")
-        .args(["build"])
-        .current_dir(&test_project)
-        .env("RUSTC_WRAPPER", kache_binary())
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .env("KACHE_EVENT_ROOT", &test_project)
-        .env("CARGO_TARGET_DIR", target_dir.path())
-        .env("KACHE_LOG", "kache=debug")
-        .status()
-        .expect("failed to run second cargo build with kache");
+    let status = hermetic_command(
+        "cargo",
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    )
+    .args(["build"])
+    .current_dir(&test_project)
+    .env("RUSTC_WRAPPER", kache_binary())
+    .env("KACHE_EVENT_ROOT", &test_project)
+    .env("CARGO_TARGET_DIR", target_dir.path())
+    .env("KACHE_LOG", "kache=debug")
+    .status()
+    .expect("failed to run second cargo build with kache");
 
     assert!(status.success(), "second build (cache hit) should succeed");
 
@@ -673,19 +685,21 @@ fn kache_caches_probe_keyed_flags(work: &Path) -> bool {
     std::fs::create_dir_all(&cache_dir).unwrap();
     std::fs::write(&source, "int gate(void) { return 0; }\n").unwrap();
 
-    let ok = std::process::Command::new(kache_binary())
-        .arg("cc")
-        .arg("-c")
-        .arg(&source)
-        .arg("-o")
-        .arg(work.join("gate.o"))
-        .args(["-fstack-protector-strong", "-O0", "-g0"])
-        .current_dir(work)
-        .env("KACHE_CACHE_DIR", &cache_dir)
-        .env("KACHE_CONFIG", isolated_config_path(&cache_dir))
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
+    let ok = hermetic_command(
+        kache_binary(),
+        &cache_dir,
+        Some(&isolated_config_path(&cache_dir)),
+    )
+    .arg("cc")
+    .arg("-c")
+    .arg(&source)
+    .arg("-o")
+    .arg(work.join("gate.o"))
+    .args(["-fstack-protector-strong", "-O0", "-g0"])
+    .current_dir(work)
+    .output()
+    .map(|o| o.status.success())
+    .unwrap_or(false);
     if !ok {
         return false;
     }
@@ -1086,17 +1100,19 @@ fn test_cc_existing_readonly_output_matches_selected_compiler() {
 
     let wrapped_output = wrapped_dir.join("output.o");
     let wrapped_before = prepare(&wrapped_output);
-    let wrapped = std::process::Command::new(kache_binary())
-        .args(["cc", "-c"])
-        .arg(&source)
-        .arg("-o")
-        .arg(&wrapped_output)
-        .args(["-O0", "-g0"])
-        .current_dir(project.path())
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .output()
-        .expect("failed to run wrapped cc");
+    let wrapped = hermetic_command(
+        kache_binary(),
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    )
+    .args(["cc", "-c"])
+    .arg(&source)
+    .arg("-o")
+    .arg(&wrapped_output)
+    .args(["-O0", "-g0"])
+    .current_dir(project.path())
+    .output()
+    .expect("failed to run wrapped cc");
 
     assert_eq!(wrapped.status.code(), plain.status.code());
     assert_eq!(state(&wrapped_output, &wrapped_before), plain_state);
@@ -1106,18 +1122,20 @@ fn test_cc_existing_readonly_output_matches_selected_compiler() {
 
     let disabled_output = disabled_dir.join("output.o");
     let disabled_before = prepare(&disabled_output);
-    let disabled = std::process::Command::new(kache_binary())
-        .args(["cc", "-c"])
-        .arg(&source)
-        .arg("-o")
-        .arg(&disabled_output)
-        .args(["-O0", "-g0"])
-        .current_dir(project.path())
-        .env("KACHE_DISABLED", "1")
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .output()
-        .expect("failed to run disabled wrapped cc");
+    let disabled = hermetic_command(
+        kache_binary(),
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    )
+    .args(["cc", "-c"])
+    .arg(&source)
+    .arg("-o")
+    .arg(&disabled_output)
+    .args(["-O0", "-g0"])
+    .current_dir(project.path())
+    .env("KACHE_DISABLED", "1")
+    .output()
+    .expect("failed to run disabled wrapped cc");
     assert_eq!(disabled.status.code(), plain.status.code());
     assert_eq!(state(&disabled_output, &disabled_before), plain_state);
 }
@@ -1151,17 +1169,19 @@ fn test_cc_passthrough_preserves_non_utf8_streams_and_exit_status() {
     let output_path = project.path().join("existing.o");
     std::fs::write(&output_path, b"existing").unwrap();
 
-    let output = std::process::Command::new(kache_binary())
-        .arg(&fake_cc)
-        .args(["-c", "foo.c", "-o"])
-        .arg(&output_path)
-        .current_dir(project.path())
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .env_remove("KACHE_LOG")
-        .env_remove("KACHE_PROGRESS")
-        .output()
-        .expect("failed to run kache cc passthrough");
+    let output = hermetic_command(
+        kache_binary(),
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    )
+    .arg(&fake_cc)
+    .args(["-c", "foo.c", "-o"])
+    .arg(&output_path)
+    .current_dir(project.path())
+    .env_remove("KACHE_LOG")
+    .env_remove("KACHE_PROGRESS")
+    .output()
+    .expect("failed to run kache cc passthrough");
 
     assert_eq!(output.status.code(), Some(7));
     assert_eq!(output.stdout, [0xff]);
@@ -1332,17 +1352,19 @@ fn test_cc_existing_readonly_hardlink_output_matches_selected_compiler() {
     let plain_state = state(&control_referent, &control_output, control_before);
 
     let (wrapped_referent, wrapped_output, wrapped_before) = prepare(&wrapped_dir);
-    let wrapped = std::process::Command::new(kache_binary())
-        .args(["cc", "-c"])
-        .arg(&source)
-        .arg("-o")
-        .arg(&wrapped_output)
-        .args(["-O0", "-g0"])
-        .current_dir(project.path())
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .output()
-        .expect("failed to run wrapped cc");
+    let wrapped = hermetic_command(
+        kache_binary(),
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    )
+    .args(["cc", "-c"])
+    .arg(&source)
+    .arg("-o")
+    .arg(&wrapped_output)
+    .args(["-O0", "-g0"])
+    .current_dir(project.path())
+    .output()
+    .expect("failed to run wrapped cc");
 
     assert_eq!(wrapped.status.code(), plain.status.code());
     assert_eq!(
@@ -1533,17 +1555,19 @@ fn test_cc_hit_preserves_missing_parent_failure() {
 
     let wrapped_parent = project.path().join("missing-wrapped");
     let wrapped_output = wrapped_parent.join("foo.o");
-    let wrapped = std::process::Command::new(kache_binary())
-        .args(["cc", "-c"])
-        .arg(&source)
-        .arg("-o")
-        .arg(&wrapped_output)
-        .args(["-O0", "-g0"])
-        .current_dir(project.path())
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .output()
-        .expect("failed to run wrapped cc");
+    let wrapped = hermetic_command(
+        kache_binary(),
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    )
+    .args(["cc", "-c"])
+    .arg(&source)
+    .arg("-o")
+    .arg(&wrapped_output)
+    .args(["-O0", "-g0"])
+    .current_dir(project.path())
+    .output()
+    .expect("failed to run wrapped cc");
 
     assert_eq!(wrapped.status.code(), plain.status.code());
     assert!(!control_parent.exists());
@@ -1563,12 +1587,14 @@ fn test_cc_relative_depinfo_stays_writable_across_repeated_hits() {
     use std::os::unix::process::CommandExt;
 
     fn run_with_umask(project: &Path, cache_dir: &Path, args: &[&str], mask: u32) {
-        let mut command = std::process::Command::new(kache_binary());
+        let mut command = hermetic_command(
+            kache_binary(),
+            cache_dir,
+            Some(&isolated_config_path(cache_dir)),
+        );
         command
             .args(args)
             .current_dir(project)
-            .env("KACHE_CACHE_DIR", cache_dir)
-            .env("KACHE_CONFIG", isolated_config_path(cache_dir))
             .env("KACHE_LOG", "kache=debug");
         // SAFETY: pre_exec runs after fork in the child, and umask is an
         // async-signal-safe syscall that changes only that child process.
@@ -2698,12 +2724,14 @@ fn test_cc_legacy_compound_depinfo_entry_self_heals_and_why_miss_explains_it() {
     std::fs::create_dir_all(project.path().join("build")).unwrap();
     run_kache_cc(project.path(), cache_dir.path(), &args);
 
-    let why = std::process::Command::new(kache_binary())
-        .args(["why-miss", "foo.c"])
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .output()
-        .expect("failed to run why-miss");
+    let why = hermetic_command(
+        kache_binary(),
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    )
+    .args(["why-miss", "foo.c"])
+    .output()
+    .expect("failed to run why-miss");
     assert!(why.status.success());
     let stdout = String::from_utf8_lossy(&why.stdout);
     assert!(
@@ -2837,12 +2865,10 @@ cache_executables = true
     std::fs::write(&config_path, config_content).unwrap();
 
     // First build (populates the cache past the size budget)
-    let output = std::process::Command::new("cargo")
+    let output = hermetic_command("cargo", cache_dir.path(), Some(&config_path))
         .args(["build"])
         .current_dir(&test_project)
         .env("RUSTC_WRAPPER", kache_binary())
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", &config_path)
         .env("CARGO_TARGET_DIR", target_dir.path())
         .env("CARGO_INCREMENTAL", "0")
         .env("KACHE_LOG", "kache=debug")
@@ -2927,12 +2953,10 @@ cache_executables = true
     .unwrap();
 
     // Second build creates a second entry and triggers put() -> maybe_spawn_auto_gc
-    let output = std::process::Command::new("cargo")
+    let output = hermetic_command("cargo", cache_dir.path(), Some(&config_path))
         .args(["build"])
         .current_dir(test_project.path())
         .env("RUSTC_WRAPPER", kache_binary())
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", &config_path)
         .env("CARGO_TARGET_DIR", target_dir.path())
         .env("CARGO_INCREMENTAL", "0")
         .env("KACHE_LOG", "kache=debug")
@@ -3007,26 +3031,26 @@ fn workspace_wrapper_passthrough_executes_every_time() {
     let out = cache_dir.path().join("out.rlib");
 
     let run = || {
-        std::process::Command::new(kache_binary())
-            .arg(&wrapper)
-            .arg("rustc")
-            .args([
-                "--edition",
-                "2024",
-                "--crate-type",
-                "lib",
-                "--crate-name",
-                "fakedriver",
-                "-o",
-                out.to_str().unwrap(),
-                src.to_str().unwrap(),
-            ])
-            .env("KACHE_CACHE_DIR", cache_dir.path())
-            .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-            .env_remove("RUSTC_WRAPPER")
-            .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
-            .output()
-            .expect("failed to run kache")
+        hermetic_command(
+            kache_binary(),
+            cache_dir.path(),
+            Some(&isolated_config_path(cache_dir.path())),
+        )
+        .arg(&wrapper)
+        .arg("rustc")
+        .args([
+            "--edition",
+            "2024",
+            "--crate-type",
+            "lib",
+            "--crate-name",
+            "fakedriver",
+            "-o",
+            out.to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run kache")
     };
 
     let out1 = run();

--- a/tests/stale_artifact_test.rs
+++ b/tests/stale_artifact_test.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use tempfile::TempDir;
 
 mod common;
-use common::{build_kache, isolated_config_path, kache_binary};
+use common::{build_kache, hermetic_command, isolated_config_path, kache_binary};
 
 /// Recursively copies a directory.
 fn copy_dir(src: &Path, dst: &Path) {
@@ -35,12 +35,10 @@ fn build_and_run(
     extra_env: &[(&str, &str)],
     extra_cargo_args: &[&str],
 ) -> String {
-    let mut cmd = std::process::Command::new("cargo");
+    let mut cmd = hermetic_command("cargo", cache_dir, Some(&isolated_config_path(cache_dir)));
     cmd.args(["build"])
         .current_dir(project)
         .env("RUSTC_WRAPPER", kache_binary())
-        .env("KACHE_CACHE_DIR", cache_dir)
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir))
         .env("CARGO_TARGET_DIR", target_dir)
         .env("CARGO_INCREMENTAL", "0")
         .env("KACHE_LOG", "kache=debug");
@@ -442,27 +440,31 @@ fn stale_concurrent_builds_safe() {
 
     // Spawn two builds in parallel sharing the same cache dir
     let kache = kache_binary();
-    let mut child1 = std::process::Command::new("cargo")
-        .args(["build"])
-        .current_dir(project.path())
-        .env("RUSTC_WRAPPER", &kache)
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .env("CARGO_TARGET_DIR", target1.path())
-        .env("CARGO_INCREMENTAL", "0")
-        .spawn()
-        .expect("failed to spawn build 1");
+    let mut child1 = hermetic_command(
+        "cargo",
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    )
+    .args(["build"])
+    .current_dir(project.path())
+    .env("RUSTC_WRAPPER", &kache)
+    .env("CARGO_TARGET_DIR", target1.path())
+    .env("CARGO_INCREMENTAL", "0")
+    .spawn()
+    .expect("failed to spawn build 1");
 
-    let mut child2 = std::process::Command::new("cargo")
-        .args(["build"])
-        .current_dir(project.path())
-        .env("RUSTC_WRAPPER", &kache)
-        .env("KACHE_CACHE_DIR", cache_dir.path())
-        .env("KACHE_CONFIG", isolated_config_path(cache_dir.path()))
-        .env("CARGO_TARGET_DIR", target2.path())
-        .env("CARGO_INCREMENTAL", "0")
-        .spawn()
-        .expect("failed to spawn build 2");
+    let mut child2 = hermetic_command(
+        "cargo",
+        cache_dir.path(),
+        Some(&isolated_config_path(cache_dir.path())),
+    )
+    .args(["build"])
+    .current_dir(project.path())
+    .env("RUSTC_WRAPPER", &kache)
+    .env("CARGO_TARGET_DIR", target2.path())
+    .env("CARGO_INCREMENTAL", "0")
+    .spawn()
+    .expect("failed to spawn build 2");
 
     let status1 = child1.wait().unwrap();
     let status2 = child2.wait().unwrap();

--- a/tests/workspace_extra_inputs_test.rs
+++ b/tests/workspace_extra_inputs_test.rs
@@ -8,7 +8,7 @@ use std::process::{Command, Output};
 use tempfile::TempDir;
 
 mod common;
-use common::{build_kache, isolated_config_path, kache_binary};
+use common::{build_kache, hermetic_command, isolated_config_path, kache_binary};
 
 const INPUT_ENV: &str = "KACHE_TEST_368_INPUT";
 const BIN_INPUT_ENV: &str = "KACHE_TEST_368_BIN_INPUT";
@@ -170,20 +170,17 @@ fn cargo_build(workspace: &Path, target: &Path, cache: &Path) -> Output {
     // Keep the shared helper linked in this test binary, but deliberately do
     // not pin it: project discovery must select `<workspace>/.kache.toml`.
     let _unused_machine_config = isolated_config_path(cache);
-    Command::new("cargo")
+    hermetic_command("cargo", cache, None)
         .args(["build", "--offline", "--workspace", "--verbose"])
         .current_dir(workspace)
         .env("RUSTC_WRAPPER", kache_binary())
         .env("CARGO_TARGET_DIR", target)
         .env("CARGO_INCREMENTAL", "0")
         .env("CARGO_TERM_COLOR", "never")
-        .env("KACHE_CACHE_DIR", cache)
         .env("KACHE_CACHE_EXECUTABLES", "1")
         .env("KACHE_LOG", "kache=debug")
         .env(INPUT_ENV, workspace.join("shared/value.txt"))
         .env(BIN_INPUT_ENV, workspace.join("shared/bin-value.txt"))
-        .env_remove("KACHE_CONFIG")
-        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
         .env_remove("RUSTC_WORKSPACE_WRAPPER")
         .env_remove("KACHE_DISABLED")
         .output()

--- a/tests/worktree_depinfo_test.rs
+++ b/tests/worktree_depinfo_test.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use tempfile::TempDir;
 
 mod common;
-use common::{build_kache, isolated_config_path, kache_binary};
+use common::{build_kache, hermetic_command, isolated_config_path, kache_binary};
 
 fn write_package(root: &Path, package: &str, manifest: &str, source: &str, name: &str) {
     let package = root.join(package);
@@ -98,18 +98,15 @@ embedded = { path = "../embedded" }
 }
 
 fn cargo_build(workspace: &Path, target: &Path, cache: &Path) -> Output {
-    Command::new("cargo")
+    hermetic_command("cargo", cache, Some(&isolated_config_path(cache)))
         .args(["build", "--offline", "--workspace", "--verbose"])
         .current_dir(workspace)
         .env("RUSTC_WRAPPER", kache_binary())
         .env("CARGO_TARGET_DIR", target)
         .env("CARGO_INCREMENTAL", "0")
         .env("CARGO_TERM_COLOR", "never")
-        .env("KACHE_CACHE_DIR", cache)
         .env("KACHE_BASE_DIR", workspace)
-        .env("KACHE_CONFIG", isolated_config_path(cache))
         .env("KACHE_LOG", "off")
-        .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
         .env_remove("RUSTC_WORKSPACE_WRAPPER")
         .env_remove("KACHE_DISABLED")
         .output()


### PR DESCRIPTION
The integration suite was not hermetic against ambient kache state. `ci.yml` already said so: an exported `KACHE_RUNTIME_DIR` would make tests read the wrong `events.jsonl` and daemon tests share a runtime directory. Only one test pinned `KACHE_RUNTIME_DIR` and only one removed `KACHE_SOCKET_PATH`; every cargo-spawning helper set `RUSTC_WRAPPER` and `KACHE_CACHE_DIR` by hand, differently.

## What changed

`tests/common/mod.rs` gains one constructor, `hermetic_command(program, cache_dir, config)`, that returns a `Command` with `KACHE_CACHE_DIR` and `KACHE_CONFIG` set as the caller asks, `KACHE_RUNTIME_DIR` pinned to the cache dir, and `KACHE_SOCKET_PATH`, `KACHE_ACTIVE`, `RUSTC_WRAPPER` and `CARGO_BUILD_RUSTC_WRAPPER` removed before the caller sets its own. Every cargo or kache spawn site in nine test files that set `KACHE_CACHE_DIR` by hand now goes through it, including the inline sites that feed the same `events.jsonl` reads. No assertion changed. The `ci.yml` comment now states what the suite pins and that in-process unit tests calling `Config::load` still see the job environment.

## Verification

- All nine touched test binaries pass: stale_artifact 12, integration 35, custom_harness 1, adaptive_incremental 4, worktree_depinfo 1, workspace_extra_inputs 1, extra_inputs_warm_target 1, cli_commands 63, cargo_proxy 6.
- The same nine pass with `KACHE_RUNTIME_DIR=/tmp/kache-hermetic-probe` and `KACHE_SOCKET_PATH=/tmp/kache-hermetic-probe/sock` exported. Control: the old `adaptive_incremental_test` under that environment fails 3 of 4 and writes its events into the probe directory; the new code writes nothing there.
- `mise exec -- just pr` on this head: fmt, clippy `-D warnings`, full workspace tests; cargo-mutants found no mutants in the changed lines (tests only).

## What a reviewer should still watch

- `cli_commands_test.rs` around line 420 overrides `KACHE_CACHE_DIR` to an unusable path after the helper ran; the runtime dir now stays pinned to the real cache dir where it used to default to the unusable path. Assertions unchanged and passing.
- On a machine where `~/.cargo/config.toml` names kache as the rustc wrapper, the probe directory still collects passthrough events from that installed wrapper: they come from Cargo compiling the test binaries and from plain `cargo clean` calls, not from a test spawn site. Not addressed here.
