### PR TITLE
feat: report the latest recorded build session

### DIFF
--- a/docs/commands/reference.mdx
+++ b/docs/commands/reference.mdx
@@ -189,9 +189,12 @@ See [Monitor](/docs/monitor).
 kache stats
 kache stats --since 15m
 kache stats --since 2h
+kache stats --last-build --root "$PWD"
 ```
 
 `--since` accepts `s`, `m`, `h`, and `d` units (`90s`, `15m`, `2h`, `7d`). A bare number is hours. The default is `24h`. The counters and the `last ...` label both describe the requested window; a value that does not parse is an error.
+
+`--last-build` shows the detailed report for the latest recorded activity session. Add `--root` to choose a build tree; without it, the latest event across all roots chooses the session. It cannot be combined with `--since`. With `--json`, the stats envelope contains a `report` object using the build report schema below.
 
 ## `kache telemetry`
 
@@ -215,6 +218,7 @@ The command compares recorded key material for the named rustc crate and reports
 ```bash
 kache report --format text --since 24h
 kache report --format markdown --root "$PWD"
+kache report --last-build --root "$PWD" --format markdown
 kache report --format json --output report.json
 kache report --format trace --output trace.json
 ```
@@ -223,11 +227,20 @@ kache report --format trace --output trace.json
 | --- | --- | --- |
 | `--format` | `text` | `json`, `trace`, `perfetto`, `chrome-trace`, `markdown`, `github`, `text` |
 | `--since` | `24h` | Event window; same forms as `kache stats` (`15m`, `2h`, `7d`, bare hours) |
+| `--last-build` | off | Latest recorded activity session; conflicts with `--since` |
 | `--root` | all roots | Include events from one build tree |
 | `--output`, `-o` | stdout | Write to a file |
 | `--top` | `10` | Number of ranked entries |
 
 `trace`, `perfetto`, and `chrome-trace` select the same trace representation. The JSON contract is documented by [`report.schema.json`](https://github.com/kunobi-ninja/kache/blob/main/docs/commands/report.schema.json).
+
+`--last-build` selects by the latest compiler event timestamp across the retained log, including events older than 24 hours. It includes only that root and session ID. For local or older events without session IDs, it infers a session from overlapping compiler activity and gaps shorter than five minutes, stopping at an event with a recorded ID. The report states which rule it used. `--root` limits the search to that tree and its descendants; the selected session still belongs to one exact root.
+
+A session can span concurrent or nearby Cargo commands. This flag does not identify one Cargo invocation. Cargo commands that do no compiler work produce no new events, running compiles have not been logged yet, and log rotation can remove the start of a session. An empty selection is an error.
+
+The session report includes cache hits, misses, bypass reasons, restored bytes and the observed compiler wall span. Compile work avoided is an aggregate estimate, not elapsed build time saved. Remote transfer totals and GC are omitted because those logs cannot identify the selected session. Store inventory and deduplication totals still describe the whole cache.
+
+JSON exposes the selection in `meta.session` (`root`, optional `session_id`, `inferred`, `inactivity_secs`); trace output carries it as `session`. In session reports, `since_secs` and `since_hours` describe the lookback to the first retained compiler start; `meta.session` defines the selection.
 
 Every report format totals the wrapper's phases per crate: startup (process start to wrapper entry), key computation with the rustc dep-info pre-pass split out by time and run count, lookup, scheduler wait (flight join plus permit acquisition), restore or store, and the unattributed remainder. Unattributed is wrapper overhead minus every measured phase, where overhead excludes the compile on a compiled crate and is the whole wrapper time on a hit. Events written by wrappers before schema 17 report zero startup, dep-info and wait time.
 

--- a/docs/commands/report.schema.json
+++ b/docs/commands/report.schema.json
@@ -55,7 +55,18 @@
         },
         "root_filter": {
           "type": ["string", "null"],
-          "description": "Root path filter if --root was specified."
+          "description": "Root path filter; for --last-build, the exact selected root."
+        },
+        "session": {
+          "type": ["object", "null"],
+          "description": "Selection for --last-build. May span Cargo commands and only covers retained, completed compiler events. When present, since_secs is the lookback to the earliest selected compiler start, not the selection rule.",
+          "required": ["root", "inferred", "inactivity_secs"],
+          "properties": {
+            "root": { "type": "string", "description": "Exact root of the selected session." },
+            "session_id": { "type": "string", "description": "Recorded ID; absent for inferred sessions." },
+            "inferred": { "type": "boolean", "description": "True when events without IDs were grouped by activity." },
+            "inactivity_secs": { "type": "integer", "minimum": 1, "description": "Idle gap that separates activity sessions." }
+          }
         }
       }
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -979,16 +979,38 @@ fn format_epoch_ms_utc(ms: u64) -> String {
 
 // ── kache report ──────────────────────────────────────────────────────────
 
+pub fn stats_last_build(
+    config: &Config,
+    root: Option<std::path::PathBuf>,
+    json: bool,
+) -> Result<()> {
+    let filter = crate::report::ReportFilter {
+        root,
+        last_build: true,
+    };
+    let report =
+        crate::report::generate_report_with_filter(config, SinceWindow::DEFAULT, 10, &filter)?;
+    if json {
+        #[derive(serde::Serialize)]
+        struct Body {
+            report: crate::report::BuildReport,
+        }
+        crate::machine::emit("stats", Body { report }, Vec::new())
+    } else {
+        println!("{}", crate::report::format_text(&report));
+        Ok(())
+    }
+}
+
 pub fn report(
     config: &Config,
     format: &str,
     window: SinceWindow,
-    root: Option<std::path::PathBuf>,
+    filter: crate::report::ReportFilter,
     output: Option<std::path::PathBuf>,
     top: usize,
 ) -> Result<()> {
-    let report = if root.is_some() {
-        let filter = crate::report::ReportFilter { root };
+    let report = if filter.root.is_some() || filter.last_build {
         crate::report::generate_report_with_filter(config, window, top, &filter)?
     } else {
         crate::report::generate_report(config, window, top)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,6 +278,15 @@ enum Commands {
         /// Event window (e.g. 15m, 2h, 7d; a bare number is hours)
         #[arg(long, default_value = "24h")]
         since: String,
+
+        /// Report the latest recorded activity session. Sessions may span Cargo
+        /// commands; events without IDs use a five-minute idle gap per root.
+        #[arg(long, conflicts_with = "since")]
+        last_build: bool,
+
+        /// Select the latest session within this build tree/root
+        #[arg(long, requires = "last_build")]
+        root: Option<PathBuf>,
     },
 
     /// Write cache counters as OTLP JSON for Kartero to import later
@@ -301,6 +310,11 @@ enum Commands {
         /// Event window (e.g. 15m, 2h, 7d; a bare number is hours)
         #[arg(long, default_value = "24h")]
         since: String,
+
+        /// Report the latest recorded activity session. Sessions may span Cargo
+        /// commands; events without IDs use a five-minute idle gap per root.
+        #[arg(long, conflicts_with = "since")]
+        last_build: bool,
 
         /// Only include compiler events from this build tree/root
         #[arg(long)]
@@ -778,14 +792,29 @@ fn main() -> Result<()> {
         Some(Commands::Report {
             format,
             since,
+            last_build,
             root,
             output,
             top,
         }) => {
             let window = parse_since_window(&since)?;
-            cli::report(&config, &format, window, root, output, top)
+            cli::report(
+                &config,
+                &format,
+                window,
+                report::ReportFilter { root, last_build },
+                output,
+                top,
+            )
         }
-        Some(Commands::Stats { since }) => {
+        Some(Commands::Stats {
+            since,
+            last_build,
+            root,
+        }) => {
+            if last_build {
+                return cli::stats_last_build(&config, root, json);
+            }
             let window = parse_since_window(&since)?;
             cli::stats(&config, &config_provenance, window, json)
         }
@@ -1212,6 +1241,8 @@ mod tests {
     fn json_support_is_limited_to_machine_readable_commands() {
         assert!(command_supports_json(&Some(Commands::Stats {
             since: "24h".to_string(),
+            last_build: false,
+            root: None,
         })));
         assert!(command_supports_json(&Some(Commands::Daemon {
             command: Some(DaemonCommands::Status),

--- a/src/report.rs
+++ b/src/report.rs
@@ -86,12 +86,45 @@ pub struct ReportMeta {
     pub since: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub root_filter: Option<String>,
+    /// Present when the report selects one activity session instead of a window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<ReportSession>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ReportSession {
+    pub root: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub session_id: String,
+    /// Local and older events lack session IDs; group their activity by idle gap.
+    pub inferred: bool,
+    pub inactivity_secs: u64,
+}
+
+impl ReportSession {
+    fn description(&self) -> String {
+        let identity = if self.inferred {
+            format!(
+                "inferred from activity ({}s idle gap)",
+                self.inactivity_secs
+            )
+        } else {
+            format!("recorded {}", self.session_id)
+        };
+        format!(
+            "Session: {identity}; root: {}. May include multiple Cargo commands. Only retained, completed compiler events are included. Store inventory covers the whole cache.",
+            self.root
+        )
+    }
 }
 
 impl ReportMeta {
     /// The window for headings: `since` when present, else the whole-hour
     /// value an older report carried.
     pub fn window_label(&self) -> String {
+        if self.session.is_some() {
+            return "build session".to_string();
+        }
         if self.since.is_empty() {
             format!("{}h", self.since_hours)
         } else {
@@ -706,6 +739,7 @@ pub struct ErrorDetail {
 #[derive(Debug, Clone, Default)]
 pub struct ReportFilter {
     pub root: Option<PathBuf>,
+    pub last_build: bool,
 }
 
 pub fn generate_report(config: &Config, window: SinceWindow, top: usize) -> Result<BuildReport> {
@@ -720,11 +754,28 @@ pub fn generate_report_with_filter(
 ) -> Result<BuildReport> {
     let now = Utc::now();
     let since = window.cutoff(now);
-    let mut build_events = events::read_events_since(&config.event_log_path(), since)?;
-    let root_filter = filter.root.as_deref().map(normalize_filter_root);
+    let mut build_events = if filter.last_build {
+        events::read_events(&config.event_log_path())?
+    } else {
+        events::read_events_since(&config.event_log_path(), since)?
+    };
+    let mut root_filter = filter.root.as_deref().map(normalize_filter_root);
     if let Some(root) = root_filter.as_deref() {
         build_events.retain(|event| event_matches_root(event, root));
     }
+    let session = if filter.last_build {
+        let session = select_last_build(&mut build_events)?;
+        root_filter = Some(session.root.clone());
+        Some(session)
+    } else {
+        None
+    };
+    let window = if filter.last_build {
+        let start = build_events.iter().map(event_start).min().unwrap();
+        SinceWindow::from_secs(now.signed_duration_since(start).num_seconds().max(0) as u64)
+    } else {
+        window
+    };
     let since_ts = window.cutoff_unix_secs(now);
     let transfers = if root_filter.is_some() {
         Vec::new()
@@ -894,6 +945,7 @@ pub fn generate_report_with_filter(
             since_secs: window.secs(),
             since: window.label(),
             root_filter: root_filter.clone(),
+            session,
         },
         summary: ReportSummary {
             hit_rate_pct: (hit_rate * 10.0).round() / 10.0,
@@ -981,8 +1033,52 @@ pub fn generate_report_with_filter(
         bypass,
         errors_detail,
         suggestions,
-        gc: load_gc_summary(&config.cache_dir, since),
+        gc: if filter.last_build {
+            None
+        } else {
+            load_gc_summary(&config.cache_dir, since)
+        },
     })
+}
+
+/// Select by completion timestamp, not append order: wrappers finish in parallel.
+/// Session IDs belong to a root. Events without IDs can only support an inferred
+/// activity group; they cannot identify individual Cargo invocations.
+fn select_last_build(events: &mut Vec<BuildEvent>) -> Result<ReportSession> {
+    let latest = events
+        .iter()
+        .max_by_key(|event| event.ts)
+        .ok_or_else(|| anyhow::anyhow!("No recorded compiler events for the selected root(s)."))?;
+    anyhow::ensure!(
+        !latest.root.is_empty(),
+        "The latest compiler event has no recorded root; use --root to select a known build tree."
+    );
+    let session = ReportSession {
+        root: latest.root.clone(),
+        session_id: latest.session_id.clone(),
+        inferred: latest.session_id.is_empty(),
+        inactivity_secs: crate::wrapper::BUILD_SESSION_SECS,
+    };
+    events.retain(|event| event.root == session.root);
+    if session.inferred {
+        events.sort_by_key(|event| event.ts);
+        let mut start = event_start(events.last().unwrap());
+        let mut first = events.len();
+        for (index, event) in events.iter().enumerate().rev() {
+            if !event.session_id.is_empty()
+                || start.signed_duration_since(event.ts)
+                    >= chrono::Duration::seconds(session.inactivity_secs as i64)
+            {
+                break;
+            }
+            first = index;
+            start = start.min(event_start(event));
+        }
+        events.drain(..first);
+    } else {
+        events.retain(|event| event.session_id == session.session_id);
+    }
+    Ok(session)
 }
 
 fn normalize_filter_root(root: &Path) -> String {
@@ -2190,6 +2286,8 @@ pub fn format_trace_json(report: &BuildReport) -> Result<String> {
         display_time_unit: &'a str,
         #[serde(rename = "traceEvents")]
         trace_events: Vec<serde_json::Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        session: Option<&'a ReportSession>,
     }
 
     // Lead with chrome-trace metadata events that name the process and each
@@ -2220,6 +2318,7 @@ pub fn format_trace_json(report: &BuildReport) -> Result<String> {
     Ok(serde_json::to_string_pretty(&TraceOutput {
         display_time_unit: &report.display_time_unit,
         trace_events,
+        session: report.meta.session.as_ref(),
     })?)
 }
 
@@ -2308,6 +2407,12 @@ pub fn format_markdown(report: &BuildReport) -> String {
     lines.push("| Metric | Value |".to_string());
     lines.push("|---|---|".to_string());
     lines.push(format!("| Window | last {} |", report.meta.window_label()));
+    if let Some(session) = &report.meta.session {
+        lines.push(format!(
+            "| Scope | {} |",
+            markdown_cell(&session.description())
+        ));
+    }
     lines.push(format!("| Hit rate (count) | {:.1}% |", s.hit_rate_pct));
     if let Some(w) = s.weighted_hit_rate_pct {
         lines.push(format!("| Hit rate (compile-cost weighted) | {:.1}% |", w));
@@ -2668,6 +2773,12 @@ pub fn format_github(report: &BuildReport) -> String {
         "| **Window** | last {} |",
         report.meta.window_label()
     ));
+    if let Some(session) = &report.meta.session {
+        lines.push(format!(
+            "| **Scope** | {} |",
+            markdown_cell(&session.description())
+        ));
+    }
     lines.push(format!(
         "| **Crates** | {} cached / {} compiled / {} total |",
         total_hits, total_compiled, s.total_crates
@@ -3157,6 +3268,9 @@ pub fn format_text(report: &BuildReport) -> String {
         "kache build report (last {})",
         report.meta.window_label()
     ));
+    if let Some(session) = &report.meta.session {
+        lines.push(format!("  {}", session.description()));
+    }
     lines.push(format!(
         "  {:.1}% hit rate — {}/{} cacheable crates cached, {} compiled",
         s.hit_rate_pct, total_hits, s.total_crates, total_compiled,
@@ -4339,6 +4453,154 @@ mod tests {
         assert_eq!(current.window_label(), "15m");
     }
 
+    fn session_event(root: &str, session: &str, second: i64, elapsed_ms: u64) -> BuildEvent {
+        let mut event = test_event("fixture", EventResult::Miss, elapsed_ms, 10, 100, "key");
+        event.root = root.to_string();
+        event.session_id = session.to_string();
+        event.ts = DateTime::from_timestamp(1_700_000_000 + second, 0).unwrap();
+        event
+    }
+
+    #[test]
+    fn last_build_selects_recorded_root_and_id_by_timestamp() {
+        let mut events = vec![
+            session_event("/repo", "new", 900, 100),
+            session_event("/repo/nested", "new", 899, 100),
+            session_event("/other", "new", 898, 100),
+            session_event("/repo", "old", 897, 100),
+            session_event("/repo", "", 896, 100),
+            session_event("/repo", "new", 0, 100),
+        ];
+        let session = select_last_build(&mut events).unwrap();
+        assert_eq!(session.root, "/repo");
+        assert_eq!(session.session_id, "new");
+        assert!(!session.inferred);
+        assert_eq!(session.inactivity_secs, 300);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].ts.timestamp(), 1_700_000_900);
+        assert_eq!(events[1].ts.timestamp(), 1_700_000_000);
+        assert!(session.description().contains("recorded new; root: /repo"));
+    }
+
+    #[test]
+    fn last_build_infers_local_activity_with_idle_and_recorded_boundaries() {
+        for (old_id, old_second) in [("", 0), ("recorded", 299)] {
+            let mut events = vec![
+                session_event("/repo", "", 1_199, 0),
+                session_event("/repo", old_id, old_second, 0),
+                // A ten-minute compile overlaps the preceding activity: do not
+                // split merely because its completion is more than 5m later.
+                session_event("/repo", "", 900, 600_000),
+                session_event("/repo", "", 300, 0),
+                session_event("/other", "", 1_198, 0),
+            ];
+            let session = select_last_build(&mut events).unwrap();
+            assert!(session.inferred);
+            assert!(session.session_id.is_empty());
+            assert_eq!(session.inactivity_secs, 300);
+            assert_eq!(events.len(), 3);
+            assert_eq!(events[0].ts.timestamp(), 1_700_000_300);
+            assert_eq!(events[2].ts.timestamp(), 1_700_001_199);
+            assert!(
+                session
+                    .description()
+                    .contains("inferred from activity (300s idle gap)")
+            );
+        }
+    }
+
+    #[test]
+    fn last_build_does_not_fall_back_to_an_older_known_root() {
+        assert!(
+            select_last_build(&mut Vec::new())
+                .unwrap_err()
+                .to_string()
+                .contains("No recorded")
+        );
+        let mut events = vec![
+            session_event("/repo", "known", 0, 0),
+            session_event("", "", 1, 0),
+        ];
+        assert!(
+            select_last_build(&mut events)
+                .unwrap_err()
+                .to_string()
+                .contains("--root")
+        );
+    }
+
+    #[test]
+    fn last_build_report_uses_retained_history_and_omits_unscoped_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = write_test_events(dir.path());
+        let root = dir.path().join("checkout-a").canonicalize().unwrap();
+        let root_str = root.to_str().unwrap();
+        let mut hit = session_event(root_str, "selected", 10, 100);
+        hit.result = EventResult::LocalHit;
+        hit.compile_time_ms = 4_000;
+        hit.copied_bytes = 512;
+        let mut miss = session_event(root_str, "selected", 0, 200);
+        miss.crate_name = "compiled".to_string();
+        let mut bypass = session_event(root_str, "selected", 5, 50);
+        bypass.result = EventResult::Passthrough;
+        bypass.passthrough_reason = "fixture bypass".to_string();
+        let old = session_event(root_str, "old", -1, 0);
+        let other = session_event("/other", "selected", 9, 0);
+        let lines =
+            [&hit, &miss, &bypass, &old, &other].map(|event| serde_json::to_string(event).unwrap());
+        std::fs::write(config.event_log_path(), lines.join("\n") + "\n").unwrap();
+        write_gc_stats(dir.path(), Utc::now());
+
+        let report = generate_report_with_filter(
+            &config,
+            SinceWindow::DEFAULT,
+            10,
+            &ReportFilter {
+                root: None,
+                last_build: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(report.meta.root_filter.as_deref(), Some(root_str));
+        assert_eq!(report.meta.session.as_ref().unwrap().session_id, "selected");
+        assert!(report.meta.since_secs > 86_400);
+        assert_eq!(report.summary.local_hits, 1);
+        assert_eq!(report.summary.misses, 1);
+        assert_eq!(report.summary.passthroughs, 1);
+        assert_eq!(report.summary.time_saved_ms, 4_000);
+        assert_eq!(report.storage.restored_bytes, 512);
+        assert_eq!(report.timeline.event_count, 3);
+        assert_eq!(report.timeline.duration_ms, 10_200);
+        assert!(report.network.is_none());
+        assert!(report.gc.is_none());
+        for text in [
+            format_text(&report),
+            format_markdown(&report),
+            format_github(&report),
+        ] {
+            assert!(text.contains("last build session"));
+            assert!(text.contains("recorded selected"));
+            assert!(text.contains("May include multiple Cargo commands"));
+            assert!(text.contains("fixture bypass"));
+        }
+        let json: serde_json::Value = serde_json::from_str(&format_json(&report).unwrap()).unwrap();
+        assert_eq!(json["meta"]["session"]["inferred"], false);
+        let trace: serde_json::Value =
+            serde_json::from_str(&format_trace_json(&report).unwrap()).unwrap();
+        assert_eq!(trace["session"]["session_id"], "selected");
+
+        let absent = generate_report_with_filter(
+            &config,
+            SinceWindow::DEFAULT,
+            10,
+            &ReportFilter {
+                root: Some(dir.path().join("missing")),
+                last_build: true,
+            },
+        );
+        assert!(absent.unwrap_err().to_string().contains("No recorded"));
+    }
+
     #[test]
     fn test_report_filters_by_root() {
         let dir = tempfile::tempdir().unwrap();
@@ -4352,6 +4614,7 @@ mod tests {
             10,
             &ReportFilter {
                 root: Some(root.clone()),
+                ..ReportFilter::default()
             },
         )
         .unwrap();

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -524,6 +524,113 @@ fn report_json_on_empty_cache_is_valid_json() {
 }
 
 #[test]
+fn last_build_commands_select_one_root_and_describe_session_scope() {
+    for recorded in [false, true] {
+        let e = env();
+        let root = e.home.canonicalize().unwrap();
+        let other = e.cache.canonicalize().unwrap();
+        let events = [
+            (3, &root, "local_hit", "selected"),
+            (1, &root, "miss", "older"),
+            (4, &other, "miss", "selected"),
+            (2, &root, "miss", "selected"),
+        ]
+        .map(|(minute, path, result, session)| {
+            serde_json::json!({
+                "ts": format!("2026-01-01T00:{:02}:00Z", minute * 10),
+                "root": path,
+                "session_id": if recorded { session } else { "" },
+                "crate_name": format!("fixture{minute}"),
+                "result": result,
+                // The selected miss runs until 00:20; the hit at 00:30
+                // starts at 00:19, so local activity remains contiguous.
+                "elapsed_ms": if minute == 3 { 660_000 } else { 0 },
+                "compile_time_ms": 100,
+                "size": 128,
+                "cache_key": "fixture-key",
+                "schema": 18,
+            })
+            .to_string()
+        });
+        std::fs::write(e.cache.join("events.jsonl"), events.join("\n") + "\n").unwrap();
+
+        for command in ["stats", "report"] {
+            e.cmd()
+                .args([command, "--last-build", "--root"])
+                .arg(&root)
+                .assert()
+                .success()
+                .stdout(predicates::str::contains("last build session"))
+                .stdout(predicates::str::contains(
+                    "May include multiple Cargo commands",
+                ))
+                .stdout(predicates::str::contains(if recorded {
+                    "recorded selected"
+                } else {
+                    "inferred from activity"
+                }));
+
+            let mut cmd = e.cmd();
+            cmd.args([command, "--last-build", "--root"]).arg(&root);
+            if command == "stats" {
+                cmd.arg("--json");
+            } else {
+                cmd.args(["--format", "json"]);
+            }
+            let output = cmd.assert().success().get_output().stdout.clone();
+            let raw: serde_json::Value = serde_json::from_slice(&output).unwrap();
+            let report = if command == "stats" {
+                assert_eq!(raw["command"], "stats");
+                assert_eq!(raw["schema_version"], 1);
+                &raw["report"]
+            } else {
+                &raw
+            };
+            assert_eq!(report["summary"]["local_hits"], 1);
+            assert_eq!(report["summary"]["misses"], 1);
+            assert_eq!(report["timeline"]["event_count"], 2);
+            assert_eq!(report["meta"]["session"]["root"], root.to_str().unwrap());
+            assert_eq!(report["meta"]["session"]["inferred"], !recorded);
+            assert!(report["network"].is_null());
+        }
+
+        let output = e
+            .cmd()
+            .args(["report", "--last-build", "--format", "json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let report: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(report["meta"]["session"]["root"], other.to_str().unwrap());
+        assert_eq!(report["timeline"]["event_count"], 1);
+    }
+}
+
+#[test]
+fn last_build_requires_recorded_events_and_conflicts_with_since() {
+    let e = env();
+    for command in ["stats", "report"] {
+        e.cmd()
+            .args([command, "--last-build"])
+            .assert()
+            .failure()
+            .stderr(predicates::str::contains("No recorded compiler events"));
+        e.cmd()
+            .args([command, "--last-build", "--since", "24h"])
+            .assert()
+            .failure()
+            .stderr(predicates::str::contains("cannot be used with"));
+    }
+    e.cmd()
+        .args(["stats", "--root", "."])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("--last-build"));
+}
+
+#[test]
 fn report_writes_to_output_file() {
     let e = env();
     let out = e.cache.join("report.json");


### PR DESCRIPTION
`kache stats --last-build` and `kache report --last-build` select the latest recorded compiler activity session, with an optional `--root`, so users can inspect its hits, misses, bypass reasons, restored bytes and observed wall span without choosing a time window.

Recorded sessions use the exact root and session ID. Local and older events without IDs use an explicitly labelled activity group with a five-minute idle gap. Sessions can span Cargo commands and only include retained, completed events. Unscoped remote transfers and GC are omitted. The existing time-window commands keep their defaults.

Validation: `just check` passes after rebasing onto `82b8b28`. Required CI and the perf gate pass on `38329ef`, including Linux, macOS, Windows, Nix and mutation tests.
