### PR TITLE
bench: turn on input predictions and sample-check them

### DIFF
--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -3447,6 +3447,9 @@ fn write_summary(
         "  kache saw     : {} compiles -> {} cached, {} passed through, {} errored",
         el.total, el.cached, el.passed_through, el.errored
     )?;
+    if let Some(line) = prediction_summary_line(&r.warm.phases, r.warm.total_crates) {
+        writeln!(out, "{line}")?;
+    }
     if !el.top_passthrough.is_empty() {
         // Decision table, not an error list: `action  category  description`.
         // The header says the build ran normally so the rows don't read as
@@ -3749,6 +3752,25 @@ struct PhaseTimes {
     store_ms: u64,
     /// Wrapper time no phase accounts for.
     unattributed_ms: u64,
+}
+
+/// The two numbers that say whether input predictions are working and whether
+/// they are honest: how many units skipped the dep-info pre-pass, and how many
+/// sampled cross-checks disagreed with it.
+///
+/// `None` when the phase spawned a pre-pass for every unit, which is what an
+/// arm that never enabled predictions looks like. Saying "0 of N skipped"
+/// there would read as a result rather than as an absent feature.
+fn prediction_summary_line(phases: &PhaseTimes, total_crates: u64) -> Option<String> {
+    let skipped = total_crates.checked_sub(phases.dep_info_runs)?;
+    if skipped == 0 {
+        return None;
+    }
+    Some(format!(
+        "  predictions   : {skipped} of {total_crates} units skipped the dep-info pre-pass; \
+         {} sampled check(s) disagreed",
+        phases.prediction_mismatches
+    ))
 }
 
 impl PhaseTimes {
@@ -4198,6 +4220,44 @@ mod tests {
             "bench-firefox",
             "pull",
         ));
+    }
+
+    /// The line only appears for a phase that actually used predictions.
+    /// "0 of N skipped" on an arm that never enabled them would read as a
+    /// result rather than as an absent feature.
+    #[test]
+    fn the_prediction_line_reports_only_a_phase_that_used_them() {
+        let phases = |runs: u64, mismatches: u64| PhaseTimes {
+            dep_info_runs: runs,
+            prediction_mismatches: mismatches,
+            ..PhaseTimes::default()
+        };
+
+        let used = prediction_summary_line(&phases(77, 0), 663).expect("predictions were used");
+        assert!(used.contains("586 of 663"), "{used}");
+        assert!(used.contains("0 sampled check(s) disagreed"), "{used}");
+
+        let disagreed = prediction_summary_line(&phases(77, 4), 663).unwrap();
+        assert!(
+            disagreed.contains("4 sampled check(s) disagreed"),
+            "{disagreed}"
+        );
+
+        assert_eq!(
+            prediction_summary_line(&phases(663, 0), 663),
+            None,
+            "every unit ran the pre-pass, so predictions did nothing here"
+        );
+        assert_eq!(
+            prediction_summary_line(&phases(0, 0), 0),
+            None,
+            "a phase with no units has nothing to report"
+        );
+        assert_eq!(
+            prediction_summary_line(&phases(700, 0), 663),
+            None,
+            "more spawns than units is not a skip count; say nothing"
+        );
     }
 
     /// Every field here is a key in `kache report --format json`. Nothing else

--- a/scenarios/bench-hk-pull/scenario.toml
+++ b/scenarios/bench-hk-pull/scenario.toml
@@ -16,6 +16,16 @@ setup = [
 ]
 
 build = """
+# Input-set predictions, with a sampled cross-check (kunobi-ninja/kache#945).
+# Predictions replace the rustc dep-info pre-pass with a recorded closure, so
+# the warm phases here measure what that is worth on a real graph. One unit in
+# 64 runs the pre-pass anyway and compares the two closures; the pre-pass
+# answer wins either way, so a disagreement costs nothing at the time. Its
+# count reaches the report, and zero across real subjects is what would
+# justify turning predictions on by default.
+export KACHE_INPUT_PREDICTIONS=1
+export KACHE_VERIFY_INPUT_PREDICTIONS=sampled
+
 repo="$(pwd -P)"
 prefix_map="-ffile-prefix-map=$repo=. -fdebug-prefix-map=$repo=. -fmacro-prefix-map=$repo=."
 export CFLAGS="${CFLAGS:-} $prefix_map"

--- a/scenarios/bench-hk/scenario.toml
+++ b/scenarios/bench-hk/scenario.toml
@@ -27,6 +27,16 @@ setup = [
 # prefix maps, SOURCE_DATE_EPOCH and KACHE_BASE_DIR are the cross-worktree
 # portability knobs the other cargo scenarios use (see bench-pr-cargo).
 build = """
+# Input-set predictions, with a sampled cross-check (kunobi-ninja/kache#945).
+# Predictions replace the rustc dep-info pre-pass with a recorded closure, so
+# the warm phases here measure what that is worth on a real graph. One unit in
+# 64 runs the pre-pass anyway and compares the two closures; the pre-pass
+# answer wins either way, so a disagreement costs nothing at the time. Its
+# count reaches the report, and zero across real subjects is what would
+# justify turning predictions on by default.
+export KACHE_INPUT_PREDICTIONS=1
+export KACHE_VERIFY_INPUT_PREDICTIONS=sampled
+
 repo="$(pwd -P)"
 prefix_map="-ffile-prefix-map=$repo=. -fdebug-prefix-map=$repo=. -fmacro-prefix-map=$repo=."
 export CFLAGS="${CFLAGS:-} $prefix_map"

--- a/scenarios/bench-lance/scenario.toml
+++ b/scenarios/bench-lance/scenario.toml
@@ -28,6 +28,16 @@ setup = [
 # prost-build, CARGO_MANIFEST_DIR) portable across the two clones so the
 # headline cross-clone metric is measuring kache, not path baking.
 build = """
+# Input-set predictions, with a sampled cross-check (kunobi-ninja/kache#945).
+# Predictions replace the rustc dep-info pre-pass with a recorded closure, so
+# the warm phases here measure what that is worth on a real graph. One unit in
+# 64 runs the pre-pass anyway and compares the two closures; the pre-pass
+# answer wins either way, so a disagreement costs nothing at the time. Its
+# count reaches the report, and zero across real subjects is what would
+# justify turning predictions on by default.
+export KACHE_INPUT_PREDICTIONS=1
+export KACHE_VERIFY_INPUT_PREDICTIONS=sampled
+
 src="$(pwd -P)"
 export KACHE_BASE_DIR="$src"
 cargo build --release -p lance

--- a/scenarios/bench-opendal/scenario.toml
+++ b/scenarios/bench-opendal/scenario.toml
@@ -31,6 +31,16 @@ setup = [
 # native-build paths/determinism the same way bench-surrealdb does. These
 # knobs change build PATHS and timestamps, not WHAT is built.
 build = """
+# Input-set predictions, with a sampled cross-check (kunobi-ninja/kache#945).
+# Predictions replace the rustc dep-info pre-pass with a recorded closure, so
+# the warm phases here measure what that is worth on a real graph. One unit in
+# 64 runs the pre-pass anyway and compares the two closures; the pre-pass
+# answer wins either way, so a disagreement costs nothing at the time. Its
+# count reaches the report, and zero across real subjects is what would
+# justify turning predictions on by default.
+export KACHE_INPUT_PREDICTIONS=1
+export KACHE_VERIFY_INPUT_PREDICTIONS=sampled
+
 repo="$(pwd -P)"
 prefix_map="-ffile-prefix-map=$repo=. -fdebug-prefix-map=$repo=. -fmacro-prefix-map=$repo=."
 export CFLAGS="${CFLAGS:-} $prefix_map"

--- a/scenarios/bench-substrate/scenario.toml
+++ b/scenarios/bench-substrate/scenario.toml
@@ -35,6 +35,16 @@ setup = [
 # set. This shell lives in config rather than Rust, which is the whole point of
 # scenarios.
 build = """
+# Input-set predictions, with a sampled cross-check (kunobi-ninja/kache#945).
+# Predictions replace the rustc dep-info pre-pass with a recorded closure, so
+# the warm phases here measure what that is worth on a real graph. One unit in
+# 64 runs the pre-pass anyway and compares the two closures; the pre-pass
+# answer wins either way, so a disagreement costs nothing at the time. Its
+# count reaches the report, and zero across real subjects is what would
+# justify turning predictions on by default.
+export KACHE_INPUT_PREDICTIONS=1
+export KACHE_VERIFY_INPUT_PREDICTIONS=sampled
+
 export RUSTUP_TOOLCHAIN=1.93.0
 if [ "$(uname)" = Darwin ]; then
   for d in "$(xcode-select -p 2>/dev/null)/Toolchains/XcodeDefault.xctoolchain/usr/lib" /Library/Developer/CommandLineTools/usr/lib; do

--- a/scenarios/bench-surrealdb/scenario.toml
+++ b/scenarios/bench-surrealdb/scenario.toml
@@ -33,6 +33,16 @@ setup = [
 # selection. This shell lives in config rather than Rust, which is the whole
 # point of scenarios.
 build = """
+# Input-set predictions, with a sampled cross-check (kunobi-ninja/kache#945).
+# Predictions replace the rustc dep-info pre-pass with a recorded closure, so
+# the warm phases here measure what that is worth on a real graph. One unit in
+# 64 runs the pre-pass anyway and compares the two closures; the pre-pass
+# answer wins either way, so a disagreement costs nothing at the time. Its
+# count reaches the report, and zero across real subjects is what would
+# justify turning predictions on by default.
+export KACHE_INPUT_PREDICTIONS=1
+export KACHE_VERIFY_INPUT_PREDICTIONS=sampled
+
 if [ "$(uname)" = Darwin ]; then
   for d in "$(xcode-select -p 2>/dev/null)/Toolchains/XcodeDefault.xctoolchain/usr/lib" /Library/Developer/CommandLineTools/usr/lib; do
     if [ -f "$d/libclang.dylib" ]; then


### PR DESCRIPTION
The predictions chain is complete and off by default (#938, #939, #942, #945,
#947). What decides whether it can be on **by default** is one number: how
often a predicted input closure disagrees with the one the dep-info pre-pass
would have discovered. That number only means anything on real code.

## What changes

The six Rust benchmark arms — substrate, surrealdb, lance, opendal, hk,
hk-pull — enable predictions with `KACHE_VERIFY_INPUT_PREDICTIONS=sampled`.
One run then produces both halves:

- most units skip the pre-pass, which is what the warm phases measure;
- one in 64 runs it anyway and compares the two closures.

The pre-pass answer wins either way, so a disagreement costs nothing at the
time it happens. It is evidence that the soundness argument has a hole, not a
failure.

The summary prints both numbers:

```
predictions   : 586 of 663 units skipped the dep-info pre-pass; 0 sampled check(s) disagreed
```

The line is omitted for an arm that never enabled predictions, so the C/C++
arms and the external-backend arms are untouched.

Firefox and LLVM are deliberately left alone: they are the long poles and
mostly C/C++, where the rustc pre-pass is not the cost.

## Expect a step change in these six arms

Measured locally on kache's own 663-unit graph, warm phase, at `-j1` so
contention does not inflate the sums:

| | off | on |
|---|---:|---:|
| units | 663 | 663 |
| **hits** | **663** | **663** |
| **misses** | **0** | **0** |
| dep-info spawns | 663 | **77** |
| time in the pre-pass | 34.9s | **12.7s** |
| total key time | 37.3s | **15.5s** |
| wall | 114.9s | **91.3s** |

88% of units stop spawning the pre-pass, and the hit and miss counts are
identical — a prediction that derived a different key would show up as a miss
and a recompile, and none do.

That subject is a `cargo check`, where each unit is cheap and the pre-pass is
therefore a large share. A linking build will show less. The nightly is what
says how much less, on subjects nobody tuned for this.

## Not in this PR

The default stays off. Flipping it is a separate decision that this run
exists to inform.