### PR TITLE
fix(macos): resolve dsymutil objects from executable output directory

### DIFF
--- a/src/compiler/platform.rs
+++ b/src/compiler/platform.rs
@@ -253,6 +253,7 @@ impl Platform for MacOsPlatform {
 
 /// Resolve paths before changing the child's cwd: cached macOS debug links
 /// use `-oso_prefix` to make OSO records relative to the binary's output dir.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn debug_bundle_command(binary: &Path, bundle_dir: &Path) -> Result<Command> {
     let binary = std::path::absolute(binary)?;
     let bundle_dir = std::path::absolute(bundle_dir)?;

--- a/src/compiler/platform.rs
+++ b/src/compiler/platform.rs
@@ -621,14 +621,12 @@ pub(crate) mod tests {
             command.get_current_dir(),
             Some(cwd.join("target/debug/deps").as_path())
         );
-        assert_eq!(
-            command.get_args().collect::<Vec<_>>(),
-            vec![
-                cwd.join(binary).into_os_string(),
-                "-o".into(),
-                cwd.join(bundle).into_os_string()
-            ]
-        );
+        let args = command.get_args().collect::<Vec<_>>();
+        assert_eq!(args.len(), 3);
+        // Windows absolute() normalizes separators; compare paths, not argv bytes.
+        assert_eq!(Path::new(args[0]), cwd.join(binary));
+        assert_eq!(args[1], "-o");
+        assert_eq!(Path::new(args[2]), cwd.join(bundle));
     }
 
     #[test]

--- a/src/compiler/platform.rs
+++ b/src/compiler/platform.rs
@@ -219,12 +219,7 @@ impl Platform for MacOsPlatform {
         //   2. lldb's adjacent-bundle lookup is by `<binary>.dSYM` sibling
         //      path, which is exactly this location.
         let bundle_dir = binary.with_file_name(format!("{file_name}.dSYM"));
-        let status = match Command::new("dsymutil")
-            .arg(binary)
-            .arg("-o")
-            .arg(&bundle_dir)
-            .status()
-        {
+        let status = match debug_bundle_command(binary, &bundle_dir)?.status() {
             Ok(status) => status,
             Err(err) => {
                 // Best-effort per the trait contract: no dsymutil (unusual
@@ -254,6 +249,23 @@ impl Platform for MacOsPlatform {
             }
         }
     }
+}
+
+/// Resolve paths before changing the child's cwd: cached macOS debug links
+/// use `-oso_prefix` to make OSO records relative to the binary's output dir.
+fn debug_bundle_command(binary: &Path, bundle_dir: &Path) -> Result<Command> {
+    let binary = std::path::absolute(binary)?;
+    let bundle_dir = std::path::absolute(bundle_dir)?;
+    let output_dir = binary
+        .parent()
+        .context("debug binary has no parent directory")?;
+    let mut command = Command::new("dsymutil");
+    command
+        .current_dir(output_dir)
+        .arg(&binary)
+        .arg("-o")
+        .arg(bundle_dir);
+    Ok(command)
 }
 
 /// Tar `bundle_dir`'s contents (paths relative to the bundle root, e.g.
@@ -595,6 +607,68 @@ pub(crate) mod tests {
                 "Contents/Resources/DWARF/fake".to_string(),
             ],
             "every file, relative to the bundle root, in sorted order"
+        );
+    }
+
+    #[test]
+    fn debug_bundle_command_resolves_relative_arguments_before_changing_directory() {
+        let binary = Path::new("target/debug/deps/demo");
+        let bundle = Path::new("target/debug/deps/demo.dSYM");
+        let command = debug_bundle_command(binary, bundle).unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        assert_eq!(
+            command.get_current_dir(),
+            Some(cwd.join("target/debug/deps").as_path())
+        );
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            vec![
+                cwd.join(binary).into_os_string(),
+                "-o".into(),
+                cwd.join(bundle).into_os_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn macos_debug_bundle_contains_symbols_with_output_relative_oso_paths() {
+        if std::env::consts::OS != "macos" {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let dir = dir.path().canonicalize().unwrap();
+        let binary = compile_debug_c_binary(&dir).expect("macOS C compiler must work");
+        // Relink with the same OSO prefix kache injects for Rust executables.
+        assert!(
+            Command::new("cc")
+                .arg(dir.join("hello.o"))
+                .arg(format!("-Wl,-oso_prefix,{}/", dir.display()))
+                .arg("-o")
+                .arg(&binary)
+                .status()
+                .unwrap()
+                .success()
+        );
+        let staging = tempfile::tempdir().unwrap();
+        MacOsPlatform
+            .package_debug_bundle(&binary, staging.path())
+            .unwrap()
+            .unwrap();
+        let dwarf = dir.join("hello-bin.dSYM/Contents/Resources/DWARF/hello-bin");
+        let dump = Command::new("dwarfdump")
+            .arg("--debug-info")
+            .arg(dwarf)
+            .output()
+            .unwrap();
+        assert!(dump.status.success());
+        let info = String::from_utf8_lossy(&dump.stdout);
+        assert!(
+            info.contains("hello.c"),
+            "bundle must contain the source compile unit: {info}"
+        );
+        assert!(
+            info.contains("DW_TAG_subprogram"),
+            "bundle must contain function debug info: {info}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #995.

Cached macOS debug links use `-oso_prefix` to make OSO object paths relative to the executable's output directory. Store-time `dsymutil` inherited the caller's working directory, so it warned that existing objects could not be opened and produced bundles missing their source debug info.

Resolve the binary and bundle paths before running `dsymutil` from the executable's output directory. Regression coverage checks relative command arguments and verifies that a real bundle contains source and function debug info after linking with `-oso_prefix`.

Reproduction: https://github.com/Dzejkop/kache-dsym-repro

## Test plan

- Local Nix flake override of the reproduction: kache build warnings drop from 1 to 0, and the generated `.dSYM` contains source debug info. All four comparison cases pass.
- Reporter also confirmed a fresh `world-id-indexer` build succeeds without these warnings after installing the pinned fix.
- Original v0.18.0 fails the same `--expect-fixed` assertions.
- All 18 targeted debug-bundle tests pass.
- Replacing the child cwd with the original caller cwd makes the new regression test fail on the missing source compile unit; the fix was restored afterward.
- `CARGO_HOME=<isolated home> RUSTUP_TOOLCHAIN=1.98.1 just check` (local installed toolchain; the repository pin is 1.98.0). The isolated home avoids a machine-global Cargo `[env] KACHE_CONFIG` overriding fixtures that test project config discovery.

The reproduction's README includes a pinned command for this fork. Existing cached bundles are not repaired by this change.

## Checklist

- [ ] CI changed-line mutation testing passes (draft PR per AGENTS.md; not run locally)
- [x] New behavior is covered by regression tests
- [x] Commit follows conventional commits
- [x] Reproduction and before/after verification are documented in the linked repository
