### PR TITLE
ci: put the scenario in the bench concurrency key

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -41,7 +41,17 @@ on:
 
 concurrency:
   # One bench run per scenario+ref at a time; don't cancel a multi-hour run.
-  group: ${{ github.workflow }}-${{ github.ref }}
+  #
+  # The scenario is part of the key because that is what the sentence above
+  # says, and for a while it was not: the key was workflow+ref alone, so every
+  # scenario on a ref shared ONE slot. An 8-minute `hk` dispatch queued behind
+  # an 8-hour `firefox-pull`, which is the exact thing this block exists to
+  # prevent. Splitting the runner pool does not help - three runners are no use
+  # to a job Actions will not even assign.
+  #
+  # A scheduled run has no inputs and keys on 'all', so the nightly still
+  # serialises against another full sweep, which is what we want.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.scenario || 'all' }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
The comment above the block already described the intended behaviour. The key did not implement it.

```yaml
# One bench run per scenario+ref at a time; don't cancel a multi-hour run.
group: ${{ github.workflow }}-${{ github.ref }}   # <- no scenario
```

Every scenario on a ref shared one slot.

## Why it matters

Arm durations are not comparable, measured from runs that succeeded:

| Arm | Real duration | Timeout cap |
| --- | ---: | ---: |
| `hk-mbx` | 3 min | 60 |
| `hk` | 8 min | 60 |
| `firefox` | — | 360 |
| `firefox-pull` | — | 480 |

An 8-minute dispatch queued behind an 8-hour one purely for sharing a ref. #925 splitting the runner pool does not address this: three runners are no use to a job Actions will not assign.

It also strands the nightly. The 03:37 sweep leaves `Bench Firefox (Windows)` and `Bench Firefox Pull (Windows)` queued whenever the self-hosted Windows runners are offline, so the run never reaches a terminal state and holds the group against every later bench on `main` — including the following night's sweep. Run 33705551044 sat queued for 12 hours with all 11 Linux arms already finished, blocking everything behind it, and had to be cancelled by hand.

## The change

```yaml
group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.scenario || 'all' }}
```

A scheduled run has no inputs and keys on `all`, so a full sweep still serialises against another full sweep — the part worth keeping. `cancel-in-progress: false` is unchanged, so nothing kills a running benchmark.

## What a reviewer should still watch

- This does **not** fix the offline Windows runners, and does not stop a nightly from hanging on them. It stops one hung nightly from taking the next one down with it. The runners are the real fix.
- Two different scenarios can now hold slots at once. They still contend for runners, so the heavy arms remain serialised by `kunobi-runners` being capped at one — which is intended.