### PR TITLE
bench: add a predictions-off hk arm and check every hk-pull prediction

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -35,7 +35,7 @@ on:
       scenario:
         description: "Which scenario(s) to run"
         type: choice
-        options: [all, substrate, surrealdb, lance, opendal, eza, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows, hk, hk-pull, hk-mbx, opendal-mbx, lance-mbx, substrate-mbx, surrealdb-mbx]
+        options: [all, substrate, surrealdb, lance, opendal, eza, firefox, firefox-sccache, llvm, firefox-windows, firefox-pull, firefox-pull-windows, hk, hk-nopred, hk-pull, hk-mbx, opendal-mbx, lance-mbx, substrate-mbx, surrealdb-mbx]
         default: all
       extra_args:
         description: "Extra args appended to `just bench <profile>` (e.g. --skip-clone, --retry)"
@@ -139,6 +139,9 @@ jobs:
           # `--warm-same-tree` adds the same-path warm phase between cold and the
           # cross-clone warm. Minutes, not hours; a C compiler is all it needs.
           hk='{"name":"hk","cmd":"bench hk --warm-same-tree","dir":"bench-hk","timeout":60,"job_timeout":90,"min_free_gb":30,"runner":"kunobi-runners"}'
+          # hk with input predictions off: the control for the arm above, so
+          # the same nightly shows what predictions are worth (#1000).
+          hk_nopred='{"name":"hk-nopred","cmd":"bench hk-nopred --warm-same-tree","dir":"bench-hk-nopred","timeout":60,"job_timeout":90,"min_free_gb":30,"runner":"kunobi-runners"}'
           # Same subject on the temporal axis: cold at the parent commit, then
           # rebuild the child in the same worktree with the store warm.
           hk_pull='{"name":"hk-pull","cmd":"bench hk-pull","dir":"bench-hk-pull","timeout":60,"job_timeout":90,"min_free_gb":30,"runner":"kunobi-runners"}'
@@ -178,6 +181,7 @@ jobs:
             llvm)                 inc="[$llvm]" ;;
             firefox-pull)         inc="[$firefox_pull]" ;;
             hk)                   inc="[$hk]" ;;
+            hk-nopred)            inc="[$hk_nopred]" ;;
             hk-pull)              inc="[$hk_pull]" ;;
             hk-mbx)               inc="[$hk_mbx]" ;;
             eza)                  inc="[$eza]" ;;
@@ -191,7 +195,7 @@ jobs:
             # and wastefully run the whole Linux `all` matrix alongside.
             firefox-windows)      inc="[]" ;;
             firefox-pull-windows) inc="[]" ;;
-            *)                    inc="[$substrate,$surrealdb,$lance,$opendal,$firefox,$firefox_sccache,$llvm,$firefox_pull,$hk,$hk_pull,$hk_mbx,$eza,$opendal_mbx,$lance_mbx,$substrate_mbx,$surrealdb_mbx]" ;;
+            *)                    inc="[$substrate,$surrealdb,$lance,$opendal,$firefox,$firefox_sccache,$llvm,$firefox_pull,$hk,$hk_nopred,$hk_pull,$hk_mbx,$eza,$opendal_mbx,$lance_mbx,$substrate_mbx,$surrealdb_mbx]" ;;
           esac
           echo "matrix={\"include\":$inc}" >> "$GITHUB_OUTPUT"
           if [ "$inc" = "[]" ]; then

--- a/scenarios/bench-hk-nopred/scenario.toml
+++ b/scenarios/bench-hk-nopred/scenario.toml
@@ -1,0 +1,72 @@
+# hk with input-set predictions off: the control arm for bench-hk.
+#
+# bench-hk runs with predictions on. This scenario is the same subject, the
+# same commit, the same wiring and the same phases, with predictions forced
+# off, so one nightly measures both sides on the same runner pool. Compare the
+# warm-same-tree phases: wall clock, total key time and dep-info pre-pass
+# count. That difference is the evidence kunobi-ninja/kache#1000 asks for
+# before predictions can default on.
+#
+# Predictions are set to 0 explicitly rather than left to the default, so this
+# arm stays a control after the default changes. Remove it once #1000 is
+# decided.
+name = "bench-hk-nopred"
+tags = ["suite:bench", "project:hk", "backend:kache", "lang:rust", "lang:cc"]
+
+requires = ["cargo", "rustc", "cc"]
+
+setup = [
+  "echo '[bench] bench-hk-nopred needs a C compiler (aws-lc-sys cc builder, vendored libgit2); cmake only as the aws-lc-sys fallback.'",
+]
+
+build = """
+# Predictions off: every rustc unit runs the dep-info pre-pass. This is the
+# baseline bench-hk's predictions are measured against (kunobi-ninja/kache#1000).
+export KACHE_INPUT_PREDICTIONS=0
+
+repo="$(pwd -P)"
+prefix_map="-ffile-prefix-map=$repo=. -fdebug-prefix-map=$repo=. -fmacro-prefix-map=$repo=."
+export CFLAGS="${CFLAGS:-} $prefix_map"
+export CXXFLAGS="${CXXFLAGS:-} $prefix_map"
+export SOURCE_DATE_EPOCH=1735689600
+export ZERO_AR_DATE=1
+export KACHE_BASE_DIR="$repo"
+
+cargo build --locked
+"""
+
+# Same wiring as bench-hk; see that scenario for why.
+[env]
+HOST_CC = "{kache} cc"
+HOST_CXX = "{kache} c++"
+CC_KNOWN_WRAPPER_CUSTOM = "kache"
+
+[source]
+kind   = "clone"
+repo   = "https://github.com/jdx/hk.git"
+# Must match bench-hk's ref, or the two arms measure different code.
+ref    = "fc29ead1456ba7c1f62826c284126410a4014b00"
+objdir = "target"
+
+[[file]]
+path = "rust-toolchain.toml"
+content = """
+[toolchain]
+channel = "1.97.1"
+profile = "minimal"
+"""
+
+# The same validity floors as bench-hk, so a broken control fails loudly
+# instead of reporting a flattering or meaningless baseline.
+[checks.assert.warm-same-tree]
+max_passthrough_pct = 40.0
+max_errors = 0
+min_hits = 200
+min_restored_bytes = 67108864 # 64 MiB
+
+[checks.assert.warm]
+min_key_stability_pct = 50.0
+max_passthrough_pct = 40.0
+max_errors = 0
+min_hits = 200
+min_restored_bytes = 67108864 # 64 MiB

--- a/scenarios/bench-hk-pull/scenario.toml
+++ b/scenarios/bench-hk-pull/scenario.toml
@@ -16,15 +16,17 @@ setup = [
 ]
 
 build = """
-# Input-set predictions, with a sampled cross-check (kunobi-ninja/kache#945).
-# Predictions replace the rustc dep-info pre-pass with a recorded closure, so
-# the warm phases here measure what that is worth on a real graph. One unit in
-# 64 runs the pre-pass anyway and compares the two closures; the pre-pass
-# answer wins either way, so a disagreement costs nothing at the time. Its
-# count reaches the report, and zero across real subjects is what would
-# justify turning predictions on by default.
+# Input-set predictions, with EVERY prediction cross-checked
+# (kunobi-ninja/kache#1000). The pull phase is the one where inputs really
+# change between builds, which is where a wrong prediction would matter, so
+# this arm checks all of them instead of sampling. Stable sampling checks the
+# same few units every night, which is too little evidence to change a
+# default. The pre-pass answer still keys, so a disagreement costs nothing at
+# the time; the pull gate below fails the run if one appears. This arm trades
+# its pre-pass saving for that coverage; bench-hk and bench-hk-nopred measure
+# the saving.
 export KACHE_INPUT_PREDICTIONS=1
-export KACHE_VERIFY_INPUT_PREDICTIONS=sampled
+export KACHE_VERIFY_INPUT_PREDICTIONS=always
 
 repo="$(pwd -P)"
 prefix_map="-ffile-prefix-map=$repo=. -fdebug-prefix-map=$repo=. -fmacro-prefix-map=$repo=."
@@ -61,7 +63,9 @@ profile = "minimal"
 
 # Pull-phase gates. Errors and unclassified passthroughs are blocking; the
 # floors catch a run that rebuilt everything. The hit rate is advisory while
-# the number is being baselined.
+# the number is being baselined. The prediction mismatch count lands in
+# report-pull.json (`timing.prediction_mismatches`); bench checks cannot
+# assert on it yet.
 [checks.assert.pull]
 max_errors          = 0
 max_passthrough_pct = 40.0


### PR DESCRIPTION
Adds the evidence #1000 needs before input predictions can default on.

## What changes

- `scenarios/bench-hk-nopred`: bench-hk with `KACHE_INPUT_PREDICTIONS=0`. Same commit, wiring, phases and checks. Set explicitly so it stays a control after the default changes.
- `scenarios/bench-hk-pull`: `KACHE_VERIFY_INPUT_PREDICTIONS` goes from `sampled` to `always`, so every prediction in the pull phase is checked against the pre-pass.
- `bench.yml`: runs `hk-nopred --warm-same-tree` nightly on `kunobi-runners` and adds it to the dispatch menu.

## Why

Five nightlies (2026-09-06 to 09-11): on hk's same-tree warm phase, predictions skip 282 of 315 pre-passes, with 890 hits and no mismatches. Two gaps remain:

- No same-night baseline to compare the warm phase against. The new arm gives one.
- Since #955 sampling is stable per unit, so `sampled` checks the same few units each night. hk-pull now checks them all, in the phase where inputs change.

## First run on this branch

- hk-nopred, warm-same-tree: 315 pre-passes, summed key time 22.4 s (16.7 s of it pre-pass). The latest bench-hk nightly: 33 pre-passes, 10.5 s (3.6 s). So predictions roughly halve summed key time on hk.
- Wall clock for that phase: 17 s off against 13 to 16 s on in recent nightlies. The off run also had the faster runner (cold 89 s against 110 to 115 s), so the wall difference needs several same-night pairs before it means anything. That is what this arm is for.
- hk-pull with `always`: 315 pre-passes (every unit checked), 0 mismatches, 889 hits and 1 miss.

## Notes

- Bench `checks.assert` has no `max_prediction_mismatches` (only fixtures do), so this reads the count from `report-pull.json` instead of gating on it.
- Validated with the workflow policy tests. The new scenario has exactly bench-hk's keys and values apart from the build script, and hk-pull's keys and checks are unchanged.
- Adds one ~10 minute job to the general pool. Remove `hk-nopred` once #1000 is decided.

