### PR TITLE
refactor(store): share blob metadata validation

### DIFF
--- a/crates/kache-store/src/blob_validation.rs
+++ b/crates/kache-store/src/blob_validation.rs
@@ -1,0 +1,56 @@
+use anyhow::{Context, Result, ensure};
+use std::{fs, path::Path};
+
+/// Check type and size from one metadata read. Callers own content verification
+/// and any repair or hit accounting after this check.
+pub(crate) fn validate_blob_metadata(blob: &Path, expected_size: u64) -> Result<()> {
+    let metadata = fs::metadata(blob).context("reading blob metadata")?;
+    ensure!(metadata.is_file(), "blob is not a regular file");
+    ensure!(
+        metadata.len() == expected_size,
+        "blob size mismatch (expected {expected_size}, got {})",
+        metadata.len()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_matching_files_including_empty_metadata_outputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob = dir.path().join("blob");
+        for contents in [b"".as_slice(), b"artifact bytes".as_slice()] {
+            fs::write(&blob, contents).unwrap();
+            validate_blob_metadata(&blob, contents.len() as u64).unwrap();
+        }
+    }
+
+    #[test]
+    fn rejects_both_shorter_and_longer_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob = dir.path().join("blob");
+        fs::write(&blob, b"12345").unwrap();
+        for expected_size in [0, 4, 6] {
+            assert!(validate_blob_metadata(&blob, expected_size).is_err());
+        }
+    }
+
+    #[test]
+    fn rejects_directories_even_when_the_size_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let size = fs::metadata(dir.path()).unwrap().len();
+        assert!(validate_blob_metadata(dir.path(), size).is_err());
+    }
+
+    #[test]
+    fn rejects_metadata_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob = dir.path().join("blob");
+        assert!(validate_blob_metadata(&blob, 0).is_err());
+        fs::write(&blob, b"bytes").unwrap();
+        assert!(validate_blob_metadata(&blob.join("child"), 0).is_err());
+    }
+}

--- a/crates/kache-store/src/lib.rs
+++ b/crates/kache-store/src/lib.rs
@@ -1,6 +1,7 @@
 //! Local artifact storage, independent of compiler parsing and remote transports.
 
 pub mod atomic;
+mod blob_validation;
 pub mod config;
 pub mod eviction;
 pub mod file_hash;

--- a/crates/kache-store/src/store.rs
+++ b/crates/kache-store/src/store.rs
@@ -1,4 +1,5 @@
 use crate::ArtifactPolicy;
+use crate::blob_validation::validate_blob_metadata;
 use anyhow::{Context, Result};
 pub use kache_format::{CachedFile, EntryMeta};
 use rusqlite::{Connection, Error as SqlError, ErrorCode, params};
@@ -685,9 +686,8 @@ pub fn probe_entry_readonly(db: &Connection, store_dir: &Path, cache_key: &str) 
 
     for cached_file in &meta.files {
         let blob = blob_path_in_store_dir(store_dir, &cached_file.hash);
-        match fs::metadata(&blob) {
-            Ok(file_meta) if file_meta.is_file() && file_meta.len() == cached_file.size => {}
-            _ => return ProbeOutcome::Fallback("blob missing or size mismatch"),
+        if validate_blob_metadata(&blob, cached_file.size).is_err() {
+            return ProbeOutcome::Fallback("blob missing or size mismatch");
         }
     }
 
@@ -1718,28 +1718,11 @@ impl<P: ArtifactPolicy> ArtifactStore<P> {
         // Verify all cached blobs still exist on disk and match expected size
         for cached_file in &meta.files {
             let blob = self.blob_path(&cached_file.hash);
-            if !blob.is_file() {
+            if let Err(error) = validate_blob_metadata(&blob, cached_file.size) {
                 tracing::warn!(
-                    "cache entry {} missing blob {} for file {}, evicting",
-                    cache_key.get(..16).unwrap_or(cache_key),
-                    &cached_file.hash[..16],
-                    cached_file.name
-                );
-                let _ = self.remove_entry(cache_key);
-                return Ok(None);
-            }
-
-            // Size validation: catches truncated/corrupt artifacts (e.g. LLVM
-            // "truncated or malformed object") without the cost of re-hashing.
-            if let Ok(file_meta) = fs::metadata(&blob)
-                && file_meta.len() != cached_file.size
-            {
-                tracing::warn!(
-                    "cache entry {} file {} size mismatch (expected {}, got {}), evicting",
+                    "cache entry {} file {} has invalid blob metadata ({error:#}), evicting",
                     cache_key.get(..16).unwrap_or(cache_key),
                     cached_file.name,
-                    cached_file.size,
-                    file_meta.len(),
                 );
                 let _ = self.remove_entry(cache_key);
                 return Ok(None);
@@ -6020,62 +6003,99 @@ mod tests {
     /// an authoritative `Miss`; anything needing repair probes `Fallback`.
     #[test]
     fn probe_entry_readonly_hit_miss_fallback() {
-        let dir = tempfile::tempdir().unwrap();
-        let config = test_config(dir.path());
-        let store = Store::open(&config).unwrap();
+        let _env_lock = crate::test_support::process_state_test_lock();
+        let _verify = EnvVarGuard::remove("KACHE_VERIFY_RESTORES");
+        for damage in ["missing", "short", "long", "directory"] {
+            let dir = tempfile::tempdir().unwrap();
+            let config = test_config(dir.path());
+            let store = Store::open(&config).unwrap();
 
-        let output_file = dir.path().join("out.rlib");
-        fs::write(&output_file, b"artifact-bytes").unwrap();
-        store
-            .put(
-                "probe_key",
-                "probe_crate",
-                &["lib".to_string()],
-                &[],
-                "x86_64-unknown-linux-gnu",
-                "dev",
-                &[(output_file, "libout.rlib".to_string())],
-                "out",
-                "err",
-            )
-            .unwrap();
+            let output_file = dir.path().join("out.rlib");
+            fs::write(&output_file, b"artifact-bytes").unwrap();
+            store
+                .put(
+                    "probe_key",
+                    "probe_crate",
+                    &["lib".to_string()],
+                    &[],
+                    "x86_64-unknown-linux-gnu",
+                    "dev",
+                    &[(output_file, "libout.rlib".to_string())],
+                    "out",
+                    "err",
+                )
+                .unwrap();
 
-        let ro = open_index_db_readonly(&config.index_db_path()).unwrap();
-        let store_dir = config.store_dir();
+            let ro = open_index_db_readonly(&config.index_db_path()).unwrap();
+            let store_dir = config.store_dir();
+            let hit_count = || {
+                store
+                    .db
+                    .query_row(
+                        "SELECT hit_count FROM entries WHERE cache_key = 'probe_key'",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap()
+            };
 
-        let meta = match probe_entry_readonly(&ro, &store_dir, "probe_key") {
-            ProbeOutcome::Hit(meta) => meta,
-            other => panic!("expected hit, got {other:?}"),
-        };
-        assert_eq!(meta.cache_key, "probe_key");
-        assert_eq!(meta.stdout, "out");
-        assert_eq!(meta.files.len(), 1);
-        let hits: i64 = store
-            .db
-            .query_row(
-                "SELECT hit_count FROM entries WHERE cache_key = 'probe_key'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(
-            hits, 0,
-            "a probe must not record a hit — the pin writer does"
-        );
+            let meta = match probe_entry_readonly(&ro, &store_dir, "probe_key") {
+                ProbeOutcome::Hit(meta) => meta,
+                other => panic!("expected hit, got {other:?}"),
+            };
+            assert_eq!(meta.cache_key, "probe_key");
+            assert_eq!(meta.stdout, "out");
+            assert_eq!(meta.stderr, "err");
+            assert_eq!(meta.files.len(), 1);
+            assert_eq!(
+                hit_count(),
+                0,
+                "the probe must leave accounting to the pin writer"
+            );
 
-        assert!(matches!(
-            probe_entry_readonly(&ro, &store_dir, "no_such_key"),
-            ProbeOutcome::Miss
-        ));
+            let local = store.get("probe_key").unwrap().unwrap();
+            assert_eq!(local.files, meta.files);
+            assert_eq!(local.stdout, meta.stdout);
+            assert_eq!(local.stderr, meta.stderr);
+            assert_eq!(hit_count(), 1, "get must record the hit");
 
-        // A blob deleted out from under the entry needs evict-and-miss (a
-        // write) — the probe must delegate that to the wrapper's local path.
-        let blob = store.blob_path(&meta.files[0].hash);
-        fs::remove_file(&blob).unwrap();
-        assert!(matches!(
-            probe_entry_readonly(&ro, &store_dir, "probe_key"),
-            ProbeOutcome::Fallback(_)
-        ));
+            assert!(matches!(
+                probe_entry_readonly(&ro, &store_dir, "no_such_key"),
+                ProbeOutcome::Miss
+            ));
+
+            let blob = store.blob_path(&meta.files[0].hash);
+            let mut perms = fs::metadata(&blob).unwrap().permissions();
+            perms.set_readonly(false);
+            fs::set_permissions(&blob, perms).unwrap();
+            fs::remove_file(&blob).unwrap();
+            match damage {
+                "missing" => {}
+                "short" => fs::write(&blob, b"short").unwrap(),
+                "long" => fs::write(&blob, b"longer than the original artifact").unwrap(),
+                "directory" => fs::create_dir(&blob).unwrap(),
+                _ => unreachable!(),
+            }
+
+            assert!(
+                matches!(
+                    probe_entry_readonly(&ro, &store_dir, "probe_key"),
+                    ProbeOutcome::Fallback("blob missing or size mismatch")
+                ),
+                "{damage}"
+            );
+            assert!(
+                store.contains("probe_key"),
+                "the probe must not evict: {damage}"
+            );
+            assert_eq!(
+                hit_count(),
+                1,
+                "a fallback must not count as a hit: {damage}"
+            );
+            assert!(store.get("probe_key").unwrap().is_none(), "{damage}");
+            assert!(!store.contains("probe_key"), "get must evict: {damage}");
+        }
     }
 
     /// `query_only` must make accidental writes through a probe connection a


### PR DESCRIPTION
## Summary

Local lookups and daemon probes now share the regular-file and exact-size check in `kache-store`. `get` reads each blob's metadata once, replacing its separate `is_file()` and `metadata()` calls.

The read-only probe returns fallback for invalid blobs without changing the entry or hit count. `get` evicts those entries and records successful hits. Content verification and sampling stay in `get`.

## Test plan

- [x] `just check` passed.
- [x] Tests cover matching and empty files, both size mismatch directions, metadata errors, directories with matching sizes, and probe/get accounting and eviction.
- [x] Removing either the type or size check makes its regression test fail; both checks were restored and the focused tests passed.
- [x] CI changed-line mutations: 2 caught, 2 unviable.
- [x] All [CI checks](https://github.com/kunobi-ninja/kache/actions/runs/33986680771) passed on `652d9fd`, including Windows, Kani, btrfs, and core/service mutations.
- [x] `just check` also passed on `main` at `1f6cfa2` with this exact patch applied, including the newly merged volume-routing tests.
- [x] [Performance gate](https://github.com/kunobi-ninja/kache/actions/runs/33987188089) passed against merge base `b9ba2fd`.

| Build | Base | PR | Change |
| --- | ---: | ---: | ---: |
| Cold | 123.627 s | 130.320 s | +5.4% |
| Warm | 16.522 s | 16.042 s | -2.9% |
| Cross-worktree | 22.791 s | 22.180 s | -2.7% |

One paired run on one runner; these measurements do not establish a sustained speedup. Both sides retained the same warm hit counts and restored bytes. The gate applies a +5% limit to the warm row.
