### PR TITLE
Make CI portable across repositories

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,0 +1,76 @@
+# Running CI in another repository
+
+Public repositories, including forks, run validation on GitHub-hosted Linux,
+macOS, and Windows runners. No runner variables or publication credentials
+are needed. Pull requests run the normal checks; pushes to `main` do too.
+
+Private repositories use the same workflows with repository Actions variables.
+Set these before enabling Actions. Each value is JSON: a quoted runner label
+or an array of labels that all have to match.
+
+| Variable | Example JSON value |
+| --- | --- |
+| `CI_RUNNER_LINUX` | `"your-linux-scale-set"` |
+| `CI_RUNNER_MACOS` | `["self-hosted", "macOS", "ARM64", "ci"]` |
+| `CI_RUNNER_WINDOWS` | `["self-hosted", "Windows", "X64", "ci"]` |
+
+The examples are placeholders for labels provisioned in your organization.
+ARC scale sets use their installation name as a single label. Missing or
+invalid selectors fail workflow evaluation instead of selecting a paid
+GitHub-hosted runner. Public validation ignores these overrides and keeps
+the hosted defaults.
+
+Private runners need the tools and permissions used by the selected jobs.
+Linux checks include Docker Buildx, Nix, and a privileged loop-mounted btrfs
+filesystem test. Platform jobs check their compiler tools before testing.
+Use disposable runners for untrusted code and restrict runner-group access
+to the intended repositories. Labels and workflow conditions do not replace
+that access policy. Keep validation runners separate from signing privileges.
+
+See GitHub's [runner selection](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job)
+and [runner-group access](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/manage-access)
+documentation.
+
+## Optional workloads
+
+The official repository retains its existing benchmark and performance pools.
+Other repositories opt in after provisioning suitable runners:
+
+| Workload | Enable variable | Runner variables, using the JSON format above |
+| --- | --- | --- |
+| PR performance measurements | `ENABLE_PERF_GATE=true` | `PERF_RUNNER_LINUX` |
+| Nightly/manual benchmarks | `ENABLE_BENCHMARKS=true` | `BENCH_RUNNER_LINUX`, `BENCH_RUNNER_LINUX_LARGE`, `BENCH_RUNNER_WINDOWS` |
+| Scheduled fuzzing | `ENABLE_SCHEDULED_JOBS=true` | Uses `CI_RUNNER_LINUX` in private repositories |
+
+Only benchmark classes selected by the scenario need a matching runner.
+Large scenarios require up to 120 GB free disk; ordinary hosted runners are
+not substitutes for those pools. A missing large-runner selector never falls
+back to the smaller pool. Retain the same hardware for paired performance
+measurements and size concurrent jobs for the available capacity.
+
+The performance workflow retains its default-branch authorization and
+refuses measurements of code from fork pull requests. Its check is optional.
+Fuzz compilation still runs on matching pull requests, and fuzzing can be
+dispatched manually without enabling the nightly schedule.
+
+## Publication
+
+Release signing, the stable branch, crates.io, package repositories, Helm
+charts, and service image publication run only in `kunobi-ninja/kache`.
+Copies build the service image without publishing it. Their normal CI and
+packaging validation do not require upstream release credentials.
+
+To publish a separately maintained distribution, configure its destinations
+and credentials and review the publication guards for that repository.
+
+## Checking workflow changes
+
+The Repository consistency job evaluates runner and publication expressions
+with GitHub's expression library across public, fork, and private repository
+fixtures. Run the same checks locally:
+
+```sh
+cd .github/tests
+npm ci --ignore-scripts --no-audit --no-fund
+npm test
+```

--- a/.github/tests/.gitignore
+++ b/.github/tests/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.github/tests/package-lock.json
+++ b/.github/tests/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "kache-workflow-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kache-workflow-tests",
+      "devDependencies": {
+        "@actions/expressions": "0.3.61",
+        "yaml": "2.9.0"
+      }
+    },
+    "node_modules/@actions/expressions": {
+      "version": "0.3.61",
+      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.61.tgz",
+      "integrity": "sha512-Ig+tXELvTjlqxQAWBQnLNn2dPpNraLMdSnT+vDzDPmJtbNUhIAH/Z9kVT8pZ8UtJi9vUGs8hwHE8JFJmbOnLEA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/.github/tests/package.json
+++ b/.github/tests/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "kache-workflow-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node workflow-policy.mjs ../.."
+  },
+  "devDependencies": {
+    "@actions/expressions": "0.3.61",
+    "yaml": "2.9.0"
+  }
+}

--- a/.github/tests/workflow-policy.mjs
+++ b/.github/tests/workflow-policy.mjs
@@ -1,0 +1,313 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { parse } from "yaml";
+import { Lexer, Parser, Evaluator, data } from "@actions/expressions";
+
+const root = process.argv[2];
+const files = Object.fromEntries(
+  fs
+    .readdirSync(`${root}/.github/workflows`)
+    .filter((n) => /\.ya?ml$/.test(n))
+    .map((n) => [
+      n,
+      parse(fs.readFileSync(`${root}/.github/workflows/${n}`, "utf8")),
+    ]),
+);
+const custom = new Map(
+  ["always", "success"].map((name) => [
+    name,
+    {
+      name,
+      minArgs: 0,
+      maxArgs: 0,
+      call: () => new data.BooleanData(true),
+    },
+  ]),
+);
+let checks = 0;
+function evaluate(source, context) {
+  const expression = source
+    .trim()
+    .replace(/^\$\{\{\s*/, "")
+    .replace(/\s*\}\}$/, "");
+  const tokens = new Lexer(expression).lex().tokens;
+  const ast = new Parser(tokens, Object.keys(context), [
+    ...custom.values(),
+  ]).parse();
+  const value = new Evaluator(
+    ast,
+    JSON.parse(JSON.stringify(context), data.reviver),
+    custom,
+  ).evaluate();
+  return JSON.parse(JSON.stringify(value, data.replacer));
+}
+function eq(actual, expected, label) {
+  checks++;
+  assert.deepEqual(actual, expected, label);
+}
+function context(repository, privateRepo, vars = {}, event = "pull_request") {
+  return {
+    github: {
+      repository,
+      event_name: event,
+      ref: "refs/tags/v0.16.1",
+      ref_name: "v0.16.1",
+      ref_type: "tag",
+      event: {
+        repository: {
+          private: privateRepo,
+          fork: repository === "contributor/example",
+        },
+        pull_request: {
+          head: { repo: { full_name: repository } },
+          draft: false,
+        },
+        workflow_run: { conclusion: "success", event: "pull_request" },
+        inputs: { scenario: "all" },
+      },
+    },
+    vars,
+    matrix: {},
+    needs: {},
+    inputs: { only: "all" },
+  };
+}
+const privateVars = {
+  CI_RUNNER_LINUX: '"private-linux"',
+  CI_RUNNER_MACOS: '["self-hosted","macOS","ARM64","ci"]',
+  CI_RUNNER_WINDOWS: '["self-hosted","Windows","X64","ci"]',
+};
+const publicRepos = [
+  "kunobi-ninja/kache",
+  "Zondax/example",
+  "contributor/example",
+];
+const privateRepos = [
+  "Zondax/example",
+  "kunobi-ninja/example",
+  "contributor/example",
+];
+const routing = [];
+for (const [file, workflow] of Object.entries(files)) {
+  for (const [id, job] of Object.entries(workflow.jobs)) {
+    if (job["runs-on"]?.includes("CI_RUNNER_"))
+      routing.push([`${file}:${id}`, job["runs-on"]]);
+    for (const row of job.strategy?.matrix?.include || []) {
+      if (row.runner?.includes("CI_RUNNER_"))
+        routing.push([`${file}:${id}:${row.os}`, row.runner]);
+    }
+  }
+}
+assert(routing.length >= 24);
+for (const [name, expression] of routing) {
+  const os = /:(test-macos|macOS)$/.test(name)
+    ? "MACOS"
+    : /:(test-windows|Windows)$/.test(name)
+      ? "WINDOWS"
+      : "LINUX";
+  const platform = `CI_RUNNER_${os}`;
+  const hosted =
+    name === "ci.yml:kani"
+      ? "ubuntu-24.04"
+      : {
+          LINUX: "ubuntu-latest",
+          MACOS: "macos-latest",
+          WINDOWS: "windows-latest",
+        }[os];
+  for (const repository of publicRepos) {
+    eq(
+      evaluate(expression, context(repository, false)),
+      hosted,
+      `${name} public default`,
+    );
+    eq(
+      evaluate(expression, context(repository, false, privateVars)),
+      hosted,
+      `${name} ignores private overrides in public`,
+    );
+  }
+  const forkPr = context("kunobi-ninja/kache", false, privateVars);
+  forkPr.github.event.pull_request.head.repo.full_name = "contributor/example";
+  eq(
+    evaluate(expression, forkPr),
+    hosted,
+    `${name} external fork PR remains hosted`,
+  );
+  for (const repository of privateRepos) {
+    eq(
+      evaluate(expression, context(repository, true, privateVars)),
+      JSON.parse(privateVars[platform]),
+      `${name} private configured`,
+    );
+    checks++;
+    assert.throws(
+      () => evaluate(expression, context(repository, true)),
+      undefined,
+      `${name} missing private selector`,
+    );
+    checks++;
+    assert.throws(
+      () =>
+        evaluate(
+          expression,
+          context(repository, true, {
+            ...privateVars,
+            [platform]: "broken JSON",
+          }),
+        ),
+      undefined,
+      `${name} malformed selector`,
+    );
+  }
+}
+
+const publication = [
+  ["ci.yml", "release"],
+  ["ci.yml", "stable-branch"],
+  ["ci.yml", "publish-chart"],
+  ["publish-crates.yaml", "publish"],
+  ["package-publish.yml", "resolve"],
+  ["service-image.yml", "release"],
+];
+for (const [file, id] of publication) {
+  for (const repository of [...publicRepos, ...privateRepos]) {
+    eq(
+      evaluate(
+        files[file].jobs[id].if,
+        context(repository, repository !== "kunobi-ninja/kache", {}, "push"),
+      ),
+      repository === "kunobi-ninja/kache",
+      `${file}:${id} canonical publication`,
+    );
+  }
+}
+const packageJobs = files["package-publish.yml"].jobs;
+function dependsOnResolve(id, seen = new Set()) {
+  if (id === "resolve") return true;
+  if (seen.has(id)) return false;
+  seen.add(id);
+  const job = packageJobs[id];
+  assert(!job.if || !/always\(|cancelled\(|failure\(/.test(job.if));
+  return [job.needs]
+    .flat()
+    .some((parent) => dependsOnResolve(parent, new Set(seen)));
+}
+for (const id of Object.keys(packageJobs))
+  eq(
+    dependsOnResolve(id),
+    true,
+    `package publication ${id} depends on guarded resolve`,
+  );
+
+for (const repo of ["Zondax/example", "contributor/example"]) {
+  const ctx = context(repo, false);
+  eq(
+    evaluate(files["bench.yml"].jobs.plan.if, ctx),
+    false,
+    "copy benchmark disabled",
+  );
+  eq(
+    evaluate(files["bench.yml"].jobs["bench-firefox-windows"].if, ctx),
+    false,
+    "copy Windows benchmark disabled",
+  );
+  eq(
+    evaluate(files["perf-gate-preflight.yml"].jobs.preflight.if, ctx),
+    false,
+    "copy perf preflight disabled",
+  );
+  eq(
+    evaluate(files["perf-gate.yml"].jobs.authorize.if, ctx),
+    false,
+    "copy perf authorization disabled",
+  );
+  const schedule = context(repo, false, {}, "schedule");
+  eq(
+    evaluate(files["fuzz.yml"].jobs["native-archive"].if, schedule),
+    false,
+    "copy scheduled fuzz disabled",
+  );
+  eq(
+    evaluate(files["fuzz.yml"].jobs["native-archive"].if, ctx),
+    true,
+    "copy PR fuzz enabled",
+  );
+  const push = context(repo, false, {}, "push");
+  eq(
+    evaluate(files["service-image.yml"].jobs["docker-dry-run"].if, push),
+    true,
+    "copy image builds without publish",
+  );
+}
+const benchmarkVars = {
+  ...privateVars,
+  ENABLE_BENCHMARKS: "true",
+  ENABLE_PERF_GATE: "true",
+  ENABLE_SCHEDULED_JOBS: "true",
+  PERF_RUNNER_LINUX: '"private-perf"',
+  BENCH_RUNNER_LINUX: '"private-bench"',
+  BENCH_RUNNER_LINUX_LARGE: '"private-large"',
+  BENCH_RUNNER_WINDOWS: '["self-hosted","Windows","bench"]',
+};
+for (const privateRepo of [false, true]) {
+  const ctx = context("Zondax/example", privateRepo, benchmarkVars, "schedule");
+  eq(evaluate(files["bench.yml"].jobs.plan.if, ctx), true, "benchmark opt-in");
+  eq(
+    evaluate(files["fuzz.yml"].jobs["native-archive"].if, ctx),
+    true,
+    "fuzz opt-in",
+  );
+  eq(
+    evaluate(files["perf-gate-preflight.yml"].jobs.preflight.if, ctx),
+    true,
+    "perf opt-in",
+  );
+  eq(
+    evaluate(files["perf-gate.yml"].jobs.measure["runs-on"], ctx),
+    "private-perf",
+    "perf configured pool",
+  );
+  for (const [pool, expected] of [
+    ["kunobi-runners", "private-bench"],
+    ["kunobi-runners-large", "private-large"],
+  ]) {
+    ctx.matrix = { runner: pool };
+    eq(
+      evaluate(files["bench.yml"].jobs.bench["runs-on"], ctx),
+      expected,
+      "benchmark configured pool",
+    );
+  }
+  delete ctx.vars.BENCH_RUNNER_LINUX_LARGE;
+  eq(
+    evaluate(files["bench.yml"].jobs.bench["runs-on"], ctx),
+    null,
+    "missing large pool does not use small pool",
+  );
+  ctx.vars.BENCH_RUNNER_LINUX_LARGE = '"private-large"';
+}
+const canonical = context("kunobi-ninja/kache", false, {}, "schedule");
+for (const pool of ["kunobi-runners", "kunobi-runners-large"]) {
+  canonical.matrix = { runner: pool };
+  eq(
+    evaluate(files["bench.yml"].jobs.bench["runs-on"], canonical),
+    pool,
+    "canonical benchmark pool retained",
+  );
+}
+eq(
+  evaluate(files["perf-gate.yml"].jobs.measure["runs-on"], canonical),
+  "kunobi-runners",
+  "canonical perf pool retained",
+);
+eq(
+  evaluate(
+    files["bench.yml"].jobs["bench-firefox-windows"]["runs-on"],
+    canonical,
+  ),
+  ["self-hosted", "Windows", "X64", "kunobi-windows"],
+  "canonical Windows pool retained",
+);
+console.log(
+  `${checks} workflow policy checks passed across ${routing.length} validation selectors.`,
+);

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -68,12 +68,13 @@ jobs:
   # a job-level `if` on `bench`: the `matrix` context is NOT available in a
   # job-level `if` (it is evaluated before the matrix is expanded, so it reads
   # empty) — a dispatch picking a single scenario would otherwise run zero arms.
-  # This tiny job runs on a GitHub-hosted runner so a skipped scenario never
-  # claims a self-hosted kunobi runner. schedule + `all` -> both; otherwise the
+  # This tiny job uses the validation runner so a skipped scenario never
+  # claims a benchmark runner. schedule + `all` -> both; otherwise the
   # one picked scenario. Per-arm timeout/min_free_gb travel with each entry.
   plan:
+    if: (github.repository == 'kunobi-ninja/kache' || vars.ENABLE_BENCHMARKS == 'true')
     name: Plan scenarios
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     outputs:
       matrix: ${{ steps.pick.outputs.matrix }}
       # Whether the Linux matrix has any arm. Windows-only scenarios produce an
@@ -217,7 +218,14 @@ jobs:
     # floor is a free-space precheck against the node filesystem, which is
     # several times larger, so it passes long before the ceiling is reached
     # and cannot catch that case on its own.
-    runs-on: ${{ matrix.runner }}
+    runs-on: >-
+      ${{ fromJSON(
+        matrix.runner == 'kunobi-runners-large' &&
+        (vars.BENCH_RUNNER_LINUX_LARGE ||
+         (github.repository == 'kunobi-ninja/kache' && '"kunobi-runners-large"') || 'null') ||
+        vars.BENCH_RUNNER_LINUX ||
+        (github.repository == 'kunobi-ninja/kache' && '"kunobi-runners"')
+      ) }}
     timeout-minutes: ${{ matrix.job_timeout }}
     strategy:
       # Arms run concurrently (up to the kunobi-runners scale-set's maxRunners).
@@ -486,10 +494,11 @@ jobs:
   bench-firefox-windows:
     name: Bench Firefox (Windows)
     if: >-
-      github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' &&
-       (github.event.inputs.scenario == 'firefox-windows' || github.event.inputs.scenario == 'all'))
-    runs-on: ${{ fromJSON('["self-hosted", "Windows", "X64", "kunobi-windows"]') }}
+      (github.repository == 'kunobi-ninja/kache' || vars.ENABLE_BENCHMARKS == 'true') &&
+      (github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' &&
+        (github.event.inputs.scenario == 'firefox-windows' || github.event.inputs.scenario == 'all')))
+    runs-on: ${{ fromJSON(vars.BENCH_RUNNER_WINDOWS || (github.repository == 'kunobi-ninja/kache' && '["self-hosted","Windows","X64","kunobi-windows"]')) }}
     timeout-minutes: 420
     defaults:
       run:
@@ -730,10 +739,11 @@ jobs:
   bench-firefox-pull-windows:
     name: Bench Firefox Pull (Windows)
     if: >-
-      github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' &&
-       (github.event.inputs.scenario == 'firefox-pull-windows' || github.event.inputs.scenario == 'all'))
-    runs-on: ${{ fromJSON('["self-hosted", "Windows", "X64", "kunobi-windows"]') }}
+      (github.repository == 'kunobi-ninja/kache' || vars.ENABLE_BENCHMARKS == 'true') &&
+      (github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' &&
+        (github.event.inputs.scenario == 'firefox-pull-windows' || github.event.inputs.scenario == 'all')))
+    runs-on: ${{ fromJSON(vars.BENCH_RUNNER_WINDOWS || (github.repository == 'kunobi-ninja/kache' && '["self-hosted","Windows","X64","kunobi-windows"]')) }}
     timeout-minutes: 540
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ concurrency:
 permissions:
   contents: read
 
-# SECURITY: validation jobs in this workflow use disposable GitHub-hosted
-# runners. Its only private-runner consumer is the tag-gated release job below;
-# runner-group policy must enforce that boundary independently of this
-# PR-editable workflow file.
+# Public repositories use GitHub-hosted validation runners, including forks.
+# Private repositories require CI_RUNNER_LINUX/MACOS/WINDOWS JSON selectors.
+# Runner-group access must enforce isolation independently of PR-editable YAML.
+# See .github/CI.md for repository configuration and publication boundaries.
 env:
   CARGO_TERM_COLOR: always
   KACHE_LOG: kache=debug
@@ -29,7 +29,7 @@ jobs:
   # any API error.
   changes:
     name: Detect changes
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     timeout-minutes: 5
     outputs:
       code: ${{ steps.filter.outputs.code }}
@@ -55,7 +55,7 @@ jobs:
   check:
     # A single Linux job keeps its required name even when it is skipped.
     name: Check (Linux)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     # Job-level cap so a hang in checkout/mise/build is killed in minutes, not
@@ -173,7 +173,7 @@ jobs:
   # serial and cannot finish that scope inside a useful CI timeout.
   mutation-plan:
     name: Mutation plan
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     needs: changes
     if: always()
     timeout-minutes: 10
@@ -252,7 +252,7 @@ jobs:
   # code PR/main push.
   mutation-core:
     name: Mutation testing (core)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     needs: [changes, check]
     if: github.ref_type != 'tag' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true')
     timeout-minutes: 20
@@ -320,7 +320,7 @@ jobs:
   # authentication, readiness, startup, and shutdown behavior cannot regress.
   mutation-service:
     name: Mutation testing (service)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     needs: [changes, check]
     if: github.ref_type != 'tag' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true')
     timeout-minutes: 35
@@ -391,7 +391,7 @@ jobs:
   # mutants, while round-robin avoids concentrating them in one shard.
   mutation-diff:
     name: Mutation testing (diff ${{ matrix.display }}/${{ matrix.total }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     needs: [check, mutation-plan]
     if: github.event_name == 'pull_request' && needs.mutation-plan.outputs.count != '0'
     timeout-minutes: 55
@@ -459,7 +459,7 @@ jobs:
   # the PR. Any failed or cancelled expected worker fails this aggregate gate.
   mutation:
     name: Mutation testing
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     needs: [changes, mutation-plan, mutation-core, mutation-service, mutation-diff]
     if: always() && github.ref_type != 'tag'
     timeout-minutes: 5
@@ -512,7 +512,7 @@ jobs:
   # drivers must pass through uncached; Kache does not model Kani's artifacts.
   kani:
     name: Kani proofs
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-24.04"' || vars.CI_RUNNER_LINUX) }}
     needs: [changes, check]
     if: github.ref_type != 'tag' && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true')
     timeout-minutes: 30
@@ -565,12 +565,23 @@ jobs:
   # matching a job name), so no job-name coupling is required.
   version-consistency:
     name: Repository consistency
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check routes and source parity
         run: bash scripts/check-docs.sh
+      - name: Set up Node for workflow policy checks
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 24
+      - name: Test workflow policy
+        working-directory: .github/tests
+        run: |
+          npm ci --ignore-scripts --no-audit --no-fund
+          npm test
+        env:
+          NPM_CONFIG_CACHE: ${{ runner.temp }}/workflow-tests-npm-cache
       - name: Test version consistency gate
         run: python3 scripts/test-version-consistency.py
       - name: Manifests agree (and match the tag on a v* tag)
@@ -615,7 +626,7 @@ jobs:
   # than blocking a tag build of already-reviewed code.
   audit:
     name: Dependency audit
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     timeout-minutes: 15
@@ -637,7 +648,7 @@ jobs:
 
   nix-package:
     name: Nix package
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     timeout-minutes: 25
@@ -668,7 +679,7 @@ jobs:
   # the ingest half; both shipped green. This lane exists so a third round can't.
   cow-filesystem:
     name: CoW filesystem (btrfs)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     timeout-minutes: 30
@@ -757,16 +768,15 @@ jobs:
       matrix:
         include:
           - os: Linux
-            runner: ubuntu-latest
+            runner: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
             exe_suffix: ""
-          # Validation routes to disposable GitHub-hosted runners. This is not
-          # the enforcement boundary: PRs can change this workflow, so private
-          # runner-group policy must independently deny validation workflows.
+          # Public validation stays hosted. Private runner groups must grant
+          # access only to the intended repositories and workflow trust level.
           - os: macOS
-            runner: macos-latest
+            runner: ${{ fromJSON(!github.event.repository.private && '"macos-latest"' || vars.CI_RUNNER_MACOS) }}
             exe_suffix: ""
           - os: Windows
-            runner: windows-latest
+            runner: ${{ fromJSON(!github.event.repository.private && '"windows-latest"' || vars.CI_RUNNER_WINDOWS) }}
             exe_suffix: ".exe"
     steps:
       - name: Report skipped E2E work
@@ -1026,7 +1036,7 @@ jobs:
   # Blocking: macOS is a first-class supported platform.
   test-macos:
     name: Test (macOS)
-    runs-on: macos-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"macos-latest"' || vars.CI_RUNNER_MACOS) }}
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     # Cargo test is additionally capped at 30m; the job cap catches setup hangs.
@@ -1116,7 +1126,7 @@ jobs:
   # Blocking: Windows is a first-class supported platform.
   test-windows:
     name: Test (Windows)
-    runs-on: windows-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"windows-latest"' || vars.CI_RUNNER_WINDOWS) }}
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     # A from-scratch `cargo test --workspace` compile has exceeded the previous
@@ -1217,7 +1227,7 @@ jobs:
     # *skipped* gate never resolves as success-equivalent and silently un-gates
     # the release. If you relax this `if:`, relax the gate's too (or drop the
     # gate's `if:` so it always runs).
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.repository == 'kunobi-ninja/kache' && startsWith(github.ref, 'refs/tags/v')
     # Gate the release (and, transitively, the crates publish it triggers) on
     # the full validation suite — `version-consistency` rejects a tag that
     # disagrees with the manifest BEFORE any binary builds; `e2e` includes the
@@ -1342,9 +1352,9 @@ jobs:
   # Bootstrap: the branch is first created manually at the latest GA tag.
   stable-branch:
     name: Advance stable branch
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    if: github.repository == 'kunobi-ninja/kache' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     needs: [release]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     timeout-minutes: 5
     permissions:
       contents: write
@@ -1368,9 +1378,9 @@ jobs:
   # its chart (kobe) and images (kobe-operator, kobe-sync) already differ.
   publish-chart:
     name: Publish Helm chart (OCI)
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.repository == 'kunobi-ninja/kache' && startsWith(github.ref, 'refs/tags/v')
     needs: [version-consistency]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -25,8 +25,9 @@ env:
 
 jobs:
   native-archive:
+    if: github.event_name != 'schedule' || github.repository == 'kunobi-ninja/kache' || vars.ENABLE_SCHEDULED_JOBS == 'true'
     name: Native archive parser
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -56,6 +56,7 @@ jobs:
   # workflow_dispatch the inputs do (with "latest"/"auto" resolution).
   # ---------------------------------------------------------------------------
   resolve:
+    if: github.repository == 'kunobi-ninja/kache'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/perf-gate-preflight.yml
+++ b/.github/workflows/perf-gate-preflight.yml
@@ -1,7 +1,7 @@
 name: Perf gate (preflight)
 
 # Untrusted half of the per-PR performance gate. It does exactly one privileged
-# thing: nothing. It runs on a disposable GitHub-hosted runner with a read-only
+# thing: nothing. It uses the repository's validation runner with a read-only
 # token, records which pull request asked for a measurement, and hands that
 # number to `perf-gate.yml` through an artifact.
 #
@@ -38,8 +38,9 @@ permissions:
 
 jobs:
   preflight:
+    if: github.repository == 'kunobi-ninja/kache' || vars.ENABLE_PERF_GATE == 'true'
     name: Record the perf-gate request
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     timeout-minutes: 5
     steps:
       # The PR number is the whole payload. Everything else — head SHA, base

--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -89,11 +89,12 @@ jobs:
   # is the only place that decides whether a self-hosted job may start.
   authorize:
     name: Authorize
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     timeout-minutes: 10
     # A failed or cancelled preflight, or a preflight that somehow fired on a
     # non-PR event, produces no measurement.
     if: >-
+      (github.repository == 'kunobi-ninja/kache' || vars.ENABLE_PERF_GATE == 'true') &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
     permissions:
@@ -184,7 +185,7 @@ jobs:
     # fits its 80Gi per-runner ceiling, and running here keeps every pull
     # request off the single reserved-node runner the heavy benchmarks queue
     # on.
-    runs-on: kunobi-runners
+    runs-on: ${{ fromJSON(vars.PERF_RUNNER_LINUX || (github.repository == 'kunobi-ninja/kache' && '"kunobi-runners"')) }}
     # Six builds of the subject (three phases x two commits) plus two builds of
     # kache itself. Normal runs land well inside this; the cap exists so a stall
     # is killed in an hour rather than at GitHub's 6h default.
@@ -447,7 +448,7 @@ jobs:
     name: Report
     needs: [authorize, measure]
     if: always() && needs.authorize.outputs.eligible == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.repository == 'kunobi-ninja/kache'
     name: Publish crates.io packages
     runs-on: ubuntu-latest
     # Every published GitHub Release publishes to crates.io, release-candidates

--- a/.github/workflows/service-image.yml
+++ b/.github/workflows/service-image.yml
@@ -29,9 +29,9 @@ permissions:
 
 jobs:
   docker-dry-run:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.repository != 'kunobi-ninja/kache'
     name: Build Service Image (Dry Run)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -39,9 +39,9 @@ jobs:
         run: docker buildx bake -f packaging/docker-bake.hcl --set '*.cache-from=' service
 
   release:
-    if: github.event_name != 'pull_request'
+    if: github.repository == 'kunobi-ninja/kache' && github.event_name != 'pull_request'
     name: Build Service Image
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
     permissions:
       contents: read
       actions: read # read CI job conclusions for the pushed commit (gate below)


### PR DESCRIPTION
Copied workflows currently request upstream benchmark pools and attempt publication using upstream destinations. Public repositories now keep GitHub-hosted validation, while private repositories supply explicit JSON runner selectors. Missing private configuration cannot fall back to paid hosted runners.

Publication remains restricted to `kunobi-ninja/kache`. Other repositories build the service image without publishing it and can opt into benchmarks, PR performance measurements, and scheduled fuzzing. The existing performance authorization and signing boundaries remain in place. Configuration is documented in `.github/CI.md`.

Validation:

- `just check`: formatting, clippy, and 3,224 passing workspace tests.
- 493 policy assertions using GitHub's expression evaluator, run in Repository consistency CI. These cover public forks, both organizations, private configuration failures, publication guards, and optional workloads.
- Two manual mutations were caught: inverted public/private routing and publication enabled in a copy.
- All eight workflows pass actionlint 1.7.12 syntax validation.
- GitHub core/service mutation suites: 135 caught, 74 unviable, none missed or timed out.
- Performance gate passed: warm build +1.9%, within the +5% limit.

The selector checks simulate repository contexts; provisioning and an actual CI run are still required when enabling a new private runner pool.
