### PR TITLE
docs(agents): run mutants in CI, not before the push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,18 +5,20 @@
 ## Before `gh pr create`
 
 ```sh
-just pr
+just check
 ```
 
-That is `just check` (fmt, clippy `-D warnings`, tests) plus `just mutants-diff` against `origin/main`. Docs-only diffs skip mutants.
+That is fmt, clippy `-D warnings`, and the workspace tests. Do not open the PR until it exits 0.
+
+Mutants run in CI, not on your machine. Open the PR as a draft; the `Mutation testing (diff k/n)` shards test every changed Rust line in parallel on Linux runners and finish in well under an hour. A red shard prints the missed mutants in its log and uploads them as `missed.txt` in its `mutation-diff-report-<k>` artifact; add the test that kills each one, push, and mark the PR ready when every shard is green. A laptop running the same diff at one to three jobs takes hours and the load makes the fixture-based tests flake.
+
+`just pr` still exists for a Linux box with cores to spare: it is `just check` plus `just mutants-diff` against `origin/main`, the same scope CI runs. If you use it:
 
 ```sh
 cargo install --locked cargo-mutants --version 27.1.0
 ```
 
 Do not invoke `cargo mutants` with `RUSTC_WRAPPER=kache`. The Justfile clears it. Hand-running mutants without `just` wraps kache in itself and the unmutated baseline dies.
-
-Do not open the PR until `just pr` exits 0.
 
 ## How mutants die here
 


### PR DESCRIPTION
\`just pr\` asked every contributor to run the changed-line mutants locally before opening a PR. CI already runs the same scope on every pull request as \`Mutation testing (diff k/n)\`, sharded at about ten mutants per Linux runner and required to merge. On a laptop the local run is one to three jobs over the same diff: today one took five hours, another was on course for eight, and the load made the fixture-based tests flake in the unmutated baseline.

## What changed

AGENTS.md now says: \`just check\` (fmt, clippy \`-D warnings\`, tests) before the push; open the PR as a draft; the shards are the mutants gate; a red shard uploads \`missed.txt\` in its \`mutation-diff-report-<k>\` artifact; add the killing test, push, mark ready when every shard is green. \`just pr\` stays documented for a Linux box with cores to spare, with the same cargo-mutants pin and the \`RUSTC_WRAPPER\` warning.

No workflow or Justfile change.

## Verification

Docs only. The artifact name and the shard job name are quoted from \`.github/workflows/ci.yml\`.