### PR TITLE
feat(gc): bound and collect a filesystem remote

### DIFF
--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -55,15 +55,31 @@ Interactive output uses `KACHE_PAGER`, then `PAGER`, then a platform default. `-
 kache gc
 kache gc --max-age 7d
 kache gc --stale-schema
+kache gc --remote --dry-run
+kache gc --remote
 ```
 
 A bare run enforces configured size and age policies. `--max-age` runs the requested age policy. `--stale-schema` removes entries created with old or unrecorded key schemas and conflicts with `--max-age`.
 
-GC affects only the local store.
+`--remote` collects a filesystem remote instead of the local store, holding it under `cache.remote.max_size`. `--dry-run` prints the computed budget and what the sweep would remove without removing it, and requires `--remote`. Both conflict with `--max-age` and `--stale-schema`, which are local policies.
+
+There is no daemon-side remote sweep: run `kache gc --remote` from cron or a systemd timer on one machine that mounts the folder. Concurrent runs are safe — a sweep takes an advisory lock (`.kache-remote-gc.lock` at the remote root) and a second one declines.
+
+An S3 remote is not swept. Bound it with a bucket lifecycle rule; `kache gc --remote` says so rather than emulating one.
 
 GC reports store bytes removed separately from bytes reclaimed on disk. It keeps an entry when its last store blob is still cloned into a build output, because unlinking that blob would free no disk and destroy a usable hit. This can leave the registered store size above `cache.local_max_size`; remove stale targets to reclaim the blocks.
 
 Set `cache.gc_evict_shared = true` or `KACHE_GC_EVICT_SHARED=1` to restore the older namespace-first policy. That lowers the registered store size but does not reclaim blocks retained by target directories, and the discarded entry becomes a future miss. See [Configuration: GC and shared build outputs](/docs/getting-started/configuration#gc-and-shared-build-outputs).
+
+### What a remote sweep evicts, and in what order
+
+A remote sweep ranks whole cache entries — a v3 manifest and its pack together — least-recently-read first, with a size tiebreak, the same ranking the local store uses under size pressure. It fires above `max_size` and stops at 90% of it.
+
+Read recency comes from `atime`, so the mount option decides how good the signal is. Under `relatime` (the Linux default) `atime` advances at most once a day, which is enough to separate a hot set from a cold tail. Under `noatime` it never advances past the write, and the sweep falls back to ranking by write time and prints a warning saying so. Remount `relatime` if you want read-recency eviction.
+
+Two things are removed regardless of the budget: a pack whose manifest is gone, and a manifest whose pack is gone. Both are unreachable, and objects younger than an hour are left alone so an upload in flight is never swept. Prefetch packs are shared between catalogs and are reference-counted: one is removed only when the last catalog naming it is evicted.
+
+Entries read or written in the last five minutes are skipped, because a build may be downloading them. If that leaves the remote over budget, the sweep says so instead of deleting them anyway.
 
 ## `kache purge`
 

--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -67,6 +67,8 @@ There is no daemon-side remote sweep: run `kache gc --remote` from cron or a sys
 
 An S3 remote is not swept. Bound it with a bucket lifecycle rule; `kache gc --remote` says so rather than emulating one.
 
+A read-only process does not sweep. When `cache.remote_readonly` or `KACHE_REMOTE_READONLY` is set, or the [CI policy](/docs/remote-cache/ci#who-may-write) has made a pull-request, tag, or unprotected-branch job read-only, `kache gc --remote` refuses with the reason and exits non-zero. `--dry-run` is still allowed and still shows the plan.
+
 GC reports store bytes removed separately from bytes reclaimed on disk. It keeps an entry when its last store blob is still cloned into a build output, because unlinking that blob would free no disk and destroy a usable hit. This can leave the registered store size above `cache.local_max_size`; remove stale targets to reclaim the blocks.
 
 Set `cache.gc_evict_shared = true` or `KACHE_GC_EVICT_SHARED=1` to restore the older namespace-first policy. That lowers the registered store size but does not reclaim blocks retained by target directories, and the discarded entry becomes a future miss. See [Configuration: GC and shared build outputs](/docs/getting-started/configuration#gc-and-shared-build-outputs).

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -183,10 +183,13 @@ Workspace rules are accepted only from the `.kache.toml` beside the active Cargo
 | `KACHE_S3_USER_AGENT` | `cache.remote.user_agent` | none | Custom HTTP User-Agent |
 | none | `cache.remote.path` | none | Filesystem remote root |
 | none | `cache.remote.atomic_write_dir` | `<path>/.kache-tmp` | Same-filesystem staging directory |
+| `KACHE_REMOTE_MAX_SIZE` | `cache.remote.max_size` | 25% of the remote disk, floored at 10GiB and capped at 500GiB | Size cap `kache gc --remote` holds a filesystem remote under. An explicit size always wins. `none` disables the budget. Rejected on an S3 remote. |
 | `KACHE_S3_CONCURRENCY` | `cache.s3_concurrency` | `16` | Concurrent operations for either backend |
 | `KACHE_S3_POOL_IDLE_SECS` | `cache.s3_pool_idle_secs` | `300` | S3 connection pool idle time |
 | `KACHE_REMOTE_RESTORE_TIMEOUT_SECS` | `cache.remote_restore_timeout_secs` | `300` | Daemon operation deadline; wrapper demand remains capped at three seconds |
 | `KACHE_REMOTE_NEGATIVE_TTL_SECS` | `cache.remote_negative_ttl_secs` | `60` | Cache definitive remote 404 results |
+
+`cache.remote.max_size` bounds a shared folder the way a bucket lifecycle rule bounds S3. Nothing enforces it automatically: run `kache gc --remote` from cron or a systemd timer on one machine that mounts the folder, and preview it first with `kache gc --remote --dry-run`. Unlike `cache.local_max_size`, `none` is accepted here — a remote is a path you chose and may already be bounded by a quota, a lifecycle-managed mount, or your own pruning job.
 
 Credentials resolve from explicit `KACHE_S3_ACCESS_KEY` and `KACHE_S3_SECRET_KEY`, standard AWS variables, the selected AWS profile, web identity, container credentials, then instance credentials.
 

--- a/docs/remote-cache/ci.mdx
+++ b/docs/remote-cache/ci.mdx
@@ -46,7 +46,7 @@ env:
 
 GitHub withholds secrets and OIDC tokens from fork pull-request jobs, so those runs cannot publish unless you also pass a write credential another way. Same-repository pull requests do receive secrets; the CI policy above is what stops them writing.
 
-Pull-request jobs can still restore entries a trusted branch already published.
+Pull-request jobs can still restore entries a trusted branch already published. They cannot sweep a filesystem remote either: `kache gc --remote` refuses in a read-only process, and only `kache gc --remote --dry-run` runs there.
 
 C and C++ objects publish through the same remote as Rust. A daemon-backed compile restores them on miss; `kache sync --pull --all` also warms them in the local store. clang-cl debug objects stay on the machine and are not published.
 

--- a/docs/remote-cache/filesystem-setup.mdx
+++ b/docs/remote-cache/filesystem-setup.mdx
@@ -53,6 +53,11 @@ Filesystem prefixes cannot contain `:`.
 
 ## Reclaim remote space
 
-Local `kache gc` never deletes remote objects. Remote deletion is manual because no protocol coordinates deletion with in-flight readers and writers.
+Local `kache gc` never deletes remote objects. A filesystem remote is bounded by `cache.remote.max_size` (or `KACHE_REMOTE_MAX_SIZE`) and swept with `kache gc --remote`:
 
-Use one designated deletion job and pause writers when pruning. Delete each manifest and pack pair together. For a small cache, removing the complete `artifacts/` subtree and allowing it to repopulate is safer than an inconsistent partial prune.
+```bash
+kache gc --remote --dry-run   # the computed budget and what a sweep would remove
+kache gc --remote             # remove it
+```
+
+Run the sweep from one machine that mounts the folder, on a timer. Concurrent sweeps are safe: a sweep takes an advisory lock at the remote root and a second one declines. A read-only process, whether `cache.remote_readonly` is set or the [CI policy](/docs/remote-cache/ci#who-may-write) made the job read-only, refuses to sweep and says why; `--dry-run` still shows the plan. See [`kache gc`](/docs/commands/reference#kache-gc) for the details.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3122,6 +3122,27 @@ pub fn gc_remote(config: &Config, dry_run: bool, json: bool) -> Result<()> {
         );
     };
 
+    // Read-only mode (`cache.remote_readonly`, `KACHE_REMOTE_READONLY`, or the
+    // untrusted-CI policy in `crate::policy`) means this process may not change
+    // what other machines share, and a sweep deletes more than any upload
+    // writes. Refuse before the lock so a pull-request job never touches the
+    // remote, not even its lock file. A dry run only plans, so it stays
+    // available: it is how a read-only machine previews the sweep.
+    if config.remote_readonly && !dry_run {
+        let reason = remote_readonly_reason(crate::policy::forced_remote_readonly());
+        if json {
+            crate::machine::emit(
+                "gc",
+                RemoteGcJson::skipped(&remote.describe(), &reason),
+                vec![remote_gc_preview_action()],
+            )?;
+        }
+        anyhow::bail!(
+            "`kache gc --remote` will not delete from the remote in read-only mode: {reason}. \
+             `kache gc --remote --dry-run` still shows the plan."
+        );
+    }
+
     // Several machines share a filesystem remote by definition, so a sweep
     // takes the same kind of advisory lock every local GC driver takes before
     // it plans anything. Declining is the right answer for the loser: the
@@ -3130,7 +3151,11 @@ pub fn gc_remote(config: &Config, dry_run: bool, json: bool) -> Result<()> {
         Some(lock) => lock,
         None => {
             if json {
-                return crate::machine::emit("gc", RemoteGcJson::skipped(), Vec::new());
+                return crate::machine::emit(
+                    "gc",
+                    RemoteGcJson::skipped(&remote.describe(), REMOTE_GC_CONTENDED),
+                    Vec::new(),
+                );
             }
             println!("Another remote GC is already running; skipping.");
             return Ok(());
@@ -3164,9 +3189,39 @@ pub fn gc_remote(config: &Config, dry_run: bool, json: bool) -> Result<()> {
     Ok(())
 }
 
+/// The reason a contended sweep reports under `--json`.
+const REMOTE_GC_CONTENDED: &str = "another remote GC is already running";
+
+/// Why remote writes are off for this process, worded the way `kache doctor`
+/// reports it: the CI policy's own reason when the policy forced read-only,
+/// otherwise the setting that turned it on.
+fn remote_readonly_reason(forced: Option<crate::policy::ForcedReadonly>) -> String {
+    match forced {
+        Some(forced) => forced.reason,
+        None => "KACHE_REMOTE_READONLY or cache.remote_readonly is set".to_string(),
+    }
+}
+
+/// The follow-up a refused sweep offers: the preview is still allowed.
+fn remote_gc_preview_action() -> crate::machine::NextAction {
+    crate::machine::NextAction {
+        argv: vec![
+            "kache".into(),
+            "gc".into(),
+            "--remote".into(),
+            "--dry-run".into(),
+        ],
+        why: "a read-only process may still preview what a sweep would remove".into(),
+    }
+}
+
 #[derive(Default, serde::Serialize)]
 struct RemoteGcJson {
     skipped: bool,
+    /// Why nothing ran. Present only when `skipped` is true: a peer holds the
+    /// lock, or this process is read-only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
     dry_run: bool,
     remote: String,
     budget_bytes: Option<u64>,
@@ -3184,12 +3239,15 @@ struct RemoteGcJson {
 }
 
 impl RemoteGcJson {
-    /// The body emitted when a peer already holds the remote GC lock. Mirrors
-    /// the local `kache gc --json` convention, where `skipped` is the only
-    /// meaningful field of a sweep that never ran.
-    fn skipped() -> Self {
+    /// The body of a sweep that never ran, because a peer holds the remote GC
+    /// lock or because this process is read-only. Mirrors the local
+    /// `kache gc --json` convention, where `skipped` is the only meaningful
+    /// counter of a sweep that never ran; `reason` says which case it was.
+    fn skipped(remote: &str, reason: &str) -> Self {
         Self {
             skipped: true,
+            reason: Some(reason.to_string()),
+            remote: remote.to_string(),
             ..Self::default()
         }
     }
@@ -3204,6 +3262,7 @@ impl RemoteGcJson {
     ) -> Self {
         Self {
             skipped: false,
+            reason: None,
             dry_run,
             remote: remote.to_string(),
             budget_bytes: plan.budget,
@@ -11411,6 +11470,7 @@ mod tests {
 
         let dry = RemoteGcJson::report("file:///srv", true, &plan, None);
         assert!(!dry.skipped && dry.dry_run);
+        assert_eq!(dry.reason, None, "a sweep that ran has nothing to excuse");
         assert_eq!(dry.remote, "file:///srv");
         assert_eq!(dry.budget_bytes, Some(1_000));
         assert_eq!(dry.remote_bytes, 5_000);
@@ -11440,12 +11500,157 @@ mod tests {
 
     #[test]
     fn remote_gc_json_marks_a_contended_sweep_as_skipped() {
-        let body = RemoteGcJson::skipped();
+        let body = RemoteGcJson::skipped("file:///srv", REMOTE_GC_CONTENDED);
         assert!(body.skipped);
+        assert_eq!(body.reason.as_deref(), Some(REMOTE_GC_CONTENDED));
+        assert_eq!(body.remote, "file:///srv");
         assert!(!body.dry_run);
         assert_eq!(body.bytes_freed, 0);
         assert_eq!(body.budget_bytes, None);
-        assert_eq!(body.remote, "");
+    }
+
+    // ── Remote GC under the read-only policy ────────────────────────────────
+
+    fn read_only_remote_gc_config(root: &std::path::Path, entries: usize) -> Config {
+        for i in 0..entries {
+            write_aged_remote_entry(root, "serde", &format!("key{i}"), 4_000);
+        }
+        let mut config = save_manifest_config(root.join("store"), Some(remote_gc_fixture(root)));
+        config.remote_readonly = true;
+        config
+    }
+
+    /// A pull-request job, a tag build, or any machine with
+    /// `KACHE_REMOTE_READONLY=1` shares the folder with writers it must not
+    /// disturb. A live sweep is refused before the lock, so the remote is left
+    /// untouched down to its lock file, and the error says how to preview.
+    #[test]
+    fn remote_gc_refuses_to_sweep_a_read_only_remote() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let config = read_only_remote_gc_config(root, 4);
+        let before = walk_bytes(&root.join("artifacts"));
+        assert!(before > 0, "the fixture must have written objects");
+
+        let error = gc_remote(&config, false, false)
+            .expect_err("a read-only process must not sweep")
+            .to_string();
+        assert!(error.contains("read-only"), "{error}");
+        assert!(error.contains("--dry-run"), "{error}");
+        assert_eq!(
+            walk_bytes(&root.join("artifacts")),
+            before,
+            "a refused sweep must not delete anything"
+        );
+        for i in 0..4 {
+            assert!(
+                root.join(format!("artifacts/v3/packs/serde/key{i}.tar.zst"))
+                    .exists()
+            );
+            assert!(
+                root.join(format!("artifacts/v3/manifests/serde/key{i}.json"))
+                    .exists()
+            );
+        }
+        assert!(
+            !root
+                .join(crate::remote_eviction::REMOTE_GC_LOCK_FILE)
+                .exists(),
+            "the refusal must come before the lock is taken"
+        );
+    }
+
+    /// `--dry-run` is how a read-only machine sees what a sweep would take, so
+    /// the policy leaves it alone. The lock file it leaves behind is the proof
+    /// it got past the guard and planned; the objects prove it removed nothing.
+    #[test]
+    fn remote_gc_dry_run_is_allowed_on_a_read_only_remote() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let config = read_only_remote_gc_config(root, 4);
+        let before = walk_bytes(&root.join("artifacts"));
+
+        gc_remote(&config, true, false).expect("a read-only dry run reports the plan");
+        gc_remote(&config, true, true).expect("a read-only dry run reports the plan as json");
+        assert!(
+            root.join(crate::remote_eviction::REMOTE_GC_LOCK_FILE)
+                .exists(),
+            "a dry run plans under the lock like any sweep"
+        );
+        assert_eq!(
+            walk_bytes(&root.join("artifacts")),
+            before,
+            "a dry run must not delete anything, read-only or not"
+        );
+        for i in 0..4 {
+            assert!(
+                root.join(format!("artifacts/v3/packs/serde/key{i}.tar.zst"))
+                    .exists()
+            );
+        }
+    }
+
+    /// The guard keys off the effective setting, so a writable process still
+    /// holds the remote under budget.
+    #[test]
+    fn remote_gc_sweeps_a_writable_remote() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let mut config = read_only_remote_gc_config(root, 1);
+        config.remote_readonly = false;
+
+        gc_remote(&config, false, false).expect("a writable sweep runs");
+        assert!(
+            !root.join("artifacts/v3/packs/serde/key0.tar.zst").exists(),
+            "a writable sweep must still delete"
+        );
+    }
+
+    /// `--json` reports the refusal on stdout as a skipped sweep that names the
+    /// reason and offers the preview as the next action, and still fails.
+    #[test]
+    fn remote_gc_json_refusal_names_the_reason_and_the_preview() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let config = read_only_remote_gc_config(root, 1);
+
+        assert!(
+            gc_remote(&config, false, true).is_err(),
+            "json output does not turn a refusal into success"
+        );
+        assert!(root.join("artifacts/v3/packs/serde/key0.tar.zst").exists());
+        assert!(
+            !root
+                .join(crate::remote_eviction::REMOTE_GC_LOCK_FILE)
+                .exists()
+        );
+
+        let body = RemoteGcJson::skipped("file:///srv", "the remote is read-only");
+        assert!(body.skipped);
+        assert_eq!(body.reason.as_deref(), Some("the remote is read-only"));
+        assert_eq!(body.remote, "file:///srv");
+        assert!(!body.dry_run);
+        assert_eq!(body.bytes_freed, 0);
+
+        let next = remote_gc_preview_action();
+        assert_eq!(next.argv, ["kache", "gc", "--remote", "--dry-run"]);
+        assert!(next.why.contains("read-only"), "{}", next.why);
+    }
+
+    /// The reason is the CI policy's own when the policy forced read-only,
+    /// otherwise the setting that turned it on, the way `kache doctor` words it.
+    #[test]
+    fn remote_readonly_reason_prefers_the_policy_reason() {
+        let forced = crate::policy::ForcedReadonly {
+            reason: "GitHub Actions pull_request (branch) is not a protected-branch push".into(),
+        };
+        assert_eq!(
+            remote_readonly_reason(Some(forced)),
+            "GitHub Actions pull_request (branch) is not a protected-branch push"
+        );
+        let configured = remote_readonly_reason(None);
+        assert!(configured.contains("KACHE_REMOTE_READONLY"), "{configured}");
+        assert!(configured.contains("cache.remote_readonly"), "{configured}");
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3003,6 +3003,223 @@ pub fn gc(
     Ok(())
 }
 
+/// Lines `kache gc --remote` prints for a plan. Split out from the command so
+/// the reporting is testable without a configured remote or a real sweep.
+fn render_remote_gc(
+    describe: &str,
+    budget_text: &str,
+    plan: &crate::remote_eviction::RemotePlan,
+    stats: Option<&crate::remote_eviction::RemoteGcStats>,
+    scan: &crate::remote_eviction::RemoteScan,
+) -> Vec<String> {
+    let mut lines = vec![
+        format!("Remote: {describe}"),
+        // #882 printed the derived local budget on every `kache gc`; a remote
+        // dry run has to answer the same "what number am I being held to?".
+        format!("Remote budget: {budget_text}"),
+        format!(
+            "Remote size: {} ({} objects)",
+            ByteSize(plan.total_bytes),
+            plan.object_count
+        ),
+    ];
+
+    match stats {
+        None => {
+            lines.push(format!(
+                "Dry run: would evict {} entr{} and {} orphan{}, freeing {}.",
+                plan.victims.len(),
+                if plan.victims.len() == 1 { "y" } else { "ies" },
+                plan.orphans.len(),
+                if plan.orphans.len() == 1 { "" } else { "s" },
+                ByteSize(plan.bytes_freed()),
+            ));
+            for victim in plan.victims.iter().take(REMOTE_GC_PREVIEW) {
+                lines.push(format!(
+                    "  evict {} ({})",
+                    victim.id,
+                    ByteSize(victim.freed)
+                ));
+            }
+            for orphan in plan.orphans.iter().take(REMOTE_GC_PREVIEW) {
+                lines.push(format!(
+                    "  remove {} ({}, {})",
+                    orphan.path.display(),
+                    ByteSize(orphan.bytes),
+                    orphan.reason.label(),
+                ));
+            }
+            let shown = plan
+                .victims
+                .len()
+                .min(REMOTE_GC_PREVIEW)
+                .saturating_add(plan.orphans.len().min(REMOTE_GC_PREVIEW));
+            let total = plan.victims.len().saturating_add(plan.orphans.len());
+            if total > shown {
+                lines.push(format!("  ... and {} more", total - shown));
+            }
+            lines.push("Nothing was removed. Re-run without --dry-run to apply.".to_string());
+        }
+        Some(stats) => {
+            lines.push(format!(
+                "Evicted {} entries and {} orphans ({} objects), freeing {}.",
+                stats.groups_evicted,
+                stats.orphans_removed,
+                stats.objects_removed,
+                ByteSize(stats.bytes_freed),
+            ));
+            if stats.delete_failures > 0 {
+                lines.push(format!(
+                    "{} objects could not be removed (a peer is reading them, or removed them \
+                     first); the next sweep re-measures.",
+                    stats.delete_failures
+                ));
+            }
+        }
+    }
+
+    lines.push(format!(
+        "Remote size after: {}",
+        ByteSize(plan.projected_bytes)
+    ));
+    if plan.pinned > 0 {
+        lines.push(format!(
+            "{} entries were skipped because a build may be restoring them right now.",
+            plan.pinned
+        ));
+    }
+    if plan.still_over_budget() {
+        lines.push(format!(
+            "Still over budget: the remainder is pinned entries plus {} that eviction does not \
+             own (build manifests and shards). Raise max_size or re-run later.",
+            ByteSize(scan.unclassified_bytes),
+        ));
+    }
+    if let Some(advisory) = crate::remote_eviction::atime_advisory(scan) {
+        lines.push(format!("warning: {advisory}"));
+    }
+    lines
+}
+
+/// How many victims and orphans `--dry-run` names before summarizing. A remote
+/// sweep can select thousands; the preview exists to make the ranking legible,
+/// not to enumerate it.
+const REMOTE_GC_PREVIEW: usize = 20;
+
+/// Collect the filesystem remote, holding it under its size budget
+/// (kunobi-ninja/kache#774).
+///
+/// Only filesystem remotes are swept. An S3 remote is bounded out of band with
+/// a bucket lifecycle rule, and emulating one from a client that may not even
+/// have `DeleteObject` would be a worse answer than pointing at the rule.
+pub fn gc_remote(config: &Config, dry_run: bool, json: bool) -> Result<()> {
+    let remote = config.require_remote()?;
+    let crate::config::RemoteBackendConfig::Filesystem(fs_remote) = &remote.backend else {
+        anyhow::bail!(
+            "`kache gc --remote` only collects a filesystem remote; this one is {}. Bound an S3 \
+             bucket with a lifecycle rule instead.",
+            remote.describe()
+        );
+    };
+
+    // Several machines share a filesystem remote by definition, so a sweep
+    // takes the same kind of advisory lock every local GC driver takes before
+    // it plans anything. Declining is the right answer for the loser: the
+    // winner's plan already covers the whole remote.
+    let _lock = match crate::remote_eviction::try_lock(fs_remote)? {
+        Some(lock) => lock,
+        None => {
+            if json {
+                return crate::machine::emit("gc", RemoteGcJson::skipped(), Vec::new());
+            }
+            println!("Another remote GC is already running; skipping.");
+            return Ok(());
+        }
+    };
+
+    let scan =
+        crate::remote_eviction::scan(fs_remote, &remote.prefix, std::time::SystemTime::now())
+            .with_context(|| format!("scanning remote {}", remote.describe()))?;
+    let budget = crate::remote_eviction::resolve_budget(fs_remote);
+    let plan = crate::remote_eviction::plan(&scan, budget);
+    let stats = (!dry_run).then(|| crate::remote_eviction::apply(&plan));
+
+    if json {
+        return crate::machine::emit(
+            "gc",
+            RemoteGcJson::report(&remote.describe(), dry_run, &plan, stats.as_ref()),
+            Vec::new(),
+        );
+    }
+
+    for line in render_remote_gc(
+        &remote.describe(),
+        &crate::remote_eviction::describe_budget(fs_remote),
+        &plan,
+        stats.as_ref(),
+        &scan,
+    ) {
+        println!("{line}");
+    }
+    Ok(())
+}
+
+#[derive(Default, serde::Serialize)]
+struct RemoteGcJson {
+    skipped: bool,
+    dry_run: bool,
+    remote: String,
+    budget_bytes: Option<u64>,
+    remote_bytes: u64,
+    objects: usize,
+    entries_evicted: usize,
+    orphans_removed: usize,
+    bytes_freed: u64,
+    entries_pinned: usize,
+    remote_bytes_after: u64,
+    still_over_budget: bool,
+    /// False when nothing in the remote showed a read newer than its write, so
+    /// the ranking used write time (a `noatime` mount).
+    read_recency_available: bool,
+}
+
+impl RemoteGcJson {
+    /// The body emitted when a peer already holds the remote GC lock. Mirrors
+    /// the local `kache gc --json` convention, where `skipped` is the only
+    /// meaningful field of a sweep that never ran.
+    fn skipped() -> Self {
+        Self {
+            skipped: true,
+            ..Self::default()
+        }
+    }
+
+    /// A dry run reports what the plan *would* do; a live sweep reports what it
+    /// actually did, which can be smaller when a peer removed an object first.
+    fn report(
+        remote: &str,
+        dry_run: bool,
+        plan: &crate::remote_eviction::RemotePlan,
+        stats: Option<&crate::remote_eviction::RemoteGcStats>,
+    ) -> Self {
+        Self {
+            skipped: false,
+            dry_run,
+            remote: remote.to_string(),
+            budget_bytes: plan.budget,
+            remote_bytes: plan.total_bytes,
+            objects: plan.object_count,
+            entries_evicted: stats.map_or(plan.victims.len(), |s| s.groups_evicted),
+            orphans_removed: stats.map_or(plan.orphans.len(), |s| s.orphans_removed),
+            bytes_freed: stats.map_or(plan.bytes_freed(), |s| s.bytes_freed),
+            entries_pinned: plan.pinned,
+            remote_bytes_after: plan.projected_bytes,
+            still_over_budget: plan.still_over_budget(),
+            read_recency_available: plan.atime_advanced,
+        }
+    }
+}
+
 /// Wipe the entire cache or entries for a specific crate.
 pub fn purge(config: &Config, crate_filter: Option<&str>) -> Result<()> {
     let store = Store::open(config)?;
@@ -10811,6 +11028,424 @@ mod tests {
         // a remote client or making any calls.
         save_manifest(&config, Some("mykey"), None)
             .expect("save_manifest should succeed by doing nothing");
+    }
+
+    // ── Remote GC (kunobi-ninja/kache#774) ──────────────────────────────────
+
+    fn remote_gc_fixture(root: &std::path::Path) -> crate::config::RemoteConfig {
+        crate::config::RemoteConfig {
+            prefix: "artifacts".to_string(),
+            backend: crate::config::RemoteBackendConfig::Filesystem(
+                crate::config::FilesystemRemoteConfig {
+                    root: root.to_path_buf(),
+                    atomic_write_dir: root.join(".kache-tmp"),
+                    budget: crate::config::RemoteBudget::Bytes(1),
+                },
+            ),
+        }
+    }
+
+    /// Write one v3 entry and backdate both objects past the recency grace so a
+    /// sweep can actually select it.
+    fn write_aged_remote_entry(root: &std::path::Path, crate_name: &str, key: &str, bytes: usize) {
+        let age = std::time::SystemTime::now() - std::time::Duration::from_secs(30 * 24 * 3600);
+        for (rel, size) in [
+            (
+                format!("artifacts/v3/manifests/{crate_name}/{key}.json"),
+                64usize,
+            ),
+            (
+                format!("artifacts/v3/packs/{crate_name}/{key}.tar.zst"),
+                bytes,
+            ),
+        ] {
+            let path = root.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, vec![3u8; size]).unwrap();
+            let stamp = filetime::FileTime::from_system_time(age);
+            filetime::set_file_times(&path, stamp, stamp).unwrap();
+        }
+    }
+
+    /// A dry run must name the computed budget, the way #882 made `kache gc`
+    /// name the local one, and must say plainly that it removed nothing.
+    #[test]
+    fn remote_gc_dry_run_reports_the_budget_and_removes_nothing() {
+        let plan = crate::remote_eviction::RemotePlan {
+            total_bytes: 319 * (1 << 30),
+            object_count: 7_556,
+            budget: Some(80 * (1 << 30)),
+            target: Some(72 * (1 << 30)),
+            victims: vec![crate::remote_eviction::PlannedVictim {
+                id: "v3:serde/abc".into(),
+                objects: vec![std::path::PathBuf::from("/srv/kache/p")],
+                freed: 1 << 20,
+            }],
+            orphans: vec![crate::remote_eviction::RemoteOrphan {
+                path: std::path::PathBuf::from("/srv/kache/orphan"),
+                bytes: 4096,
+                reason: crate::remote_eviction::OrphanReason::PackWithoutManifest,
+            }],
+            pinned: 2,
+            projected_bytes: 71 * (1 << 30),
+            atime_advanced: true,
+        };
+        let scan = crate::remote_eviction::RemoteScan {
+            object_count: 7_556,
+            atime_advanced: true,
+            ..Default::default()
+        };
+
+        let text = render_remote_gc(
+            "file:///srv/kache/artifacts",
+            "80.0 GiB (configured)",
+            &plan,
+            None,
+            &scan,
+        )
+        .join("\n");
+
+        assert!(
+            text.contains("Remote: file:///srv/kache/artifacts"),
+            "{text}"
+        );
+        assert!(
+            text.contains("Remote budget: 80.0 GiB (configured)"),
+            "{text}"
+        );
+        assert!(text.contains("7556 objects"), "{text}");
+        assert!(
+            text.contains("Dry run: would evict 1 entry and 1 orphan"),
+            "{text}"
+        );
+        assert!(text.contains("evict v3:serde/abc"), "{text}");
+        assert!(text.contains("pack without manifest"), "{text}");
+        assert!(text.contains("Nothing was removed"), "{text}");
+        assert!(text.contains("2 entries were skipped"), "{text}");
+        assert!(
+            !text.contains("noatime"),
+            "read recency was available: {text}"
+        );
+    }
+
+    /// An applied sweep reports what it did, flags an unremovable object, and
+    /// warns when the mount never recorded a read.
+    #[test]
+    fn remote_gc_reports_an_applied_sweep_and_the_noatime_fallback() {
+        let plan = crate::remote_eviction::RemotePlan {
+            total_bytes: 1_000,
+            object_count: 4,
+            budget: Some(100),
+            target: Some(90),
+            projected_bytes: 400,
+            ..Default::default()
+        };
+        let stats = crate::remote_eviction::RemoteGcStats {
+            groups_evicted: 3,
+            orphans_removed: 1,
+            objects_removed: 7,
+            bytes_freed: 600,
+            delete_failures: 2,
+        };
+        let scan = crate::remote_eviction::RemoteScan {
+            object_count: 4,
+            atime_advanced: false,
+            unclassified_bytes: 350,
+            ..Default::default()
+        };
+
+        let text = render_remote_gc(
+            "file:///srv",
+            "1.0 GiB (configured)",
+            &plan,
+            Some(&stats),
+            &scan,
+        )
+        .join("\n");
+        assert!(
+            text.contains("Evicted 3 entries and 1 orphans (7 objects), freeing 600 B"),
+            "{text}"
+        );
+        assert!(text.contains("2 objects could not be removed"), "{text}");
+        assert!(text.contains("Remote size after: 400 B"), "{text}");
+        assert!(text.contains("Still over budget"), "{text}");
+        assert!(text.contains("350 B that eviction does not own"), "{text}");
+        assert!(text.contains("noatime"), "{text}");
+    }
+
+    /// A sweep can select thousands of objects; the preview names the first
+    /// twenty of each kind and counts the rest.
+    #[test]
+    fn remote_gc_dry_run_truncates_a_long_preview() {
+        let plan = crate::remote_eviction::RemotePlan {
+            total_bytes: 5_000,
+            object_count: 60,
+            budget: Some(1_000),
+            target: Some(900),
+            victims: (0..25)
+                .map(|i| crate::remote_eviction::PlannedVictim {
+                    id: format!("v3:serde/k{i}"),
+                    objects: vec![std::path::PathBuf::from(format!("/srv/{i}"))],
+                    freed: 100,
+                })
+                .collect(),
+            orphans: (0..30)
+                .map(|i| crate::remote_eviction::RemoteOrphan {
+                    path: std::path::PathBuf::from(format!("/srv/orphan{i}")),
+                    bytes: 10,
+                    reason: crate::remote_eviction::OrphanReason::UnreferencedPrefetchPack,
+                })
+                .collect(),
+            projected_bytes: 800,
+            atime_advanced: true,
+            ..Default::default()
+        };
+        let scan = crate::remote_eviction::RemoteScan {
+            object_count: 60,
+            atime_advanced: true,
+            ..Default::default()
+        };
+
+        let lines = render_remote_gc("file:///srv", "1.0 KiB (configured)", &plan, None, &scan);
+        let text = lines.join("\n");
+        assert!(
+            text.contains("would evict 25 entries and 30 orphans"),
+            "plurals must follow the counts: {text}"
+        );
+        assert_eq!(
+            lines.iter().filter(|l| l.starts_with("  evict ")).count(),
+            REMOTE_GC_PREVIEW
+        );
+        assert_eq!(
+            lines.iter().filter(|l| l.starts_with("  remove ")).count(),
+            REMOTE_GC_PREVIEW
+        );
+        // 55 selected, 40 shown.
+        assert!(text.contains("... and 15 more"), "{text}");
+        assert!(!text.contains("Still over budget"), "{text}");
+    }
+
+    /// End to end on a real folder: `--dry-run` leaves every object in place,
+    /// and the same command without it holds the remote under its budget.
+    #[test]
+    fn remote_gc_dry_run_then_apply_on_a_real_filesystem_remote() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        for i in 0..4 {
+            write_aged_remote_entry(root, "serde", &format!("key{i}"), 4_000);
+        }
+        let config = save_manifest_config(root.join("store"), Some(remote_gc_fixture(root)));
+
+        let before = walk_bytes(&root.join("artifacts"));
+        assert!(before > 0, "the fixture must have written objects");
+        gc_remote(&config, true, false).expect("dry run");
+        assert_eq!(
+            walk_bytes(&root.join("artifacts")),
+            before,
+            "a dry run must not delete anything"
+        );
+
+        gc_remote(&config, false, false).expect("live sweep");
+        let remaining: u64 = walk_bytes(&root.join("artifacts"));
+        assert!(
+            remaining <= 1,
+            "the sweep must hold the remote under its 1-byte budget, got {remaining}"
+        );
+    }
+
+    fn walk_bytes(dir: &std::path::Path) -> u64 {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return 0;
+        };
+        entries
+            .flatten()
+            .map(|entry| match entry.file_type() {
+                Ok(kind) if kind.is_dir() => walk_bytes(&entry.path()),
+                Ok(kind) if kind.is_file() => entry.metadata().map(|m| m.len()).unwrap_or(0),
+                _ => 0,
+            })
+            .sum()
+    }
+
+    /// A second collector on the same folder declines instead of planning
+    /// against a snapshot the first is deleting from.
+    #[test]
+    fn remote_gc_declines_while_a_peer_holds_the_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_aged_remote_entry(root, "serde", "key0", 8_000);
+        let remote = remote_gc_fixture(root);
+        let crate::config::RemoteBackendConfig::Filesystem(fs_remote) = &remote.backend else {
+            unreachable!("fixture is a filesystem remote");
+        };
+        let held = crate::remote_eviction::try_lock(fs_remote)
+            .unwrap()
+            .expect("peer takes the lock first");
+
+        let config = save_manifest_config(root.join("store"), Some(remote.clone()));
+        gc_remote(&config, false, false).expect("a contended sweep is not an error");
+        assert!(
+            root.join("artifacts/v3/packs/serde/key0.tar.zst").exists(),
+            "a sweep that could not take the lock must not delete anything"
+        );
+
+        drop(held);
+        gc_remote(&config, false, false).expect("the lock is free now");
+        assert!(!root.join("artifacts/v3/packs/serde/key0.tar.zst").exists());
+    }
+
+    /// An S3 remote is bounded with a bucket lifecycle rule; the command says so
+    /// rather than pretending to sweep it.
+    #[test]
+    fn remote_gc_refuses_an_s3_remote_and_points_at_lifecycle_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = save_manifest_config(
+            dir.path().to_path_buf(),
+            Some(crate::config::RemoteConfig::test_s3("builds", "artifacts")),
+        );
+        let error = gc_remote(&config, true, false)
+            .expect_err("an S3 remote has no filesystem sweep")
+            .to_string();
+        assert!(
+            error.contains("only collects a filesystem remote"),
+            "{error}"
+        );
+        assert!(error.contains("lifecycle rule"), "{error}");
+    }
+
+    #[test]
+    fn remote_gc_reports_a_missing_remote_rather_than_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = save_manifest_config(dir.path().to_path_buf(), None);
+        assert!(gc_remote(&config, true, false).is_err());
+    }
+
+    /// A clean applied sweep says nothing about failures, pinned entries, the
+    /// budget, or the mount — every conditional line stays off.
+    #[test]
+    fn remote_gc_stays_quiet_when_there_is_nothing_to_qualify() {
+        let plan = crate::remote_eviction::RemotePlan {
+            total_bytes: 1_000,
+            object_count: 2,
+            budget: Some(1_000),
+            target: Some(900),
+            projected_bytes: 900,
+            atime_advanced: true,
+            ..Default::default()
+        };
+        let stats = crate::remote_eviction::RemoteGcStats {
+            groups_evicted: 1,
+            bytes_freed: 100,
+            objects_removed: 2,
+            ..Default::default()
+        };
+        let scan = crate::remote_eviction::RemoteScan {
+            object_count: 2,
+            atime_advanced: true,
+            ..Default::default()
+        };
+
+        let text = render_remote_gc(
+            "file:///srv",
+            "1.0 KiB (configured)",
+            &plan,
+            Some(&stats),
+            &scan,
+        )
+        .join("\n");
+        assert!(!text.contains("could not be removed"), "{text}");
+        assert!(!text.contains("were skipped"), "{text}");
+        assert!(
+            !text.contains("Still over budget"),
+            "exactly at the cap is not over it: {text}"
+        );
+        assert!(!text.contains("noatime"), "{text}");
+    }
+
+    /// A short preview names everything and adds no "and N more" tail.
+    #[test]
+    fn remote_gc_dry_run_without_truncation_adds_no_tail() {
+        let plan = crate::remote_eviction::RemotePlan {
+            budget: Some(10),
+            target: Some(9),
+            victims: vec![crate::remote_eviction::PlannedVictim {
+                id: "v3:serde/a".into(),
+                objects: vec![std::path::PathBuf::from("/srv/a")],
+                freed: 5,
+            }],
+            ..Default::default()
+        };
+        let text = render_remote_gc(
+            "file:///srv",
+            "10 B (configured)",
+            &plan,
+            None,
+            &crate::remote_eviction::RemoteScan::default(),
+        )
+        .join("\n");
+        assert!(text.contains("would evict 1 entry and 0 orphans"), "{text}");
+        assert!(!text.contains("... and"), "{text}");
+    }
+
+    #[test]
+    fn remote_gc_json_reports_the_plan_for_a_dry_run_and_the_stats_for_a_sweep() {
+        let plan = crate::remote_eviction::RemotePlan {
+            total_bytes: 5_000,
+            object_count: 9,
+            budget: Some(1_000),
+            target: Some(900),
+            victims: vec![crate::remote_eviction::PlannedVictim {
+                id: "v3:serde/a".into(),
+                objects: vec![std::path::PathBuf::from("/srv/a")],
+                freed: 4_000,
+            }],
+            orphans: vec![crate::remote_eviction::RemoteOrphan {
+                path: std::path::PathBuf::from("/srv/o"),
+                bytes: 100,
+                reason: crate::remote_eviction::OrphanReason::ManifestWithoutPack,
+            }],
+            pinned: 3,
+            projected_bytes: 1_500,
+            atime_advanced: true,
+        };
+
+        let dry = RemoteGcJson::report("file:///srv", true, &plan, None);
+        assert!(!dry.skipped && dry.dry_run);
+        assert_eq!(dry.remote, "file:///srv");
+        assert_eq!(dry.budget_bytes, Some(1_000));
+        assert_eq!(dry.remote_bytes, 5_000);
+        assert_eq!(dry.objects, 9);
+        assert_eq!(dry.entries_evicted, 1);
+        assert_eq!(dry.orphans_removed, 1);
+        assert_eq!(dry.bytes_freed, 4_100);
+        assert_eq!(dry.entries_pinned, 3);
+        assert_eq!(dry.remote_bytes_after, 1_500);
+        assert!(dry.still_over_budget);
+        assert!(dry.read_recency_available);
+
+        // A live sweep reports what it managed, not what it intended.
+        let stats = crate::remote_eviction::RemoteGcStats {
+            groups_evicted: 0,
+            orphans_removed: 0,
+            objects_removed: 0,
+            bytes_freed: 0,
+            delete_failures: 2,
+        };
+        let applied = RemoteGcJson::report("file:///srv", false, &plan, Some(&stats));
+        assert!(!applied.dry_run);
+        assert_eq!(applied.entries_evicted, 0);
+        assert_eq!(applied.orphans_removed, 0);
+        assert_eq!(applied.bytes_freed, 0);
+    }
+
+    #[test]
+    fn remote_gc_json_marks_a_contended_sweep_as_skipped() {
+        let body = RemoteGcJson::skipped();
+        assert!(body.skipped);
+        assert!(!body.dry_run);
+        assert_eq!(body.bytes_freed, 0);
+        assert_eq!(body.budget_bytes, None);
+        assert_eq!(body.remote, "");
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,21 @@ pub const DISK_SHARE_FLOOR: u64 = 5 * 1024 * 1024 * 1024;
 pub const DISK_SHARE_CAP: u64 = 100 * 1024 * 1024 * 1024;
 pub const DISK_SHARE_FALLBACK: u64 = 50 * 1024 * 1024 * 1024;
 
+/// Disk-share budget for a filesystem remote when `KACHE_REMOTE_MAX_SIZE` /
+/// `[cache.remote] max_size` are unset (kunobi-ninja/kache#774). Same shape as
+/// the local budget above, different share: a developer's store competes with
+/// everything else on that laptop, so it takes 5%, whereas a shared remote
+/// folder is usually the reason its volume exists. It is still rarely the only
+/// thing on that volume — the remote in #774 sat on the root filesystem and
+/// took it to 94% — so a quarter, not all of it. Floor 10GiB so a small
+/// builder is not left with a remote too small to hold one workspace; cap
+/// 500GiB because past that an operator is running a deliberate archive and
+/// should name a number. A failed size probe falls back to 100GiB.
+pub const REMOTE_DISK_SHARE_PERCENT: u64 = 25;
+pub const REMOTE_DISK_SHARE_FLOOR: u64 = 10 * 1024 * 1024 * 1024;
+pub const REMOTE_DISK_SHARE_CAP: u64 = 500 * 1024 * 1024 * 1024;
+pub const REMOTE_DISK_SHARE_FALLBACK: u64 = 100 * 1024 * 1024 * 1024;
+
 /// Remote resilience (kunobi-ninja/kache#327, #564). The daemon-side operation
 /// deadline matches `DEFAULT_PREFETCH_DEADLINE_SECS`: generous enough that no
 /// legitimate background transfer changes behavior while still bounding a
@@ -395,6 +410,51 @@ pub struct FilesystemRemoteConfig {
     pub root: PathBuf,
     /// Staging directory used for atomic write-then-rename completion.
     pub atomic_write_dir: PathBuf,
+    /// Size cap `kache gc --remote` enforces (kunobi-ninja/kache#774).
+    pub budget: RemoteBudget,
+}
+
+/// What `[cache.remote] max_size` / `KACHE_REMOTE_MAX_SIZE` resolved to.
+///
+/// Three states rather than `Option<u64>` because "unset" and "explicitly
+/// unbounded" are different answers here, and only the first may be replaced
+/// by a derived default.
+///
+/// **`"none"` is accepted for the remote, unlike `[cache] local_max_size`.**
+/// The local budget forbids it because every kache install has a local store
+/// on a disk the user did not choose for it, so an unbounded one is the
+/// failure GC exists to prevent, silently, on a machine nobody is watching. A
+/// filesystem remote is a path an operator picked and owns, and it is
+/// routinely already bounded by something kache cannot see: a dedicated
+/// volume, an LVM/ZFS quota, a lifecycle-managed object-store mount, or the
+/// operator's own pruning timer (which is exactly what #774 reports doing).
+/// Refusing `"none"` would make those operators write a fictitious huge
+/// number to express "not your job". The asymmetry is also cheap: remote
+/// eviction only ever runs when someone types `kache gc --remote`, so an
+/// unbounded remote cannot regress a machine that never asked for a sweep.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteBudget {
+    /// Nothing configured: derive from the volume holding the remote root.
+    Default,
+    /// An explicit byte cap. Always wins over the derived default.
+    Bytes(u64),
+    /// Explicitly unbounded: `kache gc --remote` reports and evicts nothing.
+    Unbounded,
+}
+
+impl RemoteBudget {
+    /// The effective cap in bytes, or `None` when the remote is unbounded.
+    ///
+    /// `filesystem_bytes` is the size of the volume holding the remote root,
+    /// as [`crate::cache_fs::probe`] measured it; `None` means the probe
+    /// failed and [`REMOTE_DISK_SHARE_FALLBACK`] applies.
+    pub fn resolve(self, filesystem_bytes: Option<u64>) -> Option<u64> {
+        match self {
+            Self::Default => Some(remote_disk_share_budget(filesystem_bytes)),
+            Self::Bytes(bytes) => Some(bytes),
+            Self::Unbounded => None,
+        }
+    }
 }
 
 impl Config {
@@ -692,6 +752,10 @@ pub(crate) struct RemoteFileConfig {
     pub(crate) path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) atomic_write_dir: Option<String>,
+    /// Filesystem-remote size budget (kunobi-ninja/kache#774). See
+    /// [`RemoteBudget`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) max_size: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
@@ -1632,8 +1696,13 @@ impl Config {
                 .into_iter()
                 .any(|v| v.as_deref().is_some_and(|v| !v.trim().is_empty()))
         });
+        // `max_size` counts as a filesystem field (kunobi-ninja/kache#774): an
+        // S3 remote is bounded by a bucket lifecycle rule, so accepting the key
+        // there would promise a sweep kache does not run. Listing it here makes
+        // `max_size` next to `bucket` an explicit "mixes S3 and filesystem
+        // fields" error instead of a silently ignored setting.
         let file_has_filesystem_fields = file_remote.is_some_and(|r| {
-            [&r.path, &r.atomic_write_dir]
+            [&r.path, &r.atomic_write_dir, &r.max_size]
                 .into_iter()
                 .any(|v| v.as_deref().is_some_and(|v| !v.trim().is_empty()))
         });
@@ -1650,7 +1719,8 @@ impl Config {
             Some("s3") => {
                 if file_has_filesystem_fields {
                     anyhow::bail!(
-                        "[cache.remote] type = \"s3\" cannot include path or atomic_write_dir"
+                        "[cache.remote] type = \"s3\" cannot include path, atomic_write_dir, or \
+                         max_size; bound an S3 remote with a bucket lifecycle rule"
                     );
                 }
                 false
@@ -1712,11 +1782,22 @@ impl Config {
                 anyhow::bail!("{problem}");
             }
 
+            let budget = env_or_ignored("KACHE_REMOTE_MAX_SIZE", ignore_env)
+                .ok()
+                .map(|value| parse_remote_max_size(&value, "KACHE_REMOTE_MAX_SIZE"))
+                .or_else(|| {
+                    file_remote
+                        .and_then(|r| r.max_size.as_deref())
+                        .map(|value| parse_remote_max_size(value, "[cache.remote] max_size"))
+                })
+                .unwrap_or(RemoteBudget::Default);
+
             return Ok(Some(RemoteConfig {
                 prefix,
                 backend: RemoteBackendConfig::Filesystem(FilesystemRemoteConfig {
                     root,
                     atomic_write_dir,
+                    budget,
                 }),
             }));
         }
@@ -2559,13 +2640,44 @@ pub(crate) fn parse_size(s: &str) -> Option<u64> {
 /// Pure so tests pin floor / cap / rounding without touching a real disk.
 /// `None` or `0` (probe failed) uses [`DISK_SHARE_FALLBACK`].
 pub(crate) fn disk_share_budget(filesystem_bytes: Option<u64>) -> u64 {
+    disk_share(
+        filesystem_bytes,
+        DISK_SHARE_PERCENT,
+        DISK_SHARE_FLOOR,
+        DISK_SHARE_CAP,
+        DISK_SHARE_FALLBACK,
+    )
+}
+
+/// Budget for a filesystem remote derived from the volume that holds its root
+/// (kunobi-ninja/kache#774). The local store's rule with the remote's share;
+/// see [`REMOTE_DISK_SHARE_PERCENT`] for why the share differs.
+pub(crate) fn remote_disk_share_budget(filesystem_bytes: Option<u64>) -> u64 {
+    disk_share(
+        filesystem_bytes,
+        REMOTE_DISK_SHARE_PERCENT,
+        REMOTE_DISK_SHARE_FLOOR,
+        REMOTE_DISK_SHARE_CAP,
+        REMOTE_DISK_SHARE_FALLBACK,
+    )
+}
+
+/// `percent` of `filesystem_bytes`, rounded to the nearest GiB, clamped to
+/// `floor..=cap`. A missing or zero probe yields `fallback`.
+fn disk_share(
+    filesystem_bytes: Option<u64>,
+    percent: u64,
+    floor: u64,
+    cap: u64,
+    fallback: u64,
+) -> u64 {
     let Some(total) = filesystem_bytes.filter(|&n| n > 0) else {
-        return DISK_SHARE_FALLBACK;
+        return fallback;
     };
-    let raw = total.saturating_mul(DISK_SHARE_PERCENT) / 100;
+    let raw = total.saturating_mul(percent) / 100;
     const GIB: u64 = 1024 * 1024 * 1024;
     let rounded = raw.saturating_add(GIB / 2) / GIB * GIB;
-    rounded.clamp(DISK_SHARE_FLOOR, DISK_SHARE_CAP)
+    rounded.clamp(floor, cap)
 }
 
 /// Phrase the effective store limit for stats / gc / doctor.
@@ -2585,6 +2697,48 @@ pub(crate) fn describe_max_size(max_size: u64, filesystem_bytes: Option<u64>) ->
             ByteSize(total)
         ),
         None => format!("{} (default; disk size unknown)", ByteSize(max_size)),
+    }
+}
+
+/// Phrase a filesystem remote's budget for `kache gc --remote`
+/// (kunobi-ninja/kache#774). The counterpart to [`describe_max_size`], with
+/// the extra "explicitly unbounded" state the remote allows.
+pub(crate) fn describe_remote_budget(
+    budget: RemoteBudget,
+    filesystem_bytes: Option<u64>,
+) -> String {
+    match budget {
+        RemoteBudget::Unbounded => "unbounded (max_size = \"none\")".to_string(),
+        RemoteBudget::Bytes(bytes) => format!("{} (configured)", ByteSize(bytes)),
+        RemoteBudget::Default => match filesystem_bytes.filter(|&n| n > 0) {
+            Some(total) => format!(
+                "{} ({REMOTE_DISK_SHARE_PERCENT}% of {}, floor {}, cap {})",
+                ByteSize(remote_disk_share_budget(filesystem_bytes)),
+                ByteSize(total),
+                ByteSize(REMOTE_DISK_SHARE_FLOOR),
+                ByteSize(REMOTE_DISK_SHARE_CAP),
+            ),
+            None => format!(
+                "{} (default; disk size unknown)",
+                ByteSize(REMOTE_DISK_SHARE_FALLBACK)
+            ),
+        },
+    }
+}
+
+/// Parse `[cache.remote] max_size` / `KACHE_REMOTE_MAX_SIZE`.
+///
+/// Unlike [`parse_local_max_size`], `"none"` is a legitimate answer here; see
+/// [`RemoteBudget`] for why. A malformed value warns through
+/// [`parse_size_checked`] and leaves the budget at its derived default rather
+/// than silently unbounding the remote.
+fn parse_remote_max_size(value: &str, source: &str) -> RemoteBudget {
+    if value.trim().eq_ignore_ascii_case("none") {
+        return RemoteBudget::Unbounded;
+    }
+    match parse_size_checked(value, source) {
+        Some(bytes) => RemoteBudget::Bytes(bytes),
+        None => RemoteBudget::Default,
     }
 }
 
@@ -3421,6 +3575,7 @@ remote_key_cache_refresh_secs = 900
                     user_agent: None,
                     path: None,
                     atomic_write_dir: None,
+                    max_size: None,
                 }),
                 scheduler: None,
             }),
@@ -5459,6 +5614,223 @@ exclude = ["src/generated/**", "vendor/problem/**"]
             .expect("an empty prefix must be usable")
             .expect("remote");
         assert_eq!(remote.prefix, "");
+    }
+
+    /// kunobi-ninja/kache#774. Independent literals on the right-hand side so
+    /// mutating a `REMOTE_DISK_SHARE_*` product cannot move both sides at once.
+    #[test]
+    fn remote_disk_share_budget_floors_caps_and_rounds() {
+        const GIB: u64 = 1 << 30;
+        assert_eq!(remote_disk_share_budget(None), 100 << 30);
+        assert_eq!(remote_disk_share_budget(Some(0)), 100 << 30);
+        // 20GiB volume: 25% is 5GiB, then the 10GiB floor.
+        assert_eq!(remote_disk_share_budget(Some(20 * GIB)), 10 << 30);
+        // 400GiB volume: 25% is exactly 100GiB.
+        assert_eq!(remote_disk_share_budget(Some(400 * GIB)), 100 * GIB);
+        // 250GiB volume: 25% is 62.5GiB, nearest GiB is 63GiB.
+        assert_eq!(remote_disk_share_budget(Some(250 * GIB)), 63 * GIB);
+        // 8TiB volume: 25% is 2TiB, capped at 500GiB.
+        assert_eq!(remote_disk_share_budget(Some(8 * 1024 * GIB)), 500 << 30);
+        // Exactly at the cap.
+        assert_eq!(remote_disk_share_budget(Some(2000 * GIB)), 500 << 30);
+        // The remote takes a bigger share of the same disk than the store does.
+        assert!(remote_disk_share_budget(Some(400 * GIB)) > disk_share_budget(Some(400 * GIB)));
+    }
+
+    /// Unlike `local_max_size`, `"none"` is a legitimate answer for a remote an
+    /// operator owns; see [`RemoteBudget`].
+    #[test]
+    fn parse_remote_max_size_accepts_none_and_rejects_garbage() {
+        assert_eq!(
+            parse_remote_max_size("none", "[cache.remote] max_size"),
+            RemoteBudget::Unbounded
+        );
+        assert_eq!(
+            parse_remote_max_size("  NONE  ", "KACHE_REMOTE_MAX_SIZE"),
+            RemoteBudget::Unbounded
+        );
+        assert_eq!(
+            parse_remote_max_size("80GiB", "[cache.remote] max_size"),
+            RemoteBudget::Bytes(80 << 30)
+        );
+        assert_eq!(
+            parse_remote_max_size("80 gigs", "[cache.remote] max_size"),
+            RemoteBudget::Default,
+            "a typo must fall back to the derived default, never to unbounded"
+        );
+    }
+
+    #[test]
+    fn remote_budget_resolves_explicit_bytes_none_and_the_disk_share() {
+        const GIB: u64 = 1 << 30;
+        let disk = Some(400 * GIB);
+        assert_eq!(RemoteBudget::Bytes(7).resolve(disk), Some(7));
+        assert_eq!(RemoteBudget::Unbounded.resolve(disk), None);
+        assert_eq!(
+            RemoteBudget::Default.resolve(disk),
+            Some(remote_disk_share_budget(disk))
+        );
+        assert_eq!(
+            RemoteBudget::Default.resolve(None),
+            Some(REMOTE_DISK_SHARE_FALLBACK)
+        );
+    }
+
+    #[test]
+    fn describe_remote_budget_names_how_the_number_was_reached() {
+        const GIB: u64 = 1 << 30;
+        let derived = describe_remote_budget(RemoteBudget::Default, Some(400 * GIB));
+        assert!(derived.contains("25%"), "{derived}");
+        assert!(
+            derived.contains(&ByteSize(400 * GIB).to_string()),
+            "{derived}"
+        );
+        assert!(
+            derived.contains(&ByteSize(100 * GIB).to_string()),
+            "{derived}"
+        );
+
+        let unknown = describe_remote_budget(RemoteBudget::Default, Some(0));
+        assert!(unknown.contains("disk size unknown"), "{unknown}");
+        assert!(
+            unknown.contains(&ByteSize(REMOTE_DISK_SHARE_FALLBACK).to_string()),
+            "{unknown}"
+        );
+        assert_eq!(
+            describe_remote_budget(RemoteBudget::Default, None),
+            unknown,
+            "a failed probe and a zero-byte probe read the same"
+        );
+
+        let explicit = describe_remote_budget(RemoteBudget::Bytes(80 << 30), Some(400 * GIB));
+        assert!(explicit.contains("configured"), "{explicit}");
+        assert!(
+            explicit.contains(&ByteSize(80u64 << 30).to_string()),
+            "{explicit}"
+        );
+
+        let off = describe_remote_budget(RemoteBudget::Unbounded, Some(400 * GIB));
+        assert!(off.contains("unbounded") && off.contains("none"), "{off}");
+    }
+
+    /// An explicit `[cache.remote] max_size` always wins over the derived
+    /// default, and an unset one leaves it to be derived at sweep time.
+    #[test]
+    fn filesystem_remote_reads_an_explicit_max_size() {
+        let _guard = config_path_lock();
+        let _env = set_env_for_test("KACHE_REMOTE_MAX_SIZE", None);
+        let root = tempfile::tempdir().unwrap();
+        let load = |max_size: Option<&str>| {
+            let file = FileConfig {
+                cache: Some(CacheFileConfig {
+                    remote: Some(RemoteFileConfig {
+                        _type: Some("filesystem".to_string()),
+                        path: Some(root.path().to_string_lossy().into_owned()),
+                        max_size: max_size.map(str::to_string),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            let remote = Config::load_remote_config(&Ok(file))
+                .expect("valid filesystem config")
+                .expect("filesystem remote");
+            let RemoteBackendConfig::Filesystem(fs) = remote.backend else {
+                panic!("expected filesystem remote");
+            };
+            fs.budget
+        };
+
+        assert_eq!(load(Some("80GiB")), RemoteBudget::Bytes(80 << 30));
+        assert_eq!(load(Some("none")), RemoteBudget::Unbounded);
+        assert_eq!(load(None), RemoteBudget::Default);
+    }
+
+    #[test]
+    fn remote_max_size_env_overrides_the_file() {
+        let _guard = config_path_lock();
+        let _env = set_env_var_for_test("KACHE_REMOTE_MAX_SIZE", "3GiB");
+        let root = tempfile::tempdir().unwrap();
+        let file = FileConfig {
+            cache: Some(CacheFileConfig {
+                remote: Some(RemoteFileConfig {
+                    _type: Some("filesystem".to_string()),
+                    path: Some(root.path().to_string_lossy().into_owned()),
+                    max_size: Some("80GiB".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let remote = Config::load_remote_config(&Ok(file))
+            .expect("valid filesystem config")
+            .expect("filesystem remote");
+        let RemoteBackendConfig::Filesystem(fs) = remote.backend else {
+            panic!("expected filesystem remote");
+        };
+        assert_eq!(fs.budget, RemoteBudget::Bytes(3 << 30));
+    }
+
+    /// An S3 remote is bounded by a bucket lifecycle rule, so `max_size` there
+    /// is a promise kache would not keep. Explicitly typed it is its own error;
+    /// untyped alongside a bucket it is the existing mixed-fields error.
+    #[test]
+    fn remote_max_size_is_rejected_on_an_s3_remote() {
+        let typed = FileConfig {
+            cache: Some(CacheFileConfig {
+                remote: Some(RemoteFileConfig {
+                    _type: Some("s3".to_string()),
+                    bucket: Some("builds".to_string()),
+                    max_size: Some("80GiB".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let error = Config::load_remote_config(&Ok(typed))
+            .expect_err("max_size must not be accepted on an S3 remote")
+            .to_string();
+        assert!(error.contains("max_size"), "{error}");
+        assert!(error.contains("lifecycle rule"), "{error}");
+
+        let untyped = FileConfig {
+            cache: Some(CacheFileConfig {
+                remote: Some(RemoteFileConfig {
+                    bucket: Some("builds".to_string()),
+                    max_size: Some("80GiB".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let error = Config::load_remote_config(&Ok(untyped))
+            .expect_err("an untyped mix must be rejected")
+            .to_string();
+        assert!(error.contains("mixes S3 and filesystem fields"), "{error}");
+    }
+
+    /// `max_size` alone is a filesystem field, so it demands a path rather than
+    /// being silently ignored on the S3 path.
+    #[test]
+    fn remote_max_size_alone_still_requires_a_filesystem_path() {
+        let file = FileConfig {
+            cache: Some(CacheFileConfig {
+                remote: Some(RemoteFileConfig {
+                    max_size: Some("80GiB".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let error = Config::load_remote_config(&Ok(file))
+            .expect_err("max_size without a path must be reported")
+            .to_string();
+        assert!(error.contains("requires a non-empty path"), "{error}");
     }
 
     #[test]

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -193,7 +193,7 @@ fn build_fields(file_config: &FileConfig, env: &EnvOverrides) -> Vec<FormField> 
         .filter(|value| !value.trim().is_empty())
         .or_else(|| {
             remote.and_then(|r| {
-                if r.path.is_some() || r.atomic_write_dir.is_some() {
+                if r.path.is_some() || r.atomic_write_dir.is_some() || r.max_size.is_some() {
                     Some("filesystem".to_string())
                 } else if r.bucket.is_some()
                     || r.endpoint.is_some()
@@ -484,6 +484,17 @@ fn build_fields(file_config: &FileConfig, env: &EnvOverrides) -> Vec<FormField> 
             env_locked: false,
         },
         FormField {
+            key: "fs_max_size",
+            label: "Remote max size",
+            kind: FieldKind::Text,
+            value: remote.and_then(|r| r.max_size.clone()).unwrap_or_default(),
+            env_var: "KACHE_REMOTE_MAX_SIZE",
+            env_value: env_val("KACHE_REMOTE_MAX_SIZE"),
+            default_hint: "(default: 25% of the remote disk; \"none\" for unbounded)",
+            validation_error: None,
+            env_locked: false,
+        },
+        FormField {
             key: "remote_prefix",
             label: "Prefix",
             kind: FieldKind::Text,
@@ -541,11 +552,11 @@ fn build_sections() -> Vec<Section> {
         },
         Section {
             label: "Remote",
-            fields: 10..19,
+            fields: 10..20,
         },
         Section {
             label: "Advanced",
-            fields: 19..21,
+            fields: 20..22,
         },
     ]
 }
@@ -612,7 +623,7 @@ fn validate_cross_field(fields: &[FormField]) -> Vec<(usize, String)> {
     ]
     .iter()
     .any(|key| is_set(key));
-    let has_filesystem_fields = ["fs_path", "fs_atomic_write_dir"]
+    let has_filesystem_fields = ["fs_path", "fs_atomic_write_dir", "fs_max_size"]
         .iter()
         .any(|key| is_set(key));
     let has_remote_fields = has_s3_fields || has_filesystem_fields || is_set("remote_prefix");
@@ -624,6 +635,7 @@ fn validate_cross_field(fields: &[FormField]) -> Vec<(usize, String)> {
         "s3_user_agent",
         "fs_path",
         "fs_atomic_write_dir",
+        "fs_max_size",
         "remote_prefix",
     ]
     .iter()
@@ -663,7 +675,7 @@ fn validate_cross_field(fields: &[FormField]) -> Vec<(usize, String)> {
             {
                 errors.push((idx, "Bucket required for S3 backend".to_string()));
             }
-            for key in ["fs_path", "fs_atomic_write_dir"] {
+            for key in ["fs_path", "fs_atomic_write_dir", "fs_max_size"] {
                 if is_set(key)
                     && let Some(idx) = index(key)
                 {
@@ -841,6 +853,7 @@ fn fields_to_file_config(
     let user_agent = get("s3_user_agent");
     let path = get("fs_path");
     let atomic_write_dir = get("fs_atomic_write_dir");
+    let max_size = get("fs_max_size");
     let remote_type = get("remote_type")
         .map(|value| value.trim().to_ascii_lowercase())
         .filter(|value| !value.is_empty());
@@ -852,7 +865,8 @@ fn fields_to_file_config(
         || profile.is_some()
         || user_agent.is_some()
         || path.is_some()
-        || atomic_write_dir.is_some();
+        || atomic_write_dir.is_some()
+        || max_size.is_some();
 
     let remote = if has_remote {
         Some(RemoteFileConfig {
@@ -865,6 +879,7 @@ fn fields_to_file_config(
             user_agent,
             path,
             atomic_write_dir,
+            max_size,
         })
     } else {
         None
@@ -1546,13 +1561,63 @@ mod tests {
     fn test_build_fields_count() {
         let config = FileConfig::default();
         let fields = build_fields(&config, &empty_env());
-        assert_eq!(fields.len(), 21);
+        assert_eq!(fields.len(), 22);
 
         let sections = build_sections();
         assert_eq!(sections[0].fields, 0..3);
         assert_eq!(sections[1].fields, 3..10);
-        assert_eq!(sections[2].fields, 10..19);
-        assert_eq!(sections[3].fields, 19..21);
+        assert_eq!(sections[2].fields, 10..20);
+        assert_eq!(sections[3].fields, 20..22);
+    }
+
+    /// A config predating `type` is classified by which fields it sets. Each
+    /// filesystem field has to imply "filesystem" on its own, or the editor
+    /// silently reopens a shared-folder remote as an S3 one — including
+    /// `max_size`, which only a filesystem remote accepts
+    /// (kunobi-ninja/kache#774).
+    #[test]
+    fn remote_type_is_inferred_from_any_single_backend_field() {
+        let inferred = |remote: RemoteFileConfig| {
+            let config = FileConfig {
+                cache: Some(CacheFileConfig {
+                    remote: Some(remote),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            build_fields(&config, &empty_env())
+                .into_iter()
+                .find(|field| field.key == "remote_type")
+                .expect("the form has a backend-type field")
+                .value
+        };
+
+        for filesystem_only in [
+            RemoteFileConfig {
+                path: Some("/mnt/kache".to_string()),
+                ..Default::default()
+            },
+            RemoteFileConfig {
+                atomic_write_dir: Some("/mnt/kache-tmp".to_string()),
+                ..Default::default()
+            },
+            RemoteFileConfig {
+                max_size: Some("80GiB".to_string()),
+                ..Default::default()
+            },
+        ] {
+            assert_eq!(inferred(filesystem_only), "filesystem");
+        }
+
+        assert_eq!(
+            inferred(RemoteFileConfig {
+                bucket: Some("builds".to_string()),
+                ..Default::default()
+            }),
+            "s3",
+            "configs predating the type field were always S3"
+        );
+        assert_eq!(inferred(RemoteFileConfig::default()), "");
     }
 
     #[test]
@@ -2090,6 +2155,7 @@ mod tests {
                     user_agent: Some("custom-ua/1.0".to_string()),
                     path: None,
                     atomic_write_dir: None,
+                    max_size: None,
                 }),
             }),
         };
@@ -2270,6 +2336,7 @@ mod tests {
                     prefix: Some("shared/artifacts".to_string()),
                     path: Some("/var/cache/kache".to_string()),
                     atomic_write_dir: Some("/var/cache/kache-tmp".to_string()),
+                    max_size: None,
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -2362,6 +2429,59 @@ mod tests {
         assert!(remote.profile.is_none());
         assert!(remote.path.is_none());
         assert!(remote.atomic_write_dir.is_none());
+        assert!(remote.max_size.is_none());
+    }
+
+    /// Every filesystem field on its own has to create the `[cache.remote]`
+    /// section, or saving from the editor silently drops it. `max_size` is the
+    /// newest of them (kunobi-ninja/kache#774).
+    #[test]
+    fn test_fields_to_file_config_persists_a_remote_for_any_filesystem_field() {
+        for (key, value) in [
+            ("fs_path", "/mnt/kache"),
+            ("fs_atomic_write_dir", "/mnt/kache-tmp"),
+            ("fs_max_size", "80GiB"),
+        ] {
+            let mut fields = build_fields(&FileConfig::default(), &empty_env());
+            fields
+                .iter_mut()
+                .find(|field| field.key == key)
+                .unwrap_or_else(|| panic!("the form has a {key} field"))
+                .value = value.to_string();
+
+            let result = fields_to_file_config(
+                &fields,
+                None,
+                None,
+                None,
+                PreservedAdvancedConfig::default(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            );
+            let remote = result
+                .cache
+                .as_ref()
+                .and_then(|cache| cache.remote.as_ref())
+                .unwrap_or_else(|| panic!("{key} alone must create a remote section"));
+            let saved = match key {
+                "fs_path" => remote.path.as_deref(),
+                "fs_atomic_write_dir" => remote.atomic_write_dir.as_deref(),
+                _ => remote.max_size.as_deref(),
+            };
+            assert_eq!(saved, Some(value));
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod policy;
 mod probe;
 mod remote;
 mod remote_backend;
+mod remote_eviction;
 mod remote_layout;
 mod remote_pack;
 mod remote_plan;
@@ -133,12 +134,21 @@ enum Commands {
     /// Run garbage collection
     Gc {
         /// Evict entries older than this duration (e.g. 7d, 24h)
-        #[arg(long, conflicts_with = "stale_schema")]
+        #[arg(long, conflicts_with_all = ["stale_schema", "remote"])]
         max_age: Option<String>,
 
         /// Remove entries from old or unrecorded cache-key schemas
-        #[arg(long)]
+        #[arg(long, conflicts_with = "remote")]
         stale_schema: bool,
+
+        /// Collect the filesystem remote instead of the local store, holding it
+        /// under `[cache.remote] max_size` (kunobi-ninja/kache#774)
+        #[arg(long)]
+        remote: bool,
+
+        /// Report what a remote sweep would remove without removing anything
+        #[arg(long, short = 'n', requires = "remote")]
+        dry_run: bool,
     },
 
     /// Wipe entire cache or entries for a specific crate
@@ -645,18 +655,24 @@ fn main() -> Result<()> {
         Some(Commands::Gc {
             max_age,
             stale_schema,
+            remote,
+            dry_run,
         }) => {
-            let hours = max_age
-                .as_deref()
-                .map(|value| {
-                    parse_duration_hours(value).ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "invalid --max-age {value:?}; expected hours or a duration like 24h or 7d"
-                        )
+            if remote {
+                cli::gc_remote(&config, dry_run, json)
+            } else {
+                let hours = max_age
+                    .as_deref()
+                    .map(|value| {
+                        parse_duration_hours(value).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "invalid --max-age {value:?}; expected hours or a duration like 24h or 7d"
+                            )
+                        })
                     })
-                })
-                .transpose()?;
-            cli::gc(&config, hours, stale_schema, json)
+                    .transpose()?;
+                cli::gc(&config, hours, stale_schema, json)
+            }
         }
         Some(Commands::Purge { crate_name }) => {
             if json {

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -1038,6 +1038,7 @@ mod tests {
             backend: RemoteBackendConfig::Filesystem(FilesystemRemoteConfig {
                 root: root.path().to_path_buf(),
                 atomic_write_dir: atomic_write_dir.clone(),
+                budget: crate::config::RemoteBudget::Default,
             }),
         };
         let backend = create_backend(&remote, 30).await.unwrap();
@@ -1092,6 +1093,7 @@ mod tests {
             backend: RemoteBackendConfig::Filesystem(FilesystemRemoteConfig {
                 root: root.path().to_path_buf(),
                 atomic_write_dir: root.path().join(".staging"),
+                budget: crate::config::RemoteBudget::Default,
             }),
         };
         let backend = create_backend(&remote, 30).await.unwrap();
@@ -1158,6 +1160,7 @@ mod tests {
             backend: RemoteBackendConfig::Filesystem(FilesystemRemoteConfig {
                 root: root.path().to_path_buf(),
                 atomic_write_dir: root.path().join(".staging"),
+                budget: crate::config::RemoteBudget::Default,
             }),
         };
         let backend = create_backend(&remote, 30).await.unwrap();
@@ -1491,6 +1494,7 @@ mod tests {
             backend: RemoteBackendConfig::Filesystem(FilesystemRemoteConfig {
                 root: root.path().to_path_buf(),
                 atomic_write_dir: root.path().join(".kache-tmp"),
+                budget: crate::config::RemoteBudget::Default,
             }),
         };
         let backend = create_backend(&remote, 30).await.unwrap();
@@ -1561,6 +1565,7 @@ mod tests {
             backend: RemoteBackendConfig::Filesystem(FilesystemRemoteConfig {
                 root: root.path().to_path_buf(),
                 atomic_write_dir: root.path().join(".kache-tmp"),
+                budget: crate::config::RemoteBudget::Default,
             }),
         };
         let backend = create_backend(&remote, 30).await.unwrap();
@@ -1588,6 +1593,7 @@ mod tests {
             backend: RemoteBackendConfig::Filesystem(FilesystemRemoteConfig {
                 root: root.path().to_path_buf(),
                 atomic_write_dir: root.path().join(".kache-tmp"),
+                budget: crate::config::RemoteBudget::Default,
             }),
         };
         let backend = create_backend(&remote, 30).await.unwrap();

--- a/src/remote_eviction.rs
+++ b/src/remote_eviction.rs
@@ -1,0 +1,1828 @@
+//! Size budget and eviction for a filesystem remote (kunobi-ninja/kache#774).
+//!
+//! A filesystem remote had no eviction path at all: `kache gc` bounded the
+//! local store, an S3 remote could be bounded with a bucket lifecycle rule,
+//! and a shared folder grew monotonically. The report that opened #774 measured
+//! 319 GiB in one day.
+//!
+//! Selection reuses [`crate::eviction`] rather than growing a second ranking
+//! vocabulary. Each evictable unit is described as an
+//! [`EntryFeatures`](crate::eviction::EntryFeatures) and ranked by
+//! [`SizePressurePolicy`](crate::eviction::SizePressurePolicy), and the sweep
+//! fires and stops on
+//! [`over_eviction_trigger`](crate::eviction::over_eviction_trigger) /
+//! [`eviction_target`](crate::eviction::eviction_target), so the remote
+//! inherits the local store's hysteresis band instead of thrashing on its cap.
+//!
+//! ## What the filesystem can and cannot tell us
+//!
+//! The local store records `last_accessed` in SQLite on every hit. A remote has
+//! no database, so recency has to come from `stat`, and every mount option
+//! degrades it differently:
+//!
+//! - **`strictatime`** — `atime` is true read recency. Nobody mounts a build
+//!   cache this way; it is a write per read.
+//! - **`relatime`** (the Linux default, and what #774 measured on) — `atime`
+//!   advances at most once per 24h. Read recency is therefore reliable at day
+//!   granularity and meaningless below it. That is enough here: the ranking only
+//!   has to separate a hot set re-read every build from a tail nothing has
+//!   touched in weeks.
+//! - **`noatime` / `nodiratime`** — `atime` never advances past the write, so
+//!   read recency is simply not observable. The sweep degrades to write recency
+//!   and says so, rather than pretending a frozen `atime` is a read.
+//!
+//! [`observed_access`] takes `max(atime, mtime)`, which is right under all
+//! three: a read pushes `atime` past `mtime` where the mount allows it, and
+//! collapses to write time where it does not. [`RemoteScan::atime_advanced`]
+//! records whether *any* object showed a read newer than its write, which is how
+//! `kache gc --remote` knows to warn that it is ranking by write time — #774's
+//! acceptance criterion that `noatime` degrade to a documented fallback rather
+//! than silently evicting the hot set.
+//!
+//! The issue also proposes a sidecar touch-file so `noatime` mounts regain read
+//! recency. That needs the restore path to write on every hit and is out of
+//! scope here; the advisory names the limitation instead.
+//!
+//! ## Pack sharing, and why the unit of eviction differs per layout
+//!
+//! - **v3** (`v3/manifests/{crate}/{key}.json` + `v3/packs/{crate}/{key}.tar.zst`)
+//!   is **not** shared. Both keys are derived from the same `(crate, cache_key)`
+//!   pair by `remote_layout::v3_manifest_key` / `v3_pack_key`, so exactly one
+//!   manifest can ever name a given pack. The pair is one eviction unit.
+//! - **v4 prefetch** (`v4/prefetch/packs/{dd}/{digest}.kpack`) **is** shared. A
+//!   pack is content-addressed by digest and referenced by digest from
+//!   `v4/prefetch/catalogs/{selector}/...`, so successive catalog generations
+//!   for one selector — and different selectors that happened to build the same
+//!   pack — all point at one object. The unit of eviction is the *catalog*, and
+//!   a pack is unlinked only when the last catalog referencing it goes.
+//!   [`RemoteGroup::digests`] against [`SharedPack::refs`] is that reference
+//!   count, and it feeds `reclaimable_bytes` exactly as blob refcounts do
+//!   locally (kunobi-ninja/kache#608): a catalog whose packs are all shared
+//!   frees only its own few kilobytes and ranks accordingly.
+//!
+//! A dangling reference must degrade to a miss, never to an error that fails a
+//! build, and both layouts already do that. A manifest whose pack is gone makes
+//! `RemoteLayout::download_entry` return `EntryNotFound`, which callers downcast
+//! to a clean miss (#485 Phase 0). A catalog whose pack is gone makes the
+//! daemon's `try_packed_prefetch` see `None` for that pack and fall through to
+//! the v3 coordinator. Deletion order still avoids creating them: a v3 unit
+//! drops its manifest *before* its pack, so an interrupted sweep leaves an
+//! unreferenced pack — invisible to readers, reclaimed by the next run — rather
+//! than the manifest-without-pack state #774 asks us never to leave behind.
+//!
+//! Build manifests and shards under `_manifests/` count toward the measured size
+//! but are never evicted: they are kilobyte-scale JSON that every prefetch plan
+//! starts from, so removing them costs hit rate and reclaims nothing worth
+//! having.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use crate::config::FilesystemRemoteConfig;
+use crate::eviction::{EntryFeatures, EvictionPolicy, SizePressurePolicy, eviction_target};
+
+/// How recently an object must have been read or written for the sweep to treat
+/// it as pinned by a live build and skip it.
+///
+/// The local store's `EVICTION_IDLE_GRACE` is two minutes because a local
+/// restore is a hardlink or reflink and takes milliseconds. A remote restore is
+/// a full pack GET across a shared filesystem, so this is tied to
+/// [`DEFAULT_REMOTE_RESTORE_TIMEOUT_SECS`](crate::config::DEFAULT_REMOTE_RESTORE_TIMEOUT_SECS)
+/// instead: a download still running past the daemon's own operation deadline
+/// has already been abandoned, so there is nothing left to protect.
+///
+/// This is the cheap half of the mid-download guard. The load-bearing half is
+/// POSIX unlink semantics — a reader that has already opened the pack keeps
+/// reading the unlinked inode to completion — and, on Windows, that deleting a
+/// file with an open handle fails outright and the object is skipped. The grace
+/// closes the remaining window, where a peer has listed a manifest but not yet
+/// issued the GET.
+pub(crate) const REMOTE_EVICTION_IDLE_GRACE: Duration =
+    Duration::from_secs(crate::config::DEFAULT_REMOTE_RESTORE_TIMEOUT_SECS);
+
+/// How long an unreferenced object must sit untouched before the sweep calls it
+/// an orphan.
+///
+/// An upload writes the pack and *then* the manifest, so a pack whose manifest
+/// has not landed yet is indistinguishable from one whose publisher crashed.
+/// Same reasoning and same value as
+/// [`STAGING_SWEEP_GRACE`](crate::store::STAGING_SWEEP_GRACE): the grace has to
+/// outlast any plausible in-flight put.
+pub(crate) const REMOTE_ORPHAN_GRACE: Duration = crate::store::STAGING_SWEEP_GRACE;
+
+/// Advisory lock file, at the remote root beside `.kache-tmp`.
+///
+/// Outside the prefix on purpose, so it is never mistaken for a cache object by
+/// the scan or by `RemoteLayout::list_keys`.
+pub(crate) const REMOTE_GC_LOCK_FILE: &str = ".kache-remote-gc.lock";
+
+/// Why an object is dead weight regardless of the size budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OrphanReason {
+    /// A v3 pack no manifest names. Unreachable: both `exists_entry` and
+    /// `list_keys` go through the manifest tree.
+    PackWithoutManifest,
+    /// A v3 manifest whose pack is gone. Serving it can only produce
+    /// `EntryNotFound`, so it is a miss that costs a round trip.
+    ManifestWithoutPack,
+    /// A v4 prefetch pack (or its metadata sidecar) that no surviving catalog
+    /// references.
+    UnreferencedPrefetchPack,
+}
+
+impl OrphanReason {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::PackWithoutManifest => "pack without manifest",
+            Self::ManifestWithoutPack => "manifest without pack",
+            Self::UnreferencedPrefetchPack => "unreferenced prefetch pack",
+        }
+    }
+}
+
+/// One object the sweep may unlink on its own, independent of the budget.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RemoteOrphan {
+    pub path: PathBuf,
+    pub bytes: u64,
+    pub reason: OrphanReason,
+}
+
+/// A shared v4 prefetch pack and how many catalogs still name it.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct SharedPack {
+    /// The `.kpack` and its `pack-meta` sidecar, both keyed by this digest.
+    pub objects: Vec<(PathBuf, u64)>,
+    pub bytes: u64,
+    pub refs: usize,
+}
+
+/// One evictable unit: a v3 manifest+pack pair, or a v4 catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RemoteGroup {
+    /// Stable identifier for ranking and for `--dry-run` output.
+    pub id: String,
+    /// Objects unlinked together, in an order that leaves the remote consistent
+    /// after any prefix of it.
+    pub objects: Vec<PathBuf>,
+    /// Bytes those objects occupy.
+    pub bytes: u64,
+    /// Shared v4 pack digests this group references. Empty for v3.
+    pub digests: Vec<String>,
+    /// Time since the newest observed access across the group's objects.
+    pub idle: Duration,
+}
+
+impl RemoteGroup {
+    /// Bytes evicting this group would actually free right now: its own objects
+    /// plus every shared pack it holds the last reference to.
+    ///
+    /// The remote counterpart of `EntryFeatures::reclaimable_bytes`
+    /// (kunobi-ninja/kache#608).
+    fn reclaimable(&self, shared: &BTreeMap<String, SharedPack>) -> u64 {
+        let unique: u64 = self
+            .digests
+            .iter()
+            .filter_map(|digest| shared.get(digest))
+            .filter(|pack| pack.refs <= 1)
+            .map(|pack| pack.bytes)
+            .sum();
+        self.bytes.saturating_add(unique)
+    }
+
+    fn features(&self, shared: &BTreeMap<String, SharedPack>) -> EntryFeatures {
+        EntryFeatures {
+            key: self.id.clone(),
+            size: i64::try_from(self.bytes).unwrap_or(i64::MAX),
+            // A remote has no hit counter. Holding it at zero for every group
+            // reduces `size_pressure_score` to `1 / (idle * reclaimable_mb)`,
+            // which is exactly the least-recently-read-first ranking #774 asks
+            // for, with the same marginal-bytes tiebreak the local sweep uses.
+            hit_count: 0,
+            idle_hours: self.idle.as_secs_f64() / 3600.0,
+            content_hash: None,
+            committed: true,
+            // No rebuild-cost signal crosses the remote boundary: the v3
+            // manifest does not carry `compile_time_ms` (see #594).
+            compile_time_ms: 0,
+            reclaimable_bytes: Some(i64::try_from(self.reclaimable(shared)).unwrap_or(i64::MAX)),
+        }
+    }
+}
+
+/// Everything one pass over the remote observed.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RemoteScan {
+    /// Every regular file under the prefix, including objects the sweep will
+    /// never evict. The budget is a statement about folder size, so it has to
+    /// count what is actually there.
+    pub total_bytes: u64,
+    pub object_count: usize,
+    pub groups: Vec<RemoteGroup>,
+    pub orphans: Vec<RemoteOrphan>,
+    pub shared: BTreeMap<String, SharedPack>,
+    /// Bytes under the prefix that belong to no evictable unit.
+    pub unclassified_bytes: u64,
+    /// Whether any object showed an access time later than its write time. When
+    /// false the mount is not recording reads (`noatime`), or nothing has been
+    /// read yet, and the ranking is really by write time.
+    pub atime_advanced: bool,
+}
+
+/// A victim the plan selected, with the objects the sweep will unlink for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PlannedVictim {
+    pub id: String,
+    /// The group's own objects, then any shared pack whose last reference it
+    /// held.
+    pub objects: Vec<PathBuf>,
+    pub freed: u64,
+}
+
+/// What a sweep would do, computed without touching the filesystem.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RemotePlan {
+    pub total_bytes: u64,
+    pub object_count: usize,
+    /// `None` when the remote is explicitly unbounded.
+    pub budget: Option<u64>,
+    /// Low edge of the hysteresis band the sweep evicts down to.
+    pub target: Option<u64>,
+    pub orphans: Vec<RemoteOrphan>,
+    pub victims: Vec<PlannedVictim>,
+    /// Groups the ranking selected but the recency grace protected.
+    pub pinned: usize,
+    /// Measured size once the plan is applied.
+    pub projected_bytes: u64,
+    pub atime_advanced: bool,
+}
+
+impl RemotePlan {
+    pub(crate) fn bytes_freed(&self) -> u64 {
+        let orphaned: u64 = self.orphans.iter().map(|o| o.bytes).sum();
+        let evicted: u64 = self.victims.iter().map(|v| v.freed).sum();
+        orphaned.saturating_add(evicted)
+    }
+
+    /// Whether the plan leaves the remote still over its budget. Reported
+    /// rather than retried: the residue is groups the grace pinned or bytes no
+    /// evictable unit owns, and a second pass would not shift either.
+    pub(crate) fn still_over_budget(&self) -> bool {
+        self.budget
+            .is_some_and(|budget| self.projected_bytes > budget)
+    }
+}
+
+/// What a sweep actually did.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct RemoteGcStats {
+    pub groups_evicted: usize,
+    pub orphans_removed: usize,
+    pub objects_removed: usize,
+    pub bytes_freed: u64,
+    /// Objects the plan named that could not be unlinked — a peer deleted them
+    /// first, or, on Windows, a reader still holds the handle open. Both are
+    /// benign: the next sweep sees the state that is actually there.
+    pub delete_failures: usize,
+}
+
+/// Time since `observed`, clamped at zero so clock skew between the machines
+/// sharing a remote cannot report a negative idle.
+fn idle_since(now: SystemTime, observed: SystemTime) -> Duration {
+    now.duration_since(observed).unwrap_or(Duration::ZERO)
+}
+
+/// The most recent thing we can prove happened to a file.
+///
+/// `max(atime, mtime)`. See the module docs: read recency where the mount
+/// records reads, write recency where it does not, never older than the write.
+fn observed_access(
+    accessed: Option<SystemTime>,
+    modified: Option<SystemTime>,
+) -> Option<SystemTime> {
+    match (accessed, modified) {
+        (Some(a), Some(m)) => Some(a.max(m)),
+        (Some(a), None) => Some(a),
+        (None, Some(m)) => Some(m),
+        (None, None) => None,
+    }
+}
+
+/// Whether this file's access time is evidence that the mount records reads.
+fn atime_is_advanced(accessed: Option<SystemTime>, modified: Option<SystemTime>) -> bool {
+    matches!((accessed, modified), (Some(a), Some(m)) if a > m)
+}
+
+/// A v4 catalog's contribution to the reference count.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CatalogRead {
+    /// Not a catalog at all.
+    None,
+    /// The pack digests this catalog references.
+    Digests(Vec<String>),
+    /// A catalog that could not be read or parsed. It may hold the only
+    /// reference to a pack, so the pass fails closed and orphans nothing in the
+    /// v4 tree.
+    Unreadable,
+}
+
+/// One file the scan found, before classification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ScannedFile {
+    /// Path relative to the prefix root, with `/` separators.
+    key: String,
+    path: PathBuf,
+    bytes: u64,
+    idle: Duration,
+    catalog: CatalogRead,
+}
+
+/// How a key maps onto the remote layout.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Classified {
+    V3Manifest { unit: String },
+    V3Pack { unit: String },
+    V4Catalog,
+    V4PrefetchPack { digest: String },
+    V4PrefetchPackMeta { digest: String },
+    Other,
+}
+
+/// Classify a prefix-relative key. Pure, so every layout branch is testable
+/// without materializing a remote.
+fn classify(key: &str) -> Classified {
+    if let Some(rest) = key.strip_prefix("v3/manifests/")
+        && let Some((crate_name, cache_key)) = rest.rsplit_once('/')
+        && let Some(cache_key) = cache_key.strip_suffix(".json")
+        && !crate_name.contains('/')
+    {
+        return Classified::V3Manifest {
+            unit: format!("{crate_name}/{cache_key}"),
+        };
+    }
+    if let Some(rest) = key.strip_prefix("v3/packs/")
+        && let Some((crate_name, cache_key)) = rest.rsplit_once('/')
+        && let Some(cache_key) = cache_key.strip_suffix(".tar.zst")
+        && !crate_name.contains('/')
+    {
+        return Classified::V3Pack {
+            unit: format!("{crate_name}/{cache_key}"),
+        };
+    }
+    if key.starts_with("v4/prefetch/catalogs/") && key.ends_with(".json") {
+        return Classified::V4Catalog;
+    }
+    if let Some(rest) = key.strip_prefix("v4/prefetch/packs/")
+        && let Some((shard, file)) = rest.rsplit_once('/')
+        && let Some(digest) = file.strip_suffix(".kpack")
+        && !shard.contains('/')
+    {
+        return Classified::V4PrefetchPack {
+            digest: digest.to_string(),
+        };
+    }
+    if let Some(rest) = key.strip_prefix("v4/prefetch/pack-meta/")
+        && let Some(digest) = rest.strip_suffix(".json")
+        && !digest.contains('/')
+    {
+        return Classified::V4PrefetchPackMeta {
+            digest: digest.to_string(),
+        };
+    }
+    Classified::Other
+}
+
+/// Just enough of a catalog to count references.
+///
+/// Deliberately not `remote_pack::PackCatalog`: that type is
+/// `deny_unknown_fields` and is validated against a selector and an expiry,
+/// neither of which a sweep may apply. An expired catalog still pins its packs
+/// until it is itself evicted, and a catalog written by a newer kache with an
+/// extra field must not read as unparseable and suppress the whole v4 sweep.
+#[derive(Debug, Deserialize)]
+struct CatalogRefs {
+    packs: Vec<CatalogPackRef>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CatalogPackRef {
+    digest: String,
+}
+
+fn catalog_digests(body: &[u8]) -> Result<Vec<String>> {
+    let catalog: CatalogRefs =
+        serde_json::from_slice(body).context("parsing prefetch catalog references")?;
+    Ok(catalog.packs.into_iter().map(|pack| pack.digest).collect())
+}
+
+/// Walk `dir` collecting every regular file, skipping `excluded` subtrees.
+///
+/// Per-entry errors are skipped rather than propagated: a shared remote written
+/// by two uids routinely has a directory one of them cannot read, and a sweep
+/// that refuses to run at all is worse than one that bounds what it can see.
+/// Symlinks are never followed and never counted — following one would let a
+/// symlink planted in the shared folder aim the sweep's unlinks outside the
+/// remote, the same escalation `verify_write_containment` guards the write path
+/// against.
+fn walk_files(dir: &Path, excluded: &[PathBuf], out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if excluded.contains(&path) {
+            continue;
+        }
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            walk_files(&path, excluded, out);
+        } else if file_type.is_file() {
+            out.push(path);
+        }
+    }
+}
+
+/// Measure a filesystem remote and classify everything under its prefix.
+pub(crate) fn scan(
+    remote: &FilesystemRemoteConfig,
+    prefix: &str,
+    now: SystemTime,
+) -> Result<RemoteScan> {
+    let prefix_root = if prefix.is_empty() {
+        remote.root.clone()
+    } else {
+        remote.root.join(prefix)
+    };
+    let excluded = vec![
+        remote.atomic_write_dir.clone(),
+        remote.root.join(REMOTE_GC_LOCK_FILE),
+    ];
+
+    let mut paths = Vec::new();
+    walk_files(&prefix_root, &excluded, &mut paths);
+
+    let mut files = Vec::with_capacity(paths.len());
+    let mut total_bytes = 0u64;
+    let mut object_count = 0usize;
+    let mut atime_advanced = false;
+
+    for path in paths {
+        // `symlink_metadata` so a symlink is measured as the link, never as its
+        // target; `walk_files` already refused to emit one.
+        let Ok(meta) = path.symlink_metadata() else {
+            continue;
+        };
+        let bytes = meta.len();
+        total_bytes = total_bytes.saturating_add(bytes);
+        object_count += 1;
+
+        let accessed = meta.accessed().ok();
+        let modified = meta.modified().ok();
+        atime_advanced |= atime_is_advanced(accessed, modified);
+        let idle = observed_access(accessed, modified)
+            .map(|observed| idle_since(now, observed))
+            // No timestamp at all: treat it as just touched, so the sweep never
+            // evicts something it could not date.
+            .unwrap_or(Duration::ZERO);
+
+        // A key that is not UTF-8 belongs to no eviction unit. Its bytes stay in
+        // `total_bytes` — the budget is about folder size — but nothing can
+        // select it, so the sweep leaves it alone.
+        let Some(key) = relative_key(&prefix_root, &path) else {
+            continue;
+        };
+        let catalog = if classify(&key) == Classified::V4Catalog {
+            match std::fs::read(&path)
+                .context("reading prefetch catalog")
+                .and_then(|body| catalog_digests(&body))
+            {
+                Ok(digests) => CatalogRead::Digests(digests),
+                Err(error) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        "unreadable prefetch catalog ({error:#}); \
+                         not orphaning any prefetch pack this pass"
+                    );
+                    CatalogRead::Unreadable
+                }
+            }
+        } else {
+            CatalogRead::None
+        };
+        files.push(ScannedFile {
+            key,
+            path,
+            bytes,
+            idle,
+            catalog,
+        });
+    }
+
+    let mut scan = assemble(files);
+    scan.total_bytes = total_bytes;
+    scan.object_count = object_count;
+    scan.atime_advanced = atime_advanced;
+    Ok(scan)
+}
+
+/// Prefix-relative key with `/` separators, or `None` when the path is not
+/// under the prefix or is not representable as UTF-8 (the transport rejects
+/// such keys on write, so nothing kache published can hit this).
+fn relative_key(prefix_root: &Path, path: &Path) -> Option<String> {
+    let relative = path.strip_prefix(prefix_root).ok()?;
+    let mut parts = Vec::new();
+    for component in relative.components() {
+        parts.push(component.as_os_str().to_str()?);
+    }
+    Some(parts.join("/"))
+}
+
+/// Group classified files into eviction units.
+///
+/// Pure over its input, so the pairing, reference counting, and orphan rules are
+/// testable without a filesystem. Leaves `total_bytes`, `object_count`, and
+/// `atime_advanced` for [`scan`] to fill: those describe every file under the
+/// prefix, including ones no unit claims.
+fn assemble(files: Vec<ScannedFile>) -> RemoteScan {
+    #[derive(Default)]
+    struct V3Unit {
+        manifest: Option<ScannedFile>,
+        pack: Option<ScannedFile>,
+    }
+
+    let mut scan = RemoteScan::default();
+    let mut v3: BTreeMap<String, V3Unit> = BTreeMap::new();
+    let mut catalogs: Vec<(ScannedFile, Vec<String>)> = Vec::new();
+    let mut unreadable_catalog = false;
+
+    for file in files {
+        match classify(&file.key) {
+            Classified::V3Manifest { unit } => {
+                v3.entry(unit).or_default().manifest = Some(file);
+            }
+            Classified::V3Pack { unit } => {
+                v3.entry(unit).or_default().pack = Some(file);
+            }
+            Classified::V4Catalog => match &file.catalog {
+                CatalogRead::Digests(digests) => {
+                    let digests = digests.clone();
+                    catalogs.push((file, digests));
+                }
+                // An unreadable catalog is not an eviction unit and its bytes
+                // are not reclaimable, so it counts as unclassified.
+                CatalogRead::Unreadable | CatalogRead::None => {
+                    unreadable_catalog = true;
+                    scan.unclassified_bytes = scan.unclassified_bytes.saturating_add(file.bytes);
+                }
+            },
+            Classified::V4PrefetchPack { digest } | Classified::V4PrefetchPackMeta { digest } => {
+                let shared = scan.shared.entry(digest).or_default();
+                shared.bytes = shared.bytes.saturating_add(file.bytes);
+                shared.objects.push((file.path, file.bytes));
+            }
+            Classified::Other => {
+                scan.unclassified_bytes = scan.unclassified_bytes.saturating_add(file.bytes);
+            }
+        }
+    }
+
+    for (unit, pair) in v3 {
+        match (pair.manifest, pair.pack) {
+            (Some(manifest), Some(pack)) => scan.groups.push(RemoteGroup {
+                id: format!("v3:{unit}"),
+                // Manifest first: an interrupted sweep must never leave a
+                // manifest without its pack (#774).
+                objects: vec![manifest.path, pack.path],
+                bytes: manifest.bytes.saturating_add(pack.bytes),
+                digests: Vec::new(),
+                // As idle as its freshest half: reading the pack keeps the
+                // entry alive even though the manifest is only listed.
+                idle: manifest.idle.min(pack.idle),
+            }),
+            (Some(half), None) => push_orphan(&mut scan, half, OrphanReason::ManifestWithoutPack),
+            (None, Some(half)) => push_orphan(&mut scan, half, OrphanReason::PackWithoutManifest),
+            (None, None) => unreachable!("a v3 unit exists only because a file created it"),
+        }
+    }
+
+    for (catalog, digests) in catalogs {
+        for digest in &digests {
+            if let Some(shared) = scan.shared.get_mut(digest) {
+                shared.refs += 1;
+            }
+        }
+        scan.groups.push(RemoteGroup {
+            id: format!("v4:{}", catalog.key),
+            objects: vec![catalog.path],
+            bytes: catalog.bytes,
+            digests,
+            idle: catalog.idle,
+        });
+    }
+
+    if !unreadable_catalog {
+        let unreferenced: Vec<RemoteOrphan> = scan
+            .shared
+            .values()
+            .filter(|pack| pack.refs == 0)
+            .flat_map(|pack| pack.objects.iter())
+            .map(|(path, bytes)| RemoteOrphan {
+                path: path.clone(),
+                bytes: *bytes,
+                reason: OrphanReason::UnreferencedPrefetchPack,
+            })
+            .collect();
+        scan.orphans.extend(unreferenced);
+    }
+
+    scan
+}
+
+/// Record `file` as an orphan, unless it is young enough to belong to a publish
+/// still in flight — in which case its bytes just count toward the total.
+fn push_orphan(scan: &mut RemoteScan, file: ScannedFile, reason: OrphanReason) {
+    if file.idle < REMOTE_ORPHAN_GRACE {
+        scan.unclassified_bytes = scan.unclassified_bytes.saturating_add(file.bytes);
+        return;
+    }
+    scan.orphans.push(RemoteOrphan {
+        path: file.path,
+        bytes: file.bytes,
+        reason,
+    });
+}
+
+/// Decide what to evict. Pure: no filesystem access, so the ranking, the budget
+/// arithmetic, the recency pin, and shared-pack reference counting are all
+/// directly testable.
+pub(crate) fn plan(scan: &RemoteScan, budget: Option<u64>) -> RemotePlan {
+    let orphans = scan.orphans.clone();
+    let orphaned: u64 = orphans.iter().map(|o| o.bytes).sum();
+    let mut remaining = scan.total_bytes.saturating_sub(orphaned);
+
+    let mut plan = RemotePlan {
+        total_bytes: scan.total_bytes,
+        object_count: scan.object_count,
+        budget,
+        target: budget.map(eviction_target),
+        orphans,
+        victims: Vec::new(),
+        pinned: 0,
+        projected_bytes: remaining,
+        atime_advanced: scan.atime_advanced,
+    };
+
+    // Removing orphans is repair, not budget enforcement, so it happens even on
+    // an unbounded remote. Ranked eviction needs a cap to aim at.
+    let (Some(budget), Some(target)) = (budget, plan.target) else {
+        return plan;
+    };
+    if !crate::eviction::over_eviction_trigger(remaining, budget) {
+        return plan;
+    }
+
+    let by_id: BTreeMap<&str, &RemoteGroup> =
+        scan.groups.iter().map(|g| (g.id.as_str(), g)).collect();
+    let features: Vec<EntryFeatures> = scan
+        .groups
+        .iter()
+        .map(|group| group.features(&scan.shared))
+        .collect();
+
+    // Live reference counts, decremented as catalogs are selected, so the last
+    // catalog naming a shared pack is the one that actually frees it.
+    let mut refs: BTreeMap<&str, usize> = scan
+        .shared
+        .iter()
+        .map(|(digest, pack)| (digest.as_str(), pack.refs))
+        .collect();
+
+    for id in SizePressurePolicy.select(&features) {
+        if remaining <= target {
+            break;
+        }
+        let Some(group) = by_id.get(id.as_str()) else {
+            continue;
+        };
+        if group.idle < REMOTE_EVICTION_IDLE_GRACE {
+            plan.pinned += 1;
+            continue;
+        }
+
+        let mut objects = group.objects.clone();
+        let mut freed = group.bytes;
+        for digest in &group.digests {
+            let Some(count) = refs.get_mut(digest.as_str()) else {
+                continue;
+            };
+            *count = count.saturating_sub(1);
+            if *count == 0
+                && let Some(pack) = scan.shared.get(digest)
+            {
+                objects.extend(pack.objects.iter().map(|(path, _)| path.clone()));
+                freed = freed.saturating_add(pack.bytes);
+            }
+        }
+
+        remaining = remaining.saturating_sub(freed);
+        plan.victims.push(PlannedVictim {
+            id: group.id.clone(),
+            objects,
+            freed,
+        });
+    }
+
+    plan.projected_bytes = remaining;
+    plan
+}
+
+/// Unlink everything the plan named.
+///
+/// A failed unlink is counted and stepped over, never propagated. On POSIX the
+/// realistic cause is a peer that already removed the object; on Windows it is a
+/// reader holding the handle open, which is precisely the object we must not
+/// remove. Either way the next sweep re-measures.
+pub(crate) fn apply(plan: &RemotePlan) -> RemoteGcStats {
+    let mut stats = RemoteGcStats::default();
+    for orphan in &plan.orphans {
+        if unlink(&orphan.path) {
+            stats.orphans_removed += 1;
+            stats.objects_removed += 1;
+            stats.bytes_freed = stats.bytes_freed.saturating_add(orphan.bytes);
+        } else {
+            stats.delete_failures += 1;
+        }
+    }
+    for victim in &plan.victims {
+        let mut removed_any = false;
+        for path in &victim.objects {
+            if unlink(path) {
+                stats.objects_removed += 1;
+                removed_any = true;
+            } else {
+                stats.delete_failures += 1;
+            }
+        }
+        if removed_any {
+            stats.groups_evicted += 1;
+            stats.bytes_freed = stats.bytes_freed.saturating_add(victim.freed);
+        }
+    }
+    stats
+}
+
+/// `true` when the object is gone afterwards, including when a peer had already
+/// removed it.
+fn unlink(path: &Path) -> bool {
+    match std::fs::remove_file(path) {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+        Err(error) => {
+            tracing::debug!(path = %path.display(), "remote GC could not unlink: {error}");
+            false
+        }
+    }
+}
+
+/// The cross-machine advisory lock for a remote sweep, or `None` when a peer
+/// holds it.
+///
+/// The same mechanism as `Store::try_gc_lock` — [`StoreLock`](crate::store::StoreLock),
+/// `flock(2)` on Unix and `LockFileEx` on Windows, released by the OS when the
+/// holder exits — just anchored in the shared folder instead of the local store.
+/// Two machines collecting at once is the default case for a filesystem remote,
+/// not an edge case.
+///
+/// **Known limitation.** `flock(2)` only spans machines where the filesystem
+/// implements it: it does on a local disk and on a correctly configured NFSv4 or
+/// SMB mount, and silently does not on NFSv3 without `lockd` or on some FUSE
+/// mounts. `cache_fs` already states that a shared remote needs working
+/// POSIX/`LockFileEx` locking between its participants. Where the lock is a
+/// no-op, two concurrent sweeps each plan against a snapshot the other is
+/// deleting from; the failure mode is over-eviction and wasted unlinks — both
+/// rank the same cold tail, so together they take more of it than either
+/// intended — never a torn object and never a manifest left without its pack,
+/// because every unlink is of one whole immutable object and the order within a
+/// unit does not depend on the two sweeps agreeing.
+pub(crate) fn try_lock(remote: &FilesystemRemoteConfig) -> Result<Option<crate::store::StoreLock>> {
+    crate::store::StoreLock::try_acquire(&remote.root.join(REMOTE_GC_LOCK_FILE))
+}
+
+/// Volume size behind the remote root, for the derived budget.
+pub(crate) fn volume_bytes(remote: &FilesystemRemoteConfig) -> Option<u64> {
+    crate::cache_fs::probe(&remote.root).total_bytes
+}
+
+/// The remote's effective cap in bytes, or `None` when it is unbounded.
+pub(crate) fn resolve_budget(remote: &FilesystemRemoteConfig) -> Option<u64> {
+    remote.budget.resolve(volume_bytes(remote))
+}
+
+/// How the budget was arrived at, for `kache gc --remote` to print.
+pub(crate) fn describe_budget(remote: &FilesystemRemoteConfig) -> String {
+    crate::config::describe_remote_budget(remote.budget, volume_bytes(remote))
+}
+
+/// The warning a sweep prints when read recency is not observable, or `None`
+/// when it is.
+pub(crate) fn atime_advisory(scan: &RemoteScan) -> Option<&'static str> {
+    (!scan.atime_advanced && scan.object_count > 0).then_some(
+        "no object shows a read newer than its write, so this remote is probably mounted \
+         noatime and eviction is ranking by WRITE time, not read time. Remount relatime to \
+         rank by read recency, or set an explicit max_size you are comfortable with.",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RemoteBudget;
+
+    const HOUR: Duration = Duration::from_secs(3600);
+
+    fn file(key: &str, bytes: u64, idle: Duration) -> ScannedFile {
+        ScannedFile {
+            key: key.to_string(),
+            path: PathBuf::from("/remote").join(key),
+            bytes,
+            idle,
+            catalog: CatalogRead::None,
+        }
+    }
+
+    fn catalog(key: &str, bytes: u64, idle: Duration, digests: &[&str]) -> ScannedFile {
+        ScannedFile {
+            catalog: CatalogRead::Digests(digests.iter().map(|d| d.to_string()).collect()),
+            ..file(key, bytes, idle)
+        }
+    }
+
+    fn v3_unit(crate_name: &str, cache_key: &str, bytes: u64, idle: Duration) -> Vec<ScannedFile> {
+        vec![
+            file(
+                &format!("v3/manifests/{crate_name}/{cache_key}.json"),
+                256,
+                idle,
+            ),
+            file(
+                &format!("v3/packs/{crate_name}/{cache_key}.tar.zst"),
+                bytes,
+                idle,
+            ),
+        ]
+    }
+
+    /// Mirror what [`scan`] fills in around [`assemble`], so tests can work on
+    /// synthetic files.
+    fn scan_of(files: Vec<ScannedFile>) -> RemoteScan {
+        let total_bytes = files.iter().map(|f| f.bytes).sum();
+        let object_count = files.len();
+        RemoteScan {
+            total_bytes,
+            object_count,
+            ..assemble(files)
+        }
+    }
+
+    fn test_remote(root: &Path, budget: RemoteBudget) -> FilesystemRemoteConfig {
+        FilesystemRemoteConfig {
+            root: root.to_path_buf(),
+            atomic_write_dir: root.join(".kache-tmp"),
+            budget,
+        }
+    }
+
+    // ── layout classification ───────────────────────────────────────────────
+
+    #[test]
+    fn classify_maps_each_layout_tree_to_its_eviction_unit() {
+        assert_eq!(
+            classify("v3/manifests/serde/abc123.json"),
+            Classified::V3Manifest {
+                unit: "serde/abc123".to_string()
+            }
+        );
+        assert_eq!(
+            classify("v3/packs/serde/abc123.tar.zst"),
+            Classified::V3Pack {
+                unit: "serde/abc123".to_string()
+            }
+        );
+        assert_eq!(
+            classify("v4/prefetch/catalogs/aa/0001-bb.json"),
+            Classified::V4Catalog
+        );
+        assert_eq!(
+            classify("v4/prefetch/packs/ab/abcdef.kpack"),
+            Classified::V4PrefetchPack {
+                digest: "abcdef".to_string()
+            }
+        );
+        assert_eq!(
+            classify("v4/prefetch/pack-meta/abcdef.json"),
+            Classified::V4PrefetchPackMeta {
+                digest: "abcdef".to_string()
+            }
+        );
+    }
+
+    /// Anything the layout does not produce is counted but never evicted —
+    /// including build manifests and shards, which every prefetch plan starts
+    /// from.
+    #[test]
+    fn classify_leaves_unknown_and_malformed_keys_alone() {
+        for key in [
+            "_manifests/v3/ns/shards/deadbeef.json",
+            "_manifests/build-key.json",
+            "v3/packs/serde/abc123.tar",
+            "v3/manifests/abc123.json",
+            "v3/manifests/a/b/c.json",
+            "v3/packs/a/b/c.tar.zst",
+            "v4/prefetch/packs/abcdef.kpack",
+            "v4/prefetch/packs/a/b/c.kpack",
+            "v4/prefetch/pack-meta/ab/cdef.json",
+            "v4/prefetch/catalogs/aa/0001-bb.tmp",
+            REMOTE_GC_LOCK_FILE,
+            "",
+        ] {
+            assert_eq!(classify(key), Classified::Other, "{key}");
+        }
+    }
+
+    /// The manifest and the pack of one entry land in a single group, with the
+    /// manifest unlinked first (#774: never leave a manifest without its pack).
+    #[test]
+    fn a_v3_entry_is_one_group_that_drops_its_manifest_first() {
+        let scan = scan_of(v3_unit("serde", "abc", 10_000, 100 * HOUR));
+        assert_eq!(scan.groups.len(), 1);
+        let group = &scan.groups[0];
+        assert_eq!(group.id, "v3:serde/abc");
+        assert_eq!(group.bytes, 10_256);
+        assert!(group.digests.is_empty());
+        assert_eq!(
+            group.objects,
+            vec![
+                PathBuf::from("/remote/v3/manifests/serde/abc.json"),
+                PathBuf::from("/remote/v3/packs/serde/abc.tar.zst"),
+            ]
+        );
+        assert!(scan.orphans.is_empty());
+    }
+
+    /// A group is only as idle as its *most recently* touched object: reading
+    /// the pack keeps the entry alive even when the manifest is never re-read.
+    #[test]
+    fn a_v3_group_takes_the_freshest_of_its_objects() {
+        let mut files = v3_unit("serde", "abc", 10_000, 500 * HOUR);
+        files[1].idle = 2 * HOUR;
+        assert_eq!(scan_of(files).groups[0].idle, 2 * HOUR);
+
+        let mut reversed = v3_unit("serde", "abc", 10_000, 500 * HOUR);
+        reversed[0].idle = 3 * HOUR;
+        assert_eq!(scan_of(reversed).groups[0].idle, 3 * HOUR);
+    }
+
+    // ── orphan repair ───────────────────────────────────────────────────────
+
+    #[test]
+    fn a_stale_half_of_a_v3_entry_is_an_orphan_in_either_direction() {
+        let manifest_only = scan_of(vec![file("v3/manifests/serde/a.json", 200, 100 * HOUR)]);
+        assert_eq!(manifest_only.orphans.len(), 1);
+        assert_eq!(
+            manifest_only.orphans[0].reason,
+            OrphanReason::ManifestWithoutPack
+        );
+        assert_eq!(manifest_only.orphans[0].bytes, 200);
+
+        let pack_only = scan_of(vec![file("v3/packs/serde/a.tar.zst", 900, 100 * HOUR)]);
+        assert_eq!(pack_only.orphans.len(), 1);
+        assert_eq!(
+            pack_only.orphans[0].reason,
+            OrphanReason::PackWithoutManifest
+        );
+        assert_eq!(pack_only.orphans[0].bytes, 900);
+        assert!(pack_only.groups.is_empty());
+    }
+
+    /// An upload writes the pack and only then the manifest, so a fresh
+    /// unpaired pack belongs to a build in flight and must survive.
+    #[test]
+    fn a_fresh_unpaired_pack_is_spared_by_the_publish_grace() {
+        let fresh = scan_of(vec![file(
+            "v3/packs/serde/a.tar.zst",
+            900,
+            REMOTE_ORPHAN_GRACE - Duration::from_secs(1),
+        )]);
+        assert!(
+            fresh.orphans.is_empty(),
+            "an in-flight publish must not be swept"
+        );
+        assert_eq!(fresh.unclassified_bytes, 900);
+
+        let aged = scan_of(vec![file(
+            "v3/packs/serde/a.tar.zst",
+            900,
+            REMOTE_ORPHAN_GRACE,
+        )]);
+        assert_eq!(
+            aged.orphans.len(),
+            1,
+            "at the grace boundary it is an orphan"
+        );
+        assert_eq!(aged.unclassified_bytes, 0);
+    }
+
+    #[test]
+    fn orphan_reasons_are_labelled_distinctly() {
+        let labels = [
+            OrphanReason::PackWithoutManifest.label(),
+            OrphanReason::ManifestWithoutPack.label(),
+            OrphanReason::UnreferencedPrefetchPack.label(),
+        ];
+        assert_eq!(
+            labels
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            3
+        );
+    }
+
+    /// Pins the translation into the local store's vocabulary field by field:
+    /// the ranking is `SizePressurePolicy`'s, so anything set wrong here quietly
+    /// changes what a remote sweep prefers.
+    #[test]
+    fn features_describe_a_group_in_the_local_eviction_vocabulary() {
+        let mut shared = BTreeMap::new();
+        shared.insert(
+            "sole".to_string(),
+            SharedPack {
+                objects: vec![(PathBuf::from("/remote/sole.kpack"), 4_096)],
+                bytes: 4_096,
+                refs: 1,
+            },
+        );
+        let group = RemoteGroup {
+            id: "v4:cat".into(),
+            objects: vec![PathBuf::from("/remote/cat.json")],
+            bytes: 1_024,
+            digests: vec!["sole".into()],
+            idle: 2 * HOUR,
+        };
+
+        let features = group.features(&shared);
+        assert_eq!(features.key, "v4:cat");
+        assert_eq!(features.size, 1_024);
+        assert_eq!(features.hit_count, 0, "a remote has no hit counter");
+        assert_eq!(features.idle_hours, 2.0, "idle is expressed in hours");
+        assert_eq!(features.compile_time_ms, 0);
+        assert!(features.committed);
+        assert_eq!(features.content_hash, None);
+        assert_eq!(features.reclaimable_bytes, Some(5_120));
+    }
+
+    // ── the budget ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn still_over_budget_is_strict_and_silent_without_a_budget() {
+        let at_the_line = RemotePlan {
+            budget: Some(100),
+            projected_bytes: 100,
+            ..RemotePlan::default()
+        };
+        assert!(
+            !at_the_line.still_over_budget(),
+            "exactly at the cap is fine"
+        );
+        assert!(
+            RemotePlan {
+                projected_bytes: 101,
+                ..at_the_line.clone()
+            }
+            .still_over_budget()
+        );
+        assert!(
+            !RemotePlan {
+                budget: None,
+                ..at_the_line
+            }
+            .still_over_budget()
+        );
+    }
+
+    /// The walk stops the moment it reaches the target, not one group later.
+    #[test]
+    fn a_sweep_stops_exactly_when_it_reaches_the_target() {
+        // Two groups, 110 + 90 bytes (plus 256 of manifest each). Budget 100
+        // targets 90, and evicting only the larger group lands on it exactly.
+        let mut files = v3_unit("a", "big", 110, 900 * HOUR);
+        files.extend(v3_unit("a", "small", 90, 800 * HOUR));
+        // Trim the manifests so the arithmetic is the two numbers above.
+        for f in &mut files {
+            if f.key.contains("manifests") {
+                f.bytes = 0;
+            }
+        }
+        let scan = scan_of(files);
+        assert_eq!(scan.total_bytes, 200);
+
+        let outcome = plan(&scan, Some(100));
+        assert_eq!(outcome.target, Some(90));
+        assert_eq!(
+            outcome.victims.len(),
+            1,
+            "landing exactly on the target must end the walk"
+        );
+        assert_eq!(outcome.projected_bytes, 90);
+    }
+
+    #[test]
+    fn an_unbounded_remote_still_repairs_orphans_but_evicts_nothing() {
+        let mut files = v3_unit("serde", "hot", 10_000, 1000 * HOUR);
+        files.push(file("v3/packs/serde/dead.tar.zst", 5_000, 1000 * HOUR));
+        let scan = scan_of(files);
+
+        let outcome = plan(&scan, None);
+        assert!(
+            outcome.victims.is_empty(),
+            "no cap means no ranked eviction"
+        );
+        assert_eq!(outcome.target, None);
+        assert_eq!(outcome.orphans.len(), 1);
+        assert_eq!(outcome.bytes_freed(), 5_000);
+        assert_eq!(outcome.projected_bytes, 10_256);
+        assert!(!outcome.still_over_budget());
+    }
+
+    #[test]
+    fn a_remote_under_its_budget_evicts_nothing() {
+        let scan = scan_of(v3_unit("serde", "a", 10_000, 1000 * HOUR));
+        let outcome = plan(&scan, Some(1_000_000));
+        assert!(outcome.victims.is_empty());
+        assert_eq!(outcome.projected_bytes, scan.total_bytes);
+        assert!(!outcome.still_over_budget());
+    }
+
+    /// The sweep fires above the cap and stops at the 90% target, inheriting the
+    /// local store's hysteresis band rather than parking on the line.
+    #[test]
+    fn a_sweep_stops_at_the_hysteresis_target_not_the_cap() {
+        let mut files = Vec::new();
+        for i in 0..10u32 {
+            files.extend(v3_unit(
+                "serde",
+                &format!("k{i}"),
+                100_000,
+                HOUR * (1000 - i),
+            ));
+        }
+        let scan = scan_of(files);
+        let budget = 700_000;
+        let outcome = plan(&scan, Some(budget));
+
+        assert_eq!(outcome.target, Some(eviction_target(budget)));
+        assert!(outcome.projected_bytes <= eviction_target(budget));
+        assert!(outcome.projected_bytes <= budget);
+        // It stops as soon as it is under: dropping the last victim would have
+        // left it above the target.
+        let last = outcome.victims.last().expect("at least one victim");
+        assert!(outcome.projected_bytes + last.freed > eviction_target(budget));
+    }
+
+    /// Least-recently-read first. Every group is the same size, so idle time is
+    /// the only thing separating them.
+    #[test]
+    fn ranking_evicts_the_least_recently_read_first() {
+        let mut files = Vec::new();
+        files.extend(v3_unit("a", "coldest", 100_000, 900 * HOUR));
+        files.extend(v3_unit("a", "warm", 100_000, 100 * HOUR));
+        files.extend(v3_unit("a", "hottest", 100_000, 30 * HOUR));
+        let scan = scan_of(files);
+
+        let outcome = plan(&scan, Some(200_000));
+        let ids: Vec<&str> = outcome.victims.iter().map(|v| v.id.as_str()).collect();
+        assert_eq!(ids, vec!["v3:a/coldest", "v3:a/warm"]);
+    }
+
+    /// Between two equally cold groups the bigger one goes first: a
+    /// size-pressure sweep exists to free bytes.
+    #[test]
+    fn ranking_prefers_the_bigger_of_two_equally_cold_groups() {
+        let mut files = Vec::new();
+        files.extend(v3_unit("a", "small", 10_000, 500 * HOUR));
+        files.extend(v3_unit("a", "big", 900_000, 500 * HOUR));
+        let scan = scan_of(files);
+
+        let outcome = plan(&scan, Some(500_000));
+        assert_eq!(
+            outcome.victims.first().map(|v| v.id.as_str()),
+            Some("v3:a/big")
+        );
+    }
+
+    /// A build may have listed a manifest and not yet issued the GET, so the
+    /// grace pins recently touched groups even when they rank worst.
+    #[test]
+    fn the_recency_grace_pins_a_group_a_live_build_may_be_restoring() {
+        let mut files = v3_unit("a", "inflight", 1_000_000, Duration::ZERO);
+        files.extend(v3_unit("a", "cold", 1_000, 900 * HOUR));
+        let scan = scan_of(files);
+
+        let outcome = plan(&scan, Some(1_000));
+        assert_eq!(outcome.pinned, 1);
+        assert!(
+            outcome.victims.iter().all(|v| v.id != "v3:a/inflight"),
+            "a group inside the grace window must never be selected"
+        );
+        assert!(
+            outcome.still_over_budget(),
+            "the residue must be reported, not hidden"
+        );
+    }
+
+    #[test]
+    fn the_recency_grace_boundary_is_the_remote_restore_deadline() {
+        let just_inside = scan_of(v3_unit(
+            "a",
+            "x",
+            1_000_000,
+            REMOTE_EVICTION_IDLE_GRACE - Duration::from_secs(1),
+        ));
+        let inside = plan(&just_inside, Some(1));
+        assert_eq!(inside.pinned, 1);
+        assert!(inside.victims.is_empty());
+
+        let just_outside = scan_of(v3_unit("a", "x", 1_000_000, REMOTE_EVICTION_IDLE_GRACE));
+        let outside = plan(&just_outside, Some(1));
+        assert_eq!(outside.pinned, 0);
+        assert_eq!(outside.victims.len(), 1);
+    }
+
+    // ── shared prefetch packs ───────────────────────────────────────────────
+
+    /// The case that makes reference counting necessary: two catalogs name one
+    /// content-addressed `.kpack`, so evicting the first catalog must leave the
+    /// pack alone and evicting the second must take it.
+    #[test]
+    fn a_prefetch_pack_shared_by_two_catalogs_survives_the_first_eviction() {
+        let shared_pack = PathBuf::from("/remote/v4/prefetch/packs/ab/abcd.kpack");
+        let scan = scan_of(vec![
+            file("v4/prefetch/packs/ab/abcd.kpack", 500_000, 900 * HOUR),
+            catalog(
+                "v4/prefetch/catalogs/s1/0001-aa.json",
+                1_000,
+                900 * HOUR,
+                &["abcd"],
+            ),
+            catalog(
+                "v4/prefetch/catalogs/s2/0002-bb.json",
+                1_000,
+                800 * HOUR,
+                &["abcd"],
+            ),
+        ]);
+        assert_eq!(scan.shared["abcd"].refs, 2);
+
+        let outcome = plan(&scan, Some(1_000));
+        assert_eq!(outcome.victims.len(), 2);
+        assert_eq!(
+            outcome.victims[0].id,
+            "v4:v4/prefetch/catalogs/s1/0001-aa.json"
+        );
+        assert_eq!(
+            outcome.victims[0].objects,
+            vec![PathBuf::from(
+                "/remote/v4/prefetch/catalogs/s1/0001-aa.json"
+            )],
+            "the shared pack must survive the first catalog that referenced it"
+        );
+        assert_eq!(outcome.victims[0].freed, 1_000);
+        assert!(
+            outcome.victims[1].objects.contains(&shared_pack),
+            "the last catalog referencing a pack takes it with it"
+        );
+        assert_eq!(outcome.victims[1].freed, 501_000);
+        assert_eq!(outcome.projected_bytes, 0);
+    }
+
+    /// Ranking sees the same thing: a catalog whose packs are all still shared
+    /// frees only its own bytes, so an equally cold catalog holding a sole
+    /// reference outranks it (kunobi-ninja/kache#608's marginal-bytes rule).
+    #[test]
+    fn a_catalog_holding_a_sole_reference_outranks_one_sharing_its_packs() {
+        let scan = scan_of(vec![
+            file("v4/prefetch/packs/aa/sole.kpack", 400_000, 900 * HOUR),
+            file("v4/prefetch/packs/bb/many.kpack", 400_000, 900 * HOUR),
+            catalog(
+                "v4/prefetch/catalogs/s1/0001-aa.json",
+                1_000,
+                500 * HOUR,
+                &["sole"],
+            ),
+            catalog(
+                "v4/prefetch/catalogs/s2/0002-bb.json",
+                1_000,
+                500 * HOUR,
+                &["many"],
+            ),
+            catalog(
+                "v4/prefetch/catalogs/s3/0003-cc.json",
+                1_000,
+                10 * HOUR,
+                &["many"],
+            ),
+        ]);
+
+        let sole = scan
+            .groups
+            .iter()
+            .find(|g| g.id.contains("0001"))
+            .expect("sole-reference catalog");
+        let many = scan
+            .groups
+            .iter()
+            .find(|g| g.id.contains("0002"))
+            .expect("shared-reference catalog");
+        assert_eq!(sole.reclaimable(&scan.shared), 401_000);
+        assert_eq!(
+            many.reclaimable(&scan.shared),
+            1_000,
+            "a catalog whose packs are still shared frees only itself"
+        );
+
+        let order =
+            SizePressurePolicy.select(&[many.features(&scan.shared), sole.features(&scan.shared)]);
+        assert_eq!(order, vec![sole.id.clone(), many.id.clone()]);
+    }
+
+    #[test]
+    fn a_catalog_registers_a_reference_and_its_pack_is_not_an_orphan() {
+        let scan = scan_of(vec![
+            file("v4/prefetch/packs/ab/abcd.kpack", 500_000, 900 * HOUR),
+            file("v4/prefetch/pack-meta/abcd.json", 100, 900 * HOUR),
+            catalog(
+                "v4/prefetch/catalogs/sel/0001-cc.json",
+                700,
+                900 * HOUR,
+                &["abcd"],
+            ),
+        ]);
+        assert_eq!(scan.shared["abcd"].refs, 1);
+        assert_eq!(scan.shared["abcd"].bytes, 500_100);
+        assert_eq!(scan.shared["abcd"].objects.len(), 2);
+        assert!(
+            scan.orphans.is_empty(),
+            "a referenced prefetch pack is not an orphan"
+        );
+        assert_eq!(scan.groups.len(), 1);
+        assert_eq!(scan.groups[0].digests, vec!["abcd".to_string()]);
+    }
+
+    /// Evicting the sole catalog takes the pack *and* its metadata sidecar.
+    #[test]
+    fn evicting_the_last_catalog_takes_the_pack_and_its_sidecar() {
+        let scan = scan_of(vec![
+            file("v4/prefetch/packs/ab/abcd.kpack", 500_000, 900 * HOUR),
+            file("v4/prefetch/pack-meta/abcd.json", 100, 900 * HOUR),
+            catalog(
+                "v4/prefetch/catalogs/sel/0001-cc.json",
+                700,
+                900 * HOUR,
+                &["abcd"],
+            ),
+        ]);
+        let outcome = plan(&scan, Some(1_000));
+        assert_eq!(outcome.victims.len(), 1);
+        assert_eq!(outcome.victims[0].objects.len(), 3);
+        assert_eq!(outcome.victims[0].freed, 500_800);
+    }
+
+    #[test]
+    fn an_unreferenced_prefetch_pack_is_an_orphan() {
+        let scan = scan_of(vec![
+            file("v4/prefetch/packs/ab/abcd.kpack", 500_000, 900 * HOUR),
+            file("v4/prefetch/pack-meta/abcd.json", 100, 900 * HOUR),
+        ]);
+        assert_eq!(scan.orphans.len(), 2);
+        assert!(
+            scan.orphans
+                .iter()
+                .all(|o| o.reason == OrphanReason::UnreferencedPrefetchPack)
+        );
+        assert_eq!(scan.orphans.iter().map(|o| o.bytes).sum::<u64>(), 500_100);
+    }
+
+    /// Fail closed: a catalog we cannot parse may hold the only reference to a
+    /// pack, so no prefetch pack is orphaned on a pass that saw one.
+    #[test]
+    fn an_unreadable_catalog_suppresses_prefetch_orphaning() {
+        let mut torn = file("v4/prefetch/catalogs/sel/0001-cc.json", 11, 900 * HOUR);
+        torn.catalog = CatalogRead::Unreadable;
+        let scan = scan_of(vec![
+            file("v4/prefetch/packs/ab/abcd.kpack", 500_000, 900 * HOUR),
+            torn,
+        ]);
+
+        assert!(
+            scan.orphans.is_empty(),
+            "an unparseable catalog must not let its packs look unreferenced"
+        );
+        assert!(scan.groups.is_empty());
+        assert_eq!(scan.unclassified_bytes, 11);
+    }
+
+    #[test]
+    fn catalog_digests_reads_pack_references_and_rejects_garbage() {
+        assert_eq!(
+            catalog_digests(br#"{"packs":[{"digest":"aa"},{"digest":"bb"}]}"#).unwrap(),
+            vec!["aa".to_string(), "bb".to_string()]
+        );
+        // Unknown fields are tolerated so a newer kache's catalog does not read
+        // as torn and suppress the sweep.
+        assert_eq!(
+            catalog_digests(br#"{"version":9,"packs":[{"digest":"aa","pack_bytes":7}]}"#).unwrap(),
+            vec!["aa".to_string()]
+        );
+        assert!(catalog_digests(b"not json").is_err());
+        assert!(catalog_digests(b"{}").is_err());
+    }
+
+    // ── timestamps ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn observed_access_is_the_later_of_read_and_write() {
+        let early = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+        let late = SystemTime::UNIX_EPOCH + Duration::from_secs(900);
+        // relatime/strictatime: the read is newer, so read recency wins.
+        assert_eq!(observed_access(Some(late), Some(early)), Some(late));
+        // noatime: atime is frozen at or before the write, so write time wins.
+        assert_eq!(observed_access(Some(early), Some(late)), Some(late));
+        assert_eq!(observed_access(None, Some(late)), Some(late));
+        assert_eq!(observed_access(Some(late), None), Some(late));
+        assert_eq!(observed_access(None, None), None);
+    }
+
+    #[test]
+    fn atime_is_advanced_only_when_a_read_outran_the_write() {
+        let early = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+        let late = SystemTime::UNIX_EPOCH + Duration::from_secs(900);
+        assert!(atime_is_advanced(Some(late), Some(early)));
+        assert!(!atime_is_advanced(Some(early), Some(late)));
+        assert!(!atime_is_advanced(Some(early), Some(early)));
+        assert!(!atime_is_advanced(None, Some(early)));
+        assert!(!atime_is_advanced(Some(late), None));
+        assert!(!atime_is_advanced(None, None));
+    }
+
+    #[test]
+    fn idle_never_goes_negative_under_clock_skew() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+        assert_eq!(
+            idle_since(now, SystemTime::UNIX_EPOCH + Duration::from_secs(500)),
+            Duration::ZERO
+        );
+        assert_eq!(
+            idle_since(now, SystemTime::UNIX_EPOCH + Duration::from_secs(40)),
+            Duration::from_secs(60)
+        );
+    }
+
+    /// The `noatime` advisory fires exactly when no object in a non-empty
+    /// remote shows a read newer than its write.
+    #[test]
+    fn the_noatime_advisory_tracks_whether_any_read_was_recorded() {
+        let mut scan = RemoteScan {
+            object_count: 4,
+            ..RemoteScan::default()
+        };
+        assert!(atime_advisory(&scan).is_some_and(|text| text.contains("noatime")));
+        scan.atime_advanced = true;
+        assert!(atime_advisory(&scan).is_none());
+
+        assert!(
+            atime_advisory(&RemoteScan::default()).is_none(),
+            "an empty remote proves nothing about the mount"
+        );
+    }
+
+    // ── end to end against a real directory ─────────────────────────────────
+
+    fn write_object(root: &Path, rel: &str, bytes: usize) -> PathBuf {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, vec![7u8; bytes]).unwrap();
+        path
+    }
+
+    /// Build a remote on disk, scan it, and check the measured size, the
+    /// staging exclusion, and that planning deletes nothing.
+    #[test]
+    fn scanning_a_real_remote_measures_it_and_skips_staging() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let mut remote = test_remote(root, RemoteBudget::Bytes(1));
+        // Staging is allowed to live inside the prefix as long as it is outside
+        // the v3 object tree, so put it there: that is the placement the
+        // exclusion list actually has to defend against.
+        remote.atomic_write_dir = root.join("artifacts/.staging");
+
+        write_object(root, "artifacts/v3/manifests/serde/aaa.json", 100);
+        let pack = write_object(root, "artifacts/v3/packs/serde/aaa.tar.zst", 4_000);
+        write_object(root, "artifacts/_manifests/v3/ns/shards/dd.json", 60);
+        write_object(root, "artifacts/.staging/inflight.tmp", 9_999);
+
+        let scan = scan(&remote, "artifacts", SystemTime::now()).unwrap();
+        assert_eq!(scan.object_count, 3, "staging is not a remote object");
+        assert_eq!(scan.total_bytes, 4_160);
+        assert_eq!(
+            scan.unclassified_bytes, 60,
+            "_manifests counts toward the budget but is never evicted"
+        );
+        assert_eq!(scan.groups.len(), 1);
+        assert_eq!(scan.groups[0].id, "v3:serde/aaa");
+
+        // Just-written files are inside the recency grace, so nothing is picked.
+        let dry = plan(&scan, Some(1));
+        assert_eq!(dry.pinned, 1);
+        assert!(dry.victims.is_empty());
+        assert!(pack.exists(), "planning must never touch the filesystem");
+    }
+
+    /// The scan reports whether the mount recorded a read. Timestamps are set
+    /// explicitly because the host's own mount options must not decide the
+    /// answer.
+    #[test]
+    fn scanning_detects_whether_the_mount_records_reads() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let objects = [
+            write_object(root, "artifacts/v3/manifests/serde/a.json", 10),
+            write_object(root, "artifacts/v3/packs/serde/a.tar.zst", 10),
+        ];
+        let written = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000_000);
+        let remote = test_remote(root, RemoteBudget::Default);
+
+        // noatime: the access time never outran the write.
+        let stamp = filetime::FileTime::from_system_time(written);
+        for path in &objects {
+            filetime::set_file_times(path, stamp, stamp).unwrap();
+        }
+        let frozen = scan(&remote, "artifacts", SystemTime::now()).unwrap();
+        assert!(!frozen.atime_advanced);
+        assert!(atime_advisory(&frozen).is_some());
+
+        // relatime: a read pushed the access time past the write.
+        let read_at = filetime::FileTime::from_system_time(written + 100 * HOUR);
+        for path in &objects {
+            filetime::set_file_times(path, read_at, stamp).unwrap();
+        }
+        let observed = scan(&remote, "artifacts", SystemTime::now()).unwrap();
+        assert!(observed.atime_advanced);
+        assert!(atime_advisory(&observed).is_none());
+        // And the group dates from the read, not the write.
+        assert_eq!(observed.groups.len(), 1);
+        assert!(
+            observed.groups[0].idle + 99 * HOUR < frozen.groups[0].idle,
+            "a recorded read must make the group look fresher"
+        );
+    }
+
+    /// A real catalog on disk is parsed during the scan, so its packs are
+    /// reference-counted rather than orphaned.
+    #[test]
+    fn scanning_reads_catalogs_off_disk_to_count_references() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_object(root, "artifacts/v4/prefetch/packs/ab/abcd.kpack", 2_000);
+        let catalog_path = root.join("artifacts/v4/prefetch/catalogs/sel/0001-cc.json");
+        std::fs::create_dir_all(catalog_path.parent().unwrap()).unwrap();
+        std::fs::write(&catalog_path, br#"{"packs":[{"digest":"abcd"}]}"#).unwrap();
+
+        let counted = scan(
+            &test_remote(root, RemoteBudget::Default),
+            "artifacts",
+            SystemTime::now(),
+        )
+        .unwrap();
+        assert_eq!(counted.shared["abcd"].refs, 1);
+        assert!(counted.orphans.is_empty());
+
+        // A torn catalog on the same pass suppresses v4 orphaning entirely.
+        std::fs::write(&catalog_path, b"{ half-writ").unwrap();
+        let torn = scan(
+            &test_remote(root, RemoteBudget::Default),
+            "artifacts",
+            SystemTime::now(),
+        )
+        .unwrap();
+        assert_eq!(torn.shared["abcd"].refs, 0);
+        assert!(
+            torn.orphans.is_empty(),
+            "a catalog we cannot read must fail closed"
+        );
+    }
+
+    /// Applying a plan unlinks exactly the planned objects and leaves
+    /// everything else in place.
+    #[test]
+    fn applying_a_plan_removes_only_the_planned_objects() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let manifest = root.join("m.json");
+        let pack = root.join("p.tar.zst");
+        let keep = root.join("keep.json");
+        for path in [&manifest, &pack, &keep] {
+            std::fs::write(path, b"x").unwrap();
+        }
+        let plan = RemotePlan {
+            victims: vec![PlannedVictim {
+                id: "v3:a/b".into(),
+                objects: vec![manifest.clone(), pack.clone()],
+                freed: 2,
+            }],
+            orphans: vec![RemoteOrphan {
+                path: root.join("gone-already.json"),
+                bytes: 5,
+                reason: OrphanReason::PackWithoutManifest,
+            }],
+            ..RemotePlan::default()
+        };
+
+        let stats = apply(&plan);
+        assert!(!manifest.exists() && !pack.exists());
+        assert!(keep.exists());
+        assert_eq!(stats.groups_evicted, 1);
+        assert_eq!(stats.orphans_removed, 1);
+        assert_eq!(stats.objects_removed, 3);
+        assert_eq!(stats.bytes_freed, 7);
+        assert_eq!(
+            stats.delete_failures, 0,
+            "an object a peer already removed is not a failure"
+        );
+    }
+
+    /// An object that cannot be unlinked — the stand-in for a Windows reader
+    /// holding the handle open — is counted and stepped over, never propagated.
+    #[test]
+    fn an_undeletable_object_is_counted_and_does_not_abort_the_sweep() {
+        let dir = tempfile::tempdir().unwrap();
+        let stuck = dir.path().join("stuck");
+        std::fs::create_dir(&stuck).unwrap();
+        assert!(!unlink(&stuck));
+        assert!(unlink(&dir.path().join("absent")));
+
+        // Both loops have to survive it: a stuck orphan and a stuck victim.
+        let stats = apply(&RemotePlan {
+            orphans: vec![RemoteOrphan {
+                path: stuck.clone(),
+                bytes: 7,
+                reason: OrphanReason::PackWithoutManifest,
+            }],
+            victims: vec![PlannedVictim {
+                id: "v3:a/b".into(),
+                objects: vec![stuck.clone()],
+                freed: 99,
+            }],
+            ..RemotePlan::default()
+        });
+        assert_eq!(stats.delete_failures, 2);
+        assert_eq!(stats.orphans_removed, 0);
+        assert_eq!(stats.objects_removed, 0);
+        assert_eq!(stats.groups_evicted, 0);
+        assert_eq!(stats.bytes_freed, 0);
+        assert!(stuck.exists());
+    }
+
+    #[test]
+    fn a_symlink_under_the_prefix_is_never_walked_or_counted() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let outside = root.join("outside.bin");
+        std::fs::write(&outside, vec![1u8; 5_000]).unwrap();
+        std::fs::create_dir_all(root.join("artifacts/v3/packs/serde")).unwrap();
+        let link = root.join("artifacts/v3/packs/serde/a.tar.zst");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&outside, &link).unwrap();
+
+        let scan = scan(
+            &test_remote(root, RemoteBudget::Default),
+            "artifacts",
+            SystemTime::now(),
+        )
+        .unwrap();
+        assert_eq!(scan.object_count, 0, "a symlink is not a remote object");
+        assert_eq!(scan.total_bytes, 0);
+        assert!(outside.exists());
+    }
+
+    #[test]
+    fn an_empty_prefix_scans_the_remote_root_and_still_skips_the_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_object(root, "v3/packs/serde/a.tar.zst", 300);
+        write_object(root, REMOTE_GC_LOCK_FILE, 4);
+
+        let scan = scan(
+            &test_remote(root, RemoteBudget::Default),
+            "",
+            SystemTime::now(),
+        )
+        .unwrap();
+        assert_eq!(scan.total_bytes, 300);
+        assert_eq!(scan.object_count, 1);
+    }
+
+    #[test]
+    fn relative_key_rejects_paths_outside_the_prefix() {
+        assert_eq!(
+            relative_key(
+                Path::new("/remote/artifacts"),
+                Path::new("/remote/artifacts/v3/a.json")
+            ),
+            Some("v3/a.json".to_string())
+        );
+        assert_eq!(
+            relative_key(
+                Path::new("/remote/artifacts"),
+                Path::new("/elsewhere/a.json")
+            ),
+            None
+        );
+    }
+
+    // ── the concurrency guard ───────────────────────────────────────────────
+
+    /// Two collectors on one shared folder: the second must decline rather than
+    /// plan against a snapshot the first is deleting from.
+    #[test]
+    fn only_one_remote_sweep_holds_the_advisory_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let remote = test_remote(dir.path(), RemoteBudget::Default);
+
+        let first = try_lock(&remote).unwrap().expect("the first sweep wins");
+        assert!(
+            try_lock(&remote).unwrap().is_none(),
+            "a second concurrent sweep must be turned away"
+        );
+        drop(first);
+        assert!(
+            try_lock(&remote).unwrap().is_some(),
+            "the lock is released when the sweep ends"
+        );
+        assert!(
+            dir.path().join(REMOTE_GC_LOCK_FILE).exists(),
+            "the lock file persists so contenders share one inode"
+        );
+    }
+
+    // ── budget resolution ───────────────────────────────────────────────────
+
+    #[test]
+    fn an_explicit_budget_wins_over_the_derived_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let remote = |budget| test_remote(dir.path(), budget);
+        assert_eq!(
+            resolve_budget(&remote(RemoteBudget::Bytes(80 << 30))),
+            Some(80 << 30)
+        );
+        assert_eq!(resolve_budget(&remote(RemoteBudget::Unbounded)), None);
+        assert_eq!(
+            resolve_budget(&remote(RemoteBudget::Default)),
+            Some(crate::config::remote_disk_share_budget(volume_bytes(
+                &remote(RemoteBudget::Default)
+            )))
+        );
+        assert!(
+            volume_bytes(&remote(RemoteBudget::Default)).is_some_and(|n| n > 1_000_000),
+            "a real directory must yield a volume size"
+        );
+
+        assert!(describe_budget(&remote(RemoteBudget::Unbounded)).contains("none"));
+        assert!(describe_budget(&remote(RemoteBudget::Bytes(1 << 30))).contains("configured"));
+        assert!(describe_budget(&remote(RemoteBudget::Default)).contains('%'));
+    }
+
+    #[test]
+    fn plan_totals_add_up_across_orphans_and_victims() {
+        let mut files = v3_unit("a", "cold", 100_000, 900 * HOUR);
+        files.push(file("v3/packs/a/dead.tar.zst", 7_000, 900 * HOUR));
+        let scan = scan_of(files);
+        let outcome = plan(&scan, Some(1_000));
+
+        assert_eq!(outcome.orphans.len(), 1);
+        assert_eq!(outcome.victims.len(), 1);
+        assert_eq!(outcome.bytes_freed(), 7_000 + 100_256);
+        assert_eq!(outcome.projected_bytes, 0);
+        assert_eq!(outcome.total_bytes, 107_256);
+        assert_eq!(outcome.object_count, 3);
+        assert!(!outcome.still_over_budget());
+    }
+}


### PR DESCRIPTION
Closes #774.

A filesystem remote had no eviction path. `kache gc` bounds the local store and an S3 bucket takes a lifecycle rule, but a shared folder only grew; the report behind #774 measured 319 GiB in one day.

## What changed

- `cache.remote.max_size` / `KACHE_REMOTE_MAX_SIZE` bounds a filesystem remote. The default is 25% of the remote's disk, floored at 10 GiB and capped at 500 GiB; an explicit size wins, and `none` is accepted here, unlike the local budget, because a remote is a path you chose and may already be bounded by a quota or your own pruning job. It is rejected on an S3 remote.
- `kache gc --remote` sweeps the remote down to that budget. `--dry-run` prints the computed budget and what a sweep would remove. `--json` emits the plan and the outcome for a timer job to record. Nothing runs it automatically: schedule it from cron or a systemd timer on one machine that mounts the folder.
- Selection reuses the local eviction policy (`crate::eviction`): the same features, the same size-pressure ranking, the same hysteresis band, so the remote does not thrash on its cap.
- Recency comes from `stat`, and the sweep says what it can see. On `relatime` mounts `atime` is reliable at day granularity, which separates a hot set from a tail untouched for weeks. On `noatime` mounts read recency is unobservable; the sweep ranks by write time and warns that it is doing so, rather than evicting the hot set silently.
- The unit of eviction follows the layout. A v3 manifest and its pack are named from the same key and only ever reference each other, so they go together. v4 prefetch packs are content-addressed and shared between catalog generations, so the unit is the catalog and a pack is unlinked only when its last reference goes.
- Concurrent sweeps are safe: a sweep takes an advisory lock at the remote root and a second one declines with a skipped report.
- A read-only process never deletes. When `cache.remote_readonly`, `KACHE_REMOTE_READONLY`, or the untrusted-CI policy applies, `kache gc --remote` refuses before taking the lock, names the reason the same way `kache doctor` does, and exits non-zero; `--dry-run` still shows the plan. The `--json` refusal carries `skipped`, the reason, and the dry-run as the next action.

Docs: the configuration table, the `kache gc` reference, the CI write-policy page, and the filesystem remote page, whose "deletion is manual" paragraph is replaced.

## Verification

- Unit tests in `remote_eviction` cover budget resolution (default, explicit, `none`, S3 rejection), recency under each mount behaviour, v3 pairing, v4 shared-pack reference counting, the lock, and dry-run never mutating.
- Read-only tests: refusal with apply deletes nothing and leaves no lock file; dry-run on a read-only remote plans without deleting; a writable remote still deletes; the JSON refusal names the reason and the next action. Each guard inversion (`true`, `false`, `&& dry_run`, `|| !dry_run`) is killed by at least two of them.
- `mise exec -- just check` on this head after the rebase onto main: fmt, clippy `-D warnings`, full workspace tests. CI's `Mutation testing (diff k/n)` shards are the mutants gate for this PR, per the gate change of 2026-09-02; the PR was opened as a draft for them and marked ready once every shard was green.

## What a reviewer should still watch

- The sidecar touch-file the issue proposes for `noatime` mounts is out of scope: it needs the restore path to write on every hit. The sweep documents the degradation instead.
- `--dry-run` still creates the lock file on the remote. On a mount that is read-only at the OS level, a dry run fails at the lock with a permission error; that is separate from the kache read-only flag and left as is.
- The JSON refusal writes the document to stdout and exits non-zero, the same shape as `kache doctor --json`. Say if you would rather have exit 0 with `skipped: true`.
