### PR TITLE
fix(remote): cap compressed v3 downloads

### DIFF
--- a/docs/remote-cache/filesystem-setup.mdx
+++ b/docs/remote-cache/filesystem-setup.mdx
@@ -51,6 +51,8 @@ Kache rejects a configuration that cannot provide atomic final renames.
 
 Filesystem prefixes cannot contain `:`.
 
+The [v3 download limits](/docs/remote-cache/s3-setup#object-layout-and-policy) also apply to shared folders: 8 GiB compressed and 8 GiB extracted per entry. Compiler invocations recompile when a remote entry exceeds either limit.
+
 ## Reclaim remote space
 
 kache never deletes remote objects. The owner of the directory runs a prune job; [Bound a remote](/docs/remote-cache/bounding) has the script and the ages that keep manifests and packs consistent.

--- a/docs/remote-cache/s3-setup.mdx
+++ b/docs/remote-cache/s3-setup.mdx
@@ -94,6 +94,8 @@ The default prefix is `artifacts`. Writers need `s3:GetObject`, `s3:PutObject`, 
 
 Remote packs use zstd; local blobs remain uncompressed. Configure the level with `cache.compression_level` or `KACHE_COMPRESSION_LEVEL`.
 
+Each v3 entry download is limited to 8 GiB of compressed data and 8 GiB of extracted file data. Kache rejects an oversized download before restoring it; a compiler invocation recompiles when the remote entry cannot be restored. These are per-entry limits, not a total memory budget for concurrent downloads.
+
 kache never deletes remote objects. Bound the bucket with a lifecycle rule; [Bound a remote](/docs/remote-cache/bounding) lists the prefixes and ages.
 
 ## macOS LAN access

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -1227,7 +1227,10 @@ mod tests {
 
     #[tokio::test]
     async fn s3_wire_rejects_advertised_oversize_before_returning_body() {
-        let (endpoint, _requests) = mock_http_server(vec![http_response("200 OK", "hello")]).await;
+        // Send headers alone: the size check must reject without reading a
+        // body. Reading it would produce a truncation error instead.
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\n";
+        let (endpoint, _requests) = mock_http_server(vec![response.to_string()]).await;
         let backend = anonymous_s3_backend(&endpoint);
 
         let error = backend
@@ -1236,6 +1239,69 @@ mod tests {
             .expect_err("content-length above cap must fail")
             .to_string();
         assert!(error.contains("too large"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn s3_wire_accepts_a_body_at_the_size_limit() {
+        let (endpoint, _requests) = mock_http_server(vec![http_response("200 OK", "hello")]).await;
+        let backend = anonymous_s3_backend(&endpoint);
+
+        let fetched = backend.get("key", Some(5)).await.unwrap().unwrap();
+        assert_eq!(fetched.body, "hello");
+    }
+
+    #[tokio::test]
+    async fn s3_wire_rejects_streamed_oversize_without_content_length() {
+        let response = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\
+                        Connection: close\r\n\r\n2\r\nhe\r\n3\r\nllo\r\n0\r\n\r\n";
+        let (endpoint, _requests) = mock_http_server(vec![response.to_string()]).await;
+        let backend = anonymous_s3_backend(&endpoint);
+
+        let error = backend
+            .get("key", Some(4))
+            .await
+            .expect_err("the body must be bounded even without Content-Length")
+            .to_string();
+        assert!(
+            error.contains("too large: at least 5 bytes (max 4)"),
+            "{error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn v3_download_rejects_oversize_before_publishing_an_entry() {
+        // Advertise one byte above 8 GiB without allocating a large body. Pin
+        // the public download path and its ceiling, not just Backend::get.
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 8589934593\r\n\
+                        Connection: close\r\n\r\n";
+        let (endpoint, requests) = mock_http_server(vec![response.to_string()]).await;
+        let backend = anonymous_s3_backend(&endpoint);
+        let remote = RemoteConfig::test_s3("bucket", "artifacts");
+        let layout = crate::remote_layout::RemoteLayout::new(&backend, &remote);
+        let temp = tempfile::tempdir().unwrap();
+        let destination = temp.path().join("entry");
+        let blobs = temp.path().join("blobs");
+
+        let error = layout
+            .download_entry("key123", "foo", &destination, &blobs)
+            .await
+            .err()
+            .expect("an oversized v3 pack must be rejected before extraction");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("too large: 8589934593 bytes (max 8589934592)"),
+            "{message}"
+        );
+        assert!(
+            std::fs::read_dir(temp.path()).unwrap().next().is_none(),
+            "a rejected download must not publish files or leave extraction debris"
+        );
+        let requests = requests.await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].lines().next(),
+            Some("GET /bucket/artifacts/v3/packs/foo/key123.tar.zst HTTP/1.1")
+        );
     }
 
     #[tokio::test]

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -21,6 +21,10 @@ const V3_MANIFEST_VERSION: u32 = 3;
 /// terabytes. Paired with [`MAX_ZSTD_WINDOW_LOG`] on the decoder (#212).
 const MAX_EXTRACTED_BYTES: u64 = 8 * 1024 * 1024 * 1024; // 8 GiB
 
+/// Cap the compressed body buffered by GET before extraction begins. This is
+/// a per-object ceiling; concurrent downloads can each hold up to this much.
+const MAX_COMPRESSED_BYTES: u64 = 8 * 1024 * 1024 * 1024; // 8 GiB
+
 /// Max zstd window-log accepted on decode (2^27 = 128 MiB). Bounds the
 /// decoder's allocation regardless of what the frame header claims (#212).
 const MAX_ZSTD_WINDOW_LOG: u32 = 27;
@@ -109,7 +113,10 @@ impl<'a> RemoteLayout<'a> {
         // likely-present keys go straight to GET, and a stale key-cache
         // positive degrades to a miss, not an error.
         let fetched = crate::remote_resilience::RemoteDeadline::from_instant(deadline)
-            .run("remote object GET", self.backend.get(&object_key, None))
+            .run(
+                "remote object GET",
+                self.backend.get(&object_key, Some(MAX_COMPRESSED_BYTES)),
+            )
             .await
             .context("downloading v3 pack")?
             .ok_or_else(|| {


### PR DESCRIPTION
V3 remote downloads now reject compressed objects above 8 GiB before extraction. The existing backend checks Content-Length and the streamed body; compiler invocations recompile when the remote entry cannot be restored.

The extracted-data limit remains 8 GiB. Both limits apply per entry; streaming to disk and a budget shared across concurrent downloads remain follow-ups.

Tests cover headers-only rejection, chunked overflow, an exact-size body, and v3 rejection without creating entry files. Manually bypassing or changing the cap made the v3 regression test fail.

Validation: `CARGO_INCREMENTAL=0 RUST_TEST_THREADS=1 just check` and [CI](https://github.com/kunobi-ninja/kache/actions/runs/34103849237) passed, including Linux, macOS, Windows and all mutation suites. Changed-line mutations: 6 caught, 1 unviable. The [performance gate](https://github.com/kunobi-ninja/kache/actions/runs/34105737972) passed: warm build +2.0% in one paired run, within the 5% threshold.

Related to #327; weighted permits remain outside this PR.
