### PR TITLE
fix(key): let a predicted key ask the remote before re-deriving it

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2158,38 +2158,200 @@ fn run_parsed_rustc(
 
     tracing::debug!("cache key for {}: {}", crate_name, &cache_key[..16]);
 
-    // 1. Check local store
-    let lookup_start = std::time::Instant::now();
-    let lookup_result = match store.get(&cache_key) {
-        Ok(result) => result,
-        Err(e) => {
-            tracing::warn!(
-                "local store lookup failed for {}: {} — recompiling",
-                crate_name,
-                e
-            );
-            return passthrough_with_event(
-                config,
-                args,
-                crate_name,
-                &event_root,
-                start,
-                format!("store lookup failed: {e}"),
-            );
-        }
-    };
-    let mut lookup_ms = lookup_start.elapsed().as_millis() as u64;
-
-    // The rule that keeps a prediction from ever reaching the cache as an
-    // authority: a derived key that MISSES locally is re-derived from a real
-    // pre-pass, and looked up again, before anything downstream sees it.
+    // A prediction may READ the cache, local or remote, before it has been
+    // checked. The soundness argument does not distinguish the two: an entry
+    // anywhere was stored under a key computed from a discovered closure, so
+    // matching it proves the prediction reproduced that closure. What a
+    // prediction may not do is CLAIM or STORE, so the re-derivation moved to
+    // the point below where both lookups have missed.
     //
-    // A hit needs no such thing — the entry it matched was stored under a key
-    // computed from a discovered closure, so matching it proves the prediction
-    // reproduced that closure. A miss proves nothing, and a stale record on a
-    // second machine could otherwise derive the same wrong key and hit an
-    // entry compiled from a larger input set.
-    let (lookup_result, redrive) = if needs_rederivation(predicted, lookup_result.is_some()) {
+    // Re-deriving before the remote check, as this did originally, made the
+    // whole feature worthless for the case it was built for: a fresh clone has
+    // an empty local store, so every unit missed locally and paid the pre-pass
+    // before the warm remote was ever asked.
+    //
+    // The loop runs at most twice. A re-derivation that changes the key has
+    // produced a key nothing has looked up yet, and on a shared cache another
+    // machine may well hold it; a second pass is one lookup against a compile.
+    // Summed across both passes: a second lookup is real time this
+    // invocation spent looking.
+    let mut lookup_ms = 0_u64;
+    let mut record_closure = should_record_closure(predicted, false);
+    let mut rederived = false;
+    loop {
+        // 1. Check local store
+        let lookup_start = std::time::Instant::now();
+        let lookup_result = match store.get(&cache_key) {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::warn!(
+                    "local store lookup failed for {}: {} — recompiling",
+                    crate_name,
+                    e
+                );
+                return passthrough_with_event(
+                    config,
+                    args,
+                    crate_name,
+                    &event_root,
+                    start,
+                    format!("store lookup failed: {e}"),
+                );
+            }
+        };
+        lookup_ms = lookup_ms.saturating_add(lookup_start.elapsed().as_millis() as u64);
+
+        // A closure that came from a record is already recorded; re-writing it on
+        // every hit would be a database write per compile for no new information.
+        // A re-derivation is the opposite case: its closure is what the record
+        // should have said, so writing it is what repairs a stale row.
+
+        if let Some(meta) = lookup_result {
+            // Safety: skip entries with no cached files (poisoned by earlier bugs)
+            if meta.files.is_empty() {
+                tracing::warn!(
+                    "cache entry for {} has no files, evicting and recompiling",
+                    crate_name
+                );
+                let _ = store.remove_entry(&cache_key);
+            } else {
+                tracing::debug!("local cache hit for {} ({})", crate_name, &cache_key[..16]);
+                let restore_start = std::time::Instant::now();
+                if let Err(e) = restore_from_cache(
+                    config,
+                    compiler,
+                    &BlobSource::Store(&store),
+                    args,
+                    &meta,
+                    extra_inputs,
+                ) {
+                    tracing::warn!(
+                        "restoring local cache hit for {} failed: {} — recompiling",
+                        crate_name,
+                        e
+                    );
+                    return passthrough_with_event(
+                        config,
+                        args,
+                        crate_name,
+                        &event_root,
+                        start,
+                        format!("restore failed: {e}"),
+                    );
+                }
+                let restore_ms = restore_start.elapsed().as_millis() as u64;
+                let elapsed = start.elapsed().as_millis() as u64;
+                let size: u64 = meta.files.iter().map(|f| f.size).sum();
+                log_event_with_hash_stats(
+                    config,
+                    &event_root,
+                    crate_name,
+                    EventResult::LocalHit,
+                    elapsed,
+                    meta.compile_time_ms,
+                    size,
+                    &cache_key,
+                    key_ms,
+                    key_hash_stats,
+                    lookup_ms,
+                    restore_ms,
+                    0,
+                );
+                record_input_prediction(config, Some(&store), args, record_closure);
+                print_progress(crate_name, EventResult::LocalHit, elapsed, size);
+                replay_cached_diagnostics(&meta, std::io::stdout(), std::io::stderr());
+                clean_incremental_dir(config, args);
+                reset_adaptive_unit(adaptive_unit.as_ref());
+
+                return Ok(0);
+            }
+        }
+
+        // Build-session detection: send prefetch hint before remote work.
+        // Placed after local-hit check so warm-cache invocations skip this entirely.
+        maybe_trigger_prefetch(config, args);
+
+        // 2. Check remote cache via daemon (if configured)
+        if config.remote.is_some() {
+            let entry_dir = store.entry_dir(&cache_key);
+            // No `if result.found` guard: it only predicts what the read
+            // below settles. Reaching here means the local lookup already
+            // missed on this pass, so the entry is present exactly when
+            // the daemon just fetched it — which is what `found` reports.
+            // In the race where another process stored it meanwhile,
+            // serving it beats recompiling; only the label is imprecise,
+            // and `prefetched` still separates a prefetch from a fetch.
+            // A daemon that never answered is a miss; the build compiles.
+            if let Some(result) =
+                crate::daemon::send_remote_check(config, &cache_key, &entry_dir, crate_name)
+                && let Ok(Some(meta)) = store.get(&cache_key)
+            {
+                let event_result = if result.prefetched {
+                    tracing::debug!(
+                        "prefetch cache hit for {} ({})",
+                        crate_name,
+                        &cache_key[..16]
+                    );
+                    EventResult::PrefetchHit
+                } else {
+                    tracing::debug!("remote cache hit for {} ({})", crate_name, &cache_key[..16]);
+                    EventResult::RemoteHit
+                };
+                let restore_start = std::time::Instant::now();
+                if let Err(e) = restore_from_cache(
+                    config,
+                    compiler,
+                    &BlobSource::Store(&store),
+                    args,
+                    &meta,
+                    extra_inputs,
+                ) {
+                    tracing::warn!(
+                        "restoring cache hit for {} failed: {} — recompiling",
+                        crate_name,
+                        e
+                    );
+                    return passthrough_with_event(
+                        config,
+                        args,
+                        crate_name,
+                        &event_root,
+                        start,
+                        format!("restore failed: {e}"),
+                    );
+                }
+                let restore_ms = restore_start.elapsed().as_millis() as u64;
+                let elapsed = start.elapsed().as_millis() as u64;
+                let size: u64 = meta.files.iter().map(|f| f.size).sum();
+                log_event_with_hash_stats(
+                    config,
+                    &event_root,
+                    crate_name,
+                    event_result,
+                    elapsed,
+                    meta.compile_time_ms,
+                    size,
+                    &cache_key,
+                    key_ms,
+                    key_hash_stats,
+                    lookup_ms,
+                    restore_ms,
+                    0,
+                );
+                print_progress(crate_name, event_result, elapsed, size);
+                replay_cached_diagnostics(&meta, std::io::stdout(), std::io::stderr());
+                clean_incremental_dir(config, args);
+                reset_adaptive_unit(adaptive_unit.as_ref());
+                return Ok(0);
+            }
+        }
+
+        if !owes_rederivation(predicted, rederived) {
+            break;
+        }
+        rederived = true;
+        record_closure = should_record_closure(predicted, rederived);
+        let previous_key = cache_key.clone();
         match recompute_key_without_prediction(
             config,
             compiler,
@@ -2213,13 +2375,6 @@ fn run_parsed_rustc(
                     recomputed.key_too_new,
                 );
                 guard_inputs.extend(recomputed.guard_inputs);
-                // Look up again unconditionally. The key has usually changed,
-                // and when it has not this is one index read set against the
-                // whole pre-pass just paid for.
-                let retry = std::time::Instant::now();
-                let result = store.get(&cache_key).unwrap_or_default();
-                lookup_ms = lookup_ms.saturating_add(retry.elapsed().as_millis() as u64);
-                (result, true)
             }
             // The pre-pass failed, which is the ordinary uncacheable case.
             Err(e) => {
@@ -2233,164 +2388,10 @@ fn run_parsed_rustc(
                 );
             }
         }
-    } else {
-        (lookup_result, false)
-    };
-
-    // A closure that came from a record is already recorded; re-writing it on
-    // every hit would be a database write per compile for no new information.
-    // A re-derivation is the opposite case: its closure is what the record
-    // should have said, so writing it is what repairs a stale row.
-    let record_closure = should_record_closure(predicted, redrive);
-
-    if let Some(meta) = lookup_result {
-        // Safety: skip entries with no cached files (poisoned by earlier bugs)
-        if meta.files.is_empty() {
-            tracing::warn!(
-                "cache entry for {} has no files, evicting and recompiling",
-                crate_name
-            );
-            let _ = store.remove_entry(&cache_key);
-        } else {
-            tracing::debug!("local cache hit for {} ({})", crate_name, &cache_key[..16]);
-            let restore_start = std::time::Instant::now();
-            if let Err(e) = restore_from_cache(
-                config,
-                compiler,
-                &BlobSource::Store(&store),
-                args,
-                &meta,
-                extra_inputs,
-            ) {
-                tracing::warn!(
-                    "restoring local cache hit for {} failed: {} — recompiling",
-                    crate_name,
-                    e
-                );
-                return passthrough_with_event(
-                    config,
-                    args,
-                    crate_name,
-                    &event_root,
-                    start,
-                    format!("restore failed: {e}"),
-                );
-            }
-            let restore_ms = restore_start.elapsed().as_millis() as u64;
-            let elapsed = start.elapsed().as_millis() as u64;
-            let size: u64 = meta.files.iter().map(|f| f.size).sum();
-            log_event_with_hash_stats(
-                config,
-                &event_root,
-                crate_name,
-                EventResult::LocalHit,
-                elapsed,
-                meta.compile_time_ms,
-                size,
-                &cache_key,
-                key_ms,
-                key_hash_stats,
-                lookup_ms,
-                restore_ms,
-                0,
-            );
-            record_input_prediction(config, Some(&store), args, record_closure);
-            print_progress(crate_name, EventResult::LocalHit, elapsed, size);
-            // Print cached stdout/stderr
-            if !meta.stdout.is_empty() {
-                print!("{}", meta.stdout);
-            }
-            if !meta.stderr.is_empty() {
-                eprint!("{}", meta.stderr);
-            }
-            clean_incremental_dir(config, args);
-            reset_adaptive_unit(adaptive_unit.as_ref());
-
-            return Ok(0);
-        }
-    }
-
-    // Build-session detection: send prefetch hint before remote work.
-    // Placed after local-hit check so warm-cache invocations skip this entirely.
-    maybe_trigger_prefetch(config, args);
-
-    // 2. Check remote cache via daemon (if configured)
-    if config.remote.is_some() {
-        let entry_dir = store.entry_dir(&cache_key);
-        match crate::daemon::send_remote_check(config, &cache_key, &entry_dir, crate_name) {
-            Some(result) if result.found => {
-                // Daemon downloaded it — now read from local store and restore
-                if let Ok(Some(meta)) = store.get(&cache_key) {
-                    let event_result = if result.prefetched {
-                        tracing::debug!(
-                            "prefetch cache hit for {} ({})",
-                            crate_name,
-                            &cache_key[..16]
-                        );
-                        EventResult::PrefetchHit
-                    } else {
-                        tracing::debug!(
-                            "remote cache hit for {} ({})",
-                            crate_name,
-                            &cache_key[..16]
-                        );
-                        EventResult::RemoteHit
-                    };
-                    let restore_start = std::time::Instant::now();
-                    if let Err(e) = restore_from_cache(
-                        config,
-                        compiler,
-                        &BlobSource::Store(&store),
-                        args,
-                        &meta,
-                        extra_inputs,
-                    ) {
-                        tracing::warn!(
-                            "restoring cache hit for {} failed: {} — recompiling",
-                            crate_name,
-                            e
-                        );
-                        return passthrough_with_event(
-                            config,
-                            args,
-                            crate_name,
-                            &event_root,
-                            start,
-                            format!("restore failed: {e}"),
-                        );
-                    }
-                    let restore_ms = restore_start.elapsed().as_millis() as u64;
-                    let elapsed = start.elapsed().as_millis() as u64;
-                    let size: u64 = meta.files.iter().map(|f| f.size).sum();
-                    log_event_with_hash_stats(
-                        config,
-                        &event_root,
-                        crate_name,
-                        event_result,
-                        elapsed,
-                        meta.compile_time_ms,
-                        size,
-                        &cache_key,
-                        key_ms,
-                        key_hash_stats,
-                        lookup_ms,
-                        restore_ms,
-                        0,
-                    );
-                    print_progress(crate_name, event_result, elapsed, size);
-                    if !meta.stdout.is_empty() {
-                        print!("{}", meta.stdout);
-                    }
-                    if !meta.stderr.is_empty() {
-                        eprint!("{}", meta.stderr);
-                    }
-                    clean_incremental_dir(config, args);
-                    reset_adaptive_unit(adaptive_unit.as_ref());
-                    return Ok(0);
-                }
-            }
-            Some(_) => {} // not in remote, continue to compile
-            None => {}    // daemon unreachable, continue to compile
+        if cache_key == previous_key {
+            // The prediction was right. Both lookups already answered for
+            // this key; asking again would be the same two misses.
+            break;
         }
     }
 
@@ -3507,14 +3508,19 @@ fn compute_rustc_cache_key(
     })
 }
 
-/// Does this key still owe a re-derivation before anything may act on it?
+/// Does this key still owe a re-derivation before it may CLAIM or STORE?
 ///
-/// Only a key that came from a record AND found nothing locally. A hit needs
-/// no check: the entry it matched was stored under a key computed from a
-/// discovered closure, so matching it proves the prediction reproduced that
-/// closure. A key that was never predicted is already the discovered one.
-fn needs_rederivation(predicted: bool, found_locally: bool) -> bool {
-    predicted && !found_locally
+/// Reached only once both the local and the remote lookup have missed, since
+/// a hit returns from inside the loop. So the question is no longer "did we
+/// find it" but only "is this key still a guess": a key that was never
+/// predicted is the discovered one already, and so is one already re-derived.
+///
+/// Reading the cache under a predicted key is deliberately NOT gated here. An
+/// entry anywhere was stored under a key computed from a discovered closure,
+/// so matching it proves the prediction reproduced that closure — the same
+/// argument for a remote entry as for a local one.
+fn owes_rederivation(predicted: bool, already_rederived: bool) -> bool {
+    predicted && !already_rederived
 }
 
 /// Should this invocation write what it discovered back to the record?
@@ -5457,28 +5463,26 @@ mod tests {
         RustcCompiler::new().parse(&s(args)).unwrap()
     }
 
-    /// The two rules that keep a prediction from ever being an authority.
+    /// The rule that keeps a prediction from ever being an authority.
     ///
-    /// Between them they decide whether a key may reach the remote, the
-    /// scheduler and the store as-is, and whether a record gets rewritten.
+    /// Reached only once both lookups have missed, so it is not asking "did we
+    /// find it" — a hit has already returned. It asks whether this key is
+    /// still a guess, and a guess may not claim or store.
     #[test]
-    fn a_predicted_key_owes_a_rederivation_only_when_it_missed() {
-        // predicted, found locally
+    fn a_predicted_key_owes_a_rederivation_until_it_has_had_one() {
         assert!(
-            !needs_rederivation(true, true),
-            "a predicted key that HIT matched an entry stored under a \
-             discovered closure, which proves the prediction reproduced it"
+            owes_rederivation(true, false),
+            "a key that came from a record and matched nothing is still a guess"
         );
         assert!(
-            needs_rederivation(true, false),
-            "a predicted key that missed has proven nothing and must be \
-             recomputed before anything downstream sees it"
+            !owes_rederivation(true, true),
+            "one re-derivation is enough; a second would be the same pre-pass"
         );
         assert!(
-            !needs_rederivation(false, false),
+            !owes_rederivation(false, false),
             "a key that was never predicted is already the discovered one"
         );
-        assert!(!needs_rederivation(false, true));
+        assert!(!owes_rederivation(false, true));
     }
 
     #[test]

--- a/tests/filesystem_remote_test.rs
+++ b/tests/filesystem_remote_test.rs
@@ -62,6 +62,20 @@ impl Client {
         Self::with_runtime(shared_folder, cache_dir.to_path_buf(), runtime)
     }
 
+    /// A client that derives keys from recorded input closures. The config
+    /// carries the flag rather than the environment because these clients set
+    /// `ignore_env`.
+    fn with_predictions(shared_folder: &Path) -> Self {
+        let client = Self::new(shared_folder);
+        let config = std::fs::read_to_string(&client.config_path).unwrap();
+        std::fs::write(
+            &client.config_path,
+            config.replace("[cache]\n", "[cache]\ninput_predictions = true\n"),
+        )
+        .unwrap();
+        client
+    }
+
     fn with_runtime(shared_folder: &Path, cache_dir: PathBuf, runtime: TempDir) -> Self {
         let runtime_dir = runtime.path().to_path_buf();
         let config_path = if runtime_dir == cache_dir {
@@ -450,6 +464,157 @@ impl Drop for Client {
 /// caller's pipe handles. Daemon spawning now prevents that leak; file-backed
 /// capture and per-command deadlines remain defense in depth and make any
 /// future hang fail with a bounded, specific diagnostic.
+/// A predicted key must be allowed to ask the REMOTE before it is checked.
+///
+/// The soundness rule is that a prediction may never claim or store, not that
+/// it may never read. An entry on the remote was stored under a key computed
+/// from a discovered closure exactly as a local one was, so matching it proves
+/// the prediction reproduced that closure.
+///
+/// Re-deriving before the remote check instead made the feature worthless for
+/// the case it exists for: a checkout with an empty local store missed
+/// locally on every unit and paid a full dep-info pre-pass before the warm
+/// remote was ever asked. This pins that it no longer does.
+#[test]
+fn a_predicted_key_reaches_the_remote_without_a_pre_pass() {
+    build_kache();
+
+    let shared = TempDir::new().unwrap();
+    let source = TempDir::new().unwrap();
+    std::fs::write(
+        source.path().join("lib.rs"),
+        "pub fn answer() -> u32 { 42 }\n",
+    )
+    .unwrap();
+
+    let client = Client::with_predictions(shared.path());
+    let out = TempDir::new().unwrap();
+    client.start_daemon();
+
+    // Cold: compiles, records the closure, publishes to the folder.
+    client.compile_checkout(source.path(), out.path());
+    let cold = crate_event(&client.report(), "fsremote").clone();
+    assert!(
+        cold["result"] == "miss" || cold["result"] == "dup",
+        "the first compile must be a real compile: {cold}"
+    );
+    assert_eq!(
+        cold["dep_info_runs"], 1,
+        "a cold compile has no record to derive from: {cold}"
+    );
+    let cache_key = cold["cache_key"].as_str().unwrap().to_owned();
+    wait_for_remote_entry(shared.path(), "fsremote", &cache_key);
+
+    // Drop the local artifact and keep the recorded closure. That is the
+    // shape of a fresh checkout against a warm remote: the key can be
+    // derived, and nothing is stored locally to serve it.
+    // Delete the entry's blobs so the local store cannot serve it. The
+    // recorded closure lives in the index and survives, which is exactly the
+    // asymmetry a fresh checkout has once records are distributed: it can
+    // derive the key and has no artifact behind it.
+    let mut blobs = Vec::new();
+    collect_files(&client.cache_dir.join("store/blobs"), &mut blobs);
+    assert!(
+        !blobs.is_empty(),
+        "the cold compile should have stored blobs"
+    );
+    for blob in &blobs {
+        std::fs::remove_file(blob).unwrap();
+    }
+
+    std::fs::remove_dir_all(out.path()).unwrap();
+    std::fs::create_dir_all(out.path()).unwrap();
+    client.compile_checkout(source.path(), out.path());
+    let served = crate_event(&client.report(), "fsremote").clone();
+
+    assert_eq!(
+        served["cache_key"], cold["cache_key"],
+        "the derived key must be the one the pre-pass produced: {served}"
+    );
+    assert!(
+        served["result"] == "remote_hit" || served["result"] == "prefetch_hit",
+        "the remote must serve it: {served}"
+    );
+    assert_eq!(
+        served["dep_info_runs"], 0,
+        "a predicted key that the remote can serve must spawn no pre-pass: {served}"
+    );
+    assert_eq!(
+        served["compiler_runs"], 0,
+        "nothing may recompile: {served}"
+    );
+
+    client.stop_daemon_and_wait();
+}
+
+/// A record that no longer describes the tree derives a key nothing was ever
+/// stored under. The re-derivation that follows produces a key this build has
+/// not looked up yet, and on a shared cache another machine may already hold
+/// it — so the lookup phase runs a second pass rather than compiling.
+///
+/// Two clients, because one client cannot hold a stale record: its own
+/// re-derivation refreshes the record before the next build sees it. Only a
+/// second machine can publish the true key while the first still believes an
+/// older closure.
+#[test]
+fn a_stale_prediction_still_finds_the_true_key_on_the_remote() {
+    build_kache();
+
+    let shared = TempDir::new().unwrap();
+    let tree = TempDir::new().unwrap();
+    let src = tree.path().join("lib.rs");
+    std::fs::write(&src, "pub fn answer() -> u32 { 42 }\n").unwrap();
+
+    // Client A records the closure of the ORIGINAL source and stops there.
+    let alpha = Client::with_predictions(shared.path());
+    let out_a = TempDir::new().unwrap();
+    alpha.start_daemon();
+    alpha.compile_checkout(tree.path(), out_a.path());
+    let recorded = crate_event(&alpha.report(), "fsremote").clone();
+    assert_eq!(recorded["dep_info_runs"], 1, "{recorded}");
+    alpha.stop_daemon_and_wait();
+
+    // The tree grows a module. A's record now names lib.rs alone and is stale.
+    std::fs::write(tree.path().join("extra.rs"), "pub fn more() -> u32 { 1 }\n").unwrap();
+    std::fs::write(
+        &src,
+        "mod extra;\npub fn answer() -> u32 { 42 + extra::more() }\n",
+    )
+    .unwrap();
+
+    // Client B compiles the grown tree and publishes the TRUE key. B has its
+    // own cache, so nothing about A's record changes.
+    let beta = Client::new(shared.path());
+    let out_b = TempDir::new().unwrap();
+    beta.start_daemon();
+    beta.compile_checkout(tree.path(), out_b.path());
+    let published = crate_event(&beta.report(), "fsremote").clone();
+    assert_ne!(
+        published["cache_key"], recorded["cache_key"],
+        "a bigger closure must key differently: {published}"
+    );
+    let true_key = published["cache_key"].as_str().unwrap().to_owned();
+    wait_for_remote_entry(shared.path(), "fsremote", &true_key);
+    beta.stop_daemon_and_wait();
+
+    // A compiles the grown tree holding a record for the old one. The
+    // prediction derives a key nothing ever stored; the re-derivation
+    // produces the true key, which only the remote holds.
+    alpha.start_daemon();
+    alpha.compile_checkout(tree.path(), out_a.path());
+    let served = crate_event(&alpha.report(), "fsremote").clone();
+    assert_eq!(
+        served["cache_key"], published["cache_key"],
+        "the stale record must not decide the key: {served}"
+    );
+    assert_eq!(
+        served["compiler_runs"], 0,
+        "the remote holds the true key; a second pass must find it \
+         instead of recompiling: {served}"
+    );
+    alpha.stop_daemon_and_wait();
+}
+
 #[test]
 fn daemon_upload_reaches_an_independent_client_through_one_folder() {
     build_kache();


### PR DESCRIPTION
Input predictions (#938, #939, #942) exist to remove the rustc dep-info
pre-pass. The rule that keeps them sound is that a prediction may never
**claim or store** under a key it guessed.

That rule shipped as *"re-derive as soon as the LOCAL lookup misses"*, which
is stricter than the argument requires — and it defeats the case the feature
was built for.

## The defect

A checkout with an empty local store misses locally on **every** unit. So
every unit paid a full pre-pass before the warm remote was ever asked. A fresh
CI runner or a new teammate saved nothing, and distributing records would not
have helped: the pre-pass ran before the record could matter.

Measured on the parent commit — the remote served the artifact, *after* a
pre-pass that bought nothing:

```
result=remote_hit  compiler_runs=0  dep_info_runs=1
```

With this change, same scenario:

```
result=remote_hit  compiler_runs=0  dep_info_runs=0
```

## Why reading remotely is sound

Reading is not claiming. An entry on the remote was stored under a key
computed from a discovered closure exactly as a local one was, so matching it
proves the prediction reproduced that closure. The argument that already
justified serving a predicted **local** hit applies unchanged to a remote one;
nothing about it depended on where the entry lived.

## The shape

The lookup phase becomes a loop that runs at most twice:

1. Local lookup, then remote check, both under the derived key. A hit returns.
2. Only once both have missed is the key re-derived from a real pre-pass —
   before the scheduler, the claim or the store sees it.
3. If that changed the key, one more pass: the true key is one nothing has
   looked up yet, and on a shared cache another machine may hold it. One
   lookup against a compile.
4. If it did not change the key, break — asking again would be the same two
   misses.

`needs_rederivation` becomes `owes_rederivation`: it no longer asks whether
the key was found, since a hit returns from inside the loop, only whether the
key is still a guess.

## Verification

The new test fails on the parent commit and passes here. It compiles cold
against a filesystem remote, deletes the local blobs so only the recorded
closure survives — the asymmetry a fresh checkout has once records are
distributed — and asserts the rebuild is served remotely with
`dep_info_runs == 0` under the same cache key.

## Credit

Found by an adversarial cross-model review of the follow-up design note, which
spotted that the note's fresh-clone benefit contradicted its own lookup rule.
Three independent legs reached it separately.