### PR TITLE
refactor(wrapper): share Rust cache-hit completion

### DIFF
--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -6688,6 +6688,8 @@ mod tests {
     /// variables concurrently, which would otherwise decide the result.
     #[test]
     fn rustc_prediction_identity_needs_a_crate_root_and_separates_units() {
+        // The identity also reads cwd, which other tests change under this lock.
+        let _lock = crate::test_support::process_state_test_lock();
         let parse = |args: &[&str]| {
             RustcArgs::parse(&args.iter().map(|a| (*a).to_string()).collect::<Vec<_>>()).unwrap()
         };

--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -960,7 +960,8 @@ mod tests {
         let compiler =
             create_mock_probe_script(temp.path(), "mock_family_roundtrip", "echo KACHE_PROBE_GNU");
         let program = compiler.to_str().unwrap();
-        let res1 = probe_compiler_family(program).unwrap();
+        // The first call executes the freshly written script; the second must read the cache.
+        let res1 = probe_family_retrying(program).unwrap();
         let key = cache::probe_key_isolated("cc-family", program).unwrap();
         let mut hit = cache::load(temp.path(), &key).expect("probe result must be persisted");
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -21,6 +21,9 @@ use crate::link;
 use crate::scheduler::{self, FlightIdentity, MissGuard};
 use crate::store::{BuildClaim, EntryMeta, Store, StorePutResult};
 
+mod rustc_hit;
+use rustc_hit::RustcHitContext;
+
 /// Check whether progress lines should be printed to stderr.
 ///
 /// Controlled by `KACHE_PROGRESS` env var (off by default):
@@ -2109,24 +2112,23 @@ fn run_parsed_rustc(
         None
     };
 
+    let hit_context = RustcHitContext {
+        config,
+        compiler,
+        args,
+        crate_name,
+        event_root: &event_root,
+        start,
+        extra_inputs,
+    };
+
     // Daemon fast path (kunobi-ninja/kache#565): ask the running daemon
     // before opening SQLite. A served hit returns here; every other outcome
     // (miss, fallback, no daemon, restore failure) opens the store and runs
     // the fully local path below with the already-computed key.
     let mut store = store;
     if daemon_local {
-        if let Some(exit) = try_daemon_local_hit(
-            config,
-            compiler,
-            args,
-            &cache_key,
-            crate_name,
-            &event_root,
-            start,
-            key_ms,
-            key_hash_stats,
-            extra_inputs,
-        ) {
+        if let Some(exit) = try_daemon_local_hit(&hit_context, &cache_key, key_ms, key_hash_stats) {
             reset_adaptive_unit(adaptive_unit.as_ref());
             return Ok(exit);
         }
@@ -2224,14 +2226,15 @@ fn run_parsed_rustc(
                 let _ = hit_store.remove_entry(&cache_key);
             } else {
                 tracing::debug!("local cache hit for {} ({})", crate_name, &cache_key[..16]);
-                let restore_start = std::time::Instant::now();
-                if let Err(e) = restore_from_cache(
-                    config,
-                    compiler,
-                    &BlobSource::Store(hit_store),
-                    args,
+                if let Err(e) = hit_context.restore_and_finish(
+                    BlobSource::Store(hit_store),
                     &meta,
-                    extra_inputs,
+                    EventResult::LocalHit,
+                    &cache_key,
+                    key_ms,
+                    key_hash_stats,
+                    lookup_ms,
+                    record_closure.then_some(&store),
                 ) {
                     tracing::warn!(
                         "restoring local cache hit for {} failed: {} — recompiling",
@@ -2247,28 +2250,6 @@ fn run_parsed_rustc(
                         format!("restore failed: {e}"),
                     );
                 }
-                let restore_ms = restore_start.elapsed().as_millis() as u64;
-                let elapsed = start.elapsed().as_millis() as u64;
-                let size: u64 = meta.files.iter().map(|f| f.size).sum();
-                log_event_with_hash_stats(
-                    config,
-                    &event_root,
-                    crate_name,
-                    EventResult::LocalHit,
-                    elapsed,
-                    meta.compile_time_ms,
-                    size,
-                    &cache_key,
-                    key_ms,
-                    key_hash_stats,
-                    lookup_ms,
-                    restore_ms,
-                    0,
-                );
-                record_input_prediction(config, Some(&store), args, record_closure);
-                print_progress(crate_name, EventResult::LocalHit, elapsed, size);
-                replay_cached_diagnostics(&meta, std::io::stdout(), std::io::stderr());
-                clean_incremental_dir(config, args);
                 reset_adaptive_unit(adaptive_unit.as_ref());
 
                 return Ok(0);
@@ -2280,78 +2261,32 @@ fn run_parsed_rustc(
         maybe_trigger_prefetch(config, args);
 
         // 2. Check remote cache via daemon (if configured)
-        if config.remote.is_some() {
-            let entry_dir = store.entry_dir(&cache_key);
-            // No `if result.found` guard: it only predicts what the read
-            // below settles. Reaching here means the local lookup already
-            // missed on this pass, so the entry is present exactly when
-            // the daemon just fetched it — which is what `found` reports.
-            // In the race where another process stored it meanwhile,
-            // serving it beats recompiling; only the label is imprecise,
-            // and `prefetched` still separates a prefetch from a fetch.
-            // A daemon that never answered is a miss; the build compiles.
-            if let Some(result) =
-                crate::daemon::send_remote_check(config, &cache_key, &entry_dir, crate_name)
-                && let Ok(Some(meta)) = store.get(&cache_key)
-            {
-                let event_result = if result.prefetched {
-                    tracing::debug!(
-                        "prefetch cache hit for {} ({})",
-                        crate_name,
-                        &cache_key[..16]
-                    );
-                    EventResult::PrefetchHit
-                } else {
-                    tracing::debug!("remote cache hit for {} ({})", crate_name, &cache_key[..16]);
-                    EventResult::RemoteHit
-                };
-                let restore_start = std::time::Instant::now();
-                if let Err(e) = restore_from_cache(
-                    config,
-                    compiler,
-                    &BlobSource::Store(&store),
-                    args,
-                    &meta,
-                    extra_inputs,
-                ) {
-                    tracing::warn!(
-                        "restoring cache hit for {} failed: {} — recompiling",
-                        crate_name,
-                        e
-                    );
-                    return passthrough_with_event(
-                        config,
-                        args,
-                        crate_name,
-                        &event_root,
-                        start,
-                        format!("restore failed: {e}"),
-                    );
-                }
-                let restore_ms = restore_start.elapsed().as_millis() as u64;
-                let elapsed = start.elapsed().as_millis() as u64;
-                let size: u64 = meta.files.iter().map(|f| f.size).sum();
-                log_event_with_hash_stats(
-                    config,
-                    &event_root,
+        if let Some(restored) = try_rustc_remote_hit(
+            &hit_context,
+            &store,
+            &cache_key,
+            key_ms,
+            key_hash_stats,
+            lookup_ms,
+            record_closure,
+        ) {
+            if let Err(e) = restored {
+                tracing::warn!(
+                    "restoring cache hit for {} failed: {} — recompiling",
                     crate_name,
-                    event_result,
-                    elapsed,
-                    meta.compile_time_ms,
-                    size,
-                    &cache_key,
-                    key_ms,
-                    key_hash_stats,
-                    lookup_ms,
-                    restore_ms,
-                    0,
+                    e
                 );
-                print_progress(crate_name, event_result, elapsed, size);
-                replay_cached_diagnostics(&meta, std::io::stdout(), std::io::stderr());
-                clean_incremental_dir(config, args);
-                reset_adaptive_unit(adaptive_unit.as_ref());
-                return Ok(0);
+                return passthrough_with_event(
+                    config,
+                    args,
+                    crate_name,
+                    &event_root,
+                    start,
+                    format!("restore failed: {e}"),
+                );
             }
+            reset_adaptive_unit(adaptive_unit.as_ref());
+            return Ok(0);
         }
 
         if !owes_rederivation(predicted, rederived) {
@@ -2467,14 +2402,15 @@ fn run_parsed_rustc(
     };
 
     if let Some(meta) = committed {
-        let restore_start = std::time::Instant::now();
-        if let Err(e) = restore_from_cache(
-            config,
-            compiler,
-            &BlobSource::Store(&store),
-            args,
+        if let Err(e) = hit_context.restore_and_finish(
+            BlobSource::Store(&store),
             &meta,
-            extra_inputs,
+            EventResult::LocalHit,
+            &cache_key,
+            key_ms,
+            key_hash_stats,
+            lookup_ms,
+            record_closure.then_some(&store),
         ) {
             tracing::warn!(
                 "restoring cache hit for {} failed: {} — recompiling",
@@ -2490,29 +2426,6 @@ fn run_parsed_rustc(
                 format!("restore failed: {e}"),
             );
         }
-        let restore_ms = restore_start.elapsed().as_millis() as u64;
-        let elapsed = start.elapsed().as_millis() as u64;
-        let size: u64 = meta.files.iter().map(|f| f.size).sum();
-        log_event_with_hash_stats(
-            config,
-            &event_root,
-            crate_name,
-            EventResult::LocalHit,
-            elapsed,
-            meta.compile_time_ms,
-            size,
-            &cache_key,
-            key_ms,
-            key_hash_stats,
-            lookup_ms,
-            restore_ms,
-            0,
-        );
-        record_input_prediction(config, Some(&store), args, record_closure);
-        // Replay the original compiler diagnostics, exactly as the other hit
-        // sites do, so a coalesced compile does not swallow warnings or notes.
-        replay_cached_diagnostics(&meta, std::io::stdout(), std::io::stderr());
-        clean_incremental_dir(config, args);
         reset_adaptive_unit(adaptive_unit.as_ref());
         return Ok(0);
     }
@@ -3572,30 +3485,68 @@ fn recompute_key_without_prediction(
     )
 }
 
+/// Complete an entry made available by a remote check. `None` means no entry;
+/// a restore error stays distinct so the caller recompiles without reporting a hit.
+fn try_rustc_remote_hit(
+    hit: &RustcHitContext<'_>,
+    store: &Store,
+    cache_key: &str,
+    key_ms: u64,
+    key_hash_stats: FileHashStats,
+    lookup_ms: u64,
+    record_closure: bool,
+) -> Option<Result<()>> {
+    hit.config.remote.as_ref()?;
+    let entry_dir = store.entry_dir(cache_key);
+    let reply =
+        crate::daemon::send_remote_check(hit.config, cache_key, &entry_dir, hit.crate_name)?;
+    // A concurrent writer can also supply the entry. Read the store even when
+    // the reply says `found: false`; only `prefetched` affects the hit label.
+    let meta = store.get(cache_key).ok()??;
+    let result = if reply.prefetched {
+        tracing::debug!(
+            "prefetch cache hit for {} ({})",
+            hit.crate_name,
+            &cache_key[..16]
+        );
+        EventResult::PrefetchHit
+    } else {
+        tracing::debug!(
+            "remote cache hit for {} ({})",
+            hit.crate_name,
+            &cache_key[..16]
+        );
+        EventResult::RemoteHit
+    };
+    Some(hit.restore_and_finish(
+        BlobSource::Store(store),
+        &meta,
+        result,
+        cache_key,
+        key_ms,
+        key_hash_stats,
+        lookup_ms,
+        record_closure.then_some(store),
+    ))
+}
+
 /// Daemon fast path (kunobi-ninja/kache#565): returns `Some(exit_code)` only
 /// when the daemon served a hit AND the restore succeeded. Every other
 /// outcome returns `None` and the caller runs the fully local path — which
 /// owns eviction/repair for whatever the daemon or restore stumbled on.
-#[allow(clippy::too_many_arguments)]
 fn try_daemon_local_hit(
-    config: &Config,
-    compiler: &RustcCompiler,
-    args: &RustcArgs,
+    hit: &RustcHitContext<'_>,
     cache_key: &str,
-    crate_name: &str,
-    event_root: &str,
-    start: std::time::Instant,
     key_ms: u64,
     key_hash_stats: FileHashStats,
-    extra_inputs: Option<&crate::extra_inputs::ExtraInputsSnapshot>,
 ) -> Option<i32> {
     let lookup_start = std::time::Instant::now();
-    let target_dir = args.target_dir();
+    let target_dir = hit.args.target_dir();
     let reply = crate::daemon::send_local_lookup(
-        config,
+        hit.config,
         cache_key,
         target_dir.as_deref(),
-        args.path_normalization_root(),
+        hit.args.path_normalization_root(),
     )?;
     let lookup_ms = lookup_start.elapsed().as_millis() as u64;
     if reply.outcome != "hit" {
@@ -3606,44 +3557,25 @@ fn try_daemon_local_hit(
         return None;
     }
 
-    let restore_start = std::time::Instant::now();
-    let blobs = BlobSource::StoreDir(config.store_dir());
-    if let Err(e) = restore_from_cache(config, compiler, &blobs, args, &meta, extra_inputs) {
-        // Includes a blob evicted between the daemon's pin and our reflink —
-        // the local path below recompiles; never serve a partial hit.
-        tracing::warn!(
-            "daemon local hit restore failed for {}: {} — running local path",
-            crate_name,
-            e
-        );
-        return None;
-    }
-    let restore_ms = restore_start.elapsed().as_millis() as u64;
-    let elapsed = start.elapsed().as_millis() as u64;
-    let size: u64 = meta.files.iter().map(|f| f.size).sum();
-    log_event_with_hash_stats(
-        config,
-        event_root,
-        crate_name,
+    if let Err(e) = hit.restore_and_finish(
+        BlobSource::StoreDir(hit.config.store_dir()),
+        &meta,
         EventResult::LocalHit,
-        elapsed,
-        meta.compile_time_ms,
-        size,
         cache_key,
         key_ms,
         key_hash_stats,
         lookup_ms,
-        restore_ms,
-        0,
-    );
-    print_progress(crate_name, EventResult::LocalHit, elapsed, size);
-    if !meta.stdout.is_empty() {
-        print!("{}", meta.stdout);
+        None,
+    ) {
+        // Includes a blob evicted between the daemon's pin and our reflink —
+        // the local path below recompiles; never serve a partial hit.
+        tracing::warn!(
+            "daemon local hit restore failed for {}: {} — running local path",
+            hit.crate_name,
+            e
+        );
+        return None;
     }
-    if !meta.stderr.is_empty() {
-        eprint!("{}", meta.stderr);
-    }
-    clean_incremental_dir(config, args);
     Some(0)
 }
 
@@ -5294,6 +5226,8 @@ fn clean_incremental_dir(config: &Config, args: &RustcArgs) {
 
 #[cfg(test)]
 mod tests {
+    mod rustc_hit;
+
     use super::*;
     use crate::cache_key::FileHasher;
     use crate::transport::{ListenerOptions, socket_name};
@@ -5391,6 +5325,7 @@ mod tests {
     /// unit's inputs under its own identity.
     #[test]
     fn input_predictions_record_only_when_enabled_and_backed_by_a_store() {
+        let _lock = crate::test_support::process_state_test_lock();
         let dir = tempfile::tempdir().unwrap();
         let mut config = test_config(dir.path().join("cache"));
         let store = Store::open(&config).unwrap();
@@ -8362,6 +8297,14 @@ exit 0
 
     impl RemoteCheckReplyDaemon {
         fn spawn(socket_path: PathBuf, found: bool) -> Self {
+            Self::with_reply(
+                socket_path,
+                serde_json::json!({ "ok": true, "found": found }),
+            )
+        }
+
+        fn with_reply(socket_path: PathBuf, reply: serde_json::Value) -> Self {
+            let body = format!("{reply}\n");
             if let Some(parent) = socket_path.parent() {
                 std::fs::create_dir_all(parent).unwrap();
             }
@@ -8402,7 +8345,6 @@ exit 0
                         continue;
                     }
                     requests_thread.fetch_add(1, Ordering::SeqCst);
-                    let body = format!("{}\n", serde_json::json!({ "ok": true, "found": found }));
                     let _ = stream.write_all(body.as_bytes());
                 }
             });

--- a/src/wrapper/rustc_hit.rs
+++ b/src/wrapper/rustc_hit.rs
@@ -1,0 +1,69 @@
+use super::{
+    BlobSource, Config, EntryMeta, EventResult, FileHashStats, RustcArgs, RustcCompiler, Store,
+    clean_incremental_dir, log_event_with_hash_stats, print_progress, record_input_prediction,
+    replay_cached_diagnostics, restore_from_cache,
+};
+use anyhow::Result;
+use std::time::Instant;
+
+/// Invocation state shared by every Rust cache-hit path.
+pub(super) struct RustcHitContext<'a> {
+    pub config: &'a Config,
+    pub compiler: &'a RustcCompiler,
+    pub args: &'a RustcArgs,
+    pub crate_name: &'a str,
+    pub event_root: &'a str,
+    pub start: Instant,
+    pub extra_inputs: Option<&'a crate::extra_inputs::ExtraInputsSnapshot>,
+}
+
+impl RustcHitContext<'_> {
+    /// Report a hit only after all artifacts restore successfully. Prediction
+    /// records belong to the store used for key computation, which can differ
+    /// from the store that supplied the artifacts after a volume-shard miss.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn restore_and_finish(
+        &self,
+        blobs: BlobSource<'_>,
+        meta: &EntryMeta,
+        result: EventResult,
+        cache_key: &str,
+        key_ms: u64,
+        key_hash_stats: FileHashStats,
+        lookup_ms: u64,
+        prediction_store: Option<&Store>,
+    ) -> Result<()> {
+        let restore_start = Instant::now();
+        restore_from_cache(
+            self.config,
+            self.compiler,
+            &blobs,
+            self.args,
+            meta,
+            self.extra_inputs,
+        )?;
+        let restore_ms = restore_start.elapsed().as_millis() as u64;
+        let elapsed = self.start.elapsed().as_millis() as u64;
+        let size = meta.files.iter().map(|file| file.size).sum();
+        log_event_with_hash_stats(
+            self.config,
+            self.event_root,
+            self.crate_name,
+            result,
+            elapsed,
+            meta.compile_time_ms,
+            size,
+            cache_key,
+            key_ms,
+            key_hash_stats,
+            lookup_ms,
+            restore_ms,
+            0,
+        );
+        record_input_prediction(self.config, prediction_store, self.args, true);
+        print_progress(self.crate_name, result, elapsed, size);
+        replay_cached_diagnostics(meta, std::io::stdout(), std::io::stderr());
+        clean_incremental_dir(self.config, self.args);
+        Ok(())
+    }
+}

--- a/src/wrapper/tests/rustc_hit.rs
+++ b/src/wrapper/tests/rustc_hit.rs
@@ -1,0 +1,456 @@
+use super::*;
+use std::time::{Duration, Instant};
+
+const CACHE_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+struct Fixture {
+    dir: tempfile::TempDir,
+    config: Config,
+    store: Store,
+    compiler: RustcCompiler,
+    args: RustcArgs,
+    meta: EntryMeta,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path().join("cache"));
+        config.input_predictions = true;
+        let store = Store::open(&config).unwrap();
+        let out_dir = dir.path().join("target/debug/deps");
+        let incremental = dir.path().join("incremental");
+        std::fs::create_dir(&incremental).unwrap();
+        std::fs::write(incremental.join("state"), b"incremental state").unwrap();
+        let source = dir.path().join("lib.rs");
+        std::fs::write(&source, "pub fn f() {}\n").unwrap();
+        let args = rustc_args(&[
+            "rustc",
+            source.to_str().unwrap(),
+            "--crate-name",
+            "foo",
+            "--emit",
+            "metadata",
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+            "-C",
+            &format!("incremental={}", incremental.display()),
+        ]);
+        let files = [
+            ("libfoo.rmeta", b"metadata".as_slice()),
+            ("second.rmeta", b"second".as_slice()),
+        ]
+        .into_iter()
+        .map(|(name, content)| {
+            let hash = blake3::hash(content).to_hex().to_string();
+            create_blob(&store, &hash, content);
+            let mut file = cached_file(name, &hash);
+            file.size = content.len() as u64;
+            file
+        })
+        .collect();
+        let mut meta = entry_meta(CACHE_KEY, files, &["metadata"]);
+        meta.stdout = "HIT-STDOUT\n".into();
+        meta.stderr = "HIT-STDERR\n".into();
+        Self {
+            dir,
+            config,
+            store,
+            compiler: RustcCompiler::new(),
+            args,
+            meta,
+        }
+    }
+
+    fn context(&self) -> RustcHitContext<'_> {
+        RustcHitContext {
+            config: &self.config,
+            compiler: &self.compiler,
+            args: &self.args,
+            crate_name: "foo",
+            event_root: "/consumer",
+            start: Instant::now() - Duration::from_millis(1500),
+            extra_inputs: None,
+        }
+    }
+
+    fn closure(&self) -> crate::cache_key::DepInfo {
+        crate::cache_key::DepInfo {
+            source_files: vec![self.dir.path().join("lib.rs")],
+            env_deps: Vec::new(),
+        }
+    }
+
+    fn publish(&self) {
+        let entry_dir = self.store.entry_dir(CACHE_KEY);
+        std::fs::create_dir_all(&entry_dir).unwrap();
+        std::fs::write(
+            entry_dir.join("meta.json"),
+            serde_json::to_vec(&self.meta).unwrap(),
+        )
+        .unwrap();
+        self.store.insert_entry_row_for_test(CACHE_KEY);
+    }
+}
+
+// Run in a subprocess so assertions can observe the real compiler streams.
+#[test]
+#[ignore]
+fn completion_child() {
+    let mode = std::env::var("KACHE_TEST_RUSTC_HIT").unwrap();
+    let fixture = Fixture::new();
+    let is_daemon = mode == "daemon";
+    let fails = mode == "failure";
+    if fails {
+        std::fs::remove_file(fixture.store.blob_path(&fixture.meta.files[1].hash)).unwrap();
+    }
+    let result = match mode.as_str() {
+        "remote" => EventResult::RemoteHit,
+        "prefetch" => EventResult::PrefetchHit,
+        _ => EventResult::LocalHit,
+    };
+    crate::cache_key::stash_last_dep_info_for_test(fixture.closure());
+    let source = if is_daemon {
+        BlobSource::StoreDir(fixture.config.store_dir())
+    } else {
+        BlobSource::Store(&fixture.store)
+    };
+    let restored = fixture.context().restore_and_finish(
+        source,
+        &fixture.meta,
+        result,
+        CACHE_KEY,
+        41,
+        FileHashStats {
+            cache_hits: 3,
+            cache_misses: 5,
+            bytes_hashed: 73,
+        },
+        29,
+        (!is_daemon).then_some(&fixture.store),
+    );
+    let identity = crate::cache_key::rustc_prediction_identity(&fixture.args).unwrap();
+    let prediction = fixture.store.file_hasher().input_prediction(&identity);
+    if fails {
+        assert!(restored.is_err());
+        assert!(
+            !fixture.config.event_log_path().exists(),
+            "a failed restore must not report a hit"
+        );
+        assert!(fixture.args.incremental.as_ref().unwrap().is_dir());
+        assert!(prediction.is_none());
+        assert!(crate::cache_key::take_last_dep_info().is_some());
+        return;
+    }
+    restored.unwrap();
+    assert_eq!(
+        std::fs::read(fixture.args.out_dir.as_ref().unwrap().join("libfoo.rmeta")).unwrap(),
+        b"metadata"
+    );
+    assert_eq!(
+        std::fs::read(fixture.args.out_dir.as_ref().unwrap().join("second.rmeta")).unwrap(),
+        b"second"
+    );
+    assert!(!fixture.args.incremental.as_ref().unwrap().exists());
+    assert_eq!(prediction.is_some(), !is_daemon);
+    assert!(crate::cache_key::take_last_dep_info().is_none());
+    let events = events::read_events(&fixture.config.event_log_path()).unwrap();
+    assert_eq!(events.len(), 1);
+    let event = &events[0];
+    assert_eq!(event.result, result);
+    assert_eq!(event.root, "/consumer");
+    assert_eq!(event.crate_name, "foo");
+    assert_eq!(event.cache_key, CACHE_KEY);
+    assert_eq!(event.size, 14);
+    assert_eq!(event.compile_time_ms, 7);
+    assert!(event.elapsed_ms >= 1500);
+    assert_eq!(event.key_ms, 41);
+    assert_eq!(event.key_hash_hits, 3);
+    assert_eq!(event.key_hash_misses, 5);
+    assert_eq!(event.key_hash_bytes, 73);
+    assert_eq!(event.lookup_ms, 29);
+    assert_eq!(event.store_ms, 0);
+}
+
+#[test]
+fn completion_replays_diagnostics_and_progress_only_after_success() {
+    let _lock = crate::test_support::process_state_test_lock();
+    for (mode, label) in [
+        ("local", "local hit"),
+        ("remote", "remote hit"),
+        ("prefetch", "prefetch hit"),
+        ("daemon", "local hit"),
+        ("failure", ""),
+    ] {
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "wrapper::tests::rustc_hit::completion_child",
+                "--ignored",
+                "--nocapture",
+            ])
+            .env("KACHE_TEST_RUSTC_HIT", mode)
+            .env("KACHE_PROGRESS", "1")
+            .env_remove("CARGO_MANIFEST_DIR")
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "{mode}: {stdout}\n{stderr}");
+        let expected = usize::from(mode != "failure");
+        assert_eq!(
+            stdout.matches("HIT-STDOUT\n").count(),
+            expected,
+            "{mode}: {stdout}"
+        );
+        assert_eq!(
+            stderr.matches("HIT-STDERR\n").count(),
+            expected,
+            "{mode}: {stderr}"
+        );
+        assert_eq!(
+            stderr.contains("[kache] foo:"),
+            mode != "failure",
+            "{mode}: {stderr}"
+        );
+        if mode != "failure" {
+            assert!(
+                stderr.contains(&format!("[kache] foo: {label}")),
+                "{mode}: {stderr}"
+            );
+        }
+    }
+}
+
+#[test]
+fn predictions_belong_to_the_key_store_and_are_not_rewritten_when_declined() {
+    let _lock = crate::test_support::process_state_test_lock();
+    let _manifest = TestEnvGuard::remove("CARGO_MANIFEST_DIR");
+    let fixture = Fixture::new();
+    let fallback = Store::open(&test_config(fixture.dir.path().join("fallback"))).unwrap();
+    for file in &fixture.meta.files {
+        let bytes = std::fs::read(fixture.store.blob_path(&file.hash)).unwrap();
+        create_blob(&fallback, &file.hash, &bytes);
+        std::fs::remove_file(fixture.store.blob_path(&file.hash)).unwrap();
+    }
+    let closure = fixture.closure();
+    crate::cache_key::stash_last_dep_info_for_test(closure.clone());
+    fixture
+        .context()
+        .restore_and_finish(
+            BlobSource::Store(&fallback),
+            &fixture.meta,
+            EventResult::LocalHit,
+            CACHE_KEY,
+            0,
+            FileHashStats::default(),
+            0,
+            Some(&fixture.store),
+        )
+        .unwrap();
+    let identity = crate::cache_key::rustc_prediction_identity(&fixture.args).unwrap();
+    assert_eq!(
+        fixture
+            .store
+            .file_hasher()
+            .input_prediction(&identity)
+            .unwrap()
+            .sources,
+        closure.source_files
+    );
+    assert!(fallback.file_hasher().input_prediction(&identity).is_none());
+
+    crate::cache_key::stash_last_dep_info_for_test(crate::cache_key::DepInfo {
+        source_files: vec!["do-not-record.rs".into()],
+        env_deps: Vec::new(),
+    });
+    fixture
+        .context()
+        .restore_and_finish(
+            BlobSource::Store(&fallback),
+            &fixture.meta,
+            EventResult::LocalHit,
+            CACHE_KEY,
+            0,
+            FileHashStats::default(),
+            0,
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        fixture
+            .store
+            .file_hasher()
+            .input_prediction(&identity)
+            .unwrap()
+            .sources,
+        closure.source_files
+    );
+    assert!(crate::cache_key::take_last_dep_info().is_none());
+}
+
+#[test]
+fn remote_hits_preserve_labels_and_record_fresh_predictions() {
+    let _lock = crate::test_support::process_state_test_lock();
+    let _manifest = TestEnvGuard::remove("CARGO_MANIFEST_DIR");
+    for (prefetched, found, record_closure) in [
+        (false, true, true),
+        (true, true, true),
+        (false, false, true),
+        (false, true, false),
+    ] {
+        let mut fixture = Fixture::new();
+        fixture.config.remote = Some(crate::config::RemoteConfig::test_s3("bucket", "artifacts"));
+        fixture.publish();
+        let daemon = RemoteCheckReplyDaemon::with_reply(
+            fixture.config.socket_path(),
+            serde_json::json!({"ok": true, "found": found, "prefetched": prefetched}),
+        );
+        crate::cache_key::stash_last_dep_info_for_test(fixture.closure());
+        try_rustc_remote_hit(
+            &fixture.context(),
+            &fixture.store,
+            CACHE_KEY,
+            41,
+            FileHashStats::default(),
+            29,
+            record_closure,
+        )
+        .expect("a committed entry is usable even if the daemon reports found:false")
+        .unwrap();
+        assert_eq!(daemon.request_count(), 1);
+        let events = events::read_events(&fixture.config.event_log_path()).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].result,
+            if prefetched {
+                EventResult::PrefetchHit
+            } else {
+                EventResult::RemoteHit
+            }
+        );
+        let identity = crate::cache_key::rustc_prediction_identity(&fixture.args).unwrap();
+        let prediction = fixture.store.file_hasher().input_prediction(&identity);
+        assert_eq!(prediction.is_some(), record_closure);
+        if let Some(prediction) = prediction {
+            assert_eq!(prediction.sources, fixture.closure().source_files);
+        }
+        assert!(crate::cache_key::take_last_dep_info().is_none());
+    }
+}
+
+#[test]
+fn remote_misses_and_failed_restores_do_not_complete_hits() {
+    let _lock = crate::test_support::process_state_test_lock();
+    let _manifest = TestEnvGuard::remove("CARGO_MANIFEST_DIR");
+    for mode in ["disabled", "no-reply", "no-entry", "restore-error"] {
+        let mut fixture = Fixture::new();
+        if mode != "disabled" {
+            fixture.config.remote =
+                Some(crate::config::RemoteConfig::test_s3("bucket", "artifacts"));
+        }
+        if mode == "restore-error" {
+            fixture.meta.emit_kinds = vec!["link".into()];
+        }
+        if mode != "no-entry" {
+            fixture.publish();
+        }
+        let daemon = (mode != "no-reply")
+            .then(|| RemoteCheckReplyDaemon::spawn(fixture.config.socket_path(), true));
+        let restored = try_rustc_remote_hit(
+            &fixture.context(),
+            &fixture.store,
+            CACHE_KEY,
+            0,
+            FileHashStats::default(),
+            0,
+            true,
+        );
+        if mode == "restore-error" {
+            assert!(restored.unwrap().is_err());
+        } else {
+            assert!(restored.is_none(), "{mode}");
+        }
+        if let Some(daemon) = daemon {
+            assert_eq!(daemon.request_count(), usize::from(mode != "disabled"));
+        }
+        assert!(!fixture.config.event_log_path().exists(), "{mode}");
+        assert!(
+            fixture.args.incremental.as_ref().unwrap().is_dir(),
+            "{mode}"
+        );
+    }
+}
+
+#[test]
+fn daemon_hits_need_no_writable_index() {
+    let _lock = crate::test_support::process_state_test_lock();
+    let _manifest = TestEnvGuard::remove("CARGO_MANIFEST_DIR");
+    let Fixture {
+        dir: _dir,
+        config,
+        store,
+        compiler,
+        args,
+        meta,
+    } = Fixture::new();
+    drop(store);
+    std::fs::remove_file(config.index_db_path()).unwrap();
+    std::fs::create_dir(config.index_db_path()).unwrap();
+    let _daemon = RemoteCheckReplyDaemon::with_reply(
+        config.socket_path(),
+        serde_json::json!({"ok": true, "local_lookup": crate::daemon::LocalLookupReply::hit(meta)}),
+    );
+    let hit = RustcHitContext {
+        config: &config,
+        compiler: &compiler,
+        args: &args,
+        crate_name: "foo",
+        event_root: "/consumer",
+        start: Instant::now(),
+        extra_inputs: None,
+    };
+    assert_eq!(
+        try_daemon_local_hit(&hit, CACHE_KEY, 0, FileHashStats::default()),
+        Some(0)
+    );
+    assert!(config.index_db_path().is_dir());
+    assert_eq!(
+        events::read_events(&config.event_log_path()).unwrap().len(),
+        1
+    );
+}
+
+#[test]
+fn daemon_declines_invalid_replies_and_failed_restores() {
+    let _lock = crate::test_support::process_state_test_lock();
+    let _manifest = TestEnvGuard::remove("CARGO_MANIFEST_DIR");
+    for mode in ["miss", "no-meta", "empty", "wrong-key", "missing-blob"] {
+        let fixture = Fixture::new();
+        let mut reply = crate::daemon::LocalLookupReply::hit(fixture.meta.clone());
+        match mode {
+            "miss" => reply.outcome = "miss".into(),
+            "no-meta" => reply.meta = None,
+            "empty" => reply.meta.as_mut().unwrap().files.clear(),
+            "wrong-key" => reply.meta.as_mut().unwrap().cache_key = "other-key".into(),
+            "missing-blob" => {
+                std::fs::remove_file(fixture.store.blob_path(&fixture.meta.files[0].hash)).unwrap()
+            }
+            _ => unreachable!(),
+        }
+        let _daemon = RemoteCheckReplyDaemon::with_reply(
+            fixture.config.socket_path(),
+            serde_json::json!({"ok": true, "local_lookup": reply}),
+        );
+        assert_eq!(
+            try_daemon_local_hit(&fixture.context(), CACHE_KEY, 0, FileHashStats::default()),
+            None,
+            "{mode}"
+        );
+        assert!(!fixture.config.event_log_path().exists(), "{mode}");
+        assert!(
+            fixture.args.incremental.as_ref().unwrap().is_dir(),
+            "{mode}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Use one Rust cache-hit completion handler for local, remote, prefetched, and coalesced hits, including the daemon fast path. It restores artifacts before recording a hit, then handles input predictions, progress, cached diagnostics, and incremental cleanup.

This fixes two differences between those paths: coalesced hits now print `KACHE_PROGRESS` output, and remote/prefetched hits save freshly discovered input predictions. Predictions remain in the store used to compute the key, including when artifacts come from a fallback store. Daemon hits still need no writable SQLite index.

This continues the refactor after #959 with a private wrapper module.

The probe-cache roundtrip fixture also uses the existing bounded retry for its first script launch. Its cached read still runs once.

The existing prediction-identity tests now take the process-state lock so concurrent cwd or environment changes cannot alter their identities between assertions.

## Test plan

- [x] `CARGO_INCREMENTAL=0 RUST_TEST_THREADS=1 just check`: formatting, clippy, resource-guard checks, and workspace tests.
- [x] Regression tests cover completion side effects, diagnostic streams, remote/prefetch routing, fallback-store predictions, invalid daemon replies, and failed restores.
- [x] Manually verified that tests fail when restore errors are ignored, the remote prediction policy is inverted, or diagnostic streams are swapped. Restored the source after each check.
- [x] [CI](https://github.com/kunobi-ninja/kache/actions/runs/33995486319): Linux, macOS, Windows, Nix, btrfs, package verification, Kani, and mutation suites passed. All 10 changed-line mutants were caught; workspace line coverage is 91.2%.
- [x] [Performance gate](https://github.com/kunobi-ninja/kache/actions/runs/33996380045): warm 16.202 s → 15.044 s, with matching hit counts and restored bytes. These measurements come from one paired run.

## Checklist

- [x] New behavior has regression coverage.
- [x] Commit follows the repository's conventional commit format.
- [x] Existing CLI and configuration documentation remains accurate.
