### PR TITLE
bench: show the perf gate where the warm build's time went

### DIFF
--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -3711,6 +3711,59 @@ struct PhaseMetrics {
     /// Storage savings — restore method (reflink/hardlink/copy) and
     /// content dedup, from the report's `storage` section.
     storage: StorageInfo,
+    /// Where the phase's wrapper time went, summed over cacheable crates.
+    /// The wall-clock above says a build got slower; this says which part of
+    /// the wrapper did it.
+    phases: PhaseTimes,
+}
+
+/// Wrapper time by phase, in wrapper order, summed over every cacheable crate
+/// of one build phase.
+///
+/// These are the same numbers the Perfetto trace draws per crate. Carried in
+/// the result JSON so the per-PR gate can compare them between the head and
+/// its merge base: a change that moves 200 ms per crate out of `compile` and
+/// into `store` leaves the total wall-clock alone and is invisible without
+/// this breakdown.
+///
+/// Every field is zero for a build whose events predate schema 17, and for
+/// external cache backends, which have no wrapper to instrument.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PhaseTimes {
+    /// Process start to wrapper entry.
+    startup_ms: u64,
+    /// Key computation, including the dep-info pre-pass below.
+    key_ms: u64,
+    /// The rustc dep-info pre-pass: a whole extra compiler start per
+    /// invocation, inside `key_ms`.
+    dep_info_ms: u64,
+    /// How many of those the phase actually spawned.
+    dep_info_runs: u64,
+    lookup_ms: u64,
+    /// Flight join plus permit acquisition.
+    wait_ms: u64,
+    restore_ms: u64,
+    store_ms: u64,
+    /// Wrapper time no phase accounts for.
+    unattributed_ms: u64,
+}
+
+impl PhaseTimes {
+    fn from_raw(raw: &serde_json::Value) -> Self {
+        let sum = &raw["summary"];
+        let ms = |key: &str| sum[key].as_u64().unwrap_or(0);
+        Self {
+            startup_ms: ms("total_startup_ms"),
+            key_ms: ms("total_key_ms"),
+            dep_info_ms: ms("total_dep_info_ms"),
+            dep_info_runs: ms("dep_info_runs"),
+            lookup_ms: ms("total_lookup_ms"),
+            wait_ms: ms("total_wait_ms"),
+            restore_ms: ms("total_restore_ms"),
+            store_ms: ms("total_store_ms"),
+            unattributed_ms: ms("total_unattributed_ms"),
+        }
+    }
 }
 
 impl PhaseMetrics {
@@ -3751,6 +3804,7 @@ impl PhaseMetrics {
             event_log,
             leak_warnings,
             storage: StorageInfo::from_raw(raw),
+            phases: PhaseTimes::from_raw(raw),
         }
     }
 }
@@ -4092,14 +4146,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let marker = dir.path().join("invoked.txt");
         let kache = fake_kache_that_records(dir.path(), &marker, 0);
-        let dest = dir.path().join("cache-otlp-warm");
-        assert!(write_cache_otlp_or_warn(
+        assert!(write_otlp_until_spawned(
             &kache,
             dir.path(),
-            &dir.path().join("kache.toml"),
-            &dest,
+            &marker,
             "bench-firefox",
-            "warm",
+            "warm"
         ));
         let invoked = std::fs::read_to_string(&marker).unwrap();
         assert!(
@@ -4121,15 +4173,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let marker = dir.path().join("invoked.txt");
         let kache = fake_kache_that_records(dir.path(), &marker, 1);
-        assert!(!write_cache_otlp_or_warn(
+        assert!(!write_otlp_until_spawned(
             &kache,
             dir.path(),
-            &dir.path().join("kache.toml"),
-            &dir.path().join("cache-otlp-cold"),
+            &marker,
             "bench-firefox",
-            "cold",
+            "cold"
         ));
-        assert!(marker.is_file());
+        assert!(marker.is_file(), "the stand-in never ran");
     }
 
     #[test]
@@ -4143,6 +4194,88 @@ mod tests {
             "bench-firefox",
             "pull",
         ));
+    }
+
+    /// Every field here is a key in `kache report --format json`. Nothing else
+    /// couples the two, so a renamed field in the report would silently turn
+    /// this table into zeroes — which reads as "the phase did not run" rather
+    /// than "we stopped reading it".
+    #[test]
+    fn phase_times_read_the_report_summary_field_by_field() {
+        let raw = serde_json::json!({
+            "summary": {
+                "total_startup_ms": 11,
+                "total_key_ms": 22,
+                "total_dep_info_ms": 33,
+                "dep_info_runs": 44,
+                "total_lookup_ms": 55,
+                "total_wait_ms": 66,
+                "total_restore_ms": 77,
+                "total_store_ms": 88,
+                "total_unattributed_ms": 99,
+            }
+        });
+        let phases = PhaseTimes::from_raw(&raw);
+        assert_eq!(phases.startup_ms, 11);
+        assert_eq!(phases.key_ms, 22);
+        assert_eq!(phases.dep_info_ms, 33);
+        assert_eq!(phases.dep_info_runs, 44);
+        assert_eq!(phases.lookup_ms, 55);
+        assert_eq!(phases.wait_ms, 66);
+        assert_eq!(phases.restore_ms, 77);
+        assert_eq!(phases.store_ms, 88);
+        assert_eq!(phases.unattributed_ms, 99);
+
+        // A report without them — an external cache backend, or events from
+        // before the schema carried these — reads as zero, and the gate then
+        // prints no table rather than a wall of 0.0% deltas.
+        assert_eq!(
+            PhaseTimes::from_raw(&serde_json::json!({"summary": {}})),
+            PhaseTimes::default()
+        );
+        assert_eq!(
+            PhaseTimes::from_raw(&serde_json::json!({})),
+            PhaseTimes::default()
+        );
+    }
+
+    /// Call `write_cache_otlp_or_warn` until the stand-in it spawns actually
+    /// ran, and return what the call reported.
+    ///
+    /// Linux refuses to exec a file any process still holds open for writing
+    /// (ETXTBSY). This suite runs in parallel and spawns processes, so a child
+    /// can inherit the writable fd of a stand-in another test just wrote, and
+    /// the exec fails for as long as that child lives — microseconds, and
+    /// nothing to do with the behaviour under test. macOS does not enforce
+    /// this at all, which is how a test that fails on Linux and passes here
+    /// shipped: nothing runs the e2e crate's tests on Linux except the
+    /// mutation lane's baseline, and only when a change touches this crate.
+    ///
+    /// The retry is bounded, so a stand-in that genuinely never runs still
+    /// fails the assertion that follows rather than hanging.
+    fn write_otlp_until_spawned(
+        kache: &Path,
+        dir: &Path,
+        marker: &Path,
+        scenario: &str,
+        phase: &str,
+    ) -> bool {
+        let mut reported = false;
+        for _ in 0..50 {
+            reported = write_cache_otlp_or_warn(
+                kache,
+                dir,
+                &dir.join("kache.toml"),
+                &dir.join(format!("cache-otlp-{phase}")),
+                scenario,
+                phase,
+            );
+            if marker.is_file() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        reported
     }
 
     fn fake_kache_that_records(dir: &Path, marker: &Path, exit: i32) -> PathBuf {
@@ -4602,6 +4735,7 @@ mod tests {
                 blob_bytes: 0,
                 dedup_saved_bytes: 0,
             },
+            phases: PhaseTimes::default(),
         }
     }
 

--- a/scripts/perf-gate-compare.sh
+++ b/scripts/perf-gate-compare.sh
@@ -169,6 +169,63 @@ cross_pct="$(pct "$base_cross" "$head_cross")"
 regressed="$(awk -v b="$base_warm" -v h="$head_warm" -v lim="$WARM_REGRESSION_LIMIT_PCT" \
     'BEGIN { print (b + 0 > 0 && (h - b) * 100.0 / b > lim + 0) ? "yes" : "no" }')"
 
+# ── Where the warm build's time went ─────────────────────────────────────────
+# The wall-clock rows above say a build got slower. This says which part of the
+# wrapper did it, from the same phase totals the Perfetto trace draws per crate.
+#
+# Reported, never blocking. A phase can move a long way on a small absolute
+# number, and moving time BETWEEN phases is often the intended effect of a
+# change rather than a fault — the reviewer is the one who can tell which.
+# What it removes is the blind spot: a change that shifts time out of one phase
+# into another leaves the total alone and was previously invisible here.
+#
+# Phases are summed over cacheable crates, so they do not add up to the wall
+# clock: a parallel build overlaps them, and passthrough compiles are absent.
+# Zero on both sides means the phase did not run; the row is dropped rather
+# than printed as a 0.0% delta, which would read as "measured and unchanged".
+phase_ms() { jq -r ".warm_same_tree.phases.${2} // 0" "$1"; }
+
+phase_row() {
+    local label="$1" key="$2"
+    local b h
+    b="$(phase_ms "$base_json" "$key")"
+    h="$(phase_ms "$head_json" "$key")"
+    [ "$b" = "0" ] && [ "$h" = "0" ] && return 0
+    echo "| $label | ${b} ms | ${h} ms | $(pct "$b" "$h")% |"
+}
+
+phase_table() {
+    local body
+    body="$(
+        phase_row "startup" startup_ms
+        phase_row "key" key_ms
+        phase_row "&nbsp;&nbsp;dep-info pre-pass" dep_info_ms
+        phase_row "lookup" lookup_ms
+        phase_row "wait (flight + permit)" wait_ms
+        phase_row "restore" restore_ms
+        phase_row "store" store_ms
+        phase_row "unattributed" unattributed_ms
+    )"
+    # Nothing to say for an external backend or pre-schema-17 events.
+    [ -z "$body" ] && return 0
+
+    echo "<details><summary>Warm build, wrapper time by phase</summary>"
+    echo
+    echo "| phase | merge base | PR head | delta |"
+    echo "| --- | ---: | ---: | ---: |"
+    echo "$body"
+    echo
+    echo "Summed over cacheable crates, so these do not add up to the wall clock:"
+    echo "a parallel build overlaps them and passthrough compiles are absent."
+    echo "Reported only — none of these rows fails the gate."
+    local base_runs head_runs
+    base_runs="$(phase_ms "$base_json" dep_info_runs)"
+    head_runs="$(phase_ms "$head_json" dep_info_runs)"
+    echo
+    echo "dep-info pre-pass spawns: ${base_runs} (merge base) / ${head_runs} (PR head)."
+    echo "</details>"
+}
+
 # The workflow's report step parses this first line into the commit status:
 # it strips the leading `## Perf gate: ` and keeps the rest. Keep the grammar.
 if [ "$regressed" = "yes" ]; then
@@ -192,6 +249,8 @@ fi
     echo "are reported for context while their noise floor is still being established."
     echo
     echo "Milliseconds (merge base / PR head): cold ${base_cold} / ${head_cold}, warm ${base_warm} / ${head_warm}, cross-worktree ${base_cross} / ${head_cross}."
+    echo
+    phase_table
 } | tee "$md_out"
 
 if [ "$regressed" = "yes" ]; then


### PR DESCRIPTION
The gate compares one number — warm wall-clock, head against merge base. That
catches a build getting slower and misses a change that moves time *between*
wrapper phases, because the total does not move. Shifting 200 ms per crate out
of `compile` and into `store` passes today.

The phase totals already existed: the report aggregates them, and the Perfetto
trace draws them per crate. The gate never read them, because the bench result
JSON did not carry them.

## What changed

`PhaseMetrics` gains a `phases` object — startup, key, the dep-info pre-pass
inside it, lookup, wait, restore, store, and the unattributed remainder,
summed over the cacheable crates of each build phase.

The gate prints them as a collapsed second table under the wall-clock rows:

```
| phase                  | merge base | PR head |   delta |
| ---------------------- | ---------: | ------: | ------: |
| startup                |     500 ms |  500 ms |   +0.0% |
| key                    |    8000 ms | 3000 ms |  -62.5% |
|   dep-info pre-pass    |    6500 ms |    0 ms | -100.0% |
| lookup                 |     900 ms |  900 ms |   +0.0% |
| restore                |    2000 ms | 2000 ms |   +0.0% |
| store                  |    1200 ms | 1400 ms |  +16.7% |
| unattributed           |     400 ms |  400 ms |   +0.0% |

dep-info pre-pass spawns: 330 (merge base) / 0 (PR head).
```

**Reported, never blocking.** A phase can move a long way on a small absolute
number, and moving time between phases is often the intended effect of a
change rather than a fault. The reviewer is the one who can tell which. What
this removes is the blind spot, not the judgement.

The phases are summed over cacheable crates, so they deliberately do not add
up to the wall clock: a parallel build overlaps them and passthrough compiles
are absent. The table says so.

## Edge cases

- Rows where both sides are zero are dropped rather than printed as an
  unchanged `0.0%`, which would read as "measured and did not move".
- A result with no phase data at all — an external cache backend, or events
  predating the schema that carries these fields — prints no table.

## Verification

Exercised against synthetic result JSON for three cases: a phase shift (table
above), a result with no phase data (no table, exit 0), and a real regression
(still fails, `FAIL — warm build +10.0%`).