### PR TITLE
bench: measure every eligible subject side by side

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,7 @@ on:
       scenario:
         description: "Which scenario(s) to run"
         type: choice
-        options: [all, substrate, surrealdb, lance, opendal, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows, hk, hk-pull, hk-mbx, opendal-mbx, lance-mbx]
+        options: [all, substrate, surrealdb, lance, opendal, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows, hk, hk-pull, hk-mbx, opendal-mbx, lance-mbx, substrate-mbx, surrealdb-mbx]
         default: all
       extra_args:
         description: "Extra args appended to `just bench <profile>` (e.g. --skip-clone, --retry)"
@@ -150,6 +150,12 @@ jobs:
           # carrying the multi-hour arms.
           opendal_mbx='{"name":"opendal-mbx","cmd":"bench-mbx opendal","dir":"bench-opendal-mbx","timeout":120,"job_timeout":165,"min_free_gb":40,"runner":"kunobi-runners-small"}'
           lance_mbx='{"name":"lance-mbx","cmd":"bench-mbx lance","dir":"bench-lance-mbx","timeout":180,"job_timeout":225,"min_free_gb":60,"runner":"kunobi-runners-small"}'
+          # The two heavyweights complete the set: these five are every subject
+          # mbx can serve at all. They keep their kache arms' disk floors, and
+          # 80Gi is above the small pool's per-runner reservation, so they run
+          # on the heavy pool as their kache counterparts do.
+          substrate_mbx='{"name":"substrate-mbx","cmd":"bench-mbx substrate","dir":"bench-substrate-mbx","timeout":180,"job_timeout":225,"min_free_gb":60,"runner":"kunobi-runners"}'
+          surrealdb_mbx='{"name":"surrealdb-mbx","cmd":"bench-mbx surrealdb","dir":"bench-surrealdb-mbx","timeout":180,"job_timeout":225,"min_free_gb":80,"runner":"kunobi-runners"}'
           case "$SCENARIO" in
             substrate)            inc="[$substrate]" ;;
             surrealdb)            inc="[$surrealdb]" ;;
@@ -164,13 +170,15 @@ jobs:
             hk-mbx)               inc="[$hk_mbx]" ;;
             opendal-mbx)          inc="[$opendal_mbx]" ;;
             lance-mbx)            inc="[$lance_mbx]" ;;
+            substrate-mbx)        inc="[$substrate_mbx]" ;;
+            surrealdb-mbx)        inc="[$surrealdb_mbx]" ;;
             # Windows-only scenarios are served by their own self-hosted jobs
             # below, so the Linux matrix is EMPTY for them (an empty include
             # skips the `bench` job cleanly). Without this they'd fall to `*)`
             # and wastefully run the whole Linux `all` matrix alongside.
             firefox-windows)      inc="[]" ;;
             firefox-pull-windows) inc="[]" ;;
-            *)                    inc="[$substrate,$surrealdb,$lance,$opendal,$firefox,$firefox_sccache,$llvm,$firefox_pull,$hk,$hk_pull,$hk_mbx,$opendal_mbx,$lance_mbx]" ;;
+            *)                    inc="[$substrate,$surrealdb,$lance,$opendal,$firefox,$firefox_sccache,$llvm,$firefox_pull,$hk,$hk_pull,$hk_mbx,$opendal_mbx,$lance_mbx,$substrate_mbx,$surrealdb_mbx]" ;;
           esac
           echo "matrix={\"include\":$inc}" >> "$GITHUB_OUTPUT"
           if [ "$inc" = "[]" ]; then

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,7 @@ on:
       scenario:
         description: "Which scenario(s) to run"
         type: choice
-        options: [all, substrate, surrealdb, lance, opendal, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows, hk, hk-pull, hk-mbx]
+        options: [all, substrate, surrealdb, lance, opendal, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows, hk, hk-pull, hk-mbx, opendal-mbx, lance-mbx]
         default: all
       extra_args:
         description: "Extra args appended to `just bench <profile>` (e.g. --skip-clone, --retry)"
@@ -142,6 +142,14 @@ jobs:
           # (as firefox-sccache is for firefox). mbx comes from mise at its
           # latest release; the run records the version it measured.
           hk_mbx='{"name":"hk-mbx","cmd":"bench-mbx hk","dir":"bench-hk-mbx","timeout":60,"job_timeout":90,"min_free_gb":30,"runner":"kunobi-runners-small"}'
+          # Two more subjects on the same side-by-side axis. mbx fronts Cargo,
+          # so the arms it can serve at all are exactly the cargo-driven ones:
+          # firefox (mach/gn/ninja) and llvm (cmake) are out of reach, which is
+          # why firefox's comparison arm is sccache instead. Both sit on the
+          # small pool — the heavy pool runs one job at a time and is already
+          # carrying the multi-hour arms.
+          opendal_mbx='{"name":"opendal-mbx","cmd":"bench-mbx opendal","dir":"bench-opendal-mbx","timeout":120,"job_timeout":165,"min_free_gb":40,"runner":"kunobi-runners-small"}'
+          lance_mbx='{"name":"lance-mbx","cmd":"bench-mbx lance","dir":"bench-lance-mbx","timeout":180,"job_timeout":225,"min_free_gb":60,"runner":"kunobi-runners-small"}'
           case "$SCENARIO" in
             substrate)            inc="[$substrate]" ;;
             surrealdb)            inc="[$surrealdb]" ;;
@@ -154,13 +162,15 @@ jobs:
             hk)                   inc="[$hk]" ;;
             hk-pull)              inc="[$hk_pull]" ;;
             hk-mbx)               inc="[$hk_mbx]" ;;
+            opendal-mbx)          inc="[$opendal_mbx]" ;;
+            lance-mbx)            inc="[$lance_mbx]" ;;
             # Windows-only scenarios are served by their own self-hosted jobs
             # below, so the Linux matrix is EMPTY for them (an empty include
             # skips the `bench` job cleanly). Without this they'd fall to `*)`
             # and wastefully run the whole Linux `all` matrix alongside.
             firefox-windows)      inc="[]" ;;
             firefox-pull-windows) inc="[]" ;;
-            *)                    inc="[$substrate,$surrealdb,$lance,$opendal,$firefox,$firefox_sccache,$llvm,$firefox_pull,$hk,$hk_pull,$hk_mbx]" ;;
+            *)                    inc="[$substrate,$surrealdb,$lance,$opendal,$firefox,$firefox_sccache,$llvm,$firefox_pull,$hk,$hk_pull,$hk_mbx,$opendal_mbx,$lance_mbx]" ;;
           esac
           echo "matrix={\"include\":$inc}" >> "$GITHUB_OUTPUT"
           if [ "$inc" = "[]" ]; then

--- a/scenarios/bench-lance-mbx/scenario.toml
+++ b/scenarios/bench-lance-mbx/scenario.toml
@@ -1,0 +1,89 @@
+# Lance through mbx: the same subject, commit, toolchain and build command as
+# bench-lance, driven by mbx instead of kache, so the two arms read side by
+# side.
+#
+# mbx fronts Cargo and installs its own shims for build scripts, so this
+# scenario sets no compiler wiring and no KACHE_BASE_DIR; the harness puts its
+# `cargo` shim on PATH and points MBX_CACHE_DIR at the store. The generated
+# well-known protobuf schemas below are part of the SUBJECT, not the cache
+# wiring, so they are carried over verbatim.
+#
+# Cold and warm only — external backends have no same-tree phase and no key
+# tracing, so the correctness assertions of the kache arm become advisory
+# measure checks here. Nightly arm: lance-mbx in bench.yml.
+name = "bench-lance-mbx"
+tags = ["suite:bench", "project:lance", "backend:mbx", "lang:rust"]
+
+requires = ["cargo", "rustc", "protoc"]
+
+# Lance ships a rust-toolchain.toml (channel = "1.97.0"), so there is nothing
+# to pin here: rustup auto-installs and selects that toolchain on the first
+# cargo invocation in the tree, and the bench workflow clears RUSTUP_TOOLCHAIN
+# so the file is honoured. System protobuf (`protoc`) is required by
+# prost-build; openssl headers / pkg-config are needed by a few default-feature
+# cloud backends. They are NOT auto-installed — the bench runner already
+# provisions them (see .github/workflows/bench.yml), and the echo below
+# documents them for a local run.
+setup = [
+  "echo '[bench] lance default features need system deps: protoc (REQUIRED), pkg-config, openssl headers, a C compiler. macOS: brew install protobuf pkg-config openssl. Debian: apt install protobuf-compiler pkg-config libssl-dev build-essential.'",
+]
+
+# Build the `lance` crate with its DEFAULT features (aws, azure, gcp, oss,
+# huggingface, tencent, tos, goosefs, geo) — i.e. what Lance actually ships.
+# No RUSTUP_TOOLCHAIN pin: the tree's rust-toolchain.toml drives toolchain
+# selection. KACHE_BASE_DIR keeps checkout-absolute paths (OUT_DIR from
+# prost-build, CARGO_MANIFEST_DIR) portable across the two clones so the
+# headline cross-clone metric is measuring kache, not path baking.
+build = """
+src="$(pwd -P)"
+cargo build --release -p lance
+"""
+
+[source]
+kind = "clone"
+repo = "https://github.com/lance-format/lance.git"
+# Latest stable release as of 2026-08-27. This tag pins Rust via
+# rust-toolchain.toml (channel "1.97.0"), honoured automatically (see setup note).
+ref    = "v10.0.0"
+objdir = "target"
+
+# Lance v10 invokes protoc with only its local proto directory but imports
+# three well-known types. Supply their schemas inside the include tree Lance
+# already passes to protoc.
+[[file]]
+path = "protos/google/protobuf/empty.proto"
+mode = "write"
+content = '''
+syntax = "proto3";
+package google.protobuf;
+message Empty {}
+'''
+
+[[file]]
+path = "protos/google/protobuf/any.proto"
+mode = "write"
+content = '''
+syntax = "proto3";
+package google.protobuf;
+message Any {
+  string type_url = 1;
+  bytes value = 2;
+}
+'''
+
+[[file]]
+path = "protos/google/protobuf/timestamp.proto"
+mode = "write"
+content = '''
+syntax = "proto3";
+package google.protobuf;
+message Timestamp {
+  int64 seconds = 1;
+  int32 nanos = 2;
+}
+'''
+
+# Advisory only, as for the sccache and hk-mbx arms: the number is the point,
+# and the assertions above it need kache's own instrumentation.
+[checks.measure.warm]
+min_hit_rate_pct = 50.0

--- a/scenarios/bench-opendal-mbx/scenario.toml
+++ b/scenarios/bench-opendal-mbx/scenario.toml
@@ -1,0 +1,70 @@
+# OpenDAL core through mbx: the same subject, commit, toolchain, feature set
+# and build command as bench-opendal, driven by mbx instead of kache, so the
+# two arms read side by side.
+#
+# mbx fronts Cargo and installs its own shims for build scripts, so this
+# scenario sets no compiler wiring and no KACHE_BASE_DIR; the harness puts its
+# `cargo` shim on PATH and points MBX_CACHE_DIR at the store.
+#
+# Cold and warm only — external backends have no same-tree phase and no key
+# tracing, so the correctness assertions of the kache arm become advisory
+# measure checks here. Nightly arm: opendal-mbx in bench.yml.
+name = "bench-opendal-mbx"
+tags = ["suite:bench", "project:opendal", "backend:mbx", "lang:rust"]
+
+requires = ["cargo", "rustc"]
+
+# OpenDAL ships rust-toolchain.toml with channel = "stable" at the repo
+# root, so — like surrealdb — there is nothing to pin here: rustup
+# auto-selects that toolchain on the first cargo invocation in the tree,
+# and the bench workflow clears RUSTUP_TOOLCHAIN so the file is honoured.
+# The Cargo workspace lives under `core/` (no root Cargo.toml). The feature
+# set is OpenDAL's own portable `build_all_platforms` list: common object-
+# storage / HTTP / embedded services, excluding ones that need a
+# preinstalled native library (rocksdb, foundationdb, hdfs) or that are
+# known-broken on some hosts (sftp). System deps are NOT auto-installed —
+# the bench runner already provisions a C compiler + cmake + protoc (see
+# .github/workflows/bench.yml), and the echo below documents them for a
+# local run.
+setup = [
+  "echo '[bench] opendal selected features need system deps: a C/C++ compiler + cmake (aws-lc-sys via rustls), protoc (tikv). macOS: brew install cmake protobuf. Debian: apt install build-essential cmake protobuf-compiler pkg-config.'",
+]
+
+# Build the `opendal` facade from `core/` with the portable service set.
+# Cross-clone cache-key portability (the headline metric this bench
+# measures): each clone builds at a different absolute path, so pin
+# native-build paths/determinism the same way bench-surrealdb does. These
+# knobs change build PATHS and timestamps, not WHAT is built.
+build = """
+repo="$(pwd -P)"
+prefix_map="-ffile-prefix-map=$repo=. -fdebug-prefix-map=$repo=. -fmacro-prefix-map=$repo=."
+export CFLAGS="${CFLAGS:-} $prefix_map"
+export CXXFLAGS="${CXXFLAGS:-} $prefix_map"
+export SOURCE_DATE_EPOCH=1735689600
+export ZERO_AR_DATE=1
+
+cd core || exit
+opendal_features="services-alluxio services-azblob services-azdls services-cacache"
+opendal_features="$opendal_features services-cos services-dashmap services-dropbox services-etcd"
+opendal_features="$opendal_features services-fs services-ftp services-gcs services-gdrive services-ghac"
+opendal_features="$opendal_features services-http services-hf services-ipfs services-ipmfs services-memcached"
+opendal_features="$opendal_features services-memory services-mini-moka services-moka services-obs services-onedrive"
+opendal_features="$opendal_features services-oss services-persy services-postgresql services-redb services-redis"
+opendal_features="$opendal_features services-s3 services-seafile services-sled services-swift services-tikv"
+opendal_features="$opendal_features services-vercel-artifacts services-webdav services-webhdfs"
+cargo build --release --locked --features "$opendal_features"
+"""
+
+[source]
+kind = "clone"
+repo = "https://github.com/apache/opendal.git"
+# Latest stable release as of 2026-08-21. rust-toolchain.toml is
+# channel = "stable" (honoured automatically; see setup note). Cargo
+# workspace + lockfile live under `core/`.
+ref    = "v0.58.2"
+objdir = "core/target"
+
+# Advisory only, as for the sccache and hk-mbx arms: the number is the point,
+# and the assertions above it need kache's own instrumentation.
+[checks.measure.warm]
+min_hit_rate_pct = 50.0

--- a/scenarios/bench-substrate-mbx/scenario.toml
+++ b/scenarios/bench-substrate-mbx/scenario.toml
@@ -1,0 +1,70 @@
+# Substrate (polkadot-sdk) through mbx: the same subject, commit, Rust pin and
+# build command as bench-substrate, driven by mbx instead of kache, so the two
+# arms read side by side.
+#
+# mbx fronts Cargo and installs its own shims for build scripts, so this
+# scenario sets no compiler wiring; the harness puts its `cargo` shim on PATH
+# and points MBX_CACHE_DIR at the store. The 1.93.0 pin below is part of the
+# SUBJECT, not the cache wiring: this ref ships no rust-toolchain.toml and a
+# newer stable breaks the wasm runtime link, so it is carried over verbatim,
+# including for substrate-wasm-builder's child cargo.
+#
+# Cold and warm only — external backends have no same-tree phase and no key
+# tracing, so the correctness assertions of the kache arm become advisory
+# measure checks here. Nightly arm: substrate-mbx in bench.yml.
+name     = "bench-substrate-mbx"
+tags     = ["suite:bench", "project:substrate", "backend:mbx", "lang:rust"]
+
+requires = ["cargo", "rustc"]
+
+# polkadot-stable2603-3 has NO rust-toolchain.toml, so the build would otherwise
+# float to whatever Rust is ambient. A too-new stable (e.g. 1.96) breaks the
+# wasm runtime link (sp_io host fns come out as undefined symbols instead of
+# imports), so we pin substrate's intended Rust (1.93.0) explicitly here and via
+# RUSTUP_TOOLCHAIN in `build`. Install it + its wasm targets / rust-src. Best-
+# effort (|| true) so a non-rustup env doesn't abort; system deps are NOT
+# auto-installed — see the echo'd note.
+setup = [
+  "echo '[bench] substrate needs system deps: protoc (REQUIRED), clang, cmake, pkg-config, openssl headers. macOS: brew install protobuf cmake. Debian: apt install protobuf-compiler clang cmake pkg-config libssl-dev.'",
+  "rustup toolchain install 1.93.0 --profile minimal --no-self-update || true",
+  "rustup component add --toolchain 1.93.0 rust-src || true",
+  "rustup target add --toolchain 1.93.0 wasm32v1-none || true",
+  "rustup target add --toolchain 1.93.0 wasm32-unknown-unknown || true",
+]
+
+# Build the polkadot node. RUSTUP_TOOLCHAIN pins substrate's Rust (1.93.0) for
+# THIS build and — critically — for substrate-wasm-builder's child cargo, which
+# inherits the env (it unsets RUSTC/CARGO_ENCODED_RUSTFLAGS but NOT
+# RUSTUP_TOOLCHAIN). Set here (not just the workflow) so the pin holds wherever
+# the scenario runs; a non-empty value also overrides the workflow's empty reset.
+# macOS prelude: librocksdb-sys's bindgen build script links @rpath/libclang.dylib
+# with no embedded rpath, so point the loader (and clang-sys via LIBCLANG_PATH) at
+# the active Xcode/CLT lib — no-op off macOS or when an existing LIBCLANG_PATH is
+# set. This shell lives in config rather than Rust, which is the whole point of
+# scenarios.
+build = """
+export RUSTUP_TOOLCHAIN=1.93.0
+if [ "$(uname)" = Darwin ]; then
+  for d in "$(xcode-select -p 2>/dev/null)/Toolchains/XcodeDefault.xctoolchain/usr/lib" /Library/Developer/CommandLineTools/usr/lib; do
+    if [ -f "$d/libclang.dylib" ]; then
+      [ -n "${LIBCLANG_PATH:-}" ] || export LIBCLANG_PATH="$d"
+      export DYLD_FALLBACK_LIBRARY_PATH="$d${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+      break
+    fi
+  done
+fi
+cargo build --release -p polkadot
+"""
+
+[source]
+kind = "clone"
+repo = "https://github.com/paritytech/polkadot-sdk.git"
+# Latest stable as of 2026-05-28. NB: this ref has no rust-toolchain.toml — the
+# Rust pin is enforced by us (1.93.0, see setup/build above), not by the tree.
+ref = "polkadot-stable2603-3"
+objdir = "target"
+
+# Advisory only, as for the sccache and other -mbx arms: the number is the
+# point, and the assertions above it need kache's own instrumentation.
+[checks.measure.warm]
+min_hit_rate_pct = 50.0

--- a/scenarios/bench-surrealdb-mbx/scenario.toml
+++ b/scenarios/bench-surrealdb-mbx/scenario.toml
@@ -1,0 +1,101 @@
+# SurrealDB through mbx: the same subject, commit, toolchain and build command
+# as bench-surrealdb, driven by mbx instead of kache, so the two arms read side
+# by side.
+#
+# mbx fronts Cargo and installs its own shims for build scripts, so this
+# scenario sets no compiler wiring and no KACHE_BASE_DIR; the harness puts its
+# `cargo` shim on PATH and points MBX_CACHE_DIR at the store. The native-build
+# determinism flags are carried over verbatim: they pin build PATHS and
+# timestamps, which is what makes a cross-clone comparison mean anything for
+# either tool.
+#
+# Cold and warm only — external backends have no same-tree phase and no key
+# tracing, so the correctness assertions of the kache arm become advisory
+# measure checks here. Nightly arm: surrealdb-mbx in bench.yml.
+name = "bench-surrealdb-mbx"
+tags = ["suite:bench", "project:surrealdb", "backend:mbx", "lang:rust"]
+
+requires = ["cargo", "rustc"]
+
+# SurrealDB ships a rust-toolchain.toml (channel = "1.95"), so — unlike
+# substrate — there is NOTHING to pin here: rustup auto-installs and selects
+# that toolchain on the first cargo invocation in the tree, and the bench
+# workflow clears RUSTUP_TOOLCHAIN so the file is honoured (a forced pin would
+# override it). The only out-of-band need is native system deps for the default
+# storage/scripting features; they are NOT auto-installed — the bench runner
+# already provisions them (see .github/workflows/bench.yml), and the echo below
+# documents them for a local run.
+setup = [
+  "echo '[bench] surrealdb default features need system deps: clang + libclang (rocksdb bindgen), cmake, protoc (storage-tikv/grpcio), pkg-config, openssl headers, a C/C++ compiler. macOS: brew install protobuf cmake llvm. Debian: apt install build-essential protobuf-compiler clang libclang-dev cmake pkg-config libssl-dev.'",
+]
+
+# Build the `surreal` server binary with its DEFAULT features (storage-mem,
+# storage-surrealkv, storage-rocksdb, storage-tikv, scripting, http, graphql,
+# mcp, cli, allocator, …) — i.e. what SurrealDB actually ships, the fairest
+# representative workload for the cache. macOS prelude mirrors substrate:
+# librocksdb-sys's bindgen build script links @rpath/libclang.dylib with no
+# embedded rpath, so point the loader (and clang-sys via LIBCLANG_PATH) at the
+# active Xcode/CLT lib — no-op off macOS or when LIBCLANG_PATH is already set.
+# No RUSTUP_TOOLCHAIN pin: the tree's rust-toolchain.toml drives toolchain
+# selection. This shell lives in config rather than Rust, which is the whole
+# point of scenarios.
+build = """
+if [ "$(uname)" = Darwin ]; then
+  for d in "$(xcode-select -p 2>/dev/null)/Toolchains/XcodeDefault.xctoolchain/usr/lib" /Library/Developer/CommandLineTools/usr/lib; do
+    if [ -f "$d/libclang.dylib" ]; then
+      [ -n "${LIBCLANG_PATH:-}" ] || export LIBCLANG_PATH="$d"
+      export DYLD_FALLBACK_LIBRARY_PATH="$d${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+      break
+    fi
+  done
+fi
+
+# Cross-clone cache-key portability (the headline metric this bench measures).
+# Each clone builds at a different absolute path; without help a few EXPENSIVE
+# crates re-key across clones and tank the compile-time-WEIGHTED warm hit rate
+# (~47%) even though count hit rate is ~97%. These knobs make the native build
+# byte-reproducible across clones. They change build PATHS and determinism, not
+# WHAT is built — the feature set stays exactly what SurrealDB ships, so the
+# workload remains faithful (mirrors bench-firefox's KACHE_BASE_DIR usage).
+#
+# What this recovers (validated by --trace-keys, run 28462889652):
+#   - tikv-jemalloc-sys / libjemalloc_pic.a becomes byte-identical -> warm HIT
+#     (autotools build with path-stable object names; only the timestamp/path
+#     reproducibility axes diverged, which these flags pin).
+#
+# Known residuals it does NOT fix (root-caused; tracked in #471):
+#   - rquickjs-sys / libquickjs.a (and wasm-opt-cc): the .o CONTENT is identical
+#     across clones, but the `cc` crate names each archive MEMBER with a hash
+#     derived from the absolute build path (cafca65b…-quickjs.o vs 4af22b2a…),
+#     and kache content-hashes the .a including those names. -ffile-prefix-map
+#     can't touch member names — needs an upstream cc/rquickjs path-stable-name
+#     fix, or a kache-core "hash static= members by content, ignore name" change
+#     (safe: member names don't affect linking). This cascades into the big
+#     surrealdb_core/server crates via scripting.
+#   - DEBUG_OUTPUT_DIR (wasmtime/wiggle) and OUT_DIR (cxx `scratch`): kache keeps
+#     these ABSOLUTE because they fail its include-only / no-runtime-value gate
+#     (genuine runtime value use). KACHE_PATH_ONLY_ENV_VARS=DEBUG_OUTPUT_DIR was
+#     tried and confirmed a NO-OP (the gate still kept it absolute, as it must to
+#     avoid miscaching), so it is intentionally NOT set here.
+src="$(pwd -P)"
+prefix_map="-ffile-prefix-map=$src=. -fdebug-prefix-map=$src=. -fmacro-prefix-map=$src=."
+export CFLAGS="${CFLAGS:-} $prefix_map"
+export CXXFLAGS="${CXXFLAGS:-} $prefix_map"
+export SOURCE_DATE_EPOCH=1735689600
+export ZERO_AR_DATE=1
+
+cargo build --release -p surreal
+"""
+
+[source]
+kind = "clone"
+repo = "https://github.com/surrealdb/surrealdb.git"
+# Latest stable release as of 2026-06-29. This tag pins Rust via
+# rust-toolchain.toml (channel "1.95"), honoured automatically (see setup note).
+ref    = "v3.1.5"
+objdir = "target"
+
+# Advisory only, as for the sccache and other -mbx arms: the number is the
+# point, and the assertions above it need kache's own instrumentation.
+[checks.measure.warm]
+min_hit_rate_pct = 50.0


### PR DESCRIPTION
The side-by-side comparison rested on one subject (hk). This adds the other
four, which is the whole eligible set.

## Why exactly these four

The comparison tool fronts Cargo rather than wrapping rustc, so it reaches
cargo-driven builds and nothing else. Firefox builds through mach/gn/ninja and
LLVM through CMake, so neither can be measured this way at all — which is why
Firefox's comparison arm is sccache.

That leaves substrate, surrealdb, lance and opendal. All four are now wired.

## What the scenarios are

Each is its kache counterpart with the cache wiring removed: same repo, same
commit, same toolchain, same feature set, same build command, and the same
path/timestamp determinism knobs, so the two arms build identical inputs.
The build blocks differ from the kache arms by exactly one line each, and
substrate's not at all:

```
-export KACHE_BASE_DIR="$repo"     # opendal
-export KACHE_BASE_DIR="$src"      # lance, surrealdb
                                   # substrate: byte-identical
```

Substrate's 1.93.0 Rust pin and Lance's generated well-known protobuf
schemas are part of the *subject*, not the cache wiring, so both are carried
over verbatim — including the pin that substrate-wasm-builder's child cargo
inherits.

`[checks.assert.warm]` becomes `[checks.measure.warm]`, as on the sccache and
hk-mbx arms: key stability and passthrough accounting need kache's own
instrumentation, so for an external backend the number is the point.

## Runner placement, and what it costs

opendal-mbx (40 GB) and lance-mbx (60 GB) go on the small pool. substrate-mbx
and surrealdb-mbx keep their kache arms' disk floors, and surrealdb's 80 GB is
above the small pool's per-runner reservation, so both run on the heavy pool
as their counterparts do.

Last night the heavy pool ran 8h13m serially (surrealdb 66m, llvm 35m,
firefox-sccache 76m, firefox 123m, firefox-pull 114m, lance 23m, substrate
56m). The two new heavy arms add roughly two hours, so the nightly still
finishes long before the next one starts.

## Wiring

No new steps. The apt step already installs protoc and cmake for every arm,
the comparison tool installs on the `-mbx` suffix all four names carry, and
the telemetry `cache_tool` attribute resolves from the same suffix.

Verified by running the matrix-selection script directly: `all` yields 15
arms, each new scenario name selects exactly its own arm on the expected
pool, and the Windows-only scenarios still yield an empty matrix.
`kache-scenario --list --cache-backend mbx` discovers all five subjects.