### PR TITLE
fix(key): verify guarded inputs across clock domains

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -2519,6 +2519,11 @@ pub struct FileHasher<'db> {
     runtime_env_uses: RefCell<HashMap<(String, String), bool>>,
     stats: FileHashStatsCells,
     too_new: TooNewGuard,
+    /// Fingerprints of every file hashed while the too-new guard was armed.
+    /// Drained after the compile so the wrapper can prove clock-independently
+    /// that none of them changed mid-build (see
+    /// [`FileHasher::guarded_inputs_unchanged_since_hash`]).
+    guard_inputs: RefCell<Vec<FileFingerprint>>,
 }
 
 /// Optional "too-new input" guard (kunobi-ninja/kache#324). When armed, any
@@ -2625,6 +2630,7 @@ impl FileHasher<'static> {
             runtime_env_uses: RefCell::new(HashMap::new()),
             stats: FileHashStatsCells::default(),
             too_new: TooNewGuard::default(),
+            guard_inputs: RefCell::new(Vec::new()),
         }
     }
 
@@ -2639,6 +2645,7 @@ impl FileHasher<'static> {
                 runtime_env_uses: RefCell::new(HashMap::new()),
                 stats: FileHashStatsCells::default(),
                 too_new: TooNewGuard::default(),
+                guard_inputs: RefCell::new(Vec::new()),
             },
             Err(e) => {
                 tracing::debug!(
@@ -2661,6 +2668,7 @@ impl<'db> FileHasher<'db> {
             runtime_env_uses: RefCell::new(HashMap::new()),
             stats: FileHashStatsCells::default(),
             too_new: TooNewGuard::default(),
+            guard_inputs: RefCell::new(Vec::new()),
         }
     }
 
@@ -2680,6 +2688,34 @@ impl<'db> FileHasher<'db> {
     /// Whether any hashed input was "too new" since the guard was armed.
     pub fn too_new(&self) -> bool {
         self.too_new.saw_too_new.get()
+    }
+
+    /// Drain the fingerprints hashed while the guard was armed. The wrapper
+    /// carries them past the compile and hands them to
+    /// [`FileHasher::guarded_inputs_unchanged_since_hash`].
+    pub fn take_guarded_inputs(&self) -> Vec<FileFingerprint> {
+        std::mem::take(&mut *self.guard_inputs.borrow_mut())
+    }
+
+    /// Clock-independent proof that guarded inputs did not change since they
+    /// were hashed: every recorded fingerprint still matches a fresh stat and
+    /// carries a strong identity. Comparing a file's metadata against itself
+    /// never orders either side against the host clock, so this stays valid
+    /// when the filesystem lives in another clock domain (NFS skew, a fresh
+    /// checkout with future mtimes) where the wall-clock guard misfires.
+    ///
+    /// Fails closed: an empty set, a missing or changed file, or an input
+    /// without an inode (non-Unix, where replace-by-rename is invisible)
+    /// never excuses a tripped guard.
+    pub fn guarded_inputs_unchanged_since_hash(inputs: &[FileFingerprint]) -> bool {
+        if inputs.is_empty() {
+            return false;
+        }
+        inputs.iter().all(|expected| {
+            expected.inode != 0
+                && FileFingerprint::from_path(Path::new(&expected.path))
+                    .is_ok_and(|current| current == *expected)
+        })
     }
 
     fn note_too_new(&self, fingerprint: &FileFingerprint) {
@@ -2946,6 +2982,11 @@ impl<'db> FileHasher<'db> {
     /// Hash a file's contents, using the persistent cache when available.
     pub fn hash(&self, path: &Path) -> Result<String> {
         let (hash, fingerprint) = self.hash_inner(path)?;
+        if self.too_new.invocation_start_ns > 0
+            && let Some(fingerprint) = &fingerprint
+        {
+            self.guard_inputs.borrow_mut().push(fingerprint.clone());
+        }
         self.recent_hashes.borrow_mut().insert(
             absolute_path(path),
             RecentHash {
@@ -8614,6 +8655,105 @@ pub const OUT_DIR_AT_COMPILE_TIME: &str = env!("OUT_DIR");
         assert!(
             cacheless.too_new(),
             "a cacheless hasher must enforce the same too-new guard"
+        );
+    }
+
+    #[test]
+    fn guarded_inputs_record_only_while_armed() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("input.rs");
+        std::fs::write(&file, b"pub fn x() {}").unwrap();
+
+        let disarmed = FileHasher::new();
+        disarmed.hash(&file).unwrap();
+        assert!(
+            disarmed.take_guarded_inputs().is_empty(),
+            "a disarmed hasher records nothing to verify"
+        );
+
+        let mut armed = FileHasher::new();
+        armed.arm_too_new_guard(1, 0);
+        armed.hash(&file).unwrap();
+        armed.hash(&file).unwrap();
+        assert_eq!(
+            armed.take_guarded_inputs().len(),
+            2,
+            "every hash while armed is recorded for post-compile verification"
+        );
+        assert!(
+            armed.take_guarded_inputs().is_empty(),
+            "taking the snapshot drains it"
+        );
+    }
+
+    #[test]
+    fn guarded_inputs_empty_set_never_excuses() {
+        assert!(
+            !FileHasher::guarded_inputs_unchanged_since_hash(&[]),
+            "a vacuous check must not waive a tripped guard"
+        );
+    }
+
+    #[test]
+    fn guarded_inputs_reject_changed_or_missing_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("input.rs");
+        std::fs::write(&file, b"pub fn x() {}").unwrap();
+        let recorded = FileFingerprint::from_path(&file).unwrap();
+
+        std::fs::write(&file, b"pub fn x() { 1 }").unwrap();
+        assert!(
+            !FileHasher::guarded_inputs_unchanged_since_hash(std::slice::from_ref(&recorded)),
+            "rewritten bytes must fail verification even when the wall clock cannot tell"
+        );
+
+        std::fs::remove_file(&file).unwrap();
+        assert!(
+            !FileHasher::guarded_inputs_unchanged_since_hash(std::slice::from_ref(&recorded)),
+            "a file that vanished mid-build must fail verification"
+        );
+    }
+
+    #[test]
+    fn guarded_inputs_reject_weak_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("input.rs");
+        std::fs::write(&file, b"pub fn x() {}").unwrap();
+        let mut recorded = FileFingerprint::from_path(&file).unwrap();
+        recorded.inode = 0;
+        assert!(
+            !FileHasher::guarded_inputs_unchanged_since_hash(std::slice::from_ref(&recorded)),
+            "without an inode a replace-by-rename is invisible, so verification must fail closed"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn guarded_inputs_verify_despite_future_mtimes() {
+        // The clock-domain case: the filesystem clock runs ahead of the host
+        // (NFS skew, a fresh checkout stamped in the future), so the
+        // wall-clock guard trips on files the build never touched. Identical
+        // fingerprints before and after still prove nothing changed.
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("input.rs");
+        std::fs::write(&file, b"pub fn x() {}").unwrap();
+        filetime::set_file_mtime(&file, filetime::FileTime::from_unix_time(2_000_000_000, 0))
+            .unwrap();
+
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as i64;
+        let mut hasher = FileHasher::new();
+        hasher.arm_too_new_guard(now_ns, 0);
+        hasher.hash(&file).unwrap();
+        assert!(
+            hasher.too_new(),
+            "a future mtime must still trip the wall-clock guard"
+        );
+        assert!(
+            FileHasher::guarded_inputs_unchanged_since_hash(&hasher.take_guarded_inputs()),
+            "untouched bytes verify despite the skewed clock"
         );
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -5,6 +5,7 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::args::RustcArgs;
 use crate::cache_key::FileHashStats;
+use crate::cache_key::FileHasher;
 use crate::compile;
 use crate::compiler::cc::CcCompiler;
 use crate::compiler::rustc::RustcCompiler;
@@ -1666,6 +1667,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
 
     let extra_inputs_hash_stats = extra_inputs_hasher.stats();
     let extra_inputs_too_new = extra_inputs_hasher.too_new();
+    let extra_inputs_guard_inputs = extra_inputs_hasher.take_guarded_inputs();
     let extra_inputs_key_ms = extra_inputs_key_start.elapsed().as_millis() as u64;
     // A fallback cache does not know Kache's extra-input digest. If Kache
     // declines an invocation, delegating it could restore the exact stale
@@ -1696,6 +1698,7 @@ pub fn run(config: &Config, wrapper_args: &[String]) -> Result<i32> {
         extra_inputs_hash_stats,
         extra_inputs_too_new,
         extra_inputs_key_ms,
+        extra_inputs_guard_inputs,
     )?;
 
     if exit == 0 {
@@ -1788,9 +1791,15 @@ fn extra_inputs_changed_during_compile(
             return true;
         }
     };
-    if before != after.as_ref() || hasher.too_new() {
+    if before != after.as_ref() {
         tracing::warn!(
             "not caching {crate_name}: extra_inputs changed while the compiler was running"
+        );
+        return true;
+    }
+    if key_inputs_changed_during_compile(hasher.too_new(), &hasher.take_guarded_inputs()) {
+        tracing::warn!(
+            "not caching {crate_name}: extra_inputs may have changed while the compiler was running"
         );
         return true;
     }
@@ -1807,6 +1816,7 @@ fn run_parsed_rustc(
     extra_inputs_hash_stats: FileHashStats,
     extra_inputs_too_new: bool,
     extra_inputs_key_ms: u64,
+    extra_inputs_guard_inputs: Vec<crate::cache_key::FileFingerprint>,
 ) -> Result<i32> {
     let crate_name = args.crate_name.as_deref().unwrap_or("unknown");
     let event_root = rustc_event_root(args);
@@ -2016,6 +2026,7 @@ fn run_parsed_rustc(
         extra_inputs_hash_stats,
         extra_inputs_too_new,
         extra_inputs_key_ms,
+        extra_inputs_guard_inputs,
     ) {
         Ok(keyed) => keyed,
         Err(e) => {
@@ -2040,6 +2051,7 @@ fn run_parsed_rustc(
         key_ms,
         key_hash_stats,
         key_too_new,
+        guard_inputs,
     } = keyed;
     // A force-list request that could not obtain its immediate lease must not
     // retry through the post-key adaptive seed path in the same invocation.
@@ -2465,12 +2477,16 @@ fn run_parsed_rustc(
     // racy versus what rustc actually read — refuse to store (the compile
     // already ran and is in place; we just don't cache it). Off by default;
     // the lookup above still ran, so a sound prior entry can still be served.
+    // A tripped wall-clock flag is excused when post-compile verification
+    // proves no guarded input changed: the flag also fires across clock
+    // domains where nothing is actually racy.
     let extra_inputs_racy = args.is_primary
         && extra_inputs_changed_during_compile(config, args, extra_inputs, invocation_start_ns);
+    let key_inputs_changed = key_inputs_changed_during_compile(key_too_new, &guard_inputs);
     if should_skip_cache_store_for_input_race(
         extra_inputs_racy,
         config.modified_input_guard,
-        key_too_new,
+        key_inputs_changed,
     ) {
         let elapsed = start.elapsed().as_millis() as u64;
         log_event_with_hash_stats(
@@ -3223,6 +3239,10 @@ struct ComputedKey {
     key_ms: u64,
     key_hash_stats: FileHashStats,
     key_too_new: bool,
+    /// Fingerprints hashed for the key (plus the extra-inputs resolve) while
+    /// the too-new guard was armed, carried past the compile for
+    /// clock-independent verification.
+    guard_inputs: Vec<crate::cache_key::FileFingerprint>,
 }
 
 fn should_skip_cache_store_for_input_race(
@@ -3231,6 +3251,19 @@ fn should_skip_cache_store_for_input_race(
     key_too_new: bool,
 ) -> bool {
     extra_inputs_racy || (modified_input_guard && key_too_new)
+}
+
+/// Whether keyed inputs actually changed during the compile. A tripped
+/// wall-clock flag alone is not proof: it also fires when the filesystem
+/// clock runs ahead of the host (NFS skew, future-stamped checkouts). When
+/// every guarded input still matches its hash-time fingerprint with a strong
+/// identity, nothing changed and the store refusal is excused. Anything else
+/// — a mismatch, a missing file, a weak identity — keeps the refusal.
+fn key_inputs_changed_during_compile(
+    key_too_new: bool,
+    guard_inputs: &[crate::cache_key::FileFingerprint],
+) -> bool {
+    key_too_new && !FileHasher::guarded_inputs_unchanged_since_hash(guard_inputs)
 }
 
 fn combine_key_measurements(
@@ -3268,6 +3301,7 @@ fn compute_rustc_cache_key(
     extra_inputs_hash_stats: FileHashStats,
     extra_inputs_too_new: bool,
     extra_inputs_key_ms: u64,
+    mut extra_inputs_guard_inputs: Vec<crate::cache_key::FileFingerprint>,
 ) -> Result<ComputedKey> {
     let key_start = std::time::Instant::now();
     let mut file_hasher = match store {
@@ -3306,6 +3340,7 @@ fn compute_rustc_cache_key(
     };
     let cache_key = compiler.cache_key(args, &key_ctx)?;
     let key_hash_stats = file_hasher.stats();
+    extra_inputs_guard_inputs.extend(file_hasher.take_guarded_inputs());
     let (key_ms, key_hash_stats, key_too_new) = combine_key_measurements(
         key_start.elapsed().as_millis() as u64,
         extra_inputs_key_ms,
@@ -3319,6 +3354,7 @@ fn compute_rustc_cache_key(
         key_ms,
         key_hash_stats,
         key_too_new,
+        guard_inputs: extra_inputs_guard_inputs,
     })
 }
 
@@ -5747,6 +5783,38 @@ mod tests {
                 ),
                 expected
             );
+        }
+    }
+
+    #[test]
+    fn key_inputs_changed_excuses_skewed_clocks_but_not_real_changes() {
+        use crate::cache_key::FileFingerprint;
+
+        // No tripped flag: nothing to excuse, whatever was recorded.
+        assert!(!key_inputs_changed_during_compile(false, &[]));
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("input.rs");
+        std::fs::write(&file, b"pub fn x() {}").unwrap();
+        let recorded = FileFingerprint::from_path(&file).unwrap();
+        assert!(!key_inputs_changed_during_compile(
+            false,
+            std::slice::from_ref(&recorded)
+        ));
+        // Tripped flag with nothing verifiable stays a refusal.
+        assert!(key_inputs_changed_during_compile(true, &[]));
+        #[cfg(unix)]
+        {
+            // Tripped flag, untouched inputs: a skewed clock, not a race.
+            assert!(!key_inputs_changed_during_compile(
+                true,
+                std::slice::from_ref(&recorded)
+            ));
+            // Tripped flag, rewritten inputs: a real race.
+            std::fs::write(&file, b"pub fn x() { 1 }").unwrap();
+            assert!(key_inputs_changed_during_compile(
+                true,
+                std::slice::from_ref(&recorded)
+            ));
         }
     }
 


### PR DESCRIPTION
The too-new guard ordered file mtimes against the host wall clock, so it misfired wherever the filesystem lives in another clock domain.

Two failure modes: a filesystem clock ahead of the host (NFS skew, a future-stamped fresh checkout) makes every input look racy and so the store silently never populates; a clock behind can hide a real mid-build rewrite. The cc memo path already stopped trusting the wall clock in #927/#928; this extends the same reasoning to the main rustc key path and the extra_inputs revalidation.

What changed: the hasher records every fingerprint hashed while the guard is armed and drains the set past the compile. A tripped flag is excused only when post-compile re-stat shows every recorded fingerprint identical with a strong (inode-carrying) identity. Anything else keeps the refusal, and the check runs only when the flag actually tripped, so the common path costs nothing. Non-Unix inputs always fail closed exactly as before. Lookups are untouched; this only ever governed store admission.

Refs #324.

Verification:
- `cargo fmt --check` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `just check` green on the exact head before push.
- New tests: recording discipline, empty-set/vanished/rewritten/weak-identity rejection, a future-mtime file that trips the guard yet verifies (unix), and the wrapper composition table. Each mutant-killable condition (empty, mismatch, weak, missing) has its own failing case.
- Mutation testing runs on the CI shards for this PR.

What a reviewer should still watch: the excuse spans key-compute to post-compile, so a file changed and changed back between the two reads as unchanged. That window pre-exists (hash vs compiler read) and identical bytes key identically, so there is nothing unsound to store.