### PR TITLE
perf(cc): make the preprocessor memo reachable

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -2553,6 +2553,23 @@ enum FileHashCache<'db> {
     Owned(Connection),
 }
 
+/// One input of a memoised preprocessor run: its metadata at the time the
+/// expansion was hashed, plus the hash of its contents.
+///
+/// The metadata is a fast path — identical metadata means identical bytes,
+/// with no read. The content hash is what makes the memo survive everything
+/// metadata cannot: a second worktree (new inodes and mtimes for the same
+/// bytes), a fresh CI checkout, and a header a build script regenerated
+/// byte-for-byte. Those are the cases a compile cache exists for, and they
+/// are exactly the ones metadata alone rejects.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct CcPreprocessMemoInput {
+    #[serde(flatten)]
+    fingerprint: FileFingerprint,
+    /// blake3 of the file's contents when the expansion was hashed.
+    content: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) struct FileFingerprint {
     path: String,
@@ -2680,9 +2697,19 @@ impl<'db> FileHasher<'db> {
         self.cache.is_some()
     }
 
-    /// Reuse a preprocessor-output hash only when every source/header still
-    /// has the exact metadata fingerprint captured by the successful probe.
-    /// Any database, decoding, metadata, or freshness uncertainty is a miss.
+    /// Reuse a preprocessor-output hash only when every source and header the
+    /// probe read still holds the same bytes.
+    ///
+    /// Metadata first, because identical metadata needs no read. When it
+    /// differs the file is hashed and compared, so bytes that merely moved
+    /// (another worktree, a fresh checkout) or were rewritten unchanged (a
+    /// build script regenerating a header) still hit.
+    ///
+    /// The too-new guard deliberately does not apply. It exists because
+    /// metadata cannot tell a file written a moment ago from one still being
+    /// written; a content hash can, because a file that changes afterwards
+    /// simply fails the next comparison. Any database, decoding, or metadata
+    /// uncertainty is still a miss.
     pub(crate) fn cc_preprocess_memo_lookup(&self, memo_key: &str) -> Option<String> {
         let cache = self.cache.as_ref()?;
         let record = match cache.get_cc_preprocess_memo(memo_key) {
@@ -2701,46 +2728,73 @@ impl<'db> FileHasher<'db> {
             tracing::debug!("cc preprocess memo hash is invalid");
             return None;
         }
-        let fingerprints: Vec<FileFingerprint> = match serde_json::from_str(&record.1) {
-            Ok(fingerprints) => fingerprints,
+        let inputs: Vec<CcPreprocessMemoInput> = match serde_json::from_str(&record.1) {
+            Ok(inputs) => inputs,
             Err(error) => {
                 tracing::debug!("cc preprocess memo inputs are invalid: {error}");
                 return None;
             }
         };
-        if fingerprints.is_empty() {
+        if inputs.is_empty() {
             return None;
         }
-        for expected in &fingerprints {
-            let current = match FileFingerprint::from_path(Path::new(&expected.path)) {
-                Ok(current) => current,
-                Err(error) => {
-                    tracing::debug!(
-                        "cc preprocess memo input {} is unavailable: {error}",
-                        expected.path
-                    );
-                    return None;
-                }
-            };
-            self.note_too_new(&current);
-            if current != *expected || self.too_new() {
+        for expected in &inputs {
+            if !self.memo_input_is_unchanged(expected) {
                 return None;
             }
         }
         Some(record.0)
     }
 
-    /// Capture the source/header metadata observed immediately after a full
-    /// preprocess probe. The caller revalidates this snapshot after a
-    /// successful compile or restore before committing it.
+    /// Does this input still hold the bytes the memo was recorded against?
+    ///
+    /// Identical metadata answers yes without a read. Otherwise the file is
+    /// hashed through the ordinary content cache, so a header shared by many
+    /// translation units is read once per build rather than once per unit.
+    fn memo_input_is_unchanged(&self, expected: &CcPreprocessMemoInput) -> bool {
+        let path = Path::new(&expected.fingerprint.path);
+        match FileFingerprint::from_path(path) {
+            Ok(current) => {
+                self.note_too_new(&current);
+                if current == expected.fingerprint {
+                    return true;
+                }
+            }
+            Err(error) => {
+                tracing::debug!(
+                    "cc preprocess memo input {} is unavailable: {error}",
+                    expected.fingerprint.path
+                );
+                return false;
+            }
+        }
+        match self.hash(path) {
+            Ok(content) => content == expected.content,
+            Err(error) => {
+                tracing::debug!(
+                    "cc preprocess memo input {} could not be hashed: {error}",
+                    expected.fingerprint.path
+                );
+                false
+            }
+        }
+    }
+
+    /// Capture the source/header metadata and contents observed immediately
+    /// after a full preprocess probe. The caller revalidates this snapshot
+    /// after a successful compile or restore before committing it.
+    ///
+    /// Hashing here is what the memo is validated against later. It is not
+    /// free on a cold build, but every hash goes through the content cache,
+    /// so a header included by many translation units is read once.
     pub(crate) fn cc_preprocess_fingerprints(
         &self,
         paths: &[PathBuf],
-    ) -> Option<Vec<FileFingerprint>> {
+    ) -> Option<Vec<CcPreprocessMemoInput>> {
         if paths.is_empty() {
             return None;
         }
-        let mut fingerprints = Vec::with_capacity(paths.len());
+        let mut inputs = Vec::with_capacity(paths.len());
         for path in paths {
             let fingerprint = match FileFingerprint::from_path(path) {
                 Ok(fingerprint) => fingerprint,
@@ -2753,37 +2807,53 @@ impl<'db> FileHasher<'db> {
                 }
             };
             self.note_too_new(&fingerprint);
-            fingerprints.push(fingerprint);
+            let content = match self.hash(path) {
+                Ok(content) => content,
+                Err(error) => {
+                    tracing::debug!(
+                        "cc preprocess memo input {} could not be hashed: {error}",
+                        path.display()
+                    );
+                    return None;
+                }
+            };
+            inputs.push(CcPreprocessMemoInput {
+                fingerprint,
+                content,
+            });
         }
-        fingerprints.sort_by(|a, b| a.path.cmp(&b.path));
-        fingerprints.dedup_by(|a, b| a.path == b.path);
-        Some(fingerprints)
+        inputs.sort_by(|a, b| a.fingerprint.path.cmp(&b.fingerprint.path));
+        inputs.dedup_by(|a, b| a.fingerprint.path == b.fingerprint.path);
+        Some(inputs)
     }
 
-    /// Commit a pending preprocessor memo after proving its inputs remained
-    /// unchanged through the successful compiler/restore boundary.
+    /// Commit a pending preprocessor memo after proving its inputs held the
+    /// same bytes through the successful compiler/restore boundary.
+    ///
+    /// An input written during this build no longer blocks the record. What
+    /// it was blocking is a torn read, and a torn read is caught where it
+    /// matters: the recorded hash is of whatever bytes were there, so the
+    /// finished file simply fails the next comparison and the expansion is
+    /// recomputed. Refusing to record instead meant a fresh checkout — every
+    /// CI runner, every new worktree — could never memoise anything at all.
     pub(crate) fn cc_preprocess_memo_record_if_unchanged(
         &self,
         memo_key: &str,
         preprocessed_hash: &str,
-        fingerprints: &[FileFingerprint],
+        inputs: &[CcPreprocessMemoInput],
     ) {
         let Some(cache) = &self.cache else {
             return;
         };
-        if fingerprints.is_empty() {
+        if inputs.is_empty() {
             return;
         }
-        for expected in fingerprints {
-            let Ok(current) = FileFingerprint::from_path(Path::new(&expected.path)) else {
-                return;
-            };
-            self.note_too_new(&current);
-            if current != *expected || self.too_new() {
+        for expected in inputs {
+            if !self.memo_input_is_unchanged(expected) {
                 return;
             }
         }
-        let inputs_json = match serde_json::to_string(fingerprints) {
+        let inputs_json = match serde_json::to_string(inputs) {
             Ok(inputs_json) => inputs_json,
             Err(error) => {
                 tracing::debug!("cc preprocess memo inputs could not be encoded: {error}");
@@ -8306,12 +8376,18 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         assert_eq!(hasher.cc_preprocess_memo_lookup("short-hash"), None);
         assert_eq!(hasher.cc_preprocess_memo_lookup("non-hex-hash"), None);
 
+        // An input written inside the invocation window is what a fresh
+        // checkout looks like. It used to refuse both halves of the memo,
+        // which meant CI could never memoise anything; the content hash makes
+        // the recency irrelevant.
         let mut fresh_hasher = FileHasher::persistent(&db);
-        fresh_hasher.arm_too_new_guard(1, 0);
+        fresh_hasher.arm_too_new_guard(i64::MAX, 0);
         assert_eq!(
-            fresh_hasher.cc_preprocess_memo_lookup("memo-key"),
-            None,
-            "an input too new for the invocation must force preprocessing"
+            fresh_hasher
+                .cc_preprocess_memo_lookup("memo-key")
+                .as_deref(),
+            Some(pp_hash.as_str()),
+            "unchanged bytes must hit however recently they were written"
         );
         fresh_hasher.cc_preprocess_memo_record_if_unchanged("too-new", &pp_hash, &inputs);
         assert!(
@@ -8321,8 +8397,8 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
                 .unwrap()
                 .get_cc_preprocess_memo("too-new")
                 .unwrap()
-                .is_none(),
-            "too-new inputs must not publish a memo"
+                .is_some(),
+            "a fresh checkout must still be able to publish a memo"
         );
 
         std::fs::write(&header, "#define VALUE 12345\n").unwrap();
@@ -8341,6 +8417,61 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
                 .unwrap()
                 .is_none(),
             "changed inputs must not publish a memo"
+        );
+    }
+
+    /// The case the memo exists for and used to miss: the same bytes at new
+    /// metadata. A second worktree gives every file a new inode and mtime,
+    /// and a build script that regenerates a header rewrites it identically.
+    /// Neither changes what the preprocessor would produce.
+    #[test]
+    fn cc_preprocess_memo_survives_new_metadata_for_unchanged_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("idx.sqlite");
+        let source = dir.path().join("source.c");
+        let header = dir.path().join("header.h");
+        let source_bytes = "#include \"header.h\"\nint v(void) { return VALUE; }\n";
+        let header_bytes = "#define VALUE 1\n";
+        std::fs::write(&source, source_bytes).unwrap();
+        std::fs::write(&header, header_bytes).unwrap();
+
+        let hasher = FileHasher::persistent(&db);
+        let inputs = hasher
+            .cc_preprocess_fingerprints(&[source.clone(), header.clone()])
+            .unwrap();
+        assert!(
+            inputs.iter().all(|input| input.content.len() == 64),
+            "every recorded input carries a content hash"
+        );
+        let pp_hash = "b".repeat(64);
+        hasher.cc_preprocess_memo_record_if_unchanged("memo-key", &pp_hash, &inputs);
+
+        // Rewrite both files with identical bytes. Remove first, so the
+        // replacement gets a new inode as well as a new mtime — the shape a
+        // second checkout produces.
+        for (path, bytes) in [(&source, source_bytes), (&header, header_bytes)] {
+            std::fs::remove_file(path).unwrap();
+            std::fs::write(path, bytes).unwrap();
+        }
+        let rewritten = FileFingerprint::from_path(&header).unwrap();
+        assert_ne!(
+            rewritten, inputs[0].fingerprint,
+            "the rewrite must actually change the metadata this test is about"
+        );
+
+        let reader = FileHasher::persistent(&db);
+        assert_eq!(
+            reader.cc_preprocess_memo_lookup("memo-key").as_deref(),
+            Some(pp_hash.as_str()),
+            "identical bytes at new metadata must reuse the expansion"
+        );
+
+        // One byte of difference is still a miss, whatever the metadata says.
+        std::fs::write(&header, "#define VALUE 2\n").unwrap();
+        assert_eq!(
+            FileHasher::persistent(&db).cc_preprocess_memo_lookup("memo-key"),
+            None,
+            "changed bytes must force a fresh preprocess"
         );
     }
 

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1560,7 +1560,7 @@ fn parse_preprocess_dependencies(raw: &str, cwd: &Path) -> Result<Vec<PathBuf>> 
 #[derive(Debug)]
 struct PreprocessHash {
     hash: String,
-    fingerprints: Option<Vec<crate::cache_key::FileFingerprint>>,
+    fingerprints: Option<Vec<crate::cache_key::CcPreprocessMemoInput>>,
 }
 
 fn preprocess_hash(
@@ -3841,9 +3841,49 @@ fn fold_cc_memo_field(hasher: &mut blake3::Hasher, label: &[u8], value: &[u8]) {
     hasher.update(value);
 }
 
-/// Local identity for a preprocessor invocation. The full environment is
-/// intentionally included: compiler-specific include variables are numerous,
-/// and an extra miss is safer than overlooking one that changes expansion.
+/// Environment variables that cannot change a preprocessor expansion and do
+/// change between two otherwise identical invocations.
+///
+/// The memo key folds the environment wholesale, because compiler-specific
+/// include variables are numerous and an extra miss is safer than overlooking
+/// one. That stays true — this is a deny list, not an allow list, so anything
+/// unrecognised is still keyed and the worst case remains a wasted preprocess.
+///
+/// Without it the memo is unreachable rather than merely conservative. A
+/// shell exports `_`, `PWD` and `OLDPWD` fresh for every command, cargo hands
+/// each build script a jobserver on file descriptors it picked this run, and
+/// kache's own runtime variables move with the cache directory. Any one of
+/// those gives every invocation its own key, so nothing is ever reused.
+/// `cwd` is folded separately and explicitly, so dropping `PWD` here loses
+/// nothing.
+const CC_MEMO_VOLATILE_ENV: &[&str] = &[
+    // Shell bookkeeping, rewritten per command.
+    "_",
+    "OLDPWD",
+    "PWD",
+    "SHLVL",
+    // Build-driver parallelism: `--jobserver-fds=3,5` names this run's fds.
+    "CARGO_MAKEFLAGS",
+    "MAKEFLAGS",
+    "MFLAGS",
+    "MAKELEVEL",
+    "NUM_JOBS",
+];
+
+/// Is this a variable the memo key deliberately ignores? kache's own
+/// `KACHE_*` settings are included: they steer the wrapper, never the
+/// preprocessor, and they differ between any two cache directories.
+fn cc_memo_env_is_volatile(name: &OsStr) -> bool {
+    let Some(name) = name.to_str() else {
+        return false;
+    };
+    name.starts_with("KACHE_") || CC_MEMO_VOLATILE_ENV.contains(&name)
+}
+
+/// Local identity for a preprocessor invocation. The environment is included
+/// apart from [`cc_memo_env_is_volatile`]: compiler-specific include
+/// variables are numerous, and an extra miss is safer than overlooking one
+/// that changes expansion.
 fn cc_preprocess_memo_key(
     parsed: &CcArgs,
     prefix_maps: &[CcPrefixMap],
@@ -3854,7 +3894,7 @@ fn cc_preprocess_memo_key(
     let compiler_path = super::resolve_program_on_path(&parsed.program)?;
     let compiler_metadata = std::fs::metadata(&compiler_path).ok()?;
     let mut hasher = blake3::Hasher::new();
-    fold_cc_memo_field(&mut hasher, b"schema", b"cc-preprocess-memo-v1");
+    fold_cc_memo_field(&mut hasher, b"schema", b"cc-preprocess-memo-v2");
     fold_cc_memo_field(
         &mut hasher,
         b"compiler-program",
@@ -3909,6 +3949,7 @@ fn cc_preprocess_memo_key(
     }
 
     let mut environment: Vec<(Vec<u8>, Vec<u8>)> = std::env::vars_os()
+        .filter(|(name, _)| !cc_memo_env_is_volatile(name))
         .map(|(name, value)| (cc_memo_os_bytes(&name), cc_memo_os_bytes(&value)))
         .collect();
     environment.sort();
@@ -4437,7 +4478,7 @@ fn cc_include_name_counts(name: &OsStr) -> bool {
 struct PendingCcPreprocessMemo {
     memo_key: String,
     preprocessed_hash: String,
-    fingerprints: Vec<crate::cache_key::FileFingerprint>,
+    fingerprints: Vec<crate::cache_key::CcPreprocessMemoInput>,
 }
 
 #[derive(Default)]
@@ -8880,6 +8921,48 @@ mod tests {
         assert!(
             key.bytes()
                 .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        );
+    }
+
+    /// A variable that cannot reach the preprocessor must not give every
+    /// invocation its own memo, and one that can must still be keyed.
+    #[test]
+    fn cc_preprocess_memo_key_ignores_only_volatile_environment() {
+        let _lock = crate::test_support::process_state_test_lock();
+        let compiler = std::env::current_exe()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let parsed =
+            CcArgs::parse(&[compiler, "-c".to_string(), "memo-source.c".to_string()]).unwrap();
+        let key = || cc_preprocess_memo_key(&parsed, &[], "test compiler version").unwrap();
+
+        let baseline = key();
+        for (name, value) in [
+            ("_", "/usr/bin/whatever"),
+            ("OLDPWD", "/somewhere/else"),
+            ("SHLVL", "9"),
+            ("CARGO_MAKEFLAGS", "-j --jobserver-fds=7,9"),
+            ("NUM_JOBS", "13"),
+            ("KACHE_CACHE_DIR", "/tmp/some-other-cache"),
+        ] {
+            // SAFETY: the process-state lock serialises environment edits.
+            unsafe { std::env::set_var(name, value) };
+            assert_eq!(
+                key(),
+                baseline,
+                "{name} cannot change an expansion and must not change the memo key"
+            );
+            unsafe { std::env::remove_var(name) };
+        }
+
+        // SAFETY: as above.
+        unsafe { std::env::set_var("CPATH", "/opt/extra/include") };
+        let with_cpath = key();
+        unsafe { std::env::remove_var("CPATH") };
+        assert_ne!(
+            with_cpath, baseline,
+            "an include-path variable changes which headers are found and must be keyed"
         );
     }
 


### PR DESCRIPTION
Refs #762.

A warm build of a C-heavy workspace spawns the preprocessor once per translation unit even when nothing has changed. Measured on the hk benchmark: **575 of 575 cc units preprocessed in all three phases**, including the same-tree rebuild where no source moved. Key computation is 42.7s of the 46.7s a warm build attributes, and restore is 1.65s of it, so this is most of what a cache hit costs us.

The memo that exists to prevent exactly this could never be reached.

## Why it could not hit

- **It validated by metadata.** `FileFingerprint` is path, size, mtime, ctime and inode. A second worktree gives identical bytes new inodes and mtimes, so a cross-clone lookup could not match by construction.
- **It refused to record when any input was newer than the build start.** A fresh checkout makes every file newer than the build start, so a CI runner never recorded a memo in the first place, and neither did the benchmark's cold phase.
- **Its key folded the entire environment**, including variables that cannot reach the preprocessor and differ on every invocation: the shell's `_`, `PWD`, `OLDPWD` and `SHLVL`, the jobserver file descriptors cargo passes in `CARGO_MAKEFLAGS`, and kache's own `KACHE_*` settings. Every invocation therefore had a key of its own.

## What changed

- Memo inputs carry a content hash. Metadata still short-circuits the common case with no read; bytes decide when it differs. Hashing goes through the existing content cache, so a header included by many units is read once per build.
- The recency refusal is gone. It existed because metadata cannot distinguish a file written a moment ago from one still being written. A content hash can: a file that changes afterwards simply fails the next comparison and the expansion is recomputed.
- The memo key excludes the volatile variables by name. It is a deny list, not an allow list, so anything unrecognised is still keyed and the worst case is still a wasted preprocess rather than a wrong answer.
- The memo schema label moves to v2, so no record written by the old rules is read under the new ones.

No cache key changes, and nothing that used to invalidate a key stops doing so: the expansion is still hashed from scratch whenever the recorded bytes differ.

## Verification

- Five unit tests, including the two cases this is about: identical bytes at new inode and mtime must hit, one changed byte must not; and a variable that cannot reach the preprocessor must not change the key while `CPATH` must.
- End to end with a real compiler, three invocations over two directories: before this change every run preprocessed; after it, a rebuild in the same tree preprocesses zero times and a changed header still forces one.
- `mise exec -- just check`: fmt, clippy `-D warnings`, full workspace tests. Draft for the mutation shards.

## What a reviewer should still watch

- **Cross-worktree still preprocesses.** The memo key folds the raw working directory and argv, and recorded input paths are absolute, so a second checkout misses on the key before any of this applies. Making it worktree-independent means folding the prefix-mapped forms and re-rooting recorded paths; that is a larger change and is not here.
- Cold builds now hash the inputs they discover, which they did not before. Those reads are cached and shared across units, but a cold build does slightly more work in exchange for every later build doing far less.
- The deny list is the place a future volatile variable shows up. The symptom would be a memo that stops hitting, never a wrong key.