### PR TITLE
bench: export the same-tree warm phase to the telemetry

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -357,6 +357,18 @@ jobs:
           retention-days: 3
           if-no-files-found: warn
 
+      # Only the arms that pass `--warm-same-tree` write this directory; the
+      # step is skipped elsewhere so a missing phase never reads as a warning.
+      - name: Upload cache telemetry (warm-same-tree)
+        if: always() && contains(matrix.cmd, '--warm-same-tree')
+        timeout-minutes: 10
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemetry-otlp-v1-cache-${{ matrix.name }}-warm-same-tree
+          path: tmp/bench/${{ matrix.dir }}/cache-otlp-warm-same-tree/
+          retention-days: 3
+          if-no-files-found: warn
+
   # Firefox compile-cache bench on the self-hosted Windows runner (clang-cl +
   # MSVC under MozillaBuild). Separate from the `bench` matrix above: that runs
   # on the ephemeral Linux ARC (`kunobi-runners`); this needs the persistent

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -646,10 +646,13 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
             cache_size_bytes: crate::bench_otlp::OtlpRun::bytes_from_mib(result.cache_size_mb),
             key_stability_pct: Some(result.key_stability.stable_pct),
             disk_measured_bytes: result.disk_measured_bytes,
-            phases: vec![
-                otlp_phase("cold", &result.cold, result.cold_objdir_bytes),
-                otlp_phase("warm", &result.warm, result.warm_objdir_bytes),
-            ],
+            phases: otlp_phases(
+                &result.cold,
+                result.warm_same_tree.as_ref(),
+                &result.warm,
+                result.cold_objdir_bytes,
+                result.warm_objdir_bytes,
+            ),
         },
     );
 
@@ -800,6 +803,29 @@ fn is_run_artifact(name: &str) -> bool {
         || (name.starts_with("bench-") && name.ends_with(".json"))
         || name == crate::bench_otlp::METRICS_FILE
         || name == crate::bench_otlp::SCHEMA_VERSION_FILE
+}
+
+/// The phase dimension of the bench gauges, in run order: cold, the same-tree
+/// warm when `--warm-same-tree` ran, then the cross-clone warm. The same-tree
+/// rebuild happens in the cold clone's objdir, so it reports that directory's
+/// size; without the phase the vector is what it always was.
+fn otlp_phases(
+    cold: &PhaseMetrics,
+    warm_same_tree: Option<&PhaseMetrics>,
+    warm: &PhaseMetrics,
+    cold_objdir_bytes: u64,
+    warm_objdir_bytes: u64,
+) -> Vec<crate::bench_otlp::OtlpPhase> {
+    let mut phases = vec![otlp_phase(Phase::Cold.name(), cold, cold_objdir_bytes)];
+    if let Some(same_tree) = warm_same_tree {
+        phases.push(otlp_phase(
+            Phase::WarmSameTree.name(),
+            same_tree,
+            cold_objdir_bytes,
+        ));
+    }
+    phases.push(otlp_phase(Phase::Warm.name(), warm, warm_objdir_bytes));
+    phases
 }
 
 fn otlp_phase(
@@ -4903,5 +4929,41 @@ build = "sleep 0.2"
         assert!(!stale.exists(), "the objdir is wiped before the build");
         assert!(work_dir.join("build-cold.log").exists());
         assert!(work_dir.join("wrapper-cold.log").exists());
+    }
+
+    /// The same-tree warm is a phase of the same gauges, present only when it
+    /// ran, between cold and the cross-clone warm, and measured on the cold
+    /// clone's objdir.
+    #[test]
+    fn otlp_phases_carry_the_same_tree_warm_only_when_it_ran() {
+        let cold = PhaseMetrics {
+            wall_s: 100,
+            ..Default::default()
+        };
+        let same_tree = PhaseMetrics {
+            wall_s: 20,
+            ..Default::default()
+        };
+        let warm = PhaseMetrics {
+            wall_s: 30,
+            ..Default::default()
+        };
+
+        let without = otlp_phases(&cold, None, &warm, 7, 9);
+        assert_eq!(
+            without
+                .iter()
+                .map(|phase| (phase.name, phase.wall_s, phase.objdir_bytes))
+                .collect::<Vec<_>>(),
+            vec![("cold", 100, 7), ("warm", 30, 9)]
+        );
+
+        let with = otlp_phases(&cold, Some(&same_tree), &warm, 7, 9);
+        assert_eq!(
+            with.iter()
+                .map(|phase| (phase.name, phase.wall_s, phase.objdir_bytes))
+                .collect::<Vec<_>>(),
+            vec![("cold", 100, 7), ("warm-same-tree", 20, 7), ("warm", 30, 9)]
+        );
     }
 }


### PR DESCRIPTION
The bench gauges kartero imports carried two phases, cold and the cross-clone warm. The same-tree warm that `--warm-same-tree` adds (objdir wiped, same path, store warm) was written to the JSON report and its cache counters went to `cache-otlp-warm-same-tree/`, but neither reached SigNoz: the OTLP writer was handed only cold and warm, and the workflow uploaded only those two counter directories. #915 made hk the first nightly arm to run that phase, so the number it exists to measure would have been visible in the job's report and absent from the dashboards.

## What changed

- `otlp_phases` builds the phase dimension in run order: cold, `warm-same-tree` when it ran, warm. The same-tree rebuild happens in the cold clone's objdir, so it reports that directory's size. Without the phase the vector is unchanged.
- `bench.yml` uploads `cache-otlp-warm-same-tree/` as `telemetry-otlp-v1-cache-<name>-warm-same-tree`, only for arms whose command passes `--warm-same-tree`, so the other arms do not warn about a directory they never write.

No metric names change; the phase is a dimension value on the existing gauges, the same way `pull` is.

## Verification

- Unit test: without the phase the gauges carry `cold` and `warm` as before; with it, `warm-same-tree` sits between them with its own wall time and the cold objdir size.
- `mise exec -- just check` on this head: fmt, clippy `-D warnings`, full workspace tests. CI's `Mutation testing (diff k/n)` shards are the mutants gate for this PR, per the gate change of 2026-09-02; the PR was opened as a draft for them and marked ready once every shard was green.

## What a reviewer should still watch

- kartero's published allowlist covers metric and attribute names, not phase values; if it turns out to reject an unknown phase, the nightly validate step will say so on the hk arm.
- Only hk uses the phase in the nightly today. The `pull` arms are unaffected.
