### PR TITLE
feat(tui): group the monitor by build and explain each build's misses

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -49,7 +49,7 @@ Use `kache init --check` to preview the changes, or `kache init --no-service` to
 | Remote cache | S3-compatible and filesystem backends |
 | Build visibility | Live monitor, stats, miss explanations, and reports |
 
-Kache passes unsupported compiler invocations through unchanged. A passthrough is not a cache hit or miss; inspect its reason in the monitor's Passthrough tab or debug logs.
+Kache passes unsupported compiler invocations through unchanged. A passthrough is not a cache hit or miss; inspect its reason in the monitor's Why tab or debug logs.
 
 ## Tested nightly on real projects
 

--- a/docs/monitor.mdx
+++ b/docs/monitor.mdx
@@ -28,13 +28,17 @@ The monitor attempts to start the daemon for transfer statistics. It still reads
 
 ## Tabs
 
-1. `Build` shows compiler events, outcome, action, timing, and size.
-2. `Projects` lists observed target directories and disk use. Press `r` to rescan.
-3. `Store` lists cache entries. Press `s` to change sort order.
-4. `Transfer` shows recent remote uploads and downloads.
-5. `Passthrough` shows the route, exit code, and reason for uncached invocations.
+1. `Build` lists the builds the event log has seen, newest on top and running ones first, and shows the selected build's compiler events with outcome, action, timing, and size. The panel title carries the build's cost strip: compile time saved, compile time spent in misses, and kache's own overhead.
+2. `Why` explains the selected build. Misses are collapsed to their causes, most frequent first: a failed store or a rejected lookup (a caching failure to fix), a dependency cascade named by the crate that actually changed, the crate's own changed inputs, no earlier compile in the loaded history, or unexplained. Passthroughs are grouped by reason, with queries such as `--print` kept apart from compiles. Crates that keep missing across builds of the same tree are listed as chronic, and every passthrough in the build is listed at the end. The whole tab is one body; PgUp and PgDn scroll it.
+3. `Projects` lists observed target directories and disk use. Press `r` to rescan.
+4. `Store` lists cache entries. Press `s` to change sort order.
+5. `Transfer` shows recent remote uploads and downloads.
 
-`dup` means the compiler ran after a key miss but produced blobs already in the store. It is not a cache hit.
+A build is every event sharing the session id the wrapper mints per `cargo build`. Events from older wrappers have no id and are grouped by build root, split at idle gaps of five minutes. Those builds carry a `~` after their name.
+
+Cascade causes need per-dependency digests on the events, which `[cache] explain_miss = true` records. Without it the Why tab says so. Every figure on the tab describes the loaded history: with `--since`, a crate whose last compile is before the cutoff reads as having no earlier compile.
+
+`dup` means the compiler ran after a key miss but produced blobs already in the store. It is not a cache hit. A passthrough is not a miss either: kache never consulted the cache for it.
 
 ## Keys
 
@@ -43,7 +47,8 @@ q, Ctrl+C         quit
 p                 pause and resume (the log keeps its place; nothing is lost)
 Tab, Shift+Tab    next and previous tab
 1 2 3 4 5         select a tab
-Up / Down, j / k  scroll one row
+Up / Down, j / k  on Build and Why: pick a build; elsewhere: scroll one row
+Enter             on Build: open Why for the picked build
 PgUp / PgDn       scroll one page
 Home / End        first and last row; End on Build follows new events again
 f                 filter the current supported tab
@@ -51,6 +56,8 @@ s                 change Store sort
 c                 clear Build events
 r                 rescan Projects
 ```
+
+Above the top build is "following the top build": the monitor starts there and returns there when you press Up past the first row. The top build is the newest running one, or the newest finished one when nothing is running.
 
 Clicking a tab title selects it and the mouse wheel scrolls the current panel.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ use compiler_store as store;
 mod test_support;
 mod transport;
 mod tui;
+mod tui_sessions;
 mod verify_compare;
 mod wrapper;
 mod wrapper_config;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -19,6 +19,7 @@ use crate::config::Config;
 use crate::daemon;
 use crate::events::{self, BuildEvent, EventRecord, EventResult, EventTailer, HeartbeatEvent};
 use crate::since::SinceWindow;
+use crate::tui_sessions::{self, Analysis, Cause, Session, SessionState};
 
 // ── Terminal mode guard ────────────────────────────────────────────────────
 
@@ -96,19 +97,21 @@ fn restore_terminal() {
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum Tab {
     Build,
+    /// Why the selected build missed: causes, passthrough reasons, chronic
+    /// misses. Sits next to Build because Enter on a build lands here.
+    Why,
     Projects,
     Store,
     Transfer,
-    Passthrough,
 }
 
 impl Tab {
     const ORDER: [Tab; 5] = [
         Tab::Build,
+        Tab::Why,
         Tab::Projects,
         Tab::Store,
         Tab::Transfer,
-        Tab::Passthrough,
     ];
 
     fn index(self) -> usize {
@@ -283,7 +286,7 @@ fn reset_filtered_viewports(state: &mut AppState) {
     match state.active_tab {
         Tab::Build => state.build_scroll.reset(),
         Tab::Store => state.store_scroll.reset(),
-        Tab::Passthrough => state.passthrough_scroll.reset(),
+        Tab::Why => state.why_scroll.reset(),
         Tab::Projects | Tab::Transfer => {}
     }
 }
@@ -401,7 +404,7 @@ struct AppState {
     /// and help bar showing nothing about it.
     build_filter: String,
     store_filter: String,
-    passthrough_filter: String,
+    why_filter: String,
     filter_active: bool,
 
     // Store tab
@@ -418,9 +421,28 @@ struct AppState {
     last_project_refresh: Instant,
     project_scroll: Viewport,
 
+    // Build sessions (kunobi-ninja/kache#583). Regrouped when the log grew,
+    // re-sorted every tick. The selected build drives the Build event panel
+    // and the Why tab.
+    sessions: Vec<Session>,
+    /// `events.len()` the sessions were grouped from.
+    grouped_len: usize,
+    /// The session the reader picked, by key; `None` follows the top row,
+    /// which is the newest running build.
+    selected_session: Option<String>,
+    /// The build the panels showed last tick, and how many events it had,
+    /// so a change of build resets the viewports and new rows in the same
+    /// build keep a scrolled reader in place.
+    shown: Option<(String, usize)>,
+    /// The Why analysis for `(session key, event count)` it was computed
+    /// for. Recomputed only when either changes: the cascade walk is per
+    /// miss and not free.
+    why_cache: Option<(String, usize, Analysis)>,
+
     // Transfer tab
     transfer_scroll: Viewport,
-    passthrough_scroll: Viewport,
+    /// Why tab: the whole explanation is one scrollable body.
+    why_scroll: Viewport,
     prev_bytes_uploaded: u64,
     prev_bytes_downloaded: u64,
     upload_speed_bps: f64,
@@ -454,7 +476,7 @@ impl AppState {
             Tab::Projects => &mut self.project_scroll,
             Tab::Store => &mut self.store_scroll,
             Tab::Transfer => &mut self.transfer_scroll,
-            Tab::Passthrough => &mut self.passthrough_scroll,
+            Tab::Why => &mut self.why_scroll,
         }
     }
 
@@ -507,27 +529,130 @@ impl AppState {
             && self.last_project_refresh.elapsed() >= PROJECT_REFRESH_INTERVAL
     }
 
-    /// Append a tailed build event and keep every scrolled-away reader on the
-    /// rows they were looking at.
+    /// Append a tailed build event. Scroll bookkeeping happens when the
+    /// sessions are refreshed, once the event is known to belong to the
+    /// build on screen.
     fn push_event(&mut self, event: BuildEvent) {
-        if self.build_filter.is_empty() || event.crate_name.contains(&self.build_filter) {
-            self.build_scroll.rows_arrived(1);
-        }
-        if matches!(event.result, EventResult::Passthrough)
-            && (self.passthrough_filter.is_empty()
-                || event.crate_name.contains(&self.passthrough_filter)
-                || event.passthrough_reason.contains(&self.passthrough_filter))
-        {
-            self.passthrough_scroll.rows_arrived(1);
-        }
         self.events.push(event);
     }
+
+    /// Bring the sessions up to date: regroup when the log grew, decide
+    /// which are live and sort them every tick (a build goes from running to
+    /// done by sitting idle), then reconcile the panels with the build that
+    /// ends up selected.
+    fn refresh_sessions(&mut self, now: chrono::DateTime<chrono::Utc>) {
+        let live_roots: std::collections::HashSet<String> = self
+            .in_flight_view()
+            .into_iter()
+            .map(|entry| entry.root)
+            .filter(|root| !root.is_empty())
+            .collect();
+        if self.grouped_len != self.events.len() {
+            self.sessions = tui_sessions::group(
+                &self.events,
+                Duration::from_secs(crate::wrapper::BUILD_SESSION_SECS),
+            );
+            self.grouped_len = self.events.len();
+        }
+        tui_sessions::refresh_state(&mut self.sessions, now, &live_roots);
+        self.reconcile_shown_build();
+    }
+
+    /// Keep the Build and Why panels honest about which build they show.
+    /// A different build (a pick, or the top row changing while following)
+    /// starts both panels from their default edge. The same build with new
+    /// rows keeps a scrolled-back reader on the rows they were reading;
+    /// rows from other builds never move anything.
+    fn reconcile_shown_build(&mut self) {
+        let now_shown = self
+            .selected_session()
+            .map(|session| (session.key.clone(), session.events.len()));
+        match (&self.shown, &now_shown) {
+            (Some((was, had)), Some((is, has))) if was == is => {
+                let arrived = self
+                    .selected_session()
+                    .map(|session| {
+                        session.events[*had..*has]
+                            .iter()
+                            .filter(|&&index| {
+                                let event = &self.events[index];
+                                self.build_filter.is_empty()
+                                    || event.crate_name.contains(&self.build_filter)
+                            })
+                            .count()
+                    })
+                    .unwrap_or(0);
+                self.build_scroll.rows_arrived(arrived);
+            }
+            (Some(_), Some(_)) | (None, Some(_)) => {
+                self.build_scroll.reset();
+                self.why_scroll.reset();
+            }
+            (_, None) => {}
+        }
+        self.shown = now_shown;
+    }
+
+    /// The build the Build and Why tabs are about: the reader's pick when it
+    /// still exists, else the top row.
+    fn selected_session(&self) -> Option<&Session> {
+        self.selected_session
+            .as_deref()
+            .and_then(|key| self.sessions.iter().find(|s| s.key == key))
+            .or_else(|| self.sessions.first())
+    }
+
+    fn selected_index(&self) -> Option<usize> {
+        let key = self.selected_session()?.key.as_str();
+        self.sessions.iter().position(|s| s.key == key)
+    }
+
+    /// Move the selection one row down. The pick becomes explicit even on
+    /// the last row, so a new build arriving on top no longer changes what
+    /// the reader is looking at.
+    fn select_next_session(&mut self) {
+        let Some(index) = self.selected_index() else {
+            return;
+        };
+        let next = (index + 1).min(self.sessions.len().saturating_sub(1));
+        self.selected_session = Some(self.sessions[next].key.clone());
+        self.reconcile_shown_build();
+    }
+
+    /// Move the selection one row up. Above the top row is "follow the
+    /// newest build", the state the monitor starts in.
+    fn select_previous_session(&mut self) {
+        let Some(index) = self.selected_index() else {
+            return;
+        };
+        if index == 0 {
+            self.selected_session = None;
+        } else {
+            self.selected_session = Some(self.sessions[index - 1].key.clone());
+        }
+        self.reconcile_shown_build();
+    }
+
+    /// The Why analysis for the selected build, computed on first use and
+    /// whenever the event count moved.
+    fn why_analysis(&mut self) -> Option<&Analysis> {
+        let session = self.selected_session()?;
+        let key = session.key.clone();
+        let stale =
+            !matches!(&self.why_cache, Some((k, n, _)) if *k == key && *n == self.events.len());
+        if stale {
+            let analysis = tui_sessions::analyze_session(&self.events, session, &self.sessions);
+            self.why_cache = Some((key, self.events.len(), analysis));
+        }
+        self.why_cache.as_ref().map(|(_, _, analysis)| analysis)
+    }
+
     /// The active tab's filter, empty for tabs that do not filter.
     fn filter(&self) -> &str {
         match self.active_tab {
             Tab::Build => &self.build_filter,
             Tab::Store => &self.store_filter,
-            Tab::Passthrough => &self.passthrough_filter,
+            Tab::Why => &self.why_filter,
             Tab::Projects | Tab::Transfer => "",
         }
     }
@@ -538,7 +663,7 @@ impl AppState {
         match self.active_tab {
             Tab::Build => Some(&mut self.build_filter),
             Tab::Store => Some(&mut self.store_filter),
-            Tab::Passthrough => Some(&mut self.passthrough_filter),
+            Tab::Why => Some(&mut self.why_filter),
             Tab::Projects | Tab::Transfer => None,
         }
     }
@@ -639,7 +764,7 @@ pub fn run_monitor(config: &Config, since: Option<SinceWindow>) -> Result<()> {
         build_scroll: Viewport::new(ScrollAnchor::Bottom),
         build_filter: String::new(),
         store_filter: String::new(),
-        passthrough_filter: String::new(),
+        why_filter: String::new(),
         filter_active: false,
         sort_mode: SortMode::Size,
         store_scroll: Viewport::new(ScrollAnchor::Top),
@@ -649,8 +774,13 @@ pub fn run_monitor(config: &Config, since: Option<SinceWindow>) -> Result<()> {
         project_scan,
         last_project_refresh: Instant::now(),
         project_scroll: Viewport::new(ScrollAnchor::Top),
+        sessions: Vec::new(),
+        grouped_len: 0,
+        selected_session: None,
+        shown: None,
+        why_cache: None,
         transfer_scroll: Viewport::new(ScrollAnchor::Top),
-        passthrough_scroll: Viewport::new(ScrollAnchor::Top),
+        why_scroll: Viewport::new(ScrollAnchor::Top),
         prev_bytes_uploaded: 0,
         prev_bytes_downloaded: 0,
         upload_speed_bps: 0.0,
@@ -676,6 +806,10 @@ pub fn run_monitor(config: &Config, since: Option<SinceWindow>) -> Result<()> {
         state
             .live_heartbeats
             .retain(|_, (seen, _)| seen.elapsed() < stale_after);
+
+        // Sessions depend on the clock (a build goes from running to done by
+        // sitting idle), so they are regrouped every tick, paused or not.
+        state.refresh_sessions(chrono::Utc::now());
 
         // Check for completed background rustc_version
         if let Ok(mut slot) = state.rustc_version_slot.lock()
@@ -818,7 +952,7 @@ fn switch_tab(state: &mut AppState, tab: Tab) {
     match tab {
         Tab::Projects => state.last_project_refresh = Instant::now() - PROJECT_REFRESH_INTERVAL,
         Tab::Store => state.last_stats_fetch = Instant::now() - SNAPSHOT_REFRESH_INTERVAL,
-        Tab::Build | Tab::Transfer | Tab::Passthrough => {}
+        Tab::Build | Tab::Transfer | Tab::Why => {}
     }
 }
 
@@ -913,14 +1047,24 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
         }
         // Tab switching
         KeyCode::Char('1') => switch_tab(state, Tab::Build),
-        KeyCode::Char('2') => switch_tab(state, Tab::Projects),
-        KeyCode::Char('3') => switch_tab(state, Tab::Store),
-        KeyCode::Char('4') => switch_tab(state, Tab::Transfer),
-        KeyCode::Char('5') => switch_tab(state, Tab::Passthrough),
+        KeyCode::Char('2') => switch_tab(state, Tab::Why),
+        KeyCode::Char('3') => switch_tab(state, Tab::Projects),
+        KeyCode::Char('4') => switch_tab(state, Tab::Store),
+        KeyCode::Char('5') => switch_tab(state, Tab::Transfer),
         KeyCode::Tab => switch_tab(state, state.active_tab.next()),
         // Shift+Tab used to share an arm with Tab and cycle forward too, so
         // there was no way back except by number.
         KeyCode::BackTab => switch_tab(state, state.active_tab.previous()),
+        // On Build and Why, Up/Down pick the build; the event panel scrolls by
+        // page and by End. A flat list needed one axis, a list of builds with
+        // a panel each needs two.
+        KeyCode::Up | KeyCode::Char('k') if matches!(state.active_tab, Tab::Build | Tab::Why) => {
+            state.select_previous_session();
+        }
+        KeyCode::Down | KeyCode::Char('j') if matches!(state.active_tab, Tab::Build | Tab::Why) => {
+            state.select_next_session();
+        }
+        KeyCode::Enter if state.active_tab == Tab::Build => switch_tab(state, Tab::Why),
         // Scrolling: one row, one page, or straight to either end. `j`/`k`
         // for hands that live on the home row.
         KeyCode::Up | KeyCode::Char('k') => state.active_viewport().scroll_up(),
@@ -940,6 +1084,9 @@ fn handle_key(state: &mut AppState, key: KeyCode) {
         }
         KeyCode::Char('c') if state.active_tab == Tab::Build => {
             state.events.clear();
+            state.sessions.clear();
+            state.selected_session = None;
+            state.why_cache = None;
             state.build_scroll.reset();
         }
         // Store tab
@@ -996,7 +1143,7 @@ fn draw_ui(frame: &mut Frame, state: &mut AppState) {
         Tab::Projects => draw_projects_tab(frame, state, chunks[1]),
         Tab::Store => draw_store_tab(frame, state, chunks[1]),
         Tab::Transfer => draw_transfer_tab(frame, state, chunks[1]),
-        Tab::Passthrough => draw_passthrough_tab(frame, state, chunks[1]),
+        Tab::Why => draw_why_tab(frame, state, chunks[1]),
     }
 }
 
@@ -1033,10 +1180,10 @@ fn draw_tab_bar(frame: &mut Frame, state: &AppState, area: Rect) {
 fn tab_titles() -> [(Tab, &'static str, u16); 5] {
     const LABELS: [(Tab, &str); 5] = [
         (Tab::Build, " [1] Build "),
-        (Tab::Projects, "[2] Projects"),
-        (Tab::Store, "[3] Store "),
-        (Tab::Transfer, "[4] Transfer "),
-        (Tab::Passthrough, "[5] Passthrough "),
+        (Tab::Why, "[2] Why "),
+        (Tab::Projects, "[3] Projects"),
+        (Tab::Store, "[4] Store "),
+        (Tab::Transfer, "[5] Transfer "),
     ];
     let mut x = 0u16;
     LABELS.map(|(tab, label)| {
@@ -1067,11 +1214,23 @@ fn draw_build_tab(frame: &mut Frame, state: &mut AppState, area: Rect) {
         // can't crowd out the event stream.
         (in_flight.len().min(6) + 2) as u16
     };
+    // Builds panel: border (2) + header (1) + up to five rows. Absent until
+    // there is a build to list, so an idle monitor keeps the classic layout.
+    let has_builds = !state.sessions.is_empty();
+    let builds_rows = if has_builds {
+        (state.sessions.len().min(5) + 3) as u16
+    } else {
+        0
+    };
+    // On a short terminal the sparkline goes before the event rows do.
+    let show_spark = area.height >= 30;
+    let spark_rows = if show_spark { 5 } else { 0 };
     let chunks = Layout::vertical([
         Constraint::Length(9),              // Stats bar
         Constraint::Length(in_flight_rows), // In-flight compiles (if any)
-        Constraint::Min(8),                 // Live build events
-        Constraint::Length(5),              // Sparkline
+        Constraint::Length(builds_rows),    // Builds (if any)
+        Constraint::Min(6),                 // Selected build's events
+        Constraint::Length(spark_rows),     // Sparkline
         Constraint::Length(1),              // Help bar
     ])
     .split(area);
@@ -1080,9 +1239,153 @@ fn draw_build_tab(frame: &mut Frame, state: &mut AppState, area: Rect) {
     if in_flight_rows > 0 {
         draw_in_flight(frame, &in_flight, chunks[1]);
     }
-    draw_live_build(frame, state, chunks[2]);
-    draw_sparkline(frame, state, chunks[3]);
-    draw_build_help(frame, state, chunks[4]);
+    if has_builds {
+        draw_builds(frame, state, chunks[2]);
+    }
+    draw_live_build(frame, state, chunks[3]);
+    if show_spark {
+        draw_sparkline(frame, state, chunks[4]);
+    }
+    draw_build_help(frame, state, chunks[5]);
+}
+
+/// `4m12s`-style compact milliseconds for cost strips; blank for zero.
+fn fmt_saved_ms(ms: u64) -> String {
+    if ms == 0 {
+        return "0s".to_string();
+    }
+    if ms < 1000 {
+        return format!("{ms}ms");
+    }
+    fmt_secs(ms / 1000)
+}
+
+/// The Builds table: one row per session, running builds first, the selected
+/// one marked. Selecting a build scopes the event panel and the Why tab.
+fn draw_builds(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    let selected = state.selected_index().unwrap_or(0);
+    let count = state.sessions.len();
+    let following = state.selected_session.is_none();
+    let title = format!(
+        " Builds · {}/{}{} ",
+        selected + 1,
+        count,
+        if following {
+            " · following the top build"
+        } else {
+            ""
+        }
+    );
+    let block = Block::bordered()
+        .title(title)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let wide = area.width >= 100;
+    let mut labels = vec!["Build", "Started", "State"];
+    let mut widths = vec![
+        Constraint::Min(16),
+        Constraint::Length(8),
+        Constraint::Length(8),
+    ];
+    let numeric_from = labels.len();
+    labels.extend(["hit", "miss"]);
+    widths.extend([Constraint::Length(6), Constraint::Length(6)]);
+    if wide {
+        labels.push("pass");
+        widths.push(Constraint::Length(6));
+    }
+    labels.push("rate");
+    widths.push(Constraint::Length(5));
+    if wide {
+        labels.push("saved");
+        widths.push(Constraint::Length(8));
+    }
+    let header = Row::new(
+        labels
+            .iter()
+            .enumerate()
+            .map(|(i, label)| {
+                let line = Line::from(*label);
+                Cell::from(if i >= numeric_from {
+                    line.right_aligned()
+                } else {
+                    line
+                })
+            })
+            .collect::<Vec<_>>(),
+    )
+    .style(Style::default().fg(Color::DarkGray));
+
+    let right = |text: String, style: Style| Cell::from(Line::styled(text, style).right_aligned());
+    let count_cell = |value: u64, color: Color| {
+        right(
+            value.to_string(),
+            Style::default().fg(if value == 0 { Color::DarkGray } else { color }),
+        )
+    };
+    let rows: Vec<Row> = state
+        .sessions
+        .iter()
+        .map(|session| {
+            let state_style = match session.state {
+                SessionState::Live => Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+                SessionState::Finished => Style::default().fg(Color::DarkGray),
+            };
+            let name = if session.inferred {
+                format!("{} ~", session.workspace_name())
+            } else {
+                session.workspace_name().to_string()
+            };
+            let mut cells = vec![
+                Cell::from(name),
+                Cell::from(
+                    session
+                        .started
+                        .with_timezone(&chrono::Local)
+                        .format("%H:%M:%S")
+                        .to_string(),
+                ),
+                Cell::from(Span::styled(session.state.label(), state_style)),
+                count_cell(session.tally.hits, Color::Green),
+                count_cell(session.tally.compiled(), Color::White),
+            ];
+            if wide {
+                cells.push(count_cell(session.tally.passthroughs, Color::Magenta));
+            }
+            cells.push(right(
+                session
+                    .tally
+                    .hit_rate()
+                    .map_or_else(|| "-".to_string(), |rate| format!("{rate:.0}%")),
+                Style::default(),
+            ));
+            if wide {
+                cells.push(right(
+                    fmt_saved_ms(session.tally.saved_ms),
+                    Style::default().fg(Color::Green),
+                ));
+            }
+            Row::new(cells)
+        })
+        .collect();
+
+    let visible = area.height.saturating_sub(3) as usize;
+    let table = Table::new(rows, widths)
+        .header(header)
+        .highlight_symbol("▸ ")
+        .row_highlight_style(
+            Style::default()
+                .add_modifier(Modifier::BOLD)
+                .add_modifier(Modifier::REVERSED),
+        )
+        .block(block);
+    // A stateful table keeps the selected row visible past the first page.
+    let mut table_state = TableState::default()
+        .with_selected(selected)
+        .with_offset(selected.saturating_add(1).saturating_sub(visible.max(1)));
+    frame.render_stateful_widget(table, area, &mut table_state);
 }
 
 /// Render the in-flight compiles panel: oldest first, one line each.
@@ -1325,20 +1628,54 @@ fn fmt_duration_ms(ms: u64) -> String {
 fn draw_live_build(frame: &mut Frame, state: &mut AppState, area: Rect) {
     // A reader who scrolled back is told so, and told the way back: rows that
     // stop moving otherwise look like a build that stopped.
-    let title = if state.build_scroll.at_anchor() {
-        " Live Build "
+    let scrolled = if state.build_scroll.at_anchor() {
+        ""
     } else {
-        " Live Build · scrolled back, End follows "
+        " · scrolled back, End follows"
+    };
+    // The selected build's name and its cost strip: what the cache saved it,
+    // what its misses cost, and what kache itself cost. The last figure is
+    // the one nobody else reports.
+    let title = match state.selected_session() {
+        Some(session) => {
+            let t = &session.tally;
+            let overhead = t.overhead_share().map_or_else(
+                || fmt_saved_ms(t.overhead_ms),
+                |share| format!("{} ({share:.0}%)", fmt_saved_ms(t.overhead_ms)),
+            );
+            format!(
+                " {} · saved {} · in misses {} · kache {overhead}{scrolled} ",
+                session.workspace_name(),
+                fmt_saved_ms(t.saved_ms),
+                fmt_saved_ms(t.miss_ms),
+            )
+        }
+        None => format!(" Live Build{scrolled} "),
     };
     let block = Block::bordered()
-        .title(filtered_title(title, state.filter()))
+        .title(filtered_title(&title, state.filter()))
         .border_style(Style::default().fg(Color::Cyan));
+
+    if state.sessions.is_empty() {
+        frame.render_widget(
+            Paragraph::new(
+                "  Waiting for builds…\n\n  Run `cargo build` in any workspace; builds from every\n  workspace on this machine appear here, newest on top.",
+            )
+            .block(block),
+            area,
+        );
+        return;
+    }
 
     let filter_empty = state.filter().is_empty();
     let filter_label = state.filter().to_string();
-    let filtered_events: Vec<&BuildEvent> = state
-        .events
+    let selected_events: Vec<usize> = state
+        .selected_session()
+        .map(|session| session.events.clone())
+        .unwrap_or_default();
+    let filtered_events: Vec<&BuildEvent> = selected_events
         .iter()
+        .map(|&index| &state.events[index])
         .filter(|e| filter_empty || e.crate_name.contains(&filter_label))
         .collect();
 
@@ -1557,10 +1894,14 @@ fn draw_sparkline(frame: &mut Frame, state: &AppState, area: Rect) {
 }
 
 fn draw_build_help(frame: &mut Frame, state: &AppState, area: Rect) {
-    let help = help_line(
-        state,
-        "q: quit  p: pause  f: filter  ↑↓ PgUp PgDn End: scroll  ⇥/⇧⇥: tabs  c: clear",
-    );
+    // The full key list needs ~100 columns; narrower terminals get the
+    // short form rather than a clipped one.
+    let keys = if area.width >= 100 {
+        "q: quit  p: pause  ↑↓: build  Enter: why  f: filter  PgUp PgDn End: events  ⇥/⇧⇥: tabs  c: clear"
+    } else {
+        "q: quit  p: pause  ↑↓: build  ⏎: why  f: filter  PgDn/End: events  ⇥: tabs  c: clear"
+    };
+    let help = help_line(state, keys);
 
     let paragraph = Paragraph::new(help).style(Style::default().fg(Color::DarkGray));
     frame.render_widget(paragraph, area);
@@ -2294,135 +2635,424 @@ fn draw_transfer_help(frame: &mut Frame, state: &AppState, area: Rect) {
     frame.render_widget(paragraph, area);
 }
 
-// ── Passthrough tab ───────────────────────────────────────────────────────
+// ── Why tab ───────────────────────────────────────────────────────────────
 
-fn draw_passthrough_tab(frame: &mut Frame, state: &mut AppState, area: Rect) {
+/// Why the selected build missed: the misses collapsed to the few causes
+/// behind them, the passthroughs by reason, the crates that keep missing,
+/// and every passthrough in the build. One body, scrolled as a whole, so
+/// nothing is ever clipped out of reach.
+fn draw_why_tab(frame: &mut Frame, state: &mut AppState, area: Rect) {
     let chunks = Layout::vertical([
-        Constraint::Min(5),    // Passthrough table
+        Constraint::Min(3),    // Body
         Constraint::Length(1), // Help bar
     ])
     .split(area);
 
-    draw_passthrough_table(frame, state, chunks[0]);
-    draw_passthrough_help(frame, state, chunks[1]);
+    let title = match state.selected_session() {
+        Some(session) => format!(
+            " Why · {} · {} ",
+            session.workspace_name(),
+            session.state.label()
+        ),
+        None => " Why ".to_string(),
+    };
+    let block = Block::bordered()
+        .title(filtered_title(&title, state.filter()))
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(chunks[0]);
+    let lines = why_lines(state, inner.width);
+    let range = state
+        .why_scroll
+        .visible_range(lines.len(), inner.height as usize);
+    let block = if range.end < lines.len() || range.start > 0 {
+        block.title_bottom(
+            Line::from(format!(
+                " {}–{} of {} · PgUp PgDn ",
+                range.start + 1,
+                range.end,
+                lines.len()
+            ))
+            .right_aligned(),
+        )
+    } else {
+        block
+    };
+    frame.render_widget(
+        Paragraph::new(lines)
+            .scroll((range.start as u16, 0))
+            .block(block),
+        chunks[0],
+    );
+    draw_why_help(frame, state, chunks[1]);
 }
 
-fn draw_passthrough_table(frame: &mut Frame, state: &mut AppState, area: Rect) {
-    let filter_empty = state.filter().is_empty();
-    let filter_label = state.filter().to_string();
-    let events: Vec<&BuildEvent> = state
+/// A proportional bar of `width` cells, never empty for a non-zero share so
+/// a rare cause still shows as present.
+fn share_bar(count: usize, total: usize, width: usize) -> String {
+    if total == 0 || width == 0 {
+        return " ".repeat(width);
+    }
+    let filled = (count.saturating_mul(width) / total)
+        .max(usize::from(count > 0))
+        .min(width);
+    format!("{}{}", "█".repeat(filled), "░".repeat(width - filled))
+}
+
+/// Terminal cells `text` occupies. Bytes and chars both lie for CJK and
+/// combining marks; the same measure ratatui lays out with.
+fn cells(text: &str) -> usize {
+    Line::from(text).width()
+}
+
+/// Clip `text` to `width` cells with an ellipsis, on a character boundary.
+fn clip(text: &str, width: usize) -> String {
+    if cells(text) <= width {
+        return text.to_string();
+    }
+    let mut kept = String::new();
+    for ch in text.chars() {
+        if cells(&format!("{kept}{ch}…")) > width {
+            break;
+        }
+        kept.push(ch);
+    }
+    format!("{kept}…")
+}
+
+/// Pad `text` to `width` cells, clipping first if it is longer.
+fn pad(text: &str, width: usize) -> String {
+    let text = clip(text, width);
+    let padding = width.saturating_sub(cells(&text));
+    format!("{text}{}", " ".repeat(padding))
+}
+
+/// The Why body, as lines. Pure so it can be asserted on in tests without
+/// a terminal. `width` is the inner width the lines are laid out for.
+fn why_lines(state: &mut AppState, width: u16) -> Vec<Line<'static>> {
+    let muted = Style::default().fg(Color::DarkGray);
+    let heading = Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    let explain_miss = state.config.explain_miss;
+    let filter = state.filter().to_string();
+    let Some(session) = state.selected_session().cloned() else {
+        return vec![
+            Line::from("  No builds recorded yet."),
+            Line::styled(
+                "  Run `cargo build` in any workspace and its misses are explained here.",
+                muted,
+            ),
+        ];
+    };
+    // Fill the cache first, then borrow: the analysis is owned by the state.
+    state.why_analysis();
+    let Some((_, _, analysis)) = &state.why_cache else {
+        return Vec::new();
+    };
+    let t = &session.tally;
+    let width = width as usize;
+
+    let mut lines = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!("  {} ", session.workspace_name()),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!(
+                "· {} · started {} · {} hits, {} misses, {} passthroughs",
+                session.state.label(),
+                session
+                    .started
+                    .with_timezone(&chrono::Local)
+                    .format("%H:%M:%S"),
+                t.hits,
+                t.compiled(),
+                t.passthroughs,
+            ),
+            muted,
+        ),
+    ]));
+    let overhead = t.overhead_share().map_or_else(
+        || fmt_saved_ms(t.overhead_ms),
+        |share| {
+            format!(
+                "{} ({share:.0}% of lookup time)",
+                fmt_saved_ms(t.overhead_ms)
+            )
+        },
+    );
+    let restored = match t.copy_share() {
+        Some(share) if share >= 1.0 => format!(
+            " · restored {}, {share:.0}% by copy",
+            ByteSize(t.restored_bytes())
+        ),
+        Some(_) => format!(" · restored {}", ByteSize(t.restored_bytes())),
+        None => String::new(),
+    };
+    lines.push(Line::from(vec![
+        Span::raw("  saved "),
+        Span::styled(fmt_saved_ms(t.saved_ms), Style::default().fg(Color::Green)),
+        Span::raw(" · in misses "),
+        Span::styled(fmt_saved_ms(t.miss_ms), Style::default().fg(Color::White)),
+        Span::raw(format!(" · kache overhead {overhead}{restored}")),
+    ]));
+
+    // ── Misses by cause ──
+    lines.push(Line::default());
+    let capped = if analysis.misses_analyzed < analysis.misses_total {
+        format!(
+            " (newest {} of {} analyzed)",
+            analysis.misses_analyzed, analysis.misses_total
+        )
+    } else {
+        String::new()
+    };
+    lines.push(Line::styled(
+        format!(
+            "  Misses by cause · {} miss{}{capped}",
+            analysis.misses_total,
+            if analysis.misses_total == 1 { "" } else { "es" }
+        ),
+        heading,
+    ));
+    if analysis.misses_total == 0 {
+        lines.push(Line::styled(
+            if t.hits > 0 {
+                "  none: every lookup hit"
+            } else {
+                "  none: nothing was looked up"
+            },
+            muted,
+        ));
+    }
+    let bar_width = 12usize;
+    let count_width = analysis
+        .causes
+        .iter()
+        .chain(std::iter::empty())
+        .map(|g| g.count.to_string().len())
+        .chain(
+            analysis
+                .passthroughs
+                .iter()
+                .map(|g| g.count.to_string().len()),
+        )
+        .max()
+        .unwrap_or(1);
+    for group in &analysis.causes {
+        let color = if group.cause.is_failure() {
+            Color::Red
+        } else if matches!(group.cause, Cause::Unexplained) {
+            Color::DarkGray
+        } else {
+            Color::Yellow
+        };
+        let examples = if group.examples.is_empty() {
+            String::new()
+        } else {
+            let more = group.count.saturating_sub(group.examples.len());
+            format!(
+                "{}{}",
+                group.examples.join(", "),
+                if more > 0 {
+                    format!(" +{more}")
+                } else {
+                    String::new()
+                }
+            )
+        };
+        let prefix = format!(
+            "  {} {:>count_width$}  ",
+            share_bar(group.count, analysis.misses_analyzed, bar_width),
+            group.count
+        );
+        let cost = format!("  {}", fmt_saved_ms(group.compile_ms));
+        let room = width.saturating_sub(cells(&prefix) + cells(&cost) + 2);
+        let describe = group.cause.describe();
+        let describe_cells = cells(&describe);
+        let (describe_width, example_width) = if room > describe_cells + 12 {
+            (describe_cells, room - describe_cells - 2)
+        } else {
+            (room, 0)
+        };
+        let mut spans = vec![
+            Span::styled(prefix, Style::default().fg(color)),
+            Span::raw(clip(&describe, describe_width)),
+        ];
+        if example_width > 0 && !examples.is_empty() {
+            spans.push(Span::styled(
+                format!("  {}", clip(&examples, example_width)),
+                muted,
+            ));
+        }
+        spans.push(Span::styled(cost, muted));
+        lines.push(Line::from(spans));
+    }
+    if analysis.misses_total > 0 && !analysis.cascade_recorded {
+        lines.push(Line::styled(
+            if explain_miss {
+                "  no dependency digests on this build's misses; the next build records them (explain_miss is on)"
+            } else {
+                "  dependency cascades are not recorded: set [cache] explain_miss = true to name the crate that changed"
+            },
+            muted,
+        ));
+    }
+
+    // ── Passthroughs by reason ──
+    if !analysis.passthroughs.is_empty() {
+        lines.push(Line::default());
+        let total: usize = analysis.passthroughs.iter().map(|g| g.count).sum();
+        lines.push(Line::styled(
+            format!("  Passthroughs by reason · {total}"),
+            heading,
+        ));
+        for group in &analysis.passthroughs {
+            let label = if group.kind.is_empty() {
+                group.reason.clone()
+            } else {
+                format!("{}: {}", group.kind, group.reason)
+            };
+            let note = if group.probe {
+                "  (queries, not compiles)"
+            } else {
+                ""
+            };
+            let prefix = format!(
+                "  {} {:>count_width$}  ",
+                share_bar(group.count, total, bar_width),
+                group.count
+            );
+            let room = width.saturating_sub(cells(&prefix) + cells(note) + 1);
+            lines.push(Line::from(vec![
+                Span::styled(
+                    prefix,
+                    Style::default().fg(if group.probe {
+                        Color::DarkGray
+                    } else {
+                        Color::Magenta
+                    }),
+                ),
+                Span::raw(clip(&label, room)),
+                Span::styled(note, muted),
+            ]));
+        }
+    }
+
+    // ── Chronic ──
+    if !analysis.chronic.is_empty() {
+        lines.push(Line::default());
+        lines.push(Line::styled(
+            "  Chronic misses · missed in N of the M builds of this tree that looked it up",
+            heading,
+        ));
+        for chronic in &analysis.chronic {
+            lines.push(Line::from(vec![
+                Span::raw(format!(
+                    "  {} {}/{}",
+                    pad(&chronic.crate_name, 28),
+                    chronic.missed,
+                    chronic.seen
+                )),
+                Span::styled(
+                    if chronic.last_store_failed {
+                        "  its latest lookup ended in a store failure"
+                    } else {
+                        ""
+                    },
+                    Style::default().fg(Color::Red),
+                ),
+            ]));
+        }
+    }
+
+    // ── Every passthrough in the build ──
+    let passthroughs: Vec<&BuildEvent> = session
         .events
         .iter()
+        .map(|&index| &state.events[index])
         .filter(|event| matches!(event.result, EventResult::Passthrough))
         .filter(|event| {
-            filter_empty
-                || event.crate_name.contains(&filter_label)
-                || event.passthrough_reason.contains(&filter_label)
+            filter.is_empty()
+                || event.crate_name.contains(&filter)
+                || event.passthrough_reason.contains(&filter)
         })
         .collect();
-
-    let block = Block::bordered()
-        .title(filtered_title(
-            &format!(" Passthroughs ({}) ", events.len()),
-            state.filter(),
-        ))
-        .border_style(Style::default().fg(Color::Cyan));
-
-    if events.is_empty() {
-        let msg = if state.filter().is_empty() {
-            "  No passthroughs yet"
-        } else {
-            "  No passthroughs match the filter"
-        };
-        frame.render_widget(Paragraph::new(msg).block(block), area);
-        return;
+    lines.push(Line::default());
+    lines.push(Line::styled(
+        format!(
+            "  Passthroughs in this build · {}{}",
+            passthroughs.len(),
+            if filter.is_empty() {
+                String::new()
+            } else {
+                format!(" matching {filter:?}")
+            }
+        ),
+        heading,
+    ));
+    if passthroughs.is_empty() {
+        lines.push(Line::styled(
+            if filter.is_empty() {
+                "  none"
+            } else {
+                "  none match the filter"
+            },
+            muted,
+        ));
     }
-
-    // The reason is what this tab exists for, so it keeps its share of the
-    // width; route and exit code are the first to go.
-    let show_route = area.width >= 96;
-    let show_exit = area.width >= 80;
-
-    let mut labels = vec!["Time", "Crate"];
-    let mut widths = vec![Constraint::Length(9), Constraint::Min(18)];
-    if show_route {
-        labels.push("Route");
-        widths.push(Constraint::Length(10));
-    }
-    if show_exit {
-        labels.push("Exit");
-        widths.push(Constraint::Length(6));
-    }
-    labels.extend(["Kind", "Reason"]);
-    widths.extend([Constraint::Length(14), Constraint::Percentage(45)]);
-    let header = Row::new(labels).style(Style::default().add_modifier(Modifier::BOLD));
-
-    let visible_rows = (area.height as usize).saturating_sub(3);
-    let range = state
-        .passthrough_scroll
-        .visible_range(events.len(), visible_rows);
-
-    let rows: Vec<Row> = events
-        .iter()
-        .rev()
-        .skip(range.start)
-        .take(range.len())
-        .map(|event| {
-            let exit = event
-                .exit_code
-                .map(|code| code.to_string())
-                .unwrap_or_default();
+    // Route and exit code are detail; on a narrow terminal the reason wins.
+    let wide = width >= 96;
+    // The crate and kind columns give up width before the reason does.
+    let crate_width = (width / 4).clamp(8, 22);
+    let kind_width = (width / 6).clamp(6, 14);
+    for event in passthroughs.iter().rev() {
+        let (kind, reason) = tui_sessions::passthrough_parts(&event.passthrough_reason);
+        let mut spans = vec![
+            Span::styled(
+                format!(
+                    "  {}  ",
+                    event.ts.with_timezone(&chrono::Local).format("%H:%M:%S")
+                ),
+                muted,
+            ),
+            Span::raw(pad(&event.crate_name, crate_width)),
+        ];
+        if wide {
             let route = if event.fallback { "fallback" } else { "direct" };
-            let (kind, reason) = passthrough_reason_parts(&event.passthrough_reason);
-
-            let exit_style = match event.exit_code {
-                Some(0) => Style::default().fg(Color::Green),
-                Some(_) => Style::default().fg(Color::Red),
-                None => Style::default().fg(Color::DarkGray),
+            let (exit, exit_style) = match event.exit_code {
+                Some(0) => ("0".to_string(), Style::default().fg(Color::Green)),
+                Some(code) => (code.to_string(), Style::default().fg(Color::Red)),
+                None => ("-".to_string(), muted),
             };
-
-            let mut cells = vec![
-                Cell::from(event.ts.format("%H:%M:%S").to_string()),
-                Cell::from(event.crate_name.clone()),
-            ];
-            if show_route {
-                cells.push(Cell::from(route).style(Style::default().fg(Color::Magenta)));
-            }
-            if show_exit {
-                cells.push(Cell::from(exit).style(exit_style));
-            }
-            cells.push(Cell::from(kind.to_string()).style(Style::default().fg(Color::Cyan)));
-            cells.push(Cell::from(reason.to_string()));
-            Row::new(cells)
-        })
-        .collect();
-
-    let table = Table::new(rows, widths).header(header).block(block);
-    frame.render_widget(table, area);
+            spans.push(Span::styled(
+                format!("  {route:<9}"),
+                Style::default().fg(Color::Magenta),
+            ));
+            spans.push(Span::styled(format!("{exit:>4}  "), exit_style));
+        } else {
+            spans.push(Span::raw("  "));
+        }
+        let kind = if kind.is_empty() { "-" } else { kind };
+        spans.push(Span::styled(
+            pad(kind, kind_width),
+            Style::default().fg(Color::Cyan),
+        ));
+        let used: usize = spans.iter().map(|span| cells(&span.content)).sum();
+        spans.push(Span::raw(format!(
+            "  {}",
+            clip(reason, width.saturating_sub(used + 2))
+        )));
+        lines.push(Line::from(spans));
+    }
+    lines
 }
 
-fn passthrough_reason_parts(reason: &str) -> (&str, &str) {
-    let reason = reason.trim();
-    if reason.is_empty() {
-        return ("unknown", "unknown");
-    }
-
-    if let Some((kind, detail)) = reason.split_once('|') {
-        let kind = kind.trim();
-        let detail = detail.trim();
-        return (
-            if kind.is_empty() { "unknown" } else { kind },
-            if detail.is_empty() { "unknown" } else { detail },
-        );
-    }
-
-    ("N/A", reason.strip_prefix("refused: ").unwrap_or(reason))
-}
-
-fn draw_passthrough_help(frame: &mut Frame, state: &AppState, area: Rect) {
+fn draw_why_help(frame: &mut Frame, state: &AppState, area: Rect) {
     let help = help_line(
         state,
-        "q: quit  p: pause  f: filter  ↑↓ PgUp PgDn: scroll  ⇥/⇧⇥: tabs",
+        "q: quit  p: pause  ↑↓: build  f: filter  PgUp PgDn: scroll  ⇥/⇧⇥: tabs",
     );
     let paragraph = Paragraph::new(help).style(Style::default().fg(Color::DarkGray));
     frame.render_widget(paragraph, area);
@@ -2456,7 +3086,7 @@ mod tests {
         assert!(!tab_needs_entries(Tab::Projects));
         assert!(tab_needs_entries(Tab::Store));
         assert!(!tab_needs_entries(Tab::Transfer));
-        assert!(!tab_needs_entries(Tab::Passthrough));
+        assert!(!tab_needs_entries(Tab::Why));
     }
 
     #[test]
@@ -2478,19 +3108,6 @@ mod tests {
 
         // Error is the only red outcome.
         assert_eq!(event_presentation(EventResult::Error).3, Color::Red);
-    }
-
-    #[test]
-    fn passthrough_reason_parts_split_structured_reasons() {
-        assert_eq!(
-            passthrough_reason_parts("unsupported|cc unsupported flag(s): -foo — not yet"),
-            ("unsupported", "cc unsupported flag(s): -foo — not yet")
-        );
-        assert_eq!(
-            passthrough_reason_parts("refused: cc: unsupported flag(s): -m64"),
-            ("N/A", "cc: unsupported flag(s): -m64")
-        );
-        assert_eq!(passthrough_reason_parts(""), ("unknown", "unknown"));
     }
 
     #[test]
@@ -2597,7 +3214,7 @@ mod tests {
             build_scroll: Viewport::new(ScrollAnchor::Bottom),
             build_filter: String::new(),
             store_filter: String::new(),
-            passthrough_filter: String::new(),
+            why_filter: String::new(),
             filter_active: false,
             sort_mode: SortMode::Size,
             store_scroll: Viewport::new(ScrollAnchor::Top),
@@ -2607,8 +3224,13 @@ mod tests {
             project_scan: Arc::new(Mutex::new(ProjectScanData::default())),
             last_project_refresh: Instant::now(),
             project_scroll: Viewport::new(ScrollAnchor::Top),
+            sessions: Vec::new(),
+            grouped_len: 0,
+            selected_session: None,
+            shown: None,
+            why_cache: None,
             transfer_scroll: Viewport::new(ScrollAnchor::Top),
-            passthrough_scroll: Viewport::new(ScrollAnchor::Top),
+            why_scroll: Viewport::new(ScrollAnchor::Top),
             prev_bytes_uploaded: 0,
             prev_bytes_downloaded: 0,
             upload_speed_bps: 0.0,
@@ -2738,13 +3360,13 @@ mod tests {
     fn handle_key_number_keys_switch_tabs() {
         let mut s = test_state();
         handle_key(&mut s, KeyCode::Char('2'));
-        assert_eq!(s.active_tab, Tab::Projects);
+        assert_eq!(s.active_tab, Tab::Why);
         handle_key(&mut s, KeyCode::Char('3'));
-        assert_eq!(s.active_tab, Tab::Store);
+        assert_eq!(s.active_tab, Tab::Projects);
         handle_key(&mut s, KeyCode::Char('4'));
-        assert_eq!(s.active_tab, Tab::Transfer);
+        assert_eq!(s.active_tab, Tab::Store);
         handle_key(&mut s, KeyCode::Char('5'));
-        assert_eq!(s.active_tab, Tab::Passthrough);
+        assert_eq!(s.active_tab, Tab::Transfer);
         handle_key(&mut s, KeyCode::Char('1'));
         assert_eq!(s.active_tab, Tab::Build);
     }
@@ -2784,10 +3406,10 @@ mod tests {
     fn handle_key_tab_cycles_forward_and_wraps() {
         let mut s = test_state();
         let order = [
+            Tab::Why,
             Tab::Projects,
             Tab::Store,
             Tab::Transfer,
-            Tab::Passthrough,
             Tab::Build,
         ];
         for expected in order {
@@ -2869,13 +3491,15 @@ mod tests {
     fn arriving_rows_do_not_move_a_scrolled_reader() {
         let mut s = test_state();
         for i in 0..20 {
-            s.events.push(sample_build_event(
+            s.push_event(session_event(
                 &format!("c{i}"),
                 EventResult::Miss,
-                1,
-                1,
+                "/w",
+                "s1",
+                100,
             ));
         }
+        s.refresh_sessions(chrono::Utc::now());
         let range = s.build_scroll.visible_range(20, 5);
         assert_eq!(range, 15..20, "following the newest");
 
@@ -2884,19 +3508,29 @@ mod tests {
         assert_eq!(range, 5..10);
 
         for i in 20..23 {
-            s.push_event(sample_build_event(
+            s.push_event(session_event(
                 &format!("c{i}"),
                 EventResult::Miss,
-                1,
-                1,
+                "/w",
+                "s1",
+                50,
             ));
         }
+        s.refresh_sessions(chrono::Utc::now());
         let range = s.build_scroll.visible_range(23, 5);
         assert_eq!(range, 5..10, "same rows after three arrivals");
 
+        // Rows for another, older build move nothing here.
+        s.push_event(session_event("x", EventResult::Miss, "/v", "s2", 400));
+        s.refresh_sessions(chrono::Utc::now());
+        assert_eq!(s.selected_session().unwrap().key, "id:s1");
+        let range = s.build_scroll.visible_range(23, 5);
+        assert_eq!(range, 5..10);
+
         // At the live edge the newest rows are the view.
         s.build_scroll.end();
-        s.push_event(sample_build_event("c23", EventResult::Miss, 1, 1));
+        s.push_event(session_event("c23", EventResult::Miss, "/w", "s1", 30));
+        s.refresh_sessions(chrono::Utc::now());
         let range = s.build_scroll.visible_range(24, 5);
         assert_eq!(range, 19..24);
 
@@ -2904,10 +3538,12 @@ mod tests {
         // filter shows does.
         s.build_scroll.scroll_up_by(10);
         s.build_filter = "zzz".to_string();
-        s.push_event(sample_build_event("c24", EventResult::Miss, 1, 1));
+        s.push_event(session_event("c24", EventResult::Miss, "/w", "s1", 20));
+        s.refresh_sessions(chrono::Utc::now());
         assert_eq!(s.build_scroll.offset, 10);
         s.build_filter = "c2".to_string();
-        s.push_event(sample_build_event("c25", EventResult::Miss, 1, 1));
+        s.push_event(session_event("c25", EventResult::Miss, "/w", "s1", 10));
+        s.refresh_sessions(chrono::Utc::now());
         assert_eq!(s.build_scroll.offset, 11, "a matching filter still counts");
     }
 
@@ -2983,7 +3619,7 @@ mod tests {
 
         let mut s = test_state();
         let area = Rect::new(0, 0, 120, 40);
-        let (_, _, store_x) = titles[2];
+        let (_, _, store_x) = titles[3];
         handle_mouse(
             &mut s,
             MouseEvent {
@@ -3108,7 +3744,261 @@ mod tests {
             }];
             scan.scanned = true;
         }
+        state.refresh_sessions(chrono::Utc::now());
         state
+    }
+
+    /// An event stamped with a build root and session id, as the wrapper
+    /// writes them.
+    fn session_event(
+        crate_name: &str,
+        result: EventResult,
+        root: &str,
+        session: &str,
+        secs_ago: i64,
+    ) -> BuildEvent {
+        let mut event = sample_build_event(crate_name, result, 100, 1);
+        event.root = root.to_string();
+        event.session_id = session.to_string();
+        event.ts = chrono::Utc::now() - chrono::Duration::seconds(secs_ago);
+        event.compile_time_ms = 2_000;
+        event
+    }
+
+    /// Two builds: an old finished one and a fresh one. Up/Down pick between
+    /// them, the top row is followed until a pick is made, and Enter opens
+    /// Why for the pick.
+    #[test]
+    fn arrows_pick_a_build_and_enter_opens_why() {
+        let mut s = test_state();
+        s.events = vec![
+            session_event("old_a", EventResult::Miss, "/w/old", "s-old", 900),
+            session_event("old_b", EventResult::LocalHit, "/w/old", "s-old", 899),
+            session_event("new_a", EventResult::Miss, "/w/new", "s-new", 5),
+        ];
+        s.refresh_sessions(chrono::Utc::now());
+        assert_eq!(s.sessions.len(), 2);
+        assert_eq!(s.sessions[0].key, "id:s-new", "newest on top");
+        assert!(s.selected_session.is_none(), "following by default");
+        assert_eq!(s.selected_session().unwrap().key, "id:s-new");
+
+        let screen = rendered_tab(&mut s, Tab::Build);
+        assert!(screen.contains("following the top build"), "{screen}");
+        assert!(screen.contains("new_a"), "the event panel is the top build");
+        assert!(!screen.contains("old_a"), "other builds' events stay out");
+
+        handle_key(&mut s, KeyCode::Down);
+        assert_eq!(s.selected_session.as_deref(), Some("id:s-old"));
+        let screen = rendered_tab(&mut s, Tab::Build);
+        assert!(
+            screen.contains("old_a") && !screen.contains("new_a"),
+            "{screen}"
+        );
+        assert!(!screen.contains("following the top build"));
+
+        // Past the top row is back to following.
+        handle_key(&mut s, KeyCode::Up);
+        assert_eq!(s.selected_session.as_deref(), Some("id:s-new"));
+        handle_key(&mut s, KeyCode::Up);
+        assert!(s.selected_session.is_none());
+
+        // Enter lands on Why for the selected build.
+        handle_key(&mut s, KeyCode::Down);
+        handle_key(&mut s, KeyCode::Enter);
+        assert_eq!(s.active_tab, Tab::Why);
+        let screen = rendered_tab(&mut s, Tab::Why);
+        assert!(screen.contains("Why · old"), "{screen}");
+
+        // Clearing forgets the pick along with the events.
+        s.active_tab = Tab::Build;
+        handle_key(&mut s, KeyCode::Char('c'));
+        assert!(s.sessions.is_empty() && s.selected_session.is_none());
+    }
+
+    /// A pick survives the session list reordering under it: the key, not
+    /// the row index, is what is remembered.
+    #[test]
+    fn a_picked_build_stays_picked_when_rows_reorder() {
+        let mut s = test_state();
+        s.events = vec![
+            session_event("a", EventResult::Miss, "/w/one", "s1", 500),
+            session_event("b", EventResult::Miss, "/w/two", "s2", 400),
+        ];
+        s.refresh_sessions(chrono::Utc::now());
+        assert_eq!(s.sessions[0].key, "id:s2");
+        handle_key(&mut s, KeyCode::Down);
+        assert_eq!(s.selected_session.as_deref(), Some("id:s1"));
+        // s1 wakes up and moves to the top.
+        s.push_event(session_event("c", EventResult::Miss, "/w/one", "s1", 1));
+        s.refresh_sessions(chrono::Utc::now());
+        assert_eq!(s.sessions[0].key, "id:s1");
+        assert_eq!(s.selected_session().unwrap().key, "id:s1");
+        assert_eq!(s.selected_index(), Some(0));
+    }
+
+    /// Forty misses downstream of one changed leaf read as one cause naming
+    /// the leaf, with the crates it took down and what they cost.
+    #[test]
+    fn why_tab_collapses_a_cascade_to_its_root() {
+        let externs = |mut e: BuildEvent, digest: &str| {
+            e.key_externs = [("leaf".to_string(), digest.to_string())]
+                .into_iter()
+                .collect();
+            e.key_externs_recorded = true;
+            e
+        };
+        let leaf = |mut e: BuildEvent, sources: &str| {
+            e.key_externs_recorded = true;
+            e.key_fields = [("sources".to_string(), sources.to_string())]
+                .into_iter()
+                .collect();
+            e
+        };
+        let mut events = vec![leaf(
+            session_event("leaf", EventResult::LocalHit, "/w", "before", 1000),
+            "1111",
+        )];
+        for i in 0..40 {
+            events.push(externs(
+                session_event(
+                    &format!("app{i}"),
+                    EventResult::LocalHit,
+                    "/w",
+                    "before",
+                    999,
+                ),
+                "aaaa",
+            ));
+        }
+        let mut leaf_miss = leaf(
+            session_event("leaf", EventResult::Miss, "/w", "now", 10),
+            "2222",
+        );
+        leaf_miss.key_diff = vec!["sources".to_string()];
+        events.push(leaf_miss);
+        for i in 0..40 {
+            events.push(externs(
+                session_event(&format!("app{i}"), EventResult::Miss, "/w", "now", 9),
+                "bbbb",
+            ));
+        }
+        let mut s = test_state();
+        s.events = events;
+        s.refresh_sessions(chrono::Utc::now());
+        assert_eq!(s.selected_session().unwrap().key, "id:now");
+
+        let lines: Vec<String> = why_lines(&mut s, 118)
+            .iter()
+            .map(|line| line.to_string())
+            .collect();
+        let text = lines.join("\n");
+        assert!(text.contains("41 misses"), "{text}");
+        let downstream = lines
+            .iter()
+            .find(|l| l.contains("downstream of leaf"))
+            .unwrap_or_else(|| panic!("{text}"));
+        assert!(downstream.contains("40"), "{downstream}");
+        assert!(downstream.contains("app0, app1, app2 +37"), "{downstream}");
+        assert!(
+            downstream.contains("1m20s"),
+            "40 x 2s of compile: {downstream}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("own inputs changed: sources")),
+            "{text}"
+        );
+        assert!(
+            !text.contains("explain_miss"),
+            "digests were recorded, so no hint to enable them: {text}"
+        );
+        assert!(text.contains("saved "), "cost strip: {text}");
+
+        let screen = rendered_tab(&mut s, Tab::Why);
+        assert!(screen.contains("downstream of leaf"), "{screen}");
+
+        // Narrow: the examples still fit at 60 columns (bar, count, and the
+        // cost take 28), and are the first thing to go below that.
+        let narrow = why_lines(&mut s, 60)
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(narrow.contains("downstream of leaf  app0"), "{narrow}");
+        // At 58 the room is exactly the description plus twelve: examples
+        // need more than that, so none; at 60 they fit but are clipped to the
+        // twelve cells left.
+        let edge = why_text(&mut s, 58).join("\n");
+        assert!(
+            edge.contains("downstream of leaf  1m20s"),
+            "no ellipsis: {edge}"
+        );
+        assert!(!edge.contains("app0"), "{edge}");
+        assert!(narrow.contains("app0, app1,…"), "{narrow}");
+        assert!(!narrow.contains("app2"), "{narrow}");
+        let narrower = why_lines(&mut s, 55)
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(narrower.contains("downstream of leaf"), "{narrower}");
+        assert!(!narrower.contains("app0"), "{narrower}");
+    }
+
+    /// Misses with nothing recorded are said to be unexplained, and the
+    /// reader is told what to switch on.
+    #[test]
+    fn why_tab_says_when_it_cannot_explain_and_how_to_fix_that() {
+        let mut s = test_state();
+        s.events = vec![
+            session_event("x", EventResult::LocalHit, "/w", "before", 500),
+            session_event("x", EventResult::Miss, "/w", "now", 5),
+            session_event("y", EventResult::Miss, "/w", "now", 4),
+        ];
+        s.refresh_sessions(chrono::Utc::now());
+        let text: Vec<String> = why_lines(&mut s, 100)
+            .iter()
+            .map(|line| line.to_string())
+            .collect();
+        let text = text.join("\n");
+        assert!(text.contains("unexplained"), "{text}");
+        assert!(
+            text.contains("no earlier compile in the loaded history"),
+            "{text}"
+        );
+        assert!(text.contains("explain_miss = true"), "{text}");
+
+        s.config.explain_miss = true;
+        s.why_cache = None;
+        let text: Vec<String> = why_lines(&mut s, 100)
+            .iter()
+            .map(|line| line.to_string())
+            .collect();
+        assert!(
+            !text.join("\n").contains("explain_miss = true"),
+            "already on, so no hint"
+        );
+    }
+
+    #[test]
+    fn why_tab_without_builds_says_so() {
+        let mut s = test_state();
+        let screen = rendered_tab(&mut s, Tab::Why);
+        assert!(screen.contains("No builds recorded yet"), "{screen}");
+    }
+
+    #[test]
+    fn share_bar_never_hides_a_present_cause() {
+        assert_eq!(share_bar(0, 10, 4), "░░░░");
+        assert_eq!(share_bar(1, 1000, 4), "█░░░");
+        assert_eq!(share_bar(10, 10, 4), "████");
+        assert_eq!(share_bar(3, 0, 2), "  ");
+        assert_eq!(clip("abcdef", 4), "abc…");
+        assert_eq!(clip("abc", 4), "abc");
+        assert_eq!(fmt_saved_ms(0), "0s");
+        assert_eq!(fmt_saved_ms(750), "750ms");
+        assert_eq!(fmt_saved_ms(80_000), "1m20s");
     }
 
     /// Every tab at a laptop-sized and a wide terminal: the seeded row is on
@@ -3121,7 +4011,7 @@ mod tests {
             (Tab::Store, "serde", "Created"),
             (Tab::Projects, "myproj", "Fprint"),
             (Tab::Transfer, "serde", ""),
-            (Tab::Passthrough, "build.rs", "Route"),
+            (Tab::Why, "build.rs", "direct"),
         ] {
             for (width, height) in [(80u16, 24u16), (120, 40)] {
                 let mut state = populated_state();
@@ -3215,7 +4105,7 @@ mod tests {
 
         s.active_tab = Tab::Store;
         assert_eq!(s.filter(), "", "Store keeps its own filter");
-        s.active_tab = Tab::Passthrough;
+        s.active_tab = Tab::Why;
         assert_eq!(s.filter(), "", "Passthrough keeps its own filter");
 
         // Tabs that cannot filter report no filter and ignore `f`.
@@ -3240,12 +4130,12 @@ mod tests {
         s.active_tab = Tab::Build;
 
         handle_key(&mut s, KeyCode::Tab);
-        assert_eq!(s.active_tab, Tab::Projects);
+        assert_eq!(s.active_tab, Tab::Why);
         handle_key(&mut s, KeyCode::BackTab);
         assert_eq!(s.active_tab, Tab::Build);
         // And it wraps to the last tab rather than sticking.
         handle_key(&mut s, KeyCode::BackTab);
-        assert_eq!(s.active_tab, Tab::Passthrough);
+        assert_eq!(s.active_tab, Tab::Transfer);
         handle_key(&mut s, KeyCode::Tab);
         assert_eq!(s.active_tab, Tab::Build);
     }
@@ -3277,7 +4167,7 @@ mod tests {
         for (tab, expected) in [
             (Tab::Build, "c: clear"),
             (Tab::Store, "s: sort"),
-            (Tab::Passthrough, "f: filter"),
+            (Tab::Why, "f: filter"),
         ] {
             let mut state = test_state();
             let rendered = rendered_tab(&mut state, tab);
@@ -3365,10 +4255,10 @@ mod tests {
         handle_key(&mut s, KeyCode::Up);
         assert_eq!(s.store_scroll.offset, 1);
         // A different tab tracks its own offset.
-        s.active_tab = Tab::Passthrough;
-        s.passthrough_scroll.max_offset = 10;
+        s.active_tab = Tab::Transfer;
+        s.transfer_scroll.max_offset = 10;
         handle_key(&mut s, KeyCode::Down);
-        assert_eq!(s.passthrough_scroll.offset, 1);
+        assert_eq!(s.transfer_scroll.offset, 1);
         assert_eq!(s.store_scroll.offset, 1, "store offset is untouched");
     }
 
@@ -3377,7 +4267,7 @@ mod tests {
         let mut s = test_state();
         s.active_tab = Tab::Build;
         s.build_scroll.max_offset = 10;
-        handle_key(&mut s, KeyCode::Up);
+        handle_key(&mut s, KeyCode::PageUp);
         assert_eq!(s.build_scroll.offset, 1);
         handle_key(&mut s, KeyCode::Char('c'));
         assert!(s.events.is_empty());
@@ -3423,7 +4313,7 @@ mod tests {
             Tab::Projects,
             Tab::Store,
             Tab::Transfer,
-            Tab::Passthrough,
+            Tab::Why,
         ] {
             let mut state = test_state();
             state.active_tab = tab;
@@ -3571,7 +4461,7 @@ mod tests {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
 
-        for tab in [Tab::Build, Tab::Store, Tab::Passthrough, Tab::Transfer] {
+        for tab in [Tab::Build, Tab::Store, Tab::Why, Tab::Transfer] {
             let mut state = test_state();
             state.active_tab = tab;
             // Build events (varied results incl. a passthrough) drive the build +
@@ -3589,6 +4479,7 @@ mod tests {
             state.stats_snapshot.entry_count = 2;
             state.stats_snapshot.total_size = 3_500_000;
             state.stats_loaded = true;
+            state.refresh_sessions(chrono::Utc::now());
             // Transfer-tab counters/speeds.
             state.stats_snapshot.uploads_completed = 3;
             state.upload_speed_bps = 2_500_000.0;
@@ -3601,7 +4492,7 @@ mod tests {
             let buffer = terminal.backend().buffer().clone();
             let rendered: String = buffer.content().iter().map(|c| c.symbol()).collect();
             // Populated tabs surface a crate name we seeded.
-            if matches!(tab, Tab::Build | Tab::Store | Tab::Passthrough) {
+            if matches!(tab, Tab::Build | Tab::Store | Tab::Why) {
                 assert!(
                     rendered.contains("serde")
                         || rendered.contains("tokio")
@@ -3763,7 +4654,7 @@ mod tests {
         assert!(s.should_quit);
 
         let mut s = test_state();
-        let (_, _, store_x) = tab_titles()[2];
+        let (_, _, store_x) = tab_titles()[3];
         handle_terminal_event(
             &mut s,
             Event::Mouse(MouseEvent {
@@ -3948,7 +4839,6 @@ mod tests {
             (Tab::Build, "Compile", 78u16),
             (Tab::Store, "Profile", 84),
             (Tab::Projects, "[debug]", 80),
-            (Tab::Passthrough, "Exit", 80),
         ] {
             for width in [min_width - 1, min_width, 120] {
                 let screen = rendered_lines(&mut state, tab, width, 40).join("\n");
@@ -3971,33 +4861,401 @@ mod tests {
     }
 
     #[test]
-    fn passthrough_arrivals_move_only_a_scrolled_passthrough_reader() {
+    fn changing_build_resets_both_panels_and_a_lone_build_can_be_pinned() {
         let mut s = test_state();
-        s.passthrough_scroll.visible_range(50, 10);
-        s.passthrough_scroll.scroll_down_by(5);
-        assert_eq!(s.passthrough_scroll.offset, 5);
+        s.push_event(session_event("a", EventResult::Miss, "/w/one", "s1", 500));
+        s.refresh_sessions(chrono::Utc::now());
+        assert!(s.selected_session.is_none());
+        // Down on the only row pins it rather than doing nothing.
+        handle_key(&mut s, KeyCode::Down);
+        assert_eq!(s.selected_session.as_deref(), Some("id:s1"));
 
-        // A miss is not a passthrough row.
-        s.push_event(sample_build_event("a", EventResult::Miss, 1, 1));
-        assert_eq!(s.passthrough_scroll.offset, 5);
+        // Scroll both panels away from their edges, then let a newer build
+        // arrive: the pin holds and nothing resets.
+        s.build_scroll.visible_range(50, 10);
+        s.build_scroll.scroll_up_by(5);
+        s.why_scroll.visible_range(50, 10);
+        s.why_scroll.scroll_down_by(7);
+        s.push_event(session_event("b", EventResult::Miss, "/w/two", "s2", 1));
+        s.refresh_sessions(chrono::Utc::now());
+        assert_eq!(s.sessions[0].key, "id:s2");
+        assert_eq!(s.selected_session().unwrap().key, "id:s1");
+        assert_eq!((s.build_scroll.offset, s.why_scroll.offset), (5, 7));
 
-        // A passthrough is, when no filter or a matching one is set.
-        s.push_event(sample_build_event("b", EventResult::Passthrough, 1, 1));
-        assert_eq!(s.passthrough_scroll.offset, 6);
-        s.passthrough_filter = "linker".to_string();
-        s.push_event(sample_build_event("c", EventResult::Passthrough, 1, 1));
-        assert_eq!(s.passthrough_scroll.offset, 7, "reason matches the filter");
-        s.passthrough_filter = "zzz".to_string();
-        s.push_event(sample_build_event("d", EventResult::Passthrough, 1, 1));
-        assert_eq!(s.passthrough_scroll.offset, 7, "filtered out: no arrival");
-        s.passthrough_filter = "d".to_string();
-        s.push_event(sample_build_event("d", EventResult::Passthrough, 1, 1));
-        assert_eq!(s.passthrough_scroll.offset, 8, "crate name matches");
+        // Picking the other build starts both panels from their edge.
+        handle_key(&mut s, KeyCode::Up);
+        assert_eq!(s.selected_session().unwrap().key, "id:s2");
+        assert_eq!((s.build_scroll.offset, s.why_scroll.offset), (0, 0));
 
-        // At the live edge nothing moves, whatever arrives.
-        s.passthrough_scroll.reset();
-        s.passthrough_filter.clear();
-        s.push_event(sample_build_event("e", EventResult::Passthrough, 1, 1));
-        assert_eq!(s.passthrough_scroll.offset, 0);
+        // Following, a new top build resets them too.
+        handle_key(&mut s, KeyCode::Up);
+        assert!(s.selected_session.is_none());
+        s.build_scroll.visible_range(50, 10);
+        s.build_scroll.scroll_up_by(3);
+        s.push_event(session_event("c", EventResult::Miss, "/w/three", "s3", 0));
+        s.refresh_sessions(chrono::Utc::now());
+        assert_eq!(s.selected_session().unwrap().key, "id:s3");
+        assert_eq!(s.build_scroll.offset, 0);
+    }
+    fn why_text(s: &mut AppState, width: u16) -> Vec<String> {
+        why_lines(s, width)
+            .iter()
+            .map(|line| line.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn build_tab_layout_thresholds() {
+        // No builds: no Builds panel at all, not an empty one.
+        let mut s = test_state();
+        let screen = rendered_tab(&mut s, Tab::Build);
+        assert!(!screen.contains("Builds ·"), "{screen}");
+
+        // The sparkline needs 30 content rows (31 with the tab bar).
+        let mut s = populated_state();
+        let tall = rendered_lines(&mut s, Tab::Build, 100, 31).join("\n");
+        assert!(tall.contains("Lookups · last"), "{tall}");
+        let short = rendered_lines(&mut s, Tab::Build, 100, 30).join("\n");
+        assert!(!short.contains("Lookups · last"), "{short}");
+        assert!(
+            short.contains("Builds ·"),
+            "the builds panel stays: {short}"
+        );
+
+        // The long help needs 100 columns.
+        let wide = rendered_lines(&mut s, Tab::Build, 100, 40).join("\n");
+        assert!(
+            wide.contains("Enter: why") && wide.contains("PgUp PgDn End"),
+            "{wide}"
+        );
+        let narrow = rendered_lines(&mut s, Tab::Build, 99, 40).join("\n");
+        assert!(
+            narrow.contains("⏎: why") && !narrow.contains("Enter: why"),
+            "{narrow}"
+        );
+    }
+
+    /// A body taller than the panel gets a position marker, and so does a
+    /// body scrolled away from the top even when its end is in view.
+    #[test]
+    fn why_tab_marks_its_scroll_position_only_when_there_is_more() {
+        let mut s = test_state();
+        s.events = vec![session_event("a", EventResult::Miss, "/w", "s1", 5)];
+        s.refresh_sessions(chrono::Utc::now());
+        let screen = rendered_tab(&mut s, Tab::Why);
+        assert!(!screen.contains('–'), "everything fits: {screen}");
+
+        for i in 0..30 {
+            let mut e = session_event(&format!("cc{i}"), EventResult::Passthrough, "/w", "s1", 4);
+            e.passthrough_reason = "unsupported|flag".to_string();
+            s.push_event(e);
+        }
+        s.refresh_sessions(chrono::Utc::now());
+        let screen = rendered_lines(&mut s, Tab::Why, 100, 20).join("\n");
+        assert!(screen.contains("1–16 of"), "{screen}");
+        assert!(screen.contains("PgUp PgDn"), "{screen}");
+
+        s.active_tab = Tab::Why;
+        handle_key(&mut s, KeyCode::End);
+        let screen = rendered_lines(&mut s, Tab::Why, 100, 20).join("\n");
+        let total = why_lines(&mut s, 98).len();
+        assert!(
+            screen.contains(&format!("{total} of {total}")),
+            "scrolled to the end: {screen}"
+        );
+    }
+
+    #[test]
+    fn why_cost_strip_mentions_copies_only_when_there_are_any() {
+        let mut s = test_state();
+        let mut hit = session_event("a", EventResult::LocalHit, "/w", "s1", 5);
+        hit.reflinked_bytes = 1000;
+        s.events = vec![hit];
+        s.refresh_sessions(chrono::Utc::now());
+        let text = why_text(&mut s, 120).join("\n");
+        assert!(text.contains("restored 1000 B"), "{text}");
+        assert!(!text.contains("by copy"), "{text}");
+        assert!(text.contains("none: every lookup hit"), "{text}");
+        assert!(!text.contains("explain_miss"), "no misses, no hint: {text}");
+
+        let mut hit = session_event("b", EventResult::LocalHit, "/w", "s1", 4);
+        hit.copied_bytes = 1000;
+        s.push_event(hit);
+        s.refresh_sessions(chrono::Utc::now());
+        let text = why_text(&mut s, 120).join("\n");
+        assert!(text.contains("50% by copy"), "{text}");
+
+        // A build with only passthroughs looked nothing up.
+        let mut s = test_state();
+        let mut pt = session_event("cc", EventResult::Passthrough, "/w", "s2", 3);
+        pt.passthrough_reason = "unsupported|flag".to_string();
+        s.events = vec![pt];
+        s.refresh_sessions(chrono::Utc::now());
+        let text = why_text(&mut s, 120).join("\n");
+        assert!(text.contains("none: nothing was looked up"), "{text}");
+    }
+
+    #[test]
+    fn why_counts_misses_in_english_and_says_when_capped() {
+        let mut s = test_state();
+        s.events = vec![session_event("a", EventResult::Miss, "/w", "s1", 5)];
+        s.refresh_sessions(chrono::Utc::now());
+        let text = why_text(&mut s, 120).join("\n");
+        assert!(text.contains("Misses by cause · 1 miss\n"), "{text}");
+        assert!(!text.contains("Misses by cause · 1 misses"), "{text}");
+        assert!(!text.contains("analyzed)"), "{text}");
+        assert!(!text.contains("none:"), "there is a miss: {text}");
+        assert!(
+            !text.contains("Passthroughs by reason"),
+            "none to group: {text}"
+        );
+        assert!(!text.contains("Chronic misses"), "none: {text}");
+
+        for i in 0..(tui_sessions::MAX_ANALYZED_MISSES + 9) {
+            s.push_event(session_event(
+                &format!("m{i}"),
+                EventResult::Miss,
+                "/w",
+                "s1",
+                4,
+            ));
+        }
+        s.refresh_sessions(chrono::Utc::now());
+        let text = why_text(&mut s, 120).join("\n");
+        assert!(
+            text.contains(&format!(
+                "{} misses (newest {} of {} analyzed)",
+                tui_sessions::MAX_ANALYZED_MISSES + 10,
+                tui_sessions::MAX_ANALYZED_MISSES,
+                tui_sessions::MAX_ANALYZED_MISSES + 10
+            )),
+            "{text}"
+        );
+    }
+
+    /// Every bar line and every passthrough row is laid out inside the
+    /// width it was asked for, including long reasons and the probe note.
+    fn fit_state() -> AppState {
+        let mut s = test_state();
+        let long = "unsupported|cc flag -march=native -mtune=native -fno-omit-frame-pointer -Wl,--as-needed";
+        for i in 0..3 {
+            let mut e = session_event(
+                &format!("a_rather_long_crate_name_{i}"),
+                EventResult::Passthrough,
+                "/w",
+                "s1",
+                5,
+            );
+            e.passthrough_reason = long.to_string();
+            s.push_event(e);
+        }
+        let mut probe = session_event("rustc", EventResult::Passthrough, "/w", "s1", 4);
+        probe.passthrough_reason =
+            "not-a-compile|--print cfg with a long tail of arguments, and then some more"
+                .to_string();
+        s.push_event(probe);
+        s.push_event(session_event("m", EventResult::Miss, "/w", "s1", 3));
+        s.refresh_sessions(chrono::Utc::now());
+        s
+    }
+
+    #[test]
+    fn why_lines_fit_the_width_they_are_given() {
+        let mut s = fit_state();
+        for width in [50u16, 60, 78, 100] {
+            for line in why_lines(&mut s, width) {
+                let text = line.to_string();
+                let laid_out = text.contains('░')
+                    || text.contains('█')
+                    || text.trim_start().starts_with(|c: char| c.is_ascii_digit());
+                if laid_out {
+                    assert!(
+                        line.width() <= width as usize,
+                        "{width}: {} cells: {text:?}",
+                        line.width()
+                    );
+                }
+            }
+        }
+        // Exact widths: the crate column is width/4 (8..22) and the kind
+        // column width/6 (6..14), so at 60 a passthrough row shows 15 cells
+        // of crate and 10 of kind, and at 88 the full 22 and 14.
+        let at_60 = why_text(&mut s, 60).join("\n");
+        assert!(
+            at_60.contains("  a_rather_long_…  unsupport…  cc flag"),
+            "{at_60}"
+        );
+        let at_88 = why_text(&mut s, 88).join("\n");
+        assert!(
+            at_88.contains("  a_rather_long_crate_n…  unsupported     cc flag"),
+            "{at_88}"
+        );
+        // The probe group line at 100: label, then the note, and the label
+        // is cut so that exactly the note and one cell of slack remain.
+        let group_line = why_lines(&mut s, 100)
+            .iter()
+            .map(|line| line.to_string())
+            .find(|line| line.contains("(queries, not compiles)"))
+            .unwrap();
+        assert_eq!(
+            Line::from(group_line.as_str()).width(),
+            99,
+            "{group_line:?}"
+        );
+        let text = why_text(&mut s, 100).join("\n");
+        assert!(text.contains("(queries, not compiles)"), "{text}");
+        assert!(text.contains("not-a-compile: --print cfg with"), "{text}");
+
+        // The filter narrows the passthrough list and says so.
+        s.why_filter = "rustc".to_string();
+        s.active_tab = Tab::Why;
+        let text = why_text(&mut s, 100).join("\n");
+        assert!(
+            text.contains("Passthroughs in this build · 1 matching \"rustc\""),
+            "{text}"
+        );
+        assert!(
+            text.contains("  rustc") && !text.contains("a_rather_long"),
+            "{text}"
+        );
+        s.why_filter = "-march".to_string();
+        let text = why_text(&mut s, 100).join("\n");
+        assert!(text.contains("· 3 matching"), "reason matches too: {text}");
+        s.why_filter = "zzz".to_string();
+        let text = why_text(&mut s, 100).join("\n");
+        assert!(text.contains("none match the filter"), "{text}");
+    }
+    #[test]
+    fn enter_opens_why_only_from_build() {
+        let mut s = test_state();
+        s.active_tab = Tab::Store;
+        handle_key(&mut s, KeyCode::Enter);
+        assert_eq!(s.active_tab, Tab::Store);
+        s.active_tab = Tab::Build;
+        handle_key(&mut s, KeyCode::Enter);
+        assert_eq!(s.active_tab, Tab::Why);
+    }
+
+    #[test]
+    fn fmt_saved_ms_switches_units_at_one_second() {
+        assert_eq!(fmt_saved_ms(999), "999ms");
+        assert_eq!(fmt_saved_ms(1000), "1s");
+    }
+
+    /// A heartbeat for a tree keeps that tree's newest build running past
+    /// the grace period.
+    #[test]
+    fn in_flight_compile_keeps_its_build_running() {
+        let mut s = test_state();
+        s.events = vec![session_event("a", EventResult::Miss, "/w", "s1", 300)];
+        s.refresh_sessions(chrono::Utc::now());
+        assert_eq!(s.sessions[0].state, SessionState::Finished);
+        let beat = HeartbeatEvent {
+            schema: 1,
+            event: "heartbeat".to_string(),
+            ts: chrono::Utc::now(),
+            crate_name: "b".to_string(),
+            root: "/w".to_string(),
+            pid: 7,
+            elapsed_s: 5,
+            typical_s: None,
+            eta_s: None,
+        };
+        s.live_heartbeats.insert(7, (Instant::now(), beat));
+        s.refresh_sessions(chrono::Utc::now());
+        assert_eq!(s.sessions[0].state, SessionState::Live);
+        let screen = rendered_tab(&mut s, Tab::Build);
+        assert!(screen.contains("running"), "{screen}");
+    }
+
+    /// Render `tab` and return the raw buffer, for assertions on style.
+    fn rendered_buffer(state: &mut AppState, tab: Tab, width: u16, height: u16) -> Buffer {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        state.active_tab = tab;
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|frame| draw_ui(frame, state))
+            .expect("draw should succeed");
+        terminal.backend().buffer().clone()
+    }
+
+    fn row_text(buffer: &Buffer, y: u16) -> String {
+        (0..buffer.area.width)
+            .map(|x| buffer[(x, y)].symbol())
+            .collect()
+    }
+
+    /// The Builds table: a lone build gets its row, the selected row is
+    /// highlighted, zero counts are muted, headers sit left and numbers
+    /// right, and the pass and saved columns need 100 columns.
+    #[test]
+    fn builds_table_layout_and_styling() {
+        let mut s = test_state();
+        s.events = vec![
+            session_event("a", EventResult::Miss, "/w/one", "s1", 5),
+            session_event("b", EventResult::LocalHit, "/w/two", "s2", 400),
+        ];
+        s.refresh_sessions(chrono::Utc::now());
+
+        let buffer = rendered_buffer(&mut s, Tab::Build, 100, 40);
+        let rows: Vec<String> = (0..40).map(|y| row_text(&buffer, y)).collect();
+        let header_y = rows
+            .iter()
+            .position(|row| row.contains("Started") && row.contains("State"))
+            .unwrap_or_else(|| panic!("{}", rows.join("\n")));
+        let header = &rows[header_y];
+        assert!(header.starts_with("│  Build"), "labels left: {header:?}");
+        assert!(
+            header.contains("pass") && header.contains("saved"),
+            "{header:?}"
+        );
+        assert!(
+            header.trim_end_matches('│').trim_end().ends_with("saved"),
+            "numbers right: {header:?}"
+        );
+
+        let selected_y = header_y + 1;
+        assert!(rows[selected_y].contains("▸ one"), "{}", rows[selected_y]);
+        let mark = rows[selected_y].find('▸').unwrap() as u16;
+        let style = &buffer[(mark + 2, selected_y as u16)];
+        assert!(style.modifier.contains(Modifier::REVERSED), "{style:?}");
+        assert!(style.modifier.contains(Modifier::BOLD), "{style:?}");
+
+        // "two" has 0 misses: that cell is muted; its 1 hit is not.
+        let other_y = selected_y + 1;
+        assert!(rows[other_y].contains("two"), "{}", rows[other_y]);
+        // Column, not byte offset: the border glyphs are multi-byte.
+        let col_of = |row: &str, needle: &str| -> usize {
+            let chars: Vec<char> = row.chars().collect();
+            let needle: Vec<char> = needle.chars().collect();
+            chars
+                .windows(needle.len())
+                .position(|window| window == needle.as_slice())
+                .unwrap()
+        };
+        let miss_x = col_of(header, "miss") + 3;
+        let hit_x = col_of(header, "hit") + 2;
+        assert_eq!(buffer[(miss_x as u16, other_y as u16)].symbol(), "0");
+        assert_eq!(buffer[(miss_x as u16, other_y as u16)].fg, Color::DarkGray);
+        assert_eq!(buffer[(hit_x as u16, other_y as u16)].symbol(), "1");
+        assert_eq!(buffer[(hit_x as u16, other_y as u16)].fg, Color::Green);
+
+        let narrow = rendered_lines(&mut s, Tab::Build, 99, 40);
+        let header = narrow
+            .iter()
+            .find(|row| row.contains("Started") && row.contains("State"))
+            .unwrap();
+        assert!(
+            !header.contains("pass") && !header.contains("saved"),
+            "{header:?}"
+        );
+
+        // One build alone still gets its row (border, header, one row).
+        let mut s = test_state();
+        s.events = vec![session_event("a", EventResult::Miss, "/w/one", "s1", 5)];
+        s.refresh_sessions(chrono::Utc::now());
+        let screen = rendered_tab(&mut s, Tab::Build);
+        assert!(screen.contains("▸ one"), "{screen}");
     }
 }

--- a/src/tui_sessions.rs
+++ b/src/tui_sessions.rs
@@ -1,0 +1,1315 @@
+//! Build sessions and miss causes for the monitor.
+//!
+//! The event log is one flat stream across every workspace and every
+//! `cargo build` on the machine. A person watching it wants two things the
+//! stream does not give directly: "which build is this row from" and "why did
+//! that build miss". This module answers both as pure functions over the
+//! events the monitor already holds, so `tui` only renders.
+//!
+//! # Sessions
+//!
+//! A session is one build: every event sharing a `session_id` (minted per
+//! build by the wrapper, kunobi-ninja/kache#583). Events without one, from
+//! older wrappers or non-cargo invocations, are grouped the way `kache report`
+//! groups them: by build root, split wherever the root sat idle for at least
+//! the wrapper's own session timeout.
+//!
+//! # Causes
+//!
+//! A miss row says what happened; the cause says why, using what the wrapper
+//! recorded on the event. Precedence follows `kache why-miss`: a failed store
+//! or a rejected lookup outranks everything, because either is a caching
+//! failure to act on. Below that, a recorded dependency cascade names the
+//! crate that actually changed (`miss_chain`), so forty downstream misses read
+//! as one line. Then the crate's own changed key groups, then "no earlier
+//! compile in the loaded history", and last "unexplained", which is what the
+//! monitor says when the wrapper recorded nothing it could reason from.
+//!
+//! Everything here describes the loaded history, never more: with `--since`
+//! the history starts at the cutoff, and the wording says so.
+
+use crate::events::{BuildEvent, EventResult};
+use crate::miss_chain;
+use chrono::{DateTime, Utc};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::time::Duration;
+
+/// How long after its last event a session with nothing in flight still
+/// counts as live. Long enough to bridge cargo's own gaps between compiles,
+/// short enough that a finished build stops claiming the top row.
+pub(crate) const LIVE_GRACE: Duration = Duration::from_secs(30);
+
+/// The most misses one session's cause analysis walks. The cascade walk is
+/// per miss and scans history, so a 3,000-crate cold build must not stall
+/// the draw loop; the analysis says when it was capped.
+pub(crate) const MAX_ANALYZED_MISSES: usize = 400;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SessionState {
+    Live,
+    Finished,
+}
+
+impl SessionState {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            SessionState::Live => "running",
+            SessionState::Finished => "done",
+        }
+    }
+}
+
+/// Per-session counts and timings. Everything a row or a cost strip shows.
+/// Sums saturate: a corrupt event with an absurd duration must not take the
+/// monitor down, and a saturated total is visibly wrong rather than wrapped.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct Tally {
+    pub hits: u64,
+    pub misses: u64,
+    pub dups: u64,
+    /// Passthroughs that were real compiles kache declined to cache.
+    pub passthroughs: u64,
+    /// Passthroughs that were queries (`--print`, `-vV`, `cc -###`), not
+    /// compiles. Counted apart so they never read as a caching failure.
+    pub probes: u64,
+    pub skipped: u64,
+    pub errors: u64,
+    /// Compile time the hits did not have to spend (the entry's recorded
+    /// compile cost).
+    pub saved_ms: u64,
+    /// Compile time spent in misses and dups.
+    pub miss_ms: u64,
+    /// Time kache itself spent around the compiler on lookups: the whole of
+    /// a hit, and everything but the compile of a miss or dup. Passthroughs
+    /// carry no compile timing, so they are left out rather than counted as
+    /// pure overhead.
+    pub overhead_ms: u64,
+    /// Summed invocation time of those same lookups, the denominator for the
+    /// overhead share. Invocations overlap under `-j`, so this is not the
+    /// build's wall time.
+    pub lookup_elapsed_ms: u64,
+    pub reflinked_bytes: u64,
+    pub hardlinked_bytes: u64,
+    pub copied_bytes: u64,
+}
+
+/// Outcomes that consulted the cache: the only ones a hit rate, an overhead
+/// share, or a chronic-miss count may be built from.
+fn is_lookup(event: &BuildEvent) -> bool {
+    matches!(
+        event.result,
+        EventResult::LocalHit
+            | EventResult::PrefetchHit
+            | EventResult::RemoteHit
+            | EventResult::Miss
+            | EventResult::Dup
+    )
+}
+
+fn is_miss(event: &BuildEvent) -> bool {
+    matches!(event.result, EventResult::Miss | EventResult::Dup)
+}
+
+impl Tally {
+    pub(crate) fn add(&mut self, event: &BuildEvent) {
+        match event.result {
+            EventResult::LocalHit | EventResult::PrefetchHit | EventResult::RemoteHit => {
+                self.hits = self.hits.saturating_add(1);
+                self.saved_ms = self.saved_ms.saturating_add(event.compile_time_ms);
+            }
+            EventResult::Miss => {
+                self.misses = self.misses.saturating_add(1);
+                self.miss_ms = self.miss_ms.saturating_add(event.compile_time_ms);
+            }
+            EventResult::Dup => {
+                self.dups = self.dups.saturating_add(1);
+                self.miss_ms = self.miss_ms.saturating_add(event.compile_time_ms);
+            }
+            EventResult::Passthrough if is_probe(event) => {
+                self.probes = self.probes.saturating_add(1);
+            }
+            EventResult::Passthrough => {
+                self.passthroughs = self.passthroughs.saturating_add(1);
+            }
+            EventResult::Skipped => self.skipped = self.skipped.saturating_add(1),
+            EventResult::Error => self.errors = self.errors.saturating_add(1),
+        }
+        if is_lookup(event) {
+            self.overhead_ms = self.overhead_ms.saturating_add(event.overhead_ms());
+            self.lookup_elapsed_ms = self.lookup_elapsed_ms.saturating_add(event.elapsed_ms);
+        }
+        self.reflinked_bytes = self.reflinked_bytes.saturating_add(event.reflinked_bytes);
+        self.hardlinked_bytes = self.hardlinked_bytes.saturating_add(event.hardlinked_bytes);
+        self.copied_bytes = self.copied_bytes.saturating_add(event.copied_bytes);
+    }
+
+    /// Misses and dups together: compiles that entered the cache and lost.
+    pub(crate) fn compiled(&self) -> u64 {
+        self.misses.saturating_add(self.dups)
+    }
+
+    /// Lookups that hit, over lookups alone. Passthroughs and probes never
+    /// consulted the cache, so they are not in the denominator; folding them
+    /// in would report a number no cache could move.
+    pub(crate) fn hit_rate(&self) -> Option<f64> {
+        let lookups = self.hits.saturating_add(self.compiled());
+        (lookups > 0).then(|| self.hits as f64 * 100.0 / lookups as f64)
+    }
+
+    pub(crate) fn restored_bytes(&self) -> u64 {
+        self.reflinked_bytes
+            .saturating_add(self.hardlinked_bytes)
+            .saturating_add(self.copied_bytes)
+    }
+
+    /// Share of restored bytes that were physically copied, as a percentage.
+    /// Anything much above zero on a CoW filesystem is worth a look.
+    pub(crate) fn copy_share(&self) -> Option<f64> {
+        let total = self.restored_bytes();
+        (total > 0).then(|| self.copied_bytes as f64 * 100.0 / total as f64)
+    }
+
+    /// kache's own time as a share of the lookups' summed invocation time,
+    /// as a percentage.
+    pub(crate) fn overhead_share(&self) -> Option<f64> {
+        (self.lookup_elapsed_ms > 0)
+            .then(|| self.overhead_ms as f64 * 100.0 / self.lookup_elapsed_ms as f64)
+    }
+}
+
+/// One build, as far as the events show it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Session {
+    /// Stable identity across redraws: `id:<session_id>` for a recorded
+    /// session, `inferred:<root>:<ordinal>` for one grouped by idle gap. The
+    /// prefixes keep the two from ever colliding.
+    pub key: String,
+    pub root: String,
+    /// Grouped by idle gap rather than by a recorded id.
+    pub inferred: bool,
+    pub started: DateTime<Utc>,
+    pub last_activity: DateTime<Utc>,
+    /// Indices into the monitor's event list, in log order.
+    pub events: Vec<usize>,
+    pub tally: Tally,
+    pub state: SessionState,
+}
+
+impl Session {
+    /// The last path component of the root, which is what a reader
+    /// recognizes; the whole root when there is no component to take.
+    pub(crate) fn workspace_name(&self) -> &str {
+        if self.root.is_empty() {
+            return "(unknown root)";
+        }
+        std::path::Path::new(&self.root)
+            .file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .filter(|name| !name.is_empty())
+            .unwrap_or(&self.root)
+    }
+
+    /// The recorded session id behind the key.
+    #[cfg(test)]
+    pub(crate) fn recorded_id(&self) -> Option<&str> {
+        self.key.strip_prefix("id:")
+    }
+
+    /// The newest event index, the tie-breaker for "newest first".
+    fn last_index(&self) -> usize {
+        self.events.last().copied().unwrap_or(0)
+    }
+}
+
+fn is_probe(event: &BuildEvent) -> bool {
+    matches!(event.result, EventResult::Passthrough)
+        && event
+            .passthrough_reason
+            .split('|')
+            .next()
+            .unwrap_or("")
+            .trim()
+            == "not-a-compile"
+}
+
+fn event_start(event: &BuildEvent) -> DateTime<Utc> {
+    let elapsed = i64::try_from(event.elapsed_ms).unwrap_or(i64::MAX);
+    event
+        .ts
+        .checked_sub_signed(chrono::Duration::milliseconds(elapsed))
+        .unwrap_or(event.ts)
+}
+
+/// Group `events` into sessions, newest first with running builds on top.
+/// [`group`] and [`refresh_state`] in one call; the monitor calls the two
+/// apart so it can skip the regrouping on ticks where the log did not grow.
+#[cfg(test)]
+pub(crate) fn group_sessions(
+    events: &[BuildEvent],
+    now: DateTime<Utc>,
+    live_roots: &HashSet<String>,
+    idle_gap: Duration,
+) -> Vec<Session> {
+    let mut sessions = group(events, idle_gap);
+    refresh_state(&mut sessions, now, live_roots);
+    sessions
+}
+
+/// Group `events` into sessions, in order of first appearance and with no
+/// state yet. Depends on the events alone, so the caller can keep the result
+/// while the log does not grow and only [`refresh_state`] it each tick.
+///
+/// `idle_gap` splits inferred sessions; pass the wrapper's own session
+/// timeout so the monitor and `kache report` agree on what one build is.
+pub(crate) fn group(events: &[BuildEvent], idle_gap: Duration) -> Vec<Session> {
+    let mut sessions: Vec<Session> = Vec::new();
+    let mut by_id: HashMap<&str, usize> = HashMap::new();
+    let mut inferred_by_root: HashMap<&str, usize> = HashMap::new();
+    let idle_gap = chrono::Duration::from_std(idle_gap).unwrap_or(chrono::Duration::MAX);
+
+    for (index, event) in events.iter().enumerate() {
+        let slot = if !event.session_id.is_empty() {
+            *by_id.entry(event.session_id.as_str()).or_insert_with(|| {
+                sessions.push(Session {
+                    key: format!("id:{}", event.session_id),
+                    root: event.root.clone(),
+                    inferred: false,
+                    started: event_start(event),
+                    last_activity: event.ts,
+                    events: Vec::new(),
+                    tally: Tally::default(),
+                    state: SessionState::Finished,
+                });
+                sessions.len() - 1
+            })
+        } else {
+            let current = inferred_by_root.get(event.root.as_str()).copied();
+            match current {
+                // Same rule as `kache report`: a gap of at least the timeout
+                // is a new build. A backwards timestamp (clock step) joins
+                // the current session rather than opening a phantom one.
+                Some(slot)
+                    if event.ts.signed_duration_since(sessions[slot].last_activity) < idle_gap =>
+                {
+                    slot
+                }
+                _ => {
+                    // The key carries the session's ordinal, so two
+                    // idle-split sessions of one root never collide, and it
+                    // stays stable while the log only grows.
+                    let ordinal = sessions.len();
+                    sessions.push(Session {
+                        key: format!("inferred:{}:{ordinal}", event.root),
+                        root: event.root.clone(),
+                        inferred: true,
+                        started: event_start(event),
+                        last_activity: event.ts,
+                        events: Vec::new(),
+                        tally: Tally::default(),
+                        state: SessionState::Finished,
+                    });
+                    inferred_by_root.insert(event.root.as_str(), sessions.len() - 1);
+                    sessions.len() - 1
+                }
+            }
+        };
+        let session = &mut sessions[slot];
+        session.events.push(index);
+        session.tally.add(event);
+        session.started = session.started.min(event_start(event));
+        session.last_activity = session.last_activity.max(event.ts);
+        // A recorded id can outlive a root change only in a broken log; the
+        // first root wins and later ones are ignored rather than flapping.
+        if session.root.is_empty() {
+            session.root = event.root.clone();
+        }
+    }
+    sessions
+}
+
+/// Decide which sessions are live and sort them: running builds first, then
+/// newest activity first, ties broken by log position.
+///
+/// `live_roots` are the build roots with a compile in flight right now (the
+/// daemon registry or tailed heartbeats). A root names a tree, not a build,
+/// so it can only keep the root's newest session live; it never revives an
+/// older build of the same tree. Only time between the last event and `now`
+/// counts as recent: an event stamped in the future is a clock problem, not
+/// a running build.
+pub(crate) fn refresh_state(
+    sessions: &mut [Session],
+    now: DateTime<Utc>,
+    live_roots: &HashSet<String>,
+) {
+    // Owned keys: the map outlives the shared borrow it is built from.
+    let mut newest_by_root: HashMap<String, usize> = HashMap::new();
+    for session in sessions.iter() {
+        if session.root.is_empty() {
+            continue;
+        }
+        let last = session.last_index();
+        newest_by_root
+            .entry(session.root.clone())
+            .and_modify(|newest| *newest = (*newest).max(last))
+            .or_insert(last);
+    }
+    let grace = chrono::Duration::from_std(LIVE_GRACE).unwrap_or(chrono::Duration::MAX);
+    for session in sessions.iter_mut() {
+        let age = now.signed_duration_since(session.last_activity);
+        let recent = age >= chrono::Duration::zero() && age < grace;
+        let compiling = live_roots.contains(&session.root)
+            && newest_by_root.get(&session.root) == Some(&session.last_index());
+        session.state = if recent || compiling {
+            SessionState::Live
+        } else {
+            SessionState::Finished
+        };
+    }
+    // The build somebody is watching is the reason they opened the monitor.
+    sessions.sort_by(|a, b| {
+        (a.state != SessionState::Live)
+            .cmp(&(b.state != SessionState::Live))
+            .then_with(|| b.last_activity.cmp(&a.last_activity))
+            .then_with(|| b.last_index().cmp(&a.last_index()))
+            .then_with(|| a.key.cmp(&b.key))
+    });
+}
+
+/// Why a miss missed, in `why-miss` precedence.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum Cause {
+    /// `Store::put` failed after the compile (kunobi-ninja/kache#629). The
+    /// output was built and not cached.
+    StoreFailed(String),
+    /// An entry for this exact key existed but could not serve the
+    /// invocation (kunobi-ninja/kache#655).
+    LookupRejected(String),
+    /// Downstream of dependencies whose artifacts changed; `root` names the
+    /// crates at the bottom of the cascade, resolved ones first
+    /// (kunobi-ninja/kache#609). `complete` is false when the walk was cut
+    /// short or left a branch unresolved, so the names are contributors,
+    /// not the whole story.
+    Downstream { root: String, complete: bool },
+    /// This crate's own key inputs changed; the groups that moved.
+    OwnInputs(Vec<String>),
+    /// No earlier compile of this crate in this build tree is in the loaded
+    /// history. A cold cache or the `--since` cutoff; the events cannot tell.
+    NoHistory,
+    /// Earlier compiles exist but the wrapper recorded nothing that
+    /// explains the change. Recording is off, the event predates it, or the
+    /// root is unknown.
+    Unexplained,
+}
+
+impl Cause {
+    /// One line a reader can act on.
+    pub(crate) fn describe(&self) -> String {
+        match self {
+            Cause::StoreFailed(reason) => format!("compiled but not cached: {reason}"),
+            Cause::LookupRejected(reason) => format!("entry rejected at lookup: {reason}"),
+            Cause::Downstream {
+                root,
+                complete: true,
+            } => format!("downstream of {root}"),
+            Cause::Downstream {
+                root,
+                complete: false,
+            } => format!("downstream of {root} (and more; cascade not fully resolved)"),
+            Cause::OwnInputs(groups) => format!("own inputs changed: {}", groups.join(", ")),
+            Cause::NoHistory => "no earlier compile in the loaded history".to_string(),
+            Cause::Unexplained => "unexplained (no key diff recorded)".to_string(),
+        }
+    }
+
+    /// Whether the cause is a caching failure rather than a changed input:
+    /// something to fix, not something that changed.
+    pub(crate) fn is_failure(&self) -> bool {
+        matches!(self, Cause::StoreFailed(_) | Cause::LookupRejected(_))
+    }
+}
+
+/// Misses sharing one cause.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CauseGroup {
+    pub cause: Cause,
+    pub count: usize,
+    /// Compile time these misses cost.
+    pub compile_ms: u64,
+    /// Up to three crate names, in log order, so the group is recognizable.
+    pub examples: Vec<String>,
+}
+
+/// Passthroughs sharing one reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PassthroughGroup {
+    pub kind: String,
+    pub reason: String,
+    pub count: usize,
+    pub probe: bool,
+}
+
+/// A crate that keeps missing across builds of the same tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Chronic {
+    pub crate_name: String,
+    /// Builds in which it missed, over builds in which it was looked up.
+    pub missed: usize,
+    pub seen: usize,
+    /// Its latest lookup in the loaded history ended in a store failure.
+    pub last_store_failed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Analysis {
+    pub causes: Vec<CauseGroup>,
+    pub passthroughs: Vec<PassthroughGroup>,
+    pub chronic: Vec<Chronic>,
+    pub misses_total: usize,
+    pub misses_analyzed: usize,
+    /// Some miss in the session (analyzed or not) carried dependency
+    /// digests, so cascade roots were possible. When false and there were
+    /// misses, the reader should be told what recording is missing.
+    pub cascade_recorded: bool,
+}
+
+/// Explain the selected session's misses and passthroughs.
+///
+/// `events` is the monitor's whole list, in log order, because the cascade
+/// walk and the history test both look at events before the session.
+/// `sessions` is every session, for the chronic-miss count.
+pub(crate) fn analyze_session(
+    events: &[BuildEvent],
+    session: &Session,
+    sessions: &[Session],
+) -> Analysis {
+    let misses: Vec<usize> = session
+        .events
+        .iter()
+        .copied()
+        .filter(|&i| is_miss(&events[i]))
+        .collect();
+    let misses_total = misses.len();
+    let cascade_recorded = misses.iter().any(|&i| events[i].key_externs_recorded);
+    // Newest misses are the ones a reader is looking at; when capped, keep
+    // those and drop the oldest.
+    let analyzed: Vec<usize> = misses
+        .iter()
+        .copied()
+        .skip(misses_total.saturating_sub(MAX_ANALYZED_MISSES))
+        .collect();
+
+    // The history test asks "was this crate compiled in this tree before
+    // index i". One pass over the log answers it for every miss at once
+    // instead of rescanning the prefix per miss.
+    let mut first_compile: HashMap<(&str, &str), usize> = HashMap::new();
+    for (index, event) in events.iter().enumerate() {
+        let compiled = is_lookup(event)
+            || (matches!(event.result, EventResult::Passthrough) && !is_probe(event));
+        if compiled && !event.root.is_empty() {
+            first_compile
+                .entry((event.root.as_str(), event.crate_name.as_str()))
+                .or_insert(index);
+        }
+    }
+
+    let mut groups: BTreeMap<Cause, CauseGroup> = BTreeMap::new();
+    for &index in &analyzed {
+        let event = &events[index];
+        let cause = cause_of(events, index, &first_compile);
+        let group = groups.entry(cause.clone()).or_insert_with(|| CauseGroup {
+            cause,
+            count: 0,
+            compile_ms: 0,
+            examples: Vec::new(),
+        });
+        group.count += 1;
+        group.compile_ms = group.compile_ms.saturating_add(event.compile_time_ms);
+        if group.examples.len() < 3 && !group.examples.contains(&event.crate_name) {
+            group.examples.push(event.crate_name.clone());
+        }
+    }
+    let mut causes: Vec<CauseGroup> = groups.into_values().collect();
+    causes.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| b.compile_ms.cmp(&a.compile_ms))
+            .then_with(|| a.cause.cmp(&b.cause))
+    });
+
+    let mut passes: BTreeMap<(String, String), PassthroughGroup> = BTreeMap::new();
+    for &index in &session.events {
+        let event = &events[index];
+        if !matches!(event.result, EventResult::Passthrough) {
+            continue;
+        }
+        let (kind, reason) = passthrough_parts(&event.passthrough_reason);
+        let group = passes
+            .entry((kind.to_string(), reason.to_string()))
+            .or_insert_with(|| PassthroughGroup {
+                kind: kind.to_string(),
+                reason: reason.to_string(),
+                count: 0,
+                probe: is_probe(event),
+            });
+        group.count += 1;
+    }
+    let mut passthroughs: Vec<PassthroughGroup> = passes.into_values().collect();
+    // Real compiles before probes, then most frequent first: the reason worth
+    // acting on is the common one that was a compile.
+    passthroughs.sort_by(|a, b| {
+        a.probe
+            .cmp(&b.probe)
+            .then_with(|| b.count.cmp(&a.count))
+            .then_with(|| a.reason.cmp(&b.reason))
+    });
+
+    Analysis {
+        causes,
+        passthroughs,
+        chronic: chronic_misses(events, sessions, &session.root),
+        misses_total,
+        misses_analyzed: analyzed.len(),
+        cascade_recorded,
+    }
+}
+
+/// The `kind|detail` split kache writes into passthrough reasons, with the
+/// legacy `refused: ...` form mapped to an empty kind.
+pub(crate) fn passthrough_parts(reason: &str) -> (&str, &str) {
+    let reason = reason.trim();
+    if reason.is_empty() {
+        return ("", "unknown");
+    }
+    match reason.split_once('|') {
+        Some((kind, detail)) => (kind.trim(), detail.trim()),
+        None => ("", reason.strip_prefix("refused: ").unwrap_or(reason)),
+    }
+}
+
+fn cause_of(
+    events: &[BuildEvent],
+    index: usize,
+    first_compile: &HashMap<(&str, &str), usize>,
+) -> Cause {
+    let event = &events[index];
+    if !event.store_error.is_empty() {
+        return Cause::StoreFailed(event.store_error.clone());
+    }
+    if !event.lookup_rejection.is_empty() {
+        return Cause::LookupRejected(event.lookup_rejection.clone());
+    }
+    if let Some(chain) = miss_chain::analyze(events, index)
+        && !chain.roots.is_empty()
+    {
+        // The walk ranks roots by how many branches converge on them. Every
+        // root is named, resolved ones first, so a miss below two changed
+        // crates does not read as below one; and the line admits when that
+        // is not the whole story: a branch unresolved, or the walk cut short.
+        let mut names: Vec<&str> = Vec::new();
+        for root in chain
+            .roots
+            .iter()
+            .filter(|root| root.kind.is_resolved())
+            .chain(chain.roots.iter().filter(|root| !root.kind.is_resolved()))
+        {
+            if !names.contains(&root.crate_name.as_str()) {
+                names.push(root.crate_name.as_str());
+            }
+        }
+        // The walk itself caps the roots it returns; the renderer clips the
+        // line, so every name is kept.
+        let root = names.join(", ");
+        let complete =
+            chain.truncated.is_none() && chain.roots.iter().all(|root| root.kind.is_resolved());
+        return Cause::Downstream { root, complete };
+    }
+    if !event.key_diff.is_empty() {
+        let mut groups = event.key_diff.clone();
+        groups.sort();
+        groups.dedup();
+        return Cause::OwnInputs(groups);
+    }
+    if event.root.is_empty() {
+        // "Here" has no identity; two unknown-root events with one crate
+        // name may be unrelated workspaces.
+        return Cause::Unexplained;
+    }
+    let seen_before = first_compile
+        .get(&(event.root.as_str(), event.crate_name.as_str()))
+        .is_some_and(|&first| first < index);
+    if seen_before {
+        Cause::Unexplained
+    } else {
+        Cause::NoHistory
+    }
+}
+
+/// Crates in `root` that missed in at least three of its builds, or in two
+/// with a store failure on the latest lookup, most often first. Only
+/// lookups count as a build "seeing" a crate: a build that only ran a query
+/// never tried the cache. Capped so the panel stays a list, not a log.
+fn chronic_misses(events: &[BuildEvent], sessions: &[Session], root: &str) -> Vec<Chronic> {
+    if root.is_empty() {
+        return Vec::new();
+    }
+    struct Seen {
+        seen: usize,
+        missed: usize,
+    }
+    let mut by_crate: BTreeMap<&str, Seen> = BTreeMap::new();
+    for session in sessions {
+        if session.root != root {
+            continue;
+        }
+        let mut looked_up: HashSet<&str> = HashSet::new();
+        let mut missed: HashSet<&str> = HashSet::new();
+        for &index in &session.events {
+            let event = &events[index];
+            if !is_lookup(event) {
+                continue;
+            }
+            looked_up.insert(event.crate_name.as_str());
+            if is_miss(event) {
+                missed.insert(event.crate_name.as_str());
+            }
+        }
+        for name in looked_up {
+            let entry = by_crate.entry(name).or_insert(Seen { seen: 0, missed: 0 });
+            entry.seen += 1;
+            if missed.contains(name) {
+                entry.missed += 1;
+            }
+        }
+    }
+    // The newest lookup per crate, by log position: sessions are sorted
+    // running-first, which is not chronological, so walk the log instead
+    // and let the last write win.
+    let mut latest_failed: HashMap<&str, bool> = HashMap::new();
+    for event in events {
+        if event.root == root && is_lookup(event) {
+            latest_failed.insert(
+                event.crate_name.as_str(),
+                is_miss(event) && !event.store_error.is_empty(),
+            );
+        }
+    }
+    let mut chronic: Vec<Chronic> = by_crate
+        .into_iter()
+        .map(|(name, seen)| Chronic {
+            crate_name: name.to_string(),
+            missed: seen.missed,
+            seen: seen.seen,
+            last_store_failed: latest_failed.get(name).copied().unwrap_or(false),
+        })
+        .filter(|c| c.missed >= 3 || (c.missed >= 2 && c.last_store_failed))
+        .collect();
+    chronic.sort_by(|a, b| {
+        b.last_store_failed
+            .cmp(&a.last_store_failed)
+            .then_with(|| b.missed.cmp(&a.missed))
+            .then_with(|| a.crate_name.cmp(&b.crate_name))
+    });
+    chronic.truncate(8);
+    chronic
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(1_700_000_000 + secs, 0).unwrap()
+    }
+
+    fn event(
+        crate_name: &str,
+        result: EventResult,
+        at: i64,
+        root: &str,
+        session: &str,
+    ) -> BuildEvent {
+        let mut e = BuildEvent::new_for_test(crate_name, result);
+        e.ts = ts(at);
+        e.root = root.to_string();
+        e.session_id = session.to_string();
+        e.elapsed_ms = 100;
+        e.compile_time_ms = match result {
+            EventResult::Miss | EventResult::Dup => 1_000,
+            EventResult::LocalHit | EventResult::PrefetchHit | EventResult::RemoteHit => 5_000,
+            _ => 0,
+        };
+        e
+    }
+
+    fn no_live() -> HashSet<String> {
+        HashSet::new()
+    }
+
+    fn gap() -> Duration {
+        Duration::from_secs(300)
+    }
+
+    #[test]
+    fn state_labels_are_the_words_on_screen() {
+        assert_eq!(SessionState::Live.label(), "running");
+        assert_eq!(SessionState::Finished.label(), "done");
+    }
+
+    #[test]
+    fn recorded_ids_group_and_running_sessions_sort_first() {
+        let events = vec![
+            event("a", EventResult::Miss, 0, "/w/one", "s1"),
+            event("b", EventResult::LocalHit, 1, "/w/one", "s1"),
+            event("c", EventResult::Miss, 500, "/w/two", "s2"),
+            event("d", EventResult::Passthrough, 501, "/w/two", "s2"),
+        ];
+        // s1 is old and idle; s2 finished 100s ago but its root is compiling.
+        let live: HashSet<String> = ["/w/two".to_string()].into_iter().collect();
+        let sessions = group_sessions(&events, ts(601), &live, gap());
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].key, "id:s2");
+        assert_eq!(sessions[0].recorded_id(), Some("s2"));
+        assert_eq!(sessions[0].state, SessionState::Live);
+        assert_eq!(sessions[0].workspace_name(), "two");
+        assert_eq!(sessions[0].tally.passthroughs, 1);
+        assert_eq!(sessions[1].key, "id:s1");
+        assert_eq!(sessions[1].state, SessionState::Finished);
+        assert_eq!(sessions[1].tally.hits, 1);
+        assert_eq!(sessions[1].tally.misses, 1);
+        assert_eq!(sessions[1].tally.saved_ms, 5_000);
+        assert_eq!(sessions[1].tally.miss_ms, 1_000);
+        assert_eq!(sessions[1].tally.hit_rate(), Some(50.0));
+        assert_eq!(sessions[1].events, vec![0, 1]);
+    }
+
+    /// A root names a tree, not a build: activity there keeps only the
+    /// tree's newest session live, never an older build of the same tree.
+    #[test]
+    fn a_live_root_revives_only_its_newest_session() {
+        let events = vec![
+            event("a", EventResult::Miss, 0, "/w", "old"),
+            event("b", EventResult::Miss, 5_000, "/w", "new"),
+        ];
+        let live: HashSet<String> = ["/w".to_string()].into_iter().collect();
+        let sessions = group_sessions(&events, ts(10_000), &live, gap());
+        assert_eq!(sessions[0].key, "id:new");
+        assert_eq!(sessions[0].state, SessionState::Live);
+        assert_eq!(sessions[1].key, "id:old");
+        assert_eq!(sessions[1].state, SessionState::Finished);
+    }
+
+    #[test]
+    fn recent_activity_alone_keeps_a_session_live_but_the_future_does_not() {
+        let events = vec![event("a", EventResult::Miss, 0, "/w", "s1")];
+        let sessions = group_sessions(&events, ts(10), &no_live(), gap());
+        assert_eq!(sessions[0].state, SessionState::Live);
+        let sessions = group_sessions(&events, ts(30), &no_live(), gap());
+        assert_eq!(
+            sessions[0].state,
+            SessionState::Finished,
+            "the grace is exclusive"
+        );
+        // Stamped 10s in the future: a clock problem, not a running build.
+        let sessions = group_sessions(&events, ts(-10), &no_live(), gap());
+        assert_eq!(sessions[0].state, SessionState::Finished);
+    }
+
+    #[test]
+    fn events_without_ids_split_by_idle_gap_per_root() {
+        let events = vec![
+            event("a", EventResult::Miss, 0, "/w", ""),
+            event("b", EventResult::Miss, 100, "/w", ""),
+            event("x", EventResult::Miss, 150, "/other", ""),
+            // 299s after b: still the same build.
+            event("b2", EventResult::Miss, 399, "/w", ""),
+            // 300s after b2: a new build of /w (the gap is "at least").
+            event("c", EventResult::LocalHit, 699, "/w", ""),
+            event("d", EventResult::LocalHit, 700, "/w", ""),
+        ];
+        let sessions = group_sessions(&events, ts(10_000), &no_live(), gap());
+        assert_eq!(sessions.len(), 3);
+        assert!(sessions.iter().all(|s| s.inferred));
+        assert!(sessions.iter().all(|s| s.recorded_id().is_none()));
+        let keys: Vec<&str> = sessions.iter().map(|s| s.key.as_str()).collect();
+        assert_eq!(
+            keys.len(),
+            keys.iter().collect::<HashSet<_>>().len(),
+            "keys are unique"
+        );
+        assert_eq!(sessions[0].events, vec![4, 5], "newest first");
+        assert_eq!(
+            sessions[0].started,
+            ts(699) - chrono::Duration::milliseconds(100)
+        );
+        assert_eq!(sessions[1].events, vec![0, 1, 3], "last active at 399s");
+        assert_eq!(sessions[2].events, vec![2], "last active at 150s");
+    }
+
+    #[test]
+    fn keys_are_stable_as_the_log_grows_and_ties_follow_log_order() {
+        let mut events = vec![
+            event("a", EventResult::Miss, 0, "/w", ""),
+            event("x", EventResult::Miss, 1, "/other", ""),
+        ];
+        let before: Vec<String> = group_sessions(&events, ts(2), &no_live(), gap())
+            .into_iter()
+            .map(|s| s.key)
+            .collect();
+        events.push(event("b", EventResult::Miss, 2, "/w", ""));
+        events.push(event("c", EventResult::Miss, 900, "/w", ""));
+        let after: Vec<String> = group_sessions(&events, ts(901), &no_live(), gap())
+            .into_iter()
+            .map(|s| s.key)
+            .collect();
+        for key in &before {
+            assert!(after.contains(key), "{key} vanished: {after:?}");
+        }
+        assert_eq!(after.len(), 3);
+
+        // Same timestamp, two sessions: the one that logged last is newest.
+        let events = vec![
+            event("a", EventResult::Miss, 5, "/w", "zzz"),
+            event("b", EventResult::Miss, 5, "/w", "aaa"),
+        ];
+        let sessions = group_sessions(&events, ts(10_000), &no_live(), gap());
+        assert_eq!(sessions[0].key, "id:aaa");
+    }
+
+    /// Regrouping only when the log grew, and refreshing state every tick,
+    /// gives the same answer as grouping from scratch.
+    #[test]
+    fn refresh_state_matches_a_fresh_grouping() {
+        let events = vec![
+            event("a", EventResult::Miss, 0, "/w", "s1"),
+            event("b", EventResult::Miss, 100, "/v", "s2"),
+        ];
+        let mut cached = group(&events, gap());
+        refresh_state(&mut cached, ts(101), &no_live());
+        assert_eq!(cached, group_sessions(&events, ts(101), &no_live(), gap()));
+        // Later, s1's root is compiling: it moves back to the top.
+        let live: HashSet<String> = ["/w".to_string()].into_iter().collect();
+        refresh_state(&mut cached, ts(5_000), &live);
+        assert_eq!(cached, group_sessions(&events, ts(5_000), &live, gap()));
+        assert_eq!(cached[0].key, "id:s1");
+    }
+
+    #[test]
+    fn tally_separates_probes_rates_only_lookups_and_saturates() {
+        let mut t = Tally::default();
+        let mut probe = event("rustc", EventResult::Passthrough, 0, "/w", "s");
+        probe.passthrough_reason = "not-a-compile|--print cfg".to_string();
+        let mut pass = event("cc", EventResult::Passthrough, 0, "/w", "s");
+        pass.passthrough_reason = "unsupported|cc flag -march".to_string();
+        t.add(&probe);
+        t.add(&pass);
+        assert_eq!((t.probes, t.passthroughs), (1, 1));
+        assert_eq!(t.hit_rate(), None, "no lookups, no rate");
+        assert_eq!(t.overhead_ms, 0, "passthroughs are not overhead");
+        assert_eq!(t.overhead_share(), None);
+        let mut hit = event("a", EventResult::LocalHit, 0, "/w", "s");
+        hit.reflinked_bytes = 900;
+        hit.copied_bytes = 100;
+        t.add(&hit);
+        t.add(&event("b", EventResult::Dup, 0, "/w", "s"));
+        assert_eq!(t.hit_rate(), Some(50.0));
+        assert_eq!(t.copy_share(), Some(10.0));
+        assert_eq!(t.restored_bytes(), 1000);
+        // A hit's whole elapsed time is overhead; the dup's 100ms elapsed
+        // minus 1000ms compile clamps to zero.
+        assert_eq!(t.overhead_ms, 100);
+        assert_eq!(t.lookup_elapsed_ms, 200);
+        assert_eq!(t.overhead_share(), Some(50.0));
+
+        let mut huge = event("z", EventResult::LocalHit, 0, "/w", "s");
+        huge.compile_time_ms = u64::MAX;
+        t.add(&huge);
+        t.add(&huge);
+        assert_eq!(t.saved_ms, u64::MAX, "saturated, not wrapped");
+        assert_eq!(
+            Tally::default().copy_share(),
+            None,
+            "nothing restored, no share"
+        );
+    }
+
+    fn analyze_one(events: &[BuildEvent]) -> Analysis {
+        let sessions = group_sessions(events, ts(1_000_000), &no_live(), gap());
+        let selected = sessions.iter().find(|s| s.key == "id:now").unwrap();
+        analyze_session(events, selected, &sessions)
+    }
+
+    #[test]
+    fn causes_follow_why_miss_precedence() {
+        let mut store_failed = event("sf", EventResult::Miss, 100, "/w", "now");
+        store_failed.store_error = "disk full".to_string();
+        store_failed.key_diff = vec!["sources".to_string()];
+        let mut rejected = event("rj", EventResult::Miss, 101, "/w", "now");
+        rejected.lookup_rejection = "artifact set incomplete".to_string();
+        let mut own = event("own", EventResult::Miss, 102, "/w", "now");
+        own.key_diff = vec![
+            "sources".to_string(),
+            "args".to_string(),
+            "sources".to_string(),
+        ];
+        let mut unknown_root = event("nowhere", EventResult::Miss, 106, "", "now");
+        unknown_root.root.clear();
+        let events = vec![
+            event("seen", EventResult::LocalHit, 0, "/w", "before"),
+            // A real passthrough compile counts as history; a probe does not.
+            {
+                let mut e = event("passed", EventResult::Passthrough, 1, "/w", "before");
+                e.passthrough_reason = "unsupported|flag".to_string();
+                e
+            },
+            {
+                let mut e = event("probed", EventResult::Passthrough, 2, "/w", "before");
+                e.passthrough_reason = "not-a-compile|--print".to_string();
+                e
+            },
+            store_failed,
+            rejected,
+            own,
+            event("first", EventResult::Miss, 103, "/w", "now"),
+            event("seen", EventResult::Miss, 104, "/w", "now"),
+            event("passed", EventResult::Miss, 105, "/w", "now"),
+            event("probed", EventResult::Miss, 105, "/w", "now"),
+            unknown_root,
+        ];
+        let analysis = analyze_one(&events);
+        let by_cause: BTreeMap<&Cause, usize> = analysis
+            .causes
+            .iter()
+            .map(|g| (&g.cause, g.count))
+            .collect();
+        assert_eq!(by_cause[&Cause::StoreFailed("disk full".into())], 1);
+        assert_eq!(
+            by_cause[&Cause::LookupRejected("artifact set incomplete".into())],
+            1
+        );
+        assert_eq!(
+            by_cause[&Cause::OwnInputs(vec!["args".into(), "sources".into()])],
+            1
+        );
+        let examples = |cause: &Cause| -> Vec<String> {
+            analysis
+                .causes
+                .iter()
+                .find(|g| &g.cause == cause)
+                .map(|g| g.examples.clone())
+                .unwrap_or_default()
+        };
+        assert_eq!(by_cause[&Cause::NoHistory], 2, "{by_cause:?}");
+        assert_eq!(
+            examples(&Cause::NoHistory),
+            vec!["first", "probed"],
+            "a probe is not a prior compile"
+        );
+        assert_eq!(by_cause[&Cause::Unexplained], 3, "{by_cause:?}");
+        assert_eq!(
+            examples(&Cause::Unexplained),
+            vec!["seen", "passed", "nowhere"],
+            "a real passthrough compile is; an unknown root is never a first build"
+        );
+        assert_eq!(analysis.misses_total, 8);
+        assert!(!analysis.cascade_recorded);
+        assert!(Cause::StoreFailed(String::new()).is_failure());
+        assert!(!Cause::NoHistory.is_failure());
+        assert_eq!(
+            Cause::NoHistory.describe(),
+            "no earlier compile in the loaded history"
+        );
+    }
+
+    fn with_externs(mut e: BuildEvent, externs: &[(&str, &str)]) -> BuildEvent {
+        e.key_externs = externs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        e.key_externs_recorded = true;
+        e
+    }
+
+    fn with_fields(mut e: BuildEvent, fields: &[(&str, &str)]) -> BuildEvent {
+        e.key_fields = fields
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        e
+    }
+
+    /// Forty crates downstream of one changed leaf collapse to one cause
+    /// naming the leaf, and the leaf itself is its own cause.
+    #[test]
+    fn a_cascade_collapses_to_its_root() {
+        let mut events = vec![with_fields(
+            with_externs(event("leaf", EventResult::LocalHit, 0, "/w", "before"), &[]),
+            &[("sources", "1111")],
+        )];
+        for i in 0..40 {
+            events.push(with_externs(
+                event(&format!("app{i}"), EventResult::LocalHit, 1, "/w", "before"),
+                &[("leaf", "aaaa")],
+            ));
+        }
+        let mut leaf_miss = with_fields(
+            with_externs(event("leaf", EventResult::Miss, 100, "/w", "now"), &[]),
+            &[("sources", "2222")],
+        );
+        leaf_miss.key_diff = vec!["sources".to_string()];
+        events.push(leaf_miss);
+        for i in 0..40 {
+            events.push(with_externs(
+                event(&format!("app{i}"), EventResult::Miss, 101, "/w", "now"),
+                &[("leaf", "bbbb")],
+            ));
+        }
+        let analysis = analyze_one(&events);
+        assert!(analysis.cascade_recorded);
+        assert_eq!(analysis.misses_total, 41);
+        assert_eq!(analysis.causes.len(), 2, "{:?}", analysis.causes);
+        assert_eq!(
+            analysis.causes[0].cause,
+            Cause::Downstream {
+                root: "leaf".into(),
+                complete: true
+            }
+        );
+        assert_eq!(analysis.causes[0].count, 40);
+        assert_eq!(analysis.causes[0].examples, vec!["app0", "app1", "app2"]);
+        assert_eq!(
+            analysis.causes[1].cause,
+            Cause::OwnInputs(vec!["sources".into()])
+        );
+        assert_eq!(analysis.causes[0].cause.describe(), "downstream of leaf");
+    }
+
+    /// A miss below two changed leaves names both, not the first one the
+    /// walk happened to rank higher.
+    #[test]
+    fn a_cascade_with_two_roots_names_both() {
+        let leaf = |name: &str, result, at, session, sources: &str| {
+            with_fields(
+                with_externs(event(name, result, at, "/w", session), &[]),
+                &[("sources", sources)],
+            )
+        };
+        let events = vec![
+            leaf("alpha", EventResult::LocalHit, 0, "before", "a1"),
+            leaf("beta", EventResult::LocalHit, 1, "before", "b1"),
+            with_externs(
+                event("app", EventResult::LocalHit, 2, "/w", "before"),
+                &[("alpha", "aaaa"), ("beta", "bbbb")],
+            ),
+            leaf("alpha", EventResult::Miss, 100, "now", "a2"),
+            leaf("beta", EventResult::Miss, 101, "now", "b2"),
+            with_externs(
+                event("app", EventResult::Miss, 102, "/w", "now"),
+                &[("alpha", "aaa2"), ("beta", "bbb2")],
+            ),
+        ];
+        let analysis = analyze_one(&events);
+        let downstream = analysis
+            .causes
+            .iter()
+            .find(|g| matches!(g.cause, Cause::Downstream { .. }))
+            .unwrap_or_else(|| panic!("{:?}", analysis.causes));
+        assert_eq!(
+            downstream.cause,
+            Cause::Downstream {
+                root: "alpha, beta".into(),
+                complete: true
+            }
+        );
+    }
+
+    /// A cascade whose walk dead-ends says so rather than naming the one
+    /// endpoint it reached as the whole explanation.
+    #[test]
+    fn an_unresolved_cascade_is_not_presented_as_complete() {
+        // `dep` changed, but has no compile of its own in the window: the
+        // walk reaches it and cannot explain it.
+        let events = vec![
+            with_externs(
+                event("app", EventResult::LocalHit, 0, "/w", "before"),
+                &[("dep", "aaaa")],
+            ),
+            with_externs(
+                event("app", EventResult::Miss, 100, "/w", "now"),
+                &[("dep", "bbbb")],
+            ),
+        ];
+        let analysis = analyze_one(&events);
+        assert_eq!(analysis.causes.len(), 1);
+        match &analysis.causes[0].cause {
+            Cause::Downstream { root, complete } => {
+                assert_eq!(root, "dep");
+                assert!(!complete);
+            }
+            other => panic!("{other:?}"),
+        }
+        assert!(
+            analysis.causes[0]
+                .cause
+                .describe()
+                .contains("not fully resolved")
+        );
+    }
+
+    /// The recording flag describes the whole session, not the analyzed
+    /// sample, so a capped analysis never tells a user to switch on what
+    /// they already have.
+    #[test]
+    fn cascade_recorded_looks_past_the_cap() {
+        let mut events = vec![with_externs(
+            event("first", EventResult::Miss, 0, "/w", "now"),
+            &[],
+        )];
+        for i in 1..=MAX_ANALYZED_MISSES {
+            events.push(event(
+                &format!("c{i}"),
+                EventResult::Miss,
+                i as i64,
+                "/w",
+                "now",
+            ));
+        }
+        let analysis = analyze_one(&events);
+        assert_eq!(analysis.misses_analyzed, MAX_ANALYZED_MISSES);
+        assert_eq!(analysis.misses_total, MAX_ANALYZED_MISSES + 1);
+        assert!(analysis.cascade_recorded);
+    }
+
+    #[test]
+    fn passthroughs_rank_compiles_before_probes() {
+        let mut probe = event("rustc", EventResult::Passthrough, 100, "/w", "now");
+        probe.passthrough_reason = "not-a-compile|--print cfg".to_string();
+        let mut cc = event("cc", EventResult::Passthrough, 101, "/w", "now");
+        cc.passthrough_reason = "unsupported|cc flag -march".to_string();
+        let mut legacy = event("old", EventResult::Passthrough, 102, "/w", "now");
+        legacy.passthrough_reason = "refused: linker invocation".to_string();
+        let events = vec![probe.clone(), probe.clone(), probe, cc, legacy];
+        let analysis = analyze_one(&events);
+        let listed: Vec<(&str, &str, usize, bool)> = analysis
+            .passthroughs
+            .iter()
+            .map(|g| (g.kind.as_str(), g.reason.as_str(), g.count, g.probe))
+            .collect();
+        assert_eq!(
+            listed,
+            vec![
+                ("unsupported", "cc flag -march", 1, false),
+                ("", "linker invocation", 1, false),
+                ("not-a-compile", "--print cfg", 3, true),
+            ]
+        );
+        assert_eq!(passthrough_parts(""), ("", "unknown"));
+    }
+
+    /// Chronic misses are per tree, count only builds that looked the crate
+    /// up, and take "latest" from log order, which session order is not.
+    #[test]
+    fn chronic_misses_need_repeats_across_builds_of_one_tree() {
+        let mut events = Vec::new();
+        for (n, session) in ["s1", "s2", "s3", "s4"].iter().enumerate() {
+            let at = n as i64 * 1000;
+            events.push(event("flaky", EventResult::Miss, at, "/w", session));
+            events.push(event("stable", EventResult::LocalHit, at, "/w", session));
+            let mut broken = event("broken", EventResult::Miss, at, "/w", session);
+            if n >= 2 {
+                broken.store_error = "read-only store".to_string();
+            }
+            events.push(broken);
+            if n == 0 {
+                events.push(event("once", EventResult::Miss, at, "/w", session));
+            }
+            // Missed twice with a failure, then recovered: not chronic.
+            let mut healed = event("healed", EventResult::Miss, at, "/w", session);
+            if n < 2 {
+                healed.store_error = "disk full".to_string();
+            } else {
+                healed.result = EventResult::LocalHit;
+                healed.compile_time_ms = 5_000;
+            }
+            events.push(healed);
+            // Looked up only by probes in later builds: those builds never
+            // tried the cache for it, so they do not dilute its count.
+            let mut queried = event("queried", EventResult::Miss, at, "/w", session);
+            if n >= 3 {
+                queried.result = EventResult::Passthrough;
+                queried.passthrough_reason = "not-a-compile|--print".to_string();
+            }
+            events.push(queried);
+        }
+        // Missed twice, the latest with a store failure: chronic on that
+        // ground alone. Missed once with a failure: not yet.
+        for session in ["s3", "s4"] {
+            let mut twice = event("twice", EventResult::Miss, 8_000, "/w", session);
+            twice.store_error = "disk full".to_string();
+            events.push(twice);
+        }
+        let mut once_failed = event("once_failed", EventResult::Miss, 8_500, "/w", "s4");
+        once_failed.store_error = "disk full".to_string();
+        events.push(once_failed);
+        // A later query for a failed crate is not a lookup: it must not
+        // clear the failure flag.
+        let mut queried_broken = event("broken", EventResult::Passthrough, 8_700, "/w", "s4");
+        queried_broken.passthrough_reason = "not-a-compile|--print".to_string();
+        events.push(queried_broken);
+        // The same crate missing in three other trees is their problem.
+        for (n, root) in ["/a", "/b", "/c"].iter().enumerate() {
+            events.push(event(
+                "elsewhere",
+                EventResult::Miss,
+                9_000 + n as i64,
+                root,
+                "x",
+            ));
+        }
+        let sessions = group_sessions(&events, ts(1_000_000), &no_live(), gap());
+        let selected = sessions.iter().find(|s| s.key == "id:s4").unwrap();
+        let analysis = analyze_session(&events, selected, &sessions);
+        let names: Vec<(&str, usize, usize, bool)> = analysis
+            .chronic
+            .iter()
+            .map(|c| (c.crate_name.as_str(), c.missed, c.seen, c.last_store_failed))
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                ("broken", 4, 4, true),
+                ("twice", 2, 2, true),
+                ("flaky", 4, 4, false),
+                ("queried", 3, 3, false),
+            ],
+            "once, once_failed, stable, healed, and elsewhere are not chronic"
+        );
+        // A session with no root has nothing to compare against.
+        let mut rootless = event("r", EventResult::Miss, 1, "", "nr");
+        rootless.root.clear();
+        let events = vec![rootless];
+        let sessions = group_sessions(&events, ts(1_000_000), &no_live(), gap());
+        assert!(
+            analyze_session(&events, &sessions[0], &sessions)
+                .chronic
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn analysis_caps_the_walk_and_says_so() {
+        let mut events = Vec::new();
+        for i in 0..(MAX_ANALYZED_MISSES + 10) {
+            events.push(event(
+                &format!("c{i}"),
+                EventResult::Miss,
+                i as i64,
+                "/w",
+                "now",
+            ));
+        }
+        let analysis = analyze_one(&events);
+        assert_eq!(analysis.misses_total, MAX_ANALYZED_MISSES + 10);
+        assert_eq!(analysis.misses_analyzed, MAX_ANALYZED_MISSES);
+    }
+}


### PR DESCRIPTION
Stacked on #980; retarget to `main` once that lands.

## What

The Build tab was one flat stream across every workspace and every cargo invocation on the machine. It now lists builds (every event sharing the wrapper's per-build session id; older events are grouped by root at idle gaps, as `kache report` does), running ones first, newest on top, and shows the selected build's events. Up/Down pick a build, Enter opens Why for it, and above the top row is "following the top build", where the monitor starts.

The new Why tab replaces Passthrough. It collapses the selected build's misses to their causes in `why-miss` precedence: a failed store or a rejected lookup first (a caching failure to fix), then a recorded dependency cascade walked with `miss_chain` so forty downstream misses read as one line naming the crates that changed, then the crate's own changed key groups, then no earlier compile in the loaded history, then unexplained with a note on what to switch on. Passthroughs are grouped by reason with queries kept apart from compiles, crates that keep missing across builds of the same tree are listed as chronic, and every passthrough in the build is listed at the end. The whole tab is one scrollable body.

Both tabs carry the build's cost strip: compile time saved, compile time in misses, and kache's own overhead as a share of lookup time, plus the restore mix when copies show up.

## How

The grouping and the analysis are pure functions in `src/tui_sessions.rs` over the events the monitor already holds. Grouping is redone only when the log grew; live state and order are refreshed every tick. The analysis is cached per (build, event count), capped at the newest 400 misses (and says so), and uses one prefix index for the history test instead of a scan per miss.

Every figure describes the loaded history: with `--since`, a crate whose last compile is before the cutoff reads as having no earlier compile.

## Tests

Unit tests on the module for grouping, key stability, live state, tie order, the tally arithmetic, cause precedence, single- and multi-root cascades, unresolved cascades, the analysis cap, and chronic misses. Monitor tests for picking a build, the pin surviving reorders, both panels resetting on a build change while rows of the same build keep a scrolled reader in place, and the Why body rendered at 80 and 120 columns.

`just check` is green locally.
