### PR TITLE
refactor: remove unused daemon and transport helpers

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1124,15 +1124,6 @@ pub struct CompileFinishedRequest {
     pub started_at_ms: u64,
 }
 
-#[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct BatchResponse {
-    pub ok: bool,
-    pub results: Vec<Response>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StatsResponse {
     pub total_size: u64,
@@ -7769,45 +7760,6 @@ fn hash_files_results_from_response_line(resp_str: &str) -> Result<Vec<HashFileR
         );
     }
     Ok(resp.hash_results.unwrap_or_default())
-}
-
-/// Send a prefetch request to the daemon. Non-blocking — sends the hint and returns.
-/// Auto-starts daemon if needed. Uses fire-and-forget (no response wait).
-#[allow(dead_code)]
-pub fn send_prefetch(config: &Config, keys: &[(String, String)]) -> Result<()> {
-    let socket_path = config.socket_path();
-
-    let req = Request::Prefetch(PrefetchRequest {
-        keys: keys.to_vec(),
-        warm_all: false,
-    });
-
-    let try_send = |path: &Path| -> Result<()> { send_request_fire_and_forget(path, &req) };
-
-    match try_send(&socket_path) {
-        Ok(()) => return Ok(()),
-        Err(_) => match start_daemon_background() {
-            Ok(true) => {}
-            Ok(false) | Err(_) => {
-                tracing::warn!("could not reach or start daemon, skipping prefetch");
-                return Ok(());
-            }
-        },
-    }
-
-    for attempt in 1..=3u32 {
-        match try_send(&socket_path) {
-            Ok(()) => return Ok(()),
-            Err(e) => {
-                if attempt < 3 {
-                    std::thread::sleep(send_retry_delay(attempt, std::process::id()));
-                } else {
-                    tracing::warn!("prefetch send failed after {attempt} retries: {e}");
-                }
-            }
-        }
-    }
-    Ok(()) // Non-blocking: don't fail
 }
 
 /// Send a build-started hint to the daemon. Non-blocking, fire-and-forget.
@@ -15762,21 +15714,6 @@ mod tests {
         assert_eq!(req.keys, vec![(valid_key, "serde".into())]);
     }
 
-    #[test]
-    fn test_batch_response_serde() {
-        let batch = BatchResponse {
-            ok: true,
-            results: vec![Response::found(true), Response::found(false)],
-            error: None,
-        };
-        let json = serde_json::to_string(&batch).unwrap();
-        let parsed: BatchResponse = serde_json::from_str(&json).unwrap();
-        assert_eq!(batch, parsed);
-        assert_eq!(parsed.results.len(), 2);
-        assert_eq!(parsed.results[0].found, Some(true));
-        assert_eq!(parsed.results[1].found, Some(false));
-    }
-
     // ── Warming barrier tests ─────────────────────────────────────
 
     #[tokio::test]
@@ -17616,34 +17553,6 @@ mod tests {
             .await
             .expect("the cc upload request must reach the live daemon")
             .unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_send_prefetch_client_roundtrip() {
-        // CLIENT side: send_prefetch's first fire-and-forget try_send reaches a
-        // live server and returns Ok(()) immediately (daemon.rs 3369-3370),
-        // without falling through to the start-daemon/retry path.
-        let dir = tempfile::tempdir().unwrap();
-        let config = test_config(dir.path());
-        let socket_path = config.socket_path();
-        std::fs::create_dir_all(socket_path.parent().unwrap()).unwrap();
-
-        let listener = bind_listener(&socket_path);
-        let daemon = Arc::new(Daemon::new(config.clone()));
-        let server = tokio::spawn(async move {
-            let stream = listener.accept().await.expect("accept");
-            let _ =
-                handle_connection(stream, &daemon, &AtomicBool::new(false), &Notify::new()).await;
-        });
-
-        let cfg = config.clone();
-        let result = tokio::task::spawn_blocking(move || {
-            send_prefetch(&cfg, &[("a".repeat(64), "serde".to_string())])
-        })
-        .await
-        .unwrap();
-        server.await.unwrap();
-        assert!(result.is_ok(), "prefetch hint should send to a live daemon");
     }
 
     #[tokio::test]

--- a/src/shards.rs
+++ b/src/shards.rs
@@ -79,13 +79,6 @@ pub fn parse_cargo_lock(path: &Path) -> Result<Vec<(String, String)>> {
     Ok(deps)
 }
 
-/// Build a namespace string from known build config.
-/// Format: `{target}/{rustc_hash}/{profile}`
-#[allow(dead_code)]
-pub fn build_namespace(target: &str, rustc_hash: &str, profile: &str) -> String {
-    format!("{target}/{rustc_hash}/{profile}")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,11 +229,5 @@ dependencies = ["serde"]
     fn test_parse_cargo_lock_nonexistent() {
         let result = parse_cargo_lock(Path::new("/nonexistent/Cargo.lock"));
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_build_namespace() {
-        let ns = build_namespace("x86_64-unknown-linux-gnu", "abc123", "release");
-        assert_eq!(ns, "x86_64-unknown-linux-gnu/abc123/release");
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -140,21 +140,9 @@ pub fn is_reachable(path: &Path) -> bool {
     SyncStream::connect(name).is_ok()
 }
 
-/// True for I/O errors that mean the peer disconnected. Cross-platform —
-/// covers Unix `BrokenPipe` / `ConnectionReset` / `EPIPE` and the
-/// Windows-pipe variants of the same.
-pub fn is_peer_disconnect(e: &std::io::Error) -> bool {
-    use std::io::ErrorKind::*;
-    matches!(
-        e.kind(),
-        BrokenPipe | ConnectionReset | ConnectionAborted | UnexpectedEof
-    ) || e.raw_os_error() == Some(32) // EPIPE; macOS sometimes reports as ErrorKind::Other
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{Error, ErrorKind};
 
     #[test]
     fn socket_name_builds_for_a_plausible_path() {
@@ -187,44 +175,6 @@ mod tests {
             .create_sync()
             .expect("bind listener");
         assert!(is_reachable(&path));
-    }
-
-    #[test]
-    fn peer_disconnect_recognizes_disconnect_error_kinds() {
-        for kind in [
-            ErrorKind::BrokenPipe,
-            ErrorKind::ConnectionReset,
-            ErrorKind::ConnectionAborted,
-            ErrorKind::UnexpectedEof,
-        ] {
-            assert!(
-                is_peer_disconnect(&Error::from(kind)),
-                "{kind:?} should be treated as a peer disconnect"
-            );
-        }
-    }
-
-    #[test]
-    fn peer_disconnect_recognizes_raw_epipe() {
-        // macOS can surface EPIPE as ErrorKind::Other; the raw-os-error
-        // fallback must still classify it as a disconnect.
-        let err = Error::from_raw_os_error(32);
-        assert!(is_peer_disconnect(&err));
-    }
-
-    #[test]
-    fn peer_disconnect_ignores_unrelated_errors() {
-        for kind in [
-            ErrorKind::NotFound,
-            ErrorKind::PermissionDenied,
-            ErrorKind::InvalidInput,
-            ErrorKind::TimedOut,
-        ] {
-            assert!(
-                !is_peer_disconnect(&Error::from(kind)),
-                "{kind:?} should not be treated as a peer disconnect"
-            );
-        }
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Remove four internal helpers whose only workspace references were their definitions and tests: `BatchResponse`, `send_prefetch`, `build_namespace`, and `transport::is_peer_disconnect`.

The Prefetch request handling and the daemon's active disconnect classifier remain unchanged. The removed tests exercised the unused helpers.

Validation: `CARGO_INCREMENTAL=0 RUST_TEST_THREADS=1 just check` passed.
