### PR TITLE
ci: give the service mutation lane room for a slow runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, check]
     if: github.ref_type != 'tag' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true')
-    timeout-minutes: 20
+    timeout-minutes: 35
     env:
       RUSTC_WRAPPER: ""
       CARGO_INCREMENTAL: "1"
@@ -370,7 +370,15 @@ jobs:
           echo "kache-service mutants: $count"
           test "$count" -gt 0
       - name: Mutate all kache-service behavior
-        timeout-minutes: 15
+        # The mutation run itself takes about ten minutes; the old 15-minute
+        # cap left too little for a slow shared runner. One that took half as
+        # long again killed the step at 15m51s AFTER all 74 mutants had been
+        # accounted for (50 caught, 24 unviable, none missed) — a red check
+        # reporting nothing but the runner's speed.
+        #
+        # Hangs are already caught closer in: `--timeout 180` bounds each
+        # mutant's test run, so this cap only has to bound the whole lane.
+        timeout-minutes: 30
         env:
           CARGO_INCREMENTAL: "1"
         run: |


### PR DESCRIPTION
The service mutation step was capped at 15 minutes. It normally takes about
ten:

```
success   12.4 min     (whole job, including checkout + toolchain)
success   12.2 min
success   11.7 min
success   12.3 min
success   12.1 min
```

A slow shared runner killed it at **15m51s** — after every one of its 74
mutants had been accounted for. From the run's own `outcomes.json`:

```
50 caught, 24 unviable, 0 missed, 0 timed out
```

So the red check reported the runner's speed and nothing about the code, and
the artifact it uploaded said the lane had passed.

30 minutes is three times the usual run. Hangs are already bounded closer in
— `--timeout 180` caps each mutant's own test run — so this cap only has to
bound the lane as a whole, and the job timeout moves to 35 to stay above it.

Found while babysitting #939, whose only failure was this.