### PR TITLE
chore(release): prepare 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "kache"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "kache-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "kache-e2e"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "kache-format"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "kache-fs"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "libc",
  "serde",
@@ -2004,11 +2004,11 @@ dependencies = [
 
 [[package]]
 name = "kache-proofs"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "kache-service"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "kache-store"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 description = "Zero-copy, content-addressed build cache for Rust, C/C++ and more, with S3 and shared-filesystem remotes."
 license = "Apache-2.0"
@@ -35,8 +35,8 @@ exclude = ["tmp"]
 resolver = "3"
 
 [dependencies]
-kache-format = { version = "0.17.0", path = "crates/kache-format" }
-kache-store = { version = "0.17.0", path = "crates/kache-store" }
+kache-format = { version = "0.18.0", path = "crates/kache-format" }
+kache-store = { version = "0.18.0", path = "crates/kache-store" }
 blake3 = "1"
 bytes = "1"
 # OpenDAL 0.58 publishes its modules as separate crates. Depending on only the
@@ -54,7 +54,7 @@ reqsign-aws-v4 = { version = "=3.3.0", default-features = false }
 reqsign-core = { version = "=3.3.1", default-features = false }
 # Direct dep so OpenDAL/reqwest can use ring without reintroducing aws-lc.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-kache-core = { version = "0.17.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
+kache-core = { version = "0.18.0", path = "crates/kache-core", default-features = false, features = ["planning"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "fs", "io-util", "net", "time", "signal", "sync"] }
 serde = { version = "1", features = ["derive"] }
@@ -111,7 +111,7 @@ windows-sys = { version = "0.61", features = [
 ] }
 
 [dev-dependencies]
-kache-store = { version = "0.17.0", path = "crates/kache-store", features = ["test-support"] }
+kache-store = { version = "0.18.0", path = "crates/kache-store", features = ["test-support"] }
 assert_cmd = "2"
 axum = "0.8"
 predicates = "3"

--- a/crates/kache-core/Cargo.toml
+++ b/crates/kache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-core"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 description = "Core planner data structures and algorithms for kache."
 license = "Apache-2.0"

--- a/crates/kache-e2e/Cargo.toml
+++ b/crates/kache-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-e2e"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/kunobi-ninja/kache"

--- a/crates/kache-format/Cargo.toml
+++ b/crates/kache-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-format"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Cache-entry metadata and validation for kache."

--- a/crates/kache-fs/Cargo.toml
+++ b/crates/kache-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-fs"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Filesystem measurements, file identity, native cloning and copying."

--- a/crates/kache-proofs/Cargo.toml
+++ b/crates/kache-proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-proofs"
-version = "0.17.0"
+version = "0.18.0"
 publish = false
 edition = "2024"
 description = "Repository-only formal verification harnesses for kache."

--- a/crates/kache-service/Cargo.toml
+++ b/crates/kache-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-service"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 description = "Remote service shell for kache planner endpoints"
 license = "Apache-2.0"

--- a/crates/kache-store/Cargo.toml
+++ b/crates/kache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kache-store"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Local content-addressed artifact storage for kache."
@@ -11,8 +11,8 @@ repository = "https://github.com/kunobi-ninja/kache"
 test-support = []
 
 [dependencies]
-kache-format = { version = "0.17.0", path = "../kache-format" }
-kache-fs = { version = "0.17.0", path = "../kache-fs", features = ["staging"] }
+kache-format = { version = "0.18.0", path = "../kache-format" }
+kache-fs = { version = "0.18.0", path = "../kache-fs", features = ["staging"] }
 anyhow = "1"
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }

--- a/packaging/charts/kache-service/Chart.yaml
+++ b/packaging/charts/kache-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kache-service
 description: Advisory remote planner service for kache
 type: application
-version: 0.17.0
-appVersion: "0.17.0"
+version: 0.18.0
+appVersion: "0.18.0"
 keywords:
   - rust
   - cache


### PR DESCRIPTION
## Summary

Prepare Kache 0.18.0 with the changes merged since v0.17.0:

- Group the monitor by build and explain each build's cache misses in the Why tab (#981).
- Fix Ctrl+C and add paging, pause/resume, mouse navigation and a time-based lookup history (#980).
- Cap compressed v3 remote downloads before extraction (#979).
- Improve release publication and CI support for forks (#977, #975, #982, #983).

This PR updates workspace versions, local dependency pins, Cargo.lock and the Helm chart. Registry dependency versions are unchanged. The new monitor behavior warrants a minor release.

After merge, run `just release` from a clean main checkout at the merged commit. The tag starts the gated binary, crates.io, image, chart and package publication workflows.

## Test plan

- [x] `just bump 0.18.0`: workspace check and version consistency passed.
- [x] Verified that all five crates already have Trusted Publishing configured.
- [x] `just pr origin/main`: formatting, clippy, resource-guard checks and workspace tests.
- [x] `git diff --check`; lockfile changes are limited to workspace package versions.

## Checklist

- [x] `just pr` passes locally.
- [x] Conventional commit; this PR changes version metadata only.
- [x] User-visible features and fixes are documented in their merged PRs.

Local checks ran with process inspection available. The sandbox denies `/bin/ps` and caused three process-introspection tests to fail on the first pass; the complete unsandboxed pass succeeded. Changed-line mutants were skipped because this PR changes no Rust source.
