### PR TITLE
Catch hardcoded runners in workflow policy tests

### DIFF
--- a/.github/tests/package.json
+++ b/.github/tests/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node workflow-policy.mjs ../.."
+    "test": "node workflow-policy.mjs ../.. && node --test workflow-policy.test.mjs"
   },
   "devDependencies": {
     "@actions/expressions": "0.3.61",

--- a/.github/tests/workflow-policy.mjs
+++ b/.github/tests/workflow-policy.mjs
@@ -87,18 +87,46 @@ const privateRepos = [
   "kunobi-ninja/example",
   "contributor/example",
 ];
+// Publication-only workflows and measurement pools have separate checks below.
+// Discover every other runner, even if its expression loses CI_RUNNER_*.
+const publicationWorkflows = new Set([
+  "package-publish.yml",
+  "publish-crates.yaml",
+]);
+const measurementJobs = new Set([
+  "bench.yml:bench",
+  "bench.yml:bench-firefox-windows",
+  "bench.yml:bench-firefox-pull-windows",
+  "perf-gate.yml:measure",
+]);
 const routing = [];
 for (const [file, workflow] of Object.entries(files)) {
+  if (publicationWorkflows.has(file)) continue;
   for (const [id, job] of Object.entries(workflow.jobs)) {
-    if (job["runs-on"]?.includes("CI_RUNNER_"))
-      routing.push([`${file}:${id}`, job["runs-on"]]);
-    for (const row of job.strategy?.matrix?.include || []) {
-      if (row.runner?.includes("CI_RUNNER_"))
-        routing.push([`${file}:${id}:${row.os}`, row.runner]);
+    const name = `${file}:${id}`;
+    if (measurementJobs.has(name) || job.uses) continue;
+    assert(Object.hasOwn(job, "runs-on"), `${name} must select a runner`);
+    if (/^\$\{\{\s*matrix\.runner\s*\}\}$/.test(job["runs-on"])) {
+      const rows = job.strategy?.matrix?.include;
+      assert(rows?.length, `${name} must declare its runner matrix`);
+      for (const row of rows) {
+        assert(
+          Object.hasOwn(row, "runner"),
+          `${name}:${row.os} needs a runner`,
+        );
+        routing.push([`${name}:${row.os}`, row.runner]);
+      }
+    } else {
+      routing.push([name, job["runs-on"]]);
     }
   }
 }
-assert(routing.length >= 24);
+assert(routing.length > 0);
+function resolveRunner(source, context) {
+  return typeof source === "string" && source.trim().startsWith("${{")
+    ? evaluate(source, context)
+    : source;
+}
 for (const [name, expression] of routing) {
   const os = /:(test-macos|macOS)$/.test(name)
     ? "MACOS"
@@ -116,12 +144,12 @@ for (const [name, expression] of routing) {
         }[os];
   for (const repository of publicRepos) {
     eq(
-      evaluate(expression, context(repository, false)),
+      resolveRunner(expression, context(repository, false)),
       hosted,
       `${name} public default`,
     );
     eq(
-      evaluate(expression, context(repository, false, privateVars)),
+      resolveRunner(expression, context(repository, false, privateVars)),
       hosted,
       `${name} ignores private overrides in public`,
     );
@@ -129,26 +157,26 @@ for (const [name, expression] of routing) {
   const forkPr = context("kunobi-ninja/kache", false, privateVars);
   forkPr.github.event.pull_request.head.repo.full_name = "contributor/example";
   eq(
-    evaluate(expression, forkPr),
+    resolveRunner(expression, forkPr),
     hosted,
     `${name} external fork PR remains hosted`,
   );
   for (const repository of privateRepos) {
     eq(
-      evaluate(expression, context(repository, true, privateVars)),
+      resolveRunner(expression, context(repository, true, privateVars)),
       JSON.parse(privateVars[platform]),
       `${name} private configured`,
     );
     checks++;
     assert.throws(
-      () => evaluate(expression, context(repository, true)),
+      () => resolveRunner(expression, context(repository, true)),
       undefined,
       `${name} missing private selector`,
     );
     checks++;
     assert.throws(
       () =>
-        evaluate(
+        resolveRunner(
           expression,
           context(repository, true, {
             ...privateVars,

--- a/.github/tests/workflow-policy.test.mjs
+++ b/.github/tests/workflow-policy.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { parse, stringify } from "yaml";
+
+const root = fileURLToPath(new URL("../../", import.meta.url));
+const checker = fileURLToPath(new URL("workflow-policy.mjs", import.meta.url));
+
+const regressions = [
+  [
+    "a validation job hardcodes a hosted runner",
+    (ci) => {
+      ci.jobs.check["runs-on"] = "ubuntu-latest";
+    },
+  ],
+  [
+    "a matrix entry hardcodes a hosted runner",
+    (ci) => {
+      ci.jobs.e2e.strategy.matrix.include.find(
+        (row) => row.os === "Windows",
+      ).runner = "windows-latest";
+    },
+  ],
+  [
+    "a job bypasses its configured runner matrix",
+    (ci) => {
+      ci.jobs.e2e["runs-on"] = "ubuntu-latest";
+    },
+  ],
+  [
+    "a new helper job hardcodes a hosted runner",
+    (ci) => {
+      ci.jobs["new-helper"] = {
+        "runs-on": "ubuntu-latest",
+        steps: [{ run: "true" }],
+      };
+    },
+  ],
+];
+
+for (const [name, mutate] of regressions) {
+  test(name, () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "kache-policy-"));
+    try {
+      fs.cpSync(
+        path.join(root, ".github/workflows"),
+        path.join(fixture, ".github/workflows"),
+        { recursive: true },
+      );
+      const ciPath = path.join(fixture, ".github/workflows/ci.yml");
+      const ci = parse(fs.readFileSync(ciPath, "utf8"));
+      mutate(ci);
+      fs.writeFileSync(ciPath, stringify(ci));
+
+      const result = spawnSync(process.execPath, [checker, fixture], {
+        encoding: "utf8",
+        timeout: 10_000,
+      });
+      assert.ifError(result.error);
+      assert.equal(result.status, 1, result.stdout + result.stderr);
+      assert.match(result.stderr, /AssertionError.*private configured/);
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
The runner policy suite discovered jobs only when their selector still contained `CI_RUNNER_*`. Replacing a selector with `ubuntu-latest` removed that job from validation, so the suite passed despite routing private builds to hosted runners. It also missed matrix entries, a job bypassing its matrix, and newly added helpers.

Discover every validation job from the workflow structure and check literal selectors as well as expressions. Publication-only workflows and measurement pools retain their separate checks. Four regression tests exercise the checker against modified workflow copies; all four passed incorrectly before this fix and are now rejected for violating private routing.

Validation:

- 493 existing policy assertions pass.
- All four regression tests pass.
- `just check`: formatting, clippy, and 3,248 passing workspace tests.
- [GitHub CI](https://github.com/kunobi-ninja/kache/actions/runs/34116803130) passed, including all eight required checks. Core and service mutation checks tested 209 mutants: 135 caught, 74 unviable, none missed.

The advisory performance check first reported [warm time +11.6%](https://github.com/kunobi-ninja/kache/actions/runs/34118205858/job/101729931617), above the 5% limit. A single independent repeat on the same head [passed at -2.7%](https://github.com/kunobi-ninja/kache/actions/runs/34118205858/job/101734711423). Source trees, manifests, lockfile, toolchain, scripts, and scenarios are identical between base and head; only the three workflow-test files differ. The two results point to measurement variability without identifying its cause.

Refs #975.
