### PR TITLE
chore(release): prepare 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "kache-format"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "kache-fs"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "libc",
  "serde",
@@ -2004,11 +2004,11 @@ dependencies = [
 
 [[package]]
 name = "kache-proofs"
-version = "0.16.1"
+version = "0.17.0"
 
 [[package]]
 name = "kache-service"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "kache-store"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more, with S3 and shared-filesystem remotes."
 license = "Apache-2.0"
@@ -35,8 +35,8 @@ exclude = ["tmp"]
 resolver = "3"
 
 [dependencies]
-kache-format = { version = "0.16.1", path = "crates/kache-format" }
-kache-store = { version = "0.16.1", path = "crates/kache-store" }
+kache-format = { version = "0.17.0", path = "crates/kache-format" }
+kache-store = { version = "0.17.0", path = "crates/kache-store" }
 blake3 = "1"
 bytes = "1"
 # OpenDAL 0.58 publishes its modules as separate crates. Depending on only the
@@ -54,7 +54,7 @@ reqsign-aws-v4 = { version = "=3.3.0", default-features = false }
 reqsign-core = { version = "=3.3.1", default-features = false }
 # Direct dep so OpenDAL/reqwest can use ring without reintroducing aws-lc.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.16.1", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.17.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }
@@ -111,7 +111,7 @@ windows-sys = { version = "0.61", features = [
 ] }
 
 [dev-dependencies]
-kache-store = { version = "0.16.1", path = "crates/kache-store", features = ["test-support"] }
+kache-store = { version = "0.17.0", path = "crates/kache-store", features = ["test-support"] }
 assert_cmd = "2"
 axum = "0.8"
 predicates = "3"

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-format/Cargo.toml
+++ b/crates/kache-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-format"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Cache-entry metadata and validation for kache."

--- a/crates/kache-fs/Cargo.toml
+++ b/crates/kache-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-fs"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Filesystem measurements, file identity, native cloning and copying."

--- a/crates/kache-proofs/Cargo.toml
+++ b/crates/kache-proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-proofs"
-version = "0.16.1"
+version = "0.17.0"
 publish = false
 edition = "2024"
 description = "Repository-only formal verification harnesses for kache."

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"

--- a/crates/kache-store/Cargo.toml
+++ b/crates/kache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-store"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Local content-addressed artifact storage for kache."
@@ -11,8 +11,8 @@ repository = "https://github.com/kunobi-ninja/kache"
 test-support = []
 
 [dependencies]
-kache-format = { version = "0.16.1", path = "../kache-format" }
-kache-fs = { version = "0.16.1", path = "../kache-fs", features = ["staging"] }
+kache-format = { version = "0.17.0", path = "../kache-format" }
+kache-fs = { version = "0.17.0", path = "../kache-fs", features = ["staging"] }
 anyhow = "1"
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }

--- a/packaging/charts/kache-service/Chart.yaml
+++ b/packaging/charts/kache-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kache-service
 description: Advisory remote planner service for kache
 type: application
-version: 0.16.1
-appVersion: "0.16.1"
+version: 0.17.0
+appVersion: "0.17.0"
 keywords:
   - rust
   - cache


### PR DESCRIPTION
## Summary

Version bump for the 0.17.0 release. Ships since v0.16.1 (tag exists; there is no GitHub Release for 0.16.1, so the last published release is still v0.16.0).

Volume-local stores (#191):

- #948 `[cache.volumes]` maps a volume to its own store shard
- #957 wrapper looks up and stores on that shard first
- #962 daemon remote import lands in the requesting shard
- #946 / #949 cross-volume hardlink advisory and doctor probe

Build cache:

- #938 / #939 / #942 / #945 / #947 rustc key from a recorded input closure, with prediction evidence
- #885 machine-wide compile scheduler
- #884 compile-and-compare verify on hits
- #935 / #883 C/C++ preprocessor-mode cache and remote publish
- #882 `kache gc` defaults local_max_size to 5% of the cache disk

Observability and planner:

- #966 report the latest recorded build session
- #917 attribute wrapper time to nested trace phases
- #970 daemon counters as cumulative sums
- #954 planner store from SurrealDB to SQLite

Fixes that change what hits and what gets cleaned:

- #937 don't report an unflushed file as unreclaimable
- #936 / #934 / #912 key / dep-info pre-pass
- #918 key native Windows MSVC link inputs
- #923 honour `--since` and label it honestly
- #955 sampled verification actually samples
- #972 perf-gate ignores a warm delta when cold slowed as much (runner, not cache)

Also in the tree but not user-visible: store/fs/wrapper extractions (#950, #953, #959, #961, #965, #969), Nix shims (#963), docs (#900, #902, #903, #960, #967), bench/CI (#901, #911, #925, #940, #941, #952, #956, #968, #973).

Minor bump: volume shards, predicted keys, the scheduler, and C/C++ preprocessor cache are new behaviour, not a patch on 0.16.

After merge: from a clean `main` in sync with origin, `just release` tags `v0.17.0` and CI creates the GitHub Release. Do not draft the release in the UI.

## Checklist

- [x] Version bumped in workspace + crates + Helm chart (same shape as #865)
- [x] `just bump 0.17.0` (`cargo set-version --workspace`, lock settled by `cargo check`)
- [x] `scripts/check-version-consistency.sh` passes: publishable crates at 0.17.0
- [x] `cargo check --workspace` clean