### PR TITLE
fix(init): configure compiler PATH and clarify setup prompts

### DIFF
--- a/docs/getting-started/c-cpp.mdx
+++ b/docs/getting-started/c-cpp.mdx
@@ -15,14 +15,22 @@ PATH shims also cover Cargo's C bits when the crate invokes `cc` or `gcc` from `
 
 ## Make, CMake, autotools, PKGBUILD
 
-The Unix path is the same idea as ccache's masquerade method: put a directory of compiler-named symlinks first on `PATH`. `make`, CMake, autotools, and Arch PKGBUILDs that call `gcc` or `clang` by name then go through Kache. There is no `CC=` edit and no shell wrapper.
+Run `kache init` to enable C/C++ caching for terminal builds on Unix. It creates compiler links and offers to save the PATH setup for zsh, bash, or fish. It shows the files before changing them and backs up existing files.
+
+```bash
+kache init
+```
+
+Open a new terminal after setup, or run the activation command printed by init in the current terminal. Then use Make, CMake, or your existing build command. Compiler calls made through `PATH` go through Kache; explicit compiler paths are unchanged. Previously configured CMake build directories may need reconfiguration to select the compiler links.
+
+Use `kache init --no-shell` to leave terminal setup alone while configuring Cargo. For managed dotfiles or another shell, use the manual setup:
 
 ```bash
 kache install-shims
 export PATH="$HOME/.local/lib/kache/shims:$PATH"
 ```
 
-`kache init` can create that directory. It does not edit your shell rc or `PATH`. Add the `export` to the shell you build from, or for `makepkg`:
+For `makepkg`, you can set the path directly:
 
 ```bash
 # ~/.makepkg.conf
@@ -52,7 +60,7 @@ This is a native symlink to the `kache` binary. Do not wrap Kache in a shell scr
 
 Kache is a larger process than ccache. On a tree of many tiny `.c` files, measure both before replacing ccache.
 
-`kache doctor` reports whether a compiler name on `PATH` is a Kache shim. The check is informational, so a Rust-only setup does not fail doctor for skipping it.
+`kache doctor` checks the current terminal's PATH. If init saved shell setup but doctor still reports inactive shims, open a new terminal or run the activation command. Init cannot change its parent shell's environment.
 
 ## Prefix method
 

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -93,8 +93,11 @@ The report stays at `$kache_trial/reuse.md`. Git may refuse to remove a worktree
 ```bash
 kache init --check       # print proposed changes only
 kache init --no-service  # configure Cargo without a login service
+kache init --no-shell    # leave terminal C/C++ setup unchanged
 kache init --yes         # accept defaults without prompts
 ```
+
+Init asks before editing Cargo or shell configuration and backs up existing files. If you enable C/C++ caching, open a new terminal afterward or run the activation command it prints. `--check` shows the planned changes without prompts or modifications.
 
 To try the worktree example without persistent setup, skip `kache init` and prefix both `cargo build` commands with `RUSTC_WRAPPER=kache`. For example:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11081,10 +11081,10 @@ pub fn init(yes: bool, no_service: bool, no_shell: bool, check: bool) -> Result<
 
     let cargo_path = cargo_config_target_path();
     let plan = plan_cargo_wrapper_edit(&cargo_path)?;
-    let existing = match std::fs::read_to_string(&cargo_path) {
-        Ok(content) => content,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(error) => return Err(error).context("read Cargo configuration"),
+    let existing = if plan == CargoWrapperPlan::Create {
+        String::new()
+    } else {
+        std::fs::read_to_string(&cargo_path).context("read Cargo configuration")?
     };
     let env_missing = crate::cargo_env::missing_assignments_from_path(&cargo_path)?;
     let mut cargo_ready = plan == CargoWrapperPlan::AlreadySet && env_missing.is_empty();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7587,14 +7587,6 @@ mod tests {
     }
 
     #[test]
-    fn dry_run_never_writes_an_init_edit() {
-        assert!(should_write_init_step(false, true));
-        assert!(!should_write_init_step(true, true));
-        assert!(!should_write_init_step(false, false));
-        assert!(!should_write_init_step(true, false));
-    }
-
-    #[test]
     fn test_cargo_wrapper_edit_create() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
@@ -7650,17 +7642,6 @@ mod tests {
         let new = apply_cargo_wrapper_edit(existing, &plan);
         assert!(new.contains("[net]"));
         assert!(new.trim_end().ends_with("rustc-wrapper = \"kache\""));
-    }
-
-    #[test]
-    fn test_backup_path_has_kache_backup_suffix() {
-        let path = std::path::Path::new("/tmp/cargo/config.toml");
-        let backup = backup_path_for(path).unwrap();
-        let name = backup.file_name().unwrap().to_string_lossy();
-        assert!(name.starts_with("config.toml.kache-backup."), "got {name}");
-        // Timestamp is a 15-char suffix: YYYYMMDD-HHMMSS
-        assert_eq!(name.len(), "config.toml.kache-backup.".len() + 15);
-        assert_eq!(backup.parent(), path.parent());
     }
 
     #[test]
@@ -10950,7 +10931,7 @@ mod tests {
 //   1b. Adds HOST_CC / HOST_CXX / CC_KNOWN_WRAPPER_CUSTOM under `[env]`
 //       when those keys are absent. Never sets CC or CXX.
 //   1c. Unix: offers compiler-name shims in ~/.local/lib/kache/shims.
-//       Does not edit PATH or shell rc.
+//       Saves shell PATH setup after confirmation; activation needs a new terminal.
 //   2. Installs the daemon as a login service (launchd/systemd)
 //   3. Starts the daemon
 //
@@ -11041,12 +11022,6 @@ pub(crate) fn apply_cargo_wrapper_edit(existing: &str, plan: &CargoWrapperPlan) 
     }
 }
 
-/// Whether an init file-edit step should write. Dry-run (`check`) never
-/// writes, even if the operator would have accepted the prompt.
-fn should_write_init_step(check: bool, accepted: bool) -> bool {
-    !check && accepted
-}
-
 fn prompt_yes_no(question: &str, default_yes: bool, auto_yes: bool) -> Result<bool> {
     use std::io::{BufRead, Write};
 
@@ -11061,23 +11036,15 @@ fn prompt_yes_no(question: &str, default_yes: bool, auto_yes: bool) -> Result<bo
 
     let stdin = std::io::stdin();
     let mut line = String::new();
-    stdin.lock().read_line(&mut line)?;
+    if stdin.lock().read_line(&mut line)? == 0 {
+        println!("skipped (no input; use --yes to accept defaults)");
+        return Ok(false);
+    }
     let trimmed = line.trim().to_ascii_lowercase();
     if trimmed.is_empty() {
         return Ok(default_yes);
     }
     Ok(matches!(trimmed.as_str(), "y" | "yes"))
-}
-
-/// Build a timestamped sibling path for a pre-edit backup.
-///
-/// Format: `<name>.kache-backup.YYYYMMDD-HHMMSS`. Timestamped so repeated
-/// runs don't silently overwrite an earlier backup.
-fn backup_path_for(path: &std::path::Path) -> Option<std::path::PathBuf> {
-    use chrono::Utc;
-    let file_name = path.file_name()?.to_string_lossy().into_owned();
-    let timestamp = Utc::now().format("%Y%m%d-%H%M%S");
-    Some(path.with_file_name(format!("{file_name}.kache-backup.{timestamp}")))
 }
 
 /// `$CARGO_HOME`, falling back to `~/.cargo` (cargo's documented default).
@@ -11106,161 +11073,82 @@ fn cargo_config_target_path() -> std::path::PathBuf {
     }
 }
 
-pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
-    println!();
-    println!("  kache init — set up cache wrapper and daemon");
-    println!();
-
+pub fn init(yes: bool, no_service: bool, no_shell: bool, check: bool) -> Result<()> {
+    println!("\n  Set up Kache\n");
     if check {
-        println!("  (dry-run — no files will be modified)");
-        println!();
+        println!("  Preview only. No files or services will change.\n");
     }
 
-    // ── Step 1: cargo config wrapper ─────────────────────────────
     let cargo_path = cargo_config_target_path();
     let plan = plan_cargo_wrapper_edit(&cargo_path)?;
-
-    match &plan {
-        CargoWrapperPlan::AlreadySet => {
-            println!(
-                "  \x1b[32m✓\x1b[0m rustc-wrapper already set to kache in {}",
-                crate::wrapper_config::display_path(&cargo_path)
-            );
-        }
-        other => {
-            let (summary, question) = match other {
-                CargoWrapperPlan::Create => (
-                    format!("create {} with rustc-wrapper = kache", cargo_path.display()),
-                    "Create cargo config?".to_string(),
-                ),
-                CargoWrapperPlan::Replace(old) => (
-                    format!(
-                        "replace rustc-wrapper = \"{old}\" with \"kache\" in {}",
-                        cargo_path.display()
-                    ),
-                    format!("Replace existing wrapper ({old}) with kache?"),
-                ),
-                CargoWrapperPlan::AddUnderBuild => (
-                    format!(
-                        "add rustc-wrapper = \"kache\" to existing [build] section in {}",
-                        cargo_path.display()
-                    ),
-                    "Add rustc-wrapper = kache?".to_string(),
-                ),
-                CargoWrapperPlan::AppendSection => (
-                    format!(
-                        "append [build] section with rustc-wrapper = \"kache\" to {}",
-                        cargo_path.display()
-                    ),
-                    "Append [build] section?".to_string(),
-                ),
-                CargoWrapperPlan::AlreadySet => unreachable!(),
-            };
-            println!("  \x1b[33m→\x1b[0m {summary}");
-            if should_write_init_step(check, prompt_yes_no(&question, true, yes)?) {
-                if let Some(parent) = cargo_path.parent() {
-                    std::fs::create_dir_all(parent)
-                        .with_context(|| format!("creating {}", parent.display()))?;
-                }
-                // Back up existing content before overwriting, so users can restore
-                // if something goes sideways. Skipped for brand-new files (nothing
-                // to preserve).
-                if cargo_path.exists()
-                    && let Some(backup_path) = backup_path_for(&cargo_path)
-                {
-                    std::fs::copy(&cargo_path, &backup_path)
-                        .with_context(|| format!("writing backup to {}", backup_path.display()))?;
-                    println!(
-                        "    \x1b[32m✓\x1b[0m backup saved to {}",
-                        backup_path.display()
-                    );
-                }
-                let existing = std::fs::read_to_string(&cargo_path).unwrap_or_default();
-                let new = apply_cargo_wrapper_edit(&existing, &plan);
-                std::fs::write(&cargo_path, new)
-                    .with_context(|| format!("writing {}", cargo_path.display()))?;
-                println!("    \x1b[32m✓\x1b[0m wrote {}", cargo_path.display());
-            }
-        }
-    }
-
-    // ── Step 1b: cargo [env] host C wrappers ─────────────────────
-    // HOST_CC/HOST_CXX wrap host compiles from the `cc` crate without replacing
-    // `cargo build --target`'s cross compiler. CC/CXX are never set here.
+    let existing = match std::fs::read_to_string(&cargo_path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error).context("read Cargo configuration"),
+    };
     let env_missing = crate::cargo_env::missing_assignments_from_path(&cargo_path)?;
-    if env_missing.is_empty() {
-        println!(
-            "  \x1b[32m✓\x1b[0m cargo [env] host C wrappers already set in {}",
-            crate::wrapper_config::display_path(&cargo_path)
-        );
+    let mut cargo_ready = plan == CargoWrapperPlan::AlreadySet && env_missing.is_empty();
+    if cargo_ready {
+        println!("  ✓ Cargo caching: configured");
     } else {
-        let names = env_missing
-            .iter()
-            .map(|assignment| assignment.name)
-            .collect::<Vec<_>>()
-            .join(", ");
+        println!("  Cargo caching: Rust and native dependencies");
         println!(
-            "  \x1b[33m→\x1b[0m set {names} in {} (does not set CC or CXX)",
+            "    Config: {}",
             crate::wrapper_config::display_path(&cargo_path)
         );
-        if should_write_init_step(
-            check,
-            prompt_yes_no(
-                "Set host C compiler wrappers for Cargo build scripts?",
-                true,
-                yes,
-            )?,
-        ) {
+        let question = if let CargoWrapperPlan::Replace(old) = &plan {
+            format!("Replace {old} with Kache for Cargo builds?")
+        } else {
+            "Enable caching for Cargo builds?".into()
+        };
+        if check {
+            println!("    Would configure Cargo. Existing compiler choices are preserved.");
+        } else if prompt_yes_no(&question, true, yes)? {
+            let wrapped = apply_cargo_wrapper_edit(&existing, &plan);
+            let updated = crate::cargo_env::apply_cargo_env_edit(&wrapped, &env_missing);
+            // Do not report success if a nonstandard existing wrapper could
+            // not be replaced by the formatting-preserving editor.
+            let parsed: toml::Value = toml::from_str(&updated)?;
+            anyhow::ensure!(
+                parsed
+                    .get("build")
+                    .and_then(|v| v.get("rustc-wrapper"))
+                    .and_then(toml::Value::as_str)
+                    == Some("kache"),
+                "could not update Cargo's existing wrapper; edit {} manually",
+                cargo_path.display()
+            );
             if let Some(parent) = cargo_path.parent() {
-                std::fs::create_dir_all(parent)
-                    .with_context(|| format!("creating {}", parent.display()))?;
+                std::fs::create_dir_all(parent)?;
             }
-            if cargo_path.exists()
-                && let Some(backup_path) = backup_path_for(&cargo_path)
-            {
-                std::fs::copy(&cargo_path, &backup_path)
-                    .with_context(|| format!("writing backup to {}", backup_path.display()))?;
+            if cargo_path.exists() {
+                use std::io::Write;
+                let mut backup = tempfile::Builder::new()
+                    .prefix(".kache-cargo-backup-")
+                    .tempfile_in(cargo_path.parent().context("Cargo config has no parent")?)?;
+                backup.write_all(existing.as_bytes())?;
+                backup.as_file().sync_all()?;
+                let (_, backup) = backup.keep()?;
                 println!(
-                    "    \x1b[32m✓\x1b[0m backup saved to {}",
-                    backup_path.display()
+                    "    Backup: {}",
+                    crate::wrapper_config::display_path(&backup)
                 );
             }
-            let existing = std::fs::read_to_string(&cargo_path).unwrap_or_default();
-            let new = crate::cargo_env::apply_cargo_env_edit(&existing, &env_missing);
-            std::fs::write(&cargo_path, new)
-                .with_context(|| format!("writing {}", cargo_path.display()))?;
-            println!("    \x1b[32m✓\x1b[0m wrote {}", cargo_path.display());
+            std::fs::write(&cargo_path, updated).context("save Cargo configuration")?;
+            cargo_ready = true;
+            println!("  ✓ Cargo caching: configured");
+        } else {
+            println!("  • Cargo caching: skipped");
         }
     }
 
-    // ── Step 1c: C/C++ compiler-name shims (Unix) ───────────────
-    // Creates ~/.local/lib/kache/shims. Does not edit shell rc or PATH.
     #[cfg(unix)]
-    {
-        let shim_dir = crate::compiler::shim::default_shim_dir();
-        if shim_dir_is_ready(&shim_dir) {
-            println!(
-                "  \x1b[32m✓\x1b[0m C/C++ shims already in {}",
-                shim_dir.display()
-            );
-            println!("    export PATH=\"{}:$PATH\"", shim_dir.display());
-        } else {
-            println!(
-                "  \x1b[33m→\x1b[0m install C/C++ compiler shims in {}",
-                shim_dir.display()
-            );
-            if should_write_init_step(
-                check,
-                prompt_yes_no(
-                    "Install C/C++ compiler shims for Make, CMake, and PKGBUILD?",
-                    true,
-                    yes,
-                )?,
-            ) {
-                install_shims(&shim_dir, false)?;
-            }
-        }
-    }
+    let shell_pending = init_compiler_setup(yes, no_shell, check)?;
+    #[cfg(not(unix))]
+    let shell_pending = {
+        let _ = no_shell;
+        false
+    };
 
     // ── Step 2: daemon service ───────────────────────────────────
     let service_path = crate::service::service_file_path();
@@ -11272,9 +11160,9 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
     let mut service_action_taken = false;
 
     if no_service {
-        println!("  \x1b[33m→\x1b[0m skipping service install (--no-service)");
+        println!("  \x1b[33m→\x1b[0m Login service: skipped (--no-service)");
     } else if let Some(mismatch) = service_mismatch {
-        println!("  \x1b[33m→\x1b[0m update daemon service to current kache binary");
+        println!("  \x1b[33m→\x1b[0m Background service: update to this Kache binary");
         println!("    installed: {}", mismatch.installed.display());
         println!("    current:   {}", mismatch.current.display());
         if !check && prompt_yes_no("Update service?", true, yes)? {
@@ -11283,12 +11171,12 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
         }
     } else if service_installed {
         println!(
-            "  \x1b[32m✓\x1b[0m daemon service already installed at {}",
+            "  \x1b[32m✓\x1b[0m Login service: configured ({})",
             service_path.as_ref().unwrap().display()
         );
     } else {
-        println!("  \x1b[33m→\x1b[0m install daemon as a login service (launchd/systemd)");
-        if !check && prompt_yes_no("Install service?", true, yes)? {
+        println!("  \x1b[33m→\x1b[0m Background service: start Kache when you log in");
+        if !check && prompt_yes_no("Start Kache automatically at login?", true, yes)? {
             crate::service::install()?;
             service_action_taken = true;
         }
@@ -11297,6 +11185,11 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
     // ── Step 3: daemon running ───────────────────────────────────
     // service::install() on macOS/Linux also starts the daemon, so skip the
     // manual start if we just installed it.
+    if check {
+        println!("  Background cache: would check and start if needed.");
+        println!("\n  Preview only. Run kache init to apply.\n");
+        return Ok(());
+    }
     let config = crate::config::Config::load().ok();
     let is_daemon_reachable = |cfg: &Option<crate::config::Config>| {
         cfg.as_ref()
@@ -11306,21 +11199,23 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
     let mut daemon_step_failed = false;
 
     if is_daemon_reachable(&config) {
-        println!("  \x1b[32m✓\x1b[0m daemon is running");
+        println!("  \x1b[32m✓\x1b[0m Background cache: running");
     } else if service_action_taken {
         // Service install typically starts the daemon. Give it a moment and re-check.
         std::thread::sleep(std::time::Duration::from_millis(500));
         if is_daemon_reachable(&config) {
-            println!("  \x1b[32m✓\x1b[0m daemon started by service");
+            println!("  \x1b[32m✓\x1b[0m Background cache: started");
         } else {
-            println!("  \x1b[33m→\x1b[0m daemon not reachable yet — it may take a few seconds");
+            println!(
+                "  \x1b[33m→\x1b[0m Background cache: still starting; check with kache doctor"
+            );
         }
     } else if service_installed {
         // Service is installed (from a previous run) but daemon isn't reachable.
         // Prefer `launchctl kickstart` / `systemctl restart` over a manual spawn
         // so the service manager clears any stale state (lockfiles, half-dead
         // processes) and owns the new process.
-        println!("  \x1b[33m→\x1b[0m restart daemon via service manager (daemon offline)");
+        println!("  \x1b[33m→\x1b[0m Background cache: stopped");
         if !check
             && prompt_yes_no("Restart daemon?", true, yes)?
             && let Some(ref cfg) = config
@@ -11334,7 +11229,7 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
             }
         }
     } else {
-        println!("  \x1b[33m→\x1b[0m start daemon in background");
+        println!("  \x1b[33m→\x1b[0m Background cache: not running");
         if !check && prompt_yes_no("Start daemon now?", true, yes)? {
             match crate::daemon::start_daemon_background()? {
                 true => println!("    \x1b[32m✓\x1b[0m daemon started"),
@@ -11347,19 +11242,104 @@ pub fn init(yes: bool, no_service: bool, check: bool) -> Result<()> {
     }
 
     println!();
-    if check {
-        println!("  Dry run complete — re-run without --check to apply.");
-        println!();
-        Ok(())
-    } else if daemon_step_failed {
-        println!("  \x1b[31m✗\x1b[0m Setup incomplete — see messages above.");
-        println!("     Run \x1b[1mkache doctor\x1b[0m for diagnostics.");
-        println!();
+    if daemon_step_failed {
+        println!("  Background cache setup failed. Run kache doctor for details.\n");
         anyhow::bail!("init did not complete: daemon not reachable");
+    }
+    if cargo_ready {
+        println!("  Ready for Cargo builds. Use cargo as usual.");
+    }
+    if shell_pending {
+        println!("  Open a new terminal to activate C/C++ caching.");
+    }
+    println!("  Run kache doctor to check this terminal.\n");
+    Ok(())
+}
+
+#[cfg(unix)]
+fn init_compiler_setup(yes: bool, no_shell: bool, check: bool) -> Result<bool> {
+    use crate::init_shell::{Edit, Shell};
+    if no_shell {
+        println!("  • Terminal C/C++ caching: skipped (--no-shell)");
+        return Ok(false);
+    }
+    let shim_dir = crate::compiler::shim::default_shim_dir();
+    let home = dirs::home_dir().context("could not find your home directory")?;
+    let shell = std::env::var_os("SHELL")
+        .as_deref()
+        .and_then(|shell| Shell::detect(std::path::Path::new(shell)));
+    let Some(shell) = shell else {
+        println!("  • Terminal C/C++ caching: shell not supported for automatic setup");
+        println!(
+            "    Use kache install-shims, then add {} to your shell's PATH.",
+            shim_dir.display()
+        );
+        return Ok(false);
+    };
+    let zdotdir = std::env::var_os("ZDOTDIR")
+        .filter(|v| !v.is_empty())
+        .map(std::path::PathBuf::from);
+    let xdg = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|v| !v.is_empty())
+        .map(std::path::PathBuf::from);
+    let activation = shell.activation(&shim_dir)?;
+    let edits = shell
+        .paths(&home, zdotdir.as_deref(), xdg.as_deref())?
+        .into_iter()
+        .map(|path| Edit::plan(path, &activation))
+        .collect::<Result<Vec<_>>>();
+    let edits = match edits {
+        Ok(edits) => edits,
+        Err(error) => {
+            println!("  • Terminal C/C++ caching: shell config needs manual attention");
+            println!("    {error}");
+            println!("    No shell files were changed.");
+            return Ok(false);
+        }
+    };
+    let shims_ready = shim_dir_is_ready(&shim_dir);
+    let needs_edit = edits.iter().any(Edit::changed);
+    if !shims_ready || needs_edit {
+        println!("  C/C++ caching: terminal builds using cc, gcc or clang");
+        for edit in edits.iter().filter(|edit| edit.changed()) {
+            println!(
+                "    Shell config: {}",
+                crate::wrapper_config::display_path(&edit.path)
+            );
+        }
+        if check {
+            println!("    Would install compiler links and save the shell setup.");
+            return Ok(false);
+        }
+        if !prompt_yes_no("Enable C/C++ caching in new terminals?", true, yes)? {
+            println!("  • Terminal C/C++ caching: skipped");
+            return Ok(false);
+        }
+        if !shims_ready {
+            install_shims_named_with_output(&shim_dir, false, &[], false)?;
+            anyhow::ensure!(
+                shim_dir_is_ready(&shim_dir),
+                "existing files in {} prevent compiler setup; inspect them before using kache install-shims --force",
+                shim_dir.display()
+            );
+        }
+        for edit in &edits {
+            if let Some(backup) = edit.apply()? {
+                println!(
+                    "    Backup: {}",
+                    crate::wrapper_config::display_path(&backup)
+                );
+            }
+        }
+    }
+    if crate::compiler::shim::live_shim_path_status().on_path {
+        println!("  ✓ Terminal C/C++ caching: active");
+        Ok(false)
     } else {
-        println!("  Setup complete. Run \x1b[1mkache doctor\x1b[0m to verify.");
-        println!();
-        Ok(())
+        println!("  ✓ Terminal C/C++ caching: configured for new terminals");
+        println!("    For this terminal, run:");
+        println!("    {}", shell.command(&shim_dir)?);
+        Ok(true)
     }
 }
 
@@ -11388,15 +11368,20 @@ fn shim_dir_is_ready(dir: &std::path::Path) -> bool {
 /// dispatch so this stays a single, fully testable definition rather than two
 /// same-named ones the mutation lane cannot tell apart.
 #[cfg(unix)]
-pub(crate) fn install_shims(dir: &std::path::Path, force: bool) -> anyhow::Result<()> {
-    install_shims_named(dir, force, &[])
-}
-
-#[cfg(unix)]
 pub(crate) fn install_shims_named(
     dir: &std::path::Path,
     force: bool,
     extra_names: &[String],
+) -> anyhow::Result<()> {
+    install_shims_named_with_output(dir, force, extra_names, true)
+}
+
+#[cfg(unix)]
+fn install_shims_named_with_output(
+    dir: &std::path::Path,
+    force: bool,
+    extra_names: &[String],
+    verbose: bool,
 ) -> anyhow::Result<()> {
     let exe = std::env::current_exe().context("locating the kache binary")?;
     // Resolve so the shims survive kache being invoked through its own
@@ -11440,6 +11425,9 @@ pub(crate) fn install_shims_named(
         created.push(name.clone());
     }
 
+    if !verbose {
+        return Ok(());
+    }
     println!(
         "Created {} shim(s) in {} -> {}",
         created.len(),
@@ -11479,7 +11467,9 @@ pub(crate) fn install_shims_named(
 
 #[cfg(all(test, unix))]
 mod shim_install_tests {
-    use super::install_shims;
+    fn install_shims(dir: &std::path::Path, force: bool) -> anyhow::Result<()> {
+        super::install_shims_named(dir, force, &[])
+    }
     use crate::compiler::shim::SHIM_NAMES;
     use std::os::unix::fs::PermissionsExt;
 

--- a/src/incremental_policy.rs
+++ b/src/incremental_policy.rs
@@ -57,7 +57,17 @@ pub(crate) struct Lease {
     unit: AdaptiveUnit,
     kind: LeaseKind,
     completion: Completion,
-    _lock: File,
+    _lock: UnitLock,
+}
+
+struct UnitLock(File);
+
+impl Drop for UnitLock {
+    fn drop(&mut self) {
+        // Closing our descriptor is insufficient if a concurrent fork still
+        // holds a duplicate. Release ownership before that child reaches exec.
+        let _ = self.0.unlock();
+    }
 }
 
 #[derive(Debug)]
@@ -378,7 +388,7 @@ impl AdaptiveUnit {
         stored
     }
 
-    fn lock(&self) -> Option<File> {
+    fn lock(&self) -> Option<UnitLock> {
         if !self.ensure_layout() {
             return None;
         }
@@ -397,7 +407,7 @@ impl AdaptiveUnit {
             return None;
         }
         match file.try_lock() {
-            Ok(()) => Some(file),
+            Ok(()) => Some(UnitLock(file)),
             Err(std::fs::TryLockError::WouldBlock | std::fs::TryLockError::Error(_)) => None,
         }
     }
@@ -876,6 +886,41 @@ mod tests {
             .unwrap();
         fs::write(lease.unit.rustc_dir.join("dep-graph.bin"), b"seed").unwrap();
         assert!(lease.finish_at(true, at + 2));
+    }
+
+    #[test]
+    fn unit_lock_release_does_not_wait_for_inherited_descriptors() {
+        let (_temp, _args, unit) = fixture();
+        let owner = unit.lock().unwrap();
+        // A concurrent fork can inherit the same open file description until
+        // exec closes it. A duplicate reproduces that lifetime without timing.
+        let inherited = owner.0.try_clone().unwrap();
+        assert!(unit.lock().is_none(), "the owner still holds the lock");
+        drop(owner);
+        let next = unit
+            .lock()
+            .expect("release must not wait for an inherited fd");
+        drop(next);
+        drop(inherited);
+    }
+
+    #[test]
+    fn finished_and_abandoned_leases_release_inherited_locks() {
+        for finish in [false, true] {
+            let (_temp, _args, unit) = fixture();
+            let lease = unit.try_immediate_at(100).unwrap();
+            let inherited = lease._lock.0.try_clone().unwrap();
+            assert!(unit.lock().is_none(), "a live lease remains exclusive");
+            if finish {
+                fs::write(unit.rustc_dir.join("dep-graph.bin"), b"compiled").unwrap();
+                assert!(lease.finish_at(true, 101));
+            } else {
+                drop(lease);
+            }
+            let next = unit.lock().expect("the lease must release its lock");
+            drop(next);
+            drop(inherited);
+        }
     }
 
     #[test]

--- a/src/init_shell.rs
+++ b/src/init_shell.rs
@@ -1,0 +1,365 @@
+//! Plan and save the small shell startup edit used by `kache init`.
+#![cfg(unix)]
+
+use anyhow::{Context, Result, ensure};
+use std::path::{Path, PathBuf};
+
+const BEGIN: &str = "# >>> kache compiler cache >>>";
+const END: &str = "# <<< kache compiler cache <<<";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Shell {
+    Zsh,
+    Bash,
+    Fish,
+}
+
+impl Shell {
+    pub fn detect(path: &Path) -> Option<Self> {
+        match path.file_name()?.to_str()? {
+            "zsh" => Some(Self::Zsh),
+            "bash" => Some(Self::Bash),
+            "fish" => Some(Self::Fish),
+            _ => None,
+        }
+    }
+
+    pub fn paths(
+        self,
+        home: &Path,
+        zdotdir: Option<&Path>,
+        xdg: Option<&Path>,
+    ) -> Result<Vec<PathBuf>> {
+        let paths = match self {
+            Self::Zsh => vec![zdotdir.unwrap_or(home).join(".zshrc")],
+            Self::Bash => {
+                // Bash reads the first existing login profile, and .bashrc for
+                // interactive non-login shells. Do not shadow an existing profile.
+                let profile = [".bash_profile", ".bash_login", ".profile"]
+                    .into_iter()
+                    .map(|name| home.join(name))
+                    .find(|path| std::fs::symlink_metadata(path).is_ok())
+                    .unwrap_or_else(|| home.join(".bash_profile"));
+                vec![home.join(".bashrc"), profile]
+            }
+            Self::Fish => vec![
+                xdg.map(Path::to_path_buf)
+                    .unwrap_or_else(|| home.join(".config"))
+                    .join("fish/config.fish"),
+            ],
+        };
+        ensure!(
+            paths.iter().all(|path| path.is_absolute()),
+            "shell config directory must be absolute"
+        );
+        Ok(paths)
+    }
+
+    fn quote_path(self, dir: &Path) -> Result<String> {
+        let path = dir.to_str().context("compiler directory must be UTF-8")?;
+        ensure!(
+            !path.chars().any(char::is_control) && !path.contains(':'),
+            "compiler directory cannot contain control characters or ':'"
+        );
+        Ok(match self {
+            Self::Fish => format!("'{}'", path.replace('\\', "\\\\").replace('\'', "\\'")),
+            _ => format!("'{}'", path.replace('\'', "'\\''")),
+        })
+    }
+
+    pub fn command(self, dir: &Path) -> Result<String> {
+        let quoted = self.quote_path(dir)?;
+        Ok(match self {
+            Self::Fish => format!("set -gx PATH {quoted} $PATH"),
+            _ => format!("export PATH={quoted}${{PATH:+:\"$PATH\"}}"),
+        })
+    }
+
+    pub fn activation(self, dir: &Path) -> Result<String> {
+        let quoted = self.quote_path(dir)?;
+        let command = self.command(dir)?;
+        Ok(match self {
+            Self::Fish => {
+                format!("if test \"$PATH[1]\" != {quoted}\n    {command}\nend")
+            }
+            _ => {
+                format!("case \"$PATH\" in\n    {quoted}|{quoted}:*) ;;\n    *) {command} ;;\nesac")
+            }
+        })
+    }
+}
+
+pub(crate) struct Edit {
+    pub path: PathBuf,
+    original: Option<String>,
+    updated: String,
+}
+
+fn read_regular(path: &Path) -> Result<Option<String>> {
+    use std::os::unix::fs::MetadataExt;
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    ensure!(
+        metadata.is_file() && metadata.nlink() == 1,
+        "{} must be a regular file, not a symlink or hardlink; update managed dotfiles manually",
+        path.display()
+    );
+    ensure!(
+        metadata.len() <= 1_048_576,
+        "{} exceeds 1 MiB",
+        path.display()
+    );
+    std::fs::read_to_string(path)
+        .map(Some)
+        .with_context(|| format!("read {}", path.display()))
+}
+
+impl Edit {
+    pub fn plan(path: PathBuf, activation: &str) -> Result<Self> {
+        let original = read_regular(&path)?;
+        let existing = original.as_deref().unwrap_or_default();
+        let mut updated = existing.to_string();
+        let starts = existing.match_indices(BEGIN).collect::<Vec<_>>();
+        let ends = existing.match_indices(END).collect::<Vec<_>>();
+        match (starts.as_slice(), ends.as_slice()) {
+            ([], []) => {}
+            ([(start, _)], [(end, _)]) if start < end => {
+                let after = end + END.len();
+                ensure!(
+                    (*start == 0 || existing.as_bytes()[start - 1] == b'\n')
+                        && (after == existing.len() || existing.as_bytes()[after] == b'\n'),
+                    "invalid kache shell block in {}",
+                    path.display()
+                );
+                let after = after + usize::from(existing.as_bytes().get(after) == Some(&b'\n'));
+                updated.replace_range(*start..after, "");
+            }
+            _ => anyhow::bail!(
+                "incomplete or duplicate kache shell block in {}; review it before retrying",
+                path.display()
+            ),
+        }
+        if !updated.is_empty() && !updated.ends_with('\n') {
+            updated.push('\n');
+        }
+        updated.push_str(&format!("{BEGIN}\n{activation}\n{END}\n"));
+        Ok(Self {
+            path,
+            original,
+            updated,
+        })
+    }
+
+    pub fn changed(&self) -> bool {
+        self.original.as_deref() != Some(&self.updated)
+    }
+
+    /// Preserve the old file in a unique sibling before atomic replacement.
+    /// Do not replace a config that changed after the confirmation prompt.
+    pub fn apply(&self) -> Result<Option<PathBuf>> {
+        use std::io::Write;
+        ensure!(
+            read_regular(&self.path)? == self.original,
+            "{} changed during setup; retry init",
+            self.path.display()
+        );
+        if !self.changed() {
+            return Ok(None);
+        }
+        let parent = self.path.parent().context("shell file has no parent")?;
+        std::fs::create_dir_all(parent)?;
+        let mut replacement = tempfile::NamedTempFile::new_in(parent)?;
+        if self.original.is_some() {
+            replacement
+                .as_file()
+                .set_permissions(std::fs::metadata(&self.path)?.permissions())?;
+        }
+        replacement.write_all(self.updated.as_bytes())?;
+        replacement.as_file().sync_all()?;
+        let backup = if let Some(original) = &self.original {
+            let mut backup = tempfile::Builder::new()
+                .prefix(".kache-shell-backup-")
+                .tempfile_in(parent)?;
+            backup.write_all(original.as_bytes())?;
+            backup.as_file().sync_all()?;
+            Some(backup.keep()?.1)
+        } else {
+            None
+        };
+        ensure!(
+            read_regular(&self.path)? == self.original,
+            "{} changed during setup; backup preserved at {:?}",
+            self.path.display(),
+            backup
+        );
+        replacement.persist(&self.path)?;
+        std::fs::File::open(parent)?.sync_all()?;
+        Ok(backup)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_the_shells_real_startup_files() {
+        let home = tempfile::tempdir().unwrap();
+        assert_eq!(Shell::detect(Path::new("/bin/zsh")), Some(Shell::Zsh));
+        assert_eq!(Shell::detect(Path::new("/usr/bin/bash")), Some(Shell::Bash));
+        assert_eq!(Shell::detect(Path::new("/bin/fish")), Some(Shell::Fish));
+        assert_eq!(Shell::detect(Path::new("/bin/other")), None);
+        assert_eq!(
+            Shell::Zsh.paths(home.path(), None, None).unwrap(),
+            [home.path().join(".zshrc")]
+        );
+        assert_eq!(
+            Shell::Zsh
+                .paths(home.path(), Some(Path::new("/custom")), None)
+                .unwrap(),
+            [PathBuf::from("/custom/.zshrc")]
+        );
+        assert!(
+            Shell::Zsh
+                .paths(home.path(), Some(Path::new("relative")), None)
+                .is_err()
+        );
+        assert_eq!(
+            Shell::Bash.paths(home.path(), None, None).unwrap(),
+            [
+                home.path().join(".bashrc"),
+                home.path().join(".bash_profile")
+            ]
+        );
+        std::fs::write(home.path().join(".profile"), "# keep\n").unwrap();
+        assert_eq!(
+            Shell::Bash.paths(home.path(), None, None).unwrap()[1],
+            home.path().join(".profile")
+        );
+        std::fs::write(home.path().join(".bash_login"), "# keep\n").unwrap();
+        assert_eq!(
+            Shell::Bash.paths(home.path(), None, None).unwrap()[1],
+            home.path().join(".bash_login")
+        );
+        std::fs::write(home.path().join(".bash_profile"), "# keep\n").unwrap();
+        assert_eq!(
+            Shell::Bash.paths(home.path(), None, None).unwrap()[1],
+            home.path().join(".bash_profile")
+        );
+        assert_eq!(
+            Shell::Fish.paths(home.path(), None, None).unwrap(),
+            [home.path().join(".config/fish/config.fish")]
+        );
+        assert_eq!(
+            Shell::Fish
+                .paths(home.path(), None, Some(Path::new("/xdg")))
+                .unwrap(),
+            [PathBuf::from("/xdg/fish/config.fish")]
+        );
+    }
+
+    #[test]
+    fn keeps_user_content_and_permissions_and_backs_up_only_changes() {
+        use std::os::unix::fs::PermissionsExt;
+        let home = tempfile::tempdir().unwrap();
+        let path = home.path().join(".zshrc");
+        std::fs::write(&path, "# user config\nexport CUSTOM=keep\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+        let activation = Shell::Zsh.activation(Path::new("/my shims")).unwrap();
+        let edit = Edit::plan(path.clone(), &activation).unwrap();
+        assert!(edit.changed());
+        let backup = edit.apply().unwrap().unwrap();
+        assert_eq!(
+            std::fs::read_to_string(backup).unwrap(),
+            "# user config\nexport CUSTOM=keep\n"
+        );
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+        let edit = Edit::plan(path.clone(), &activation).unwrap();
+        assert!(!edit.changed());
+        assert!(edit.apply().unwrap().is_none());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content.matches(BEGIN).count(), 1);
+        assert!(content.starts_with("# user config\nexport CUSTOM=keep\n"));
+        std::fs::write(&path, format!("{content}# later user config\n")).unwrap();
+        Edit::plan(path.clone(), &activation)
+            .unwrap()
+            .apply()
+            .unwrap();
+        let content = std::fs::read_to_string(path).unwrap();
+        assert_eq!(content.matches(BEGIN).count(), 1);
+        assert!(content.find("# later").unwrap() < content.find(BEGIN).unwrap());
+    }
+
+    #[test]
+    fn refuses_managed_links_malformed_blocks_and_concurrent_edits() {
+        let home = tempfile::tempdir().unwrap();
+        let path = home.path().join(".zshrc");
+        let activation = Shell::Zsh.activation(Path::new("/shims")).unwrap();
+        let edit = Edit::plan(path.clone(), &activation).unwrap();
+        std::fs::write(&path, "new content").unwrap();
+        assert!(edit.apply().is_err());
+        for malformed in [
+            BEGIN.to_string(),
+            END.to_string(),
+            format!("{END}\n{BEGIN}"),
+            format!("{BEGIN}\n{BEGIN}\n{END}"),
+            format!("text{BEGIN}\n{END}"),
+        ] {
+            std::fs::write(&path, malformed).unwrap();
+            assert!(Edit::plan(path.clone(), &activation).is_err());
+        }
+        let link = home.path().join("link");
+        std::os::unix::fs::symlink(&path, &link).unwrap();
+        assert!(Edit::plan(link, &activation).is_err());
+        std::fs::write(&path, "# keep").unwrap();
+        let edit = Edit::plan(path.clone(), &activation).unwrap();
+        let linked = home.path().join("hardlink");
+        std::fs::hard_link(&path, linked).unwrap();
+        assert!(edit.apply().is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "# keep");
+    }
+
+    #[test]
+    fn quoted_path_is_first_and_repeated_activation_does_not_duplicate_it() {
+        // Execute only generated text in a shell with no startup files. Never
+        // source the user's configuration while testing or during init.
+        let dir = Path::new("/tmp/shims ' $name `cmd` $(cmd) \\ space");
+        for (kind, shell) in [(Shell::Bash, "/bin/bash"), (Shell::Zsh, "/bin/zsh")] {
+            if !Path::new(shell).exists() {
+                continue;
+            }
+            let activation = kind.activation(dir).unwrap();
+            let script = format!("{activation}\n{activation}\nprintf '%s' \"$PATH\"");
+            let output = std::process::Command::new(shell)
+                .args(["-f", "-c", &script])
+                .env("PATH", "/usr/bin:/bin")
+                .env_remove("BASH_ENV")
+                .env_remove("ENV")
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(
+                String::from_utf8(output.stdout).unwrap(),
+                format!("{}:/usr/bin:/bin", dir.display())
+            );
+        }
+        assert!(Shell::Zsh.activation(Path::new("/bad:path")).is_err());
+        assert!(Shell::Zsh.activation(Path::new("/bad\npath")).is_err());
+        assert!(
+            Shell::Fish
+                .activation(Path::new("/a'b\\c"))
+                .unwrap()
+                .contains("/a\\'b\\\\c")
+        );
+    }
+}

--- a/src/init_shell.rs
+++ b/src/init_shell.rs
@@ -362,4 +362,83 @@ mod tests {
                 .contains("/a\\'b\\\\c")
         );
     }
+
+    #[test]
+    fn plans_empty_files_and_blocks_at_line_boundaries() {
+        let home = tempfile::tempdir().unwrap();
+        let path = home.path().join("nested/.bashrc");
+        let block = format!("{BEGIN}\nactivate\n{END}\n");
+        let edit = Edit::plan(path.clone(), "activate").unwrap();
+        assert!(edit.changed());
+        assert!(edit.apply().unwrap().is_none());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), block);
+        for (original, expected) in [
+            (String::new(), block.clone()),
+            ("# user".into(), format!("# user\n{block}")),
+            ("# user\n".into(), format!("# user\n{block}")),
+            (block.trim_end().into(), block.clone()),
+            (block.clone(), block.clone()),
+            (
+                format!("# before\n{BEGIN}\nold\n{END}\n# after"),
+                format!("# before\n# after\n{block}"),
+            ),
+        ] {
+            std::fs::write(&path, &original).unwrap();
+            let edit = Edit::plan(path.clone(), "activate").unwrap();
+            assert_eq!(edit.changed(), original != expected);
+            assert_eq!(edit.updated, expected);
+        }
+        for malformed in [
+            format!("{BEGIN}\n{END}trailing"),
+            format!("{BEGIN}\n{END}\n{END}"),
+            format!("prefix{BEGIN}\n{END}\n"),
+        ] {
+            std::fs::write(&path, malformed).unwrap();
+            assert!(Edit::plan(path.clone(), "activate").is_err());
+        }
+    }
+
+    #[test]
+    fn limits_reads_to_regular_small_utf8_files() {
+        let home = tempfile::tempdir().unwrap();
+        assert!(read_regular(home.path()).is_err());
+        let path = home.path().join(".zshrc");
+        assert_eq!(read_regular(&path).unwrap(), None);
+        let at_limit = "x".repeat(1 << 20);
+        std::fs::write(&path, &at_limit).unwrap();
+        assert_eq!(read_regular(&path).unwrap(), Some(at_limit));
+        std::fs::write(&path, vec![b'x'; (1 << 20) + 1]).unwrap();
+        assert!(read_regular(&path).is_err());
+        std::fs::write(&path, [0xff]).unwrap();
+        assert!(read_regular(&path).is_err());
+    }
+
+    #[test]
+    fn activation_preserves_an_empty_or_already_exact_path() {
+        for initial in ["", "/shims", "/shims:/bin", "/shims-other:/bin"] {
+            let activation = Shell::Bash.activation(Path::new("/shims")).unwrap();
+            let script = format!("{activation}\nprintf '%s' \"$PATH\"");
+            let output = std::process::Command::new("/bin/bash")
+                .args(["--noprofile", "--norc", "-c", &script])
+                .env("PATH", initial)
+                .env_remove("BASH_ENV")
+                .output()
+                .unwrap();
+            assert!(output.status.success());
+            let expected = match initial {
+                "" | "/shims" => "/shims".to_owned(),
+                "/shims:/bin" => initial.to_owned(),
+                _ => format!("/shims:{initial}"),
+            };
+            assert_eq!(String::from_utf8(output.stdout).unwrap(), expected);
+        }
+        assert_eq!(
+            Shell::Fish.command(Path::new("/shims")).unwrap(),
+            "set -gx PATH '/shims' $PATH"
+        );
+        assert_eq!(
+            Shell::Fish.activation(Path::new("/shims")).unwrap(),
+            "if test \"$PATH[1]\" != '/shims'\n    set -gx PATH '/shims' $PATH\nend"
+        );
+    }
 }

--- a/src/init_shell.rs
+++ b/src/init_shell.rs
@@ -126,7 +126,12 @@ impl Edit {
         let ends = existing.match_indices(END).collect::<Vec<_>>();
         match (starts.as_slice(), ends.as_slice()) {
             ([], []) => {}
-            ([(start, _)], [(end, _)]) if start < end => {
+            ([(start, _)], [(end, _)]) => {
+                ensure!(
+                    existing[*start..].contains(END),
+                    "closing kache shell marker precedes opening marker in {}",
+                    path.display()
+                );
                 let after = end + END.len();
                 ensure!(
                     (*start == 0 || existing.as_bytes()[start - 1] == b'\n')
@@ -407,6 +412,8 @@ mod tests {
         let at_limit = "x".repeat(1 << 20);
         std::fs::write(&path, &at_limit).unwrap();
         assert_eq!(read_regular(&path).unwrap(), Some(at_limit));
+        // ENOTDIR is a lookup error, not an absent file we may create.
+        assert!(read_regular(&path.join("child")).is_err());
         std::fs::write(&path, vec![b'x'; (1 << 20) + 1]).unwrap();
         assert!(read_regular(&path).is_err());
         std::fs::write(&path, [0xff]).unwrap();
@@ -415,10 +422,14 @@ mod tests {
 
     #[test]
     fn activation_preserves_an_empty_or_already_exact_path() {
+        // Nix provides Bash in its store, not at /bin/bash. Resolve it before
+        // replacing the child's PATH with the value this test exercises.
+        let _guard = crate::test_support::process_state_test_lock();
+        let bash = crate::compiler::resolve_program_on_path("bash").expect("Bash on test PATH");
         for initial in ["", "/shims", "/shims:/bin", "/shims-other:/bin"] {
             let activation = Shell::Bash.activation(Path::new("/shims")).unwrap();
             let script = format!("{activation}\nprintf '%s' \"$PATH\"");
-            let output = std::process::Command::new("/bin/bash")
+            let output = std::process::Command::new(&bash)
                 .args(["--noprofile", "--norc", "-c", &script])
                 .env("PATH", initial)
                 .env_remove("BASH_ENV")

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,8 @@ mod fallback_planner;
 mod heartbeat;
 mod identity;
 mod incremental_policy;
+#[cfg(unix)]
+mod init_shell;
 use kache_store::link;
 mod link_probe;
 mod machine;
@@ -171,7 +173,7 @@ enum Commands {
         stale: Option<String>,
     },
 
-    /// Interactive setup: configure cargo wrapper, install and start the daemon
+    /// Set up caching for Cargo and C/C++ builds
     Init {
         /// Accept all default answers (non-interactive)
         #[arg(long, short = 'y')]
@@ -180,6 +182,10 @@ enum Commands {
         /// Do not install the daemon as a login service
         #[arg(long)]
         no_service: bool,
+
+        /// Skip C/C++ shell setup (Cargo native dependencies are still configured)
+        #[arg(long)]
+        no_shell: bool,
 
         /// Print what would change without modifying anything
         #[arg(long)]
@@ -704,8 +710,9 @@ fn main() -> Result<()> {
         Some(Commands::Init {
             yes,
             no_service,
+            no_shell,
             check,
-        }) => cli::init(yes, no_service, check),
+        }) => cli::init(yes, no_service, no_shell, check),
         Some(Commands::Doctor {
             fix,
             purge_sccache,

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -1318,6 +1318,101 @@ fn init_noninteractive_writes_isolated_cargo_config() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn init_repairs_each_half_of_terminal_setup_and_reports_activation() {
+    let e = env();
+    let shims = e.home.join(".local/lib/kache/shims");
+    e.cmd()
+        .args(["init", "--no-service"])
+        .write_stdin("\ny\nn\n")
+        .assert()
+        .success();
+    let rc = e.home.join(".bashrc");
+    let configured = std::fs::read_to_string(&rc).unwrap();
+    std::fs::write(&rc, "# new user configuration\n").unwrap();
+    e.cmd()
+        .args(["init", "--no-service"])
+        .write_stdin("yes\nn\n")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(
+            "Enable C/C++ caching in new terminals?",
+        ));
+    assert!(std::fs::read_to_string(&rc).unwrap().ends_with(&configured));
+    let repaired = std::fs::read_to_string(&rc).unwrap();
+
+    std::fs::remove_file(shims.join("cc")).unwrap();
+    e.cmd()
+        .args(["init", "--no-service"])
+        .write_stdin("y\nn\n")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(
+            "Enable C/C++ caching in new terminals?",
+        ));
+    assert_eq!(std::fs::read_to_string(&rc).unwrap(), repaired);
+    assert_eq!(
+        std::fs::canonicalize(shims.join("cc")).unwrap(),
+        std::fs::canonicalize(KACHE_BIN).unwrap()
+    );
+    e.cmd()
+        .env(
+            "PATH",
+            std::env::join_paths([shims.as_path(), Path::new("/usr/bin"), Path::new("/bin")])
+                .unwrap(),
+        )
+        .args(["init", "--no-service"])
+        .write_stdin("n\n")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Terminal C/C++ caching: active"))
+        .stdout(predicates::str::contains("Open a new terminal").not());
+
+    std::fs::remove_file(shims.join("cc")).unwrap();
+    std::fs::write(shims.join("cc"), "user-owned compiler").unwrap();
+    e.cmd()
+        .args(["init", "--no-service"])
+        .write_stdin("y\n")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("existing files"));
+    assert_eq!(
+        std::fs::read_to_string(shims.join("cc")).unwrap(),
+        "user-owned compiler"
+    );
+    assert_eq!(std::fs::read_to_string(rc).unwrap(), repaired);
+}
+
+#[cfg(unix)]
+#[test]
+fn init_leaves_unsupported_shells_and_managed_dotfiles_alone() {
+    let e = env();
+    e.cmd()
+        .env("SHELL", "/bin/unsupported")
+        .args(["init", "--no-service"])
+        .write_stdin("n\nn\n")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("shell not supported"));
+    assert!(!e.home.join(".local/lib/kache/shims").exists());
+    let managed = e.home.join("managed-rc");
+    std::fs::write(&managed, "# managed config\n").unwrap();
+    std::os::unix::fs::symlink(&managed, e.home.join(".bashrc")).unwrap();
+    e.cmd()
+        .args(["init", "--no-service"])
+        .write_stdin("n\nn\n")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("No shell files were changed."));
+    assert_eq!(
+        std::fs::read_to_string(managed).unwrap(),
+        "# managed config\n"
+    );
+    assert!(!e.home.join(".bash_profile").exists());
+    assert!(!e.home.join(".local/lib/kache/shims").exists());
+}
+
 #[test]
 fn init_writes_config_to_custom_cargo_home() {
     // When $CARGO_HOME is set, init must write the wrapper config under it,

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -1436,6 +1436,47 @@ fn init_writes_config_to_custom_cargo_home() {
 }
 
 #[test]
+fn init_adds_native_caching_to_an_existing_rust_setup() {
+    let e = env();
+    let cargo = e.home.join(".cargo/config.toml");
+    std::fs::create_dir_all(cargo.parent().unwrap()).unwrap();
+    std::fs::write(&cargo, "[build]\nrustc-wrapper = \"kache\"\n").unwrap();
+    e.cmd()
+        .args(["init", "--no-service", "--no-shell"])
+        .write_stdin("y\nn\n")
+        .assert()
+        .success();
+    let config: toml::Value = toml::from_str(&std::fs::read_to_string(cargo).unwrap()).unwrap();
+    assert_eq!(config["build"]["rustc-wrapper"].as_str(), Some("kache"));
+    assert_eq!(config["env"]["HOST_CC"].as_str(), Some("kache cc"));
+    assert_eq!(config["env"]["HOST_CXX"].as_str(), Some("kache c++"));
+}
+
+#[cfg(unix)]
+#[test]
+fn init_ignores_empty_shell_config_directory_overrides() {
+    for (shell, config) in [
+        ("/bin/zsh", ".zshrc"),
+        ("/bin/fish", ".config/fish/config.fish"),
+    ] {
+        let e = env();
+        e.cmd()
+            .env("SHELL", shell)
+            .env("ZDOTDIR", "")
+            .env("XDG_CONFIG_HOME", "")
+            .args(["init", "--no-service"])
+            .write_stdin("y\ny\nn\n")
+            .assert()
+            .success();
+        assert!(
+            std::fs::read_to_string(e.home.join(config))
+                .unwrap()
+                .contains("# >>> kache compiler cache >>>")
+        );
+    }
+}
+
+#[test]
 fn daemon_without_subcommand_succeeds() {
     // `kache daemon` (no subcommand) is allowed and reports daemon state
     // without contacting or starting any service.

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -36,6 +36,9 @@ fn kache(home: &Path, cache_dir: &Path) -> Command {
     cmd.env("KACHE_LOG", "off")
         .env("HOME", home)
         .env("CARGO_HOME", home.join(".cargo"))
+        .env("SHELL", "/bin/bash")
+        .env_remove("ZDOTDIR")
+        .env("XDG_CONFIG_HOME", home.join(".config"))
         // Daemons spawned during tests must self-exit quickly instead of
         // lingering indefinitely — otherwise, under `just coverage`,
         // they pile up and CPU-starve the rest of the suite.
@@ -1149,7 +1152,153 @@ fn init_check_is_a_dry_run() {
     // --check prints intended changes without modifying anything.
     let e = env();
     std::fs::create_dir_all(e.home.join(".cargo")).unwrap();
-    e.cmd().args(["init", "--check"]).assert().success();
+    let output = e
+        .cmd()
+        .args(["init", "--check", "--yes"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).unwrap();
+    assert!(!output.contains("[Y/n]"));
+    assert!(!e.home.join(".cargo/config.toml").exists());
+    assert!(!e.home.join(".bashrc").exists());
+    assert!(!e.home.join(".bash_profile").exists());
+    assert!(!e.home.join(".local/lib/kache/shims").exists());
+    assert!(!e.cache.join("daemon.sock").exists());
+}
+
+#[test]
+fn init_eof_does_not_accept_changes() {
+    let e = env();
+    e.cmd().args(["init", "--no-service"]).assert().success();
+    assert!(!e.home.join(".cargo/config.toml").exists());
+    assert!(!e.home.join(".bashrc").exists());
+    assert!(!e.home.join(".local/lib/kache/shims").exists());
+    assert!(!e.cache.join("daemon.sock").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn init_saves_shell_setup_preserves_cargo_choices_and_is_idempotent() {
+    let e = env();
+    let cargo = e.home.join(".cargo/config.toml");
+    std::fs::create_dir_all(cargo.parent().unwrap()).unwrap();
+    let original = "[build]\nrustc-wrapper = \"sccache\"\n[env]\nHOST_CC = \"custom-cc\"\n";
+    std::fs::write(&cargo, original).unwrap();
+    std::fs::write(e.home.join(".bashrc"), "# user rc\n").unwrap();
+    std::fs::write(e.home.join(".profile"), "# user profile\n").unwrap();
+    let output = e
+        .cmd()
+        .args(["init", "--no-service"])
+        .write_stdin("y\ny\nn\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).unwrap();
+    assert!(output.contains("Replace sccache with Kache for Cargo builds?"));
+    assert!(output.contains("Open a new terminal"));
+    assert!(!output.contains("Setup complete"));
+    assert!(!output.contains("PKGBUILD"));
+    assert!(
+        !e.home.join(".bash_profile").exists(),
+        "must not shadow .profile"
+    );
+    let configured = std::fs::read_to_string(&cargo).unwrap();
+    assert!(configured.contains("rustc-wrapper = \"kache\""));
+    assert!(configured.contains("HOST_CC = \"custom-cc\""));
+    assert!(configured.contains("HOST_CXX = \"kache c++\""));
+    let backup = std::fs::read_dir(cargo.parent().unwrap())
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .find(|path| {
+            path.file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with(".kache-cargo-backup-")
+        })
+        .unwrap();
+    assert_eq!(std::fs::read_to_string(backup).unwrap(), original);
+    let before = std::fs::read_to_string(e.home.join(".bashrc")).unwrap();
+    assert!(before.starts_with("# user rc\n"));
+    assert_eq!(before.matches("# >>> kache compiler cache >>>").count(), 1);
+    for name in ["cc", "c++", "gcc", "g++", "clang", "clang++"] {
+        assert_eq!(
+            std::fs::canonicalize(e.home.join(".local/lib/kache/shims").join(name)).unwrap(),
+            std::fs::canonicalize(KACHE_BIN).unwrap()
+        );
+    }
+    e.cmd()
+        .args(["init", "--no-service"])
+        .write_stdin("n\n")
+        .assert()
+        .success();
+    assert_eq!(
+        std::fs::read_to_string(e.home.join(".bashrc")).unwrap(),
+        before
+    );
+    assert_eq!(std::fs::read_to_string(&cargo).unwrap(), configured);
+    let shell = std::process::Command::new("/bin/bash")
+        .args([
+            "--noprofile",
+            "--rcfile",
+            e.home.join(".bashrc").to_str().unwrap(),
+            "-ic",
+            "command -v cc",
+        ])
+        .env("HOME", &e.home)
+        .env("PATH", "/usr/bin:/bin")
+        .env_remove("BASH_ENV")
+        .output()
+        .unwrap();
+    assert!(shell.status.success());
+    assert_eq!(
+        String::from_utf8(shell.stdout).unwrap().trim(),
+        e.home.join(".local/lib/kache/shims/cc").to_str().unwrap()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn init_zsh_uses_zdotdir_and_no_shell_skips_terminal_changes() {
+    let e = env();
+    let zdotdir = e.home.join("custom-zsh");
+    e.cmd()
+        .env("SHELL", "/bin/zsh")
+        .env("ZDOTDIR", &zdotdir)
+        .args(["init", "--no-service"])
+        .write_stdin("y\ny\nn\n")
+        .assert()
+        .success();
+    assert!(zdotdir.join(".zshrc").exists());
+    assert!(!e.home.join(".zshrc").exists());
+    if Path::new("/bin/zsh").exists() {
+        let output = std::process::Command::new("/bin/zsh")
+            .args(["-ic", "command -v cc"])
+            .env("HOME", &e.home)
+            .env("ZDOTDIR", &zdotdir)
+            .env("PATH", "/usr/bin:/bin")
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap().trim(),
+            e.home.join(".local/lib/kache/shims/cc").to_str().unwrap()
+        );
+    }
+    let skipped = env();
+    skipped
+        .cmd()
+        .args(["init", "--no-service", "--no-shell"])
+        .write_stdin("y\nn\n")
+        .assert()
+        .success();
+    assert!(skipped.home.join(".cargo/config.toml").exists());
+    assert!(!skipped.home.join(".local/lib/kache/shims").exists());
+    assert!(!skipped.home.join(".bashrc").exists());
 }
 
 #[test]

--- a/tests/cli_commands_test.rs
+++ b/tests/cli_commands_test.rs
@@ -1448,8 +1448,21 @@ fn init_adds_native_caching_to_an_existing_rust_setup() {
         .success();
     let config: toml::Value = toml::from_str(&std::fs::read_to_string(cargo).unwrap()).unwrap();
     assert_eq!(config["build"]["rustc-wrapper"].as_str(), Some("kache"));
-    assert_eq!(config["env"]["HOST_CC"].as_str(), Some("kache cc"));
-    assert_eq!(config["env"]["HOST_CXX"].as_str(), Some("kache c++"));
+    assert_eq!(
+        config["env"]["CC_KNOWN_WRAPPER_CUSTOM"].as_str(),
+        Some("kache")
+    );
+    #[cfg(unix)]
+    {
+        assert_eq!(config["env"]["HOST_CC"].as_str(), Some("kache cc"));
+        assert_eq!(config["env"]["HOST_CXX"].as_str(), Some("kache c++"));
+    }
+    #[cfg(windows)]
+    {
+        // Init leaves the choice between MSVC and clang-cl to the user.
+        assert!(config["env"].get("HOST_CC").is_none());
+        assert!(config["env"].get("HOST_CXX").is_none());
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
`kache init` installed C/C++ compiler links but left PATH setup to the user. It could then report setup complete while terminal builds still bypassed Kache.

This change asks to save the PATH setup for bash, zsh, or fish. It shows which files will change, backs up existing files, and tells the user when a new terminal is needed. Managed dotfiles remain untouched. `--no-shell` skips terminal setup.

The prompts now describe the build setup instead of Cargo configuration keys. `--check` neither prompts nor changes files or services, and closed stdin no longer accepts defaults.

Validation: `just check`, including isolated init tests, repeated setup, preserved Cargo compiler choices, and real bash/zsh startup checks.

CI also exposed an incremental-unit lock race: a concurrently spawned process could retain the lock after its owner finished. An explicit unlock guard fixes it, with deterministic duplicate-descriptor tests. The init test now checks the appropriate compiler settings on Windows and Unix.
