### PR TITLE
feat(bench): add eza as the small fat-LTO nightly subject

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,7 @@
 name: Bench
 
 # Clone benchmark — builds kache from THIS ref and runs the cross-clone
-# cold/warm scenarios (Firefox, Substrate, SurrealDB, Lance, OpenDAL, LLVM)
+# cold/warm scenarios (Firefox, Substrate, SurrealDB, Lance, OpenDAL, eza, LLVM)
 # against one shared cache, then
 # uploads the reports. This is the heavy, hours-long, tens-of-GB-disk job the
 # bench engine's doc-comment says is "intentionally NOT wired into [PR] CI": it
@@ -35,7 +35,7 @@ on:
       scenario:
         description: "Which scenario(s) to run"
         type: choice
-        options: [all, substrate, surrealdb, lance, opendal, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows, hk, hk-pull, hk-mbx, opendal-mbx, lance-mbx, substrate-mbx, surrealdb-mbx]
+        options: [all, substrate, surrealdb, lance, opendal, eza, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows, hk, hk-pull, hk-mbx, opendal-mbx, lance-mbx, substrate-mbx, surrealdb-mbx]
         default: all
       extra_args:
         description: "Extra args appended to `just bench <profile>` (e.g. --skip-clone, --retry)"
@@ -145,6 +145,13 @@ jobs:
           # (as firefox-sccache is for firefox). mbx comes from mise at its
           # latest release; the run records the version it measured.
           hk_mbx='{"name":"hk-mbx","cmd":"bench-mbx hk","dir":"bench-hk-mbx","timeout":60,"job_timeout":90,"min_free_gb":30,"runner":"kunobi-runners"}'
+          # eza: the smallest subject and the only one built through a fat-LTO
+          # release profile, so the final unit is one whole-program codegen
+          # instead of many small ones. Its bundled libgit2 and zlib put the
+          # majority of its cacheable units on the C side (199 of 319 in a local
+          # run). The cheapest arm in the sweep: minutes, and under a gigabyte
+          # of build output.
+          eza='{"name":"eza","cmd":"bench eza --warm-same-tree","dir":"bench-eza","timeout":60,"job_timeout":90,"min_free_gb":20,"runner":"kunobi-runners"}'
           # Two more subjects on the same side-by-side axis. mbx fronts Cargo,
           # so the arms it can serve at all are exactly the cargo-driven ones:
           # firefox (mach/gn/ninja) and llvm (cmake) are out of reach, which is
@@ -172,6 +179,7 @@ jobs:
             hk)                   inc="[$hk]" ;;
             hk-pull)              inc="[$hk_pull]" ;;
             hk-mbx)               inc="[$hk_mbx]" ;;
+            eza)                  inc="[$eza]" ;;
             opendal-mbx)          inc="[$opendal_mbx]" ;;
             lance-mbx)            inc="[$lance_mbx]" ;;
             substrate-mbx)        inc="[$substrate_mbx]" ;;
@@ -182,7 +190,7 @@ jobs:
             # and wastefully run the whole Linux `all` matrix alongside.
             firefox-windows)      inc="[]" ;;
             firefox-pull-windows) inc="[]" ;;
-            *)                    inc="[$substrate,$surrealdb,$lance,$opendal,$firefox,$firefox_sccache,$llvm,$firefox_pull,$hk,$hk_pull,$hk_mbx,$opendal_mbx,$lance_mbx,$substrate_mbx,$surrealdb_mbx]" ;;
+            *)                    inc="[$substrate,$surrealdb,$lance,$opendal,$firefox,$firefox_sccache,$llvm,$firefox_pull,$hk,$hk_pull,$hk_mbx,$eza,$opendal_mbx,$lance_mbx,$substrate_mbx,$surrealdb_mbx]" ;;
           esac
           echo "matrix={\"include\":$inc}" >> "$GITHUB_OUTPUT"
           if [ "$inc" = "[]" ]; then

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Need to choose between compiler caches? Read [Kache or sccache?](https://kunobi.
 
 ## Tested nightly on real projects
 
-The scheduled [benchmark workflow](https://github.com/kunobi-ninja/kache/actions/workflows/bench.yml) runs real cold/warm builds of Firefox, LLVM, Substrate, SurrealDB, Lance, and OpenDAL on Linux, compares Firefox with sccache, and exercises Firefox on Windows. It also measures how much of a Firefox build survives a source update.
+The scheduled [benchmark workflow](https://github.com/kunobi-ninja/kache/actions/workflows/bench.yml) runs real cold/warm builds of Firefox, LLVM, Substrate, SurrealDB, Lance, OpenDAL, and eza on Linux, compares Firefox with sccache, and exercises Firefox on Windows. It also measures how much of a Firefox build survives a source update.
 
 Each run checks its own measurement validity and uploads reports, traces, and logs for 30 days. Treat timing or hit-rate numbers as evidence only when the individual job succeeds and its benchmark verdict is `ok`.
 

--- a/crates/kache-e2e/src/bench_profile.rs
+++ b/crates/kache-e2e/src/bench_profile.rs
@@ -1143,6 +1143,45 @@ diff --git a/hello.txt b/hello.txt
         );
     }
 
+    /// The shipped eza scenario measures both compiler families: rustc through
+    /// the engine's wrapper, and the bundled libgit2/zlib objects through the
+    /// host-only cc-rs wrappers `kache init` writes. It builds release, which
+    /// is the only fat-LTO profile in the suite, honours the tree's own
+    /// rust-toolchain.toml, and pins the clone by commit SHA.
+    #[test]
+    fn shipped_eza_profile_wires_host_cc_and_builds_release() {
+        let p = BenchProfile::load(&repo_profile("eza")).expect("eza.toml loads");
+        assert_eq!(p.name, "bench-eza");
+        assert_eq!(p.objdir, "target");
+        assert_eq!(p.repo, "https://github.com/eza-community/eza.git");
+        assert_eq!(p.git_ref.len(), 40, "pin by commit SHA, not a tag");
+        assert!(
+            p.files.is_empty(),
+            "eza owns its rust-toolchain.toml — nothing to inject"
+        );
+        let env = p.build_env(Path::new("/k"));
+        let host_cc = env
+            .iter()
+            .find(|(k, _)| k == "HOST_CC")
+            .expect("HOST_CC entry");
+        assert_eq!(host_cc.1, "/k cc");
+        assert!(env.iter().any(|(k, v)| k == "HOST_CXX" && v == "/k c++"));
+        assert!(
+            env.iter()
+                .any(|(k, v)| k == "CC_KNOWN_WRAPPER_CUSTOM" && v == "kache")
+        );
+        assert!(
+            !env.iter().any(|(k, _)| k == "CC" || k == "CXX"),
+            "CC/CXX stay untouched so cc-rs picks the host-only wrappers"
+        );
+        let build = p.build_command(Path::new("/k"));
+        assert!(build.contains("cargo build --release --locked"), "{build}");
+        assert!(
+            build.contains("KACHE_BASE_DIR"),
+            "cross-clone path portability must be set in the build script"
+        );
+    }
+
     #[test]
     fn source_ref_next_parses_and_marks_pull() {
         let dir = tempfile::tempdir().unwrap();

--- a/docs/benchmarks.mdx
+++ b/docs/benchmarks.mdx
@@ -15,6 +15,7 @@ The [Bench workflow](https://github.com/kunobi-ninja/kache/actions/workflows/ben
 - Firefox source-update builds on Linux and Windows
 - hk cold, warm and next-commit builds on Linux: a mid-size Rust CLI whose build scripts compile C and assembly through cc-rs, wired the way `kache init` configures a machine
 - The same hk build through mbx at its latest release, for a side-by-side comparison
+- eza cold, warm and cross-worktree builds on Linux: the smallest subject in the matrix and the only one built through a fat-LTO release profile, with its bundled libgit2 and zlib compiled through the same cc-rs wiring
 
 Jobs upload their reports, Perfetto traces, and logs even when a benchmark fails. GitHub retains those artifacts for 30 days.
 
@@ -50,6 +51,7 @@ just bench firefox
 just bench substrate
 just bench lance
 just bench opendal
+just bench eza
 just bench llvm
 just bench-retry firefox   # reuse the saved cold state
 just bench-trace firefox   # include key-diff artifacts

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -53,7 +53,7 @@ Kache passes unsupported compiler invocations through unchanged. A passthrough i
 
 ## Tested nightly on real projects
 
-The [nightly benchmark workflow](https://github.com/kunobi-ninja/kache/actions/workflows/bench.yml) runs cold/warm builds of Firefox, LLVM, Substrate, SurrealDB, Lance, and OpenDAL, including Firefox runs on Linux and Windows and a side-by-side sccache run. Reports, traces, and logs are retained for 30 days.
+The [nightly benchmark workflow](https://github.com/kunobi-ninja/kache/actions/workflows/bench.yml) runs cold/warm builds of Firefox, LLVM, Substrate, SurrealDB, Lance, OpenDAL, and eza, including Firefox runs on Linux and Windows and a side-by-side sccache run. Reports, traces, and logs are retained for 30 days.
 
 Benchmark numbers count only when the individual job succeeds and its self-checking verdict is `ok`.
 

--- a/scenarios/bench-eza/scenario.toml
+++ b/scenarios/bench-eza/scenario.toml
@@ -1,0 +1,98 @@
+# eza (eza-community/eza) nightly compile-cache benchmark: cold,
+# warm-same-tree, warm.
+#
+# Why eza: the smallest subject in the suite and the only one built through a
+# fat-LTO release profile. eza's own [profile.release] sets lto = true,
+# codegen-units = 1, panic = "abort" and strip = true, so the final unit is one
+# whole-program LTO codegen over every dependency's bitcode rather than the many
+# small codegen units the other cargo scenarios measure. Its default `git`
+# feature pulls git2 with https and ssh off, whose libgit2-sys builds the
+# bundled libgit2 through cc-rs when no system libgit2 is on the box, and
+# libz-sys does the same for zlib. A local run measures 319 cacheable units:
+# 120 rustc, 199 C objects. The C side is the majority, in a subject that
+# finishes in minutes.
+#
+# This scenario wires the build-script compilers the way `kache init` does
+# (HOST_CC/HOST_CXX under Cargo [env], CC/CXX untouched), so both compiler
+# families are measured.
+name = "bench-eza"
+tags = ["suite:bench", "project:eza", "backend:kache", "lang:rust", "lang:cc"]
+
+requires = ["cargo", "rustc", "cc"]
+
+# git2 is declared with default-features = false, so https and ssh are off and
+# no OpenSSL or libssh2 is needed. libgit2-sys probes pkg-config first and
+# builds its bundled copy when that finds nothing; the ARC runner image ships
+# no libgit2-dev, so the bundled build is what the nightly measures.
+setup = [
+  "echo '[bench] bench-eza needs a C compiler (bundled libgit2 and zlib through cc-rs). No OpenSSL: eza takes git2 with default-features off.'",
+]
+
+# Release with --locked: eza's release profile is the point of this subject.
+# The prefix maps, SOURCE_DATE_EPOCH and KACHE_BASE_DIR are the cross-worktree
+# portability knobs the other cargo scenarios use (see bench-pr-cargo).
+# KACHE_BASE_DIR also covers eza's build script, which writes the version
+# string into OUT_DIR under the checkout for the crate to `include!`.
+build = """
+# Input-set predictions, with a sampled cross-check (kunobi-ninja/kache#945).
+# Predictions replace the rustc dep-info pre-pass with a recorded closure, so
+# the warm phases here measure what that is worth on a real graph. One unit in
+# 64 runs the pre-pass anyway and compares the two closures; the pre-pass
+# answer wins either way, so a disagreement costs nothing at the time. Its
+# count reaches the report, and zero across real subjects is what would
+# justify turning predictions on by default.
+export KACHE_INPUT_PREDICTIONS=1
+export KACHE_VERIFY_INPUT_PREDICTIONS=sampled
+
+repo="$(pwd -P)"
+prefix_map="-ffile-prefix-map=$repo=. -fdebug-prefix-map=$repo=. -fmacro-prefix-map=$repo=."
+export CFLAGS="${CFLAGS:-} $prefix_map"
+export CXXFLAGS="${CXXFLAGS:-} $prefix_map"
+export SOURCE_DATE_EPOCH=1735689600
+export ZERO_AR_DATE=1
+export KACHE_BASE_DIR="$repo"
+
+cargo build --release --locked
+"""
+
+# Exactly what `kache init` writes into Cargo [env]: host-only wrappers, CC
+# and CXX untouched. For a native build cc-rs consults HOST_CC before CC, so
+# every build-script object goes through kache. CC_KNOWN_WRAPPER_CUSTOM covers
+# the cc-rs versions in the graph that do not yet know kache as a wrapper.
+[env]
+HOST_CC = "{kache} cc"
+HOST_CXX = "{kache} c++"
+CC_KNOWN_WRAPPER_CUSTOM = "kache"
+
+[source]
+kind   = "clone"
+repo   = "https://github.com/eza-community/eza.git"
+# eza v0.23.5. Pinned by commit SHA so a repointed tag cannot read as a cache
+# change. The tree ships rust-toolchain.toml (channel "1.90"), which rustup
+# honours on the first cargo invocation because the bench workflow clears
+# RUSTUP_TOOLCHAIN — nothing to pin here. The version string the build script
+# bakes in is release-only at a tagged version, so it carries no git hash or
+# build date to diverge across clones.
+ref    = "98442ab17c2c3738701b62a7e060b1431ae2d6ea"
+objdir = "target"
+
+# Validity floors, not regression bounds: a phase that recompiled the world
+# must fail loudly rather than report a flattering wall clock. Sized far below
+# a healthy run: a macOS run of this scenario took 319 hits and restored
+# 227 MB, so 150 hits and 64 MiB leave room for the platform differences
+# (proc-mounts is Linux-only, uzers is unix-only) without letting a phase that
+# cached nothing pass.
+[checks.assert.warm-same-tree]
+max_passthrough_pct = 40.0
+max_errors = 0
+min_hits = 150
+min_restored_bytes = 67108864 # 64 MiB
+
+# The cross-worktree phase adds the path-portability check: an absolute path
+# in a key misses everything here and key stability collapses.
+[checks.assert.warm]
+min_key_stability_pct = 50.0
+max_passthrough_pct = 40.0
+max_errors = 0
+min_hits = 150
+min_restored_bytes = 67108864 # 64 MiB


### PR DESCRIPTION
Adds [eza](https://github.com/eza-community/eza) to the nightly bench sweep and to the workflow dispatch list.

## Why this subject

Two things the matrix does not measure yet:

* **A fat-LTO release profile.** eza's own `[profile.release]` sets `lto = true`, `codegen-units = 1`, `panic = "abort"` and `strip = true`. The final unit is one whole-program codegen over every dependency's bitcode instead of the many small codegen units the other cargo scenarios produce.
* **A subject where the C side is the majority.** eza's default `git` feature takes git2 with https and ssh off, whose libgit2-sys builds the bundled libgit2 through cc-rs, and libz-sys does the same for zlib. 199 of the 319 cacheable units are C objects; 120 are rustc.

It is also the cheapest arm in the sweep by a wide margin: minutes, and under a gigabyte of build output.

## Wiring

`HOST_CC` / `HOST_CXX` through kache with `CC` and `CXX` untouched, which is what `kache init` writes into Cargo `[env]`, so both compiler families are measured. The prefix maps, `SOURCE_DATE_EPOCH` and `KACHE_BASE_DIR` are the cross-worktree portability knobs the other cargo scenarios use. `KACHE_BASE_DIR` also covers eza's build script, which writes its version string into `OUT_DIR` under the checkout for the crate to `include!`.

The clone is pinned by commit SHA at v0.23.5. eza owns a `rust-toolchain.toml` (channel 1.90), so nothing is injected: rustup honours it because the workflow clears `RUSTUP_TOOLCHAIN`. At a tagged version the build script's version string is release-only, so it bakes in no git hash or build date to diverge across clones.

The nightly arm runs on `kunobi-runners` with a 60 minute timeout and a 20 GB disk floor, and passes `--warm-same-tree` for the same-path phase.

## Measured locally

Two full runs on macOS. Timings from the second, which validated the final assertion floors:

| phase | wall | cache | storage |
| --- | --- | --- | --- |
| cold | 44.1s | 310 misses | writes 227.9 MB into the store as 530 blobs; objdir 249.2 MB |
| same-tree | 5.7s (8.8x) | 319/319 hits | restores 227.3 MB, 99.1% zero-copy |
| cross-worktree | 7.2s (6.29x) | 319/319 hits, key stability 100% | restores the same 227.3 MB into clone-b |

Both verdicts `ok`, 0 errors, 4 passthroughs (probes plus one cc link). Cold is the noisy figure: the first run measured 36.5s on the same machine. Storage was byte-identical across both.

The `min_hits` and `min_restored_bytes` floors sit roughly 2x and 3.5x below what a healthy run produces, which leaves room for the platform differences (proc-mounts is Linux-only, uzers is unix-only) without letting a phase that cached nothing pass.

## Also in this change

A shipped-profile test that pins the wiring (host-only wrappers, `CC`/`CXX` absent, release build, SHA pin), and the project lists in the README and the two docs pages.