### PR TITLE
perf: share a memory budget across buffered remote downloads

### DIFF
--- a/docs/remote-cache/s3-setup.mdx
+++ b/docs/remote-cache/s3-setup.mdx
@@ -96,6 +96,8 @@ Remote packs use zstd; local blobs remain uncompressed. Configure the level with
 
 Each v3 entry download is limited to 8 GiB of compressed data and 8 GiB of extracted file data. Kache rejects an oversized download before restoring it; a compiler invocation recompiles when the remote entry cannot be restored. These are per-entry limits, not a total memory budget for concurrent downloads.
 
+Buffered downloads also share a 512 MiB admission budget per Kache process, including space for temporary copying. Larger requests run alone under the existing per-entry limits. Decoders and parsed metadata use memory outside this budget.
+
 kache never deletes remote objects. Bound the bucket with a lifecycle rule; [Bound a remote](/docs/remote-cache/bounding) lists the prefixes and ages.
 
 ## macOS LAN access

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4465,6 +4465,9 @@ impl Daemon {
             }
         };
 
+        // Parsing owns the catalog data. Release its download reservation
+        // before scheduling pack GETs against the same memory budget.
+        drop(catalog_object);
         let selected = catalog
             .packs
             .iter()
@@ -4508,7 +4511,7 @@ impl Daemon {
                         .packed_prefetch_get(
                             backend.as_ref(),
                             &key,
-                            crate::remote_pack::DEFAULT_MAX_PACK_BYTES,
+                            pack_ref.pack_bytes,
                             "packed-prefetch pack GET",
                         )
                         .await
@@ -4524,13 +4527,12 @@ impl Daemon {
                 };
                 (pack_ref, object)
             })
-            .buffer_unordered(prefetch_concurrency_cap(self.config.s3_concurrency))
-            .collect::<Vec<_>>()
-            .await;
-        fetched.sort_by(|(left, _), (right, _)| left.digest.cmp(&right.digest));
+            .buffer_unordered(prefetch_concurrency_cap(self.config.s3_concurrency));
 
         let mut verified = Vec::new();
-        for (pack_ref, pack_object) in fetched {
+        // Consume each body as it arrives. Retaining completed bodies while
+        // waiting for another GET can fill the budget and block that GET.
+        while let Some((pack_ref, pack_object)) = fetched.next().await {
             let Some(pack_object) = pack_object else {
                 continue;
             };
@@ -13666,6 +13668,46 @@ mod tests {
         v3_gets: AtomicU64,
     }
 
+    struct ReorderedPackBackend {
+        inner: Arc<dyn crate::remote_backend::RemoteBackend>,
+        first_key: String,
+        later_downloaded: Notify,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::remote_backend::RemoteBackend for ReorderedPackBackend {
+        async fn head(&self, key: &str) -> Result<bool> {
+            self.inner.head(key).await
+        }
+
+        async fn get(
+            &self,
+            key: &str,
+            max_bytes: Option<u64>,
+        ) -> Result<Option<crate::remote_backend::GetObject>> {
+            if key == self.first_key {
+                self.later_downloaded.notified().await;
+            }
+            let object = self.inner.get(key, max_bytes).await?;
+            if key != self.first_key && key.contains("/v4/prefetch/packs/") {
+                self.later_downloaded.notify_one();
+            }
+            Ok(object)
+        }
+
+        async fn put(&self, key: &str, body: Vec<u8>, content_type: Option<&str>) -> Result<()> {
+            self.inner.put(key, body, content_type).await
+        }
+
+        async fn list(&self, prefix: &str) -> Result<Vec<String>> {
+            self.inner.list(prefix).await
+        }
+
+        fn describe(&self, key: &str) -> String {
+            self.inner.describe(key)
+        }
+    }
+
     #[async_trait::async_trait]
     impl crate::remote_backend::RemoteBackend for BlockingV3Backend {
         async fn head(&self, key: &str) -> Result<bool> {
@@ -14366,6 +14408,106 @@ mod tests {
         assert!(prefetched.contains(&sentinel));
         assert!(prefetched.contains(&key_a));
         assert!(prefetched.contains(&key_b));
+    }
+
+    #[tokio::test]
+    async fn packed_prefetch_drains_bodies_with_room_for_only_one_object() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        let remote = test_remote_config();
+        config.remote = Some(remote.clone());
+        config.prefetch_max_bytes = 0;
+        config.s3_concurrency = 4;
+        let backend: Arc<dyn crate::remote_backend::RemoteBackend> = Arc::new(
+            crate::remote_backend::memory_backend_with_download_budget(1),
+        );
+        let daemon = Arc::new(Daemon::new(config));
+        let context = PackPrefetchContext::from_deps(
+            crate::identity::host_target_triple(),
+            "linux/toolchain/release",
+            &[("serde".to_string(), "1.0.0".to_string())],
+        )
+        .unwrap();
+        let mut packs = Vec::new();
+        let mut candidates = Vec::new();
+        for name in ["first", "second", "third"] {
+            let key = test_cache_key(name);
+            let (payload, meta_digest) = build_entry_pack_with_meta(&key, name);
+            let built = crate::remote_pack::build_pack(
+                "prefix",
+                vec![crate::remote_pack::PackInputEntry {
+                    cache_key: key.clone(),
+                    crate_name: name.into(),
+                    meta_digest: meta_digest.clone(),
+                    payload,
+                }],
+                1 << 20,
+            )
+            .unwrap();
+            put_test_object(&backend, &built.object_key, &built.bytes).await;
+            packs.push(crate::remote_pack::CatalogPackRef {
+                digest: built.digest,
+                pack_bytes: built.bytes.len() as u64,
+                entries: vec![crate::remote_pack::CatalogEntry {
+                    cache_key: key.clone(),
+                    crate_name: name.into(),
+                    meta_digest,
+                }],
+            });
+            candidates.push((key.clone(), name.into(), daemon.entry_dir_for(&key)));
+        }
+        let now = epoch_ms();
+        let encoded = crate::remote_pack::encode_catalog(
+            "prefix",
+            crate::remote_pack::PackCatalog {
+                version: crate::remote_pack::CATALOG_VERSION,
+                key_schema: crate::cache_key::CACHE_KEY_VERSION,
+                manifest_key: context.manifest_key.clone(),
+                namespace: context.namespace.clone(),
+                selector_hash: context.selector.clone(),
+                shard_hashes: context.shard_hashes.clone(),
+                created_at_ms: now,
+                expires_at_ms: now + 60_000,
+                packs,
+                fallback_entries: Vec::new(),
+            },
+        )
+        .unwrap();
+        put_test_object(&backend, &encoded.object_key, &encoded.bytes).await;
+        // A later pack holds the only reservation before the first GET starts.
+        // Waiting for input order would retain that body and deadlock the first.
+        let backend: Arc<dyn crate::remote_backend::RemoteBackend> =
+            Arc::new(ReorderedPackBackend {
+                inner: backend,
+                first_key: crate::remote_pack::pack_object_key(
+                    "prefix",
+                    &encoded.catalog.packs[0].digest,
+                )
+                .unwrap(),
+                later_downloaded: Notify::new(),
+            });
+        let imported = tokio::time::timeout(
+            Duration::from_secs(3),
+            daemon.try_packed_prefetch(&context, &backend, &remote, &candidates, 0),
+        )
+        .await
+        .expect("catalog and pack bodies must be released while the queue is draining");
+        assert_eq!(imported.len(), 3);
+        for (key, _, _) in candidates {
+            assert!(imported.contains(&key));
+            assert!(
+                daemon
+                    .with_store(|store| Ok(store.get(&key)?.is_some()))
+                    .unwrap()
+            );
+        }
+        assert_eq!(
+            daemon
+                .prefetch_stats
+                .pack_requests_total
+                .load(Ordering::Relaxed),
+            5
+        );
     }
 
     #[tokio::test]

--- a/src/remote_backend.rs
+++ b/src/remote_backend.rs
@@ -4,6 +4,10 @@
 //! ([`crate::remote`]) speak in opaque byte objects addressed by key. OpenDAL
 //! supplies the concrete S3 and shared-filesystem transports behind this seam.
 
+mod download_memory;
+
+use download_memory::{BudgetedBody, DOWNLOAD_MEMORY, DownloadMemory};
+
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -63,7 +67,8 @@ const LIST_MAX_KEY_BYTES: usize = 256 * 1024 * 1024;
 /// A fetched object plus the timing split callers report as transfer telemetry.
 #[derive(Debug)]
 pub struct GetObject {
-    /// `Bytes` so a restore does not copy the whole pack a second time.
+    /// Clones share the allocation and its memory reservation. Consume or drop
+    /// buffered objects before waiting for more downloads from the same budget.
     pub body: Bytes,
     /// Time to response headers, ms.
     pub request_ms: u64,
@@ -159,6 +164,7 @@ pub struct OpenDalBackend {
     /// "this backend writes real paths", which enables the extra key rules and the
     /// write-containment check.
     filesystem_root: Option<PathBuf>,
+    download_memory: Arc<DownloadMemory>,
 }
 
 impl OpenDalBackend {
@@ -167,6 +173,7 @@ impl OpenDalBackend {
             operator,
             root_description,
             filesystem_root: None,
+            download_memory: DOWNLOAD_MEMORY.clone(),
         }
     }
 
@@ -279,6 +286,13 @@ pub(crate) fn memory_backend() -> OpenDalBackend {
     OpenDalBackend::new(operator, "memory://test".to_string())
 }
 
+#[cfg(test)]
+pub(crate) fn memory_backend_with_download_budget(kib: u32) -> OpenDalBackend {
+    let mut backend = memory_backend();
+    backend.download_memory = Arc::new(DownloadMemory::new(kib));
+    backend
+}
+
 #[async_trait]
 impl RemoteBackend for OpenDalBackend {
     async fn head(&self, key: &str) -> Result<bool> {
@@ -291,12 +305,17 @@ impl RemoteBackend for OpenDalBackend {
     }
 
     async fn get(&self, key: &str, max_bytes: Option<u64>) -> Result<Option<GetObject>> {
+        self.validate_key("GET", key, false)?;
+        let memory = self.download_memory.acquire(max_bytes).await?;
         let mut body = Vec::new();
         let Some(transfer) = self.get_into(key, max_bytes, &mut body).await? else {
             return Ok(None);
         };
         Ok(Some(GetObject {
-            body: Bytes::from(body),
+            body: Bytes::from_owner(BudgetedBody {
+                body: Bytes::from(body),
+                _memory: memory,
+            }),
             request_ms: transfer.request_ms,
             body_ms: transfer.body_ms,
         }))
@@ -1081,6 +1100,70 @@ mod tests {
                 .contains("writing body of memory://test/key"),
             "{error:#}"
         );
+    }
+
+    #[tokio::test]
+    async fn separate_backends_share_memory_until_the_last_body_clone_is_dropped() {
+        let mut first = memory_backend();
+        let mut second = memory_backend();
+        assert!(Arc::ptr_eq(&first.download_memory, &second.download_memory));
+        let budget = Arc::new(DownloadMemory::new(10));
+        first.download_memory = budget.clone();
+        second.download_memory = budget;
+        first.put("key", b"hello".to_vec(), None).await.unwrap();
+        second.put("key", b"world".to_vec(), None).await.unwrap();
+        let body = first.get("key", Some(5 << 10)).await.unwrap().unwrap().body;
+        let clone = body.clone();
+        drop(body);
+        let deadline = crate::remote_resilience::RemoteDeadline::from_millis(10);
+        let error = deadline
+            .run("download memory", second.get("key", Some(5 << 10)))
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .downcast_ref::<crate::remote_resilience::RemoteDeadlineElapsed>()
+                .is_some()
+        );
+        drop(clone);
+        let object = tokio::time::timeout(Duration::from_secs(1), second.get("key", Some(5 << 10)))
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(object.body, "world");
+    }
+
+    #[tokio::test]
+    async fn misses_and_failed_reads_release_download_memory() {
+        let backend = memory_backend_with_download_budget(1);
+        backend.put("key", b"hello".to_vec(), None).await.unwrap();
+        assert!(backend.get("absent", Some(5)).await.unwrap().is_none());
+        assert!(backend.get("key", Some(4)).await.is_err());
+        let object = tokio::time::timeout(Duration::from_secs(1), backend.get("key", Some(5)))
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(object.body, "hello");
+    }
+
+    #[tokio::test]
+    async fn streaming_downloads_do_not_wait_for_buffered_memory() {
+        let backend = memory_backend_with_download_budget(1);
+        backend.put("key", b"hello".to_vec(), None).await.unwrap();
+        let buffered = backend.get("key", Some(5)).await.unwrap().unwrap();
+        let mut file = tokio::fs::File::from_std(tempfile::tempfile().unwrap());
+        let transfer = tokio::time::timeout(
+            Duration::from_secs(1),
+            backend.get_into("key", Some(5), &mut file),
+        )
+        .await
+        .expect("a disk download must not wait for a body-buffer reservation")
+        .unwrap()
+        .unwrap();
+        assert_eq!(transfer.bytes, 5);
+        assert_eq!(buffered.body, "hello");
     }
 
     #[tokio::test]

--- a/src/remote_backend/download_memory.rs
+++ b/src/remote_backend/download_memory.rs
@@ -1,0 +1,147 @@
+//! Admission and lifetime accounting for buffered remote objects.
+//!
+//! Reserve before reading, including room for the final contiguous copy. Keep
+//! the reservation with the returned bytes until their last clone is dropped.
+//! Acquiring the whole reservation at once avoids readers each holding partial
+//! allocations while waiting for one another to release the rest.
+
+use std::sync::{Arc, LazyLock};
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+const MEMORY_UNIT_BYTES: u64 = 1024;
+const BUFFER_BUDGET_UNITS: u32 = 512 << 10;
+
+pub(super) static DOWNLOAD_MEMORY: LazyLock<Arc<DownloadMemory>> =
+    LazyLock::new(|| Arc::new(DownloadMemory::new(BUFFER_BUDGET_UNITS)));
+
+pub(super) struct DownloadMemory {
+    semaphore: Arc<Semaphore>,
+    capacity: u32,
+}
+
+impl DownloadMemory {
+    // KiB permits fit Tokio's semaphore limit on 32-bit targets too.
+    pub(super) fn new(capacity: u32) -> Self {
+        Self {
+            semaphore: Arc::new(Semaphore::new(capacity as usize)),
+            capacity,
+        }
+    }
+
+    pub(super) async fn acquire(&self, max_bytes: Option<u64>) -> Result<OwnedSemaphorePermit> {
+        // Unknown-size and oversized buffered requests run alone. This keeps
+        // the existing per-object limits compatible; the admission budget is
+        // not an additional rejection limit for a single large object.
+        let reservation = max_bytes
+            .unwrap_or(u64::MAX)
+            .saturating_mul(2)
+            .div_ceil(MEMORY_UNIT_BYTES)
+            .clamp(1, u64::from(self.capacity)) as u32;
+        self.semaphore
+            .clone()
+            .acquire_many_owned(reservation)
+            .await
+            .context("waiting for remote download memory")
+    }
+}
+
+pub(super) struct BudgetedBody {
+    pub(super) body: Bytes,
+    pub(super) _memory: OwnedSemaphorePermit,
+}
+
+impl AsRef<[u8]> for BudgetedBody {
+    fn as_ref(&self) -> &[u8] {
+        &self.body
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{FutureExt, poll};
+    use std::task::Poll;
+
+    #[tokio::test]
+    async fn reservations_include_copy_space_and_are_released_on_drop() {
+        let budget = DownloadMemory::new(10);
+        let first = budget.acquire(Some(3 << 10)).await.unwrap();
+        assert_eq!(budget.semaphore.available_permits(), 4);
+        let mut second = Box::pin(budget.acquire(Some(3 << 10)));
+        assert!(poll!(&mut second).is_pending());
+        let last = budget.acquire(Some(0));
+        assert!(last.now_or_never().is_none(), "queued requests stay fair");
+        drop(first);
+        let second = second.await.unwrap();
+        assert_eq!(budget.semaphore.available_permits(), 4);
+        drop(second);
+        assert_eq!(budget.semaphore.available_permits(), 10);
+    }
+
+    #[tokio::test]
+    async fn unknown_and_oversized_requests_reserve_the_entire_budget() {
+        let budget = DownloadMemory::new(10);
+        for limit in [None, Some(5 << 10), Some(6 << 10), Some(u64::MAX)] {
+            let permit = budget.acquire(limit).await.unwrap();
+            assert_eq!(budget.semaphore.available_permits(), 0, "{limit:?}");
+            drop(permit);
+            assert_eq!(budget.semaphore.available_permits(), 10);
+        }
+        let empty = budget.acquire(Some(0)).await.unwrap();
+        assert_eq!(budget.semaphore.available_permits(), 9);
+        drop(empty);
+        let rounded = budget.acquire(Some(513)).await.unwrap();
+        assert_eq!(budget.semaphore.available_permits(), 8);
+        drop(rounded);
+        assert_eq!(
+            u64::from(BUFFER_BUDGET_UNITS) * MEMORY_UNIT_BYTES,
+            536_870_912
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelling_a_waiter_does_not_leak_its_reservation() {
+        let budget = DownloadMemory::new(10);
+        let held = budget.acquire(Some(4 << 10)).await.unwrap();
+        let mut cancelled = Box::pin(budget.acquire(Some(2 << 10)));
+        assert!(matches!(poll!(&mut cancelled), Poll::Pending));
+        drop(cancelled);
+        let remaining = budget
+            .acquire(Some(1 << 10))
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        assert_eq!(budget.semaphore.available_permits(), 0);
+        drop(remaining);
+        drop(held);
+        assert_eq!(budget.semaphore.available_permits(), 10);
+    }
+
+    #[tokio::test]
+    async fn body_clones_and_slices_hold_the_reservation_until_last_drop() {
+        let budget = DownloadMemory::new(10);
+        let body = Bytes::from_owner(BudgetedBody {
+            body: Bytes::from_static(b"hello"),
+            _memory: budget.acquire(Some(5 << 10)).await.unwrap(),
+        });
+        let clone = body.clone();
+        let slice = body.slice(1..4);
+        drop(body);
+        drop(clone);
+        assert_eq!(&slice[..], b"ell");
+        assert_eq!(budget.semaphore.available_permits(), 0);
+        drop(slice);
+        assert_eq!(budget.semaphore.available_permits(), 10);
+    }
+
+    #[tokio::test]
+    async fn a_closed_budget_reports_the_waiting_stage() {
+        let budget = DownloadMemory::new(10);
+        budget.semaphore.close();
+        let error = budget.acquire(Some(1 << 10)).await.unwrap_err();
+        assert_eq!(error.to_string(), "waiting for remote download memory");
+    }
+}


### PR DESCRIPTION
Share a 512 MiB admission budget across buffered remote downloads in each Kache process. Reserve space before reading, allow for temporary copying, and retain the reservation until the last clone of the returned bytes is dropped. Requests larger than the budget run alone under the existing object limits.

Packed prefetch now reserves against each catalog's declared pack size, releases the catalog body before scheduling packs, and consumes completed packs immediately. Holding all completed bodies, or waiting for input order, can exhaust the budget and block the remaining downloads. Catalog and pack validation remain in place.

V3 entry packs stream to disk without taking a body-buffer reservation. A regression test holds the entire buffered-download budget while a streamed download completes.

Validation: `CARGO_INCREMENTAL=0 RUST_TEST_THREADS=1 just check` passed. Tests cover sharing between clients, cloned bytes, cancellation, missing and rejected objects, and out-of-order prefetch under a one-object budget. Fault injection confirmed the tests catch retained catalogs and queued bodies that prevent progress.
