### PR TITLE
bench: add the hk subject, cold, warm and next-commit

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,7 @@ on:
       scenario:
         description: "Which scenario(s) to run"
         type: choice
-        options: [all, substrate, surrealdb, lance, opendal, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows]
+        options: [all, substrate, surrealdb, lance, opendal, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows, hk, hk-pull]
         default: all
       extra_args:
         description: "Extra args appended to `just bench <profile>` (e.g. --skip-clone, --retry)"
@@ -119,6 +119,15 @@ jobs:
           # discovery prefers the exact-name hit). The Windows variant runs in its
           # own job below, on the self-hosted Windows runner.
           firefox_pull='{"name":"firefox-pull","cmd":"bench firefox-pull","dir":"bench-firefox-pull","timeout":480,"job_timeout":525,"min_free_gb":120}'
+          # hk (jdx/hk): a mid-size Rust CLI whose build scripts compile ~750
+          # C/asm objects through cc-rs (aws-lc-sys, vendored libgit2), wired
+          # the way `kache init` does it so both compiler families are measured.
+          # `--warm-same-tree` adds the same-path warm phase between cold and the
+          # cross-clone warm. Minutes, not hours; a C compiler is all it needs.
+          hk='{"name":"hk","cmd":"bench hk --warm-same-tree","dir":"bench-hk","timeout":60,"job_timeout":90,"min_free_gb":30}'
+          # Same subject on the temporal axis: cold at the parent commit, then
+          # rebuild the child in the same worktree with the store warm.
+          hk_pull='{"name":"hk-pull","cmd":"bench hk-pull","dir":"bench-hk-pull","timeout":60,"job_timeout":90,"min_free_gb":30}'
           case "$SCENARIO" in
             substrate)            inc="[$substrate]" ;;
             surrealdb)            inc="[$surrealdb]" ;;
@@ -128,13 +137,15 @@ jobs:
             firefox-sccache)      inc="[$firefox_sccache]" ;;
             llvm)                 inc="[$llvm]" ;;
             firefox-pull)         inc="[$firefox_pull]" ;;
+            hk)                   inc="[$hk]" ;;
+            hk-pull)              inc="[$hk_pull]" ;;
             # Windows-only scenarios are served by their own self-hosted jobs
             # below, so the Linux matrix is EMPTY for them (an empty include
             # skips the `bench` job cleanly). Without this they'd fall to `*)`
             # and wastefully run the whole Linux `all` matrix alongside.
             firefox-windows)      inc="[]" ;;
             firefox-pull-windows) inc="[]" ;;
-            *)                    inc="[$substrate,$surrealdb,$lance,$opendal,$firefox,$firefox_sccache,$llvm,$firefox_pull]" ;;
+            *)                    inc="[$substrate,$surrealdb,$lance,$opendal,$firefox,$firefox_sccache,$llvm,$firefox_pull,$hk,$hk_pull]" ;;
           esac
           echo "matrix={\"include\":$inc}" >> "$GITHUB_OUTPUT"
           if [ "$inc" = "[]" ]; then

--- a/docs/benchmarks.mdx
+++ b/docs/benchmarks.mdx
@@ -13,6 +13,7 @@ The [Bench workflow](https://github.com/kunobi-ninja/kache/actions/workflows/ben
 - LLVM, Substrate, SurrealDB, Lance, and OpenDAL cold/warm builds
 - Firefox through sccache for comparison
 - Firefox source-update builds on Linux and Windows
+- hk cold, warm and next-commit builds on Linux: a mid-size Rust CLI whose build scripts compile C and assembly through cc-rs, wired the way `kache init` configures a machine
 
 Jobs upload their reports, Perfetto traces, and logs even when a benchmark fails. GitHub retains those artifacts for 30 days.
 

--- a/scenarios/bench-hk-pull/scenario.toml
+++ b/scenarios/bench-hk-pull/scenario.toml
@@ -1,0 +1,62 @@
+# hk (jdx/hk) next-commit benchmark: build the parent commit cold, then
+# check out the child in the same worktree, wipe the target directory, and
+# rebuild with the store warm. The child changes one source file (src/git.rs)
+# and adds a test, so everything except the hk crate and its binaries should
+# hit, including every C and assembly object from the build scripts.
+#
+# Same wiring as bench-hk (HOST_CC/HOST_CXX, the way `kache init` writes
+# it); see that scenario for why hk and why the C side is in scope.
+name = "bench-hk-pull"
+tags = ["suite:bench", "project:hk", "backend:kache", "lang:rust", "lang:cc", "scenario:pull"]
+
+requires = ["cargo", "rustc", "cc"]
+
+setup = [
+  "echo '[bench] bench-hk-pull needs a C compiler (aws-lc-sys cc builder, vendored libgit2); cmake only as the aws-lc-sys fallback.'",
+]
+
+build = """
+repo="$(pwd -P)"
+prefix_map="-ffile-prefix-map=$repo=. -fdebug-prefix-map=$repo=. -fmacro-prefix-map=$repo=."
+export CFLAGS="${CFLAGS:-} $prefix_map"
+export CXXFLAGS="${CXXFLAGS:-} $prefix_map"
+export SOURCE_DATE_EPOCH=1735689600
+export ZERO_AR_DATE=1
+export KACHE_BASE_DIR="$repo"
+
+cargo build --locked
+"""
+
+[env]
+HOST_CC = "{kache} cc"
+HOST_CXX = "{kache} c++"
+CC_KNOWN_WRAPPER_CUSTOM = "kache"
+
+[source]
+kind     = "clone"
+repo     = "https://github.com/jdx/hk.git"
+# parent: the cold build and the store seed
+ref      = "27bb615768b85c9ac88e2abf8895219b44462871"
+# child: one commit later; bench-hk builds this commit in isolation
+ref_next = "fc29ead1456ba7c1f62826c284126410a4014b00"
+objdir   = "target"
+
+[[file]]
+path = "rust-toolchain.toml"
+content = """
+[toolchain]
+channel = "1.97.1"
+profile = "minimal"
+"""
+
+# Pull-phase gates. Errors and unclassified passthroughs are blocking; the
+# floors catch a run that rebuilt everything. The hit rate is advisory while
+# the number is being baselined.
+[checks.assert.pull]
+max_errors          = 0
+max_passthrough_pct = 40.0
+min_hits            = 200
+min_restored_bytes  = 67108864 # 64 MiB
+
+[checks.measure.pull]
+min_hit_rate_pct = 90.0

--- a/scenarios/bench-hk/scenario.toml
+++ b/scenarios/bench-hk/scenario.toml
@@ -1,0 +1,87 @@
+# hk (jdx/hk) nightly compile-cache benchmark: cold, warm-same-tree, warm.
+#
+# Why hk: a mid-size Rust CLI (447 lockfile packages) whose build scripts
+# compile about 750 C and assembly objects through cc-rs: aws-lc-sys (293 .c
+# and 117 .S on x86_64 Linux) and vendored libgit2 (about 330 .c). That is the
+# shape where the C side decides the warm number, and where a benchmark that
+# wires only RUSTC_WRAPPER measures a partial setup: every one of those
+# objects then compiles outside the cache on every fresh target directory.
+#
+# This scenario wires the build-script compilers the way `kache init` does
+# (HOST_CC/HOST_CXX under Cargo [env], CC/CXX untouched), so both compiler
+# families are measured. The same subject at the previous commit is
+# bench-hk-pull, which measures the next-commit rebuild.
+name = "bench-hk"
+tags = ["suite:bench", "project:hk", "backend:kache", "lang:rust", "lang:cc"]
+
+requires = ["cargo", "rustc", "cc"]
+
+# aws-lc-sys uses its cc builder on Linux (cmake is only its fallback, NASM is
+# Windows-only) and hk's git2 has https and ssh off, so no OpenSSL is needed.
+setup = [
+  "echo '[bench] bench-hk needs a C compiler (aws-lc-sys cc builder, vendored libgit2); cmake only as the aws-lc-sys fallback.'",
+]
+
+# Dev profile with --locked, the command a developer runs. hk's [profile.dev]
+# keeps DWARF embedded, so the final binaries restore self-contained. The
+# prefix maps, SOURCE_DATE_EPOCH and KACHE_BASE_DIR are the cross-worktree
+# portability knobs the other cargo scenarios use (see bench-pr-cargo).
+build = """
+repo="$(pwd -P)"
+prefix_map="-ffile-prefix-map=$repo=. -fdebug-prefix-map=$repo=. -fmacro-prefix-map=$repo=."
+export CFLAGS="${CFLAGS:-} $prefix_map"
+export CXXFLAGS="${CXXFLAGS:-} $prefix_map"
+export SOURCE_DATE_EPOCH=1735689600
+export ZERO_AR_DATE=1
+export KACHE_BASE_DIR="$repo"
+
+cargo build --locked
+"""
+
+# Exactly what `kache init` writes into Cargo [env]: host-only wrappers, CC
+# and CXX untouched. For a native build cc-rs consults HOST_CC before CC, so
+# every build-script object goes through kache. cc 1.4.4 (hk's pin) already
+# knows kache as a wrapper; CC_KNOWN_WRAPPER_CUSTOM covers older cc-rs in the
+# graph.
+[env]
+HOST_CC = "{kache} cc"
+HOST_CXX = "{kache} c++"
+CC_KNOWN_WRAPPER_CUSTOM = "kache"
+
+[source]
+kind   = "clone"
+repo   = "https://github.com/jdx/hk.git"
+# hk 1.56.1. Pinned by commit SHA so a repointed tag cannot read as a cache
+# change. bench-hk-pull seeds at this commit's parent and rebuilds this one.
+ref    = "fc29ead1456ba7c1f62826c284126410a4014b00"
+objdir = "target"
+
+# hk ships no rust-toolchain.toml (rust-version 1.91.0). Pin the toolchain so
+# the numbers are comparable across runner images. `write` is right because
+# the subject does not own this file.
+[[file]]
+path = "rust-toolchain.toml"
+content = """
+[toolchain]
+channel = "1.97.1"
+profile = "minimal"
+"""
+
+# Validity floors, not regression bounds: a phase that recompiled the world
+# must fail loudly rather than report a flattering wall clock. Sized far below
+# a healthy run (about 300 rustc hits plus about 700 cc hits on a warm phase,
+# hundreds of megabytes of debug artifacts restored).
+[checks.assert.warm-same-tree]
+max_passthrough_pct = 40.0
+max_errors = 0
+min_hits = 200
+min_restored_bytes = 67108864 # 64 MiB
+
+# The cross-worktree phase adds the path-portability check: an absolute path
+# in a key misses everything here and key stability collapses.
+[checks.assert.warm]
+min_key_stability_pct = 50.0
+max_passthrough_pct = 40.0
+max_errors = 0
+min_hits = 200
+min_restored_bytes = 67108864 # 64 MiB


### PR DESCRIPTION
Adds hk (jdx/hk) to the nightly bench as two arms: `hk` (cold, warm-same-tree, warm) and `hk-pull` (cold at the parent commit, then the child rebuilt in the same worktree with the store warm).

## Why hk

hk is a mid-size Rust CLI (447 lockfile packages) whose build scripts compile about 750 C and assembly objects through cc-rs: aws-lc-sys and vendored libgit2. That is the shape where the C side decides the warm number. A benchmark that wires only `RUSTC_WRAPPER` measures a partial setup; every one of those objects then compiles outside the cache on each fresh target directory. The other cargo subjects in the suite do not exercise this path at this size.

## What changed

- `scenarios/bench-hk/scenario.toml` and `scenarios/bench-hk-pull/scenario.toml`, pinned by commit SHA (hk 1.56.1 and its parent). Both wire `HOST_CC` and `HOST_CXX` under Cargo `[env]` exactly as `kache init` writes them, with `CC` and `CXX` untouched, and set `CC_KNOWN_WRAPPER_CUSTOM` for older cc-rs in the graph. The prefix maps, `SOURCE_DATE_EPOCH` and `KACHE_BASE_DIR` are the cross-worktree portability knobs the other cargo scenarios use. A `rust-toolchain.toml` is written because hk ships none.
- Validity floors on the warm phases (errors, passthrough share, hit count, restored bytes, and key stability on the cross-worktree phase) sized far below a healthy run, so a phase that recompiled the world fails loudly rather than reporting a flattering wall clock. The pull hit rate is advisory until it is baselined.
- `.github/workflows/bench.yml`: two matrix entries (60 minute timeout, 30 GB free) and the two names in the dispatch choice.
- `docs/benchmarks.mdx` lists the subject.

## Verification

- Scenario keys checked against `crates/kache-e2e/src/scenario.rs` and `bench_profile.rs`: `ref_next`, `[[file]]`, `[env]`, `requires`, `warm-same-tree` and `pull` phase tables, and every floor name parse today.
- The kache-e2e scenario discovery, profile parse and fixture tests (47 tests, they walk every directory under `scenarios/`) pass with the two new directories present. Run from the test binary of an unchanged `crates/kache-e2e`; this branch touches no Rust.
- The first real numbers come from the next nightly run; nothing here runs on a PR.

## What a reviewer should still watch

- aws-lc-sys uses its cc builder on Linux and falls back to cmake; the runner image has both. NASM is Windows-only and not needed.
- The 60 minute timeout is a guess sized from a local build; the first nightly will show whether it is generous.
