### PR TITLE
refactor(fs): share staged file publication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,6 +1998,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "tempfile",
  "windows-sys 0.61.2",
 ]
 

--- a/crates/kache-fs/Cargo.toml
+++ b/crates/kache-fs/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/kunobi-ninja/kache"
 [dependencies]
 libc = "0.2"
 serde = { version = "1", features = ["derive"], optional = true }
+tempfile = { version = "3", optional = true }
 
 [dev-dependencies]
 serde_json = "1"
@@ -17,6 +18,7 @@ serde_json = "1"
 [features]
 default = []
 serde = ["dep:serde"]
+staging = ["dep:tempfile"]
 testing = []
 
 [lints.rust]

--- a/crates/kache-fs/README.md
+++ b/crates/kache-fs/README.md
@@ -14,6 +14,13 @@ It refuses an existing destination and returns errors to the caller for fallback
 selection. `copy_writable` copies bytes with an explicit writable mode. Hardlinks
 use `std::fs::hard_link`; their content and metadata remain shared.
 
+The `staging` feature adds `StagedFile` for writable temporary files. Callers
+write through its writer, then choose create-only publication or replacement.
+Unpublished stages use `tempfile`'s cleanup on drop. Creation uses ordinary
+writable-file permissions, including the process umask on Unix. Callers retain
+destination checks and any flush requirements; publication does not flush file
+contents or the parent directory.
+
 The default feature set is empty. `serde` enables measurement serialization;
-`testing` exposes filesystem fixtures for consumers. The crate has no runtime,
-cache index or cleanup policy.
+`testing` exposes filesystem fixtures for consumers. `tempfile` is required only
+with `staging`. The crate has no runtime, cache index or cleanup policy.

--- a/crates/kache-fs/src/lib.rs
+++ b/crates/kache-fs/src/lib.rs
@@ -17,6 +17,11 @@ pub use copy::{copy_writable, set_writable_permissions, try_reflink};
 mod identity;
 pub use identity::{directory_identity, file_identity};
 
+#[cfg(feature = "staging")]
+mod staging;
+#[cfg(feature = "staging")]
+pub use staging::StagedFile;
+
 mod ledger;
 pub use ledger::{InodeId, InodeLedger};
 

--- a/crates/kache-fs/src/staging.rs
+++ b/crates/kache-fs/src/staging.rs
@@ -1,0 +1,222 @@
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+/// A writable temporary file awaiting publication.
+///
+/// Create the stage in the destination directory, write through [`Self::writer`],
+/// then choose [`Self::publish_new`] or [`Self::replace`]. Unpublished stages use
+/// `tempfile`'s best-effort cleanup on drop, including when publication fails.
+///
+/// Callers own destination validation and durability requirements. Publication
+/// does not sync file contents or the parent directory. If durable contents are
+/// needed, sync the open file before publishing and handle directory durability
+/// separately.
+#[derive(Debug)]
+pub struct StagedFile {
+    file: tempfile::NamedTempFile,
+}
+
+impl StagedFile {
+    /// Create a stage in an existing directory with the supplied filename prefix.
+    ///
+    /// On Unix, creation requests mode `0666`, filtered by the process umask and
+    /// inherited directory ACLs, as for an ordinary writable file.
+    pub fn new_in(directory: &Path, prefix: &str) -> io::Result<Self> {
+        let mut builder = tempfile::Builder::new();
+        builder.prefix(prefix);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            builder.permissions(std::fs::Permissions::from_mode(0o666));
+        }
+        builder.tempfile_in(directory).map(|file| Self { file })
+    }
+
+    /// Access the temporary-file writer for streaming bytes into the stage.
+    pub fn writer(&mut self) -> &mut impl io::Write {
+        &mut self.file
+    }
+
+    /// Access the open file for explicit synchronization or metadata changes.
+    pub fn file_mut(&mut self) -> &mut File {
+        self.file.as_file_mut()
+    }
+
+    /// Publish at an absent destination, refusing an existing directory entry.
+    ///
+    /// The destination must be on the stage's filesystem. This preserves
+    /// `tempfile`'s create-only publication semantics without an existence check.
+    pub fn publish_new(self, target: &Path) -> io::Result<()> {
+        self.file
+            .persist_noclobber(target)
+            .map(|_| ())
+            .map_err(|error| error.error)
+    }
+
+    /// Publish at a destination, replacing an existing file entry if present.
+    ///
+    /// The destination must be on the stage's filesystem. The caller must decide
+    /// whether replacement is permitted; this method does not inspect the target.
+    pub fn replace(self, target: &Path) -> io::Result<()> {
+        self.file
+            .persist(target)
+            .map(|_| ())
+            .map_err(|error| error.error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StagedFile;
+    use std::fs;
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+
+    fn entries(directory: &Path) -> Vec<PathBuf> {
+        let mut paths: Vec<_> = fs::read_dir(directory)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect();
+        paths.sort();
+        paths
+    }
+
+    #[test]
+    fn dropping_an_unpublished_stage_removes_its_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut stage = StagedFile::new_in(dir.path(), ".staged-").unwrap();
+        stage.writer().write_all(b"unfinished").unwrap();
+        let paths = entries(dir.path());
+        assert_eq!(paths.len(), 1);
+        assert!(
+            paths[0]
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with(".staged-")
+        );
+        assert_eq!(fs::read(&paths[0]).unwrap(), b"unfinished");
+        drop(stage);
+        assert!(entries(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn publication_installs_written_bytes_and_removes_the_stage() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("output");
+        let mut stage = StagedFile::new_in(dir.path(), ".staged-").unwrap();
+        stage.writer().write_all(b"complete output").unwrap();
+        assert!(!target.exists());
+        stage.publish_new(&target).unwrap();
+        assert_eq!(fs::read(&target).unwrap(), b"complete output");
+        assert_eq!(entries(dir.path()), vec![target]);
+    }
+
+    #[test]
+    fn create_only_publication_preserves_a_race_winner() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("output");
+        let mut stage = StagedFile::new_in(dir.path(), ".staged-").unwrap();
+        stage.writer().write_all(b"staged output").unwrap();
+        fs::write(&target, b"race winner").unwrap();
+        assert_eq!(
+            stage.publish_new(&target).unwrap_err().kind(),
+            std::io::ErrorKind::AlreadyExists
+        );
+        assert_eq!(fs::read(&target).unwrap(), b"race winner");
+        assert_eq!(entries(dir.path()), vec![target]);
+    }
+
+    #[test]
+    fn replacement_preserves_other_names_for_the_old_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("output");
+        let alias = dir.path().join("alias");
+        fs::write(&target, b"old output").unwrap();
+        fs::hard_link(&target, &alias).unwrap();
+        let mut stage = StagedFile::new_in(dir.path(), ".staged-").unwrap();
+        stage.writer().write_all(b"new output").unwrap();
+        stage.replace(&target).unwrap();
+        assert_eq!(fs::read(&target).unwrap(), b"new output");
+        assert_eq!(fs::read(&alias).unwrap(), b"old output");
+        assert_eq!(entries(dir.path()), vec![alias, target]);
+    }
+
+    #[test]
+    fn failed_publication_removes_the_stage() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("missing").join("output");
+        for replace in [false, true] {
+            let mut stage = StagedFile::new_in(dir.path(), ".staged-").unwrap();
+            stage.writer().write_all(b"unpublished output").unwrap();
+            let result = if replace {
+                stage.replace(&target)
+            } else {
+                stage.publish_new(&target)
+            };
+            assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::NotFound);
+            assert!(entries(dir.path()).is_empty());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_only_publication_refuses_a_dangling_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("output");
+        let destination = dir.path().join("absent");
+        std::os::unix::fs::symlink(&destination, &target).unwrap();
+        let stage = StagedFile::new_in(dir.path(), ".staged-").unwrap();
+        assert_eq!(
+            stage.publish_new(&target).unwrap_err().kind(),
+            std::io::ErrorKind::AlreadyExists
+        );
+        assert_eq!(fs::read_link(&target).unwrap(), destination);
+        assert!(!destination.exists());
+        assert_eq!(entries(dir.path()), vec![target]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn creation_uses_the_kernel_umask() {
+        use std::os::unix::fs::PermissionsExt;
+        const MARKER: &str = "KACHE_FS_STAGING_TEST_UMASK";
+        if let Ok(mask) = std::env::var(MARKER) {
+            let (mask, expected) = match mask.as_str() {
+                "022" => (0o022, 0o644),
+                "077" => (0o077, 0o600),
+                _ => panic!("unexpected child fixture umask"),
+            };
+            // This branch runs only in the single-test child process below.
+            unsafe {
+                libc::umask(mask);
+            }
+            let dir = tempfile::tempdir().unwrap();
+            let mut stage = StagedFile::new_in(dir.path(), ".staged-").unwrap();
+            let mode = stage.file_mut().metadata().unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, expected);
+            return;
+        }
+
+        for mask in ["022", "077"] {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "staging::tests::creation_uses_the_kernel_umask",
+                    "--nocapture",
+                ])
+                .env(MARKER, mask)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "umask {mask}: {}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(String::from_utf8_lossy(&output.stdout).contains("1 passed"));
+        }
+    }
+}

--- a/crates/kache-store/Cargo.toml
+++ b/crates/kache-store/Cargo.toml
@@ -12,7 +12,7 @@ test-support = []
 
 [dependencies]
 kache-format = { version = "0.16.1", path = "../kache-format" }
-kache-fs = { version = "0.16.1", path = "../kache-fs" }
+kache-fs = { version = "0.16.1", path = "../kache-fs", features = ["staging"] }
 anyhow = "1"
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/kache-store/src/link.rs
+++ b/crates/kache-store/src/link.rs
@@ -886,7 +886,7 @@ fn copy_file(src: &Path, dst: &Path, executable: bool) -> Result<()> {
 /// umask and any inherited default ACL exactly where the final file will live.
 /// No metadata operation is performed through the final pathname.
 pub struct PreparedWritableTarget {
-    staged: tempfile::NamedTempFile,
+    staged: kache_fs::StagedFile,
     target: PathBuf,
     bytes: u64,
 }
@@ -898,15 +898,12 @@ impl PreparedWritableTarget {
 
     pub fn publish(self) -> Result<()> {
         let target = self.target;
-        self.staged
-            .persist_noclobber(&target)
-            .map_err(|error| error.error)
-            .with_context(|| {
-                format!(
-                    "publishing cc output without replacing {}",
-                    target.display()
-                )
-            })?;
+        self.staged.publish_new(&target).with_context(|| {
+            format!(
+                "publishing cc output without replacing {}",
+                target.display()
+            )
+        })?;
         crate::opcounts::record_copied(self.bytes);
         Ok(())
     }
@@ -919,28 +916,19 @@ impl PreparedWritableTarget {
     pub fn publish_replacing(self) -> Result<()> {
         let target = self.target;
         self.staged
-            .persist(&target)
-            .map_err(|error| error.error)
+            .replace(&target)
             .with_context(|| format!("publishing cc output over {}", target.display()))?;
         crate::opcounts::record_copied(self.bytes);
         Ok(())
     }
 }
 
-fn new_writable_staging_file(target: &Path) -> Result<tempfile::NamedTempFile> {
+fn new_writable_staging_file(target: &Path) -> Result<kache_fs::StagedFile> {
     let parent = target
         .parent()
         .filter(|path| !path.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
-    let mut builder = tempfile::Builder::new();
-    builder.prefix(".kache-cc-restore-");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        builder.permissions(fs::Permissions::from_mode(0o666));
-    }
-    builder
-        .tempfile_in(parent)
+    kache_fs::StagedFile::new_in(parent, ".kache-cc-restore-")
         .with_context(|| format!("creating cc restore staging file in {}", parent.display()))
 }
 
@@ -952,7 +940,7 @@ pub fn prepare_writable_target_from_file(
     let mut source = fs::File::open(src)
         .with_context(|| format!("opening cached cc artifact {}", src.display()))?;
     let mut staged = new_writable_staging_file(target)?;
-    let bytes = std::io::copy(&mut source, &mut staged).with_context(|| {
+    let bytes = std::io::copy(&mut source, staged.writer()).with_context(|| {
         format!(
             "copying cached cc artifact {} for {}",
             src.display(),
@@ -975,6 +963,7 @@ pub fn prepare_writable_target_from_bytes(
 
     let mut staged = new_writable_staging_file(target)?;
     staged
+        .writer()
         .write_all(content)
         .with_context(|| format!("writing staged cc output for {}", target.display()))?;
     Ok(PreparedWritableTarget {
@@ -3344,9 +3333,18 @@ Unified_mm_ettings-WrongChannel0.o: Unified_mm_ettings-WrongChannel0.mm \\
         fs::create_dir(&parent).unwrap();
         let target = parent.join("output.o");
 
-        let staged = new_writable_staging_file(&target).unwrap();
-
-        assert_eq!(staged.path().parent(), Some(parent.as_path()));
+        let _staged = new_writable_staging_file(&target).unwrap();
+        let entries: Vec<_> = fs::read_dir(&parent)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert_eq!(entries.len(), 1);
+        assert!(
+            entries[0]
+                .to_str()
+                .unwrap()
+                .starts_with(".kache-cc-restore-")
+        );
     }
 
     #[cfg(unix)]

--- a/crates/kache-store/tests/staged_publication.rs
+++ b/crates/kache-store/tests/staged_publication.rs
@@ -1,0 +1,51 @@
+use kache_store::link::{prepare_writable_target_from_bytes, prepare_writable_target_from_file};
+use kache_store::opcounts::copied_bytes;
+use std::fs;
+
+// One test owns this process's restore counters; other integration test binaries
+// have separate statics, so exact deltas do not race concurrent store operations.
+#[test]
+fn publication_counts_only_committed_bytes() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("source");
+    let target = dir.path().join("output");
+    fs::write(&source, b"file artifact").unwrap();
+    let before = copied_bytes();
+
+    let prepared = prepare_writable_target_from_file(&source, &target).unwrap();
+    assert_eq!(prepared.target(), target);
+    assert!(!target.exists());
+    assert_eq!(copied_bytes(), before);
+    prepared.publish().unwrap();
+    assert_eq!(fs::read(&target).unwrap(), b"file artifact");
+    assert_eq!(copied_bytes(), before + 13);
+
+    let replacement = prepare_writable_target_from_bytes(&target, b"new artifact").unwrap();
+    assert_eq!(fs::read(&target).unwrap(), b"file artifact");
+    assert_eq!(copied_bytes(), before + 13);
+    replacement.publish_replacing().unwrap();
+    assert_eq!(fs::read(&target).unwrap(), b"new artifact");
+    assert_eq!(fs::read(&source).unwrap(), b"file artifact");
+    assert_eq!(copied_bytes(), before + 25);
+
+    assert!(
+        prepare_writable_target_from_bytes(&target, b"refused")
+            .unwrap()
+            .publish()
+            .is_err()
+    );
+    assert_eq!(fs::read(&target).unwrap(), b"new artifact");
+    assert_eq!(copied_bytes(), before + 25);
+
+    let directory = dir.path().join("directory");
+    fs::create_dir(&directory).unwrap();
+    assert!(
+        prepare_writable_target_from_bytes(&directory, b"refused")
+            .unwrap()
+            .publish_replacing()
+            .is_err()
+    );
+    assert!(directory.is_dir());
+    assert_eq!(copied_bytes(), before + 25);
+    assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 3);
+}


### PR DESCRIPTION
## Summary

Move writable output staging into `kache-fs` behind an optional `staging` feature. The existing file and byte-buffer restore paths use `StagedFile`; `kache-store` keeps destination checks, compiler rules and copy counters.

Keep create-only publication and replacement separate. Preserve the temporary-file writer, creation permissions, error context and cleanup behavior. Publication adds no implicit flush. The default feature set keeps its existing dependencies.

Follows #961.

## Validation

- [x] 52 filesystem tests with all features, including publication races, cleanup, replacement and Unix umask behavior.
- [x] Store integration test checks exact copy-counter changes for successful and failed publication.
- [x] Default filesystem feature set builds with only `libc` on macOS.
- [x] Four injected regressions fail test assertions; sources restored afterward.
- [x] `just check` (format, clippy and workspace tests).
- [x] Linux and Windows filesystem clippy with all targets and features.
- [x] Filesystem package builds and all 52 tests pass from its archive.
- [x] [Native platform CI](https://github.com/kunobi-ninja/kache/actions/runs/34019891587): Linux, macOS, Windows, btrfs, Nix and Kani proofs.
- [x] Changed-line mutation testing: 4 caught, 5 unviable, none missed or timed out. Core and service lanes also passed.
- [x] [Performance gate](https://github.com/kunobi-ninja/kache/actions/runs/34020603054): warm build +2.4%, within the +5% limit (attempt 2).
