### PR TITLE
fix(nix): expose prebuilt compiler shims

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ kache install-shims
 export PATH="$HOME/.local/lib/kache/shims:$PATH"
 ```
 
-APT and AUR packages install `/usr/lib/kache`. Nix puts the same farm in `$out/lib/kache`. `kache init` can create the user farm; it does not change `PATH`. For `makepkg`, put the same assignment in `~/.makepkg.conf`. Wrap extra names already on `PATH` with `kache install-shims --from-path`.
+APT and AUR packages install `/usr/lib/kache`. Nix packages include the same symlinks in `${kache}/shims` and `${kache}/lib/kache`; see the [Nix configuration example](https://kunobi.ninja/docs/kache/getting-started/installation#nix).
+
+`kache init` can create the user farm; it does not change `PATH`. For `makepkg`, put the same assignment in `~/.makepkg.conf`. Wrap extra names already on `PATH` with `kache install-shims --from-path`.
 
 Kache inspects the real compiler invocation. Unsupported or unsafe invocations pass through. See [C and C++](https://kunobi.ninja/docs/kache/getting-started/c-cpp).
 

--- a/docs/getting-started/c-cpp.mdx
+++ b/docs/getting-started/c-cpp.mdx
@@ -35,6 +35,8 @@ The APT and AUR packages also install `/usr/lib/kache` with the same symlinks:
 export PATH="/usr/lib/kache:$PATH"
 ```
 
+Nix packages include the same symlinks in `${kache}/shims`, also available at `${kache}/lib/kache`. Add that directory to `PATH` using the [Nix configuration example](/docs/getting-started/installation#nix); no `kache install-shims` step is needed.
+
 `kache install-shims` creates `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++`. Keep the real compilers later in `PATH`; Kache skips any entry that resolves back to itself.
 
 Versioned and target-prefixed names (`gcc-13`, `x86_64-pc-linux-gnu-gcc`) work if you create them by hand or scan `PATH`:

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -103,6 +103,21 @@ nix profile install github:kunobi-ninja/kache/v0.14.2
 
 The flake also exports an overlay, NixOS module, and nix-darwin module. See the repository [`flake.nix`](https://github.com/kunobi-ninja/kache/blob/main/flake.nix) for their current names and options.
 
+The package includes `cc`, `c++`, `gcc`, `g++`, `clang`, and `clang++` symlinks in `${kache}/shims`. With this flake's `overlays.default` applied, enable them in your NixOS configuration:
+
+```nix
+{ pkgs, ... }:
+{
+  environment.systemPackages = [ pkgs.kache ];
+  environment.sessionVariables = {
+    RUSTC_WRAPPER = "${pkgs.kache}/bin/kache";
+    PATH = [ "${pkgs.kache}/shims" ];
+  };
+}
+```
+
+Keep the real compilers later in `PATH`. The shims cover C and C++; Rust still uses `RUSTC_WRAPPER`. Nix builds the symlinks, so no `kache install-shims` step is needed. The existing `${kache}/lib/kache` path remains available.
+
 ## Supported release targets
 
 | Platform | Architectures |

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -81,6 +81,7 @@ buildRustPackage {
     for name in cc c++ gcc g++ clang clang++; do
       ln -s $out/bin/kache $out/lib/kache/$name
     done
+    ln -s lib/kache $out/shims
   '';
 
   # reqwest (rustls) loads system CA certs when building a client, even for the


### PR DESCRIPTION
Nix packages now expose their compiler-name symlinks at `${kache}/shims`. The existing `${kache}/lib/kache` path remains available.

Document declarative NixOS PATH setup and retain `RUSTC_WRAPPER` for Rust builds, so users can configure caching without running `kache install-shims`.

Fixes #958.

Validation: `just check`, flake evaluation for all supported systems, the Nix formatting check, and evaluation of the documented NixOS example. Smoke checks verified all six compiler names through both shim paths and compared system C/C++ version output.
