### PR TITLE
chore(ci): bump the release workflow pin to the re-synced mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1256,7 +1256,7 @@ jobs:
     # The signing-runners allowlist pins THIS SHA. Bumping the pin without
     # updating that group's selected_workflows breaks releases SILENTLY — move
     # both in one change; the mirror's README has the one-liner.
-    uses: kunobi-ninja/_workflows/.github/workflows/_release-rust.yml@ee8dc66895f75bf79c8fa4c87e06aaeb752e7db5 # v1
+    uses: kunobi-ninja/_workflows/.github/workflows/_release-rust.yml@b43559c8bc0fc6fee5f22e48989e350df823d4db # v2
     with:
       binary_name: kache
       # Build .deb assets (kache_<version>_{amd64,arm64}.deb) for the apt repo,


### PR DESCRIPTION
Bumps `_release-rust.yml` from `@ee8dc66` (v1) to `@b43559c8` (v2).

## What that brings

[kunobi-ninja/_workflows#1](https://github.com/kunobi-ninja/_workflows/pull/1) re-syncs the mirror from `Zondax/_workflows@08a71c7`:

| upstream | change |
| --- | --- |
| Zondax#129 | `actions/download-artifact@v7` → `@v8` |
| [Zondax#132](https://github.com/Zondax/_workflows/pull/132) | the release job attaches its own artifacts, not the whole run's |

The release job downloaded **every** artifact the run produced. The build matrix uploads exactly one name, `<binary_name>-<target>`; anything else belongs to another job. `gh release upload "$TAG_NAME" artifacts/*` cannot post a directory, and a swept-in diagnostic artifact unpacks into one — so the step fails with the release **already drafted** and its binaries **unattached**.

This repo uploads diagnostics from the same run that releases, so it is exposed. kobe v0.43.0 is the worked example: images and chart published, all six CLI targets built, and the release page got four assets — two of them `kind-version.txt` and `docker-info.txt` — then stayed a draft.

## The allowlist moved with it

Per the mirror's maintenance contract the pin and the `signing-runners` allowlist are one change; bumping only one queues the Darwin signing jobs forever with no error anywhere, which is the `v0.14.0` outage the mirror was created to end.

Runner group 3 has already been PATCHed to the same SHA, preserving all four entries:

```
kunobi-ninja/_workflows/.github/workflows/_release-rust.yml@b43559c8bc0fc6fee5f22e48989e350df823d4db
kunobi-ninja/kache/.github/workflows/bench.yml@refs/heads/main
kunobi-ninja/kache/.github/workflows/ci.yml@refs/heads/main
kunobi-ninja/kobe/.github/workflows/ci.yml@refs/heads/main
```

Worth flagging: the README's example PATCH command lists only three entries and omits `kunobi-ninja/kobe/.github/workflows/ci.yml`. Since the API replaces the whole list, running it verbatim would silently drop kobe's access. The live list above is what was sent.

## Verification

Signing runners are only exercised by the release path, so ordinary CI proves nothing here. The mirror's contract says to verify with `_probe-macos.yml` on a `probe/**` branch rather than an `-rc` tag, which would publish to crates.io permanently. That probe is worth running before the next release rather than after.