### PR TITLE
refactor(service): move the planner store from SurrealDB to SQLite

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -254,6 +254,6 @@ exclude_re = [
     "src/cache_fs.rs:.*replace statfs_total_bytes_macos",
     "src/cache_fs.rs:.*replace volume_total_bytes_windows",
     "src/native_link_key.rs:.*replace WindowsProbeEnvironment::augment_from_installed_msvc .* with Ok",
-    "SurrealPlannerRepository>::identity_candidates .* with Ok\\(vec!\\[\\]\\)",
+    "SqlitePlannerRepository>::identity_candidates .* with Ok\\(vec!\\[\\]\\)",
     "crates/kache-store/src/link.rs:.*replace warn_no_cow_restore_once with \\(\\)",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,7 +613,7 @@ jobs:
   # `deny.toml`. `just audit` runs cargo-deny once PER WORKSPACE MEMBER — a
   # root-only run graphs only the `kache` bin (+ kache-core) and silently skips
   # anything reachable solely through `kache-service` (e.g. the rsa
-  # RUSTSEC-2023-0071 advisory and surrealdb's BUSL-1.1 license). Kept as its
+  # RUSTSEC-2023-0071 advisory). Kept as its
   # own job — not folded into `check` — so a newly-published advisory surfaces
   # as a dedicated red check instead of being buried in `just ci`, and so it can
   # go red on advisory-DB updates alone without touching any code. Deliberately

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,56 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93b8a41dbe230ad5087cc721f8d41611de654542180586b315d9f4cf6b72bef"
-dependencies = [
- "psl-types",
-]
-
-[[package]]
-name = "affinitypool"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a46f56d354df11b6bcd8ca4f84fa03ac816cc41c72568a1b337d8f7e5af90e"
-dependencies = [
- "arc-swap",
- "async-task",
- "crossbeam-deque",
- "crossbeam-utils",
- "libc",
- "num_cpus",
- "parking_lot",
- "thiserror 2.0.18",
- "winapi",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,18 +16,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "ammonia"
-version = "4.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
-dependencies = [
- "cssparser",
- "html5ever",
- "maplit",
- "url",
-]
 
 [[package]]
 name = "android_system_properties"
@@ -154,27 +92,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
-name = "argon2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
-dependencies = [
- "base64ct",
- "blake2",
- "cpufeatures 0.2.17",
- "password-hash",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,18 +102,6 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
-
-[[package]]
-name = "as-slice"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
-dependencies = [
- "generic-array 0.12.4",
- "generic-array 0.13.3",
- "generic-array 0.14.9",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "assert_cmd"
@@ -212,46 +117,6 @@ dependencies = [
  "predicates-tree",
  "wait-timeout",
 ]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -284,15 +149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,30 +159,6 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
-dependencies = [
- "aws-lc-sys",
- "untrusted 0.7.1",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
 
 [[package]]
 name = "axum"
@@ -422,19 +254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bcrypt"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0f5948f30df5f43ac29d310b7476793be97c50787e6ef4a63d960a0d0be827"
-dependencies = [
- "base64 0.22.1",
- "blowfish",
- "getrandom 0.3.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,27 +281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
-name = "bitvec"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "blake3"
 version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,7 +300,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array",
 ]
 
 [[package]]
@@ -513,52 +311,6 @@ checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
-
-[[package]]
-name = "blowfish"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
-dependencies = [
- "byteorder",
- "cipher",
-]
-
-[[package]]
-name = "bnum"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
-
-[[package]]
-name = "borsh"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
-dependencies = [
- "borsh-derive",
- "bytes",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "boxcar"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "bs58"
@@ -593,61 +345,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bytesize"
@@ -699,34 +406,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
+ "windows-link",
 ]
 
 [[package]]
@@ -776,7 +456,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -787,15 +467,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "cmov"
@@ -831,15 +502,6 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -934,54 +596,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-skiplist"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -1022,7 +640,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -1034,7 +652,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array",
  "typenum",
 ]
 
@@ -1054,18 +672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf 0.11.3",
-]
-
-[[package]]
-name = "cssparser"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
-dependencies = [
- "dtoa-short",
- "itoa",
- "smallvec",
+ "phf",
 ]
 
 [[package]]
@@ -1137,26 +744,6 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "data-encoding"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "defmt"
@@ -1239,12 +826,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,64 +877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diskann"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421c6cf955c6cb1451d36c8a3740ab2a22880265d0fa93d8ea22cbc425c90479"
-dependencies = [
- "anyhow",
- "bytemuck",
- "diskann-utils",
- "diskann-vector",
- "diskann-wide",
- "futures-util",
- "half",
- "hashbrown 0.16.1",
- "num-traits",
- "rand 0.9.4",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
-name = "diskann-utils"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cdf7d491910fbff13338e07460c9197a3c172268cfd4d8f8e69e5cec5a256d9"
-dependencies = [
- "bytemuck",
- "cfg-if",
- "diskann-vector",
- "diskann-wide",
- "half",
- "rand 0.9.4",
- "rand_distr",
- "rayon",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "diskann-vector"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1643bbece645f03527ef120bc7dd5e4e40557980dbe52ee51129adfb58a851"
-dependencies = [
- "cfg-if",
- "diskann-wide",
- "half",
-]
-
-[[package]]
-name = "diskann-wide"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421f02c42e57a2153dc65b66b4b95fe2be56e14bf9f95253b663abcac8521166"
-dependencies = [
- "cfg-if",
- "half",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1374,16 +897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dmp"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2dfc7a18dffd3ef60a442b72a827126f1557d914620f8fc4d1049916da43c1"
-dependencies = [
- "trice",
- "urlencoding",
-]
-
-[[package]]
 name = "doctest-file"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,41 +912,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
-
-[[package]]
-name = "dtoa-short"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
-dependencies = [
- "dtoa",
-]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "earcutr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
-dependencies = [
- "itertools 0.11.0",
- "num-traits",
-]
 
 [[package]]
 name = "ecdsa"
@@ -1489,7 +971,7 @@ dependencies = [
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
- "generic-array 0.14.9",
+ "generic-array",
  "group",
  "hkdf",
  "pem-rfc7468",
@@ -1526,39 +1008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
-dependencies = [
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
-name = "ext-sort"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5d3b056bcc471d38082b8c453acb6670f7327fd44219b3c411e40834883569"
-dependencies = [
- "log",
- "rayon",
- "rmp-serde",
- "serde",
- "tempfile",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,17 +1034,6 @@ name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
-
-[[package]]
-name = "fastnum"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020d1b59a944bc239d79903fbac2eda2365138b44890c27979562f6592059dcd"
-dependencies = [
- "bnum",
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "fastrand"
@@ -1659,17 +1097,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flatbuffers"
-version = "25.12.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
-dependencies = [
- "bitflags 2.13.0",
- "rustc_version",
- "serde",
-]
-
-[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,12 +1104,6 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "float_next_after"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fnv"
@@ -1704,34 +1125,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fst"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1822,33 +1215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,53 +1223,6 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
-]
-
-[[package]]
-name = "geo"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
-dependencies = [
- "earcutr",
- "float_next_after",
- "geo-types",
- "geographiclib-rs",
- "i_overlay",
- "log",
- "num-traits",
- "rand 0.8.6",
- "robust",
- "rstar 0.12.2",
- "serde",
- "sif-itree",
- "spade",
-]
-
-[[package]]
-name = "geo-types"
-version = "0.7.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
-dependencies = [
- "approx",
- "num-traits",
- "rayon",
- "rstar 0.10.0",
- "rstar 0.11.0",
- "rstar 0.12.2",
- "rstar 0.8.4",
- "rstar 0.9.3",
- "serde",
-]
-
-[[package]]
-name = "geographiclib-rs"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
-dependencies = [
- "libm",
 ]
 
 [[package]]
@@ -1974,80 +1293,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "guardian"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
-
-[[package]]
-name = "h2"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "bytemuck",
- "cfg-if",
- "crunchy",
- "num-traits",
- "rand 0.9.4",
- "rand_distr",
- "zerocopy",
-]
-
-[[package]]
-name = "hash32"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2087,81 +1336,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1 0.10.6",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
-]
-
-[[package]]
-name = "heapless"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
-dependencies = [
- "as-slice",
- "generic-array 0.14.9",
- "hash32 0.1.1",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32 0.2.1",
- "rustc_version",
- "spin 0.9.9",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32 0.3.1",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2203,16 +1381,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "html5ever"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
-dependencies = [
- "log",
- "markup5ever",
 ]
 
 [[package]]
@@ -2261,12 +1429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,7 +1447,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -2312,7 +1473,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2352,49 +1513,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "i_float"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010025c2c532c8d82e42d0b8bb5184afa449fa6f06c709ea9adcb16c49ae405b"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "i_key_sort"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
-
-[[package]]
-name = "i_overlay"
-version = "4.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413183068e6e0289e18d7d0a1f661b81546e6918d5453a44570b9ab30cbed1b3"
-dependencies = [
- "i_float",
- "i_key_sort",
- "i_shape",
- "i_tree",
- "rayon",
-]
-
-[[package]]
-name = "i_shape"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea154b742f7d43dae2897fcd5ead86bc7b5eefcedd305a7ebf9f69d44d61082"
-dependencies = [
- "i_float",
-]
-
-[[package]]
-name = "i_tree"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2406,7 +1524,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2565,7 +1683,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array",
 ]
 
 [[package]]
@@ -2580,12 +1698,6 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "integer-encoding"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c00403deb17c3221a1fe4fb571b9ed0370b3dcd116553c77fa294a3d918699"
 
 [[package]]
 name = "interprocess"
@@ -2625,24 +1737,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2671,7 +1765,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2714,7 +1808,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2796,31 +1890,6 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "10.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
-dependencies = [
- "aws-lc-rs",
- "base64 0.22.1",
- "ed25519-dalek",
- "getrandom 0.2.17",
- "hmac 0.12.1",
- "js-sys",
- "p256",
- "p384",
- "pem",
- "rand 0.8.6",
- "rsa",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "signature",
- "simple_asn1",
- "zeroize",
 ]
 
 [[package]]
@@ -2941,10 +2010,10 @@ dependencies = [
  "kunobi-auth",
  "kunobi-ha",
  "prometheus",
+ "rusqlite",
  "serde",
  "serde_json",
  "subtle",
- "surrealdb",
  "tempfile",
  "tokio",
  "tower",
@@ -3054,7 +2123,7 @@ dependencies = [
  "chrono",
  "hex",
  "http",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "oauth2",
  "openidconnect",
  "reqwest 0.12.28",
@@ -3098,15 +2167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin 0.9.9",
-]
-
-[[package]]
-name = "lexicmp"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8f89da8fd95c4eb6274e914694bea90c7826523b26f2a2fd863d44b9d42c43"
-dependencies = [
- "deunicode",
 ]
 
 [[package]]
@@ -3199,15 +2259,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "lz4_flex"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3215,23 +2266,6 @@ checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
  "nix",
  "winapi",
-]
-
-[[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "markup5ever"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
-dependencies = [
- "log",
- "tendril",
- "web_atoms",
 ]
 
 [[package]]
@@ -3248,26 +2282,6 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
 
 [[package]]
 name = "md-5"
@@ -3316,16 +2330,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3344,42 +2348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndarray"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
-]
-
-[[package]]
-name = "ndarray-stats"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6e54a8b65764f71827a90ca1d56965ec0c67f069f996477bd493402a901d1f"
-dependencies = [
- "indexmap 2.14.0",
- "itertools 0.13.0",
- "ndarray",
- "noisy_float",
- "num-integer",
- "num-traits",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3390,15 +2358,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "noisy_float"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16843be85dd410c6a12251c4eca0dd1d3ee8c5725f746c4d5e0fdcec0a864b2"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -3416,15 +2375,6 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
-name = "ntapi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -3459,15 +2409,6 @@ dependencies = [
  "rand 0.8.6",
  "smallvec",
  "zeroize",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -3518,16 +2459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3557,51 +2488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "object_store"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "humantime",
- "itertools 0.14.0",
- "parking_lot",
- "percent-encoding",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "walkdir",
- "wasm-bindgen-futures",
- "web-time",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3627,7 +2513,7 @@ dependencies = [
  "http",
  "jiff",
  "log",
- "md-5 0.11.0",
+ "md-5",
  "percent-encoding",
  "quick-xml",
  "reqsign-core",
@@ -3689,7 +2575,7 @@ dependencies = [
  "crc-fast",
  "http",
  "log",
- "md-5 0.11.0",
+ "md-5",
  "opendal-core",
  "quick-xml",
  "reqsign-aws-v4",
@@ -3833,22 +2719,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "papaya"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
-dependencies = [
- "equivalent",
- "seize",
-]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3868,43 +2738,8 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
-
-[[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "path-clean"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
- "password-hash",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "pdqselect"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 
 [[package]]
 name = "pem"
@@ -3980,19 +2815,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
- "serde",
+ "phf_macros",
+ "phf_shared",
 ]
 
 [[package]]
@@ -4001,18 +2825,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -4021,18 +2835,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.11.3",
+ "phf_shared",
  "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
-dependencies = [
- "fastrand",
- "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -4041,25 +2845,11 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
- "unicase",
 ]
 
 [[package]]
@@ -4072,46 +2862,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
-dependencies = [
- "siphasher",
- "unicase",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -4180,12 +2934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4222,15 +2970,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
 ]
 
 [[package]]
@@ -4295,38 +3034,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
-dependencies = [
- "prost",
-]
-
-[[package]]
 name = "protobuf"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4347,32 +3054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psl-types"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4380,18 +3061,6 @@ checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "quick_cache"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c6658afe513a3b484e3abfdaa0d03ef3c0bbf017542c178dd55f94eb3051f9"
-dependencies = [
- "ahash 0.8.12",
- "equivalent",
- "hashbrown 0.16.1",
- "parking_lot",
 ]
 
 [[package]]
@@ -4420,7 +3089,6 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4470,12 +3138,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -4534,16 +3196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_distr"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
-dependencies = [
- "num-traits",
- "rand 0.9.4",
 ]
 
 [[package]]
@@ -4657,38 +3309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "reblessive"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc4a4ea2a66a41a1152c4b3d86e8954dc087bdf33af35446e6e176db4e73c8c"
-
-[[package]]
 name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4764,15 +3384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqsign-aws-core"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4790,7 +3401,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1 0.11.0",
+ "sha1",
 ]
 
 [[package]]
@@ -4825,7 +3436,7 @@ dependencies = [
  "log",
  "mea",
  "percent-encoding",
- "sha1 0.11.0",
+ "sha1",
  "sha2 0.11.0",
  "windows-sys 0.61.2",
 ]
@@ -4876,7 +3487,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4897,10 +3508,8 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime_guess",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -4918,33 +3527,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "revision"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b48b66c1cd4bf814516ea48f727d4b3697e3fa8841be99a7d9cbb8c9ac1666"
-dependencies = [
- "bytes",
- "chrono",
- "geo",
- "regex",
- "revision-derive",
- "roaring",
- "rust_decimal",
- "uuid",
-]
-
-[[package]]
-name = "revision-derive"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d266d798eaaa2921e14188dfe998bb7cc0528ec26e894b4be0e35fe2b19c89d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -4967,74 +3549,9 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "rmp"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
-dependencies = [
- "rmp",
- "serde",
-]
-
-[[package]]
-name = "roaring"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
-dependencies = [
- "bytemuck",
- "byteorder",
- "serde",
-]
-
-[[package]]
-name = "robust"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rsa"
@@ -5068,67 +3585,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rstar"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a45c0e8804d37e4d97e55c6f258bc9ad9c5ee7b07437009dd152d764949a27c"
-dependencies = [
- "heapless 0.6.1",
- "num-traits",
- "pdqselect",
- "serde",
- "smallvec",
-]
-
-[[package]]
-name = "rstar"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40f1bfe5acdab44bc63e6699c28b74f75ec43afb59f3eda01e145aff86a25fa"
-dependencies = [
- "heapless 0.7.17",
- "num-traits",
- "serde",
- "smallvec",
-]
-
-[[package]]
-name = "rstar"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f39465655a1e3d8ae79c6d9e007f4953bfc5d55297602df9dc38f9ae9f1359a"
-dependencies = [
- "heapless 0.7.17",
- "num-traits",
- "serde",
- "smallvec",
-]
-
-[[package]]
-name = "rstar"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73111312eb7a2287d229f06c00ff35b51ddee180f017ab6dec1f69d62ac098d6"
-dependencies = [
- "heapless 0.7.17",
- "num-traits",
- "serde",
- "smallvec",
-]
-
-[[package]]
-name = "rstar"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
-dependencies = [
- "heapless 0.8.0",
- "num-traits",
- "serde",
- "smallvec",
-]
-
-[[package]]
 name = "rusqlite"
 version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5151,33 +3607,6 @@ checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
-]
-
-[[package]]
-name = "rust-stemmers"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand 0.8.6",
- "rkyv",
- "serde",
- "serde_json",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -5214,7 +3643,6 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5279,10 +3707,9 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -5296,15 +3723,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
 
 [[package]]
 name = "same-file"
@@ -5355,24 +3773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "password-hash",
- "pbkdf2",
- "salsa20",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5380,7 +3780,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array 0.14.9",
+ "generic-array",
  "pkcs8",
  "subtle",
  "zeroize",
@@ -5419,24 +3819,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "seize"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "serde"
@@ -5579,17 +3965,6 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -5635,12 +4010,6 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "sif-itree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
 
 [[package]]
 name = "signal-hook"
@@ -5730,12 +4099,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
-name = "snap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
-
-[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5746,25 +4109,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spade"
-version = "2.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
-dependencies = [
- "hashbrown 0.16.1",
- "num-traits",
- "robust",
- "smallvec",
-]
-
-[[package]]
 name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spin"
@@ -5864,52 +4212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "storekey"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9a94571bde7369ecaac47cec2e6844642d99166bd452fbd8def74b5b917b2f"
-dependencies = [
- "bytes",
- "storekey-derive",
- "uuid",
-]
-
-[[package]]
-name = "storekey-derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6079d53242246522ec982de613c5c952cc7b1380ef2f8622fcdab9bfe73c0098"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "string_cache"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.13.1",
- "precomputed-hash",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5930,7 +4232,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5941,256 +4243,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "surrealdb"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c21f360e9c3705555e5894271e4db622cf055d0faad4169f1ef52d08958705"
-dependencies = [
- "anyhow",
- "async-channel",
- "boxcar",
- "chrono",
- "futures",
- "getrandom 0.3.4",
- "indexmap 2.14.0",
- "js-sys",
- "path-clean",
- "reqwest 0.13.4",
- "ring",
- "rustls",
- "rustls-pki-types",
- "semver",
- "serde",
- "serde_json",
- "surrealdb-core",
- "surrealdb-types",
- "surrealdb-types-derive",
- "tokio",
- "tokio-tungstenite",
- "tokio-tungstenite-wasm",
- "tokio-util",
- "tracing",
- "url",
- "uuid",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasmtimer",
- "web-sys",
-]
-
-[[package]]
-name = "surrealdb-collections"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5b7ce7c31b54e9b8029179c395f78549679beecd48763fa55bc17059d8b3ff"
-dependencies = [
- "revision",
- "storekey",
-]
-
-[[package]]
-name = "surrealdb-core"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad0e632d0ba78dede6e1432ef902b3dac4d9ce7999dc413b6d12e942db57f57"
-dependencies = [
- "addr",
- "affinitypool",
- "ahash 0.8.12",
- "ammonia",
- "anyhow",
- "argon2",
- "async-channel",
- "async-stream",
- "base64 0.22.1",
- "bcrypt",
- "blake3",
- "bytes",
- "chrono",
- "ciborium",
- "dashmap",
- "deunicode",
- "diskann",
- "diskann-utils",
- "diskann-vector",
- "dmp",
- "ext-sort",
- "fastnum",
- "fst",
- "futures",
- "fuzzy-matcher",
- "geo",
- "geo-types",
- "getrandom 0.3.4",
- "half",
- "headers",
- "hex",
- "http",
- "humantime",
- "ipnet",
- "jsonwebtoken 10.4.0",
- "lexicmp",
- "md-5 0.10.6",
- "memchr",
- "mime",
- "ndarray",
- "ndarray-stats",
- "num-traits",
- "num_cpus",
- "object_store",
- "parking_lot",
- "path-clean",
- "pbkdf2",
- "phf 0.13.1",
- "pin-project-lite",
- "quick_cache",
- "rand 0.9.4",
- "rand_core 0.6.4",
- "rayon",
- "reblessive",
- "regex",
- "revision",
- "ring",
- "roaring",
- "rust-stemmers",
- "rust_decimal",
- "scrypt",
- "semver",
- "serde",
- "serde_json",
- "sha1 0.10.6",
- "sha2 0.10.9",
- "storekey",
- "strsim",
- "subtle",
- "surrealdb-collections",
- "surrealdb-protocol",
- "surrealdb-strand",
- "surrealdb-types",
- "surrealkv",
- "sysinfo",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "ulid",
- "unicase",
- "url",
- "uuid",
- "vart",
- "wasm-bindgen-futures",
- "wasmtimer",
- "web-time",
-]
-
-[[package]]
-name = "surrealdb-protocol"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4e06f586c9179a02349b88b0c18e3a0850c55431aa513e0cd66529c00da1af"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "chrono",
- "flatbuffers",
- "futures",
- "geo",
- "prost",
- "prost-types",
- "rust_decimal",
- "semver",
- "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
- "uuid",
-]
-
-[[package]]
-name = "surrealdb-strand"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a832fdd23c7cebe15b95c6940bf23e18360774307f939273e43c6a4d6722922"
-dependencies = [
- "revision",
- "serde",
- "storekey",
-]
-
-[[package]]
-name = "surrealdb-types"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191f11ad65f53f7a7b7cc65e2f455997bf9533a70bf9cfc509d58e4e061d300a"
-dependencies = [
- "anyhow",
- "async-channel",
- "bytes",
- "castaway",
- "chrono",
- "flatbuffers",
- "geo",
- "hex",
- "http",
- "papaya",
- "rand 0.9.4",
- "regex",
- "rust_decimal",
- "semver",
- "serde",
- "serde_json",
- "surrealdb-protocol",
- "surrealdb-types-derive",
- "tracing",
- "ulid",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "surrealdb-types-derive"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428bbf94f264212f3ed2f807304fae5ac8e6cc7fa2fd73f026632a3639bf673b"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "surrealkv"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0672cbbe282723a62ccee14b95232ca0b4c9bf44ea22fb520c43e7c517fb8ec"
-dependencies = [
- "arc-swap",
- "async-trait",
- "byteorder",
- "bytes",
- "chrono",
- "crc32fast",
- "crossbeam-skiplist",
- "fs2",
- "getrandom 0.3.4",
- "guardian",
- "integer-encoding",
- "log",
- "lz4_flex",
- "parking_lot",
- "quick_cache",
- "rand 0.9.4",
- "scopeguard",
- "sha2 0.10.9",
- "snap",
- "tokio",
- "xxhash-rust",
-]
 
 [[package]]
 name = "syn"
@@ -6235,26 +4287,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.37.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows",
-]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6279,16 +4311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendril"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
-dependencies = [
- "new_debug_unreachable",
- "utf-8",
-]
-
-[[package]]
 name = "termina"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6309,8 +4331,8 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -6352,7 +4374,7 @@ dependencies = [
  "ordered-float 4.6.0",
  "pest",
  "pest_derive",
- "phf 0.11.3",
+ "phf",
  "sha2 0.10.9",
  "signal-hook",
  "siphasher",
@@ -6523,52 +4545,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tungstenite",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "tokio-tungstenite-wasm"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee909c02b8863f9bda87253127eb4da0e7e1342330b2583fbc4d1795c2f8"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "httparse",
- "js-sys",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6576,7 +4552,6 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -6607,18 +4582,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
-dependencies = [
- "indexmap 2.14.0",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6634,46 +4597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
-name = "tonic"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "socket2",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6681,9 +4604,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
  "tokio-util",
@@ -6788,47 +4709,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "trice"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3aaab10ae9fac0b10f392752bf56f0fd20845f39037fec931e8537b105b515a"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.4",
- "rustls",
- "rustls-pki-types",
- "sha1 0.10.6",
- "thiserror 2.0.18",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -6843,27 +4727,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
-name = "ulid"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
-dependencies = [
- "rand 0.9.4",
- "serde",
- "web-time",
-]
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -6911,12 +4778,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -6933,18 +4794,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -6976,12 +4825,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vart"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1982d899e57d646498709735f16e9224cf1e8680676ad687f930cf8b5b555ae"
 
 [[package]]
 name = "vcpkg"
@@ -7056,7 +4899,6 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
- "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -7117,19 +4959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtimer"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot",
- "pin-utils",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7150,33 +4979,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "web_atoms"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
-dependencies = [
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "string_cache",
- "string_cache_codegen",
-]
-
-[[package]]
 name = "webpki-root-certs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -7298,41 +5106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core 0.61.2",
- "windows-future",
- "windows-link 0.1.3",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7340,20 +5113,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -7380,34 +5142,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-result"
@@ -7415,16 +5152,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -7433,7 +5161,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7460,7 +5188,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7485,7 +5213,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -7494,15 +5222,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7606,9 +5325,6 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"
@@ -7623,15 +5339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7640,12 +5347,6 @@ dependencies = [
  "libc",
  "rustix",
 ]
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "yoke"
@@ -7716,20 +5417,6 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
 
 [[package]]
 name = "zerotrie"

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -19,10 +19,10 @@ kube = { version = "3", features = ["client"] }
 prometheus = "0.14"
 kunobi-auth = { git = "https://github.com/kunobi-ninja/kunobi-auth.git", tag = "v0.3.0", default-features = false, features = ["server"] }
 kunobi-ha = { git = "https://github.com/kunobi-ninja/kunobi-ha.git", branch = "main" }
+rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 subtle = "2"
-surrealdb = { version = "3.0.5", features = ["kv-surrealkv"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal", "sync"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/crates/kache-service/src/lib.rs
+++ b/crates/kache-service/src/lib.rs
@@ -270,16 +270,26 @@ fn parse_service_account_namespace(contents: &str) -> Result<String> {
 }
 
 async fn load_repository(config: &PlannerConfig) -> Result<Option<SharedPlannerDataSource>> {
-    // Tells `open` whether a pre-SQLite store at this path is disposable: the
-    // seed is the only thing that ever refills the projections.
-    let seed_plan = match config.seed_state_file {
-        Some(_) => SeedPlan::Reseeded,
-        None => SeedPlan::None,
+    // Read and parse the seed BEFORE opening, because opening may move a
+    // pre-SQLite store aside and that is only safe if the rows really do come
+    // back. Seeding after the move meant a missing, unreadable or malformed
+    // seed failed only once the old store had already been displaced -- and a
+    // seed stored inside that directory was moved out from under its own path.
+    let seed = match config.seed_state_file.as_deref() {
+        Some(path) => Some(PlannerStateFile::read_from(path)?),
+        None => None,
+    };
+
+    // An empty seed parses fine and puts nothing back, so it is not a plan to
+    // rebuild anything.
+    let seed_plan = match &seed {
+        Some(state) if !state.is_empty() => SeedPlan::Reseeded,
+        _ => SeedPlan::None,
     };
 
     let repository = SqlitePlannerRepository::open(&config.db_path, seed_plan).await?;
-    if let Some(seed_state_file) = config.seed_state_file.as_deref() {
-        repository.seed_from_state_file(seed_state_file).await?;
+    if let Some(seed) = seed {
+        repository.seed_from_state(seed).await?;
     }
     Ok(Some(Arc::new(repository)))
 }

--- a/crates/kache-service/src/lib.rs
+++ b/crates/kache-service/src/lib.rs
@@ -30,7 +30,9 @@ mod metrics;
 
 mod state;
 
-pub use state::{DEFAULT_DB_PATH, NamespaceState, PlannerStateFile, SqlitePlannerRepository};
+pub use state::{
+    DEFAULT_DB_PATH, NamespaceState, PlannerStateFile, SeedPlan, SqlitePlannerRepository,
+};
 
 type SharedPlannerDataSource = Arc<dyn PlannerDataSource + Send + Sync>;
 
@@ -268,7 +270,14 @@ fn parse_service_account_namespace(contents: &str) -> Result<String> {
 }
 
 async fn load_repository(config: &PlannerConfig) -> Result<Option<SharedPlannerDataSource>> {
-    let repository = SqlitePlannerRepository::open(&config.db_path).await?;
+    // Tells `open` whether a pre-SQLite store at this path is disposable: the
+    // seed is the only thing that ever refills the projections.
+    let seed_plan = match config.seed_state_file {
+        Some(_) => SeedPlan::Reseeded,
+        None => SeedPlan::None,
+    };
+
+    let repository = SqlitePlannerRepository::open(&config.db_path, seed_plan).await?;
     if let Some(seed_state_file) = config.seed_state_file.as_deref() {
         repository.seed_from_state_file(seed_state_file).await?;
     }
@@ -897,9 +906,10 @@ mod tests {
     #[tokio::test]
     async fn prefetch_plan_returns_execute_when_repository_has_candidates() {
         let dir = tempfile::tempdir().unwrap();
-        let repository = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
-            .await
-            .unwrap();
+        let repository =
+            SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
+                .await
+                .unwrap();
         repository
             .seed_from_state(PlannerStateFile {
                 namespaces: HashMap::new(),
@@ -952,9 +962,10 @@ mod tests {
     #[tokio::test]
     async fn prefetch_plan_returns_use_fallback_when_repository_has_no_candidates() {
         let dir = tempfile::tempdir().unwrap();
-        let repository = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
-            .await
-            .unwrap();
+        let repository =
+            SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
+                .await
+                .unwrap();
 
         let response = test_app(None, Some(Arc::new(repository)))
             .oneshot(

--- a/crates/kache-service/src/lib.rs
+++ b/crates/kache-service/src/lib.rs
@@ -30,7 +30,7 @@ mod metrics;
 
 mod state;
 
-pub use state::{DEFAULT_DB_PATH, NamespaceState, PlannerStateFile, SurrealPlannerRepository};
+pub use state::{DEFAULT_DB_PATH, NamespaceState, PlannerStateFile, SqlitePlannerRepository};
 
 type SharedPlannerDataSource = Arc<dyn PlannerDataSource + Send + Sync>;
 
@@ -268,7 +268,7 @@ fn parse_service_account_namespace(contents: &str) -> Result<String> {
 }
 
 async fn load_repository(config: &PlannerConfig) -> Result<Option<SharedPlannerDataSource>> {
-    let repository = SurrealPlannerRepository::open(&config.db_path).await?;
+    let repository = SqlitePlannerRepository::open(&config.db_path).await?;
     if let Some(seed_state_file) = config.seed_state_file.as_deref() {
         repository.seed_from_state_file(seed_state_file).await?;
     }
@@ -897,7 +897,7 @@ mod tests {
     #[tokio::test]
     async fn prefetch_plan_returns_execute_when_repository_has_candidates() {
         let dir = tempfile::tempdir().unwrap();
-        let repository = SurrealPlannerRepository::open(&dir.path().join("planner.db"))
+        let repository = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
             .await
             .unwrap();
         repository
@@ -952,7 +952,7 @@ mod tests {
     #[tokio::test]
     async fn prefetch_plan_returns_use_fallback_when_repository_has_no_candidates() {
         let dir = tempfile::tempdir().unwrap();
-        let repository = SurrealPlannerRepository::open(&dir.path().join("planner.db"))
+        let repository = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
             .await
             .unwrap();
 

--- a/crates/kache-service/src/lib.rs
+++ b/crates/kache-service/src/lib.rs
@@ -1003,4 +1003,97 @@ mod tests {
         assert_eq!(plan.disposition, PrefetchDisposition::UseFallback);
         assert!(plan.candidates.is_empty());
     }
+
+    /// Lay out a db path holding a pre-SQLite store, plus a seed file.
+    fn legacy_store_with_seed(seed: &PlannerStateFile) -> (tempfile::TempDir, PlannerConfig) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("planner.db");
+        std::fs::create_dir(&db_path).unwrap();
+        std::fs::write(db_path.join("LOCK"), b"legacy sentinel").unwrap();
+
+        let seed_path = dir.path().join("planner-state.json");
+        std::fs::write(&seed_path, serde_json::to_vec(seed).unwrap()).unwrap();
+
+        let mut config = test_config(db_path);
+        config.seed_state_file = Some(seed_path);
+        (dir, config)
+    }
+
+    fn seed_with_one_candidate() -> PlannerStateFile {
+        PlannerStateFile {
+            namespaces: HashMap::new(),
+            history: HashMap::from([(
+                "serde".to_string(),
+                vec![kache_core::PrefetchCandidate::new(
+                    "serde-key".to_string(),
+                    "serde".to_string(),
+                )],
+            )]),
+            key_cache: HashMap::new(),
+        }
+    }
+
+    /// A seed carrying rows licenses replacing the pre-SQLite store.
+    #[tokio::test]
+    async fn startup_replaces_a_legacy_store_when_the_seed_carries_rows() {
+        let (dir, config) = legacy_store_with_seed(&seed_with_one_candidate());
+        let db_path = config.db_path.clone();
+
+        let _router = app(config).await.expect("a seeded upgrade must start");
+
+        assert!(db_path.is_file(), "the new planner db must be a file");
+        assert!(
+            std::fs::read_dir(dir.path())
+                .unwrap()
+                .filter_map(Result::ok)
+                .any(|e| e.file_name().to_string_lossy().contains(".surrealkv-")),
+            "the old store must be kept alongside"
+        );
+    }
+
+    /// An empty seed parses fine and writes nothing, so it licenses nothing.
+    #[tokio::test]
+    async fn startup_refuses_a_legacy_store_when_the_seed_is_empty() {
+        let (_dir, config) = legacy_store_with_seed(&PlannerStateFile::default());
+        let db_path = config.db_path.clone();
+
+        let err = app(config)
+            .await
+            .expect_err("an empty seed must not license replacing the store");
+        assert!(err.to_string().contains("--seed-state-file"), "{err}");
+        assert!(db_path.is_dir(), "the legacy store must stay in place");
+        assert_eq!(
+            std::fs::read(db_path.join("LOCK")).unwrap(),
+            b"legacy sentinel"
+        );
+    }
+
+    /// Configuring no seed at all is the same situation.
+    #[tokio::test]
+    async fn startup_refuses_a_legacy_store_when_no_seed_is_configured() {
+        let (_dir, mut config) = legacy_store_with_seed(&seed_with_one_candidate());
+        config.seed_state_file = None;
+        let db_path = config.db_path.clone();
+
+        assert!(app(config).await.is_err());
+        assert!(db_path.is_dir(), "the legacy store must stay in place");
+    }
+
+    /// The seed is read before the store is touched, so a broken one costs
+    /// nothing. Reading it afterwards left the store displaced by a seed that
+    /// then failed.
+    #[tokio::test]
+    async fn startup_reads_the_seed_before_touching_a_legacy_store() {
+        let (dir, config) = legacy_store_with_seed(&seed_with_one_candidate());
+        std::fs::write(config.seed_state_file.as_ref().unwrap(), b"{ not json").unwrap();
+        let db_path = config.db_path.clone();
+
+        assert!(app(config).await.is_err());
+        assert!(db_path.is_dir(), "the legacy store must stay in place");
+        assert_eq!(
+            std::fs::read_dir(dir.path()).unwrap().count(),
+            2,
+            "a failed start must leave no quarantine copy behind"
+        );
+    }
 }

--- a/crates/kache-service/src/state.rs
+++ b/crates/kache-service/src/state.rs
@@ -1,19 +1,15 @@
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use kache_core::{CandidateSource, PlannerDataSource, PrefetchCandidate};
+use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
-use surrealdb::{
-    Surreal,
-    engine::local::{Db, SurrealKv},
-};
 
 pub const DEFAULT_DB_PATH: &str = "/var/lib/kache/planner.db";
-
-const PLANNER_NAMESPACE: &str = "kache";
-const PLANNER_DATABASE: &str = "planner";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlannerStateFile {
@@ -31,29 +27,84 @@ pub struct NamespaceState {
     pub deps: HashMap<String, Vec<PrefetchCandidate>>,
 }
 
-#[derive(Debug, Clone)]
-pub struct SurrealPlannerRepository {
-    db: Surreal<Db>,
+/// The planner's artifact projections, held in a SQLite file.
+///
+/// The workload is two tables of `(key tuple) -> cache key`, read by equality
+/// and ordered by recency, written only while the leader seeds at startup.
+/// That is what the same SQLite the local cache index already uses does well,
+/// so the planner uses it too rather than a second storage engine.
+#[derive(Clone)]
+pub struct SqlitePlannerRepository {
+    db: Arc<Mutex<Connection>>,
 }
 
-impl SurrealPlannerRepository {
+impl std::fmt::Debug for SqlitePlannerRepository {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqlitePlannerRepository")
+            .finish_non_exhaustive()
+    }
+}
+
+impl SqlitePlannerRepository {
     pub async fn open(path: &Path) -> Result<Self> {
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || Self::open_blocking(&path))
+            .await
+            .context("joining planner db open task")?
+    }
+
+    fn open_blocking(path: &Path) -> Result<Self> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("creating planner db directory {}", parent.display()))?;
         }
 
-        let db = Surreal::new::<SurrealKv>(path.to_path_buf())
-            .await
-            .with_context(|| format!("opening embedded planner db at {}", path.display()))?;
-        db.use_ns(PLANNER_NAMESPACE)
-            .use_db(PLANNER_DATABASE)
-            .await
-            .context("selecting planner namespace/database")?;
+        // A pre-SQLite planner left a surrealkv *directory* at this path, and
+        // the path is a persistent volume that survives the upgrade. Opening a
+        // directory as a SQLite file fails on every start, which is the
+        // CrashLoopBackOff `init_schema` was hardened against. Move it aside
+        // instead: the tables are a projection the leader re-seeds.
+        if path.is_dir() {
+            let quarantine = quarantine_legacy_planner_db(path)?;
+            tracing::warn!(
+                path = %path.display(),
+                quarantine = %quarantine.display(),
+                "moved a pre-SQLite planner database aside; it is kept, not deleted, and can be removed once the new database is seeded"
+            );
+        }
 
-        let repo = Self { db };
-        repo.init_schema().await?;
-        Ok(repo)
+        let db = Connection::open(path)
+            .with_context(|| format!("opening planner db at {}", path.display()))?;
+
+        init_schema(&db)?;
+
+        Ok(Self {
+            db: Arc::new(Mutex::new(db)),
+        })
+    }
+
+    /// Run a closure against the connection, off the async executor.
+    ///
+    /// The point lookups here are microseconds against a local file, but
+    /// seeding walks a whole state file while the server is already answering
+    /// `/healthz`, so no query holds the runtime.
+    async fn run<T, F>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&Connection) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let db = Arc::clone(&self.db);
+        tokio::task::spawn_blocking(move || {
+            // A poisoned mutex is recovered rather than propagated: a panic in
+            // one of these closures leaves no half-applied SQLite state (an
+            // interrupted transaction rolls back when its guard drops), so
+            // refusing every later query would turn one panic into a
+            // permanently dead planner.
+            let conn = db.lock().unwrap_or_else(|err| err.into_inner());
+            f(&conn)
+        })
+        .await
+        .context("joining planner db task")?
     }
 
     pub async fn seed_from_state_file(&self, path: &Path) -> Result<()> {
@@ -65,249 +116,240 @@ impl SurrealPlannerRepository {
     }
 
     pub async fn seed_from_state(&self, state: PlannerStateFile) -> Result<()> {
-        for (namespace, namespace_state) in state.namespaces {
-            for (dep_key, candidates) in namespace_state.deps {
-                for candidate in candidates {
-                    self.upsert_namespace_artifact(&namespace, &dep_key, &candidate)
-                        .await?;
-                    self.upsert_crate_artifact(&candidate.crate_name, &candidate)
-                        .await?;
+        self.run(move |conn| {
+            // One transaction for the whole seed: a partially applied state
+            // file would serve plans from projections that never existed
+            // together.
+            let tx = conn.unchecked_transaction()?;
+
+            for (namespace, namespace_state) in state.namespaces {
+                for (dep_key, candidates) in namespace_state.deps {
+                    for candidate in candidates {
+                        upsert_namespace_artifact(&tx, &namespace, &dep_key, &candidate)?;
+                        upsert_crate_artifact(&tx, &candidate.crate_name, &candidate)?;
+                    }
                 }
             }
-        }
 
-        for (crate_name, candidates) in state.history {
-            for candidate in candidates {
-                self.upsert_crate_artifact(&crate_name, &candidate).await?;
+            for (crate_name, candidates) in state.history {
+                for candidate in candidates {
+                    upsert_crate_artifact(&tx, &crate_name, &candidate)?;
+                }
             }
-        }
 
-        for (crate_name, cache_keys) in state.key_cache {
-            for cache_key in cache_keys {
-                self.upsert_crate_artifact(
-                    &crate_name,
-                    &PrefetchCandidate::new(cache_key, crate_name.clone()),
-                )
-                .await?;
+            for (crate_name, cache_keys) in state.key_cache {
+                for cache_key in cache_keys {
+                    upsert_crate_artifact(
+                        &tx,
+                        &crate_name,
+                        &PrefetchCandidate::new(cache_key, crate_name.clone()),
+                    )?;
+                }
             }
-        }
 
-        Ok(())
-    }
-
-    /// Define the planner tables, tolerating a database that already has them.
-    ///
-    /// This runs on every `open`, so it runs on every process start — and the
-    /// planner db lives on a persistent volume in production. Plain
-    /// `DEFINE TABLE` errors with "The table 'x' already exists" the second
-    /// time, which is not a startup the service can recover from: it exits 1
-    /// and CrashLoopBackOffs forever while the volume keeps the tables that
-    /// caused it. `IF NOT EXISTS` makes each definition a no-op when present.
-    ///
-    /// Deliberately not `OVERWRITE`: on a SCHEMAFULL table that redefines
-    /// rather than skips, which would churn the schema on every start.
-    async fn init_schema(&self) -> Result<()> {
-        self.db
-            .query(
-                r#"
-DEFINE TABLE IF NOT EXISTS namespace_artifact SCHEMAFULL;
-DEFINE FIELD IF NOT EXISTS namespace ON namespace_artifact TYPE string;
-DEFINE FIELD IF NOT EXISTS dep_key ON namespace_artifact TYPE string;
-DEFINE FIELD IF NOT EXISTS cache_key ON namespace_artifact TYPE string;
-DEFINE FIELD IF NOT EXISTS crate_name ON namespace_artifact TYPE string;
-DEFINE FIELD IF NOT EXISTS last_seen_at ON namespace_artifact TYPE datetime;
-DEFINE INDEX IF NOT EXISTS namespace_dep_cache ON namespace_artifact FIELDS namespace, dep_key, cache_key UNIQUE;
-
-DEFINE TABLE IF NOT EXISTS crate_artifact SCHEMAFULL;
-DEFINE FIELD IF NOT EXISTS crate_name ON crate_artifact TYPE string;
-DEFINE FIELD IF NOT EXISTS cache_key ON crate_artifact TYPE string;
-DEFINE FIELD IF NOT EXISTS last_seen_at ON crate_artifact TYPE datetime;
-DEFINE INDEX IF NOT EXISTS crate_cache ON crate_artifact FIELDS crate_name, cache_key UNIQUE;
-"#,
-            )
-            .await
-            .context("initializing planner db schema")?
-            .check()
-            .context("validating planner db schema")?;
-
-        Ok(())
-    }
-
-    async fn upsert_namespace_artifact(
-        &self,
-        namespace: &str,
-        dep_key: &str,
-        candidate: &PrefetchCandidate,
-    ) -> Result<()> {
-        // Let the unique index own logical identity. Derived record ids can
-        // collide, while index-based upserts also update legacy-id rows.
-        self.db
-            .query(
-                r#"
-UPSERT namespace_artifact CONTENT {
-    namespace: $namespace,
-    dep_key: $dep_key,
-    cache_key: $cache_key,
-    crate_name: $crate_name,
-    last_seen_at: time::now()
-};
-"#,
-            )
-            .bind(("namespace", namespace.to_string()))
-            .bind(("dep_key", dep_key.to_string()))
-            .bind(("cache_key", candidate.cache_key.clone()))
-            .bind(("crate_name", candidate.crate_name.clone()))
-            .await
-            .context("upserting namespace artifact projection")?
-            .check()
-            .context("validating namespace artifact upsert")?;
-
-        Ok(())
-    }
-
-    async fn upsert_crate_artifact(
-        &self,
-        crate_name: &str,
-        candidate: &PrefetchCandidate,
-    ) -> Result<()> {
-        // See `upsert_namespace_artifact`: record ids are deliberately opaque.
-        self.db
-            .query(
-                r#"
-UPSERT crate_artifact CONTENT {
-    crate_name: $crate_name,
-    cache_key: $cache_key,
-    last_seen_at: time::now()
-};
-"#,
-            )
-            .bind(("crate_name", crate_name.to_string()))
-            .bind(("cache_key", candidate.cache_key.clone()))
-            .await
-            .context("upserting crate artifact projection")?
-            .check()
-            .context("validating crate artifact upsert")?;
-
-        Ok(())
+            tx.commit().context("committing planner seed")
+        })
+        .await
     }
 }
 
+/// Define the planner tables, tolerating a database that already has them.
+///
+/// This runs on every `open`, so it runs on every process start — and the
+/// planner db lives on a persistent volume in production. A schema statement
+/// that errors on the second start is not something the service recovers from:
+/// it exits 1 and CrashLoopBackOffs forever while the volume keeps the state
+/// that caused it. `IF NOT EXISTS` makes each statement a no-op when present.
+fn init_schema(db: &Connection) -> Result<()> {
+    db.pragma_update(None, "journal_mode", "WAL")
+        .context("enabling WAL on the planner db")?;
+    db.pragma_update(None, "synchronous", "NORMAL")
+        .context("setting synchronous on the planner db")?;
+    db.pragma_update(None, "busy_timeout", "5000")
+        .context("setting busy_timeout on the planner db")?;
+
+    // The key tuple *is* the primary key, so a namespace differing only by
+    // `/` vs `_` cannot collapse into one row the way a derived record id can.
+    db.execute_batch(
+        "CREATE TABLE IF NOT EXISTS namespace_artifact (
+            namespace    TEXT NOT NULL,
+            dep_key      TEXT NOT NULL,
+            cache_key    TEXT NOT NULL,
+            crate_name   TEXT NOT NULL,
+            last_seen_at INTEGER NOT NULL,
+            PRIMARY KEY (namespace, dep_key, cache_key)
+        ) WITHOUT ROWID;
+
+        CREATE TABLE IF NOT EXISTS crate_artifact (
+            crate_name   TEXT NOT NULL,
+            cache_key    TEXT NOT NULL,
+            last_seen_at INTEGER NOT NULL,
+            PRIMARY KEY (crate_name, cache_key)
+        ) WITHOUT ROWID;",
+    )
+    .context("initializing planner db schema")?;
+
+    Ok(())
+}
+
+fn upsert_namespace_artifact(
+    db: &Connection,
+    namespace: &str,
+    dep_key: &str,
+    candidate: &PrefetchCandidate,
+) -> Result<()> {
+    db.execute(
+        "INSERT INTO namespace_artifact
+             (namespace, dep_key, cache_key, crate_name, last_seen_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT (namespace, dep_key, cache_key) DO UPDATE SET
+             crate_name   = excluded.crate_name,
+             last_seen_at = excluded.last_seen_at",
+        params![
+            namespace,
+            dep_key,
+            candidate.cache_key,
+            candidate.crate_name,
+            now_nanos(),
+        ],
+    )
+    .context("upserting namespace artifact projection")?;
+
+    Ok(())
+}
+
+fn upsert_crate_artifact(
+    db: &Connection,
+    crate_name: &str,
+    candidate: &PrefetchCandidate,
+) -> Result<()> {
+    db.execute(
+        "INSERT INTO crate_artifact (crate_name, cache_key, last_seen_at)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT (crate_name, cache_key) DO UPDATE SET
+             last_seen_at = excluded.last_seen_at",
+        params![crate_name, candidate.cache_key, now_nanos()],
+    )
+    .context("upserting crate artifact projection")?;
+
+    Ok(())
+}
+
 #[async_trait]
-impl PlannerDataSource for SurrealPlannerRepository {
+impl PlannerDataSource for SqlitePlannerRepository {
     async fn shard_candidates(
         &self,
         namespace: &str,
         deps: &[(String, String)],
     ) -> Result<Vec<PrefetchCandidate>> {
-        let mut seen = HashSet::new();
-        let mut candidates = Vec::new();
+        let namespace = namespace.to_string();
+        let dep_keys: Vec<String> = deps.iter().map(|(n, v)| dep_key(n, v)).collect();
 
-        for (name, version) in deps {
-            let dep_key = dep_key(name, version);
-            let mut response = self
-                .db
-                .query(
-                    r#"
-SELECT cache_key, crate_name
-     , last_seen_at
-FROM namespace_artifact
-WHERE namespace = $namespace AND dep_key = $dep_key
-ORDER BY last_seen_at DESC;
-"#,
+        self.run(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT cache_key, crate_name
+                     FROM namespace_artifact
+                     WHERE namespace = ?1 AND dep_key = ?2
+                     ORDER BY last_seen_at DESC, cache_key ASC",
                 )
-                .bind(("namespace", namespace.to_string()))
-                .bind(("dep_key", dep_key.clone()))
-                .await
-                .context("querying namespace artifact projections")?
-                .check()
-                .context("validating namespace artifact query")?;
+                .context("preparing namespace artifact query")?;
 
-            let cache_keys: Vec<String> =
-                response.take("cache_key").context("decoding cache keys")?;
-            let crate_names: Vec<String> = response
-                .take("crate_name")
-                .context("decoding crate names")?;
+            let mut seen = HashSet::new();
+            let mut candidates = Vec::new();
 
-            for (cache_key, crate_name) in cache_keys.into_iter().zip(crate_names) {
-                if seen.insert(cache_key.clone()) {
-                    candidates.push(
-                        PrefetchCandidate::new(cache_key, crate_name)
-                            .with_source(CandidateSource::Shard),
-                    );
+            for dep_key in &dep_keys {
+                let rows = stmt
+                    .query_map(params![&namespace, dep_key], |row| {
+                        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                    })
+                    .context("querying namespace artifact projections")?;
+
+                for row in rows {
+                    let (cache_key, crate_name) =
+                        row.context("decoding namespace artifact projection")?;
+                    if seen.insert(cache_key.clone()) {
+                        candidates.push(
+                            PrefetchCandidate::new(cache_key, crate_name)
+                                .with_source(CandidateSource::Shard),
+                        );
+                    }
                 }
             }
-        }
 
-        Ok(candidates)
+            Ok(candidates)
+        })
+        .await
     }
 
     async fn history_candidates(&self, crate_names: &[String]) -> Result<Vec<PrefetchCandidate>> {
-        let mut seen = HashSet::new();
-        let mut candidates = Vec::new();
+        let crate_names = crate_names.to_vec();
 
-        for crate_name in crate_names {
-            let mut response = self
-                .db
-                .query(
-                    r#"
-SELECT cache_key, crate_name
-     , last_seen_at
-FROM crate_artifact
-WHERE crate_name = $crate_name
-ORDER BY last_seen_at DESC;
-"#,
+        self.run(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT cache_key, crate_name
+                     FROM crate_artifact
+                     WHERE crate_name = ?1
+                     ORDER BY last_seen_at DESC, cache_key ASC",
                 )
-                .bind(("crate_name", crate_name.clone()))
-                .await
-                .context("querying crate artifact history")?
-                .check()
-                .context("validating crate artifact history query")?;
+                .context("preparing crate artifact history query")?;
 
-            let cache_keys: Vec<String> =
-                response.take("cache_key").context("decoding cache keys")?;
-            let crate_names: Vec<String> = response
-                .take("crate_name")
-                .context("decoding crate names")?;
+            let mut seen = HashSet::new();
+            let mut candidates = Vec::new();
 
-            for (cache_key, row_crate_name) in cache_keys.into_iter().zip(crate_names) {
-                if seen.insert(cache_key.clone()) {
-                    candidates.push(
-                        PrefetchCandidate::new(cache_key, row_crate_name)
-                            .with_source(CandidateSource::History),
-                    );
+            for crate_name in &crate_names {
+                let rows = stmt
+                    .query_map(params![crate_name], |row| {
+                        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                    })
+                    .context("querying crate artifact history")?;
+
+                for row in rows {
+                    let (cache_key, row_crate_name) =
+                        row.context("decoding crate artifact history")?;
+                    if seen.insert(cache_key.clone()) {
+                        candidates.push(
+                            PrefetchCandidate::new(cache_key, row_crate_name)
+                                .with_source(CandidateSource::History),
+                        );
+                    }
                 }
             }
-        }
 
-        Ok(candidates)
+            Ok(candidates)
+        })
+        .await
     }
 
     async fn key_cache_keys_for_crate(&self, crate_name: &str) -> Result<Vec<String>> {
-        let mut response = self
-            .db
-            .query(
-                r#"
-SELECT cache_key, last_seen_at
-FROM crate_artifact
-WHERE crate_name = $crate_name
-ORDER BY last_seen_at DESC;
-"#,
-            )
-            .bind(("crate_name", crate_name.to_string()))
-            .await
-            .context("querying crate cache keys")?
-            .check()
-            .context("validating crate cache key query")?;
+        let crate_name = crate_name.to_string();
 
-        response
-            .take("cache_key")
-            .context("decoding crate cache keys")
+        self.run(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT cache_key
+                     FROM crate_artifact
+                     WHERE crate_name = ?1
+                     ORDER BY last_seen_at DESC, cache_key ASC",
+                )
+                .context("preparing crate cache key query")?;
+
+            let keys = stmt
+                .query_map(params![crate_name], |row| row.get::<_, String>(0))
+                .context("querying crate cache keys")?
+                .collect::<rusqlite::Result<Vec<String>>>()
+                .context("decoding crate cache keys")?;
+
+            Ok(keys)
+        })
+        .await
     }
 
     async fn identity_candidates(&self, _identity_key: &str) -> Result<Vec<PrefetchCandidate>> {
         // Identity manifests live on the object store the daemon reads, not in
-        // the planner's Surreal projections. An empty list lets shards/history
-        // fill the plan; the daemon fallback still fetches the object.
+        // the planner's projections. An empty list lets shards/history fill the
+        // plan; the daemon fallback still fetches the object.
         Ok(Vec::new())
     }
 }
@@ -316,36 +358,103 @@ fn dep_key(name: &str, version: &str) -> String {
     format!("{name}@{version}")
 }
 
+/// Recency stamp for the projections, in nanoseconds since the epoch.
+///
+/// Nanoseconds rather than millis because seeding writes a whole state file in
+/// a tight loop: at coarser resolution most rows would share a stamp and the
+/// recency ordering would collapse. Queries still tie-break on `cache_key` so
+/// the order is total even when two rows do land on the same instant.
+fn now_nanos() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(0)
+}
+
+/// Move a pre-SQLite planner database aside (to `<name>.surrealkv-<millis>`)
+/// so a fresh one can be created in place. The old state is kept, not deleted:
+/// it is an operator's data on a persistent volume, and the planner has no
+/// business destroying it.
+fn quarantine_legacy_planner_db(path: &Path) -> Result<PathBuf> {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("planner.db");
+    let quarantine = path.with_file_name(format!("{file_name}.surrealkv-{millis}"));
+
+    std::fs::rename(path, &quarantine).with_context(|| {
+        format!(
+            "moving the pre-SQLite planner database {} aside to {}",
+            path.display(),
+            quarantine.display()
+        )
+    })?;
+
+    Ok(quarantine)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     /// Defining the schema against a db that already has it must succeed.
     ///
-    /// Every other test here starts from an empty tempdir, so the suite only
-    /// ever exercised the first-ever start. Production does not: the planner db
-    /// sits on a persistent volume, so the *second* start is the normal case
-    /// and the only one that can hit "table already exists". That gap let a
-    /// non-idempotent `DEFINE TABLE` reach production, where the planner exited
-    /// 1 on boot and CrashLoopBackOffed ~3700 times over 13 days without ever
-    /// becoming ready.
-    ///
-    /// Re-runs `init_schema` rather than reopening the file: surrealkv holds an
-    /// exclusive LOCK that a dropped handle does not release synchronously, so
-    /// a genuine reopen would need a sleep-and-retry and would be flaky in CI.
-    /// A restarting pod runs exactly this statement against exactly this state.
+    /// Every other test here starts from an empty tempdir, so without this the
+    /// suite would only ever exercise the first-ever start. Production does
+    /// not: the planner db sits on a persistent volume, so the *second* start
+    /// is the normal case. That gap once let a non-idempotent schema statement
+    /// reach production, where the planner exited 1 on boot and
+    /// CrashLoopBackOffed ~3700 times over 13 days without becoming ready.
     #[tokio::test]
     async fn init_schema_is_idempotent() {
         let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("planner.db");
 
         // `open` defines the schema once.
-        let repo = SurrealPlannerRepository::open(&dir.path().join("planner.db"))
-            .await
-            .unwrap();
+        let repo = SqlitePlannerRepository::open(&db_path).await.unwrap();
+        drop(repo);
 
-        repo.init_schema()
+        // A restarting pod runs `open` again against exactly this state.
+        SqlitePlannerRepository::open(&db_path)
             .await
-            .expect("defining the schema against an existing schema must succeed");
+            .expect("reopening a database that already has the schema must succeed");
+    }
+
+    /// A surrealkv directory left at the db path must not wedge startup.
+    #[tokio::test]
+    async fn open_quarantines_a_legacy_planner_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("planner.db");
+
+        // surrealkv stored the planner as a directory, not a file.
+        std::fs::create_dir(&db_path).unwrap();
+        std::fs::write(db_path.join("LOCK"), b"").unwrap();
+
+        let repo = SqlitePlannerRepository::open(&db_path).await.unwrap();
+
+        assert!(db_path.is_file(), "the new planner db must be a file");
+        assert!(
+            repo.key_cache_keys_for_crate("anything")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let quarantined: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains(".surrealkv-"))
+            .collect();
+        assert_eq!(
+            quarantined.len(),
+            1,
+            "the old directory must be kept, not deleted: {quarantined:?}"
+        );
     }
 
     #[test]
@@ -354,49 +463,49 @@ mod tests {
         assert_eq!(dep_key("", ""), "@");
     }
 
+    /// Namespaces differing only by `/` vs `_` must stay separate rows.
+    ///
+    /// v0.16 derived a record id by replacing punctuation, so `linux/hash/debug`
+    /// and `linux_hash_debug` collapsed onto one row and each upsert clobbered
+    /// the other's `crate_name`. The key tuple is now the primary key, so the
+    /// collision is unrepresentable — this test holds the guarantee in place.
     #[tokio::test]
-    async fn namespace_upsert_preserves_legacy_row_and_colliding_tuple() {
+    async fn namespace_upsert_keeps_punctuation_variant_namespaces_apart() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = SurrealPlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
             .await
             .unwrap();
 
-        // v0.16 generated this lossy id for both `linux/hash/debug` and
-        // `linux_hash_debug`. Keep it literal so this test guards compatibility
-        // with databases written by that release, independent of new code.
-        repo.db
-            .query(
-                r#"
-UPSERT type::record("namespace_artifact", $id) CONTENT {
-    namespace: "linux/hash/debug",
-    dep_key: "serde@1.0.0",
-    cache_key: "shared-key",
-    crate_name: "legacy-value",
-    last_seen_at: time::now()
-};
-"#,
-            )
-            .bind((
-                "id",
-                "linux_hash_debug__serde_1_0_0__shared-key".to_string(),
-            ))
-            .await
-            .unwrap()
-            .check()
-            .unwrap();
-
-        repo.upsert_namespace_artifact(
-            "linux/hash/debug",
-            "serde@1.0.0",
-            &PrefetchCandidate::new("shared-key".to_string(), "slash-value".to_string()),
-        )
-        .await
-        .unwrap();
-        repo.upsert_namespace_artifact(
-            "linux_hash_debug",
-            "serde@1.0.0",
-            &PrefetchCandidate::new("shared-key".to_string(), "underscore-value".to_string()),
-        )
+        repo.seed_from_state(PlannerStateFile {
+            namespaces: HashMap::from([
+                (
+                    "linux/hash/debug".to_string(),
+                    NamespaceState {
+                        deps: HashMap::from([(
+                            "serde@1.0.0".to_string(),
+                            vec![PrefetchCandidate::new(
+                                "shared-key".to_string(),
+                                "slash-value".to_string(),
+                            )],
+                        )]),
+                    },
+                ),
+                (
+                    "linux_hash_debug".to_string(),
+                    NamespaceState {
+                        deps: HashMap::from([(
+                            "serde@1.0.0".to_string(),
+                            vec![PrefetchCandidate::new(
+                                "shared-key".to_string(),
+                                "underscore-value".to_string(),
+                            )],
+                        )]),
+                    },
+                ),
+            ]),
+            history: HashMap::new(),
+            key_cache: HashMap::new(),
+        })
         .await
         .unwrap();
 
@@ -418,40 +527,34 @@ UPSERT type::record("namespace_artifact", $id) CONTENT {
         assert_eq!(underscore[0].crate_name, "underscore-value");
     }
 
+    /// The crate projection has the same punctuation guarantee.
     #[tokio::test]
-    async fn crate_upsert_preserves_legacy_row_and_colliding_tuple() {
+    async fn crate_upsert_keeps_punctuation_variant_crates_apart() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = SurrealPlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
             .await
             .unwrap();
 
-        // v0.16 generated this same lossy id for `serde/json` and `serde_json`.
-        repo.db
-            .query(
-                r#"
-UPSERT type::record("crate_artifact", $id) CONTENT {
-    crate_name: "serde/json",
-    cache_key: "shared-key",
-    last_seen_at: time::now()
-};
-"#,
-            )
-            .bind(("id", "serde_json__shared-key".to_string()))
-            .await
-            .unwrap()
-            .check()
-            .unwrap();
-
-        repo.upsert_crate_artifact(
-            "serde/json",
-            &PrefetchCandidate::new("shared-key".to_string(), "serde/json".to_string()),
-        )
-        .await
-        .unwrap();
-        repo.upsert_crate_artifact(
-            "serde_json",
-            &PrefetchCandidate::new("shared-key".to_string(), "serde_json".to_string()),
-        )
+        repo.seed_from_state(PlannerStateFile {
+            namespaces: HashMap::new(),
+            history: HashMap::from([
+                (
+                    "serde/json".to_string(),
+                    vec![PrefetchCandidate::new(
+                        "shared-key".to_string(),
+                        "serde/json".to_string(),
+                    )],
+                ),
+                (
+                    "serde_json".to_string(),
+                    vec![PrefetchCandidate::new(
+                        "shared-key".to_string(),
+                        "serde_json".to_string(),
+                    )],
+                ),
+            ]),
+            key_cache: HashMap::new(),
+        })
         .await
         .unwrap();
 
@@ -465,12 +568,49 @@ UPSERT type::record("crate_artifact", $id) CONTENT {
         );
     }
 
+    /// Re-seeding the same tuple updates it instead of erroring or duplicating.
+    #[tokio::test]
+    async fn seeding_twice_updates_in_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
+            .await
+            .unwrap();
+
+        let state = |crate_name: &str| PlannerStateFile {
+            namespaces: HashMap::from([(
+                "ns".to_string(),
+                NamespaceState {
+                    deps: HashMap::from([(
+                        "serde@1.0.0".to_string(),
+                        vec![PrefetchCandidate::new(
+                            "shared-key".to_string(),
+                            crate_name.to_string(),
+                        )],
+                    )]),
+                },
+            )]),
+            history: HashMap::new(),
+            key_cache: HashMap::new(),
+        };
+
+        repo.seed_from_state(state("first")).await.unwrap();
+        repo.seed_from_state(state("second")).await.unwrap();
+
+        let candidates = repo
+            .shard_candidates("ns", &[("serde".to_string(), "1.0.0".to_string())])
+            .await
+            .unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].crate_name, "second");
+    }
+
     #[tokio::test]
     async fn shard_candidates_dedupes_repeated_cache_keys_across_deps() {
         // The same cache_key seen under two different deps must be returned
         // once — the planner's `seen` set guards against duplicate prefetch.
         let dir = tempfile::tempdir().unwrap();
-        let repo = SurrealPlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
             .await
             .unwrap();
         repo.seed_from_state(PlannerStateFile {
@@ -519,7 +659,7 @@ UPSERT type::record("crate_artifact", $id) CONTENT {
     #[tokio::test]
     async fn queries_return_empty_for_unknown_keys() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = SurrealPlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
             .await
             .unwrap();
 
@@ -546,7 +686,7 @@ UPSERT type::record("crate_artifact", $id) CONTENT {
     #[tokio::test]
     async fn seed_from_state_file_rejects_missing_file() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = SurrealPlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
             .await
             .unwrap();
         let err = repo
@@ -555,10 +695,30 @@ UPSERT type::record("crate_artifact", $id) CONTENT {
         assert!(err.is_err());
     }
 
+    /// A seed that fails partway must leave no rows behind.
+    #[tokio::test]
+    async fn seed_from_state_file_rejects_malformed_json_without_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
+            .await
+            .unwrap();
+
+        let seed_path = dir.path().join("planner-state.json");
+        std::fs::write(&seed_path, b"{ not json").unwrap();
+
+        assert!(repo.seed_from_state_file(&seed_path).await.is_err());
+        assert!(
+            repo.history_candidates(&["serde".to_string()])
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
     #[tokio::test]
     async fn repository_resolves_namespace_candidates_from_seed_state() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = SurrealPlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
             .await
             .unwrap();
         repo.seed_from_state(PlannerStateFile {
@@ -615,7 +775,7 @@ UPSERT type::record("crate_artifact", $id) CONTENT {
         )
         .unwrap();
 
-        let repo = SurrealPlannerRepository::open(&db_path).await.unwrap();
+        let repo = SqlitePlannerRepository::open(&db_path).await.unwrap();
         repo.seed_from_state_file(&seed_path).await.unwrap();
 
         let history = repo
@@ -627,5 +787,36 @@ UPSERT type::record("crate_artifact", $id) CONTENT {
 
         let keys = repo.key_cache_keys_for_crate("tokio").await.unwrap();
         assert_eq!(keys, vec!["tokio-key".to_string()]);
+    }
+
+    /// State survives a process restart against the same file.
+    #[tokio::test]
+    async fn seeded_state_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("planner.db");
+
+        let repo = SqlitePlannerRepository::open(&db_path).await.unwrap();
+        repo.seed_from_state(PlannerStateFile {
+            namespaces: HashMap::new(),
+            history: HashMap::from([(
+                "serde".to_string(),
+                vec![PrefetchCandidate::new(
+                    "serde-key".to_string(),
+                    "serde".to_string(),
+                )],
+            )]),
+            key_cache: HashMap::new(),
+        })
+        .await
+        .unwrap();
+        drop(repo);
+
+        let reopened = SqlitePlannerRepository::open(&db_path).await.unwrap();
+        let history = reopened
+            .history_candidates(&["serde".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].cache_key, "serde-key");
     }
 }

--- a/crates/kache-service/src/state.rs
+++ b/crates/kache-service/src/state.rs
@@ -21,6 +21,25 @@ pub struct PlannerStateFile {
     pub key_cache: HashMap<String, Vec<String>>,
 }
 
+impl PlannerStateFile {
+    pub fn read_from(path: &Path) -> Result<Self> {
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("reading planner seed state from {}", path.display()))?;
+        serde_json::from_slice(&bytes)
+            .with_context(|| format!("parsing planner seed state from {}", path.display()))
+    }
+
+    /// Whether seeding this would write no rows. Every field carries
+    /// `#[serde(default)]`, so `{}` parses successfully and means exactly this.
+    pub fn is_empty(&self) -> bool {
+        self.namespaces
+            .values()
+            .all(|namespace| namespace.deps.values().all(|c| c.is_empty()))
+            && self.history.values().all(|c| c.is_empty())
+            && self.key_cache.values().all(|k| k.is_empty())
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NamespaceState {
     #[serde(default)]
@@ -50,12 +69,19 @@ impl std::fmt::Debug for SqlitePlannerRepository {
 /// Only matters when the db path still holds a pre-SQLite planner database.
 /// Those rows can only ever have come from a seed file — nothing else in the
 /// service writes them — so whether the old store is disposable depends
-/// entirely on whether a seed is configured to put them back.
+/// entirely on whether rows are about to be put back.
+///
+/// `Reseeded` is a claim about a seed the caller has ALREADY read, parsed and
+/// found non-empty; deriving it from "a `--seed-state-file` was configured"
+/// would promise a rebuild that a missing, malformed or `{}` seed never
+/// delivers. It still does not promise the new rows match the old ones: seeding
+/// upserts and never clears, so a seed narrower than the accumulated store
+/// leaves the difference behind in the quarantined copy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SeedPlan {
-    /// A seed file follows, so a pre-SQLite database can be moved aside.
+    /// Non-empty seed state in hand, so a pre-SQLite database can be moved aside.
     Reseeded,
-    /// Nothing follows. A pre-SQLite database is the only copy of that state.
+    /// Nothing to write. A pre-SQLite database is the only copy of that state.
     None,
 }
 
@@ -89,10 +115,12 @@ impl SqlitePlannerRepository {
         if path.is_dir() {
             if seed_plan == SeedPlan::None {
                 anyhow::bail!(
-                    "planner database {} is a pre-SQLite store and no seed state file is \
-                     configured to rebuild it. Its rows are the only copy. Configure \
-                     --seed-state-file (planner.seedStateFile) to repopulate the projections, \
-                     or point --db-path (planner.dbPath) at a new path and leave this one alone.",
+                    "planner database {} is a pre-SQLite store and there is no non-empty seed \
+                     state to rebuild it from, so replacing it would drop whatever it holds. \
+                     Point --seed-state-file (planner.seedStateFile) at seed state that covers \
+                     what this planner should serve, or point --db-path (planner.dbPath) at a \
+                     new path — that starts from empty projections and every plan falls back to \
+                     the client until something seeds it, but it leaves this store untouched.",
                     path.display()
                 );
             }
@@ -140,11 +168,8 @@ impl SqlitePlannerRepository {
     }
 
     pub async fn seed_from_state_file(&self, path: &Path) -> Result<()> {
-        let bytes = std::fs::read(path)
-            .with_context(|| format!("reading planner seed state from {}", path.display()))?;
-        let state: PlannerStateFile = serde_json::from_slice(&bytes)
-            .with_context(|| format!("parsing planner seed state from {}", path.display()))?;
-        self.seed_from_state(state).await
+        self.seed_from_state(PlannerStateFile::read_from(path)?)
+            .await
     }
 
     pub async fn seed_from_state(&self, state: PlannerStateFile) -> Result<()> {
@@ -792,17 +817,46 @@ mod tests {
         );
     }
 
-    /// A seed that fails after an earlier write must leave no rows behind.
+    /// A seed that fails after an earlier write must undo that write, and must
+    /// not touch rows an earlier successful seed committed.
     ///
     /// Seeding a namespace writes both projections per candidate, so dropping
     /// `crate_artifact` makes the namespace insert succeed and the very next
     /// statement fail — a genuine mid-transaction failure. Without the enclosing
-    /// transaction the namespace row would survive and the planner would serve
-    /// half a state file.
+    /// transaction the new namespace row would survive and the planner would
+    /// serve half a state file. The pre-existing row makes the difference
+    /// between rolling back and simply wiping the table visible; an
+    /// implementation that "cleaned up" by deleting everything on error would
+    /// pass against an empty fixture.
+    ///
+    /// This proves rollback of the failing seed, not that every partial-seed
+    /// shape rolls back: one transaction per candidate would also pass here.
     #[tokio::test]
     async fn seed_rolls_back_when_a_write_fails_partway() {
         let dir = tempfile::tempdir().unwrap();
         let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
+            .await
+            .unwrap();
+
+        let namespace_seed = |dep: &str, cache_key: &str| PlannerStateFile {
+            namespaces: HashMap::from([(
+                "ns".to_string(),
+                NamespaceState {
+                    deps: HashMap::from([(
+                        dep.to_string(),
+                        vec![PrefetchCandidate::new(
+                            cache_key.to_string(),
+                            "serde".to_string(),
+                        )],
+                    )]),
+                },
+            )]),
+            history: HashMap::new(),
+            key_cache: HashMap::new(),
+        };
+
+        // Committed state the failing seed must leave alone.
+        repo.seed_from_state(namespace_seed("committed@1.0.0", "committed-key"))
             .await
             .unwrap();
 
@@ -814,32 +868,27 @@ mod tests {
         .unwrap();
 
         let err = repo
-            .seed_from_state(PlannerStateFile {
-                namespaces: HashMap::from([(
-                    "ns".to_string(),
-                    NamespaceState {
-                        deps: HashMap::from([(
-                            "serde@1.0.0".to_string(),
-                            vec![PrefetchCandidate::new(
-                                "serde-key".to_string(),
-                                "serde".to_string(),
-                            )],
-                        )]),
-                    },
-                )]),
-                history: HashMap::new(),
-                key_cache: HashMap::new(),
-            })
+            .seed_from_state(namespace_seed("serde@1.0.0", "serde-key"))
             .await;
         assert!(err.is_err(), "the seed must fail once a write fails");
 
+        let survivors = repo
+            .shard_candidates("ns", &[("committed".to_string(), "1.0.0".to_string())])
+            .await
+            .unwrap();
+        assert_eq!(
+            survivors.iter().map(|c| &c.cache_key).collect::<Vec<_>>(),
+            ["committed-key"],
+            "the failed seed must not disturb already committed rows"
+        );
+
         let rows: i64 = repo
             .run(|conn| {
-                Ok(
-                    conn.query_row("SELECT COUNT(*) FROM namespace_artifact", [], |row| {
-                        row.get(0)
-                    })?,
-                )
+                Ok(conn.query_row(
+                    "SELECT COUNT(*) FROM namespace_artifact WHERE cache_key = ?1",
+                    ["serde-key"],
+                    |row| row.get(0),
+                )?)
             })
             .await
             .unwrap();
@@ -874,33 +923,63 @@ mod tests {
             key_cache: HashMap::new(),
         };
 
-        // Seeded oldest-first, and named so that a cache_key tie-break alone
-        // would order them the other way round.
-        repo.seed_from_state(seed("zzz-older")).await.unwrap();
-        repo.seed_from_state(seed("aaa-newer")).await.unwrap();
+        let order = async |repo: &SqlitePlannerRepository| {
+            let shard: Vec<String> = repo
+                .shard_candidates("ns", &[("serde".to_string(), "1.0.0".to_string())])
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|c| c.cache_key)
+                .collect();
+            let history: Vec<String> = repo
+                .history_candidates(&["serde".to_string()])
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|c| c.cache_key)
+                .collect();
+            let keys = repo.key_cache_keys_for_crate("serde").await.unwrap();
+            (shard, history, keys)
+        };
 
-        let shard = repo
-            .shard_candidates("ns", &[("serde".to_string(), "1.0.0".to_string())])
-            .await
-            .unwrap();
-        assert_eq!(
-            shard.iter().map(|c| &c.cache_key).collect::<Vec<_>>(),
-            ["aaa-newer", "zzz-older"]
-        );
+        // Seeded oldest-first, and named so the NEWER key sorts LAST
+        // alphabetically: ordering by `cache_key` alone, or stamping every row
+        // identically and falling through to the tie-break, gives the reverse
+        // of what these assertions demand.
+        repo.seed_from_state(seed("aaa-older")).await.unwrap();
+        repo.seed_from_state(seed("zzz-newer")).await.unwrap();
 
-        assert_eq!(
-            repo.key_cache_keys_for_crate("serde").await.unwrap(),
-            ["aaa-newer", "zzz-older"]
-        );
+        let expected = ["zzz-newer".to_string(), "aaa-older".to_string()];
+        let (shard, history, keys) = order(&repo).await;
+        assert_eq!(shard, expected);
+        assert_eq!(history, expected);
+        assert_eq!(keys, expected);
 
-        let history = repo
-            .history_candidates(&["serde".to_string()])
-            .await
-            .unwrap();
-        assert_eq!(
-            history.iter().map(|c| &c.cache_key).collect::<Vec<_>>(),
-            ["aaa-newer", "zzz-older"]
-        );
+        // Re-seeding an existing tuple must refresh its recency, not just leave
+        // the row alone. Rewriting the stamps to known values first makes that
+        // observable without depending on clock resolution — and keeps the
+        // ordering they already imply, so an upsert that never refreshes
+        // `last_seen_at` leaves the assertions below reading the old order
+        // rather than falling into the `cache_key` tie-break that would happen
+        // to match.
+        repo.run(|conn| {
+            conn.execute_batch(
+                "UPDATE namespace_artifact SET last_seen_at = 1 WHERE cache_key = 'aaa-older';
+                 UPDATE namespace_artifact SET last_seen_at = 2 WHERE cache_key = 'zzz-newer';
+                 UPDATE crate_artifact SET last_seen_at = 1 WHERE cache_key = 'aaa-older';
+                 UPDATE crate_artifact SET last_seen_at = 2 WHERE cache_key = 'zzz-newer';",
+            )?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+        repo.seed_from_state(seed("aaa-older")).await.unwrap();
+
+        let refreshed = ["aaa-older".to_string(), "zzz-newer".to_string()];
+        let (shard, history, keys) = order(&repo).await;
+        assert_eq!(shard, refreshed, "the re-seeded key must sort first again");
+        assert_eq!(history, refreshed);
+        assert_eq!(keys, refreshed);
     }
 
     #[tokio::test]

--- a/crates/kache-service/src/state.rs
+++ b/crates/kache-service/src/state.rs
@@ -45,31 +45,63 @@ impl std::fmt::Debug for SqlitePlannerRepository {
     }
 }
 
+/// Whether the caller will repopulate the projections after `open`.
+///
+/// Only matters when the db path still holds a pre-SQLite planner database.
+/// Those rows can only ever have come from a seed file — nothing else in the
+/// service writes them — so whether the old store is disposable depends
+/// entirely on whether a seed is configured to put them back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeedPlan {
+    /// A seed file follows, so a pre-SQLite database can be moved aside.
+    Reseeded,
+    /// Nothing follows. A pre-SQLite database is the only copy of that state.
+    None,
+}
+
 impl SqlitePlannerRepository {
-    pub async fn open(path: &Path) -> Result<Self> {
+    pub async fn open(path: &Path, seed_plan: SeedPlan) -> Result<Self> {
         let path = path.to_path_buf();
-        tokio::task::spawn_blocking(move || Self::open_blocking(&path))
+        tokio::task::spawn_blocking(move || Self::open_blocking(&path, seed_plan))
             .await
             .context("joining planner db open task")?
     }
 
-    fn open_blocking(path: &Path) -> Result<Self> {
+    fn open_blocking(path: &Path, seed_plan: SeedPlan) -> Result<Self> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("creating planner db directory {}", parent.display()))?;
         }
 
         // A pre-SQLite planner left a surrealkv *directory* at this path, and
-        // the path is a persistent volume that survives the upgrade. Opening a
-        // directory as a SQLite file fails on every start, which is the
-        // CrashLoopBackOff `init_schema` was hardened against. Move it aside
-        // instead: the tables are a projection the leader re-seeds.
+        // under `planner.persistence.type=pvc` that path survives the upgrade.
+        // Opening a directory as a SQLite file fails on every start, which is
+        // the CrashLoopBackOff `init_schema` was hardened against, so the old
+        // store cannot simply stay where it is.
+        //
+        // What it may be replaced with depends on the seed. With one
+        // configured, the leader refills the projections seconds later and
+        // moving the old store aside costs nothing. Without one, those rows are
+        // the only copy: a service that quietly replaced them with empty tables
+        // would come up ready and answer every request with a fallback plan,
+        // which looks exactly like a cache with nothing worth prefetching.
+        // Refuse instead, and say what to do about it.
         if path.is_dir() {
+            if seed_plan == SeedPlan::None {
+                anyhow::bail!(
+                    "planner database {} is a pre-SQLite store and no seed state file is \
+                     configured to rebuild it. Its rows are the only copy. Configure \
+                     --seed-state-file (planner.seedStateFile) to repopulate the projections, \
+                     or point --db-path (planner.dbPath) at a new path and leave this one alone.",
+                    path.display()
+                );
+            }
+
             let quarantine = quarantine_legacy_planner_db(path)?;
             tracing::warn!(
                 path = %path.display(),
                 quarantine = %quarantine.display(),
-                "moved a pre-SQLite planner database aside; it is kept, not deleted, and can be removed once the new database is seeded"
+                "moved a pre-SQLite planner database aside; the configured seed state file will repopulate the projections. The old store is kept, not deleted, and can be removed once the new database is seeded"
             );
         }
 
@@ -415,26 +447,33 @@ mod tests {
         let db_path = dir.path().join("planner.db");
 
         // `open` defines the schema once.
-        let repo = SqlitePlannerRepository::open(&db_path).await.unwrap();
+        let repo = SqlitePlannerRepository::open(&db_path, SeedPlan::None)
+            .await
+            .unwrap();
         drop(repo);
 
         // A restarting pod runs `open` again against exactly this state.
-        SqlitePlannerRepository::open(&db_path)
+        SqlitePlannerRepository::open(&db_path, SeedPlan::None)
             .await
             .expect("reopening a database that already has the schema must succeed");
     }
 
-    /// A surrealkv directory left at the db path must not wedge startup.
+    /// surrealkv stored the planner as a directory, not a file.
+    fn write_legacy_planner_dir(db_path: &Path) {
+        std::fs::create_dir(db_path).unwrap();
+        std::fs::write(db_path.join("LOCK"), b"legacy sentinel").unwrap();
+    }
+
+    /// With a seed configured, a surrealkv directory is moved aside, not deleted.
     #[tokio::test]
-    async fn open_quarantines_a_legacy_planner_directory() {
+    async fn open_quarantines_a_legacy_planner_directory_when_a_seed_follows() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("planner.db");
+        write_legacy_planner_dir(&db_path);
 
-        // surrealkv stored the planner as a directory, not a file.
-        std::fs::create_dir(&db_path).unwrap();
-        std::fs::write(db_path.join("LOCK"), b"").unwrap();
-
-        let repo = SqlitePlannerRepository::open(&db_path).await.unwrap();
+        let repo = SqlitePlannerRepository::open(&db_path, SeedPlan::Reseeded)
+            .await
+            .unwrap();
 
         assert!(db_path.is_file(), "the new planner db must be a file");
         assert!(
@@ -457,6 +496,40 @@ mod tests {
         );
     }
 
+    /// With no seed configured, that same directory is the only copy of the
+    /// projections. Replacing it with empty tables would leave the service
+    /// ready and answering every request with a fallback plan, which is
+    /// indistinguishable from a planner that simply has nothing to offer. Refuse
+    /// instead, and leave the old store untouched for every retry.
+    #[tokio::test]
+    async fn open_refuses_a_legacy_planner_directory_when_nothing_will_reseed_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("planner.db");
+        write_legacy_planner_dir(&db_path);
+
+        // A CrashLoopBackOff retries; every attempt must be equally harmless.
+        for _ in 0..3 {
+            let err = SqlitePlannerRepository::open(&db_path, SeedPlan::None)
+                .await
+                .expect_err("a legacy store with no seed to rebuild it must not be replaced");
+            assert!(
+                err.to_string().contains("--seed-state-file"),
+                "the error must say how to resolve it: {err}"
+            );
+
+            assert!(db_path.is_dir(), "the legacy store must stay in place");
+            assert_eq!(
+                std::fs::read(db_path.join("LOCK")).unwrap(),
+                b"legacy sentinel"
+            );
+            assert_eq!(
+                std::fs::read_dir(dir.path()).unwrap().count(),
+                1,
+                "refusing must not leave quarantine copies behind"
+            );
+        }
+    }
+
     #[test]
     fn dep_key_joins_name_and_version() {
         assert_eq!(dep_key("serde", "1.0.0"), "serde@1.0.0");
@@ -472,7 +545,7 @@ mod tests {
     #[tokio::test]
     async fn namespace_upsert_keeps_punctuation_variant_namespaces_apart() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
             .await
             .unwrap();
 
@@ -531,7 +604,7 @@ mod tests {
     #[tokio::test]
     async fn crate_upsert_keeps_punctuation_variant_crates_apart() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
             .await
             .unwrap();
 
@@ -572,7 +645,7 @@ mod tests {
     #[tokio::test]
     async fn seeding_twice_updates_in_place() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
             .await
             .unwrap();
 
@@ -610,7 +683,7 @@ mod tests {
         // The same cache_key seen under two different deps must be returned
         // once — the planner's `seen` set guards against duplicate prefetch.
         let dir = tempfile::tempdir().unwrap();
-        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
             .await
             .unwrap();
         repo.seed_from_state(PlannerStateFile {
@@ -659,7 +732,7 @@ mod tests {
     #[tokio::test]
     async fn queries_return_empty_for_unknown_keys() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
             .await
             .unwrap();
 
@@ -686,7 +759,7 @@ mod tests {
     #[tokio::test]
     async fn seed_from_state_file_rejects_missing_file() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
             .await
             .unwrap();
         let err = repo
@@ -695,11 +768,15 @@ mod tests {
         assert!(err.is_err());
     }
 
-    /// A seed that fails partway must leave no rows behind.
+    /// A seed file that does not parse is rejected before any SQL runs.
+    ///
+    /// This does NOT exercise the seed transaction — parsing fails in
+    /// `seed_from_state_file` before `seed_from_state` opens one.
+    /// `seed_rolls_back_when_a_write_fails_partway` covers that.
     #[tokio::test]
     async fn seed_from_state_file_rejects_malformed_json_without_writing() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
             .await
             .unwrap();
 
@@ -715,10 +792,121 @@ mod tests {
         );
     }
 
+    /// A seed that fails after an earlier write must leave no rows behind.
+    ///
+    /// Seeding a namespace writes both projections per candidate, so dropping
+    /// `crate_artifact` makes the namespace insert succeed and the very next
+    /// statement fail — a genuine mid-transaction failure. Without the enclosing
+    /// transaction the namespace row would survive and the planner would serve
+    /// half a state file.
+    #[tokio::test]
+    async fn seed_rolls_back_when_a_write_fails_partway() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
+            .await
+            .unwrap();
+
+        repo.run(|conn| {
+            conn.execute_batch("DROP TABLE crate_artifact;")?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        let err = repo
+            .seed_from_state(PlannerStateFile {
+                namespaces: HashMap::from([(
+                    "ns".to_string(),
+                    NamespaceState {
+                        deps: HashMap::from([(
+                            "serde@1.0.0".to_string(),
+                            vec![PrefetchCandidate::new(
+                                "serde-key".to_string(),
+                                "serde".to_string(),
+                            )],
+                        )]),
+                    },
+                )]),
+                history: HashMap::new(),
+                key_cache: HashMap::new(),
+            })
+            .await;
+        assert!(err.is_err(), "the seed must fail once a write fails");
+
+        let rows: i64 = repo
+            .run(|conn| {
+                Ok(
+                    conn.query_row("SELECT COUNT(*) FROM namespace_artifact", [], |row| {
+                        row.get(0)
+                    })?,
+                )
+            })
+            .await
+            .unwrap();
+        assert_eq!(rows, 0, "the successful write must have rolled back");
+    }
+
+    /// Reads return the most recently seen cache key first.
+    ///
+    /// The planner's caller truncates to the FIRST entries per crate, so a
+    /// reversed order would silently hand it the stalest keys.
+    #[tokio::test]
+    async fn reads_return_the_most_recently_seeded_key_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
+            .await
+            .unwrap();
+
+        let seed = |cache_key: &str| PlannerStateFile {
+            namespaces: HashMap::from([(
+                "ns".to_string(),
+                NamespaceState {
+                    deps: HashMap::from([(
+                        "serde@1.0.0".to_string(),
+                        vec![PrefetchCandidate::new(
+                            cache_key.to_string(),
+                            "serde".to_string(),
+                        )],
+                    )]),
+                },
+            )]),
+            history: HashMap::new(),
+            key_cache: HashMap::new(),
+        };
+
+        // Seeded oldest-first, and named so that a cache_key tie-break alone
+        // would order them the other way round.
+        repo.seed_from_state(seed("zzz-older")).await.unwrap();
+        repo.seed_from_state(seed("aaa-newer")).await.unwrap();
+
+        let shard = repo
+            .shard_candidates("ns", &[("serde".to_string(), "1.0.0".to_string())])
+            .await
+            .unwrap();
+        assert_eq!(
+            shard.iter().map(|c| &c.cache_key).collect::<Vec<_>>(),
+            ["aaa-newer", "zzz-older"]
+        );
+
+        assert_eq!(
+            repo.key_cache_keys_for_crate("serde").await.unwrap(),
+            ["aaa-newer", "zzz-older"]
+        );
+
+        let history = repo
+            .history_candidates(&["serde".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(
+            history.iter().map(|c| &c.cache_key).collect::<Vec<_>>(),
+            ["aaa-newer", "zzz-older"]
+        );
+    }
+
     #[tokio::test]
     async fn repository_resolves_namespace_candidates_from_seed_state() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"))
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
             .await
             .unwrap();
         repo.seed_from_state(PlannerStateFile {
@@ -775,7 +963,9 @@ mod tests {
         )
         .unwrap();
 
-        let repo = SqlitePlannerRepository::open(&db_path).await.unwrap();
+        let repo = SqlitePlannerRepository::open(&db_path, SeedPlan::None)
+            .await
+            .unwrap();
         repo.seed_from_state_file(&seed_path).await.unwrap();
 
         let history = repo
@@ -795,7 +985,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("planner.db");
 
-        let repo = SqlitePlannerRepository::open(&db_path).await.unwrap();
+        let repo = SqlitePlannerRepository::open(&db_path, SeedPlan::None)
+            .await
+            .unwrap();
         repo.seed_from_state(PlannerStateFile {
             namespaces: HashMap::new(),
             history: HashMap::from([(
@@ -811,7 +1003,9 @@ mod tests {
         .unwrap();
         drop(repo);
 
-        let reopened = SqlitePlannerRepository::open(&db_path).await.unwrap();
+        let reopened = SqlitePlannerRepository::open(&db_path, SeedPlan::None)
+            .await
+            .unwrap();
         let history = reopened
             .history_candidates(&["serde".to_string()])
             .await

--- a/crates/kache-service/src/state.rs
+++ b/crates/kache-service/src/state.rs
@@ -561,6 +561,73 @@ mod tests {
         assert_eq!(dep_key("", ""), "@");
     }
 
+    /// `is_empty` decides whether a seed licenses replacing a legacy store, so
+    /// it has to answer for each collection on its own: a seed carrying rows in
+    /// any ONE of the three is a seed that writes something.
+    #[test]
+    fn is_empty_is_true_only_when_no_collection_carries_a_row() {
+        let candidate = || PrefetchCandidate::new("k".to_string(), "c".to_string());
+
+        assert!(PlannerStateFile::default().is_empty());
+
+        // Present but empty containers still write nothing.
+        assert!(
+            PlannerStateFile {
+                namespaces: HashMap::from([(
+                    "ns".to_string(),
+                    NamespaceState {
+                        deps: HashMap::from([("d@1".to_string(), vec![])]),
+                    },
+                )]),
+                history: HashMap::from([("c".to_string(), vec![])]),
+                key_cache: HashMap::from([("c".to_string(), vec![])]),
+            }
+            .is_empty()
+        );
+
+        assert!(
+            !PlannerStateFile {
+                namespaces: HashMap::from([(
+                    "ns".to_string(),
+                    NamespaceState {
+                        deps: HashMap::from([("d@1".to_string(), vec![candidate()])]),
+                    },
+                )]),
+                ..Default::default()
+            }
+            .is_empty(),
+            "a namespace candidate is a row"
+        );
+
+        assert!(
+            !PlannerStateFile {
+                history: HashMap::from([("c".to_string(), vec![candidate()])]),
+                ..Default::default()
+            }
+            .is_empty(),
+            "a history candidate is a row"
+        );
+
+        assert!(
+            !PlannerStateFile {
+                key_cache: HashMap::from([("c".to_string(), vec!["k".to_string()])]),
+                ..Default::default()
+            }
+            .is_empty(),
+            "a key cache entry is a row"
+        );
+    }
+
+    /// The connection is not `Debug`, so this impl is hand-written.
+    #[tokio::test]
+    async fn debug_names_the_repository() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = SqlitePlannerRepository::open(&dir.path().join("planner.db"), SeedPlan::None)
+            .await
+            .unwrap();
+        assert!(format!("{repo:?}").contains("SqlitePlannerRepository"));
+    }
+
     /// Namespaces differing only by `/` vs `_` must stay separate rows.
     ///
     /// v0.16 derived a record id by replacing punctuation, so `linux/hash/debug`

--- a/crates/kache-service/tests/concurrent_planner_db.rs
+++ b/crates/kache-service/tests/concurrent_planner_db.rs
@@ -1,0 +1,170 @@
+//! Two OS processes seeding one planner database.
+//!
+//! Nothing in the service arbitrates between them. Until 0.16 the store was
+//! surrealkv, which took an exclusive LOCK, so a second process crashed with
+//! "planner.db/LOCK is already locked by another process" — loud, and the
+//! reason the chart's `replicaCount` guard and `Recreate` strategy cite. SQLite
+//! in WAL mode does not refuse a second opener, so that noise is gone and only
+//! the chart keeps a surging rollout from producing two writers.
+//!
+//! That makes what SQLite does under two writers worth pinning down: contending
+//! writes must serialize on `busy_timeout` and every one of them must land,
+//! rather than one process losing its rows or leaving a half-written database
+//! the next start cannot read. Separate processes, not two connections in one:
+//! POSIX advisory locks are owned per process, so a single-process stand-in
+//! would exercise different locking than two Pods on a node do.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use kache_core::{PlannerDataSource, PrefetchCandidate};
+use kache_service::{NamespaceState, PlannerStateFile, SeedPlan, SqlitePlannerRepository};
+
+/// Set on a re-executed copy of this test binary to make it a writer.
+const WORKER_DB_PATH: &str = "KACHE_TEST_PLANNER_DB_PATH";
+const WORKER_ID: &str = "KACHE_TEST_PLANNER_WORKER";
+
+const WRITERS: usize = 4;
+const KEYS_PER_WRITER: usize = 25;
+
+fn crate_name(worker: usize, index: usize) -> String {
+    format!("crate-{worker}-{index}")
+}
+
+fn cache_key(worker: usize, index: usize) -> String {
+    format!("key-{worker}-{index}")
+}
+
+fn seed_state(worker: usize) -> PlannerStateFile {
+    let mut namespaces = std::collections::HashMap::new();
+    let mut deps = std::collections::HashMap::new();
+    let mut history = std::collections::HashMap::new();
+
+    for index in 0..KEYS_PER_WRITER {
+        let candidate = PrefetchCandidate::new(cache_key(worker, index), crate_name(worker, index));
+        deps.insert(
+            format!("dep-{worker}-{index}@1.0.0"),
+            vec![candidate.clone()],
+        );
+        history.insert(crate_name(worker, index), vec![candidate]);
+    }
+
+    namespaces.insert("shared".to_string(), NamespaceState { deps });
+
+    PlannerStateFile {
+        namespaces,
+        history,
+        key_cache: std::collections::HashMap::new(),
+    }
+}
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build worker runtime")
+}
+
+/// The writer half. Inert unless this process was re-executed as a worker, so
+/// a normal `cargo test` run just skips it.
+#[test]
+fn planner_db_writer_worker() {
+    let (Ok(db_path), Ok(worker)) = (std::env::var(WORKER_DB_PATH), std::env::var(WORKER_ID))
+    else {
+        return;
+    };
+    let worker: usize = worker.parse().expect("worker id");
+
+    runtime().block_on(async move {
+        let repo = SqlitePlannerRepository::open(Path::new(&db_path), SeedPlan::None)
+            .await
+            .expect("a second process must be able to open the planner db");
+        repo.seed_from_state(seed_state(worker))
+            .await
+            .expect("seeding must survive contention with the other writers");
+    });
+}
+
+fn spawn_worker(exe: &Path, db_path: &Path, worker: usize) -> std::process::Child {
+    Command::new(exe)
+        .args(["--exact", "planner_db_writer_worker", "--nocapture"])
+        .env(WORKER_DB_PATH, db_path)
+        .env(WORKER_ID, worker.to_string())
+        .spawn()
+        .expect("spawn planner db writer")
+}
+
+#[test]
+fn concurrent_processes_all_land_their_rows_in_one_planner_db() {
+    let exe = std::env::current_exe().expect("locate this test binary");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path: PathBuf = dir.path().join("planner.db");
+
+    // Create the schema up front so the writers contend on writes rather than
+    // racing to define the same tables.
+    runtime().block_on(async {
+        SqlitePlannerRepository::open(&db_path, SeedPlan::None)
+            .await
+            .expect("create the planner db");
+    });
+
+    let children: Vec<_> = (0..WRITERS)
+        .map(|worker| spawn_worker(&exe, &db_path, worker))
+        .collect();
+
+    for (worker, mut child) in children.into_iter().enumerate() {
+        let status = child.wait().expect("await planner db writer");
+        assert!(
+            status.success(),
+            "writer {worker} failed against a shared planner db: {status}"
+        );
+    }
+
+    // Every writer's rows must be readable afterwards, through a fresh open —
+    // a database left inconsistent by the contention would surface here.
+    runtime().block_on(async {
+        let repo = SqlitePlannerRepository::open(&db_path, SeedPlan::None)
+            .await
+            .expect("reopen the planner db the writers shared");
+
+        let deps: Vec<(String, String)> = (0..WRITERS)
+            .flat_map(|worker| {
+                (0..KEYS_PER_WRITER)
+                    .map(move |index| (format!("dep-{worker}-{index}"), "1.0.0".to_string()))
+            })
+            .collect();
+
+        let found: HashSet<String> = repo
+            .shard_candidates("shared", &deps)
+            .await
+            .expect("read back the shard projection")
+            .into_iter()
+            .map(|candidate| candidate.cache_key)
+            .collect();
+
+        let expected: HashSet<String> = (0..WRITERS)
+            .flat_map(|worker| (0..KEYS_PER_WRITER).map(move |index| cache_key(worker, index)))
+            .collect();
+
+        let missing: Vec<_> = expected.difference(&found).collect();
+        assert!(
+            missing.is_empty(),
+            "{} of {} rows were lost to write contention: {missing:?}",
+            missing.len(),
+            expected.len()
+        );
+
+        // The crate projection is written by the same seeds, so it must agree.
+        for worker in 0..WRITERS {
+            for index in 0..KEYS_PER_WRITER {
+                assert_eq!(
+                    repo.key_cache_keys_for_crate(&crate_name(worker, index))
+                        .await
+                        .expect("read back the crate projection"),
+                    [cache_key(worker, index)],
+                );
+            }
+        }
+    });
+}

--- a/crates/kache-store/src/atomic.rs
+++ b/crates/kache-store/src/atomic.rs
@@ -66,15 +66,36 @@ const TRANSIENT_ATTEMPTS: u32 = 10;
 /// one place. Off Windows that predicate is always false, so `op` runs exactly
 /// once and this adds nothing.
 pub(crate) fn retry_transient_windows<T>(
+    op: impl FnMut() -> std::io::Result<T>,
+) -> std::io::Result<T> {
+    retry_transient(op, is_transient_rename_error)
+}
+
+/// The retry loop itself, with the "is this worth waiting out" decision passed
+/// in.
+///
+/// Split from [`retry_transient_windows`] so the loop is reachable off Windows.
+/// With the classifier inlined, `is_transient_rename_error` is a compile-time
+/// `false` everywhere else, the retry arm is dead code on the Linux runner that
+/// scores mutants, and every mutation of the bound and the counter survives
+/// against a branch nothing can enter. The counter arithmetic and the budget
+/// are platform-independent; only the code list is not.
+fn retry_transient<T>(
     mut op: impl FnMut() -> std::io::Result<T>,
+    is_transient: impl Fn(&std::io::Error) -> bool,
 ) -> std::io::Result<T> {
     let mut attempt = 0;
     loop {
         match op() {
             Ok(value) => return Ok(value),
-            Err(e) if is_transient_rename_error(&e) && attempt + 1 < TRANSIENT_ATTEMPTS => {
+            Err(e) if is_transient(&e) && attempt + 1 < TRANSIENT_ATTEMPTS => {
                 std::thread::sleep(std::time::Duration::from_millis(rename_backoff_ms(attempt)));
-                attempt += 1;
+                let next = attempt + 1;
+                // A counter that does not advance turns this into an infinite
+                // loop, which no test can fail — it hangs instead. Assert the
+                // step so the failure is a panic a test can see.
+                debug_assert!(next > attempt, "the retry counter must advance");
+                attempt = next;
             }
             Err(e) => return Err(e),
         }
@@ -317,34 +338,79 @@ mod tests {
 
     /// A delete-pending destination clears on its own, so the retry has to
     /// outlast it and then return the eventual success.
-    #[cfg(windows)]
+    ///
+    /// Drives [`retry_transient`] with an always-transient classifier: the
+    /// wrapper's real one is a compile-time `false` off Windows, which would
+    /// leave this asserting nothing on most runners.
     #[test]
-    fn retry_transient_windows_waits_out_a_transient_failure() {
+    fn retry_transient_waits_out_a_transient_failure() {
         let mut calls = 0;
-        let value = retry_transient_windows(|| {
-            calls += 1;
-            if calls < 3 {
-                return Err(std::io::Error::from_raw_os_error(5));
-            }
-            Ok(calls)
-        })
+        let value = retry_transient(
+            || {
+                calls += 1;
+                if calls < 3 {
+                    return Err(std::io::Error::from_raw_os_error(5));
+                }
+                Ok(calls)
+            },
+            |_| true,
+        )
         .unwrap();
         assert_eq!((value, calls), (3, 3));
     }
 
     /// A state that never clears is a real failure, and the budget is what
-    /// keeps it from hanging: the last attempt's error surfaces.
-    #[cfg(windows)]
+    /// keeps it from hanging: the last attempt's error surfaces, after exactly
+    /// the budgeted number of tries. The exact count is the assertion that
+    /// pins the bound — off by one either way and this fails.
     #[test]
-    fn retry_transient_windows_gives_up_within_its_budget() {
-        let mut calls = 0;
-        let err = retry_transient_windows(|| {
-            calls += 1;
-            Err::<(), _>(std::io::Error::from_raw_os_error(32))
-        })
+    fn retry_transient_gives_up_after_exactly_its_budget() {
+        let mut calls: u32 = 0;
+        let err = retry_transient(
+            || {
+                calls += 1;
+                Err::<(), _>(std::io::Error::from_raw_os_error(32))
+            },
+            |_| true,
+        )
         .unwrap_err();
         assert_eq!(err.raw_os_error(), Some(32));
-        assert_eq!(calls, TRANSIENT_ATTEMPTS as i32);
+        assert_eq!(calls, TRANSIENT_ATTEMPTS);
+    }
+
+    /// A classifier that rejects the error settles on the first call even when
+    /// the error carries a Windows race code. This is the whole behaviour off
+    /// Windows, where nothing classifies as transient.
+    #[test]
+    fn retry_transient_respects_a_rejecting_classifier() {
+        let mut calls = 0;
+        let err = retry_transient(
+            || {
+                calls += 1;
+                Err::<(), _>(std::io::Error::from_raw_os_error(5))
+            },
+            |_| false,
+        )
+        .unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(5));
+        assert_eq!(calls, 1);
+    }
+
+    /// The wrapper wires the real classifier in, so it retries a Windows race
+    /// code there and settles at once everywhere else.
+    #[test]
+    fn retry_transient_windows_uses_the_windows_classifier() {
+        let mut calls: u32 = 0;
+        let err = retry_transient_windows(|| {
+            calls += 1;
+            Err::<(), _>(std::io::Error::from_raw_os_error(5))
+        })
+        .unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(5));
+        #[cfg(windows)]
+        assert_eq!(calls, TRANSIENT_ATTEMPTS);
+        #[cfg(not(windows))]
+        assert_eq!(calls, 1);
     }
 
     #[test]

--- a/crates/kache-store/src/atomic.rs
+++ b/crates/kache-store/src/atomic.rs
@@ -50,6 +50,37 @@ fn rename_backoff_ms(attempt: u32) -> u64 {
     (1u64 << attempt.min(6)).min(64)
 }
 
+/// How many times a transient Windows state is waited out before giving up.
+const TRANSIENT_ATTEMPTS: u32 = 10;
+
+/// Run a filesystem operation, waiting out a transient Windows sharing or
+/// delete-pending state.
+///
+/// On Unix an unlinked file keeps working through open handles and its name is
+/// free the moment it is removed, so a concurrent put/remove pair never
+/// collides on the name. Windows keeps the directory entry until the last
+/// handle closes and fails anything touching that name meanwhile with
+/// ERROR_ACCESS_DENIED or ERROR_SHARING_VIOLATION. Those clear on their own,
+/// so they are worth waiting out rather than reporting as a fault — see
+/// [`is_transient_rename_error`], which this shares so the code list stays in
+/// one place. Off Windows that predicate is always false, so `op` runs exactly
+/// once and this adds nothing.
+pub(crate) fn retry_transient_windows<T>(
+    mut op: impl FnMut() -> std::io::Result<T>,
+) -> std::io::Result<T> {
+    let mut attempt = 0;
+    loop {
+        match op() {
+            Ok(value) => return Ok(value),
+            Err(e) if is_transient_rename_error(&e) && attempt + 1 < TRANSIENT_ATTEMPTS => {
+                std::thread::sleep(std::time::Duration::from_millis(rename_backoff_ms(attempt)));
+                attempt += 1;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 /// Remove a file, clearing the read-only attribute first to ensure deletion
 /// succeeds even on Windows when the file was marked read-only.
 ///
@@ -258,6 +289,62 @@ mod tests {
             assert!(!is_transient_rename_error(&sharing_violation));
             assert!(!is_transient_rename_error(&other));
         }
+    }
+
+    /// A success and a non-transient failure both settle on the first call.
+    ///
+    /// Off Windows this is the whole behaviour, since no error classifies as
+    /// transient there: the retry must never turn a real fault into a delay.
+    #[test]
+    fn retry_transient_windows_does_not_retry_a_settled_outcome() {
+        let mut calls = 0;
+        let value = retry_transient_windows(|| {
+            calls += 1;
+            Ok::<_, std::io::Error>(7)
+        })
+        .unwrap();
+        assert_eq!((value, calls), (7, 1));
+
+        let mut calls = 0;
+        let err = retry_transient_windows(|| {
+            calls += 1;
+            Err::<(), _>(std::io::Error::from_raw_os_error(2))
+        })
+        .unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(2));
+        assert_eq!(calls, 1, "a non-transient error must not be retried");
+    }
+
+    /// A delete-pending destination clears on its own, so the retry has to
+    /// outlast it and then return the eventual success.
+    #[cfg(windows)]
+    #[test]
+    fn retry_transient_windows_waits_out_a_transient_failure() {
+        let mut calls = 0;
+        let value = retry_transient_windows(|| {
+            calls += 1;
+            if calls < 3 {
+                return Err(std::io::Error::from_raw_os_error(5));
+            }
+            Ok(calls)
+        })
+        .unwrap();
+        assert_eq!((value, calls), (3, 3));
+    }
+
+    /// A state that never clears is a real failure, and the budget is what
+    /// keeps it from hanging: the last attempt's error surfaces.
+    #[cfg(windows)]
+    #[test]
+    fn retry_transient_windows_gives_up_within_its_budget() {
+        let mut calls = 0;
+        let err = retry_transient_windows(|| {
+            calls += 1;
+            Err::<(), _>(std::io::Error::from_raw_os_error(32))
+        })
+        .unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(32));
+        assert_eq!(calls, TRANSIENT_ATTEMPTS as i32);
     }
 
     #[test]

--- a/crates/kache-store/src/atomic.rs
+++ b/crates/kache-store/src/atomic.rs
@@ -31,7 +31,7 @@ pub fn fsync_file(path: &Path) -> std::io::Result<()> {
 /// ERROR_ACCESS_DENIED (5) and ERROR_SHARING_VIOLATION (32) surface when a
 /// concurrent put/remove leaves the destination delete-pending or open; both
 /// clear on their own. No such transient rename error exists off Windows.
-fn is_transient_rename_error(e: &std::io::Error) -> bool {
+pub(crate) fn is_transient_rename_error(e: &std::io::Error) -> bool {
     #[cfg(windows)]
     {
         matches!(e.raw_os_error(), Some(5) | Some(32))

--- a/crates/kache-store/src/atomic.rs
+++ b/crates/kache-store/src/atomic.rs
@@ -80,26 +80,29 @@ pub(crate) fn retry_transient_windows<T>(
 /// scores mutants, and every mutation of the bound and the counter survives
 /// against a branch nothing can enter. The counter arithmetic and the budget
 /// are platform-independent; only the code list is not.
+/// Whether this error should be slept out and tried again. Split from the
+/// loop so a `true` match-guard mutant cannot hang: the `for` bound below
+/// still stops, and tests of this helper reject `true` / `||` directly.
+fn should_retry_transient(transient: bool, attempt: u32) -> bool {
+    transient && attempt + 1 < TRANSIENT_ATTEMPTS
+}
+
 fn retry_transient<T>(
     mut op: impl FnMut() -> std::io::Result<T>,
     is_transient: impl Fn(&std::io::Error) -> bool,
 ) -> std::io::Result<T> {
-    let mut attempt = 0;
-    loop {
+    let mut last_err = None;
+    for attempt in 0..TRANSIENT_ATTEMPTS {
         match op() {
             Ok(value) => return Ok(value),
-            Err(e) if is_transient(&e) && attempt + 1 < TRANSIENT_ATTEMPTS => {
+            Err(e) if should_retry_transient(is_transient(&e), attempt) => {
                 std::thread::sleep(std::time::Duration::from_millis(rename_backoff_ms(attempt)));
-                let next = attempt + 1;
-                // A counter that does not advance turns this into an infinite
-                // loop, which no test can fail — it hangs instead. Assert the
-                // step so the failure is a panic a test can see.
-                debug_assert!(next > attempt, "the retry counter must advance");
-                attempt = next;
+                last_err = Some(e);
             }
             Err(e) => return Err(e),
         }
     }
+    Err(last_err.expect("retry_transient records an error before the budget is spent"))
 }
 
 /// Remove a file, clearing the read-only attribute first to ensure deletion
@@ -376,6 +379,15 @@ mod tests {
         .unwrap_err();
         assert_eq!(err.raw_os_error(), Some(32));
         assert_eq!(calls, TRANSIENT_ATTEMPTS);
+    }
+
+    #[test]
+    fn should_retry_transient_requires_a_transient_error_inside_the_budget() {
+        assert!(should_retry_transient(true, 0));
+        assert!(should_retry_transient(true, TRANSIENT_ATTEMPTS - 2));
+        assert!(!should_retry_transient(true, TRANSIENT_ATTEMPTS - 1));
+        assert!(!should_retry_transient(false, 0));
+        assert!(!should_retry_transient(false, TRANSIENT_ATTEMPTS - 2));
     }
 
     /// A classifier that rejects the error settles on the first call even when

--- a/crates/kache-store/src/store.rs
+++ b/crates/kache-store/src/store.rs
@@ -4321,96 +4321,101 @@ impl<P: ArtifactPolicy> ArtifactStore<P> {
         // the removal so a corrupt entry never silently leaks (#276); callers
         // (GC / purge / `doctor --repair`) log and move on, and the entry stays
         // accounted-for until a fresh `put` (INSERT OR REPLACE) overwrites it.
-        //
-        // The read waits out a transient Windows state first. A concurrent
-        // remover holding this meta.json leaves it delete-pending, and reading
-        // it meanwhile fails with ERROR_ACCESS_DENIED rather than NotFound — so
-        // without this the losing remover of a healthy race lands in the
-        // unreadable-meta arm below and reports #276 corruption. If it settles
-        // into NotFound the arm after this one judges the race properly; if it
-        // never clears, the corruption arm still refuses, unchanged.
         let meta_content: String;
-        let hashes: Vec<String> =
-            match crate::atomic::retry_transient_windows(|| fs::read_to_string(&meta_path)) {
-                Ok(content) => {
-                    let meta: EntryMeta = serde_json::from_str(&content).with_context(|| {
-                        format!(
-                            "entry {cache_key}: meta.json unparseable — refusing removal so blob \
+        let hashes: Vec<String> = match fs::read_to_string(&meta_path) {
+            Ok(content) => {
+                let meta: EntryMeta = serde_json::from_str(&content).with_context(|| {
+                    format!(
+                        "entry {cache_key}: meta.json unparseable — refusing removal so blob \
                          refcounts are not leaked (#276)"
-                        )
-                    })?;
-                    meta_content = content;
-                    meta.files.iter().map(|f| f.hash.clone()).collect()
+                    )
+                })?;
+                meta_content = content;
+                meta.files.iter().map(|f| f.hash.clone()).collect()
+            }
+            Err(e)
+                if e.kind() == std::io::ErrorKind::NotFound
+                    || crate::atomic::is_transient_rename_error(&e) =>
+            {
+                // No readable meta.json. A same-key operation may be
+                // mid-flight: a publisher materializes meta inside its
+                // registration transaction, and a removal's cleanup pass runs
+                // in its own locked transaction (#670) — so "meta missing, row
+                // present" can be a healthy transient, not only the
+                // stranded-entry shape. Bounce off the write lock — the no-op
+                // write statement waits (busy_timeout) until any in-flight
+                // writer commits or rolls back — then judge the settled state.
+                // Both the row and the meta are checked while the lock is
+                // still held: after dropping it another writer could move the
+                // pairing again and a healthy already-absent state would
+                // misreport as #276 corruption.
+                //
+                // A concurrent remover that already unlinked this meta.json
+                // arrives here too. On Unix that read returns NotFound; on
+                // Windows the name lingers delete-pending and the read fails
+                // with ERROR_ACCESS_DENIED instead, which used to fall through
+                // to the unreadable-meta arm and report #276 corruption for two
+                // healthy removers. Both shapes mean the same thing — someone
+                // else is mid-operation — so both settle on the write lock
+                // rather than on a sleep.
+                let tx = self.db.unchecked_transaction()?;
+                tx.execute("UPDATE entries SET cache_key = cache_key WHERE 1 = 0", [])?;
+                let row_exists: i64 = tx.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM entries WHERE cache_key = ?1)",
+                    params![cache_key],
+                    |row| row.get(0),
+                )?;
+                if row_exists == 0 {
+                    // The concurrent removal won (or the key never existed);
+                    // nothing left to remove, and the meta's state cannot
+                    // change that — so decide before probing it, which on
+                    // Windows may still be delete-pending and unstattable.
+                    return Ok(RemovalAttempt::Done(None));
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    // No meta.json. A same-key operation may be mid-flight: a
-                    // publisher materializes meta inside its registration
-                    // transaction, and a removal's cleanup pass runs in its own
-                    // locked transaction (#670) — so "meta missing, row present"
-                    // can be a healthy transient, not only the stranded-entry
-                    // shape. Bounce off the write lock — the no-op write statement
-                    // waits (busy_timeout) until any in-flight writer commits or
-                    // rolls back — then judge the settled state. Both the row and
-                    // the meta are checked while the lock is still held: after
-                    // dropping it another writer could move the pairing again and
-                    // a healthy already-absent state would misreport as #276
-                    // corruption.
-                    let tx = self.db.unchecked_transaction()?;
-                    tx.execute("UPDATE entries SET cache_key = cache_key WHERE 1 = 0", [])?;
-                    let row_exists: i64 = tx.query_row(
-                        "SELECT EXISTS(SELECT 1 FROM entries WHERE cache_key = ?1)",
-                        params![cache_key],
-                        |row| row.get(0),
-                    )?;
-                    // fs::metadata, not Path::exists: exists() swallows every
-                    // error as false, and a permission failure must refuse like
-                    // the unreadable-meta arm below, not report already-absent.
-                    let meta_is_back = match fs::metadata(&meta_path) {
-                        Ok(_) => true,
-                        Err(e) => {
-                            if e.kind() != std::io::ErrorKind::NotFound {
-                                return Err(e).with_context(|| {
-                                    format!(
-                                        "entry {cache_key}: checking republished meta.json — \
+                // fs::metadata, not Path::exists: exists() swallows every
+                // error as false, and a permission failure must refuse like
+                // the unreadable-meta arm below, not report already-absent.
+                let meta_is_back = match fs::metadata(&meta_path) {
+                    Ok(_) => true,
+                    Err(e) => {
+                        if e.kind() != std::io::ErrorKind::NotFound {
+                            return Err(e).with_context(|| {
+                                format!(
+                                    "entry {cache_key}: checking republished meta.json — \
                                      refusing removal so blob refcounts are not leaked (#276)"
-                                    )
-                                });
-                            }
-                            false
+                                )
+                            });
                         }
-                    };
-                    drop(tx);
-                    if row_exists == 0 {
-                        // The concurrent removal won (or the key never existed);
-                        // nothing left to remove.
-                        return Ok(RemovalAttempt::Done(None));
+                        false
                     }
-                    if meta_is_back {
-                        // A republication landed while we waited: the row belongs
-                        // to a fresh generation whose meta is back. The caller
-                        // asked to remove whatever is currently published, so
-                        // retry against the new generation. Each retry requires
-                        // another full republication in the window, so this
-                        // cannot spin on its own.
-                        return Ok(RemovalAttempt::Republished);
-                    }
-                    // Settled: a row with no meta.json. Its blob list is unknown
-                    // and deleting the row would leak the refcounts — refuse, so
-                    // a corrupt entry never silently leaks (#276).
-                    anyhow::bail!(
-                        "entry {cache_key}: meta.json missing but DB row present — refusing \
+                };
+                drop(tx);
+                if meta_is_back {
+                    // A republication landed while we waited: the row belongs
+                    // to a fresh generation whose meta is back. The caller
+                    // asked to remove whatever is currently published, so
+                    // retry against the new generation. Each retry requires
+                    // another full republication in the window, so this
+                    // cannot spin on its own.
+                    return Ok(RemovalAttempt::Republished);
+                }
+                // Settled: a row with no meta.json. Its blob list is unknown
+                // and deleting the row would leak the refcounts — refuse, so
+                // a corrupt entry never silently leaks (#276).
+                anyhow::bail!(
+                    "entry {cache_key}: meta.json missing but DB row present — refusing \
                      removal so blob refcounts are not leaked (#276)"
-                    );
-                }
-                Err(e) => {
-                    return Err(e).with_context(|| {
-                        format!(
-                            "entry {cache_key}: reading meta.json — refusing removal so blob \
+                );
+            }
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!(
+                        "entry {cache_key}: reading meta.json — refusing removal so blob \
                          refcounts are not leaked (#276)"
-                        )
-                    });
-                }
-            };
+                    )
+                });
+            }
+        };
 
         if let Some(hook) = after_meta_read {
             hook();

--- a/crates/kache-store/src/store.rs
+++ b/crates/kache-store/src/store.rs
@@ -3179,7 +3179,14 @@ impl<P: ArtifactPolicy> ArtifactStore<P> {
             return Ok(false);
         }
         fs::create_dir_all(blob.parent().unwrap()).context("creating blob shard directory")?;
-        if let Err(e) = fs::rename(staged, &blob) {
+        // Wait out a delete-pending destination. A concurrent remove that drops
+        // this blob's last reference leaves the name occupied on Windows until
+        // its handle closes, and publishing into it meanwhile fails with
+        // ERROR_ACCESS_DENIED — a race between two healthy operations, reported
+        // as a failed put (kunobi-ninja/kache Test (Windows)). Retrying inside
+        // the publish keeps the staged file alive for the next attempt, which
+        // is why this is not `discard_staged_blob` then retry.
+        if let Err(e) = crate::atomic::retry_transient_windows(|| fs::rename(staged, &blob)) {
             Self::discard_staged_blob(staged);
             // Re-stat: only a publish that lost a race finds the destination
             // occupied *now* having found it free above.
@@ -4314,87 +4321,96 @@ impl<P: ArtifactPolicy> ArtifactStore<P> {
         // the removal so a corrupt entry never silently leaks (#276); callers
         // (GC / purge / `doctor --repair`) log and move on, and the entry stays
         // accounted-for until a fresh `put` (INSERT OR REPLACE) overwrites it.
+        //
+        // The read waits out a transient Windows state first. A concurrent
+        // remover holding this meta.json leaves it delete-pending, and reading
+        // it meanwhile fails with ERROR_ACCESS_DENIED rather than NotFound — so
+        // without this the losing remover of a healthy race lands in the
+        // unreadable-meta arm below and reports #276 corruption. If it settles
+        // into NotFound the arm after this one judges the race properly; if it
+        // never clears, the corruption arm still refuses, unchanged.
         let meta_content: String;
-        let hashes: Vec<String> = match fs::read_to_string(&meta_path) {
-            Ok(content) => {
-                let meta: EntryMeta = serde_json::from_str(&content).with_context(|| {
-                    format!(
-                        "entry {cache_key}: meta.json unparseable — refusing removal so blob \
+        let hashes: Vec<String> =
+            match crate::atomic::retry_transient_windows(|| fs::read_to_string(&meta_path)) {
+                Ok(content) => {
+                    let meta: EntryMeta = serde_json::from_str(&content).with_context(|| {
+                        format!(
+                            "entry {cache_key}: meta.json unparseable — refusing removal so blob \
                          refcounts are not leaked (#276)"
-                    )
-                })?;
-                meta_content = content;
-                meta.files.iter().map(|f| f.hash.clone()).collect()
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // No meta.json. A same-key operation may be mid-flight: a
-                // publisher materializes meta inside its registration
-                // transaction, and a removal's cleanup pass runs in its own
-                // locked transaction (#670) — so "meta missing, row present"
-                // can be a healthy transient, not only the stranded-entry
-                // shape. Bounce off the write lock — the no-op write statement
-                // waits (busy_timeout) until any in-flight writer commits or
-                // rolls back — then judge the settled state. Both the row and
-                // the meta are checked while the lock is still held: after
-                // dropping it another writer could move the pairing again and
-                // a healthy already-absent state would misreport as #276
-                // corruption.
-                let tx = self.db.unchecked_transaction()?;
-                tx.execute("UPDATE entries SET cache_key = cache_key WHERE 1 = 0", [])?;
-                let row_exists: i64 = tx.query_row(
-                    "SELECT EXISTS(SELECT 1 FROM entries WHERE cache_key = ?1)",
-                    params![cache_key],
-                    |row| row.get(0),
-                )?;
-                // fs::metadata, not Path::exists: exists() swallows every
-                // error as false, and a permission failure must refuse like
-                // the unreadable-meta arm below, not report already-absent.
-                let meta_is_back = match fs::metadata(&meta_path) {
-                    Ok(_) => true,
-                    Err(e) => {
-                        if e.kind() != std::io::ErrorKind::NotFound {
-                            return Err(e).with_context(|| {
-                                format!(
-                                    "entry {cache_key}: checking republished meta.json — \
+                        )
+                    })?;
+                    meta_content = content;
+                    meta.files.iter().map(|f| f.hash.clone()).collect()
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // No meta.json. A same-key operation may be mid-flight: a
+                    // publisher materializes meta inside its registration
+                    // transaction, and a removal's cleanup pass runs in its own
+                    // locked transaction (#670) — so "meta missing, row present"
+                    // can be a healthy transient, not only the stranded-entry
+                    // shape. Bounce off the write lock — the no-op write statement
+                    // waits (busy_timeout) until any in-flight writer commits or
+                    // rolls back — then judge the settled state. Both the row and
+                    // the meta are checked while the lock is still held: after
+                    // dropping it another writer could move the pairing again and
+                    // a healthy already-absent state would misreport as #276
+                    // corruption.
+                    let tx = self.db.unchecked_transaction()?;
+                    tx.execute("UPDATE entries SET cache_key = cache_key WHERE 1 = 0", [])?;
+                    let row_exists: i64 = tx.query_row(
+                        "SELECT EXISTS(SELECT 1 FROM entries WHERE cache_key = ?1)",
+                        params![cache_key],
+                        |row| row.get(0),
+                    )?;
+                    // fs::metadata, not Path::exists: exists() swallows every
+                    // error as false, and a permission failure must refuse like
+                    // the unreadable-meta arm below, not report already-absent.
+                    let meta_is_back = match fs::metadata(&meta_path) {
+                        Ok(_) => true,
+                        Err(e) => {
+                            if e.kind() != std::io::ErrorKind::NotFound {
+                                return Err(e).with_context(|| {
+                                    format!(
+                                        "entry {cache_key}: checking republished meta.json — \
                                      refusing removal so blob refcounts are not leaked (#276)"
-                                )
-                            });
+                                    )
+                                });
+                            }
+                            false
                         }
-                        false
+                    };
+                    drop(tx);
+                    if row_exists == 0 {
+                        // The concurrent removal won (or the key never existed);
+                        // nothing left to remove.
+                        return Ok(RemovalAttempt::Done(None));
                     }
-                };
-                drop(tx);
-                if row_exists == 0 {
-                    // The concurrent removal won (or the key never existed);
-                    // nothing left to remove.
-                    return Ok(RemovalAttempt::Done(None));
-                }
-                if meta_is_back {
-                    // A republication landed while we waited: the row belongs
-                    // to a fresh generation whose meta is back. The caller
-                    // asked to remove whatever is currently published, so
-                    // retry against the new generation. Each retry requires
-                    // another full republication in the window, so this
-                    // cannot spin on its own.
-                    return Ok(RemovalAttempt::Republished);
-                }
-                // Settled: a row with no meta.json. Its blob list is unknown
-                // and deleting the row would leak the refcounts — refuse, so
-                // a corrupt entry never silently leaks (#276).
-                anyhow::bail!(
-                    "entry {cache_key}: meta.json missing but DB row present — refusing \
+                    if meta_is_back {
+                        // A republication landed while we waited: the row belongs
+                        // to a fresh generation whose meta is back. The caller
+                        // asked to remove whatever is currently published, so
+                        // retry against the new generation. Each retry requires
+                        // another full republication in the window, so this
+                        // cannot spin on its own.
+                        return Ok(RemovalAttempt::Republished);
+                    }
+                    // Settled: a row with no meta.json. Its blob list is unknown
+                    // and deleting the row would leak the refcounts — refuse, so
+                    // a corrupt entry never silently leaks (#276).
+                    anyhow::bail!(
+                        "entry {cache_key}: meta.json missing but DB row present — refusing \
                      removal so blob refcounts are not leaked (#276)"
-                );
-            }
-            Err(e) => {
-                return Err(e).with_context(|| {
-                    format!(
-                        "entry {cache_key}: reading meta.json — refusing removal so blob \
+                    );
+                }
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!(
+                            "entry {cache_key}: reading meta.json — refusing removal so blob \
                          refcounts are not leaked (#276)"
-                    )
-                });
-            }
-        };
+                        )
+                    });
+                }
+            };
 
         if let Some(hook) = after_meta_read {
             hook();

--- a/deny.toml
+++ b/deny.toml
@@ -9,8 +9,8 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 ignore = [
   # RUSTSEC-2023-0071 — rsa 0.9.x Marvin timing sidechannel (medium 5.9).
-  # Transitive via kunobi-auth (ssh-key, openidconnect) and surrealdb
-  # (jsonwebtoken). No fixed `rsa` release exists ("Solution: No fixed
+  # Transitive via kunobi-auth (ssh-key, openidconnect). No fixed `rsa`
+  # release exists ("Solution: No fixed
   # upgrade is available!"). Re-evaluate when rsa >= 0.10 ships a
   # constant-time implementation. NOTE: only reachable through
   # `kache-service`, so cargo-deny must be run per workspace member (a
@@ -21,7 +21,7 @@ ignore = [
 [bans]
 # Multiple versions of the same crate inflate binary size and signal
 # upgrade churn. Warn (not deny) — perfect uniqueness is impractical in a
-# graph this size (aws-sdk + surrealdb + kube pull wide trees).
+# graph this size (aws-sdk + kube pull wide trees).
 multiple-versions = "warn"
 wildcards = "deny"
 # kache-service's path dep (kache-core) and first-party git deps
@@ -54,58 +54,13 @@ allow = [
     # repos' smaller graphs never reach:
     "0BSD",                # doctest-file, recvmsg (via interprocess)
     "CDLA-Permissive-2.0", # webpki-root-certs (via reqwest -> rustls-platform-verifier)
-    "BSL-1.0",             # xxhash-rust (via surrealkv) — Boost, OSI-permissive
 ]
 confidence-threshold = 0.93
-# surrealdb (and its sub-crates) ship under BUSL-1.1 — the Business Source
-# License, NOT an OSI-permissive license. It grants use and converts to
-# Apache-2.0 after a change date, but restricts offering the DB as a
-# competing hosted service. kache-service embeds surrealdb as its planner
-# store (already a dependency long before this file), so accept BUSL-1.1
-# scoped to exactly these crates rather than allowing it graph-wide.
-exceptions = [
-    { crate = "surrealdb", allow = ["BUSL-1.1"] },
-    { crate = "surrealdb-collections", allow = ["BUSL-1.1"] },
-    { crate = "surrealdb-core", allow = ["BUSL-1.1"] },
-    { crate = "surrealdb-protocol", allow = ["BUSL-1.1"] },
-    { crate = "surrealdb-strand", allow = ["BUSL-1.1"] },
-    { crate = "surrealdb-types", allow = ["BUSL-1.1"] },
-    { crate = "surrealdb-types-derive", allow = ["BUSL-1.1"] },
-]
-
-# surrealdb crates omit the `license` field in their manifest; cargo-deny
-# reads their LICENSE file but scores it 0.87 (below the 0.93 threshold),
-# so it reports them "unlicensed". Clarify the expression explicitly so
-# the exceptions above apply. All six share one LICENSE file (same hash).
-[[licenses.clarify]]
-crate = "surrealdb"
-expression = "BUSL-1.1"
-license-files = [{ path = "LICENSE", hash = 0xbb1191d7 }]
-
-[[licenses.clarify]]
-crate = "surrealdb-collections"
-expression = "BUSL-1.1"
-license-files = [{ path = "LICENSE", hash = 0xbb1191d7 }]
-
-[[licenses.clarify]]
-crate = "surrealdb-core"
-expression = "BUSL-1.1"
-license-files = [{ path = "LICENSE", hash = 0xbb1191d7 }]
-
-[[licenses.clarify]]
-crate = "surrealdb-strand"
-expression = "BUSL-1.1"
-license-files = [{ path = "LICENSE", hash = 0xbb1191d7 }]
-
-[[licenses.clarify]]
-crate = "surrealdb-types"
-expression = "BUSL-1.1"
-license-files = [{ path = "LICENSE", hash = 0xbb1191d7 }]
-
-[[licenses.clarify]]
-crate = "surrealdb-types-derive"
-expression = "BUSL-1.1"
-license-files = [{ path = "LICENSE", hash = 0xbb1191d7 }]
+# No exceptions. The planner used to embed surrealdb, whose crates ship under
+# the Business Source License rather than an OSI-permissive one and needed a
+# per-crate BUSL-1.1 carve-out here. Moving the planner to SQLite took the
+# whole tree back to the permissive list above; keep it that way.
+exceptions = []
 
 [sources]
 unknown-registry = "deny"

--- a/docs/remote-service.mdx
+++ b/docs/remote-service.mdx
@@ -20,7 +20,7 @@ The service in [`crates/kache-service`](https://github.com/kunobi-ninja/kache/tr
 
 Both plan versions use the same handler. When no useful candidates exist, the service returns a fallback disposition and the client uses its normal planner.
 
-Planner state is stored in embedded SurrealDB. `kache save-manifest` writes manifests to the configured remote; it does not post them directly to this service. Current deployments seed or ingest that data separately.
+Planner state is stored in an embedded SQLite database, at the path given by `--db-path` / `KACHE_PLANNER_DB_PATH`. `kache save-manifest` writes manifests to the configured remote; it does not post them directly to this service. Current deployments seed or ingest that data separately.
 
 ## Run locally
 

--- a/packaging/charts/kache-service/templates/deployment.yaml
+++ b/packaging/charts/kache-service/templates/deployment.yaml
@@ -8,30 +8,32 @@ metadata:
 spec:
 {{- if eq .Values.planner.persistence.type "pvc" }}
 {{- if gt (int .Values.replicaCount) 1 }}
-{{- fail "planner.persistence.type=pvc is single-writer: replicaCount must be 1. Two Pods cannot open the planner DB at once — the second fails on its LOCK file." }}
+{{- fail "planner.persistence.type=pvc is single-writer: replicaCount must be 1. The PVC is ReadWriteOnce, and the planner DB is written by whichever Pod holds it — nothing in the service arbitrates between two of them." }}
 {{- end }}
 {{- end }}
   replicas: {{ .Values.replicaCount }}
 {{- if eq .Values.planner.persistence.type "pvc" }}
   # Recreate, NOT the RollingUpdate default.
   #
-  # The planner DB takes an exclusive LOCK when opened, so exactly one Pod can
-  # hold it. RollingUpdate starts the replacement before terminating the old
-  # Pod, which deadlocks permanently: the new Pod cannot open the DB while the
-  # old one holds the LOCK, so it never becomes Ready — and the old Pod is
-  # never terminated precisely because the new one never becomes Ready. The
-  # rollout then sits there forever while the old Pod keeps serving, so the
-  # release looks healthy while the new version silently never ships.
+  # RollingUpdate starts the replacement before terminating the old Pod, so two
+  # Pods want this volume at once. The PVC is ReadWriteOnce, so on separate
+  # nodes the new Pod never mounts and the rollout stalls while the old Pod
+  # keeps serving: the release looks healthy while the new version silently
+  # never ships. On the same node both mount, and then both run the startup
+  # path that opens and seeds the planner DB.
   #
-  # Observed on int-pro: stuck 3d18h across 1061 CrashLoopBackOff restarts,
-  # each logging "planner.db/LOCK is already locked by another process".
+  # Until kache 0.16 the DB was surrealkv, which took an exclusive LOCK, so the
+  # second Pod at least crashed loudly. Observed on int-pro: stuck 3d18h across
+  # 1061 CrashLoopBackOff restarts, each logging "planner.db/LOCK is already
+  # locked by another process". SQLite in WAL mode does not refuse a second
+  # opener, so that noise is gone and this guard is now the only thing keeping
+  # a surge from quietly producing two writers.
   #
-  # Enabling `ha` does not substitute for this. Leader election would make the
-  # new Pod wait for the lease instead of crashing, but it would still never
-  # become Ready while the old Pod holds it — the same deadlock, just quieter.
+  # Enabling `ha` does not substitute for it. Leader election decides who seeds,
+  # not who mounts, so a surging rollout still hits the volume conflict.
   #
-  # Not overridable by design: any value reintroducing surge here recreates the
-  # deadlock. `ephemeral` gives each Pod its own emptyDir and keeps the
+  # Not overridable: any value reintroducing surge here brings the conflict
+  # back. `ephemeral` gives each Pod its own emptyDir and keeps the
   # RollingUpdate default.
   strategy:
     type: Recreate


### PR DESCRIPTION
Replaces the planner's SurrealDB store with SQLite.

`kache-service` keeps two projections: `(namespace, dep_key) -> cache key` and `crate_name -> cache key`. They are read by equality, returned most-recently-seen first, and written only while the HA leader seeds at startup. There is no live write endpoint. That is two keyed tables with an index, which is what the SQLite the local cache index already uses does; it did not need a second embedded storage engine.

## What this buys

`Cargo.lock` loses 2376 lines net and `grep -c surreal Cargo.lock` is now 0.

`deny.toml` drops the seven BUSL-1.1 exceptions, the six `[[licenses.clarify]]` blocks written to work around surrealdb's missing `license` field, and the `BSL-1.0` allowance for `xxhash-rust` (which only arrived via surrealkv). The whole graph is back on the permissive allow list with no exceptions. The RUSTSEC-2023-0071 ignore stays: `rsa` still arrives through `kunobi-auth -> openidconnect`, confirmed with `cargo tree -i`.

The derived-record-id collision behind #832, where namespaces differing only by `/` vs `_` landed on one row, stops being a case to defend. The key tuple is the primary key now, so it is unrepresentable.

## Upgrading an existing deployment

Deployments running `planner.persistence.type=pvc` have a surrealkv *directory* at the db path, and it survives the upgrade. Opening a directory as a SQLite file fails on every start, so it cannot stay where it is.

What happens to it depends on whether anything will put the rows back, and a seed file is the only thing that ever writes them:

- With a non-empty seed already read and parsed, the old store is moved aside to `<name>.surrealkv-<millis>`, kept rather than deleted, and the leader refills the projections.
- Without one, startup fails and names both ways out. Replacing the store would come up ready and answer every request with a fallback plan, which is indistinguishable from a planner that has nothing to offer, and restarting cannot recover it because later starts open the empty SQLite file.

The seed is read and parsed *before* the store is touched, so a missing or malformed seed no longer fails after the old store has been displaced, and a seed kept inside that directory is not moved out from under its own path. An empty seed parses fine and writes nothing, so it counts as no seed.

This trades availability for recoverability on `pvc`, where the chart is single-replica with `Recreate`: the planner stays down until an operator acts. That is deliberate. The planner is advisory and clients fall back to their own planner either way, so the choice is between a loud failure that keeps the data and a quiet empty start that loses it.

The chart default is `ephemeral` (emptyDir per Pod), which has no store to find and is unaffected.

## Tests

Three new cases: the legacy directory is quarantined with a seed and refused without one (asserting the old store is untouched across repeated starts, since a CrashLoopBackOff retries), a seed that fails mid-transaction rolls back without disturbing already committed rows, and reads come back most-recently-seen first including the `ON CONFLICT` recency refresh.

Two existing cases were weaker than their names claimed and were rewritten. The rollback test fed malformed JSON, which is rejected while parsing, before the transaction opens. The recency assertions were vacuous because the newer key sorted first alphabetically anyway.

Every ordering and rollback assertion was confirmed against deliberately broken implementations: order-by-cache_key-only, never-refresh-`last_seen_at`, constant timestamp, ASC instead of DESC, and delete-on-error all fail these tests and pass without them.

`just check` and `just audit` are green locally on all seven workspace members.
