### PR TITLE
fix(bench): unbreak the nightly and authenticate third-party clones

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -244,11 +244,55 @@ jobs:
         with:
           # Pin mise CLI — see ci.yml (v2026.6.10 regression).
           version: 2026.6.9
-          # mr-boxington (mbx) is pinned to its latest release on purpose:
-          # the hk-mbx arm tracks that tool as it ships.
-          install_args: --force rust github:casey/just github:mozilla/sccache mr-boxington@latest
+          install_args: --force rust github:casey/just github:mozilla/sccache
           cache: false
           reshim: false
+
+      # The comparison tool for the `-mbx` arms, installed from its GitHub
+      # release rather than through the shared mise step: the pinned mise CLI
+      # is older than that tool's registry entry, and a tool the other arms do
+      # not use must never be able to fail their install step. Latest release
+      # on purpose — the arm tracks the tool as it ships — with the checksum
+      # verified and the version recorded in the log.
+      - name: Install mbx (comparison arms only)
+        if: endsWith(matrix.name, '-mbx')
+        timeout-minutes: 10
+        run: |
+          set -euo pipefail
+          # curl, not `gh`: the ARC runner image ships no GitHub CLI.
+          # /releases/latest redirects to the tag, so the newest release is
+          # one HEAD request and needs no token or JSON parsing.
+          repo=https://github.com/jdx/mr-boxington
+          archive=mbx-x86_64-unknown-linux-gnu.tar.gz
+          dir="$RUNNER_TEMP/mbx"
+          mkdir -p "$dir"
+          tag="$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$repo/releases/latest" | sed 's#.*/tag/##')"
+          case "$tag" in
+            v[0-9]*) ;;
+            *) echo "::error::could not resolve the latest release tag (got '$tag')"; exit 1 ;;
+          esac
+          curl -fsSL -o "$dir/$archive" "$repo/releases/download/$tag/$archive"
+          curl -fsSL -o "$dir/SHA256SUMS" "$repo/releases/download/$tag/SHA256SUMS"
+          (cd "$dir" && grep "  $archive$" SHA256SUMS | sha256sum --check --strict -)
+          tar -xzf "$dir/$archive" -C "$dir"
+          echo "$dir" >> "$GITHUB_PATH"
+          echo "mbx release $tag"
+          "$dir/mbx" --version
+
+      # The harness clones third-party subjects over https. Anonymous
+      # requests share this cluster's egress quota, and when it is exhausted
+      # GitHub answers 401, which git reports as "could not read Username"
+      # and the bench dies before it builds anything. Authenticating with the
+      # job's own read-only token moves those fetches onto the much larger
+      # per-token limit. Ephemeral pod, so the config dies with the job.
+      - name: Authenticate git for third-party clones
+        env:
+          GH_JOB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          header="$(printf 'x-access-token:%s' "$GH_JOB_TOKEN" | base64 -w0)"
+          git config --global --replace-all \
+            "http.https://github.com/.extraheader" "AUTHORIZATION: basic $header"
 
       # Fail fast on a full disk — disk-full mid-build is the worst failure mode
       # on the emptyDir-backed work volume.

--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -364,6 +364,21 @@ jobs:
           # `clone-ref` is a SIBLING of the work dir, so it needs its own rm.
           rm -rf tmp/perf-gate/base tmp/perf-gate/base-clone-ref
 
+      # The harness clones third-party subjects over https. Anonymous
+      # requests share this cluster's egress quota, and when it is exhausted
+      # GitHub answers 401, which git reports as "could not read Username"
+      # and the bench dies before it builds anything. Authenticating with the
+      # job's own read-only token moves those fetches onto the much larger
+      # per-token limit. Ephemeral pod, so the config dies with the job.
+      - name: Authenticate git for third-party clones
+        env:
+          GH_JOB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          header="$(printf 'x-access-token:%s' "$GH_JOB_TOKEN" | base64 -w0)"
+          git config --global --replace-all \
+            "http.https://github.com/.extraheader" "AUTHORIZATION: basic $header"
+
       - name: Benchmark the PR head
         timeout-minutes: 40
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,14 @@ members = [
 # `[workspace]` so cargo treats them as standalone, which is what the
 # e2e harness (and the integration tests) need to drive them as
 # realistic standalone consumers of kache.
+#
+# `tmp/` is the bench and e2e scratch tree, where third-party subjects are
+# cloned. A subject that is itself a workspace root (substrate, opendal) stops
+# cargo's upward walk on its own, but a plain single-package subject (jdx/hk)
+# does not, and cargo then refuses to build it: "current package believes it's
+# in a workspace when it's not". We do not control those manifests, so exclude
+# the directory they land in.
+exclude = ["tmp"]
 resolver = "3"
 
 [dependencies]


### PR DESCRIPTION
Last night's nightly bench failed on every arm. Not one of them ran a build.

## What happened, in two layers

**The nightly.** #922 added `mr-boxington@latest` to the `install_args` of the bench matrix's shared "Install tools via mise" step. That workflow pins the mise CLI to 2026.6.9 (see ci.yml, the v2026.6.10 regression), and that CLI's bundled registry predates the tool's entry, so the step exits 1. Because the step is shared, substrate, surrealdb, lance, opendal, llvm, hk, hk-pull and firefox-sccache all died at it, before the free-disk precheck and before any bench ran. The four nightlies before it failed only on the two Firefox arms, which is the long-standing shape.

**What it was hiding.** With that fixed, the run got as far as the clone and died there: `fatal: could not read Username for 'https://github.com'`. The harness clones its subjects over https, anonymous requests share this cluster's egress quota, and when it is exhausted GitHub answers 401, which git reports as a credential prompt it cannot answer. That is also the intermittent `perf-gate/warm` failure on #918, #922 and #923: same message, same runners, same anonymous fetch, and it passes on a rerun once the quota recovers.

## What changed

- `install_args` goes back to rust, just and sccache.
- The comparison tool installs in its own step, `if: endsWith(matrix.name, '-mbx')`, from its GitHub release: resolve the latest tag from the `/releases/latest` redirect, download the Linux x86-64 archive and `SHA256SUMS`, verify with `sha256sum --check --strict`, extract, prepend to `PATH`, print the tag and `--version` so every run records what it measured. curl rather than `gh`, because the runner image ships no GitHub CLI.
- Both `bench.yml` and `perf-gate.yml` hand git the job's own read-only token before the clone, so third-party fetches use the per-token rate limit instead of the shared anonymous one. Ephemeral pods, so the config dies with the job.

## Verification

- The download-and-verify sequence was run locally against the current release: the tag resolves, the checksum matches, the archive contains the binary.
- `actionlint` with shellcheck reports exactly the same findings before and after, for both workflows.
- A dispatch of this workflow from this branch with `scenario=hk-mbx` is the real proof; the previous dispatch got through install (`mbx 1.5.0`) and died at the clone, which is what the second half of this change addresses.

## What a reviewer should still watch

- The install step resolves the latest tag at run time, so a release that renames its assets breaks that one arm, loudly, at the checksum or the extract.
- If the 401s turn out not to be quota after all, the token does not help and the next failure will say so in the same place.