### PR TITLE
fix(cli): honour the --since window and label it honestly

### DIFF
--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -179,16 +179,19 @@ kache monitor
 kache monitor --since 7d
 ```
 
+`--since` takes the same forms as `kache stats`.
+
 See [Monitor](/docs/monitor).
 
 ## `kache stats`
 
 ```bash
 kache stats
-kache stats --since 1h
+kache stats --since 15m
+kache stats --since 2h
 ```
 
-The default window is 24 hours.
+`--since` accepts `s`, `m`, `h`, and `d` units (`90s`, `15m`, `2h`, `7d`). A bare number is hours. The default is `24h`. The counters and the `last ...` label both describe the requested window; a value that does not parse is an error.
 
 ## `kache telemetry`
 
@@ -219,7 +222,7 @@ kache report --format trace --output trace.json
 | Flag | Default | Values or purpose |
 | --- | --- | --- |
 | `--format` | `text` | `json`, `trace`, `perfetto`, `chrome-trace`, `markdown`, `github`, `text` |
-| `--since` | `24h` | Event window |
+| `--since` | `24h` | Event window; same forms as `kache stats` (`15m`, `2h`, `7d`, bare hours) |
 | `--root` | all roots | Include events from one build tree |
 | `--output`, `-o` | stdout | Write to a file |
 | `--top` | `10` | Number of ranked entries |

--- a/docs/commands/report.schema.json
+++ b/docs/commands/report.schema.json
@@ -42,7 +42,16 @@
         "since_hours": {
           "type": "integer",
           "minimum": 0,
-          "description": "Lookback window duration in hours."
+          "description": "Lookback window in whole hours, rounded down (0 for a sub-hour window). Kept for consumers that predate since_secs."
+        },
+        "since_secs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Lookback window in seconds. Authoritative; since_hours is derived from it."
+        },
+        "since": {
+          "type": "string",
+          "description": "Lookback window as requested on the command line, e.g. 15m, 2h, 24h. Absent in reports written before this field existed."
         },
         "root_filter": {
           "type": ["string", "null"],

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use crate::config::Config;
 use crate::daemon;
 use crate::events;
+use crate::since::SinceWindow;
 use crate::store::{STAGING_SWEEP_GRACE, Store};
 
 // ── Stats snapshot (daemon-first, fallback to direct) ──────────────────────
@@ -144,18 +145,17 @@ pub(crate) fn fetch_stats_snapshot(
     config: &Config,
     include_entries: bool,
     sort_by: &str,
-    hours: Option<u64>,
+    window: SinceWindow,
     announce_auto_start: bool,
     include_summaries: bool,
 ) -> StatsSnapshot {
-    let event_hours = hours.or(Some(24));
     // Try daemon
     if let Ok(resp) = daemon::send_stats_request_options(
         config,
         include_entries,
         include_summaries,
         Some(sort_by),
-        event_hours,
+        Some(window),
     ) {
         return StatsSnapshot {
             total_size: resp.total_size,
@@ -206,7 +206,7 @@ pub(crate) fn fetch_stats_snapshot(
             include_entries,
             include_summaries,
             Some(sort_by),
-            event_hours,
+            Some(window),
         )
     {
         return StatsSnapshot {
@@ -245,13 +245,7 @@ pub(crate) fn fetch_stats_snapshot(
     }
 
     // Fallback: direct reads (no daemon reachable).
-    snapshot_from_direct_reads(
-        config,
-        include_entries,
-        sort_by,
-        event_hours,
-        include_summaries,
-    )
+    snapshot_from_direct_reads(config, include_entries, sort_by, window, include_summaries)
 }
 
 /// Build a [`StatsSnapshot`] by reading the store and event log directly, with no
@@ -261,7 +255,7 @@ pub(crate) fn snapshot_from_direct_reads(
     config: &Config,
     include_entries: bool,
     sort_by: &str,
-    event_hours: Option<u64>,
+    window: SinceWindow,
     include_summaries: bool,
 ) -> StatsSnapshot {
     let store = Store::open(config).ok();
@@ -296,8 +290,7 @@ pub(crate) fn snapshot_from_direct_reads(
         Vec::new()
     };
 
-    let h = event_hours.unwrap_or(24);
-    let since = chrono::Utc::now() - chrono::Duration::hours(h as i64);
+    let since = window.cutoff(chrono::Utc::now());
     let event_list = events::read_events_since(&config.event_log_path(), since).unwrap_or_default();
     let es = events::compute_stats(&event_list);
 
@@ -371,7 +364,13 @@ pub fn telemetry_write(
     scenario: Option<&str>,
     phase: Option<&str>,
 ) -> Result<()> {
-    let snap = match daemon::send_stats_request_options(config, false, false, None, Some(24)) {
+    let snap = match daemon::send_stats_request_options(
+        config,
+        false,
+        false,
+        None,
+        Some(SinceWindow::DEFAULT),
+    ) {
         Ok(resp) => StatsSnapshot {
             total_size: resp.total_size,
             max_size: resp.max_size,
@@ -405,7 +404,7 @@ pub fn telemetry_write(
             in_flight: resp.in_flight,
             daemon_effective_config: resp.effective_config,
         },
-        Err(_) => snapshot_from_direct_reads(config, false, "size", Some(24), false),
+        Err(_) => snapshot_from_direct_reads(config, false, "size", SinceWindow::DEFAULT, false),
     };
     crate::otel::write_otlp(
         dir,
@@ -482,11 +481,10 @@ fn cloned_targets_line(disk: &crate::machine::DiskView) -> Option<String> {
 pub fn stats(
     config: &Config,
     provenance: &crate::config::ConfigFileProvenance,
-    hours: Option<u64>,
+    window: SinceWindow,
     json: bool,
 ) -> Result<()> {
-    let hours = hours.unwrap_or(24);
-    let snap = fetch_stats_snapshot(config, false, "size", Some(hours), true, true);
+    let snap = fetch_stats_snapshot(config, false, "size", window, true, true);
 
     // #689: the numbers below are daemon-first, so before rendering them say
     // when the daemon's effective config disagrees with this invocation's —
@@ -517,7 +515,12 @@ pub fn stats(
             dups: usize,
             misses: usize,
             daemon_connected: bool,
+            /// Whole hours, rounded down (0 for a sub-hour window). Kept for
+            /// consumers that predate `since_secs`.
             hours: u64,
+            since_secs: u64,
+            /// The window as requested: `15m`, `2h`, `24h`.
+            since: String,
             #[serde(skip_serializing_if = "Option::is_none")]
             remote: Option<&'a str>,
         }
@@ -535,14 +538,16 @@ pub fn stats(
                 dups: snap.event_stats.dups,
                 misses: snap.event_stats.misses,
                 daemon_connected: snap.daemon_connected,
-                hours,
+                hours: window.hours(),
+                since_secs: window.secs(),
+                since: window.label(),
                 remote: remote.as_deref(),
             },
             crate::machine::next_for_clones(disk.cloned_into_targets_bytes),
         );
     }
 
-    for line in render_stats(&snap, config, hours) {
+    for line in render_stats(&snap, config, window) {
         println!("{line}");
     }
     if let Some(line) = cloned_targets_line(&disk) {
@@ -583,7 +588,11 @@ pub fn stats(
 /// Render the `kache stats` summary lines from a fetched snapshot. Pure (no I/O)
 /// so the dedup / weighted-hit / miss-share / daemon / remote display branches
 /// are unit-testable from crafted snapshots without a daemon or store.
-pub(crate) fn render_stats(snap: &StatsSnapshot, config: &Config, hours: u64) -> Vec<String> {
+pub(crate) fn render_stats(
+    snap: &StatsSnapshot,
+    config: &Config,
+    window: SinceWindow,
+) -> Vec<String> {
     let mut lines = Vec::new();
 
     // Store line
@@ -647,7 +656,7 @@ pub(crate) fn render_stats(snap: &StatsSnapshot, config: &Config, hours: u64) ->
         "n/a".to_string()
     };
     lines.push(format!(
-        "Time saved: {time_saved} (estimated compile work avoided, last {hours}h)"
+        "Time saved: {time_saved} (estimated compile work avoided, last {window})"
     ));
 
     // Daemon status
@@ -973,16 +982,16 @@ fn format_epoch_ms_utc(ms: u64) -> String {
 pub fn report(
     config: &Config,
     format: &str,
-    hours: u64,
+    window: SinceWindow,
     root: Option<std::path::PathBuf>,
     output: Option<std::path::PathBuf>,
     top: usize,
 ) -> Result<()> {
     let report = if root.is_some() {
         let filter = crate::report::ReportFilter { root };
-        crate::report::generate_report_with_filter(config, hours, top, &filter)?
+        crate::report::generate_report_with_filter(config, window, top, &filter)?
     } else {
-        crate::report::generate_report(config, hours, top)?
+        crate::report::generate_report(config, window, top)?
     };
 
     let text = match format {
@@ -8347,7 +8356,7 @@ mod tests {
             total_logical_size: 4096,
             savings: 2048,
         });
-        let out = render_stats(&snap, &config, 24).join("\n");
+        let out = render_stats(&snap, &config, SinceWindow::DEFAULT).join("\n");
         assert!(out.contains("Store:"));
         assert!(out.contains("Dedup:      4 unique blobs"));
         assert!(out.contains("Hit rate:"));
@@ -8373,7 +8382,7 @@ mod tests {
         let mut quiet = StatsSnapshot::default();
         quiet.daemon_connected = true;
         assert!(
-            render_stats(&quiet, &remote_config, 24)
+            render_stats(&quiet, &remote_config, SinceWindow::DEFAULT)
                 .iter()
                 .all(|line| !line.starts_with("Resilience:"))
         );
@@ -8418,7 +8427,7 @@ mod tests {
         for (signal, mut snap) in signals {
             snap.daemon_connected = true;
             assert!(
-                render_stats(&snap, &remote_config, 24)
+                render_stats(&snap, &remote_config, SinceWindow::DEFAULT)
                     .iter()
                     .any(|line| line.starts_with("Resilience:")),
                 "{signal} must independently render the resilience section"
@@ -8430,7 +8439,7 @@ mod tests {
             ..Default::default()
         };
         assert!(
-            render_stats(&disconnected, &remote_config, 24)
+            render_stats(&disconnected, &remote_config, SinceWindow::DEFAULT)
                 .iter()
                 .all(|line| !line.starts_with("Resilience:"))
         );
@@ -8440,9 +8449,13 @@ mod tests {
             ..Default::default()
         };
         assert!(
-            render_stats(&connected_without_remote, &local_config, 24)
-                .iter()
-                .all(|line| !line.starts_with("Resilience:"))
+            render_stats(
+                &connected_without_remote,
+                &local_config,
+                SinceWindow::DEFAULT
+            )
+            .iter()
+            .all(|line| !line.starts_with("Resilience:"))
         );
     }
 
@@ -8457,7 +8470,7 @@ mod tests {
         // Quiet daemon: no prefetch lines at all.
         let mut quiet = StatsSnapshot::default();
         quiet.daemon_connected = true;
-        let out = render_stats(&quiet, &config, 24).join("\n");
+        let out = render_stats(&quiet, &config, SinceWindow::DEFAULT).join("\n");
         assert!(!out.contains("Prefetch:"));
         assert!(!out.contains("Planning:"));
 
@@ -8494,7 +8507,7 @@ mod tests {
         let mut eff = effective_config_like(&config);
         eff.remote_key_cache_refresh_secs = 7;
         snap.daemon_effective_config = Some(eff);
-        let out = render_stats(&snap, &config, 24).join("\n");
+        let out = render_stats(&snap, &config, SinceWindow::DEFAULT).join("\n");
         assert!(out.contains("Prefetch:   4 downloads"));
         assert!(out.contains("2 used (50%)"));
         assert!(out.contains("CANCELLED"));
@@ -8511,14 +8524,14 @@ mod tests {
         let mut eff = effective_config_like(&initial_only);
         eff.remote_key_cache_refresh_secs = 0;
         snap.daemon_effective_config = Some(eff);
-        let out = render_stats(&snap, &initial_only, 24).join("\n");
+        let out = render_stats(&snap, &initial_only, SinceWindow::DEFAULT).join("\n");
         assert!(out.contains(
             "Key LIST:   250000 keys in 88 ms (one initial population; periodic refresh disabled)"
         ));
 
         let mut disabled = config.clone();
         disabled.prefetch_enabled = false;
-        let out = render_stats(&quiet, &disabled, 24).join("\n");
+        let out = render_stats(&quiet, &disabled, SinceWindow::DEFAULT).join("\n");
         assert!(
             out.contains("Prefetch:   disabled (exact remote lookup and uploads remain enabled)")
         );
@@ -8526,7 +8539,7 @@ mod tests {
         assert!(!out.contains("Key LIST:"));
 
         snap.prefetch.last_list_key_count = 0;
-        let out = render_stats(&snap, &config, 24).join("\n");
+        let out = render_stats(&snap, &config, SinceWindow::DEFAULT).join("\n");
         assert!(out.contains("Prefetch:   4 downloads"));
         assert!(
             !out.contains("Key LIST:"),
@@ -8539,16 +8552,16 @@ mod tests {
         snap.prefetch.pack_requests_total = 0;
         snap.prefetch.v3_requests_total = 0;
         snap.prefetch.last_plan_wall_ms = 0;
-        let out = render_stats(&snap, &config, 24).join("\n");
+        let out = render_stats(&snap, &config, SinceWindow::DEFAULT).join("\n");
         assert!(!out.contains("Transport:"));
         assert!(!out.contains("Plan wall:"));
 
         snap.prefetch.pack_requests_total = 1;
-        let out = render_stats(&snap, &config, 24).join("\n");
+        let out = render_stats(&snap, &config, SinceWindow::DEFAULT).join("\n");
         assert!(out.contains("Transport:  pack 1 requests"));
         snap.prefetch.pack_requests_total = 0;
         snap.prefetch.v3_requests_total = 1;
-        let out = render_stats(&snap, &config, 24).join("\n");
+        let out = render_stats(&snap, &config, SinceWindow::DEFAULT).join("\n");
         assert!(out.contains("v3 1 requests"));
     }
 
@@ -8589,7 +8602,7 @@ mod tests {
         eff.prefetch_enabled = true; // …but the daemon is still planning
         snap.daemon_effective_config = Some(eff);
 
-        let out = render_stats(&snap, &config, 24).join("\n");
+        let out = render_stats(&snap, &config, SinceWindow::DEFAULT).join("\n");
         assert!(
             !out.contains("Prefetch:   disabled"),
             "must not claim disabled while the daemon reports enabled: {out}"
@@ -8603,7 +8616,7 @@ mod tests {
         let mut eff = effective_config_like(&config);
         eff.prefetch_enabled = false;
         snap.daemon_effective_config = Some(eff);
-        let out = render_stats(&snap, &config, 24).join("\n");
+        let out = render_stats(&snap, &config, SinceWindow::DEFAULT).join("\n");
         assert!(
             out.contains("Prefetch:   disabled (exact remote lookup and uploads remain enabled)")
         );
@@ -8624,7 +8637,7 @@ mod tests {
         let mut snap = StatsSnapshot::default();
         snap.daemon_connected = true; // reachable, but reported no config
 
-        let out = render_stats(&snap, &config, 24).join("\n");
+        let out = render_stats(&snap, &config, SinceWindow::DEFAULT).join("\n");
         assert!(out.contains(
             "Prefetch:   disabled (exact remote lookup and uploads remain enabled) \
              [client config — daemon did not report its policy]"
@@ -8759,7 +8772,7 @@ mod tests {
         eff.remote_description = None;
         eff.remote_key_cache_refresh_secs = 7;
         snap.daemon_effective_config = Some(eff);
-        let out = render_stats(&snap, &client_remote, 24).join("\n");
+        let out = render_stats(&snap, &client_remote, SinceWindow::DEFAULT).join("\n");
         assert!(out.contains("Remote:     not configured"), "{out}");
         assert!(!out.contains("Remote:     s3://"), "{out}");
 
@@ -8767,7 +8780,7 @@ mod tests {
         let mut eff = effective_config_like(&client_local);
         eff.remote_description = Some("s3://daemon-bucket/artifacts".to_string());
         snap.daemon_effective_config = Some(eff);
-        let out = render_stats(&snap, &client_local, 24).join("\n");
+        let out = render_stats(&snap, &client_local, SinceWindow::DEFAULT).join("\n");
         assert!(
             out.contains("Remote:     s3://daemon-bucket/artifacts"),
             "{out}"
@@ -8786,7 +8799,7 @@ mod tests {
         snap.daemon_connected = true;
         snap.daemon_version = "1.0.0".to_string();
         snap.daemon_build_epoch = crate::daemon::build_epoch().wrapping_add(1); // mismatch
-        let out = render_stats(&snap, &config, 24).join("\n");
+        let out = render_stats(&snap, &config, SinceWindow::DEFAULT).join("\n");
         assert!(out.contains("MISMATCH — auto-restart pending"));
         assert!(out.contains("local-only mode"));
     }
@@ -8796,7 +8809,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = save_manifest_config(dir.path().join("cache"), None);
         let snap = StatsSnapshot::default(); // daemon_connected=false
-        let out = render_stats(&snap, &config, 24).join("\n");
+        let out = render_stats(&snap, &config, SinceWindow::DEFAULT).join("\n");
         assert!(out.contains("Daemon:     offline"));
         assert!(out.contains("Remote:     not configured"));
         // No blobs -> no Dedup line.
@@ -8820,10 +8833,15 @@ mod tests {
             ..Default::default()
         };
 
-        let out = render_stats(&snap, &config, 6).join("\n");
+        let window = SinceWindow::parse("15m").unwrap();
+        let out = render_stats(&snap, &config, window).join("\n");
         assert!(out.contains("Store:      500 B / 0 B (0 entries, 0%)"));
         assert!(out.contains("Dedup:      2 unique blobs, 500 B physical, 0.0% savings"));
-        assert!(out.contains("Time saved: n/a"));
+        // #897: the label names the requested window, not a hardcoded 24h.
+        assert!(
+            out.contains("Time saved: n/a (estimated compile work avoided, last 15m)"),
+            "{out}"
+        );
 
         let no_blobs = StatsSnapshot {
             blob_stats: Some(crate::store::BlobStats {
@@ -8834,7 +8852,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let out = render_stats(&no_blobs, &config, 6).join("\n");
+        let out = render_stats(&no_blobs, &config, window).join("\n");
         assert!(
             !out.contains("Dedup:"),
             "an empty blob snapshot must not render a dedup line: {out}"
@@ -8858,7 +8876,7 @@ mod tests {
         summaries.push('\n');
         std::fs::write(summary_path, summaries).unwrap();
 
-        let snap = snapshot_from_direct_reads(&config, false, "size", None, true);
+        let snap = snapshot_from_direct_reads(&config, false, "size", SinceWindow::DEFAULT, true);
         let ids = snap
             .recent_summaries
             .iter()
@@ -8899,7 +8917,7 @@ mod tests {
         )
         .unwrap();
 
-        let snap = snapshot_from_direct_reads(&config, true, "name", Some(24), false);
+        let snap = snapshot_from_direct_reads(&config, true, "name", SinceWindow::DEFAULT, false);
         assert!(!snap.daemon_connected, "direct reads report no daemon");
         assert_eq!(snap.entry_count, 1);
         assert_eq!(snap.entries.len(), 1);
@@ -8909,13 +8927,52 @@ mod tests {
         assert_eq!(snap.max_size, config.max_size);
     }
 
+    /// #897: `--since` must narrow the counters, not just the label. A 15m
+    /// window excludes the three-hour-old miss that a 24h window includes.
+    #[test]
+    fn snapshot_from_direct_reads_honors_a_sub_hour_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = save_manifest_config(dir.path().join("cache"), None);
+        let now = chrono::Utc::now();
+        let mut recent = build_event(
+            "serde",
+            crate::events::EventResult::LocalHit,
+            0,
+            5,
+            4096,
+            "a",
+        );
+        recent.ts = now - chrono::Duration::minutes(10);
+        let mut old = build_event(
+            "tokio",
+            crate::events::EventResult::Miss,
+            900,
+            950,
+            8192,
+            "b",
+        );
+        old.ts = now - chrono::Duration::hours(3);
+        crate::events::log_event(&config.event_log_path(), &recent).unwrap();
+        crate::events::log_event(&config.event_log_path(), &old).unwrap();
+
+        let narrow = SinceWindow::parse("15m").unwrap();
+        let snap = snapshot_from_direct_reads(&config, false, "size", narrow, false);
+        assert_eq!(snap.event_stats.local_hits, 1);
+        assert_eq!(snap.event_stats.misses, 0, "a 3h-old miss is outside 15m");
+
+        let wide = SinceWindow::parse("24h").unwrap();
+        let snap = snapshot_from_direct_reads(&config, false, "size", wide, false);
+        assert_eq!(snap.event_stats.local_hits, 1);
+        assert_eq!(snap.event_stats.misses, 1);
+    }
+
     #[test]
     fn snapshot_from_direct_reads_without_entries_skips_listing() {
         // include_entries=false -> entries list is empty even with a populated store.
         let dir = tempfile::tempdir().unwrap();
         let config = save_manifest_config(dir.path().join("cache"), None);
         put_entry(&config, "k1", "serde", dir.path());
-        let snap = snapshot_from_direct_reads(&config, false, "size", None, false);
+        let snap = snapshot_from_direct_reads(&config, false, "size", SinceWindow::DEFAULT, false);
         assert!(
             snap.entries.is_empty(),
             "entries omitted when not requested"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -806,10 +806,30 @@ pub struct StatsRequest {
     #[serde(default)]
     pub include_summaries: bool,
     pub sort_by: Option<String>,
+    /// Event window in whole hours. Older clients send only this; newer ones
+    /// send it rounded up beside `event_secs` so an older daemon still
+    /// answers with a superset of the requested window.
     pub event_hours: Option<u64>,
+    /// Event window in seconds (kunobi-ninja/kache#897). Wins over
+    /// `event_hours` when present, so `--since 15m` is a 15 minute window.
+    #[serde(default)]
+    pub event_secs: Option<u64>,
     /// Client binary mtime — lets the daemon detect when it's running stale code.
     #[serde(default)]
     pub client_epoch: u64,
+}
+
+impl StatsRequest {
+    /// The event window this request asks for: `event_secs` from a current
+    /// client, else `event_hours` from an older one, else the 24h default.
+    pub(crate) fn window(&self) -> crate::since::SinceWindow {
+        use crate::since::SinceWindow;
+        match (self.event_secs, self.event_hours) {
+            (Some(secs), _) => SinceWindow::from_secs(secs),
+            (None, Some(hours)) => SinceWindow::from_hours(hours).unwrap_or(SinceWindow::DEFAULT),
+            (None, None) => SinceWindow::DEFAULT,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -2776,8 +2796,7 @@ impl Daemon {
             Err(e) => return Response::err(format!("store open failed: {e}")),
         };
 
-        let hours = req.event_hours.unwrap_or(24);
-        let since = chrono::Utc::now() - chrono::Duration::hours(hours as i64);
+        let since = req.window().cutoff(chrono::Utc::now());
         let event_list =
             events::read_events_since(&self.config.event_log_path(), since).unwrap_or_default();
         let es = events::compute_stats(&event_list);
@@ -7749,9 +7768,9 @@ pub fn send_stats_request(
     config: &Config,
     include_entries: bool,
     sort_by: Option<&str>,
-    event_hours: Option<u64>,
+    window: Option<crate::since::SinceWindow>,
 ) -> Result<StatsResponse> {
-    send_stats_request_options(config, include_entries, false, sort_by, event_hours)
+    send_stats_request_options(config, include_entries, false, sort_by, window)
 }
 
 /// Read the daemon's stats without starting or waiting for a replacement.
@@ -7784,7 +7803,7 @@ pub(crate) fn send_stats_request_options(
     include_entries: bool,
     include_summaries: bool,
     sort_by: Option<&str>,
-    event_hours: Option<u64>,
+    window: Option<crate::since::SinceWindow>,
 ) -> Result<StatsResponse> {
     let client_epoch = build_epoch();
     let stats = fetch_stats(
@@ -7792,7 +7811,7 @@ pub(crate) fn send_stats_request_options(
         include_entries,
         include_summaries,
         sort_by,
-        event_hours,
+        window,
         STATS_READ_TIMEOUT,
     )?;
 
@@ -7808,7 +7827,7 @@ pub(crate) fn send_stats_request_options(
                 include_entries,
                 include_summaries,
                 sort_by,
-                event_hours,
+                window,
                 STATS_REFETCH_TIMEOUT,
             )
         {
@@ -7825,14 +7844,17 @@ fn fetch_stats(
     include_entries: bool,
     include_summaries: bool,
     sort_by: Option<&str>,
-    event_hours: Option<u64>,
+    window: Option<crate::since::SinceWindow>,
     read_timeout: Duration,
 ) -> Result<StatsResponse> {
     let req = Request::Stats(StatsRequest {
         include_entries,
         include_summaries,
         sort_by: sort_by.map(String::from),
-        event_hours,
+        // Rounded up, not down: a daemon that predates `event_secs` should
+        // answer with a superset of a sub-hour window rather than nothing.
+        event_hours: window.map(|w| w.secs().div_ceil(3600)),
+        event_secs: window.map(crate::since::SinceWindow::secs),
         client_epoch: build_epoch(),
     });
 
@@ -8407,6 +8429,7 @@ pub fn start_daemon_background() -> Result<bool> {
                     include_summaries: false,
                     sort_by: None,
                     event_hours: None,
+                    event_secs: None,
                     client_epoch: my_epoch,
                 }),
                 Duration::from_secs(2),
@@ -9890,6 +9913,7 @@ mod tests {
             include_summaries: false,
             sort_by: None,
             event_hours: None,
+            event_secs: None,
             client_epoch: 0,
         });
         let client_socket_path = socket_path.clone();
@@ -11894,6 +11918,7 @@ mod tests {
             include_summaries: true,
             sort_by: Some("size".into()),
             event_hours: Some(48),
+            event_secs: None,
             client_epoch: 0,
         });
         let json = serde_json::to_string(&req).unwrap();
@@ -12090,6 +12115,70 @@ mod tests {
         );
     }
 
+    /// #897: a current client sends the window in seconds beside the rounded
+    /// hours it sends for older daemons. The daemon must filter on the
+    /// seconds, otherwise `--since 15m` silently becomes a 1h window.
+    #[test]
+    fn handle_stats_filters_on_event_secs_over_event_hours() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let now = chrono::Utc::now();
+        let mut recent = events::BuildEvent::new_for_test("serde", events::EventResult::LocalHit);
+        recent.ts = now - chrono::Duration::minutes(10);
+        let mut old = events::BuildEvent::new_for_test("tokio", events::EventResult::Miss);
+        old.ts = now - chrono::Duration::minutes(40);
+        events::log_event(&config.event_log_path(), &recent).unwrap();
+        events::log_event(&config.event_log_path(), &old).unwrap();
+        let daemon = Daemon::new(config);
+
+        let request = |event_hours: Option<u64>, event_secs: Option<u64>| StatsRequest {
+            include_entries: false,
+            include_summaries: false,
+            sort_by: None,
+            event_hours,
+            event_secs,
+            client_epoch: 0,
+        };
+
+        let narrow = daemon
+            .handle_stats(&request(Some(1), Some(900)))
+            .stats
+            .unwrap();
+        assert_eq!(narrow.events.local_hits, 1);
+        assert_eq!(narrow.events.misses, 0, "40 minutes ago is outside 15m");
+
+        let legacy = daemon.handle_stats(&request(Some(1), None)).stats.unwrap();
+        assert_eq!(legacy.events.local_hits, 1);
+        assert_eq!(
+            legacy.events.misses, 1,
+            "an older client's hours still apply"
+        );
+
+        let default = daemon.handle_stats(&request(None, None)).stats.unwrap();
+        assert_eq!(default.events.misses, 1, "no window at all means 24h");
+    }
+
+    #[test]
+    fn stats_request_window_prefers_secs_then_hours_then_default() {
+        use crate::since::SinceWindow;
+        let request = |event_hours: Option<u64>, event_secs: Option<u64>| StatsRequest {
+            include_entries: false,
+            include_summaries: false,
+            sort_by: None,
+            event_hours,
+            event_secs,
+            client_epoch: 0,
+        };
+        assert_eq!(request(Some(24), Some(900)).window().secs(), 900);
+        assert_eq!(request(Some(2), None).window().secs(), 7200);
+        assert_eq!(request(None, None).window(), SinceWindow::DEFAULT);
+        assert_eq!(
+            request(Some(u64::MAX), None).window(),
+            SinceWindow::DEFAULT,
+            "an overflowing hour count falls back rather than wrapping"
+        );
+    }
+
     #[test]
     fn test_handle_stats_empty_store() {
         let dir = tempfile::tempdir().unwrap();
@@ -12111,6 +12200,7 @@ mod tests {
             include_summaries: false,
             sort_by: None,
             event_hours: Some(24),
+            event_secs: None,
             client_epoch: 0,
         });
         assert!(resp.ok);
@@ -12148,6 +12238,7 @@ mod tests {
             include_summaries: true,
             sort_by: None,
             event_hours: Some(24),
+            event_secs: None,
             client_epoch: 0,
         });
         let ids = with_summaries
@@ -12347,6 +12438,7 @@ mod tests {
             include_summaries: false,
             sort_by: Some("size".into()),
             event_hours: Some(24),
+            event_secs: None,
             client_epoch: 0,
         });
         assert!(resp.ok);
@@ -12370,6 +12462,7 @@ mod tests {
             include_summaries: false,
             sort_by: None,
             event_hours: None,
+            event_secs: None,
             client_epoch: 0,
         });
         let resp = daemon.handle_request_sync(&req);
@@ -12403,6 +12496,7 @@ mod tests {
                 include_summaries: false,
                 sort_by: Some("size".into()),
                 event_hours: Some(24),
+                event_secs: None,
                 client_epoch: 0,
             }),
         )
@@ -12882,6 +12976,7 @@ mod tests {
                 include_summaries: false,
                 sort_by: Some("size".into()),
                 event_hours: Some(24),
+                event_secs: None,
                 client_epoch: 0,
             }),
         )
@@ -12919,7 +13014,12 @@ mod tests {
         // send_stats_request is a blocking sync client; run it off the runtime.
         let cfg = config.clone();
         let stats = tokio::task::spawn_blocking(move || {
-            send_stats_request(&cfg, true, Some("size"), Some(24))
+            send_stats_request(
+                &cfg,
+                true,
+                Some("size"),
+                Some(crate::since::SinceWindow::DEFAULT),
+            )
         })
         .await
         .unwrap()
@@ -12976,6 +13076,7 @@ mod tests {
             include_summaries: false,
             sort_by: None,
             event_hours: None,
+            event_secs: None,
             client_epoch: build_epoch(),
         });
         let mut response_value = serde_json::to_value(response).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ mod report;
 mod scheduler;
 mod service;
 mod shards;
+mod since;
 // Both callers (`clean`'s classifier and `compute_link_stats`) are `cfg(unix)`,
 // because `nlink` is the signal they combine with. Windows ReFS block-cloning
 // has no read-side query to implement this against — `FSCTL_DUPLICATE_EXTENTS`
@@ -265,14 +266,15 @@ enum Commands {
 
     /// Live TUI dashboard for monitoring builds
     Monitor {
-        /// Show events from the last N hours
+        /// Preload events from this window (e.g. 15m, 2h, 7d; a bare number
+        /// is hours)
         #[arg(long)]
         since: Option<String>,
     },
 
     /// Show cache stats summary (non-interactive)
     Stats {
-        /// Show events from the last N hours (e.g. 24h, 1h, 7d)
+        /// Event window (e.g. 15m, 2h, 7d; a bare number is hours)
         #[arg(long, default_value = "24h")]
         since: String,
     },
@@ -295,7 +297,7 @@ enum Commands {
         #[arg(long, default_value = "text")]
         format: String,
 
-        /// Time window (e.g. 24h, 7d, 1h)
+        /// Event window (e.g. 15m, 2h, 7d; a bare number is hours)
         #[arg(long, default_value = "24h")]
         since: String,
 
@@ -779,12 +781,12 @@ fn main() -> Result<()> {
             output,
             top,
         }) => {
-            let hours = parse_duration_hours(&since).unwrap_or(24);
-            cli::report(&config, &format, hours, root, output, top)
+            let window = parse_since_window(&since)?;
+            cli::report(&config, &format, window, root, output, top)
         }
         Some(Commands::Stats { since }) => {
-            let hours = parse_duration_hours(&since);
-            cli::stats(&config, &config_provenance, hours, json)
+            let window = parse_since_window(&since)?;
+            cli::stats(&config, &config_provenance, window, json)
         }
         Some(Commands::Telemetry {
             command:
@@ -804,8 +806,8 @@ fn main() -> Result<()> {
                 "monitor",
                 "`kache stats --json`",
             )?;
-            let hours = since.as_deref().and_then(parse_duration_hours);
-            tui::run_monitor(&config, hours)
+            let window = since.as_deref().map(parse_since_window).transpose()?;
+            tui::run_monitor(&config, window)
         }
         #[cfg(unix)]
         Some(Commands::InstallShims {
@@ -1127,6 +1129,17 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
     std::process::exit(exit_code);
 }
 
+/// Parse a `--since` value, or fail loudly. Falling back to the default on a
+/// value that did not parse is how `--since 15m` came to report a 24h window
+/// labelled as such (kunobi-ninja/kache#897).
+fn parse_since_window(value: &str) -> Result<since::SinceWindow> {
+    since::SinceWindow::parse(value).ok_or_else(|| {
+        anyhow::anyhow!(
+            "invalid --since {value:?}; expected a duration like 15m, 2h, or 7d (a bare number is hours)"
+        )
+    })
+}
+
 /// Parse a duration string like "7d", "24h", "1h" into hours.
 fn parse_duration_hours(s: &str) -> Option<u64> {
     let s = s.trim();
@@ -1172,6 +1185,16 @@ mod tests {
             }
             result => result,
         }
+    }
+
+    #[test]
+    fn parse_since_window_accepts_minutes_and_rejects_garbage() {
+        assert_eq!(parse_since_window("15m").unwrap().secs(), 900);
+        assert_eq!(parse_since_window("2h").unwrap().secs(), 7200);
+        assert_eq!(parse_since_window("24").unwrap().secs(), 86_400);
+        let err = parse_since_window("soon").unwrap_err().to_string();
+        assert!(err.contains("invalid --since \"soon\""), "{err}");
+        assert!(err.contains("15m"), "{err}");
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,6 +7,7 @@ use crate::cli::format_duration_ms;
 use crate::config::Config;
 use crate::daemon::{TransferDirection, TransferEvent};
 use crate::events::{self, BuildEvent, EventResult};
+use crate::since::SinceWindow;
 
 // ── Data Model ──────────────────────────────────────────────────────────────
 
@@ -73,9 +74,30 @@ pub struct BuildReport {
 pub struct ReportMeta {
     pub kache_version: String,
     pub generated_at: String,
+    /// The window in whole hours, rounded down (0 for a sub-hour window).
+    /// Kept for consumers that predate `since_secs`.
     pub since_hours: u64,
+    /// The window in seconds (kunobi-ninja/kache#897). Authoritative.
+    #[serde(default)]
+    pub since_secs: u64,
+    /// The window as requested: `15m`, `2h`, `24h`. Empty in reports written
+    /// before this field existed; render through [`ReportMeta::window_label`].
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub since: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub root_filter: Option<String>,
+}
+
+impl ReportMeta {
+    /// The window for headings: `since` when present, else the whole-hour
+    /// value an older report carried.
+    pub fn window_label(&self) -> String {
+        if self.since.is_empty() {
+            format!("{}h", self.since_hours)
+        } else {
+            self.since.clone()
+        }
+    }
 }
 
 fn default_trace_display_time_unit() -> String {
@@ -653,23 +675,24 @@ pub struct ReportFilter {
     pub root: Option<PathBuf>,
 }
 
-pub fn generate_report(config: &Config, hours: u64, top: usize) -> Result<BuildReport> {
-    generate_report_with_filter(config, hours, top, &ReportFilter::default())
+pub fn generate_report(config: &Config, window: SinceWindow, top: usize) -> Result<BuildReport> {
+    generate_report_with_filter(config, window, top, &ReportFilter::default())
 }
 
 pub fn generate_report_with_filter(
     config: &Config,
-    hours: u64,
+    window: SinceWindow,
     top: usize,
     filter: &ReportFilter,
 ) -> Result<BuildReport> {
-    let since = Utc::now() - chrono::Duration::hours(hours as i64);
+    let now = Utc::now();
+    let since = window.cutoff(now);
     let mut build_events = events::read_events_since(&config.event_log_path(), since)?;
     let root_filter = filter.root.as_deref().map(normalize_filter_root);
     if let Some(root) = root_filter.as_deref() {
         build_events.retain(|event| event_matches_root(event, root));
     }
-    let since_ts = since.timestamp() as u64;
+    let since_ts = window.cutoff_unix_secs(now);
     let transfers = if root_filter.is_some() {
         Vec::new()
     } else {
@@ -826,7 +849,9 @@ pub fn generate_report_with_filter(
         meta: ReportMeta {
             kache_version: crate::VERSION.to_string(),
             generated_at: Utc::now().to_rfc3339(),
-            since_hours: hours,
+            since_hours: window.hours(),
+            since_secs: window.secs(),
+            since: window.label(),
             root_filter: root_filter.clone(),
         },
         summary: ReportSummary {
@@ -914,7 +939,7 @@ pub fn generate_report_with_filter(
         bypass,
         errors_detail,
         suggestions,
-        gc: load_gc_summary(&config.cache_dir, hours),
+        gc: load_gc_summary(&config.cache_dir, since),
     })
 }
 
@@ -943,15 +968,14 @@ fn event_matches_root(event: &BuildEvent, root: &str) -> bool {
             .is_some_and(|suffix| suffix.starts_with(std::path::MAIN_SEPARATOR))
 }
 
-/// Load GC stats from gc_stats.json if GC ran within the report window.
-fn load_gc_summary(cache_dir: &std::path::Path, hours: u64) -> Option<GcSummary> {
+/// Load GC stats from gc_stats.json if GC ran at or after `cutoff`.
+fn load_gc_summary(cache_dir: &std::path::Path, cutoff: DateTime<Utc>) -> Option<GcSummary> {
     let path = cache_dir.join("gc_stats.json");
     let content = std::fs::read_to_string(&path).ok()?;
     let persisted: GcStatsPersisted = serde_json::from_str(&content).ok()?;
 
     // Only include if GC ran within the report window
     let last_run = chrono::DateTime::parse_from_rfc3339(&persisted.last_run).ok()?;
-    let cutoff = Utc::now() - chrono::Duration::hours(hours as i64);
     if last_run < cutoff {
         return None;
     }
@@ -2197,7 +2221,7 @@ pub fn format_markdown(report: &BuildReport) -> String {
     lines.push("#### Summary".to_string());
     lines.push("| Metric | Value |".to_string());
     lines.push("|---|---|".to_string());
-    lines.push(format!("| Window | last {}h |", report.meta.since_hours));
+    lines.push(format!("| Window | last {} |", report.meta.window_label()));
     lines.push(format!("| Hit rate (count) | {:.1}% |", s.hit_rate_pct));
     if let Some(w) = s.weighted_hit_rate_pct {
         lines.push(format!("| Hit rate (compile-cost weighted) | {:.1}% |", w));
@@ -2555,8 +2579,8 @@ pub fn format_github(report: &BuildReport) -> String {
     lines.push("| | |".to_string());
     lines.push("|---|---|".to_string());
     lines.push(format!(
-        "| **Window** | last {}h |",
-        report.meta.since_hours
+        "| **Window** | last {} |",
+        report.meta.window_label()
     ));
     lines.push(format!(
         "| **Crates** | {} cached / {} compiled / {} total |",
@@ -3026,9 +3050,9 @@ pub fn format_github(report: &BuildReport) -> String {
 
     lines.push(String::new());
     lines.push(format!(
-        "*Posted by [kache-action](https://github.com/kunobi-ninja/kache-action) · kache v{} · last {}h*",
+        "*Posted by [kache-action](https://github.com/kunobi-ninja/kache-action) · kache v{} · last {}*",
         report.meta.kache_version,
-        report.meta.since_hours,
+        report.meta.window_label(),
     ));
 
     lines.join("\n")
@@ -3044,8 +3068,8 @@ pub fn format_text(report: &BuildReport) -> String {
     let total_compiled = s.dups + s.misses;
 
     lines.push(format!(
-        "kache build report (last {}h)",
-        report.meta.since_hours
+        "kache build report (last {})",
+        report.meta.window_label()
     ));
     lines.push(format!(
         "  {:.1}% hit rate — {}/{} cacheable crates cached, {} compiled",
@@ -3398,11 +3422,44 @@ mod tests {
         std::fs::write(dir.join("gc_stats.json"), persisted).unwrap();
     }
 
+    /// A run at exactly the cutoff is inside the window: the comparison is
+    /// "older than the cutoff is excluded", not "at or older". One second
+    /// either side of that instant decides it.
+    #[test]
+    fn load_gc_summary_includes_a_run_exactly_at_the_cutoff() {
+        let dir = tempfile::tempdir().unwrap();
+        let last_run = Utc::now() - chrono::Duration::hours(3);
+        write_gc_stats(dir.path(), last_run);
+        // The fixture writes an RFC 3339 string, so compare against the value
+        // that string parses back to rather than the original instant.
+        let persisted: GcStatsPersisted = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("gc_stats.json")).unwrap(),
+        )
+        .unwrap();
+        let written = chrono::DateTime::parse_from_rfc3339(&persisted.last_run)
+            .unwrap()
+            .with_timezone(&Utc);
+
+        assert!(
+            load_gc_summary(dir.path(), written).is_some(),
+            "a run at the cutoff is within the window"
+        );
+        assert!(
+            load_gc_summary(dir.path(), written - chrono::Duration::seconds(1)).is_some(),
+            "a run after the cutoff is within the window"
+        );
+        assert!(
+            load_gc_summary(dir.path(), written + chrono::Duration::seconds(1)).is_none(),
+            "a run before the cutoff is outside it"
+        );
+    }
+
     #[test]
     fn load_gc_summary_returns_recent_run_within_window() {
         let dir = tempfile::tempdir().unwrap();
         write_gc_stats(dir.path(), Utc::now() - chrono::Duration::hours(1));
-        let gc = load_gc_summary(dir.path(), 24).expect("recent gc run is within the 24h window");
+        let gc = load_gc_summary(dir.path(), SinceWindow::DEFAULT.cutoff(Utc::now()))
+            .expect("recent gc run is within the 24h window");
         assert_eq!(gc.entries_evicted, 3);
         assert_eq!(gc.bytes_freed, 4096);
         assert_eq!(gc.blobs_removed, 5);
@@ -3413,7 +3470,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         write_gc_stats(dir.path(), Utc::now() - chrono::Duration::hours(48));
         assert!(
-            load_gc_summary(dir.path(), 24).is_none(),
+            load_gc_summary(dir.path(), SinceWindow::DEFAULT.cutoff(Utc::now())).is_none(),
             "a run 48h ago must fall outside the 24h window"
         );
     }
@@ -3421,14 +3478,14 @@ mod tests {
     #[test]
     fn load_gc_summary_absent_when_no_stats_file() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(load_gc_summary(dir.path(), 24).is_none());
+        assert!(load_gc_summary(dir.path(), SinceWindow::DEFAULT.cutoff(Utc::now())).is_none());
     }
 
     #[test]
     fn load_gc_summary_absent_on_malformed_stats_file() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("gc_stats.json"), b"not json").unwrap();
-        assert!(load_gc_summary(dir.path(), 24).is_none());
+        assert!(load_gc_summary(dir.path(), SinceWindow::DEFAULT.cutoff(Utc::now())).is_none());
     }
 
     fn test_event(
@@ -3730,7 +3787,7 @@ mod tests {
         failed.store_error = "refusing to cache zero-byte artifact: liblint.rmeta".to_string();
         events::log_event(&config.event_log_path(), &failed).unwrap();
 
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         assert_eq!(report.summary.store_failures, 1);
         // Still a miss: the compiler ran, and demoting it would drop it out of
@@ -3762,7 +3819,7 @@ mod tests {
         let mut bogus = test_event("serde", EventResult::LocalHit, 5, 300, 1024, "abc123def456");
         bogus.store_error = "should not be counted".to_string();
         events::log_event(&config.event_log_path(), &bogus).unwrap();
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         assert_eq!(report.summary.store_failures, 1);
 
         let text = format_text(&report);
@@ -3777,7 +3834,7 @@ mod tests {
     fn test_generate_report_with_all_result_types() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         assert_eq!(report.summary.total_crates, 5); // excludes errors from cacheable count
         assert_eq!(report.summary.local_hits, 1);
@@ -4035,7 +4092,7 @@ mod tests {
     fn test_format_json_conforms_to_schema_contract() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         let json = format_json(&report).unwrap();
         let val: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -4049,7 +4106,7 @@ mod tests {
     fn test_validator_rejects_out_of_bounds_number_maximum() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         let json = format_json(&report).unwrap();
         let mut val: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -4064,7 +4121,7 @@ mod tests {
     fn test_validator_rejects_out_of_bounds_integer_minimum() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         let json = format_json(&report).unwrap();
         let mut val: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -4079,7 +4136,7 @@ mod tests {
     fn test_validator_rejects_invalid_schema_version() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         let json = format_json(&report).unwrap();
         let mut val: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -4094,7 +4151,7 @@ mod tests {
     fn test_validator_rejects_missing_required_key() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         let json = format_json(&report).unwrap();
         let mut val: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -4108,7 +4165,7 @@ mod tests {
     fn test_json_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         let json = format_json(&report).unwrap();
         let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -4136,6 +4193,55 @@ mod tests {
         assert_eq!(parsed.all_events[0].end_time, report.all_events[0].end_time);
     }
 
+    /// #897: the report's window is the one requested, in counters, in
+    /// `meta`, and in every heading.
+    #[test]
+    fn report_window_narrows_events_and_labels_itself() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = write_test_events(dir.path());
+        let mut stale = test_event("ancient", EventResult::Miss, 5000, 4800, 1024, "old");
+        stale.ts = Utc::now() - chrono::Duration::hours(3);
+        events::log_event(&config.event_log_path(), &stale).unwrap();
+
+        let wide = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
+        let narrow = generate_report(&config, SinceWindow::parse("15m").unwrap(), 10).unwrap();
+        assert_eq!(wide.summary.misses, narrow.summary.misses + 1);
+        assert!(
+            !narrow.all_events.iter().any(|e| e.crate_name == "ancient"),
+            "a 3h-old event is outside a 15m window"
+        );
+
+        assert_eq!(narrow.meta.since, "15m");
+        assert_eq!(narrow.meta.since_secs, 900);
+        assert_eq!(narrow.meta.since_hours, 0, "whole hours, rounded down");
+        assert_eq!(wide.meta.since_hours, 24);
+        assert_eq!(wide.meta.since_secs, 86_400);
+
+        assert!(format_text(&narrow).contains("kache build report (last 15m)"));
+        assert!(format_markdown(&narrow).contains("| Window | last 15m |"));
+        assert!(format_github(&narrow).contains("| **Window** | last 15m |"));
+        assert!(format_github(&narrow).contains("· last 15m*"));
+        let json: serde_json::Value = serde_json::from_str(&format_json(&narrow).unwrap()).unwrap();
+        assert_eq!(json["meta"]["since"], "15m");
+        assert_eq!(json["meta"]["since_secs"], 900);
+    }
+
+    /// A report written before `meta.since` existed still gets a heading.
+    #[test]
+    fn window_label_falls_back_to_whole_hours() {
+        let meta: ReportMeta = serde_json::from_str(
+            r#"{"kache_version":"0.1.0","generated_at":"2026-01-01T00:00:00Z","since_hours":6}"#,
+        )
+        .unwrap();
+        assert_eq!(meta.window_label(), "6h");
+        assert_eq!(meta.since_secs, 0);
+        let current = ReportMeta {
+            since: "15m".to_string(),
+            ..meta
+        };
+        assert_eq!(current.window_label(), "15m");
+    }
+
     #[test]
     fn test_report_filters_by_root() {
         let dir = tempfile::tempdir().unwrap();
@@ -4145,7 +4251,7 @@ mod tests {
 
         let report = generate_report_with_filter(
             &config,
-            24,
+            SinceWindow::DEFAULT,
             10,
             &ReportFilter {
                 root: Some(root.clone()),
@@ -4177,7 +4283,7 @@ mod tests {
     fn test_trace_json_format_is_minimal_chrome_trace_container() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         let json = format_trace_json(&report).unwrap();
         let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -4447,7 +4553,7 @@ mod tests {
     fn report_totals_the_wrapper_phases() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_phase_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         let t = &report.timing;
         assert_eq!(t.total_startup_ms, 7);
         assert_eq!(t.avg_startup_ms, 3.5);
@@ -4489,7 +4595,7 @@ mod tests {
     fn text_markdown_and_github_reports_show_the_wrapper_phases() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_phase_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         let text = format_text(&report);
         for line in [
@@ -4532,7 +4638,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
         events::clear_events(&config.event_log_path()).unwrap();
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         assert_eq!(report.summary.total_crates, 0);
         assert!(!format_text(&report).contains("Startup:"));
         assert!(!format_markdown(&report).contains("| Startup |"));
@@ -4543,7 +4649,7 @@ mod tests {
     fn trace_json_emits_each_crate_slice_followed_by_its_phases() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_phase_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         let json = format_trace_json(&report).unwrap();
         let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
         let arr = raw["traceEvents"].as_array().unwrap();
@@ -4621,7 +4727,7 @@ mod tests {
     fn test_markdown_contains_sections() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         let md = format_markdown(&report);
         assert!(md.contains("### kache build report"));
@@ -4688,7 +4794,7 @@ mod tests {
         let event = test_event("serde", EventResult::LocalHit, 5, 300, 1024, "abc");
         events::log_event(&config.event_log_path(), &event).unwrap();
 
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         assert!(report.network.is_none());
         assert!(
             report
@@ -4763,7 +4869,7 @@ mod tests {
         let hit = test_event("hit", EventResult::LocalHit, 5, 100, 1024, "hk");
         events::log_event(&config.event_log_path(), &hit).unwrap();
 
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         assert!(
             report
                 .suggestions
@@ -4836,7 +4942,7 @@ mod tests {
             events::log_event(&config.event_log_path(), &e).unwrap();
         }
 
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         assert!(
             report
                 .suggestions
@@ -4909,7 +5015,7 @@ mod tests {
             events::log_transfer(&config.transfer_log_path(), t).unwrap();
         }
 
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         let joined = report.suggestions.join("\n");
         assert!(
             joined.contains("downloads failed"),
@@ -5009,7 +5115,7 @@ mod tests {
         };
         events::log_transfer(&config.transfer_log_path(), &slow).unwrap();
 
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         let joined = report.suggestions.join("\n");
         assert!(
             joined.contains("semaphore wait"),
@@ -5032,7 +5138,7 @@ mod tests {
     fn test_github_format_has_collapsible_sections() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         let gh = format_github(&report);
         assert!(gh.contains("### kache build cache"));
@@ -5063,7 +5169,7 @@ mod tests {
     fn test_text_output() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         let text = format_text(&report);
         assert!(text.contains("kache build report"));
@@ -5081,7 +5187,7 @@ mod tests {
         // Storage and GC sections (markdown:1415/text:2111/github:1853 + GC).
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let mut report = generate_report(&config, 24, 10).unwrap();
+        let mut report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         report.storage = StorageBreakdown {
             reflinked_bytes: 1024,
@@ -5137,7 +5243,7 @@ mod tests {
         // phase, cumulative-phase, GET-fan-out, and error-table branches.
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let mut report = generate_report(&config, 24, 10).unwrap();
+        let mut report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
 
         report.network = Some(NetworkAnalysis {
             configured_backend: "s3".to_string(),
@@ -5377,7 +5483,7 @@ mod tests {
             remote_negative_ttl_secs: crate::config::DEFAULT_REMOTE_NEGATIVE_TTL_SECS,
         };
 
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         assert_eq!(report.summary.total_crates, 0);
         assert_eq!(report.summary.hit_rate_pct, 0.0);
         assert!(report.network.is_none());
@@ -5714,7 +5820,7 @@ mod tests {
         }
 
         // Must aggregate without panicking across all format arms.
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         assert!(
             report.network.is_some(),
             "downloads should yield network analysis"
@@ -5760,7 +5866,7 @@ mod tests {
         // back to the "{logical} logical, {blobs} blobs" form (the else arm).
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let mut report = generate_report(&config, 24, 10).unwrap();
+        let mut report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         report.storage = StorageBreakdown {
             reflinked_bytes: 0,
             hardlinked_bytes: 0,
@@ -5787,7 +5893,7 @@ mod tests {
     fn storage_render_flags_impossible_dedup_accounting() {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
-        let mut report = generate_report(&config, 24, 10).unwrap();
+        let mut report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         report.storage.logical_bytes = 29;
         report.storage.blob_bytes = 56;
         report.storage.dedup_saved_bytes = 0;
@@ -5808,7 +5914,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = write_test_events(dir.path());
         let render = |logical_bytes, blob_bytes, accounting_consistent| {
-            let mut report = generate_report(&config, 24, 10).unwrap();
+            let mut report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
             report.storage.restored_bytes = 0;
             report.storage.logical_bytes = logical_bytes;
             report.storage.blob_bytes = blob_bytes;
@@ -5834,7 +5940,7 @@ mod tests {
             "{github}"
         );
 
-        let mut restored = generate_report(&config, 24, 10).unwrap();
+        let mut restored = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         restored.storage.restored_bytes = 1024;
         restored.storage.logical_bytes = 1;
         restored.storage.blob_bytes = 1;
@@ -5849,7 +5955,7 @@ mod tests {
         assert!(!blob_accounting_consistent(4, 5));
 
         let state = |logical_bytes, blob_bytes, accounting_consistent| {
-            let mut report = generate_report(&config, 24, 10).unwrap();
+            let mut report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
             report.storage.logical_bytes = logical_bytes;
             report.storage.blob_bytes = blob_bytes;
             report.storage.accounting_consistent = accounting_consistent;
@@ -5861,7 +5967,7 @@ mod tests {
         assert_eq!(state(1, 0, false), StorageAccountingState::Inconsistent);
         assert_eq!(state(0, 1, false), StorageAccountingState::Inconsistent);
 
-        let report = generate_report(&config, 24, 10).unwrap();
+        let report = generate_report(&config, SinceWindow::DEFAULT, 10).unwrap();
         let mut old_json = serde_json::to_value(&report.storage).unwrap();
         old_json
             .as_object_mut()

--- a/src/report.schema.json
+++ b/src/report.schema.json
@@ -42,7 +42,16 @@
         "since_hours": {
           "type": "integer",
           "minimum": 0,
-          "description": "Lookback window duration in hours."
+          "description": "Lookback window in whole hours, rounded down (0 for a sub-hour window). Kept for consumers that predate since_secs."
+        },
+        "since_secs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Lookback window in seconds. Authoritative; since_hours is derived from it."
+        },
+        "since": {
+          "type": "string",
+          "description": "Lookback window as requested on the command line, e.g. 15m, 2h, 24h. Absent in reports written before this field existed."
         },
         "root_filter": {
           "type": ["string", "null"],

--- a/src/since.rs
+++ b/src/since.rs
@@ -1,0 +1,239 @@
+//! The `--since` lookback window shared by `kache stats`, `kache report`, and
+//! `kache monitor` (kunobi-ninja/kache#897).
+//!
+//! The window used to be parsed straight to whole hours, so `--since 15m` did
+//! not parse, fell back to the 24h default, and was then labelled "last 24h".
+//! Keeping the parsed value here, in seconds plus the unit the user typed,
+//! means every consumer filters by the same cutoff and prints the same label.
+
+use chrono::{DateTime, Utc};
+
+/// The unit a window was written in. Kept so the label says `15m` when the
+/// user typed `15m` and `24h` when they typed `24h` (or a bare `24`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Unit {
+    Secs,
+    Mins,
+    Hours,
+    Days,
+}
+
+impl Unit {
+    fn secs(self) -> u64 {
+        match self {
+            Unit::Secs => 1,
+            Unit::Mins => 60,
+            Unit::Hours => 3600,
+            Unit::Days => 86_400,
+        }
+    }
+
+    fn suffix(self) -> char {
+        match self {
+            Unit::Secs => 's',
+            Unit::Mins => 'm',
+            Unit::Hours => 'h',
+            Unit::Days => 'd',
+        }
+    }
+}
+
+/// A lookback window: "events from the last N seconds".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SinceWindow {
+    secs: u64,
+    unit: Unit,
+}
+
+impl SinceWindow {
+    /// The default window every windowed command used before #897 and still
+    /// uses when `--since` is not given.
+    pub(crate) const DEFAULT: SinceWindow = SinceWindow {
+        secs: 24 * 3600,
+        unit: Unit::Hours,
+    };
+
+    /// A window from a raw second count, as carried over the daemon protocol.
+    /// The label unit is the largest one that divides the count evenly.
+    pub(crate) fn from_secs(secs: u64) -> Self {
+        let unit = [Unit::Days, Unit::Hours, Unit::Mins]
+            .into_iter()
+            .find(|unit| secs > 0 && secs.is_multiple_of(unit.secs()))
+            .unwrap_or(Unit::Secs);
+        SinceWindow { secs, unit }
+    }
+
+    /// A whole-hour window. `None` on overflow.
+    pub(crate) fn from_hours(hours: u64) -> Option<Self> {
+        Some(SinceWindow {
+            secs: hours.checked_mul(3600)?,
+            unit: Unit::Hours,
+        })
+    }
+
+    /// Parse `15m`, `2h`, `7d`, `90s`, or a bare integer (hours, kept for
+    /// compatibility with the pre-#897 flag). Whitespace around the value is
+    /// ignored. `None` for anything else, including overflow and an empty
+    /// number.
+    pub(crate) fn parse(input: &str) -> Option<Self> {
+        let input = input.trim();
+        let (digits, unit) = match input.chars().last()? {
+            's' => (&input[..input.len() - 1], Unit::Secs),
+            'm' => (&input[..input.len() - 1], Unit::Mins),
+            'h' => (&input[..input.len() - 1], Unit::Hours),
+            'd' => (&input[..input.len() - 1], Unit::Days),
+            // No unit suffix: the whole value is the count, in hours. A
+            // trailing character that is not a digit is rejected by the
+            // all-digits check below, so this arm needs no guard of its own.
+            _ => (input, Unit::Hours),
+        };
+        if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        let count: u64 = digits.parse().ok()?;
+        Some(SinceWindow {
+            secs: count.checked_mul(unit.secs())?,
+            unit,
+        })
+    }
+
+    pub(crate) fn secs(self) -> u64 {
+        self.secs
+    }
+
+    /// Whole hours, rounded down. `0` for a sub-hour window. Kept for the
+    /// `since_hours` / `hours` fields older consumers read; `secs()` is the
+    /// authoritative value.
+    pub(crate) fn hours(self) -> u64 {
+        self.secs / 3600
+    }
+
+    /// The window written in the unit it was requested in: `15m`, `2h`, `24h`.
+    pub(crate) fn label(self) -> String {
+        format!("{}{}", self.secs / self.unit.secs(), self.unit.suffix())
+    }
+
+    /// The instant events must be at or after to fall inside the window.
+    /// Saturates at the earliest representable time rather than wrapping.
+    pub(crate) fn cutoff(self, now: DateTime<Utc>) -> DateTime<Utc> {
+        let secs = i64::try_from(self.secs).unwrap_or(i64::MAX);
+        chrono::Duration::try_seconds(secs)
+            .and_then(|d| now.checked_sub_signed(d))
+            .unwrap_or(DateTime::<Utc>::MIN_UTC)
+    }
+
+    /// [`Self::cutoff`] as Unix seconds, for the transfer log whose timestamps
+    /// are stored that way. Clamped at zero for a window older than the epoch.
+    pub(crate) fn cutoff_unix_secs(self, now: DateTime<Utc>) -> u64 {
+        u64::try_from(self.cutoff(now).timestamp()).unwrap_or(0)
+    }
+}
+
+impl std::fmt::Display for SinceWindow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.label())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn parses_every_unit() {
+        assert_eq!(SinceWindow::parse("90s").unwrap().secs(), 90);
+        assert_eq!(SinceWindow::parse("15m").unwrap().secs(), 900);
+        assert_eq!(SinceWindow::parse("2h").unwrap().secs(), 7200);
+        assert_eq!(SinceWindow::parse("7d").unwrap().secs(), 604_800);
+    }
+
+    #[test]
+    fn bare_integer_means_hours() {
+        let window = SinceWindow::parse("48").unwrap();
+        assert_eq!(window.secs(), 172_800);
+        assert_eq!(window.hours(), 48);
+        assert_eq!(window.label(), "48h");
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_ignored() {
+        assert_eq!(SinceWindow::parse(" 15m \n").unwrap().secs(), 900);
+    }
+
+    #[test]
+    fn rejects_invalid_input() {
+        for bad in [
+            "", " ", "invalid", "m", "h", "15x", "1.5h", "-2h", "2 h", "15mm", "+3h",
+        ] {
+            assert!(SinceWindow::parse(bad).is_none(), "{bad:?} must not parse");
+        }
+    }
+
+    #[test]
+    fn rejects_overflow() {
+        assert!(SinceWindow::parse("18446744073709551615d").is_none());
+        assert!(SinceWindow::parse("18446744073709551615h").is_none());
+        assert!(SinceWindow::parse("18446744073709551615m").is_none());
+        assert!(SinceWindow::parse("18446744073709551616s").is_none());
+        assert!(SinceWindow::from_hours(u64::MAX).is_none());
+    }
+
+    #[test]
+    fn label_keeps_the_requested_unit() {
+        assert_eq!(SinceWindow::parse("15m").unwrap().label(), "15m");
+        assert_eq!(SinceWindow::parse("2h").unwrap().label(), "2h");
+        assert_eq!(SinceWindow::parse("24h").unwrap().label(), "24h");
+        assert_eq!(SinceWindow::parse("1d").unwrap().label(), "1d");
+        assert_eq!(SinceWindow::parse("90s").unwrap().label(), "90s");
+        assert_eq!(SinceWindow::DEFAULT.label(), "24h");
+        assert_eq!(SinceWindow::DEFAULT.to_string(), "24h");
+        assert_eq!(SinceWindow::from_hours(3).unwrap().label(), "3h");
+    }
+
+    #[test]
+    fn from_secs_picks_the_largest_even_unit() {
+        assert_eq!(SinceWindow::from_secs(900).label(), "15m");
+        assert_eq!(SinceWindow::from_secs(7200).label(), "2h");
+        assert_eq!(SinceWindow::from_secs(86_400).label(), "1d");
+        assert_eq!(SinceWindow::from_secs(90).label(), "90s");
+        assert_eq!(SinceWindow::from_secs(0).label(), "0s");
+        assert_eq!(SinceWindow::from_secs(900).secs(), 900);
+        assert_eq!(
+            SinceWindow::from_secs(900),
+            SinceWindow::parse("15m").unwrap()
+        );
+    }
+
+    #[test]
+    fn default_is_twenty_four_hours() {
+        assert_eq!(SinceWindow::DEFAULT.secs(), 86_400);
+        assert_eq!(SinceWindow::DEFAULT.hours(), 24);
+        assert_eq!(SinceWindow::DEFAULT, SinceWindow::parse("24h").unwrap());
+    }
+
+    #[test]
+    fn sub_hour_windows_floor_to_zero_hours() {
+        assert_eq!(SinceWindow::parse("15m").unwrap().hours(), 0);
+        assert_eq!(SinceWindow::parse("90m").unwrap().hours(), 1);
+    }
+
+    #[test]
+    fn cutoff_subtracts_the_window() {
+        let now = Utc.with_ymd_and_hms(2026, 9, 1, 12, 0, 0).unwrap();
+        let window = SinceWindow::parse("15m").unwrap();
+        assert_eq!(
+            window.cutoff(now),
+            Utc.with_ymd_and_hms(2026, 9, 1, 11, 45, 0).unwrap()
+        );
+        assert_eq!(window.cutoff_unix_secs(now), now.timestamp() as u64 - 900);
+    }
+
+    #[test]
+    fn cutoff_saturates_for_absurd_windows() {
+        let now = Utc.with_ymd_and_hms(2026, 9, 1, 12, 0, 0).unwrap();
+        let window = SinceWindow::parse("18446744073709551615s").unwrap();
+        assert_eq!(window.cutoff(now), DateTime::<Utc>::MIN_UTC);
+        assert_eq!(window.cutoff_unix_secs(now), 0);
+    }
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -15,6 +15,7 @@ use crate::cli;
 use crate::config::Config;
 use crate::daemon;
 use crate::events::{self, BuildEvent, EventRecord, EventResult, EventTailer, HeartbeatEvent};
+use crate::since::SinceWindow;
 
 // ── Terminal mode guard ────────────────────────────────────────────────────
 
@@ -419,21 +420,21 @@ const SNAPSHOT_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 // ── Entry point ────────────────────────────────────────────────────────────
 
 /// Run the TUI monitor dashboard.
-pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
+pub fn run_monitor(config: &Config, since: Option<SinceWindow>) -> Result<()> {
     let _terminal_mode = TerminalModeGuard::enter()?;
 
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::new(backend)?;
 
-    let tailer = if since_hours.is_some() {
+    let tailer = if since.is_some() {
         EventTailer::from_start(config.event_log_path())
     } else {
         EventTailer::new(config.event_log_path())
     };
 
-    let initial_events = if let Some(hours) = since_hours {
-        let since = chrono::Utc::now() - chrono::Duration::hours(hours as i64);
-        events::read_events_since(&config.event_log_path(), since).unwrap_or_default()
+    let initial_events = if let Some(window) = since {
+        let cutoff = window.cutoff(chrono::Utc::now());
+        events::read_events_since(&config.event_log_path(), cutoff).unwrap_or_default()
     } else {
         Vec::new()
     };
@@ -580,8 +581,14 @@ pub fn run_monitor(config: &Config, since_hours: Option<u64>) -> Result<()> {
             std::thread::spawn(move || {
                 // Auto-start stays silent here: the raw-mode alternate screen
                 // owns the terminal, so a stderr notice would corrupt it.
-                let snap =
-                    cli::fetch_stats_snapshot(&cfg, include_entries, &sort, Some(24), false, false);
+                let snap = cli::fetch_stats_snapshot(
+                    &cfg,
+                    include_entries,
+                    &sort,
+                    SinceWindow::DEFAULT,
+                    false,
+                    false,
+                );
                 if let Ok(mut s) = slot.lock() {
                     *s = Some(snap);
                 }

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -366,6 +366,33 @@ fn stats_on_empty_cache_succeeds() {
     e.cmd().args(["stats", "--since", "1h"]).assert().success();
 }
 
+/// #897: a sub-hour window is accepted and named as requested, and a value
+/// that does not parse is an error rather than a silent 24h fallback.
+#[test]
+fn stats_and_report_label_the_requested_window() {
+    let e = env();
+    e.cmd()
+        .args(["stats", "--since", "15m"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("last 15m)"));
+    e.cmd()
+        .args(["report", "--format", "text", "--since", "90m"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("kache build report (last 90m)"));
+    e.cmd()
+        .args(["stats", "--since", "soon"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("invalid --since \"soon\""));
+    e.cmd()
+        .args(["report", "--since", "1.5h"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("invalid --since"));
+}
+
 /// #689 end-to-end: `stats` announces a daemon auto-start on stderr, and a
 /// later invocation pointing `KACHE_CONFIG` at a different file still renders
 /// the daemon's values — now with a warning naming both values and both


### PR DESCRIPTION
Closes #897.

`kache stats --since 15m` returned the same counters as `--since 2h`, and labelled itself "last 24h". The window was parsed straight to whole hours: anything under an hour did not parse, the command fell back to the 24 hour default, and the label printed that default rather than what was asked for. The reporter saw byte-identical counters for windows eight times apart.

## What changed

- `src/since.rs` parses a window once, into seconds plus the unit that was typed: `90s`, `15m`, `2h`, `7d`, and a bare integer as hours, which is the spelling that worked before. A value that does not parse is now an error instead of a silent fall back to 24 hours.
- The report meta carries `since_secs` beside the existing `since_hours`, so a consumer that predates this keeps working while the filter has full resolution. The human label prints the window that was requested.
- The daemon filters events on seconds. Before, the cutoff it received was already rounded to hours, which is where the sub-hour windows were lost.
- `kache stats`, `kache report` and `kache monitor` all take the same forms, and the reference page says so.

## Verification

- Unit tests on the parser: each unit, the bare-integer form, rejection of garbage and of an empty value, the label round trip, and that `from_secs` labels with the largest unit that divides evenly.
- An end-to-end test drives `kache stats` and `kache report` with two different windows against one event log and asserts both the counters and the label differ accordingly.
- `mise exec -- just check` on this head after rebasing onto `main`: fmt, clippy `-D warnings`, full workspace tests. CI's `Mutation testing (diff k/n)` shards are the mutants gate; opened as a draft for them.

## What a reviewer should still watch

- `since_hours` stays in the JSON meta and is now a floor: it reads 0 for a sub-hour window. Removing it is a schema break and is not done here.
- The rebase onto #917 needed four report tests updated to the new signature; nothing else in that PR's phase work interacts with the window.