### PR TITLE
chore(release): group GitHub release notes with git-cliff

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -150,6 +150,11 @@ safety net the publish job re-checks (`scripts/require-ci-green.sh`) that CI
 passed for the tagged commit and refuses to publish otherwise — but pushing the
 tag is the intended, friction-free path.
 
+The GitHub Release is created with GitHub's auto-generated PR list. After it
+is published, `.github/workflows/release-notes.yml` replaces the body with
+grouped notes from git-cliff (`just release-notes`). Add a highlights blurb
+on the published notes if the grouped list is not enough.
+
 ### Publishing to crates.io
 
 Publishing is automated by `.github/workflows/publish-crates.yaml`, triggered when

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,38 @@
+name: Release notes
+
+# The reusable rust-release workflow creates the GitHub Release with
+# `gh release create --generate-notes` (a flat PR list). After that
+# release is published, replace the body with grouped notes from git-cliff.
+# Title and notes remain editable on immutable releases.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  notes:
+    name: Replace GitHub release notes
+    if: startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        with:
+          tool: git-cliff
+
+      - name: Write grouped notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          notes="$(mktemp)"
+          ./scripts/release-notes.sh "$TAG" > "$notes"
+          gh release edit "$TAG" --notes-file "$notes"

--- a/Justfile
+++ b/Justfile
@@ -515,6 +515,14 @@ release:
   git push origin "$tag"
   echo "pushed $tag — the gated release pipeline will run; watch CI."
 
+# Group conventional commits into GitHub Release notes (git-cliff).
+# TAG defaults to the latest v* tag. Needs git-cliff on PATH
+# (`cargo binstall -y git-cliff`). Usage: `just release-notes` /
+# `just release-notes v0.17.0`
+[group('release')]
+release-notes TAG="":
+  ./scripts/release-notes.sh {{TAG}}
+
 # Remove build artifacts.
 clean:
   cargo clean

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,50 @@
+# git-cliff config for GitHub Release notes.
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = ""
+body = """
+{%- for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits -%}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif -%}
+{%- if commit.breaking %}**breaking** {% endif -%}
+{{ commit.message | split(pat="\n") | first | trim | upper_first }}
+{% endfor -%}
+{% endfor -%}
+"""
+footer = ""
+trim = true
+postprocessors = [
+  { pattern = '\(#([0-9]+)\)', replace = "([#$1](https://github.com/kunobi-ninja/kache/pull/$1))" },
+]
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+protect_breaking_commits = false
+filter_commits = true
+tag_pattern = "v[0-9].*"
+topo_order = false
+sort_commits = "oldest"
+commit_parsers = [
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore: release", skip = true },
+  { message = "^Merge ", skip = true },
+  { message = "^test", skip = true },
+  { message = "^ci", skip = true },
+  { message = "^chore\\(ci\\)", skip = true },
+  { message = "^chore\\(deps\\)", skip = true },
+  { message = "^bench", skip = true },
+  { message = "^feat\\(bench\\)", skip = true },
+  { message = "^fix\\(bench\\)", skip = true },
+  { message = "^feat\\(ci\\)", skip = true },
+  { message = "^fix\\(ci\\)", skip = true },
+  { message = "^docs\\(agents\\)", skip = true },
+  { message = "^feat", group = "<!-- 1 -->Features" },
+  { message = "^fix", group = "<!-- 2 -->Fixes" },
+  { message = "^perf", group = "<!-- 3 -->Performance" },
+  { message = "^doc", group = "<!-- 4 -->Docs" },
+  { message = "^refactor", group = "<!-- 5 -->Internals" },
+]

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Print GitHub Release notes for a tag, grouped from conventional commits.
+#
+# Usage:
+#   scripts/release-notes.sh            # latest v* tag
+#   scripts/release-notes.sh v0.17.0
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+if ! command -v git-cliff >/dev/null 2>&1; then
+  echo "git-cliff not found — install with: cargo binstall -y git-cliff" >&2
+  exit 1
+fi
+
+tag="${1:-}"
+if [ -z "$tag" ]; then
+  tag="$(git describe --tags --abbrev=0 --match 'v*')"
+fi
+case "$tag" in
+  v*) ;;
+  *) echo "tag must look like vX.Y.Z, got: $tag" >&2; exit 1 ;;
+esac
+git rev-parse -q --verify "refs/tags/$tag" >/dev/null \
+  || { echo "tag $tag is not in this clone" >&2; exit 1; }
+
+prev="$(git describe --tags --abbrev=0 --match 'v*' "$tag^" 2>/dev/null || true)"
+version="${tag#v}"
+
+echo "Install with \`cargo install kache --locked\` or \`mise use -g github:kunobi-ninja/kache@${version}\`."
+echo
+git-cliff --config "$root/cliff.toml" "${prev:+$prev..}""$tag" 2>/dev/null
+if [ -n "$prev" ]; then
+  echo
+  echo "**Full changelog:** https://github.com/kunobi-ninja/kache/compare/${prev}...${tag}"
+fi


### PR DESCRIPTION
## Summary

The GitHub Release is created with `gh release create --generate-notes`, which is a flat PR list. After the release is published, replace that body with notes grouped from conventional commits (feat/fix/perf/docs/refactor).

v0.17.0 notes were already rewritten by hand on the published release (title + highlights). This is so the next tag does not go back to the dump.

`just release-notes` prints the same body locally (`cargo binstall -y git-cliff`).

## Test plan

- [x] `scripts/release-notes.sh v0.17.0` emits grouped Features/Fixes/Performance/Docs/Internals
- [x] Published [v0.17.0](https://github.com/kunobi-ninja/kache/releases/tag/v0.17.0) notes already use the new shape
- [ ] Next `v*` tag: this workflow runs after `release: published` and overwrites `--generate-notes`

## Checklist

- [x] New behaviour is covered by tests where it makes sense (script smoke on v0.17.0)
- [x] Commit messages follow conventional commits
- [x] Maintainer docs: `.github/CONTRIBUTING.md`