### PR TITLE
feat(bench): publish why a compile was not cached, split by kind

### DIFF
--- a/crates/kache-e2e/src/bench_otlp.rs
+++ b/crates/kache-e2e/src/bench_otlp.rs
@@ -78,6 +78,16 @@ pub struct OtlpPhase {
     /// be reconstructed from the metrics, and a fall in coverage looks
     /// identical to a fall in hit rate.
     pub unconsulted: Option<u64>,
+    /// Compiles the tool declined to cache and ran straight through, split by
+    /// why. `(category, count)`, already bounded by the caller.
+    ///
+    /// The two categories are not the same kind of thing and want opposite
+    /// responses. `not-a-compile` is a query or probe that was never a
+    /// compilation, and no amount of work makes it cacheable. `unsupported` is
+    /// a real compile the tool could cache and does not model yet -- an
+    /// engineering backlog, visible as a number. Summed together they say only
+    /// "some things were skipped".
+    pub passthrough: Vec<(&'static str, u64)>,
 }
 
 impl OtlpRun {
@@ -141,6 +151,7 @@ fn metrics_for(run: &OtlpRun) -> Vec<Value> {
     let mut objdir_points = Vec::new();
     let mut miss_cost_points = Vec::new();
     let mut unconsulted_points = Vec::new();
+    let mut passthrough_points = Vec::new();
 
     for phase in &run.phases {
         let phase_attrs = common_attrs(run, Some(phase.name));
@@ -164,6 +175,13 @@ fn metrics_for(run: &OtlpRun) -> Vec<Value> {
         // name is not: it comes from the dependency tree of whatever is being
         // benchmarked. `attribute_set_is_the_allowlist` holds that line.
         //
+        for (category, count) in &phase.passthrough {
+            passthrough_points.push(as_int(
+                *count,
+                &run.time_unix_nano,
+                &unit_attrs(run, phase.name, category),
+            ));
+        }
         // What a metric can carry is the shape: how much of the build the
         // costliest misses account for. A project whose top ten misses are 78
         // percent of the wall clock and one where they are 5 percent have the
@@ -242,6 +260,13 @@ fn metrics_for(run: &OtlpRun) -> Vec<Value> {
     metrics.push(gauge("kache.bench.objdir.size", "By", objdir_points));
     if !miss_cost_points.is_empty() {
         metrics.push(gauge("kache.bench.miss.cost", "s", miss_cost_points));
+    }
+    if !passthrough_points.is_empty() {
+        metrics.push(gauge(
+            "kache.bench.cache.passthrough",
+            "{unit}",
+            passthrough_points,
+        ));
     }
     if !unconsulted_points.is_empty() {
         metrics.push(gauge(
@@ -375,6 +400,7 @@ mod tests {
                     objdir_bytes: 8_000_000_000,
                     top_misses: Vec::new(),
                     unconsulted: Some(3),
+                    passthrough: Vec::new(),
                 },
                 OtlpPhase {
                     name: "warm",
@@ -391,6 +417,7 @@ mod tests {
                     objdir_bytes: 8_100_000_000,
                     top_misses: vec![("gecko".into(), 97), ("style".into(), 42)],
                     unconsulted: Some(11),
+                    passthrough: vec![("not-a-compile", 12), ("unsupported", 3)],
                 },
             ],
         }
@@ -559,6 +586,7 @@ mod tests {
             objdir_bytes: 1,
             top_misses: Vec::new(),
             unconsulted: None,
+            passthrough: Vec::new(),
         }];
         let body = serialize_metrics(&run);
         let duration = &metric(&body, "kache.bench.build.duration")["gauge"]["dataPoints"][0];
@@ -594,6 +622,7 @@ mod tests {
                 objdir_bytes: 9,
                 top_misses: Vec::new(),
                 unconsulted: None,
+                passthrough: Vec::new(),
             }],
         };
         let body = serialize_metrics(&run);
@@ -731,5 +760,85 @@ mod costliest_misses {
             .find(|p| attr(p, "kache.bench.phase") == Some("warm"))
             .unwrap();
         assert_eq!(warm["asDouble"], 11.0);
+    }
+}
+
+#[cfg(test)]
+mod passthrough_split {
+    use serde_json::Value;
+
+    fn points<'a>(body: &'a Value, name: &str) -> &'a Vec<Value> {
+        body["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["name"] == name)
+            .unwrap_or_else(|| panic!("{name} is not in the payload"))["gauge"]["dataPoints"]
+            .as_array()
+            .unwrap()
+    }
+
+    fn attr<'a>(point: &'a Value, key: &str) -> Option<&'a str> {
+        point["attributes"]
+            .as_array()?
+            .iter()
+            .find(|a| a["key"] == key)?["value"]["stringValue"]
+            .as_str()
+    }
+
+    /// The split is the point. `unsupported` is a real compile the tool could
+    /// cache and does not model yet -- a backlog item with a number on it --
+    /// and `not-a-compile` is a probe that never could be. A single
+    /// "passthroughs: 15" cannot tell the two apart, and they want opposite
+    /// responses.
+    #[test]
+    fn the_two_categories_are_separate_series() {
+        let body = super::tests::payload_for_kache_run();
+        let pts = points(&body, "kache.bench.cache.passthrough");
+        let by = |result: &str| {
+            pts.iter()
+                .find(|p| {
+                    attr(p, "kache.bench.result") == Some(result)
+                        && attr(p, "kache.bench.phase") == Some("warm")
+                })
+                .unwrap_or_else(|| panic!("no {result} point"))["asInt"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        };
+        assert_eq!(by("not-a-compile"), "12");
+        assert_eq!(by("unsupported"), "3");
+    }
+
+    /// The categories stay a bounded vocabulary. They come from kache's own
+    /// `RefuseReason::category`, which has two variants, plus the single
+    /// figure an external backend reports; anything else here would be a
+    /// series per refusal detail.
+    #[test]
+    fn the_vocabulary_stays_small() {
+        let body = super::tests::payload_for_kache_run();
+        let mut seen: Vec<&str> = points(&body, "kache.bench.cache.passthrough")
+            .iter()
+            .filter_map(|p| attr(p, "kache.bench.result"))
+            .collect();
+        seen.sort_unstable();
+        seen.dedup();
+        assert!(
+            seen.iter()
+                .all(|r| matches!(*r, "not-a-compile" | "unsupported" | "declined")),
+            "an unbounded refusal reason reached the payload: {seen:?}"
+        );
+    }
+
+    /// A phase that declined nothing opens no series.
+    #[test]
+    fn a_phase_that_declined_nothing_contributes_nothing() {
+        let body = super::tests::payload_for_kache_run();
+        assert!(
+            points(&body, "kache.bench.cache.passthrough")
+                .iter()
+                .all(|p| attr(p, "kache.bench.phase") == Some("warm")),
+            "the cold phase declared no passthrough and must not appear"
+        );
     }
 }

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -905,6 +905,14 @@ fn otlp_phase(
         weighted_hit_rate_pct: Some(metrics.weighted_hit_rate_pct),
         leak_warnings: Some(metrics.leak_warnings),
         objdir_bytes,
+        // The two categories kache's own RefuseReason draws: a probe that was
+        // never a compilation, and a real compile it does not model yet. The
+        // second is a backlog item with a number on it; the first never will
+        // be. Summed together they say only "some things were skipped".
+        passthrough: vec![
+            ("not-a-compile", metrics.event_log.probed),
+            ("unsupported", metrics.event_log.passed_through),
+        ],
         top_misses: metrics
             .top_misses
             .iter()
@@ -942,6 +950,8 @@ fn otlp_sccache_phase(
         weighted_hit_rate_pct: None,
         leak_warnings: None,
         objdir_bytes,
+        // sccache reports no passthrough breakdown.
+        passthrough: Vec::new(),
         // sccache reports neither: it has no per-unit cost breakdown, and no
         // count of what it looked at without consulting the cache.
         top_misses: Vec::new(),
@@ -2754,6 +2764,11 @@ fn otlp_mbx_phase(
         weighted_hit_rate_pct: None,
         leak_warnings: None,
         objdir_bytes,
+        // Its report splits bypasses eleven ways, on a vocabulary of its own
+        // that does not map onto kache's two categories without inventing the
+        // mapping. The total is comparable; the split is not, so only the
+        // total is carried.
+        passthrough: vec![("declined", metrics.bypassed)],
         // No per-unit cost in its report.
         top_misses: Vec::new(),
         unconsulted: Some(metrics.unconsulted),
@@ -5942,6 +5957,30 @@ build = "sleep 0.2"
         assert!(!stale.exists(), "the objdir is wiped before the build");
         assert!(work_dir.join("build-cold.log").exists());
         assert!(work_dir.join("wrapper-cold.log").exists());
+    }
+
+    /// The two refusal categories must reach the payload as two numbers, from
+    /// the two counters that mean different things: `probed` is a query that
+    /// was never a compilation, `passed_through` a real compile kache does not
+    /// model yet. Collapsing them into one loses the only part anyone can act
+    /// on, and does so without any test on the emitter noticing -- the emitter
+    /// is handed whatever this function built.
+    #[test]
+    fn the_refusal_categories_come_from_their_own_counters() {
+        let metrics = PhaseMetrics {
+            event_log: EventLogStats {
+                probed: 272,
+                passed_through: 12,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let phase = otlp_phase("warm", &metrics, 0);
+        assert_eq!(
+            phase.passthrough,
+            vec![("not-a-compile", 272), ("unsupported", 12)],
+            "the categories must not be summed or swapped"
+        );
     }
 
     /// The same-tree warm is a phase of the same gauges, present only when it


### PR DESCRIPTION
`kache report` hides passthrough events and the metrics carry none of them, so the most the telemetry can say is *some compiles were skipped*. The two kinds it hides are not the same thing:

| Category | What it is | What you do about it |
|---|---|---|
| `not-a-compile` | a query or probe — `--print`, `-vV` — that was never a compilation | nothing; it is inherent |
| `unsupported` | a real compile kache could cache and does not model yet | a backlog item, with a number on it |

Summed together the number says nothing. For substrate's warm phase they are 272 and 12 — which is the difference between *most of this is probes, ignore it* and *twelve compiles are leaving the cache for a reason we could fix*.

## Bounded, deliberately

The categories come from kache's own `RefuseReason::category`, whose doc comment already calls them "the passthrough report's category column". Two variants, so this is a vocabulary rather than a series per refusal detail — the full reason string is `not-a-compile|query / probe (--print, -vV)` and those compose, which would not have been.

The external backend reports its own eleven-way split on a vocabulary that does not map onto these two without inventing the mapping, so only its total is carried, as `declined`. Comparable at the total; not pretended otherwise.

`attribute_set_is_the_allowlist` still passes — `result` was already an attribute and only carries new values.

## Mutation testing found the test I did not write

Collapsing the two counters into one, or swapping them, **passed every test I had written**:

```
passthrough: vec![("not-a-compile", probed + passed_through)]     18 passed
```

All three of my new tests build the payload from a fixture and never exercise `otlp_phase`, the function that fills it from `PhaseMetrics`. The emitter was tested; the wiring into it was not.

`the_refusal_categories_come_from_their_own_counters` covers that function directly. Both mutants now fail:

| Mutant | Before | Now |
|---|---|---|
| the two counters summed into one | 18 passed | FAILED |
| the two categories swapped | — | FAILED |

That is the third time in this stretch of work the same gap has appeared — a test that exercises a function and not the call that feeds it — so it is worth naming rather than quietly fixing.

## Verification

```
cargo test -p kache-e2e --lib      172 passed
cargo clippy -D warnings           clean
cargo fmt --check                  clean
```

`kache.bench.cache.passthrough` is admitted by the collector's allowlist as deployed, under the existing `kache\.(bench|cache|prefetch|ci)\..+` pattern, with no new attribute key.