### PR TITLE
perf: stream remote entry packs to temporary files

### DIFF
--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -964,7 +964,11 @@ mod tests {
         tokio::spawn(async move {
             let mut requests = Vec::new();
             for response in responses {
-                let (mut stream, _) = listener.accept().await.unwrap();
+                let (mut stream, _) =
+                    tokio::time::timeout(Duration::from_secs(10), listener.accept())
+                        .await
+                        .expect("the operation must issue the expected HTTP request")
+                        .unwrap();
                 let mut request = Vec::new();
                 let mut chunk = [0_u8; 4096];
                 loop {
@@ -1460,7 +1464,11 @@ mod tests {
         let deadline = Instant::now() + Duration::from_secs(1);
         let download =
             layout.download_entry_until("key123", "foo", &destination, &blobs, Some(deadline));
-        let (result, started) = tokio::join!(download, started_rx);
+        let (result, started) = tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(download, started_rx)
+        })
+        .await
+        .expect("the restore must start its GET before the test deadline");
         started.expect("the timeout must occur during a response body");
         let error = result
             .err()

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -29,6 +29,7 @@ use reqsign_core::{
     CommandExecute, Context as SigningContext, Env, OsEnv, ProvideCredential,
     ProvideCredentialChain,
 };
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 use crate::config::{FilesystemRemoteConfig, RemoteBackendConfig, RemoteConfig, S3RemoteConfig};
 
@@ -70,6 +71,14 @@ pub struct GetObject {
     pub body_ms: u64,
 }
 
+/// Byte count and timings for a download written to a caller-owned sink.
+#[derive(Debug)]
+pub struct GetTransfer {
+    pub bytes: u64,
+    pub request_ms: u64,
+    pub body_ms: u64,
+}
+
 /// Outcome of an atomic create-only remote publication.
 #[allow(dead_code)] // consumed by the packed-prefetch publisher in the next slice
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -94,6 +103,29 @@ pub trait RemoteBackend: Send + Sync {
     /// buffered when metadata is available, and always enforces the cap while
     /// streaming the body.
     async fn get(&self, key: &str, max_bytes: Option<u64>) -> Result<Option<GetObject>>;
+
+    /// Fetch into `destination`, flushing it before returning. A failure may
+    /// leave partial bytes in the sink; callers must discard them.
+    ///
+    /// Backends should override this to stream. The buffered fallback keeps
+    /// transports that implement only `get` usable by the restore path.
+    async fn get_into(
+        &self,
+        key: &str,
+        max_bytes: Option<u64>,
+        destination: &mut (dyn AsyncWrite + Unpin + Send),
+    ) -> Result<Option<GetTransfer>> {
+        let Some(object) = self.get(key, max_bytes).await? else {
+            return Ok(None);
+        };
+        destination.write_all(&object.body).await?;
+        destination.flush().await?;
+        Ok(Some(GetTransfer {
+            bytes: object.body.len() as u64,
+            request_ms: object.request_ms,
+            body_ms: object.body_ms,
+        }))
+    }
 
     /// Store `body` at `key`.
     async fn put(&self, key: &str, body: Vec<u8>, content_type: Option<&str>) -> Result<()>;
@@ -259,6 +291,23 @@ impl RemoteBackend for OpenDalBackend {
     }
 
     async fn get(&self, key: &str, max_bytes: Option<u64>) -> Result<Option<GetObject>> {
+        let mut body = Vec::new();
+        let Some(transfer) = self.get_into(key, max_bytes, &mut body).await? else {
+            return Ok(None);
+        };
+        Ok(Some(GetObject {
+            body: Bytes::from(body),
+            request_ms: transfer.request_ms,
+            body_ms: transfer.body_ms,
+        }))
+    }
+
+    async fn get_into(
+        &self,
+        key: &str,
+        max_bytes: Option<u64>,
+        destination: &mut (dyn AsyncWrite + Unpin + Send),
+    ) -> Result<Option<GetTransfer>> {
         self.validate_key("GET", key, false)?;
         let request_start = Instant::now();
         let reader = self
@@ -298,7 +347,6 @@ impl RemoteBackend for OpenDalBackend {
         }
 
         let body_start = Instant::now();
-        let mut chunks = Vec::new();
         let mut length = 0_u64;
         loop {
             let chunk = match stream.try_next().await {
@@ -320,7 +368,12 @@ impl RemoteBackend for OpenDalBackend {
                     self.describe(key)
                 );
             }
-            chunks.extend(chunk);
+            for bytes in chunk {
+                destination
+                    .write_all(&bytes)
+                    .await
+                    .with_context(|| format!("writing body of {}", self.describe(key)))?;
+            }
         }
         // A stream that ends early is not a valid object. The layout layer's
         // blake3 gate would reject a truncated pack anyway, but catching it here
@@ -328,12 +381,15 @@ impl RemoteBackend for OpenDalBackend {
         // known) instead of surfacing as a confusing hash mismatch, and it also
         // covers objects fetched outside that gate.
         verify_complete_body(advertised_length, length, &self.describe(key))?;
+        destination
+            .flush()
+            .await
+            .context("flushing downloaded body")?;
 
         let body_ms = body_start.elapsed().as_millis() as u64;
-        let body = chunks.into_iter().collect::<opendal::Buffer>().to_bytes();
 
-        Ok(Some(GetObject {
-            body,
+        Ok(Some(GetTransfer {
+            bytes: length,
             request_ms,
             body_ms,
         }))
@@ -953,6 +1009,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_into_delivers_bytes_before_the_remote_finishes() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            while !request.ends_with(b"\r\n\r\n") {
+                request.push(socket.read_u8().await.unwrap());
+            }
+            assert!(request.starts_with(b"GET /bucket/key HTTP/1.1\r\n"));
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhe")
+                .await
+                .unwrap();
+            finish_rx.await.unwrap();
+            socket.write_all(b"llo").await.unwrap();
+        });
+        let backend = anonymous_s3_backend(&endpoint);
+        let (mut destination, mut received) = tokio::io::duplex(8);
+        let download =
+            tokio::spawn(async move { backend.get_into("key", Some(5), &mut destination).await });
+        let mut prefix = [0; 2];
+        tokio::time::timeout(Duration::from_secs(5), received.read_exact(&mut prefix))
+            .await
+            .expect("the sink must receive bytes without waiting for EOF")
+            .unwrap();
+        assert_eq!(&prefix, b"he");
+        finish_tx.send(()).unwrap();
+        let mut suffix = Vec::new();
+        received.read_to_end(&mut suffix).await.unwrap();
+        assert_eq!(suffix, b"llo");
+        let transfer = download.await.unwrap().unwrap().unwrap();
+        assert_eq!(transfer.bytes, 5);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn get_into_flushes_a_file_and_reports_write_failures() {
+        let backend = memory_backend();
+        backend.put("key", b"hello".to_vec(), None).await.unwrap();
+        let mut file = tokio::fs::File::from_std(tempfile::tempfile().unwrap());
+        let transfer = backend
+            .get_into("key", Some(5), &mut file)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(transfer.bytes, 5);
+        let mut file = file
+            .try_into_std()
+            .expect("the download must finish pending writes");
+        std::io::Seek::rewind(&mut file).unwrap();
+        let mut body = String::new();
+        std::io::Read::read_to_string(&mut file, &mut body).unwrap();
+        assert_eq!(body, "hello");
+
+        let (mut closed_sink, reader) = tokio::io::duplex(1);
+        drop(reader);
+        let error = backend
+            .get_into("key", Some(5), &mut closed_sink)
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("writing body of memory://test/key"),
+            "{error:#}"
+        );
+    }
+
+    #[tokio::test]
     async fn object_round_trip_head_get_and_list() {
         let backend = memory_backend();
         assert!(!backend.head("nested/key").await.unwrap());
@@ -1302,6 +1429,48 @@ mod tests {
             requests[0].lines().next(),
             Some("GET /bucket/artifacts/v3/packs/foo/key123.tar.zst HTTP/1.1")
         );
+    }
+
+    #[tokio::test]
+    async fn v3_download_timeout_discards_the_partial_file() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            while !request.ends_with(b"\r\n\r\n") {
+                request.push(socket.read_u8().await.unwrap());
+            }
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\npartial")
+                .await
+                .unwrap();
+            started_tx.send(()).unwrap();
+            // Keep the response open until the caller cancels it.
+            let mut remaining = Vec::new();
+            let _ = socket.read_to_end(&mut remaining).await;
+        });
+        let backend = anonymous_s3_backend(&endpoint);
+        let remote = RemoteConfig::test_s3("bucket", "artifacts");
+        let layout = crate::remote_layout::RemoteLayout::new(&backend, &remote);
+        let temp = tempfile::tempdir().unwrap();
+        let destination = temp.path().join("entry");
+        let blobs = temp.path().join("blobs");
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let download =
+            layout.download_entry_until("key123", "foo", &destination, &blobs, Some(deadline));
+        let (result, started) = tokio::join!(download, started_rx);
+        started.expect("the timeout must occur during a response body");
+        let error = result
+            .err()
+            .expect("an incomplete response must hit its deadline");
+        assert!(format!("{error:#}").contains("deadline"), "{error:#}");
+        assert!(std::fs::read_dir(temp.path()).unwrap().next().is_none());
+        tokio::time::timeout(Duration::from_secs(5), server)
+            .await
+            .unwrap()
+            .unwrap();
     }
 
     #[tokio::test]

--- a/src/remote_layout.rs
+++ b/src/remote_layout.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result, bail};
 pub(crate) use kache_format::{is_blob_hash, is_safe_artifact_name};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::io::Seek;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -21,8 +22,7 @@ const V3_MANIFEST_VERSION: u32 = 3;
 /// terabytes. Paired with [`MAX_ZSTD_WINDOW_LOG`] on the decoder (#212).
 const MAX_EXTRACTED_BYTES: u64 = 8 * 1024 * 1024 * 1024; // 8 GiB
 
-/// Cap the compressed body buffered by GET before extraction begins. This is
-/// a per-object ceiling; concurrent downloads can each hold up to this much.
+/// Cap compressed bytes downloaded to the temporary file before extraction.
 const MAX_COMPRESSED_BYTES: u64 = 8 * 1024 * 1024 * 1024; // 8 GiB
 
 /// Max zstd window-log accepted on decode (2^27 = 128 MiB). Bounds the
@@ -108,6 +108,17 @@ impl<'a> RemoteLayout<'a> {
 
         tracing::debug!("downloading v3 pack {}", self.backend.describe(&object_key));
 
+        deadline_io_check(deadline, "download setup")?;
+        let parent = entry_dir
+            .parent()
+            .context("v3 entry has no parent directory")?;
+        std::fs::create_dir_all(parent)?;
+        // Keep the spool on the cache disk, including when the cache is on an
+        // external volume. The anonymous file is removed when its handle closes,
+        // including cancellation and failed validation.
+        let spool = tempfile::tempfile_in(parent).context("creating v3 download file")?;
+        let mut spool = tokio::fs::File::from_std(spool);
+
         // A missing object is a clean miss, not a transfer failure. Callers
         // downcast to `EntryNotFound` to take the miss path (#485 Phase 0):
         // likely-present keys go straight to GET, and a stale key-cache
@@ -115,7 +126,8 @@ impl<'a> RemoteLayout<'a> {
         let fetched = crate::remote_resilience::RemoteDeadline::from_instant(deadline)
             .run(
                 "remote object GET",
-                self.backend.get(&object_key, Some(MAX_COMPRESSED_BYTES)),
+                self.backend
+                    .get_into(&object_key, Some(MAX_COMPRESSED_BYTES), &mut spool),
             )
             .await
             .context("downloading v3 pack")?
@@ -127,12 +139,13 @@ impl<'a> RemoteLayout<'a> {
             })?;
         let request_ms = fetched.request_ms;
         let body_ms = fetched.body_ms;
-        let compressed = fetched.body;
-        let compressed_len = compressed.len() as u64;
+        let compressed_len = fetched.bytes;
+        let mut compressed = spool.into_std().await;
+        compressed.rewind().context("rewinding v3 download file")?;
 
         let extract_start = std::time::Instant::now();
         let guarded = DeadlineReader {
-            inner: std::io::Cursor::new(&compressed),
+            inner: compressed,
             deadline,
         };
         let mut decoder =


### PR DESCRIPTION
Download v3 entry packs to an anonymous temporary file on the cache disk, then decompress and validate from that file. Large restores no longer retain the entire compressed pack in RAM. Closing the file removes it on success, failure, or cancellation.

Buffered metadata downloads and streamed entry downloads share the same OpenDAL read loop, including advertised and streamed size checks, missing-object handling, truncation checks, and transfer timings. The v3 object keys, 8 GiB compressed limit, extraction limits, and content verification remain compatible.

Validation: `CARGO_INCREMENTAL=0 RUST_TEST_THREADS=1 just check` passed. Tests exercise delivery before response EOF, file flushing, write failures, timeout cleanup, existing S3 wire behavior, and filesystem restore round trips.
