### PR TITLE
docs(agents): three mutation lessons the list did not have

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,9 @@ Prefer tests and deleting dead branches over skip annotations.
 - macOS-only helpers Linux never calls: `#[cfg(any(test, target_os = "macos"))]`.
 - `Drop` / file locks — a second process must acquire after the first drops.
 - New event-log fields — grep `event.schema` in the same commit and bump the tests.
+- A test that passes is not a test that kills the mutant. Apply the mutation by hand, watch the test fail, then revert. A stale-record test passed under both `==` and `!=` because a single client refreshed its own record before the branch was ever reached; it took two clients to make the branch observable.
+- Moving code without changing it still marks every moved line as changed, so the lane mutates lines your change never touched. Wrapping a 200-line block in a `loop` cost six survivors, four of them in code that predated the branch. Extract a function instead: the call site is one changed line and the body is none.
+- Tests that read the live process environment race the rest of the suite, which mutates it (`set_env_for_test`). Take a snapshot and pass it in, or the test passes alone and fails in `just check`.
 
 ## PRs
 


### PR DESCRIPTION
`AGENTS.md` already has a "How mutants die here" list, and it already covered
the two patterns that cost the most time this week:

> `if !s.is_empty() { print!("{s}") }` — printing `""` is a no-op, so
> `delete !` is missed. Call a helper that already has empty vs nonempty
> tests (`replay_cached_diagnostics`).

> New event-log fields — grep `event.schema` in the same commit and bump the
> tests.

Both were hit anyway, in #947 and #945, by not reading the file. The list
works; it just needs to be read. These three are not in it.

**A passing test is not a killing test.** Apply the mutation by hand, watch
the test fail, revert. The first stale-record test in #947 passed under both
`==` and `!=`: one client refreshes its own record before the branch is ever
reached, so the branch was unobservable. It took two clients to make it
testable at all.

**Moving code marks every moved line as changed.** The lane then mutates
lines the change never touched. Wrapping a 200-line block in a `loop`
produced six survivors, four of them in code that predated the branch.
Extracting a function costs one changed line instead of two hundred.

**Tests that read the live process environment race the suite**, which
mutates it through `set_env_for_test`. They pass alone and fail under
`just check` — which is the worst failure shape, because it reads as
unrelated flake.

Docs only; no Rust changes.