### PR TITLE
perf(cc): resolve include shadowing instead of enumerating it

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -245,7 +245,7 @@ use std::path::{Path, PathBuf};
 // passthrough. Windows GNU, cross-target, and metadata invocations remain
 // unprobed. Existing Windows linked-output keys did not contain this
 // identity, so invalidate them rather than mix schemas.
-pub(crate) const CACHE_KEY_VERSION: u32 = 30;
+pub(crate) const CACHE_KEY_VERSION: u32 = 31;
 const MIN_PERSISTED_HASH_BYTES: i64 = 64 * 1024;
 
 /// Collapse runs of ASCII whitespace into single spaces and trim
@@ -2587,6 +2587,14 @@ pub(crate) struct CcPreprocessMemoInput {
     mapped: String,
 }
 
+impl CcPreprocessMemoInput {
+    /// Where this input was when it was recorded. Local to the recording
+    /// checkout; a reader that resolved the name elsewhere has its own path.
+    pub(crate) fn local_path(&self) -> &str {
+        &self.fingerprint.path
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) struct FileFingerprint {
     path: String,
@@ -2732,7 +2740,7 @@ impl<'db> FileHasher<'db> {
         memo_key: &str,
         resolve: impl Fn(&str) -> Vec<PathBuf>,
         mapped_content: &impl Fn(&Path) -> Option<String>,
-    ) -> Option<String> {
+    ) -> Option<(String, Vec<PathBuf>)> {
         let cache = self.cache.as_ref()?;
         let record = match cache.get_cc_preprocess_memo(memo_key) {
             Ok(record) => record?,
@@ -2760,12 +2768,14 @@ impl<'db> FileHasher<'db> {
         if inputs.is_empty() {
             return None;
         }
+        // The paths that satisfied the memo are the inputs this invocation
+        // would have discovered by preprocessing, and the caller needs them to
+        // resolve include shadowing without a fresh dependency capture.
+        let mut satisfied = Vec::with_capacity(inputs.len());
         for expected in &inputs {
-            if !self.memo_input_is_unchanged(expected, &resolve, mapped_content) {
-                return None;
-            }
+            satisfied.push(self.memo_input_is_unchanged(expected, &resolve, mapped_content)?);
         }
-        Some(record.0)
+        Some((record.0, satisfied))
     }
 
     /// Does this input still hold the bytes the memo was recorded against?
@@ -2778,7 +2788,7 @@ impl<'db> FileHasher<'db> {
         expected: &CcPreprocessMemoInput,
         resolve: &impl Fn(&str) -> Vec<PathBuf>,
         mapped_content: &impl Fn(&Path) -> Option<String>,
-    ) -> bool {
+    ) -> Option<PathBuf> {
         // Only where THIS invocation resolves the recorded name. The path the
         // recording checkout used is not a candidate on its own merit: it may
         // still exist, unmodified, while the tree being compiled now has an
@@ -2797,18 +2807,18 @@ impl<'db> FileHasher<'db> {
             // bytes come from the content cache, and only a file differing in
             // both is read through the maps.
             if current == expected.fingerprint {
-                return true;
+                return Some(path.clone());
             }
             if self
                 .hash(path)
                 .is_ok_and(|content| content == expected.content)
             {
-                return true;
+                return Some(path.clone());
             }
             if !expected.mapped.is_empty()
                 && mapped_content(path).is_some_and(|mapped| mapped == expected.mapped)
             {
-                return true;
+                return Some(path.clone());
             }
         }
         tracing::debug!(
@@ -2816,7 +2826,7 @@ impl<'db> FileHasher<'db> {
             expected.name,
             candidates.len()
         );
-        false
+        None
     }
 
     /// Capture the source/header metadata and contents observed immediately
@@ -2896,11 +2906,14 @@ impl<'db> FileHasher<'db> {
             // Recording happens in the checkout that just ran the preprocess,
             // so each name resolves to the path it was captured from.
             let recorded_path = PathBuf::from(&expected.fingerprint.path);
-            if !self.memo_input_is_unchanged(
-                expected,
-                &|_: &str| vec![recorded_path.clone()],
-                mapped_content,
-            ) {
+            if self
+                .memo_input_is_unchanged(
+                    expected,
+                    &|_: &str| vec![recorded_path.clone()],
+                    mapped_content,
+                )
+                .is_none()
+            {
                 return;
             }
         }
@@ -8444,6 +8457,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         assert_eq!(
             hasher
                 .cc_preprocess_memo_lookup("memo-key", no_remap, &no_mapping)
+                .map(|(hash, _)| hash)
                 .as_deref(),
             Some(pp_hash.as_str())
         );
@@ -8474,6 +8488,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         assert_eq!(
             fresh_hasher
                 .cc_preprocess_memo_lookup("memo-key", no_remap, &no_mapping)
+                .map(|(hash, _)| hash)
                 .as_deref(),
             Some(pp_hash.as_str()),
             "unchanged bytes must hit however recently they were written"
@@ -8580,6 +8595,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         assert_eq!(
             FileHasher::persistent(&db)
                 .cc_preprocess_memo_lookup("memo-key", resolve_in_b, &map_under(&b))
+                .map(|(hash, _)| hash)
                 .as_deref(),
             Some(pp_hash.as_str()),
             "the same header under another root must reuse the expansion"
@@ -8651,6 +8667,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         assert_eq!(
             FileHasher::persistent(&db)
                 .cc_preprocess_memo_lookup("memo-key", resolve_in_relocated, &no_mapping)
+                .map(|(hash, _)| hash)
                 .as_deref(),
             Some(pp_hash.as_str()),
             "an identical copy in another tree must still reuse the expansion"
@@ -8706,6 +8723,7 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         assert_eq!(
             reader
                 .cc_preprocess_memo_lookup("memo-key", no_remap, &no_mapping)
+                .map(|(hash, _)| hash)
                 .as_deref(),
             Some(pp_hash.as_str()),
             "identical bytes at new metadata must reuse the expansion"

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -4385,6 +4385,99 @@ fn cc_trace_name(parsed: &CcArgs) -> String {
         .unwrap_or_else(|| "cc".to_string())
 }
 
+/// Digest the shadowing risk for the headers a preprocess actually read.
+///
+/// The walk below exists because a header appearing in an earlier include
+/// directory can shadow one that was read, without changing any recorded
+/// fingerprint. It answers that by listing everything that could exist. This
+/// answers it by looking only at what could actually shadow: a new file can
+/// only take the place of a header we read if it carries the **same relative
+/// name** and sits **earlier in the search order** than the directory that
+/// provided it.
+///
+/// So for each header read, resolve which user include directory first
+/// provides its relative name and fold that position. A file appearing ahead
+/// of it moves the position and therefore the key; a file appearing anywhere
+/// else cannot shadow anything and is correctly ignored, where the walk would
+/// have invalidated every unit naming that directory.
+///
+/// Costs one `stat` per candidate directory up to the first that provides the
+/// name, rather than a full enumeration, so there is no cap to exceed. A stat
+/// that fails for any reason other than absence fails closed, as the walk
+/// does for an unreadable directory.
+fn digest_cc_include_shadowing(parsed: &CcArgs, read_inputs: &[PathBuf]) -> Result<String> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let dirs = cc_user_include_dirs(parsed, &cwd);
+
+    // One entry per distinct relative name: the same header read twice, or
+    // two units reading it, resolve identically.
+    let mut names: Vec<PathBuf> = Vec::new();
+    for input in read_inputs {
+        let absolute = absolutize_path(&cwd, input);
+        // Two spellings could have reached this file, and the search order
+        // is checked for both. The path relative to the MOST SPECIFIC user
+        // directory containing it, which is what an `#include "sub/h.h"`
+        // resolves through; directories nest, so the first match is not
+        // necessarily the one that provided it. And the bare file name,
+        // which is what an angle include resolves through and the only
+        // spelling available for a header read from outside every user
+        // directory. Folding both over-detects rather than under-detects:
+        // an extra resolution can only cost a miss.
+        let mut candidates: Vec<PathBuf> = Vec::new();
+        if let Some(relative) = dirs
+            .iter()
+            .filter_map(|dir| absolute.strip_prefix(dir).ok())
+            .min_by_key(|relative| relative.components().count())
+        {
+            candidates.push(relative.to_path_buf());
+        }
+        if let Some(file_name) = absolute.file_name() {
+            candidates.push(PathBuf::from(file_name));
+        }
+        for candidate in candidates {
+            if !names.contains(&candidate) {
+                names.push(candidate);
+            }
+        }
+    }
+    names.sort();
+
+    let mut hasher = blake3::Hasher::new();
+    for name in &names {
+        hasher.update(name.as_os_str().as_encoded_bytes());
+        hasher.update(b"\x1f");
+        match cc_first_include_dir_providing(&dirs, name)? {
+            Some(index) => {
+                hasher.update(b"@");
+                hasher.update(index.to_string().as_bytes());
+            }
+            None => {
+                hasher.update(b"-");
+            }
+        }
+        hasher.update(b"\n");
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+/// Index of the first user include directory that provides `name`, stopping
+/// at the first hit. `None` when no directory does, which is itself a fact
+/// worth keying: a directory later gaining the name changes it.
+fn cc_first_include_dir_providing(dirs: &[PathBuf], name: &Path) -> Result<Option<usize>> {
+    for (index, dir) in dirs.iter().enumerate() {
+        let candidate = dir.join(name);
+        match std::fs::symlink_metadata(&candidate) {
+            Ok(_) => return Ok(Some(index)),
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => anyhow::bail!(
+                "cc include candidate {} is unreadable ({error})",
+                candidate.display()
+            ),
+        }
+    }
+    Ok(None)
+}
+
 /// Maximum file names walked across every user include dir. A partial
 /// listing could miss the shadowing header the digest exists to catch,
 /// so overflow is fail-closed passthrough rather than a truncated key.
@@ -4575,7 +4668,9 @@ pub struct CcCompiler {
     /// cc key probes and the real compiler invocation.
     base_dirs: Vec<String>,
     pending_preprocess_memo: RefCell<Option<PendingCcPreprocessMemo>>,
-    pending_include_dir_digest: RefCell<Option<String>>,
+    /// The shadowing digest folded into the key, with the read set it was
+    /// resolved from, so the publish-time recheck can reproduce it exactly.
+    pending_include_dir_digest: RefCell<Option<(String, Option<Vec<PathBuf>>)>>,
 }
 
 const C_FAMILY_DRIVERS: [(&str, ToolFamily); 7] = [
@@ -4685,10 +4780,18 @@ impl CcCompiler {
     /// the key. A new shadowing header during compile must not be published
     /// under the old key.
     pub(crate) fn include_dir_names_still_match(&self, parsed: &CcArgs) -> bool {
-        let Ok(now) = digest_cc_include_dir_names(parsed) else {
+        let pending = self.pending_include_dir_digest.borrow();
+        let Some((digest, read_inputs)) = pending.as_ref() else {
             return false;
         };
-        self.pending_include_dir_digest.borrow().as_deref() == Some(now.as_str())
+        // Recompute the way the key did. Resolving against a different set of
+        // names than the key used would compare two unrelated digests and
+        // refuse every store.
+        let now = match read_inputs {
+            Some(inputs) => digest_cc_include_shadowing(parsed, inputs),
+            None => digest_cc_include_dir_names(parsed),
+        };
+        now.is_ok_and(|now| now == *digest)
     }
 
     /// Does this argv invoke a C-family compiler?
@@ -5262,25 +5365,6 @@ impl Compiler for CcCompiler {
             );
         }
 
-        // Names in user include dirs. Preprocess fingerprints only cover
-        // files that were already read; a header that appears in an earlier
-        // `-I`/`-iquote` dir (or next to the source) can shadow one of those
-        // without changing the fingerprints. Digest names, not contents.
-        // Unreadable dirs and a walk that exceeds the cap fail closed.
-        let include_dir_digest = digest_cc_include_dir_names(parsed)?;
-        self.pending_include_dir_digest
-            .borrow_mut()
-            .replace(include_dir_digest.clone());
-        hasher.update(b"include_dir_names:");
-        hasher.update(include_dir_digest.as_bytes());
-        hasher.update(b"\n");
-        tracing::trace!(
-            target: "kache::cache_key",
-            "[key:{}] include_dir_names={}",
-            trace_name,
-            include_dir_digest
-        );
-
         // Preprocessor expansion — the load-bearing input. Captures
         // the source plus every transitively-included header plus
         // macro expansion. `-E -P` strips line markers so header
@@ -5291,22 +5375,32 @@ impl Compiler for CcCompiler {
             .supports_cc_preprocess_memo()
             .then(|| cc_preprocess_memo_key(parsed, &prefix_maps, &resolved.version_line))
             .flatten();
-        let pp_hash = if let Some(memo_hash) = memo_key.as_ref().and_then(|key| {
-            ctx.file_hasher.cc_preprocess_memo_lookup(
-                key,
-                |name| cc_unmapped_path_candidates(name, &prefix_maps),
-                &|path| cc_mapped_content_hash(path, &prefix_maps),
-            )
-        }) {
+        // The read set comes back with the expansion, from the memo when it
+        // answers and from the dependency capture otherwise. It is what makes
+        // the shadowing resolution below possible.
+        let (pp_hash, read_inputs) = if let Some((memo_hash, satisfied)) =
+            memo_key.as_ref().and_then(|key| {
+                ctx.file_hasher.cc_preprocess_memo_lookup(
+                    key,
+                    |name| cc_unmapped_path_candidates(name, &prefix_maps),
+                    &|path| cc_mapped_content_hash(path, &prefix_maps),
+                )
+            }) {
             tracing::trace!(
                 target: "kache::cache_key",
                 "[key:{}] preprocessed_memo=hit",
                 trace_name
             );
-            memo_hash
+            (memo_hash, Some(satisfied))
         } else {
             let preprocessed =
                 preprocess_hash(parsed, &prefix_maps, ctx.file_hasher, memo_key.is_some())?;
+            let read_inputs = preprocessed.fingerprints.as_ref().map(|inputs| {
+                inputs
+                    .iter()
+                    .map(|input| PathBuf::from(input.local_path()))
+                    .collect::<Vec<_>>()
+            });
             if let (Some(memo_key), Some(fingerprints)) = (memo_key, preprocessed.fingerprints) {
                 self.pending_preprocess_memo
                     .borrow_mut()
@@ -5322,7 +5416,7 @@ impl Compiler for CcCompiler {
                 "[key:{}] preprocessed_memo=miss",
                 trace_name
             );
-            preprocessed.hash
+            (preprocessed.hash, read_inputs)
         };
         hasher.update(b"preprocessed:");
         hasher.update(pp_hash.as_bytes());
@@ -5332,6 +5426,31 @@ impl Compiler for CcCompiler {
             "[key:{}] preprocessed={}",
             trace_name,
             pp_hash
+        );
+
+        // Shadowing. A header appearing in an earlier `-I`/`-iquote` dir (or
+        // next to the source) can take the place of one that was read without
+        // changing any fingerprint, so the key has to notice it. With the read
+        // set in hand this resolves only the names that could actually be
+        // shadowed; without it (a compiler whose dependency capture failed)
+        // fall back to enumerating the directories, which is what the capped
+        // walk has always done.
+        let (include_dir_digest, include_dir_mode) = match &read_inputs {
+            Some(inputs) => (digest_cc_include_shadowing(parsed, inputs)?, "resolved"),
+            None => (digest_cc_include_dir_names(parsed)?, "walked"),
+        };
+        self.pending_include_dir_digest
+            .borrow_mut()
+            .replace((include_dir_digest.clone(), read_inputs));
+        hasher.update(b"include_dir_names:");
+        hasher.update(include_dir_digest.as_bytes());
+        hasher.update(b"\n");
+        tracing::trace!(
+            target: "kache::cache_key",
+            "[key:{}] include_dir_names={} mode={}",
+            trace_name,
+            include_dir_digest,
+            include_dir_mode
         );
 
         let key = hasher.finalize().to_hex().to_string();
@@ -10708,6 +10827,140 @@ mod tests {
         (crate::cache_key::FileHasher::new(), dir.join("cache"))
     }
 
+    /// The property the whole guard exists for, on the resolution path: a
+    /// header appearing in an earlier directory shadows one that was read,
+    /// without changing any recorded content, so the key has to move.
+    #[test]
+    fn include_shadowing_notices_a_header_appearing_ahead_of_the_one_read() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("first");
+        let second = temp.path().join("second");
+        fs::create_dir(&first).unwrap();
+        fs::create_dir(&second).unwrap();
+        let read = second.join("header.h");
+        fs::write(&read, "#define A 1\n").unwrap();
+        let source = temp.path().join("unit.c");
+        fs::write(&source, "#include \"header.h\"\nint x;\n").unwrap();
+
+        let parsed = CcArgs::parse(&s(&[
+            "cc",
+            "-c",
+            source.to_str().unwrap(),
+            "-I",
+            first.to_str().unwrap(),
+            "-I",
+            second.to_str().unwrap(),
+        ]))
+        .unwrap();
+        let inputs = vec![source.clone(), read.clone()];
+
+        let before = digest_cc_include_shadowing(&parsed, &inputs).unwrap();
+        fs::write(first.join("header.h"), "#define A 2\n").unwrap();
+        let after = digest_cc_include_shadowing(&parsed, &inputs).unwrap();
+        assert_ne!(
+            before, after,
+            "a header ahead of the one that was read must change the key"
+        );
+
+        // And removing it again returns to the original resolution.
+        fs::remove_file(first.join("header.h")).unwrap();
+        assert_eq!(
+            digest_cc_include_shadowing(&parsed, &inputs).unwrap(),
+            before
+        );
+    }
+
+    /// The precision the walk did not have. A file that no unit could
+    /// include cannot shadow anything, so it must not move the key; the walk
+    /// invalidated every unit naming that directory.
+    #[test]
+    fn include_shadowing_ignores_a_name_that_was_never_read() {
+        let temp = tempfile::tempdir().unwrap();
+        let include = temp.path().join("inc");
+        fs::create_dir(&include).unwrap();
+        let read = include.join("header.h");
+        fs::write(&read, "int h;\n").unwrap();
+        let source = temp.path().join("unit.c");
+        fs::write(&source, "#include \"header.h\"\nint x;\n").unwrap();
+        let parsed = CcArgs::parse(&s(&[
+            "cc",
+            "-c",
+            source.to_str().unwrap(),
+            "-I",
+            include.to_str().unwrap(),
+        ]))
+        .unwrap();
+        let inputs = vec![source.clone(), read.clone()];
+
+        let before = digest_cc_include_shadowing(&parsed, &inputs).unwrap();
+        for name in ["unrelated.h", "other.hpp", "header.o", "notes.txt"] {
+            fs::write(include.join(name), "x").unwrap();
+        }
+        assert_eq!(
+            digest_cc_include_shadowing(&parsed, &inputs).unwrap(),
+            before,
+            "names no unit read cannot shadow and must not churn the key"
+        );
+
+        // The scale this buys: thousands of unrelated names cost nothing,
+        // where the walk refused past its cap.
+        let big = temp.path().join("big");
+        fs::create_dir(&big).unwrap();
+        for i in 0..12_000 {
+            fs::write(big.join(format!("h{i}.h")), "x").unwrap();
+        }
+        let wide = CcArgs::parse(&s(&[
+            "cc",
+            "-c",
+            source.to_str().unwrap(),
+            "-I",
+            include.to_str().unwrap(),
+            "-I",
+            big.to_str().unwrap(),
+        ]))
+        .unwrap();
+        assert!(
+            digest_cc_include_shadowing(&wide, &inputs).is_ok(),
+            "a large include tree must resolve rather than refuse"
+        );
+        assert!(
+            digest_cc_include_dir_names(&wide).is_err(),
+            "the walk this replaces would have refused the same tree"
+        );
+    }
+
+    /// A header read from outside any user directory can still be shadowed by
+    /// one, since user directories are searched first.
+    #[test]
+    fn include_shadowing_covers_headers_read_from_outside_the_user_dirs() {
+        let temp = tempfile::tempdir().unwrap();
+        let user = temp.path().join("user");
+        let elsewhere = temp.path().join("elsewhere");
+        fs::create_dir(&user).unwrap();
+        fs::create_dir(&elsewhere).unwrap();
+        let read = elsewhere.join("stdio.h");
+        fs::write(&read, "int puts(const char*);\n").unwrap();
+        let source = temp.path().join("unit.c");
+        fs::write(&source, "int x;\n").unwrap();
+        let parsed = CcArgs::parse(&s(&[
+            "cc",
+            "-c",
+            source.to_str().unwrap(),
+            "-I",
+            user.to_str().unwrap(),
+        ]))
+        .unwrap();
+        let inputs = vec![source.clone(), read.clone()];
+
+        let before = digest_cc_include_shadowing(&parsed, &inputs).unwrap();
+        fs::write(user.join("stdio.h"), "int puts(const char*);\n").unwrap();
+        assert_ne!(
+            digest_cc_include_shadowing(&parsed, &inputs).unwrap(),
+            before,
+            "a user dir gaining the name of a system header must change the key"
+        );
+    }
+
     #[test]
     fn include_dir_digest_changes_when_an_earlier_dir_gains_a_header() {
         let temp = tempfile::tempdir().unwrap();
@@ -11027,6 +11280,43 @@ mod tests {
         fs::write(system.join("shadow.h"), "int s;\n").unwrap();
         let after = digest_cc_include_dir_names(&parsed).unwrap();
         assert_eq!(before, after, "-isystem roots must stay exempt");
+    }
+
+    /// A directory we cannot stat into is not the same as one that does not
+    /// have the header. Only ENOENT means absent; anything else leaves the
+    /// resolution unknown, and an unknown shadowing order must refuse rather
+    /// than key as if the search had reached the end.
+    #[cfg(unix)]
+    #[test]
+    fn include_dir_resolution_separates_absent_from_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("first");
+        let second = temp.path().join("second");
+        fs::create_dir(&first).unwrap();
+        fs::create_dir(&second).unwrap();
+        fs::write(second.join("shadow.h"), "int s;\n").unwrap();
+        let dirs = vec![first.clone(), second.clone()];
+        let name = Path::new("shadow.h");
+
+        assert_eq!(
+            cc_first_include_dir_providing(&dirs, name).unwrap(),
+            Some(1),
+            "an empty first dir is genuinely absent, so the search goes on"
+        );
+        assert_eq!(
+            cc_first_include_dir_providing(&dirs, Path::new("nowhere.h")).unwrap(),
+            None,
+            "no dir providing the name is an answer in itself"
+        );
+
+        // The same search, with the first directory unreadable rather than
+        // empty, must not silently arrive at the second one.
+        fs::set_permissions(&first, fs::Permissions::from_mode(0o000)).unwrap();
+        let blocked = cc_first_include_dir_providing(&dirs, name);
+        fs::set_permissions(&first, fs::Permissions::from_mode(0o755)).unwrap();
+        let err = blocked.expect_err("an unreadable include dir must fail closed");
+        assert!(err.to_string().contains("unreadable"), "got {err}");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Closes #931.

**4,276 of Firefox's 5,652 compiles** are refused with `cc include dir name walk exceeded 8192 entries`. A warm Firefox build takes 3,112s against 3,727s cold, a 1.2x speedup, while the cache reports a 92.7% hit rate on the 954 units it is allowed to touch. The nightly arm has been failing its own validity gate on this, which is why it went unnoticed.

## The guard is right, the strategy was not

Preprocess fingerprints only cover files that were **read**. A header appearing in an earlier `-I`/`-iquote` directory can shadow one of them without changing any fingerprint, so the key has to notice it. The old answer enumerated every name in every include directory and, past 8,192 entries, refused to cache rather than truncate.

A new file can only shadow a header we read if it carries the **same relative name** and sits **earlier in the search order** than the directory that provided it. We already know what was read: the dependency capture on a preprocess, and the memo when it answers. So the key resolves those names instead, folding for each one the index of the first user include directory that provides it. One `stat` per directory up to the first hit, no enumeration, no cap.

It is also **more precise**. Any new file anywhere used to move the digest and invalidate every unit naming that directory, even a file nothing could include. Now only a genuine shadowing candidate does.

Both spellings a header could have been reached by are resolved: the path relative to the most specific directory containing it, and its bare name. That covers an angle include and a header read from outside every user directory, where user directories are still searched first.

## What is kept

- The walk remains for compilers whose dependency capture fails, since there is no read set to resolve. Its cap and its fail-closed behaviour are unchanged.
- Unreadable paths still fail closed: a `stat` that fails for any reason other than absence is an error, not an absence.
- The publish-time recheck reproduces whichever mode the key used.

## Verification

- A header placed ahead of the one that was read changes the key; removing it restores the original.
- A name nothing read does not move the key, and 12,000 unrelated names resolve fine where the walk refuses the same tree outright.
- A header read from outside every user directory is still shadowable by one.
- End to end: two identical compiles hit; adding a shadowing header ahead produces a new key.
- `mise exec -- just check`: fmt, clippy `-D warnings`, full workspace tests. Draft for the mutation shards.

## Two things the tests caught

Nested directories meant the *first* matching prefix was not the one that provided the header, so the relative name was wrong. And the publish-time recheck still used the walk, comparing a walked digest against a resolved one, which silently refused every store; `cc_compile_roundtrips_through_cache` failed on exactly that.

## The cost

`CACHE_KEY_VERSION` 30 to 31. Every existing C entry, local and remote, becomes unreachable on upgrade. That is the right trade for four thousand newly cacheable units, but it is a one-time repopulation for anyone with a warm remote and should be a deliberate decision rather than a side effect.

The Firefox arm is the proof; I will dispatch it once this is on main.