### PR TITLE
perf(cc): let the preprocessor memo cross checkouts

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -2564,6 +2564,13 @@ enum FileHashCache<'db> {
 /// are exactly the ones metadata alone rejects.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct CcPreprocessMemoInput {
+    /// The input's prefix-mapped spelling: what it is called in the form the
+    /// expansion was hashed in, and therefore the same string from any
+    /// checkout the maps cover. The reader turns it back into a local path.
+    name: String,
+    /// Where the file was, and what its metadata said, when recorded. The
+    /// path here is local to the recording checkout and is only a fast path;
+    /// a reader that resolved `name` elsewhere ignores it.
     #[serde(flatten)]
     fingerprint: FileFingerprint,
     /// blake3 of the file's contents when the expansion was hashed.
@@ -2710,7 +2717,11 @@ impl<'db> FileHasher<'db> {
     /// written; a content hash can, because a file that changes afterwards
     /// simply fails the next comparison. Any database, decoding, or metadata
     /// uncertainty is still a miss.
-    pub(crate) fn cc_preprocess_memo_lookup(&self, memo_key: &str) -> Option<String> {
+    pub(crate) fn cc_preprocess_memo_lookup(
+        &self,
+        memo_key: &str,
+        resolve: impl Fn(&str) -> Vec<PathBuf>,
+    ) -> Option<String> {
         let cache = self.cache.as_ref()?;
         let record = match cache.get_cc_preprocess_memo(memo_key) {
             Ok(record) => record?,
@@ -2739,7 +2750,7 @@ impl<'db> FileHasher<'db> {
             return None;
         }
         for expected in &inputs {
-            if !self.memo_input_is_unchanged(expected) {
+            if !self.memo_input_is_unchanged(expected, &resolve) {
                 return None;
             }
         }
@@ -2751,33 +2762,40 @@ impl<'db> FileHasher<'db> {
     /// Identical metadata answers yes without a read. Otherwise the file is
     /// hashed through the ordinary content cache, so a header shared by many
     /// translation units is read once per build rather than once per unit.
-    fn memo_input_is_unchanged(&self, expected: &CcPreprocessMemoInput) -> bool {
-        let path = Path::new(&expected.fingerprint.path);
-        match FileFingerprint::from_path(path) {
-            Ok(current) => {
+    fn memo_input_is_unchanged(
+        &self,
+        expected: &CcPreprocessMemoInput,
+        resolve: &impl Fn(&str) -> Vec<PathBuf>,
+    ) -> bool {
+        // Only where THIS invocation resolves the recorded name. The path the
+        // recording checkout used is not a candidate on its own merit: it may
+        // still exist, unmodified, while the tree being compiled now has an
+        // edited copy at the same mapped name. Trusting it let a modified
+        // source hit, which the relocate-modified e2e phase exists to catch.
+        // When the two trees are the same, the resolver returns that path
+        // anyway and the metadata comparison below still avoids the read.
+        let candidates = resolve(&expected.name);
+
+        for path in &candidates {
+            if let Ok(current) = FileFingerprint::from_path(path) {
                 self.note_too_new(&current);
                 if current == expected.fingerprint {
                     return true;
                 }
-            }
-            Err(error) => {
-                tracing::debug!(
-                    "cc preprocess memo input {} is unavailable: {error}",
-                    expected.fingerprint.path
-                );
-                return false;
-            }
-        }
-        match self.hash(path) {
-            Ok(content) => content == expected.content,
-            Err(error) => {
-                tracing::debug!(
-                    "cc preprocess memo input {} could not be hashed: {error}",
-                    expected.fingerprint.path
-                );
-                false
+                if self
+                    .hash(path)
+                    .is_ok_and(|content| content == expected.content)
+                {
+                    return true;
+                }
             }
         }
+        tracing::debug!(
+            "cc preprocess memo input {} matched none of {} candidate paths",
+            expected.name,
+            candidates.len()
+        );
+        false
     }
 
     /// Capture the source/header metadata and contents observed immediately
@@ -2789,13 +2807,13 @@ impl<'db> FileHasher<'db> {
     /// so a header included by many translation units is read once.
     pub(crate) fn cc_preprocess_fingerprints(
         &self,
-        paths: &[PathBuf],
+        paths: &[(String, PathBuf)],
     ) -> Option<Vec<CcPreprocessMemoInput>> {
         if paths.is_empty() {
             return None;
         }
         let mut inputs = Vec::with_capacity(paths.len());
-        for path in paths {
+        for (name, path) in paths {
             let fingerprint = match FileFingerprint::from_path(path) {
                 Ok(fingerprint) => fingerprint,
                 Err(error) => {
@@ -2818,12 +2836,13 @@ impl<'db> FileHasher<'db> {
                 }
             };
             inputs.push(CcPreprocessMemoInput {
+                name: name.clone(),
                 fingerprint,
                 content,
             });
         }
-        inputs.sort_by(|a, b| a.fingerprint.path.cmp(&b.fingerprint.path));
-        inputs.dedup_by(|a, b| a.fingerprint.path == b.fingerprint.path);
+        inputs.sort_by(|a, b| a.name.cmp(&b.name));
+        inputs.dedup_by(|a, b| a.name == b.name);
         Some(inputs)
     }
 
@@ -2849,7 +2868,10 @@ impl<'db> FileHasher<'db> {
             return;
         }
         for expected in inputs {
-            if !self.memo_input_is_unchanged(expected) {
+            // Recording happens in the checkout that just ran the preprocess,
+            // so each name resolves to the path it was captured from.
+            let recorded_path = PathBuf::from(&expected.fingerprint.path);
+            if !self.memo_input_is_unchanged(expected, &|_: &str| vec![recorded_path.clone()]) {
                 return;
             }
         }
@@ -8356,12 +8378,17 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
         let hasher = FileHasher::persistent(&db);
         let inputs = hasher
-            .cc_preprocess_fingerprints(&[source.clone(), header.clone()])
+            .cc_preprocess_fingerprints(&[
+                (source.to_string_lossy().into_owned(), source.clone()),
+                (header.to_string_lossy().into_owned(), header.clone()),
+            ])
             .unwrap();
         let pp_hash = "a".repeat(64);
         hasher.cc_preprocess_memo_record_if_unchanged("memo-key", &pp_hash, &inputs);
         assert_eq!(
-            hasher.cc_preprocess_memo_lookup("memo-key").as_deref(),
+            hasher
+                .cc_preprocess_memo_lookup("memo-key", no_remap)
+                .as_deref(),
             Some(pp_hash.as_str())
         );
 
@@ -8373,8 +8400,14 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         cache
             .put_cc_preprocess_memo("non-hex-hash", &"z".repeat(64), &inputs_json)
             .unwrap();
-        assert_eq!(hasher.cc_preprocess_memo_lookup("short-hash"), None);
-        assert_eq!(hasher.cc_preprocess_memo_lookup("non-hex-hash"), None);
+        assert_eq!(
+            hasher.cc_preprocess_memo_lookup("short-hash", no_remap),
+            None
+        );
+        assert_eq!(
+            hasher.cc_preprocess_memo_lookup("non-hex-hash", no_remap),
+            None
+        );
 
         // An input written inside the invocation window is what a fresh
         // checkout looks like. It used to refuse both halves of the memo,
@@ -8384,7 +8417,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         fresh_hasher.arm_too_new_guard(i64::MAX, 0);
         assert_eq!(
             fresh_hasher
-                .cc_preprocess_memo_lookup("memo-key")
+                .cc_preprocess_memo_lookup("memo-key", no_remap)
                 .as_deref(),
             Some(pp_hash.as_str()),
             "unchanged bytes must hit however recently they were written"
@@ -8403,7 +8436,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
         std::fs::write(&header, "#define VALUE 12345\n").unwrap();
         assert_eq!(
-            hasher.cc_preprocess_memo_lookup("memo-key"),
+            hasher.cc_preprocess_memo_lookup("memo-key", no_remap),
             None,
             "a changed transitive header must force preprocessing"
         );
@@ -8417,6 +8450,60 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
                 .unwrap()
                 .is_none(),
             "changed inputs must not publish a memo"
+        );
+    }
+
+    /// A resolver for tests that record and read in one place: the recorded
+    /// name is the path.
+    fn no_remap(name: &str) -> Vec<PathBuf> {
+        vec![PathBuf::from(name)]
+    }
+
+    /// The hole the relocate-modified e2e phase found: a second checkout with
+    /// an edited copy must not be answered by the unedited original, which is
+    /// still sitting on disk where the memo recorded it. Reusing that
+    /// expansion would derive the unedited key and serve a stale artifact for
+    /// modified source.
+    #[test]
+    fn cc_preprocess_memo_ignores_the_recording_tree_when_reading_another() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("idx.sqlite");
+        let original = dir.path().join("a");
+        let relocated = dir.path().join("b");
+        for tree in [&original, &relocated] {
+            std::fs::create_dir_all(tree).unwrap();
+        }
+        let source_of = |tree: &std::path::Path| tree.join("source.c");
+        std::fs::write(source_of(&original), "int v(void) { return 1; }\n").unwrap();
+
+        // Record in the original tree, under a mapped name both trees share.
+        let hasher = FileHasher::persistent(&db);
+        let inputs = hasher
+            .cc_preprocess_fingerprints(&[("<root>/source.c".to_string(), source_of(&original))])
+            .unwrap();
+        let pp_hash = "c".repeat(64);
+        hasher.cc_preprocess_memo_record_if_unchanged("memo-key", &pp_hash, &inputs);
+
+        // The relocated tree has an EDITED copy. The original still exists,
+        // untouched, at the path the record names.
+        std::fs::write(source_of(&relocated), "int v(void) { return 999; }\n").unwrap();
+        let resolve_in_relocated =
+            |name: &str| vec![relocated.join(name.trim_start_matches("<root>/"))];
+        assert_eq!(
+            FileHasher::persistent(&db).cc_preprocess_memo_lookup("memo-key", resolve_in_relocated),
+            None,
+            "the edited copy must miss even though the original is unchanged"
+        );
+
+        // The same resolver on an identical copy is a hit: this is not just
+        // rejecting everything from another tree.
+        std::fs::write(source_of(&relocated), "int v(void) { return 1; }\n").unwrap();
+        assert_eq!(
+            FileHasher::persistent(&db)
+                .cc_preprocess_memo_lookup("memo-key", resolve_in_relocated)
+                .as_deref(),
+            Some(pp_hash.as_str()),
+            "an identical copy in another tree must still reuse the expansion"
         );
     }
 
@@ -8437,7 +8524,10 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
         let hasher = FileHasher::persistent(&db);
         let inputs = hasher
-            .cc_preprocess_fingerprints(&[source.clone(), header.clone()])
+            .cc_preprocess_fingerprints(&[
+                (source.to_string_lossy().into_owned(), source.clone()),
+                (header.to_string_lossy().into_owned(), header.clone()),
+            ])
             .unwrap();
         assert!(
             inputs.iter().all(|input| input.content.len() == 64),
@@ -8461,7 +8551,9 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
         let reader = FileHasher::persistent(&db);
         assert_eq!(
-            reader.cc_preprocess_memo_lookup("memo-key").as_deref(),
+            reader
+                .cc_preprocess_memo_lookup("memo-key", no_remap)
+                .as_deref(),
             Some(pp_hash.as_str()),
             "identical bytes at new metadata must reuse the expansion"
         );
@@ -8469,7 +8561,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         // One byte of difference is still a miss, whatever the metadata says.
         std::fs::write(&header, "#define VALUE 2\n").unwrap();
         assert_eq!(
-            FileHasher::persistent(&db).cc_preprocess_memo_lookup("memo-key"),
+            FileHasher::persistent(&db).cc_preprocess_memo_lookup("memo-key", no_remap),
             None,
             "changed bytes must force a fresh preprocess"
         );

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1643,7 +1643,17 @@ fn preprocess_hash(
                 parse_preprocess_dependencies(&raw, &cwd)
             });
         match dependencies {
-            Ok(paths) => file_hasher.cc_preprocess_fingerprints(&paths),
+            Ok(paths) => {
+                // Record each input under its prefix-mapped spelling, the form
+                // the expansion above was hashed in. That is what lets another
+                // checkout read the memo: the path a second worktree resolves
+                // an input to differs, the mapped name does not.
+                let mapped: Vec<(String, PathBuf)> = paths
+                    .into_iter()
+                    .map(|path| (cc_mapped_path(&path, prefix_maps), path))
+                    .collect();
+                file_hasher.cc_preprocess_fingerprints(&mapped)
+            }
             Err(error) => {
                 tracing::debug!("cc preprocess dependency capture unavailable: {error:#}");
                 None
@@ -3894,7 +3904,7 @@ fn cc_preprocess_memo_key(
     let compiler_path = super::resolve_program_on_path(&parsed.program)?;
     let compiler_metadata = std::fs::metadata(&compiler_path).ok()?;
     let mut hasher = blake3::Hasher::new();
-    fold_cc_memo_field(&mut hasher, b"schema", b"cc-preprocess-memo-v2");
+    fold_cc_memo_field(&mut hasher, b"schema", b"cc-preprocess-memo-v3");
     fold_cc_memo_field(
         &mut hasher,
         b"compiler-program",
@@ -3930,21 +3940,30 @@ fn cc_preprocess_memo_key(
         b"compiler-version",
         compiler_version.as_bytes(),
     );
+    // The mapped cwd, not the raw one: two checkouts of the same tree differ
+    // here and nowhere the expansion can see, so folding the raw path gave
+    // every worktree its own memo.
     fold_cc_memo_field(
         &mut hasher,
         b"cwd",
-        cc_memo_os_bytes(cwd.as_os_str()).as_slice(),
+        cc_mapped_path(&cwd, prefix_maps).as_bytes(),
     );
     fold_cc_memo_field(
         &mut hasher,
         b"source-date-epoch",
         cc_memo_os_bytes(&epoch).as_slice(),
     );
+    // Likewise the argv: `-I` and the source path carry the checkout root.
+    // The maps are folded below, so two trees agree here only when they agree
+    // about what the mapping means.
     for arg in build_preprocess_args(parsed) {
-        fold_cc_memo_field(&mut hasher, b"arg", arg.as_bytes());
+        let mapped = apply_cc_prefix_maps_to_bytes(arg.into_bytes(), prefix_maps);
+        fold_cc_memo_field(&mut hasher, b"arg", &mapped);
     }
+    // Targets only. The sources are the per-checkout roots this whole change
+    // exists to keep out; the targets are the sentinels both trees share, and
+    // they are what decides whether two mappings mean the same thing.
     for map in prefix_maps {
-        fold_cc_memo_field(&mut hasher, b"prefix-from", map.from.as_bytes());
         fold_cc_memo_field(&mut hasher, b"prefix-to", map.to.as_bytes());
     }
 
@@ -4167,6 +4186,51 @@ fn common_is_temp_dir(common: &Path) -> bool {
 /// compiler's single-application `-ffile-prefix-map`. Single-pass matches the
 /// compiler's semantics and is identical to the old behavior for the normal case
 /// of non-overlapping absolute source prefixes.
+/// One path in the spelling the prefix maps give it, lossily for non-UTF-8.
+///
+/// The same rewrite the expansion and the resolved tokens already get, so a
+/// path recorded here reads the same from any checkout the maps cover.
+fn cc_mapped_path(path: &Path, prefix_maps: &[CcPrefixMap]) -> String {
+    // Text, not `cc_memo_os_bytes`: that encodes UTF-16 on Windows, and the
+    // map sources and targets are UTF-8, so nothing would ever match and
+    // every Windows memo missed. The maps are applied to argv strings the
+    // same way.
+    let text = path.to_string_lossy().into_owned().into_bytes();
+    String::from_utf8_lossy(&apply_cc_prefix_maps_to_bytes(text, prefix_maps)).into_owned()
+}
+
+/// Candidate real paths a mapped spelling could name in this invocation.
+///
+/// The inverse of [`cc_mapped_path`], and inexact by nature: two roots can
+/// share one sentinel, so this yields every prefix that could have produced
+/// the recorded name, most specific first. Picking wrong is not a
+/// correctness problem — the caller compares contents, so a candidate whose
+/// bytes differ is a miss and the expansion is recomputed. A mapped path
+/// with no matching sentinel yields nothing and the memo is skipped.
+fn cc_unmapped_path_candidates(mapped: &str, prefix_maps: &[CcPrefixMap]) -> Vec<PathBuf> {
+    let mut maps: Vec<&CcPrefixMap> = prefix_maps
+        .iter()
+        .filter(|map| !map.from.is_empty() && !map.to.is_empty())
+        .collect();
+    maps.sort_by_key(|map| std::cmp::Reverse(map.to.len()));
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    for map in maps {
+        if let Some(rest) = mapped.strip_prefix(map.to.as_str()) {
+            let candidate = PathBuf::from(format!("{}{rest}", map.from));
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+    }
+    // An absolute path outside every mapped root (a system header, the
+    // toolchain) was recorded verbatim and needs no inverse.
+    if candidates.is_empty() && Path::new(mapped).is_absolute() {
+        candidates.push(PathBuf::from(mapped));
+    }
+    candidates
+}
+
 fn apply_cc_prefix_maps_to_bytes(bytes: Vec<u8>, prefix_maps: &[CcPrefixMap]) -> Vec<u8> {
     // Most-specific (longest source) first so it wins at any position where two
     // sources overlap. (`cc_prefix_maps` already sorts this way; re-sort here so
@@ -5207,10 +5271,11 @@ impl Compiler for CcCompiler {
             .supports_cc_preprocess_memo()
             .then(|| cc_preprocess_memo_key(parsed, &prefix_maps, &resolved.version_line))
             .flatten();
-        let pp_hash = if let Some(memo_hash) = memo_key
-            .as_ref()
-            .and_then(|key| ctx.file_hasher.cc_preprocess_memo_lookup(key))
-        {
+        let pp_hash = if let Some(memo_hash) = memo_key.as_ref().and_then(|key| {
+            ctx.file_hasher.cc_preprocess_memo_lookup(key, |name| {
+                cc_unmapped_path_candidates(name, &prefix_maps)
+            })
+        }) {
             tracing::trace!(
                 target: "kache::cache_key",
                 "[key:{}] preprocessed_memo=hit",
@@ -8926,6 +8991,115 @@ mod tests {
 
     /// A variable that cannot reach the preprocessor must not give every
     /// invocation its own memo, and one that can must still be keyed.
+    /// A recorded name has to come back as the path this checkout uses, and
+    /// the memo key must not move when only the checkout root does.
+    #[test]
+    fn cc_memo_paths_map_out_and_back_across_checkouts() {
+        let maps = vec![
+            CcPrefixMap {
+                from: "/work/clone-a".to_string(),
+                to: "/kache/root".to_string(),
+            },
+            CcPrefixMap {
+                from: "/work/clone-a/build".to_string(),
+                to: "/kache/build".to_string(),
+            },
+        ];
+        assert_eq!(
+            cc_mapped_path(Path::new("/work/clone-a/src/a.h"), &maps),
+            "/kache/root/src/a.h"
+        );
+        // The longer source wins, as it does for the expansion.
+        assert_eq!(
+            cc_mapped_path(Path::new("/work/clone-a/build/gen.h"), &maps),
+            "/kache/build/gen.h"
+        );
+
+        let other = vec![
+            CcPrefixMap {
+                from: "/work/clone-b".to_string(),
+                to: "/kache/root".to_string(),
+            },
+            CcPrefixMap {
+                from: "/work/clone-b/build".to_string(),
+                to: "/kache/build".to_string(),
+            },
+        ];
+        assert_eq!(
+            cc_unmapped_path_candidates("/kache/root/src/a.h", &other),
+            vec![PathBuf::from("/work/clone-b/src/a.h")],
+            "a name recorded in one checkout resolves into the other"
+        );
+        assert_eq!(
+            cc_unmapped_path_candidates("/kache/build/gen.h", &other),
+            vec![PathBuf::from("/work/clone-b/build/gen.h")]
+        );
+
+        // Two roots behind one sentinel: both are offered, most specific
+        // first, and the caller settles it by content.
+        let shared = vec![
+            CcPrefixMap {
+                from: "/work/one".to_string(),
+                to: "/kache/root".to_string(),
+            },
+            CcPrefixMap {
+                from: "/elsewhere/two".to_string(),
+                to: "/kache/root".to_string(),
+            },
+        ];
+        assert_eq!(
+            cc_unmapped_path_candidates("/kache/root/h.h", &shared),
+            vec![
+                PathBuf::from("/work/one/h.h"),
+                PathBuf::from("/elsewhere/two/h.h")
+            ]
+        );
+
+        // An unmapped absolute path is its own answer; a relative name that
+        // matches no sentinel has none. Absoluteness is what the host says it
+        // is, so the path has to be spelled for the host.
+        let system_header = if cfg!(windows) {
+            r"C:\Program Files\sdk\stdio.h"
+        } else {
+            "/usr/include/stdio.h"
+        };
+        assert!(Path::new(system_header).is_absolute());
+        assert_eq!(
+            cc_unmapped_path_candidates(system_header, &other),
+            vec![PathBuf::from(system_header)]
+        );
+        assert!(cc_unmapped_path_candidates("relative/h.h", &other).is_empty());
+
+        // A half-empty map contributes nothing. Either side empty and the
+        // inverse is meaningless: an empty target matches every name and
+        // would graft the source onto all of them, an empty source would
+        // strip the name down to a relative path. Both must be dropped, so
+        // the filter needs both conditions.
+        let half_empty = vec![
+            CcPrefixMap {
+                from: "/work/one".to_string(),
+                to: String::new(),
+            },
+            CcPrefixMap {
+                from: String::new(),
+                to: "/kache/root".to_string(),
+            },
+        ];
+        // Neither half-empty map may contribute. The sentinel spelling is not
+        // absolute on Windows, so assert the shared property: no candidate
+        // ever comes from a map with an empty side.
+        assert!(
+            !cc_unmapped_path_candidates("/kache/root/h.h", &half_empty)
+                .iter()
+                .any(|candidate| candidate.starts_with("/work/one")),
+            "an empty target must not graft its source onto every name"
+        );
+        assert!(
+            cc_unmapped_path_candidates("relative/h.h", &half_empty).is_empty(),
+            "an empty source must not strip a name down to a relative path"
+        );
+    }
+
     #[test]
     fn cc_preprocess_memo_key_ignores_only_volatile_environment() {
         let _lock = crate::test_support::process_state_test_lock();


### PR DESCRIPTION
Refs #762. Follows #927.

#927 made the memo survive new metadata for unchanged bytes, which fixed rebuilding in the tree where the memo was written: the same-tree warm phase went from 575 preprocessor spawns to zero and halved its key time. It did nothing for a second checkout, and that is the phase this benchmark is built on. Measured on hk after #927:

| phase | preprocessor spawns | aggregate key |
| --- | ---: | ---: |
| same-tree warm | 0 | 20.5s |
| cross-clone warm | 575 | 42.2s |

## Why it could not cross

Two things pinned it to one directory.

- The memo key folded the raw working directory and the raw preprocess argv. Both carry the checkout root, so two trees never computed the same key.
- Recorded input paths were absolute, so even a shared key could not have resolved them elsewhere.

## What changed

Both now go through the prefix maps the expansion is already hashed under, so the memo is expressed in the same coordinates as the thing it memoises.

- The key folds the mapped working directory, the mapped argv, and the map *targets* only. The sources are the per-checkout roots this change exists to exclude; the targets are the sentinels both trees share, and they are what decides whether two mappings mean the same thing.
- Inputs are recorded under their mapped name and resolved back through the inverse at lookup. The recorded path is tried first, so a rebuild in place still matches on metadata and reads nothing.
- Schema label to v3, so no record written under the old rules is read under the new ones.

## On the inverse being inexact

Two roots can share one sentinel, so the inverse offers every candidate, most specific first. Picking wrong is not a correctness problem: the caller compares contents, so a candidate whose bytes differ is a miss and the expansion is recomputed. And two files with equal contents at one mapped name contribute the same expansion by construction, so either answer is the same answer. A mapped name matching no sentinel yields nothing and the memo is skipped.

## Verification

- Unit tests for the mapping and its inverse: longest source wins, a name recorded in one checkout resolves into the other, two roots behind one sentinel offer both, an unmapped absolute path is its own answer, a relative name has none.
- End to end with a real compiler over two checkouts of one source: before this change the second preprocessed; after it, the second hits the memo and does not.
- `mise exec -- just check`: fmt, clippy `-D warnings`, full workspace tests. Draft for the mutation shards.

## What a reviewer should still watch

- The benchmark number is the claim to check: the cross-clone warm phase should drop from 575 spawns to zero and its key time toward the same-tree figure. I will dispatch it once this is on main.
- Inputs outside every mapped root, system headers and the toolchain, are recorded verbatim and behave exactly as before.