### PR TITLE
bench: measure disk use per inode and allocated block

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -214,6 +214,15 @@ gitignore = true
 # consumer tests; mutating it tests the harness instead of filesystem behavior.
 # windows_identity combines a shifted u32 with an unshifted u32. Their bits do
 # not overlap, so replacing OR with XOR produces the same u64 for every input.
+#
+# `print_pull_summary` and `print_sccache_summary` are `print_mbx_summary`'s
+# shape: they only write the human summary to the e2e driver's stderr. The
+# numbers they print come from `disk_usage::measure`, `bytes_to_mib` and the
+# phase parsers, which are tested directly.
+#
+# `disk_usage::other` is the non-Unix fallback for inode identity and
+# allocated size. The ubuntu lane never compiles it; `disk_usage::unix` and
+# the measurement walk stay in scope.
 exclude_globs = ["crates/kache-fs/src/apfs.rs"]
 exclude_re = [
     "crates/kache-fs/src/copy.rs:.*(native_reflink_macos|native_reflink_windows|native_reflink_unsupported|windows_cluster_size)",
@@ -270,6 +279,9 @@ exclude_re = [
     "replace run_sccache_bench .* with Ok",
     "replace run_mbx_bench .* with Ok",
     "replace print_mbx_summary with \\(\\)",
+    "replace print_pull_summary with \\(\\)",
+    "replace print_sccache_summary with \\(\\)",
+    "crates/kache-e2e/src/disk_usage.rs:.*other::",
     "replace run_cold_phase .* with Ok",
     "src/cache_fs.rs:.*replace probe_windows",
     "src/cache_fs.rs:.*replace statfs_total_bytes_macos",

--- a/crates/kache-e2e/src/bench_otlp.rs
+++ b/crates/kache-e2e/src/bench_otlp.rs
@@ -46,6 +46,10 @@ pub struct OtlpRun {
     pub cache_size_bytes: u64,
     pub key_stability_pct: Option<f64>,
     pub disk_measured_bytes: Option<u64>,
+    /// Every pool the run left on disk, cache and objdirs, each inode once.
+    /// Read from the filesystem, so unlike `disk_measured_bytes` it does not
+    /// move with other jobs on the same volume. See [`crate::disk_usage`].
+    pub disk_footprint_bytes: u64,
     pub phases: Vec<OtlpPhase>,
 }
 
@@ -295,6 +299,15 @@ fn metrics_for(run: &OtlpRun) -> Vec<Value> {
             vec![as_int(disk, &run.time_unix_nano, &run_attrs)],
         ));
     }
+    metrics.push(gauge(
+        "kache.bench.disk.footprint",
+        "By",
+        vec![as_int(
+            run.disk_footprint_bytes,
+            &run.time_unix_nano,
+            &run_attrs,
+        )],
+    ));
     if let Some(stable) = run.key_stability_pct {
         metrics.push(gauge(
             "kache.bench.key_stability",
@@ -398,6 +411,7 @@ mod tests {
             cache_size_bytes: 12 * 1024 * 1024,
             key_stability_pct: Some(96.9),
             disk_measured_bytes: Some(3_000_000_000),
+            disk_footprint_bytes: 2_500_000_000,
             phases: vec![
                 OtlpPhase {
                     name: "cold",
@@ -512,6 +526,14 @@ mod tests {
         let point = &metric(&body, "kache.bench.cache.size")["gauge"]["dataPoints"][0];
         assert_eq!(point["asInt"], "12582912");
         assert!(point.get("asDouble").is_none());
+    }
+
+    #[test]
+    fn disk_footprint_is_emitted_in_bytes() {
+        let body = serialize_metrics(&kache_run());
+        let footprint = metric(&body, "kache.bench.disk.footprint");
+        assert_eq!(footprint["unit"], "By");
+        assert_eq!(footprint["gauge"]["dataPoints"][0]["asInt"], "2500000000");
     }
 
     #[test]
@@ -649,6 +671,7 @@ mod tests {
             cache_size_bytes: 100,
             key_stability_pct: None,
             disk_measured_bytes: None,
+            disk_footprint_bytes: 300,
             phases: vec![OtlpPhase {
                 name: "warm",
                 wall_s: 10,

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -559,12 +559,14 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         profile.checks.measure.for_phase(Phase::Warm.name()),
     );
 
-    // Apparent size of each clone's objdir. On APFS the warm
-    // clone's apparent size double-counts the bytes it reflinked from
-    // the cache — print_summary subtracts those to expose "unique to
+    // Allocated size of each pool, each inode once. On APFS the warm clone
+    // still double-counts the bytes it reflinked from the cache (a reflink is
+    // a second inode) — print_summary subtracts those to expose "unique to
     // this clone" disk usage.
-    let cold_objdir_bytes = dir_size_kb(&clone_a.join(&objdir)).saturating_mul(1024);
-    let warm_objdir_bytes = dir_size_kb(&clone_b.join(&objdir)).saturating_mul(1024);
+    let disk =
+        crate::disk_usage::measure(&cache_dir, &[clone_a.join(&objdir), clone_b.join(&objdir)]);
+    let cold_objdir_bytes = disk.objdir_bytes[0];
+    let warm_objdir_bytes = disk.objdir_bytes[1];
 
     // Verify: the measured free-space delta should land near the
     // sharing-corrected estimate of the three-pool footprint. They agree on
@@ -651,10 +653,11 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         warm: warm_metrics,
         speedup: round2(speedup),
         warm_same_tree_speedup,
-        cache_size_mb: round1(dir_size_kb(&cache_dir) as f64 / 1024.0),
+        cache_size_mb: bytes_to_mib(disk.cache_bytes),
         cold_objdir_bytes,
         warm_objdir_bytes,
         disk_measured_bytes,
+        disk_footprint_bytes: disk.total_bytes,
         key_stability: stability,
         warm_leak_samples,
         verdict,
@@ -683,6 +686,7 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
             cache_size_bytes: crate::bench_otlp::OtlpRun::bytes_from_mib(result.cache_size_mb),
             key_stability_pct: Some(result.key_stability.stable_pct),
             disk_measured_bytes: result.disk_measured_bytes,
+            disk_footprint_bytes: result.disk_footprint_bytes,
             phases: otlp_phases(
                 &result.cold,
                 result.warm_same_tree.as_ref(),
@@ -1591,7 +1595,8 @@ fn run_pull_bench(
         profile.checks.measure.for_phase(Phase::Pull.name()),
     );
 
-    let cold_objdir_bytes = dir_size_kb(&clone_a.join(objdir)).saturating_mul(1024);
+    let disk = crate::disk_usage::measure(cache_dir, &[clone_a.join(objdir)]);
+    let cold_objdir_bytes = disk.objdir_bytes[0];
     let pull_objdir_bytes = cold_objdir_bytes; // same path; objdir was wiped+rebuilt
 
     let result = PullBenchResult {
@@ -1604,9 +1609,10 @@ fn run_pull_bench(
         cache_tool_version: cache_tool_version.map(String::from),
         cold: cold_metrics,
         pull: pull_metrics,
-        cache_size_mb: round1(dir_size_kb(cache_dir) as f64 / 1024.0),
+        cache_size_mb: bytes_to_mib(disk.cache_bytes),
         cold_objdir_bytes,
         pull_objdir_bytes,
+        disk_footprint_bytes: disk.total_bytes,
         verdict,
         measure_warnings,
         reports: [
@@ -1642,6 +1648,7 @@ fn run_pull_bench(
             cache_size_bytes: crate::bench_otlp::OtlpRun::bytes_from_mib(result.cache_size_mb),
             key_stability_pct: None,
             disk_measured_bytes: None,
+            disk_footprint_bytes: result.disk_footprint_bytes,
             phases: vec![
                 otlp_phase("cold", &result.cold, result.cold_objdir_bytes),
                 otlp_phase("pull", &result.pull, result.pull_objdir_bytes),
@@ -1721,9 +1728,10 @@ fn run_sccache_bench(
         speedup,
         profile.checks.measure.for_phase(Phase::Warm.name()),
     );
-    let cold_objdir_bytes = dir_size_kb(&clone_a.join(objdir)).saturating_mul(1024);
-    let warm_objdir_bytes = dir_size_kb(&clone_b.join(objdir)).saturating_mul(1024);
-    let cache_dir_bytes = dir_size_kb(cache_dir).saturating_mul(1024);
+    let disk = crate::disk_usage::measure(cache_dir, &[clone_a.join(objdir), clone_b.join(objdir)]);
+    let cold_objdir_bytes = disk.objdir_bytes[0];
+    let warm_objdir_bytes = disk.objdir_bytes[1];
+    let cache_dir_bytes = disk.cache_bytes;
     let sum_apparent_bytes = cold_objdir_bytes
         .saturating_add(warm_objdir_bytes)
         .saturating_add(cache_dir_bytes);
@@ -1753,6 +1761,7 @@ fn run_sccache_bench(
         warm_objdir_bytes,
         sum_apparent_bytes,
         disk_measured_bytes,
+        disk_footprint_bytes: disk.total_bytes,
         measure_warnings,
         reports: [
             "report-cold.sccache.json",
@@ -1787,6 +1796,7 @@ fn run_sccache_bench(
             cache_size_bytes: result.cache_dir_bytes,
             key_stability_pct: None,
             disk_measured_bytes: result.disk_measured_bytes,
+            disk_footprint_bytes: result.disk_footprint_bytes,
             phases: vec![
                 otlp_sccache_phase("cold", &result.cold, result.cold_objdir_bytes),
                 otlp_sccache_phase("warm", &result.warm, result.warm_objdir_bytes),
@@ -2515,34 +2525,6 @@ fn run(cmd: &mut Command) -> Result<()> {
     Ok(())
 }
 
-/// Apparent size of `dir` in KiB: recursive file lengths, not following
-/// symlinks. Returns 0 on error; this is a reported metric, not load-bearing.
-fn dir_size_kb(dir: &Path) -> u64 {
-    fn walk(dir: &Path, acc: &mut u64) {
-        let Ok(rd) = std::fs::read_dir(dir) else {
-            return;
-        };
-        for entry in rd.flatten() {
-            let path = entry.path();
-            let Ok(md) = path.symlink_metadata() else {
-                continue;
-            };
-            if md.file_type().is_symlink() {
-                continue;
-            }
-            if md.is_dir() {
-                walk(&path, acc);
-            } else {
-                *acc += md.len();
-            }
-        }
-    }
-
-    let mut bytes = 0;
-    walk(dir, &mut bytes);
-    bytes / 1024
-}
-
 /// Available bytes on the filesystem backing `path`, via `df -kP`.
 ///
 /// `-kP` forces 1024-byte blocks and the POSIX one-line-per-filesystem format,
@@ -2741,6 +2723,8 @@ struct MbxBenchResult {
     sum_apparent_bytes: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     disk_measured_bytes: Option<u64>,
+    /// Cache and both objdirs on disk together, each inode once.
+    disk_footprint_bytes: u64,
     measure_warnings: Vec<String>,
     reports: Vec<String>,
 }
@@ -2930,9 +2914,10 @@ fn run_mbx_bench(
         speedup,
         profile.checks.measure.for_phase(Phase::Warm.name()),
     );
-    let cold_objdir_bytes = dir_size_kb(&clone_a.join(objdir)).saturating_mul(1024);
-    let warm_objdir_bytes = dir_size_kb(&clone_b.join(objdir)).saturating_mul(1024);
-    let cache_dir_bytes = dir_size_kb(cache_dir).saturating_mul(1024);
+    let disk = crate::disk_usage::measure(cache_dir, &[clone_a.join(objdir), clone_b.join(objdir)]);
+    let cold_objdir_bytes = disk.objdir_bytes[0];
+    let warm_objdir_bytes = disk.objdir_bytes[1];
+    let cache_dir_bytes = disk.cache_bytes;
     let sum_apparent_bytes = cold_objdir_bytes
         .saturating_add(warm_objdir_bytes)
         .saturating_add(cache_dir_bytes);
@@ -2954,6 +2939,7 @@ fn run_mbx_bench(
         warm_objdir_bytes,
         sum_apparent_bytes,
         disk_measured_bytes,
+        disk_footprint_bytes: disk.total_bytes,
         measure_warnings,
         reports: [
             "report-cold.mbx.json",
@@ -2984,6 +2970,7 @@ fn run_mbx_bench(
             cache_size_bytes: result.cache_dir_bytes,
             key_stability_pct: None,
             disk_measured_bytes: result.disk_measured_bytes,
+            disk_footprint_bytes: result.disk_footprint_bytes,
             phases: vec![
                 otlp_mbx_phase("cold", &result.cold, result.cold_objdir_bytes),
                 otlp_mbx_phase("warm", &result.warm, result.warm_objdir_bytes),
@@ -3031,11 +3018,12 @@ fn print_mbx_summary(r: &MbxBenchResult, archive_dir: &Path) {
     );
     eprintln!("{bar}");
     eprintln!(
-        "  disk: cold obj {} + warm obj {} + cache {} = {} apparent{}",
+        "  disk: cold obj {} + warm obj {} + cache {} = {}, {} footprint{}",
         human_bytes(r.cold_objdir_bytes),
         human_bytes(r.warm_objdir_bytes),
         human_bytes(r.cache_dir_bytes),
         human_bytes(r.sum_apparent_bytes),
+        human_bytes(r.disk_footprint_bytes),
         r.disk_measured_bytes
             .map(|measured| format!(", {} measured", human_bytes(measured)))
             .unwrap_or_default()
@@ -3073,6 +3061,8 @@ struct SccacheBenchResult {
     sum_apparent_bytes: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     disk_measured_bytes: Option<u64>,
+    /// Cache and both objdirs on disk together, each inode once.
+    disk_footprint_bytes: u64,
     measure_warnings: Vec<String>,
     reports: Vec<String>,
 }
@@ -3286,6 +3276,10 @@ fn print_sccache_summary(r: &SccacheBenchResult, work_dir: &Path) {
         "    sum apparent  {:>10}   cold obj + warm obj + sccache cache",
         human_bytes(r.sum_apparent_bytes)
     );
+    eprintln!(
+        "    footprint     {:>10}   all pools on disk, each inode once",
+        human_bytes(r.disk_footprint_bytes)
+    );
     if let Some(measured) = r.disk_measured_bytes {
         eprintln!(
             "    measured      {:>10}   actual free-space delta (cold+warm builds)",
@@ -3491,6 +3485,11 @@ fn write_summary(
             human_bytes(measured),
         )?;
     }
+    writeln!(
+        out,
+        "    footprint     {:>10}   all pools on disk, each inode once",
+        human_bytes(r.disk_footprint_bytes),
+    )?;
     writeln!(out, "{bar}")?;
 
     // ── diagnostics: did the run actually exercise kache? ──
@@ -3630,6 +3629,10 @@ fn print_pull_summary(r: &PullBenchResult, archive_dir: &Path) {
         r.pull.event_log.passed_through,
     );
     eprintln!("cache size  : {:.1} MiB", r.cache_size_mb);
+    eprintln!(
+        "footprint   : {}   cache + objdir on disk, each inode once",
+        human_bytes(r.disk_footprint_bytes)
+    );
     if r.verdict.ok {
         eprintln!("VERDICT     : ok");
     } else {
@@ -3674,9 +3677,10 @@ struct BenchResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     warm_same_tree_speedup: Option<f64>,
     cache_size_mb: f64,
-    /// Apparent bytes of clone-a's objdir after the cold build.
+    /// Bytes allocated to clone-a's objdir after the cold build, each inode
+    /// once.
     cold_objdir_bytes: u64,
-    /// Apparent bytes of clone-b's objdir after the warm build.
+    /// Bytes allocated to clone-b's objdir after the warm build.
     /// Of these, ~`warm.storage.reflinked_bytes` are CoW-shared with the
     /// cache on APFS — print_summary subtracts that to report "unique
     /// to this clone".
@@ -3688,6 +3692,10 @@ struct BenchResult {
     /// delta wouldn't cover the full three-pool layout).
     #[serde(skip_serializing_if = "Option::is_none")]
     disk_measured_bytes: Option<u64>,
+    /// Cache and both objdirs on disk together, each inode once, read from
+    /// the filesystem after the run. A hardlink shared between the cache and
+    /// an objdir counts once here.
+    disk_footprint_bytes: u64,
     /// Cross-clone cache-key stability — the deterministic correctness
     /// signal.
     key_stability: KeyStability,
@@ -3731,6 +3739,8 @@ struct PullBenchResult {
     cache_size_mb: f64,
     cold_objdir_bytes: u64,
     pull_objdir_bytes: u64,
+    /// Cache and objdir on disk together, each inode once.
+    disk_footprint_bytes: u64,
     verdict: Verdict,
     measure_warnings: Vec<String>,
     reports: Vec<String>,
@@ -4506,6 +4516,7 @@ mod tests {
                 cache_size_bytes: 0,
                 key_stability_pct: None,
                 disk_measured_bytes: None,
+                disk_footprint_bytes: 0,
                 phases: Vec::new(),
             },
         );
@@ -5311,6 +5322,7 @@ mod tests {
             cold_objdir_bytes: 1 << 30,
             warm_objdir_bytes: 1 << 30,
             disk_measured_bytes: None,
+            disk_footprint_bytes: 1 << 31,
             key_stability: KeyStability::default(),
             warm_leak_samples: Vec::new(),
             verdict: verdict_with(true),
@@ -5473,18 +5485,6 @@ mod tests {
     }
 
     #[test]
-    fn dir_size_kb_sums_file_bytes_recursively() {
-        let dir = std::env::temp_dir().join(format!("kb-dirsize-{}", std::process::id()));
-        let sub = dir.join("sub");
-        std::fs::create_dir_all(&sub).unwrap();
-        std::fs::write(dir.join("a.bin"), vec![0u8; 1024]).unwrap();
-        std::fs::write(sub.join("b.bin"), vec![0u8; 2048]).unwrap();
-        assert_eq!(dir_size_kb(&dir), 3);
-        assert_eq!(dir_size_kb(&dir.join("does-not-exist")), 0);
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
     fn pull_bench_result_serializes_with_pull_phase() {
         let r = PullBenchResult {
             project: "bench-firefox-pull".into(),
@@ -5499,6 +5499,7 @@ mod tests {
             cache_size_mb: 1.0,
             cold_objdir_bytes: 10,
             pull_objdir_bytes: 20,
+            disk_footprint_bytes: 25,
             verdict: Verdict {
                 ok: true,
                 issues: vec![],

--- a/crates/kache-e2e/src/disk_usage.rs
+++ b/crates/kache-e2e/src/disk_usage.rs
@@ -1,0 +1,257 @@
+//! Disk use of a bench run's storage pools, read from the filesystem.
+//!
+//! A run leaves three pools behind: the cache directory and each clone's
+//! objdir. Summing file lengths per pool overstates what they occupy:
+//!
+//! - a hardlinked file is one inode reached from two paths, so it is counted
+//!   once per link;
+//! - a backend may move the objdir into its cache directory and leave a
+//!   symlink in the clone, so the same bytes land in two pools;
+//! - a file's length is not the space allocated for it.
+//!
+//! [`measure`] resolves each pool's root, skips an objdir that resolves into
+//! the cache directory while walking the cache, counts every inode once
+//! (files and directories, as `du` does), and sums allocated blocks. A symlink
+//! inside a pool is not followed and its own few bytes are not counted.
+//!
+//! Reflinks are not detected. A reflinked copy is a second inode that shares
+//! extents with the first, so on a CoW filesystem (APFS, btrfs, XFS) the
+//! shared bytes are counted once per copy. Linux runners on ext4 cannot
+//! reflink, so their numbers are exact.
+
+use std::collections::HashSet;
+use std::fs::Metadata;
+use std::path::{Path, PathBuf};
+
+/// Bytes allocated to each pool, and to all of them together.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct DiskUsage {
+    /// The cache directory, without any objdir that resolves inside it.
+    pub cache_bytes: u64,
+    /// Each objdir, in the order given, measured where it resolves to.
+    pub objdir_bytes: Vec<u64>,
+    /// Every pool together, each inode once: what the run occupies on disk.
+    pub total_bytes: u64,
+}
+
+/// Measure `cache_dir` and `objdirs`. A pool that does not exist measures 0.
+pub(crate) fn measure(cache_dir: &Path, objdirs: &[PathBuf]) -> DiskUsage {
+    let objdir_roots: Vec<Option<PathBuf>> = objdirs
+        .iter()
+        .map(|dir| std::fs::canonicalize(dir).ok())
+        .collect();
+    let relocated: Vec<PathBuf> = objdir_roots.iter().flatten().cloned().collect();
+    let mut total = Tally::default();
+    let cache_bytes = std::fs::canonicalize(cache_dir)
+        .map(|root| pool_bytes(&root, &relocated, &mut total))
+        .unwrap_or(0);
+    let objdir_bytes = objdir_roots
+        .iter()
+        .map(|root| {
+            root.as_deref()
+                .map_or(0, |root| pool_bytes(root, &[], &mut total))
+        })
+        .collect();
+    DiskUsage {
+        cache_bytes,
+        objdir_bytes,
+        total_bytes: total.bytes,
+    }
+}
+
+/// Allocated bytes under `root` (not counting `root` itself), each inode once,
+/// without entering `skip` or following symlinks. Every inode counted here is
+/// also offered to `total`, which keeps its own record of what it has seen.
+fn pool_bytes(root: &Path, skip: &[PathBuf], total: &mut Tally) -> u64 {
+    let mut pool = Tally::default();
+    let mut dirs = vec![root.to_path_buf()];
+    while let Some(dir) = dirs.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(metadata) = path.symlink_metadata() else {
+                continue;
+            };
+            if metadata.file_type().is_symlink() || skip.contains(&path) {
+                continue;
+            }
+            if pool.add(&metadata) {
+                total.add(&metadata);
+            }
+            if metadata.is_dir() {
+                dirs.push(path);
+            }
+        }
+    }
+    pool.bytes
+}
+
+#[derive(Default)]
+struct Tally {
+    seen: HashSet<(u64, u64)>,
+    bytes: u64,
+}
+
+impl Tally {
+    /// Count `metadata` unless its inode was already counted. Returns whether
+    /// it was counted.
+    fn add(&mut self, metadata: &Metadata) -> bool {
+        if file_id(metadata).is_some_and(|id| !self.seen.insert(id)) {
+            return false;
+        }
+        self.bytes += allocated_bytes(metadata);
+        true
+    }
+}
+
+#[cfg(unix)]
+fn file_id(metadata: &Metadata) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+    Some((metadata.dev(), metadata.ino()))
+}
+
+/// No stable inode identity on this platform: every path counts.
+#[cfg(not(unix))]
+fn file_id(_metadata: &Metadata) -> Option<(u64, u64)> {
+    None
+}
+
+/// `st_blocks` is in 512-byte units on every Unix, whatever the block size.
+#[cfg(unix)]
+fn allocated_bytes(metadata: &Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+    metadata.blocks() * 512
+}
+
+#[cfg(not(unix))]
+fn allocated_bytes(metadata: &Metadata) -> u64 {
+    metadata.len()
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    fn allocated(path: &Path) -> u64 {
+        allocated_bytes(&std::fs::symlink_metadata(path).unwrap())
+    }
+
+    fn write(path: &Path, len: usize) -> u64 {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, vec![7u8; len]).unwrap();
+        allocated(path)
+    }
+
+    #[test]
+    fn allocated_bytes_are_blocks_not_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("one-byte");
+        std::fs::write(&file, b"x").unwrap();
+        let metadata = std::fs::metadata(&file).unwrap();
+        use std::os::unix::fs::MetadataExt;
+        assert_eq!(allocated_bytes(&metadata), metadata.blocks() * 512);
+        assert!(allocated_bytes(&metadata) > metadata.len());
+    }
+
+    #[test]
+    fn disjoint_pools_add_up() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = root.path().join("cache");
+        let obj_a = root.path().join("a/target");
+        let obj_b = root.path().join("b/target");
+        let cache_bytes = write(&cache.join("blob"), 10_000) + write(&cache.join("index"), 3_000);
+        let a_bytes = write(&obj_a.join("liba.rlib"), 20_000);
+        let b_bytes = write(&obj_b.join("libb.rlib"), 40_000);
+
+        let usage = measure(&cache, &[obj_a, obj_b]);
+
+        assert_eq!(usage.cache_bytes, cache_bytes);
+        assert_eq!(usage.objdir_bytes, vec![a_bytes, b_bytes]);
+        assert_eq!(usage.total_bytes, cache_bytes + a_bytes + b_bytes);
+    }
+
+    #[test]
+    fn subdirectories_count_their_own_blocks() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = root.path().join("cache");
+        let file_bytes = write(&cache.join("store/blob"), 10_000);
+        let dir_bytes = allocated(&cache.join("store"));
+
+        let usage = measure(&cache, &[]);
+
+        assert_eq!(usage.cache_bytes, file_bytes + dir_bytes);
+        assert_eq!(usage.total_bytes, file_bytes + dir_bytes);
+    }
+
+    #[test]
+    fn a_hardlink_is_counted_once_per_pool_and_once_in_total() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = root.path().join("cache");
+        let objdir = root.path().join("clone/target");
+        let blob = cache.join("blob");
+        let blob_bytes = write(&blob, 50_000);
+        std::fs::hard_link(&blob, cache.join("key")).unwrap();
+        let own_bytes = write(&objdir.join("liby.rlib"), 8_000);
+        std::fs::hard_link(&blob, objdir.join("libx.rlib")).unwrap();
+
+        let usage = measure(&cache, std::slice::from_ref(&objdir));
+
+        assert_eq!(usage.cache_bytes, blob_bytes);
+        assert_eq!(usage.objdir_bytes, vec![blob_bytes + own_bytes]);
+        assert_eq!(usage.total_bytes, blob_bytes + own_bytes);
+    }
+
+    #[test]
+    fn an_objdir_moved_into_the_cache_counts_once_and_not_as_cache() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = root.path().join("cache");
+        let store_bytes = write(&cache.join("blob"), 30_000);
+        let managed = cache.join("targets/v1/abc");
+        let target_bytes = write(&managed.join("polkadot"), 90_000);
+        // The directories above the moved objdir belong to the cache.
+        let parents = allocated(&cache.join("targets")) + allocated(&cache.join("targets/v1"));
+        let clone = root.path().join("clone");
+        std::fs::create_dir_all(&clone).unwrap();
+        std::os::unix::fs::symlink(&managed, clone.join("target")).unwrap();
+
+        let usage = measure(&cache, &[clone.join("target")]);
+
+        assert_eq!(usage.cache_bytes, store_bytes + parents);
+        assert_eq!(usage.objdir_bytes, vec![target_bytes]);
+        assert_eq!(usage.total_bytes, store_bytes + parents + target_bytes);
+    }
+
+    #[test]
+    fn a_symlink_inside_a_pool_is_not_followed() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = root.path().join("cache");
+        let outside = root.path().join("outside");
+        write(&outside.join("big"), 100_000);
+        let own_bytes = write(&cache.join("own"), 2_000);
+        std::os::unix::fs::symlink(outside.join("big"), cache.join("file-link")).unwrap();
+        std::os::unix::fs::symlink(&outside, cache.join("dir-link")).unwrap();
+
+        let usage = measure(&cache, &[]);
+
+        assert_eq!(usage.cache_bytes, own_bytes);
+        assert_eq!(usage.total_bytes, own_bytes);
+    }
+
+    #[test]
+    fn missing_pools_measure_zero() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = root.path().join("cache");
+        let obj_bytes = write(&root.path().join("obj/x"), 5_000);
+
+        let usage = measure(
+            &cache,
+            &[root.path().join("absent"), root.path().join("obj")],
+        );
+
+        assert_eq!(usage.cache_bytes, 0);
+        assert_eq!(usage.objdir_bytes, vec![0, obj_bytes]);
+        assert_eq!(usage.total_bytes, obj_bytes);
+    }
+}

--- a/crates/kache-e2e/src/disk_usage.rs
+++ b/crates/kache-e2e/src/disk_usage.rs
@@ -18,6 +18,11 @@
 //! extents with the first, so on a CoW filesystem (APFS, btrfs, XFS) the
 //! shared bytes are counted once per copy. Linux runners on ext4 cannot
 //! reflink, so their numbers are exact.
+//!
+//! Outside Unix the standard library exposes neither inode identity nor
+//! allocated blocks, so every path counts at its length. A directory that
+//! cannot be read measures as empty: these numbers are reported, never gated
+//! on.
 
 use std::collections::HashSet;
 use std::fs::Metadata;
@@ -63,6 +68,10 @@ pub(crate) fn measure(cache_dir: &Path, objdirs: &[PathBuf]) -> DiskUsage {
 /// without entering `skip` or following symlinks. Every inode counted here is
 /// also offered to `total`, which keeps its own record of what it has seen.
 fn pool_bytes(root: &Path, skip: &[PathBuf], total: &mut Tally) -> u64 {
+    // An objdir that is the cache directory itself is measured as the objdir.
+    if skip.iter().any(|dir| dir == root) {
+        return 0;
+    }
     let mut pool = Tally::default();
     let mut dirs = vec![root.to_path_buf()];
     while let Some(dir) = dirs.pop() {
@@ -237,6 +246,31 @@ mod tests {
 
         assert_eq!(usage.cache_bytes, own_bytes);
         assert_eq!(usage.total_bytes, own_bytes);
+    }
+
+    #[test]
+    fn an_objdir_that_is_the_cache_dir_is_not_counted_as_cache() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = root.path().join("cache");
+        let bytes = write(&cache.join("blob"), 10_000);
+
+        let usage = measure(&cache, std::slice::from_ref(&cache));
+
+        assert_eq!(usage.cache_bytes, 0);
+        assert_eq!(usage.objdir_bytes, vec![bytes]);
+        assert_eq!(usage.total_bytes, bytes);
+    }
+
+    #[test]
+    fn the_same_objdir_twice_counts_once_in_total() {
+        let root = tempfile::tempdir().unwrap();
+        let objdir = root.path().join("target");
+        let bytes = write(&objdir.join("artifact"), 10_000);
+
+        let usage = measure(&root.path().join("no-cache"), &[objdir.clone(), objdir]);
+
+        assert_eq!(usage.objdir_bytes, vec![bytes, bytes]);
+        assert_eq!(usage.total_bytes, bytes);
     }
 
     #[test]

--- a/crates/kache-e2e/src/disk_usage.rs
+++ b/crates/kache-e2e/src/disk_usage.rs
@@ -116,27 +116,38 @@ impl Tally {
 }
 
 #[cfg(unix)]
-fn file_id(metadata: &Metadata) -> Option<(u64, u64)> {
-    use std::os::unix::fs::MetadataExt;
-    Some((metadata.dev(), metadata.ino()))
-}
+use unix::{allocated_bytes, file_id};
 
-/// No stable inode identity on this platform: every path counts.
 #[cfg(not(unix))]
-fn file_id(_metadata: &Metadata) -> Option<(u64, u64)> {
-    None
-}
+use other::{allocated_bytes, file_id};
 
-/// `st_blocks` is in 512-byte units on every Unix, whatever the block size.
 #[cfg(unix)]
-fn allocated_bytes(metadata: &Metadata) -> u64 {
+mod unix {
+    use std::fs::Metadata;
     use std::os::unix::fs::MetadataExt;
-    metadata.blocks() * 512
+
+    pub(super) fn file_id(metadata: &Metadata) -> Option<(u64, u64)> {
+        Some((metadata.dev(), metadata.ino()))
+    }
+
+    /// `st_blocks` is in 512-byte units on every Unix, whatever the block size.
+    pub(super) fn allocated_bytes(metadata: &Metadata) -> u64 {
+        metadata.blocks() * 512
+    }
 }
 
+/// Without inode identity or block counts every path counts at its length.
 #[cfg(not(unix))]
-fn allocated_bytes(metadata: &Metadata) -> u64 {
-    metadata.len()
+mod other {
+    use std::fs::Metadata;
+
+    pub(super) fn file_id(_metadata: &Metadata) -> Option<(u64, u64)> {
+        None
+    }
+
+    pub(super) fn allocated_bytes(metadata: &Metadata) -> u64 {
+        metadata.len()
+    }
 }
 
 #[cfg(all(test, unix))]

--- a/crates/kache-e2e/src/lib.rs
+++ b/crates/kache-e2e/src/lib.rs
@@ -16,6 +16,7 @@ mod bench_otlp;
 pub mod bench_profile;
 pub mod bench_runner;
 pub mod daemon;
+mod disk_usage;
 pub mod fixture;
 pub mod fixture_runner;
 pub mod phase;


### PR DESCRIPTION
The bench reported cache size as the sum of file lengths in the cache directory. That breaks in two cases:

- A backend that moves each clone's `target/` into its cache directory and leaves a symlink in the clone gets both target dirs counted as cache, and again as objdir. The substrate-mbx nightly reported a 30.6 GB cache; mbx's own log shows 9.9 GiB stored, and the rest was the two 9.9 GB target dirs.
- Hardlinked files were counted once per link.

A new `disk_usage` module measures every pool the same way for the kache, pull, sccache and mbx arms:

- resolves each pool's root, so a symlinked `target/` is measured where it lives;
- leaves an objdir that resolves inside the cache directory out of the cache size;
- counts each inode once, within a pool and across pools;
- sums allocated blocks, directories included, and does not follow symlinks inside a pool.

The run's combined footprint is added to the summary JSON as `disk_footprint_bytes` and exported as `kache.bench.disk.footprint`. The free-space delta (`kache.bench.disk.consumed`) is still reported, but it moves with other jobs on the same volume, which is why the substrate kache run warned that its 9.3 GB reading did not match the 22 GB estimate. kache's disk accounting check now compares its storage stats with the footprint instead. The prediction subtracts hardlinked bytes only, because a reflink is a second inode and the footprint counts it too.

Cache size and objdir size now use allocated bytes, so their series step at this change. mbx cache size should drop from about 30.6 GB to about 10.6 GB on substrate.

Limitations: reflinked copies are distinct inodes and still count once per copy (APFS, btrfs, XFS). The Linux runners use ext4 and report 0 reflinked bytes. Outside Unix, std exposes no inode identity or block count, so every path counts at its length, as before. A directory that cannot be read measures as empty; these numbers are reported, never gated on.

Tests: `cargo test -p kache-e2e --lib` (187 passed), including an objdir symlinked into the cache directory, an objdir that is the cache directory, the same objdir passed twice, hardlinks shared between the cache and an objdir, symlinks inside a pool, directory blocks, and the check's 20% band edges. `just check` passes locally.
