### PR TITLE
perf(cc): compare memo inputs as the expansion sees them

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -2575,6 +2575,16 @@ pub(crate) struct CcPreprocessMemoInput {
     fingerprint: FileFingerprint,
     /// blake3 of the file's contents when the expansion was hashed.
     content: String,
+    /// blake3 of those contents with the prefix maps applied, which is how
+    /// the expansion itself is hashed.
+    ///
+    /// A generated header that names its own build directory has different
+    /// bytes in two checkouts and contributes the same expansion to both,
+    /// because the maps rewrite the path either way. Comparing raw bytes
+    /// alone made the memo stricter than the key it feeds, and `-sys` crates
+    /// put such a header in front of nearly every unit.
+    #[serde(default)]
+    mapped: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -2721,6 +2731,7 @@ impl<'db> FileHasher<'db> {
         &self,
         memo_key: &str,
         resolve: impl Fn(&str) -> Vec<PathBuf>,
+        mapped_content: &impl Fn(&Path) -> Option<String>,
     ) -> Option<String> {
         let cache = self.cache.as_ref()?;
         let record = match cache.get_cc_preprocess_memo(memo_key) {
@@ -2750,7 +2761,7 @@ impl<'db> FileHasher<'db> {
             return None;
         }
         for expected in &inputs {
-            if !self.memo_input_is_unchanged(expected, &resolve) {
+            if !self.memo_input_is_unchanged(expected, &resolve, mapped_content) {
                 return None;
             }
         }
@@ -2766,6 +2777,7 @@ impl<'db> FileHasher<'db> {
         &self,
         expected: &CcPreprocessMemoInput,
         resolve: &impl Fn(&str) -> Vec<PathBuf>,
+        mapped_content: &impl Fn(&Path) -> Option<String>,
     ) -> bool {
         // Only where THIS invocation resolves the recorded name. The path the
         // recording checkout used is not a candidate on its own merit: it may
@@ -2777,17 +2789,26 @@ impl<'db> FileHasher<'db> {
         let candidates = resolve(&expected.name);
 
         for path in &candidates {
-            if let Ok(current) = FileFingerprint::from_path(path) {
-                self.note_too_new(&current);
-                if current == expected.fingerprint {
-                    return true;
-                }
-                if self
-                    .hash(path)
-                    .is_ok_and(|content| content == expected.content)
-                {
-                    return true;
-                }
+            let Ok(current) = FileFingerprint::from_path(path) else {
+                continue;
+            };
+            self.note_too_new(&current);
+            // Cheapest first: identical metadata needs no read, identical raw
+            // bytes come from the content cache, and only a file differing in
+            // both is read through the maps.
+            if current == expected.fingerprint {
+                return true;
+            }
+            if self
+                .hash(path)
+                .is_ok_and(|content| content == expected.content)
+            {
+                return true;
+            }
+            if !expected.mapped.is_empty()
+                && mapped_content(path).is_some_and(|mapped| mapped == expected.mapped)
+            {
+                return true;
             }
         }
         tracing::debug!(
@@ -2808,6 +2829,7 @@ impl<'db> FileHasher<'db> {
     pub(crate) fn cc_preprocess_fingerprints(
         &self,
         paths: &[(String, PathBuf)],
+        mapped_content: &impl Fn(&Path) -> Option<String>,
     ) -> Option<Vec<CcPreprocessMemoInput>> {
         if paths.is_empty() {
             return None;
@@ -2835,10 +2857,12 @@ impl<'db> FileHasher<'db> {
                     return None;
                 }
             };
+            let mapped = mapped_content(path)?;
             inputs.push(CcPreprocessMemoInput {
                 name: name.clone(),
                 fingerprint,
                 content,
+                mapped,
             });
         }
         inputs.sort_by(|a, b| a.name.cmp(&b.name));
@@ -2860,6 +2884,7 @@ impl<'db> FileHasher<'db> {
         memo_key: &str,
         preprocessed_hash: &str,
         inputs: &[CcPreprocessMemoInput],
+        mapped_content: &impl Fn(&Path) -> Option<String>,
     ) {
         let Some(cache) = &self.cache else {
             return;
@@ -2871,7 +2896,11 @@ impl<'db> FileHasher<'db> {
             // Recording happens in the checkout that just ran the preprocess,
             // so each name resolves to the path it was captured from.
             let recorded_path = PathBuf::from(&expected.fingerprint.path);
-            if !self.memo_input_is_unchanged(expected, &|_: &str| vec![recorded_path.clone()]) {
+            if !self.memo_input_is_unchanged(
+                expected,
+                &|_: &str| vec![recorded_path.clone()],
+                mapped_content,
+            ) {
                 return;
             }
         }
@@ -8378,16 +8407,19 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
         let hasher = FileHasher::persistent(&db);
         let inputs = hasher
-            .cc_preprocess_fingerprints(&[
-                (source.to_string_lossy().into_owned(), source.clone()),
-                (header.to_string_lossy().into_owned(), header.clone()),
-            ])
+            .cc_preprocess_fingerprints(
+                &[
+                    (source.to_string_lossy().into_owned(), source.clone()),
+                    (header.to_string_lossy().into_owned(), header.clone()),
+                ],
+                &no_mapping,
+            )
             .unwrap();
         let pp_hash = "a".repeat(64);
-        hasher.cc_preprocess_memo_record_if_unchanged("memo-key", &pp_hash, &inputs);
+        hasher.cc_preprocess_memo_record_if_unchanged("memo-key", &pp_hash, &inputs, &no_mapping);
         assert_eq!(
             hasher
-                .cc_preprocess_memo_lookup("memo-key", no_remap)
+                .cc_preprocess_memo_lookup("memo-key", no_remap, &no_mapping)
                 .as_deref(),
             Some(pp_hash.as_str())
         );
@@ -8401,11 +8433,11 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
             .put_cc_preprocess_memo("non-hex-hash", &"z".repeat(64), &inputs_json)
             .unwrap();
         assert_eq!(
-            hasher.cc_preprocess_memo_lookup("short-hash", no_remap),
+            hasher.cc_preprocess_memo_lookup("short-hash", no_remap, &no_mapping),
             None
         );
         assert_eq!(
-            hasher.cc_preprocess_memo_lookup("non-hex-hash", no_remap),
+            hasher.cc_preprocess_memo_lookup("non-hex-hash", no_remap, &no_mapping),
             None
         );
 
@@ -8417,12 +8449,17 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         fresh_hasher.arm_too_new_guard(i64::MAX, 0);
         assert_eq!(
             fresh_hasher
-                .cc_preprocess_memo_lookup("memo-key", no_remap)
+                .cc_preprocess_memo_lookup("memo-key", no_remap, &no_mapping)
                 .as_deref(),
             Some(pp_hash.as_str()),
             "unchanged bytes must hit however recently they were written"
         );
-        fresh_hasher.cc_preprocess_memo_record_if_unchanged("too-new", &pp_hash, &inputs);
+        fresh_hasher.cc_preprocess_memo_record_if_unchanged(
+            "too-new",
+            &pp_hash,
+            &inputs,
+            &no_mapping,
+        );
         assert!(
             fresh_hasher
                 .cache
@@ -8436,11 +8473,11 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
         std::fs::write(&header, "#define VALUE 12345\n").unwrap();
         assert_eq!(
-            hasher.cc_preprocess_memo_lookup("memo-key", no_remap),
+            hasher.cc_preprocess_memo_lookup("memo-key", no_remap, &no_mapping),
             None,
             "a changed transitive header must force preprocessing"
         );
-        hasher.cc_preprocess_memo_record_if_unchanged("changed", &pp_hash, &inputs);
+        hasher.cc_preprocess_memo_record_if_unchanged("changed", &pp_hash, &inputs, &no_mapping);
         assert!(
             hasher
                 .cache
@@ -8453,10 +8490,92 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         );
     }
 
+    /// Tests that do not exercise prefix maps hash contents as they are.
+    fn no_mapping(path: &Path) -> Option<String> {
+        hash_file(path).ok()
+    }
+
     /// A resolver for tests that record and read in one place: the recorded
     /// name is the path.
     fn no_remap(name: &str) -> Vec<PathBuf> {
         vec![PathBuf::from(name)]
+    }
+
+    /// The case the benchmark exposed: a generated header names its own build
+    /// directory, so two checkouts hold different bytes that the prefix maps
+    /// rewrite to the same thing. The expansion is hashed after mapping, so
+    /// the key already treats them as equal; comparing raw bytes alone left
+    /// the memo stricter than the key it feeds, and every `-sys` unit behind
+    /// such a header preprocessed again in the second checkout.
+    #[test]
+    fn cc_preprocess_memo_compares_contents_as_the_expansion_sees_them() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("idx.sqlite");
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        for tree in [&a, &b] {
+            std::fs::create_dir_all(tree).unwrap();
+        }
+        // Each tree's header names its own directory, as a build script writes.
+        std::fs::write(a.join("gen.h"), format!("#define P \"{}\"\n", a.display())).unwrap();
+        std::fs::write(b.join("gen.h"), format!("#define P \"{}\"\n", b.display())).unwrap();
+
+        // The maps each tree would use: its own root onto one shared sentinel.
+        let map_under = |root: &std::path::Path| {
+            let root = root.to_string_lossy().into_owned();
+            move |path: &Path| -> Option<String> {
+                let text = std::fs::read_to_string(path).ok()?;
+                Some(
+                    blake3::hash(text.replace(&root, "<root>").as_bytes())
+                        .to_hex()
+                        .to_string(),
+                )
+            }
+        };
+
+        let hasher = FileHasher::persistent(&db);
+        let inputs = hasher
+            .cc_preprocess_fingerprints(
+                &[("<root>/gen.h".to_string(), a.join("gen.h"))],
+                &map_under(&a),
+            )
+            .unwrap();
+        assert_ne!(
+            inputs[0].content, inputs[0].mapped,
+            "raw and mapped hashes differ for a file that names its own path"
+        );
+        let pp_hash = "d".repeat(64);
+        hasher.cc_preprocess_memo_record_if_unchanged(
+            "memo-key",
+            &pp_hash,
+            &inputs,
+            &map_under(&a),
+        );
+
+        let resolve_in_b = |name: &str| vec![b.join(name.trim_start_matches("<root>/"))];
+        assert_eq!(
+            FileHasher::persistent(&db)
+                .cc_preprocess_memo_lookup("memo-key", resolve_in_b, &map_under(&b))
+                .as_deref(),
+            Some(pp_hash.as_str()),
+            "the same header under another root must reuse the expansion"
+        );
+
+        // A real difference still misses, mapping or no mapping.
+        std::fs::write(
+            b.join("gen.h"),
+            format!("#define P \"{}\"\n#define EXTRA 1\n", b.display()),
+        )
+        .unwrap();
+        assert_eq!(
+            FileHasher::persistent(&db).cc_preprocess_memo_lookup(
+                "memo-key",
+                resolve_in_b,
+                &map_under(&b)
+            ),
+            None,
+            "a header that gained a definition must force a fresh preprocess"
+        );
     }
 
     /// The hole the relocate-modified e2e phase found: a second checkout with
@@ -8479,10 +8598,13 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         // Record in the original tree, under a mapped name both trees share.
         let hasher = FileHasher::persistent(&db);
         let inputs = hasher
-            .cc_preprocess_fingerprints(&[("<root>/source.c".to_string(), source_of(&original))])
+            .cc_preprocess_fingerprints(
+                &[("<root>/source.c".to_string(), source_of(&original))],
+                &no_mapping,
+            )
             .unwrap();
         let pp_hash = "c".repeat(64);
-        hasher.cc_preprocess_memo_record_if_unchanged("memo-key", &pp_hash, &inputs);
+        hasher.cc_preprocess_memo_record_if_unchanged("memo-key", &pp_hash, &inputs, &no_mapping);
 
         // The relocated tree has an EDITED copy. The original still exists,
         // untouched, at the path the record names.
@@ -8490,7 +8612,11 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         let resolve_in_relocated =
             |name: &str| vec![relocated.join(name.trim_start_matches("<root>/"))];
         assert_eq!(
-            FileHasher::persistent(&db).cc_preprocess_memo_lookup("memo-key", resolve_in_relocated),
+            FileHasher::persistent(&db).cc_preprocess_memo_lookup(
+                "memo-key",
+                resolve_in_relocated,
+                &no_mapping
+            ),
             None,
             "the edited copy must miss even though the original is unchanged"
         );
@@ -8500,7 +8626,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         std::fs::write(source_of(&relocated), "int v(void) { return 1; }\n").unwrap();
         assert_eq!(
             FileHasher::persistent(&db)
-                .cc_preprocess_memo_lookup("memo-key", resolve_in_relocated)
+                .cc_preprocess_memo_lookup("memo-key", resolve_in_relocated, &no_mapping)
                 .as_deref(),
             Some(pp_hash.as_str()),
             "an identical copy in another tree must still reuse the expansion"
@@ -8524,17 +8650,20 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
 
         let hasher = FileHasher::persistent(&db);
         let inputs = hasher
-            .cc_preprocess_fingerprints(&[
-                (source.to_string_lossy().into_owned(), source.clone()),
-                (header.to_string_lossy().into_owned(), header.clone()),
-            ])
+            .cc_preprocess_fingerprints(
+                &[
+                    (source.to_string_lossy().into_owned(), source.clone()),
+                    (header.to_string_lossy().into_owned(), header.clone()),
+                ],
+                &no_mapping,
+            )
             .unwrap();
         assert!(
             inputs.iter().all(|input| input.content.len() == 64),
             "every recorded input carries a content hash"
         );
         let pp_hash = "b".repeat(64);
-        hasher.cc_preprocess_memo_record_if_unchanged("memo-key", &pp_hash, &inputs);
+        hasher.cc_preprocess_memo_record_if_unchanged("memo-key", &pp_hash, &inputs, &no_mapping);
 
         // Rewrite both files with identical bytes. Remove first, so the
         // replacement gets a new inode as well as a new mtime — the shape a
@@ -8552,7 +8681,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         let reader = FileHasher::persistent(&db);
         assert_eq!(
             reader
-                .cc_preprocess_memo_lookup("memo-key", no_remap)
+                .cc_preprocess_memo_lookup("memo-key", no_remap, &no_mapping)
                 .as_deref(),
             Some(pp_hash.as_str()),
             "identical bytes at new metadata must reuse the expansion"
@@ -8561,7 +8690,11 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         // One byte of difference is still a miss, whatever the metadata says.
         std::fs::write(&header, "#define VALUE 2\n").unwrap();
         assert_eq!(
-            FileHasher::persistent(&db).cc_preprocess_memo_lookup("memo-key", no_remap),
+            FileHasher::persistent(&db).cc_preprocess_memo_lookup(
+                "memo-key",
+                no_remap,
+                &no_mapping
+            ),
             None,
             "changed bytes must force a fresh preprocess"
         );

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -1652,7 +1652,9 @@ fn preprocess_hash(
                     .into_iter()
                     .map(|path| (cc_mapped_path(&path, prefix_maps), path))
                     .collect();
-                file_hasher.cc_preprocess_fingerprints(&mapped)
+                file_hasher.cc_preprocess_fingerprints(&mapped, &|path| {
+                    cc_mapped_content_hash(path, prefix_maps)
+                })
             }
             Err(error) => {
                 tracing::debug!("cc preprocess dependency capture unavailable: {error:#}");
@@ -4199,6 +4201,20 @@ fn cc_mapped_path(path: &Path, prefix_maps: &[CcPrefixMap]) -> String {
     String::from_utf8_lossy(&apply_cc_prefix_maps_to_bytes(text, prefix_maps)).into_owned()
 }
 
+/// blake3 of a file's contents with the prefix maps applied.
+///
+/// The expansion is hashed this way, so an input has to be compared this way
+/// too. A `-sys` crate's generated config header names its own build
+/// directory: the raw bytes differ between two checkouts, the mapped bytes do
+/// not, and the expansion each produces is identical. Comparing raw bytes
+/// alone therefore made the memo stricter than the key it feeds. `None` when
+/// the file cannot be read, which the caller treats as "cannot reuse".
+fn cc_mapped_content_hash(path: &Path, prefix_maps: &[CcPrefixMap]) -> Option<String> {
+    let bytes = std::fs::read(path).ok()?;
+    let mapped = apply_cc_prefix_maps_to_bytes(bytes, prefix_maps);
+    Some(blake3::hash(&mapped).to_hex().to_string())
+}
+
 /// Candidate real paths a mapped spelling could name in this invocation.
 ///
 /// The inverse of [`cc_mapped_path`], and inexact by nature: two roots can
@@ -4543,6 +4559,9 @@ struct PendingCcPreprocessMemo {
     memo_key: String,
     preprocessed_hash: String,
     fingerprints: Vec<crate::cache_key::CcPreprocessMemoInput>,
+    /// The maps the expansion and the inputs were hashed under. Revalidation
+    /// at commit time has to use the same ones.
+    prefix_maps: Vec<CcPrefixMap>,
 }
 
 #[derive(Default)]
@@ -4658,6 +4677,7 @@ impl CcCompiler {
             &pending.memo_key,
             &pending.preprocessed_hash,
             &pending.fingerprints,
+            &|path| cc_mapped_content_hash(path, &pending.prefix_maps),
         );
     }
 
@@ -5272,9 +5292,11 @@ impl Compiler for CcCompiler {
             .then(|| cc_preprocess_memo_key(parsed, &prefix_maps, &resolved.version_line))
             .flatten();
         let pp_hash = if let Some(memo_hash) = memo_key.as_ref().and_then(|key| {
-            ctx.file_hasher.cc_preprocess_memo_lookup(key, |name| {
-                cc_unmapped_path_candidates(name, &prefix_maps)
-            })
+            ctx.file_hasher.cc_preprocess_memo_lookup(
+                key,
+                |name| cc_unmapped_path_candidates(name, &prefix_maps),
+                &|path| cc_mapped_content_hash(path, &prefix_maps),
+            )
         }) {
             tracing::trace!(
                 target: "kache::cache_key",
@@ -5292,6 +5314,7 @@ impl Compiler for CcCompiler {
                         memo_key,
                         preprocessed_hash: preprocessed.hash.clone(),
                         fingerprints,
+                        prefix_maps: prefix_maps.clone(),
                     });
             }
             tracing::trace!(
@@ -8991,6 +9014,54 @@ mod tests {
 
     /// A variable that cannot reach the preprocessor must not give every
     /// invocation its own memo, and one that can must still be keyed.
+    /// The mapped-content hash is what decides whether two checkouts share an
+    /// expansion, so it has to be a real digest of the mapped bytes: equal
+    /// where the maps make the contents equal, different otherwise, and
+    /// absent for a file that cannot be read.
+    #[test]
+    fn cc_mapped_content_hash_digests_the_mapped_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.h");
+        let b = dir.path().join("b.h");
+        std::fs::write(&a, "#define P \"/work/one/out\"\n").unwrap();
+        std::fs::write(&b, "#define P \"/work/two/out\"\n").unwrap();
+
+        let maps = vec![
+            CcPrefixMap {
+                from: "/work/one".to_string(),
+                to: "/kache/root".to_string(),
+            },
+            CcPrefixMap {
+                from: "/work/two".to_string(),
+                to: "/kache/root".to_string(),
+            },
+        ];
+        let hash_a = cc_mapped_content_hash(&a, &maps).unwrap();
+        let hash_b = cc_mapped_content_hash(&b, &maps).unwrap();
+        assert_eq!(hash_a.len(), 64, "a blake3 digest, not a placeholder");
+        assert_eq!(
+            hash_a, hash_b,
+            "contents the maps make equal must hash equal"
+        );
+        // The digest is of the MAPPED bytes, so it is not the raw digest.
+        assert_ne!(
+            hash_a,
+            crate::cache_key::hash_file(&a).unwrap(),
+            "mapping must actually change what is hashed"
+        );
+        // And two files the maps do not reconcile stay apart.
+        assert_ne!(
+            hash_a,
+            cc_mapped_content_hash(&b, &[]).unwrap(),
+            "without the maps the two contents differ"
+        );
+        assert_eq!(
+            cc_mapped_content_hash(&dir.path().join("absent.h"), &maps),
+            None,
+            "an unreadable input cannot be reused"
+        );
+    }
+
     /// A recorded name has to come back as the path this checkout uses, and
     /// the memo key must not move when only the checkout root does.
     #[test]


### PR DESCRIPTION
Refs #762. Follows #927 and #928.

After #928 I dispatched the benchmark expecting the cross-clone phase to stop preprocessing. It did not: 575 of 575 units again, while the same-tree phase did none. This is why.

## The defect, exactly

The expansion is hashed **after** the prefix maps are applied. The memo compared input bytes **before**. So the memo was strictly stricter than the key it feeds.

A `-sys` crate's generated config header names its own build directory. Two checkouts hold different bytes there. The maps rewrite both to the same text, so the expansions are equal and the cache key is equal — and the memo still missed on the raw bytes. Nearly every unit in such a crate sits behind one of those headers.

Reproduced with a real compiler before touching anything:

```
1 build dir a                              miss       preprocessor_runs=1 key=dc5d64350e23
2 build dir b, header names its own path   local_hit  preprocessor_runs=1 key=dc5d64350e23
```

Same key, memo miss. After this change the second line reads `preprocessor_runs=0`.

## What changed

Inputs carry a second hash: their contents with the maps applied, the same transformation the expansion gets. Comparison now tries three tiers, cheapest first:

1. identical metadata, no read at all;
2. identical raw bytes, answered from the existing content cache;
3. identical mapped bytes, which is the only tier that reads and transforms.

So the common cases stay as cheap as they were and only a file that genuinely differs raw is read through the maps.

## Verification

- Unit test with two roots and a header naming its own: raw and mapped hashes differ, the memo is reused across roots, and a header that gains a definition still misses.
- The end-to-end reproduction above, before and after.
- `mise exec -- just check`: fmt, clippy `-D warnings`, full workspace tests. Draft for the mutation shards.

## What a reviewer should still watch

- The benchmark is the claim. I will dispatch hk after merge; the cross-clone phase should finally drop from 575 spawns toward the same-tree figure. If it does not, there is a fourth reason and I will find it rather than assume this was it.
- The third tier reads the file. That is bounded by "raw bytes differ", so it costs only where the memo would previously have failed outright.
- Note on the last benchmark run: every phase was slower than the previous one (cold 107s against 90s), which I attribute to the arm moving to the smaller shared pool in #925 rather than to any change here. Cross-run wall-clock comparisons need the repetition and baseline controls that are still outstanding.