### PR TITLE
feat(cc): cache preprocessor-mode compiles that name their output

### DIFF
--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -727,9 +727,15 @@ impl CcArgs {
             CompileMode::Link => reasons.push(RefuseReason::Unsupported(
                 "cc link mode (whole-program caching) — not yet",
             )),
-            CompileMode::Preprocess => reasons.push(RefuseReason::Unsupported(
-                "cc preprocessor mode -E — not yet",
-            )),
+            // `-E` writing to a named file is an ordinary single-output
+            // compile: the expansion is the artifact, and the key already
+            // covers everything that can change it. Writing to stdout would
+            // need the entry to carry an output no file holds, so that shape
+            // keeps its own refusal and stays countable.
+            CompileMode::Preprocess if self.output.is_none() => reasons.push(
+                RefuseReason::Unsupported("cc preprocessor mode -E to stdout — not yet"),
+            ),
+            CompileMode::Preprocess => {}
             CompileMode::Assemble => {
                 reasons.push(RefuseReason::Unsupported("cc assembly mode -S — not yet"))
             }
@@ -5369,13 +5375,18 @@ impl Compiler for CcCompiler {
             .with_context(|| format!("executing {}", parsed.program))?;
         let exit_code = output.status.code().unwrap_or(1);
 
-        // Output discovery: on a successful `-c` compile, the object
-        // file is the cacheable artifact. Skip on failure (nothing to
-        // cache) or non-Compile mode (refused upstream anyway). Objects
-        // retain their basename; dep-info gets a semantic store name because
-        // `-MF` permits arbitrary suffixes and restore already takes its real
-        // destination from the current invocation (kunobi-ninja/kache#655).
-        let artifacts = if exit_code == 0 && parsed.mode == CompileMode::Compile {
+        // Output discovery: on a successful compile the named output is the
+        // cacheable artifact. Skip on failure, and skip for the modes that
+        // are still refused upstream, where discovery would guess at a file
+        // the invocation never wrote. `-E` writing to a named file reaches
+        // here now, and its expansion is discovered the same way an object
+        // is. Objects retain their basename; dep-info gets a semantic store
+        // name because `-MF` permits arbitrary suffixes and restore already
+        // takes its real destination from the current invocation
+        // (kunobi-ninja/kache#655).
+        let discovers_outputs = matches!(parsed.mode, CompileMode::Compile)
+            || (parsed.mode == CompileMode::Preprocess && parsed.output.is_some());
+        let artifacts = if exit_code == 0 && discovers_outputs {
             discover_cc_output_artifacts(parsed)
         } else {
             ArtifactSet::empty()
@@ -9919,6 +9930,36 @@ mod tests {
             last = compiler.execute(parsed);
         }
         last
+    }
+
+    #[cfg(unix)]
+    /// `-E` to a named file is a cacheable single-output compile; `-E` to
+    /// stdout still is not, and says so in its own words so the two can be
+    /// counted apart in a report.
+    #[test]
+    fn preprocess_to_a_file_is_cacheable_and_to_stdout_is_not() {
+        let to_file = CcArgs::parse(&s(&["cc", "-E", "unit.c", "-o", "unit.i"])).unwrap();
+        assert_eq!(to_file.mode, CompileMode::Preprocess);
+        assert!(
+            to_file.refuse_reasons(&[]).is_empty(),
+            "a named output is the artifact: {:?}",
+            to_file.refuse_reasons(&[])
+        );
+        assert_eq!(
+            to_file.object_output_path(),
+            Some(PathBuf::from("unit.i")),
+            "the named output is what restore has to write"
+        );
+
+        let to_stdout = CcArgs::parse(&s(&["cc", "-E", "unit.c"])).unwrap();
+        let reasons = to_stdout.refuse_reasons(&[]);
+        assert!(
+            reasons.iter().any(|reason| matches!(
+                reason,
+                RefuseReason::Unsupported(message) if message.contains("to stdout")
+            )),
+            "stdout has no file to store: {reasons:?}"
+        );
     }
 
     #[cfg(unix)]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1233,6 +1233,28 @@ fn cc_cache_entry_satisfies_invocation(
     cc_cache_entry_rejection_reason(parsed, meta).is_none()
 }
 
+/// Where a cached preprocess artifact goes, if this invocation is the one
+/// that asked for it.
+///
+/// A preprocess output is not an object and has no fixed extension, so the
+/// only thing that identifies it is the name the invocation named. `None` for
+/// any other mode, and for an entry naming a different file: restoring one of
+/// those would report a hit and leave the build with the wrong bytes, or with
+/// none at all.
+fn cc_preprocess_restore_target(
+    parsed: &crate::compiler::cc::CcArgs,
+    cached_name: &str,
+) -> Option<std::path::PathBuf> {
+    if parsed.mode != crate::compiler::cc::CompileMode::Preprocess {
+        return None;
+    }
+    let target = parsed.object_output_path()?;
+    let names_match = target
+        .file_name()
+        .is_some_and(|name| name.to_string_lossy() == cached_name);
+    names_match.then_some(target)
+}
+
 fn cc_cache_entry_rejection_reason(
     parsed: &crate::compiler::cc::CcArgs,
     meta: &crate::store::EntryMeta,
@@ -1246,8 +1268,19 @@ fn cc_cache_entry_rejection_reason(
         .iter()
         .any(|file| classify_by_filename(&file.name) == ArtifactKind::DepInfo);
 
-    if !has_object {
+    // A preprocess names its own output and it is not an object, so require
+    // that the entry carries the file this invocation asked for rather than
+    // an object it was never going to produce.
+    let wants_object = parsed.mode != crate::compiler::cc::CompileMode::Preprocess;
+    let has_named_output = meta
+        .files
+        .iter()
+        .any(|file| cc_preprocess_restore_target(parsed, &file.name).is_some());
+
+    if wants_object && !has_object {
         Some("matching entry lacks the object artifact required by this invocation")
+    } else if !wants_object && !has_named_output {
+        Some("matching entry lacks the preprocessed output required by this invocation")
     } else if parsed.depinfo_output_path().is_some() && !has_depinfo {
         Some("matching entry lacks dep-info required by this invocation")
     } else {
@@ -1502,14 +1535,20 @@ fn restore_cc_from_cache(
                     continue;
                 }
             },
-            _ => {
-                tracing::debug!(
-                    "cc restore: cached artifact {} has unsupported kind {:?}; skipping",
-                    cached.name,
-                    kind
-                );
-                continue;
-            }
+            // Anything else is this invocation's own preprocessor output or
+            // nothing we can place. Asking once keeps the answer and the
+            // decision to use it from ever disagreeing.
+            _ => match cc_preprocess_restore_target(parsed, &cached.name) {
+                Some(target) => target,
+                None => {
+                    tracing::debug!(
+                        "cc restore: cached artifact {} has unsupported kind {:?}; skipping",
+                        cached.name,
+                        kind
+                    );
+                    continue;
+                }
+            },
         };
 
         // Recheck immediately before the path-based restore. The initial
@@ -6625,6 +6664,132 @@ mod tests {
 
     /// Degenerate cc invocations with no object path fail before blob access,
     /// giving callers a clean miss instead of materializing to an unknown path.
+    /// A preprocess hit has to land the expansion where `-o` asked for it.
+    /// Nothing else in the restore path knows how to place a `.i`, so if this
+    /// arm stops firing the caller reports a hit and leaves no output at all.
+    #[test]
+    fn restore_cc_from_cache_writes_the_preprocessed_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path().join("cache"));
+        let store = Store::open(&config).unwrap();
+        let hash = "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd";
+        create_blob(&store, hash, b"# 1 \"unit.c\"\nint expanded;\n");
+
+        let output = dir.path().join("unit.i");
+        let output_str = output.to_string_lossy().into_owned();
+        let parsed = CcCompiler::new()
+            .parse(&s(&["cc", "-E", "unit.c", "-o", &output_str]))
+            .unwrap();
+        let meta = entry_meta("cc-preprocess-key", vec![cached_file("unit.i", hash)], &[]);
+
+        restore_cc_from_cache(&store, &parsed, &meta).unwrap();
+        assert_eq!(
+            std::fs::read(&output).unwrap(),
+            b"# 1 \"unit.c\"\nint expanded;\n",
+            "the cached expansion must reach the path -o named"
+        );
+
+        // An entry naming some other file is not this invocation's output, and
+        // skipping it must not invent one.
+        let other = dir.path().join("other.i");
+        let other_str = other.to_string_lossy().into_owned();
+        let mismatched = CcCompiler::new()
+            .parse(&s(&["cc", "-E", "unit.c", "-o", &other_str]))
+            .unwrap();
+        restore_cc_from_cache(&store, &mismatched, &meta).unwrap();
+        assert!(
+            !other.exists(),
+            "an entry for a different name must leave nothing behind"
+        );
+    }
+
+    /// The rule that decides where a cached preprocess artifact goes, and
+    /// whether it belongs to this invocation at all. Restore and hit
+    /// qualification both use it, so they cannot disagree.
+    #[test]
+    fn cc_preprocess_restore_target_matches_only_the_named_output() {
+        use crate::compiler::cc::CcArgs;
+        let parse = |args: &[&str]| {
+            CcArgs::parse(&args.iter().map(|a| (*a).to_string()).collect::<Vec<_>>()).unwrap()
+        };
+
+        let preprocess = parse(&["cc", "-E", "unit.c", "-o", "build/unit.i"]);
+        assert_eq!(
+            cc_preprocess_restore_target(&preprocess, "unit.i"),
+            Some(std::path::PathBuf::from("build/unit.i")),
+            "the cached name is the file this invocation asked for"
+        );
+        assert_eq!(
+            cc_preprocess_restore_target(&preprocess, "other.i"),
+            None,
+            "an entry naming a different file must not be written here"
+        );
+        assert_eq!(
+            cc_preprocess_restore_target(&preprocess, "unit.o"),
+            None,
+            "an object is not this invocation's output"
+        );
+
+        // Every other mode is somebody else's business, whatever the name.
+        for args in [
+            ["cc", "-c", "unit.c", "-o", "unit.i"].as_slice(),
+            ["cc", "unit.c", "-o", "unit.i"].as_slice(),
+        ] {
+            let other = parse(args);
+            assert_eq!(
+                cc_preprocess_restore_target(&other, "unit.i"),
+                None,
+                "{args:?} is not a preprocess and must not take this path"
+            );
+        }
+    }
+
+    /// A preprocess entry qualifies on the file the invocation asked for,
+    /// not on an object it was never going to produce. Getting this wrong
+    /// reports a hit and leaves the build without its output.
+    #[test]
+    fn cc_entry_qualification_accepts_a_preprocess_output() {
+        use crate::compiler::cc::CcArgs;
+        let args: Vec<String> = ["cc", "-E", "unit.c", "-o", "unit.i"]
+            .iter()
+            .map(|a| (*a).to_string())
+            .collect();
+        let parsed = CcArgs::parse(&args).unwrap();
+
+        let entry = |name: &str| entry_meta_with_files(&[name]);
+
+        assert_eq!(
+            cc_cache_entry_rejection_reason(&parsed, &entry("unit.i")),
+            None,
+            "the named expansion is what this invocation needs"
+        );
+        assert_eq!(
+            cc_cache_entry_rejection_reason(&parsed, &entry("other.i")),
+            Some("matching entry lacks the preprocessed output required by this invocation"),
+            "an entry naming a different output cannot serve this one"
+        );
+        assert_eq!(
+            cc_cache_entry_rejection_reason(&parsed, &entry("unit.o")),
+            Some("matching entry lacks the preprocessed output required by this invocation"),
+            "an object is not a preprocess output"
+        );
+
+        // And an ordinary compile still requires its object.
+        let compile_args: Vec<String> = ["cc", "-c", "unit.c", "-o", "unit.o"]
+            .iter()
+            .map(|a| (*a).to_string())
+            .collect();
+        let compile = CcArgs::parse(&compile_args).unwrap();
+        assert_eq!(
+            cc_cache_entry_rejection_reason(&compile, &entry("unit.o")),
+            None
+        );
+        assert_eq!(
+            cc_cache_entry_rejection_reason(&compile, &entry("unit.i")),
+            Some("matching entry lacks the object artifact required by this invocation")
+        );
+    }
+
     #[test]
     fn restore_cc_from_cache_requires_object_output_for_object_blob() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Closes #932.

162 Firefox compiles pass through as `cc preprocessor mode -E — not yet`.

An `-E` invocation writing to a named file is an ordinary single-output compile: deterministic, one artifact, and every input that can change it is already in the key, because the key path runs the preprocessor itself to hash the expansion. There was nothing to design, only four places that assumed the output was an object.

## The four

- **The refusal** now applies only to `-E` writing to stdout, which would need the entry to carry an output no file holds. It keeps its own wording so the two shapes stay countable in a report.
- **Output discovery** ran only for `-c`, on the stated assumption that other modes were refused upstream. That assumption is no longer true.
- **Hit qualification** demanded an object artifact. A preprocess qualifies on the file the invocation actually asked for; an entry naming a different output, or an object, does not serve it.
- **Restore** skipped any artifact whose kind it did not recognise. This was the one that mattered: it reported a hit, returned zero, and left the build without its output. A silent wrong answer rather than a slow one.

## Verification

With a real compiler, three invocations: the first misses, the second hits and restores bytes **identical to the uncached run**, and after editing a header the third misses and produces the new expansion. That sequence is what caught the restore defect, which the unit tests alone would not have.

Unit tests cover the refusal split, the output path a restore has to write, and qualification in both directions, including that an ordinary compile still requires its object.

`mise exec -- just check`: fmt, clippy `-D warnings`, full workspace tests. Draft for the mutation shards.

## What a reviewer should still watch

- `-E` to stdout stays refused. Doing it needs an entry whose output is stdout rather than a file, which the store does not model today.
- The key already covered this shape, so no key version change and no invalidation.
- Independent of #933, which is the include-directory work on the same subject; they touch different code and can land in either order.