### PR TITLE
bench(firefox-windows): apply Mozilla's gecko-profiler bindgen fix for Firefox 151

### DIFF
--- a/crates/kache-e2e/src/bench_profile.rs
+++ b/crates/kache-e2e/src/bench_profile.rs
@@ -1016,7 +1016,7 @@ diff --git a/hello.txt b/hello.txt
     }
 
     #[test]
-    fn shipped_firefox_windows_profile_uses_only_the_upstream_cbindgen_fix() {
+    fn shipped_firefox_windows_profile_uses_only_upstream_firefox_fixes() {
         let p = BenchProfile::load(&repo_profile("firefox-windows"))
             .expect("firefox-windows.toml loads");
         assert_eq!(p.name, "bench-firefox-windows");
@@ -1024,15 +1024,14 @@ diff --git a/hello.txt b/hello.txt
             .files
             .iter()
             .filter(|file| file.mode == FileMode::Patch)
+            .map(|file| file.content_file.as_deref().expect("patch file"))
             .collect::<Vec<_>>();
-        assert_eq!(patches.len(), 1);
-        assert!(
-            patches[0]
-                .content_file
-                .as_deref()
-                .expect("patch file")
-                .ends_with("firefox-cbindgen-visibility.patch")
-        );
+        // Both are Mozilla's own fixes that FIREFOX_151_0_RELEASE lacks:
+        // cbindgen visibility (Bug 2046162) and the gecko-profiler bindgen
+        // alias under libclang 21 (Bug 2038918, #1017).
+        assert_eq!(patches.len(), 2, "{patches:?}");
+        assert!(patches[0].ends_with("firefox-cbindgen-visibility.patch"));
+        assert!(patches[1].ends_with("firefox-gecko-profiler-bindgen.patch"));
         let mozconfig = p
             .files
             .iter()

--- a/scenarios/bench-firefox-windows/scenario.toml
+++ b/scenarios/bench-firefox-windows/scenario.toml
@@ -105,6 +105,15 @@ path         = "gfx/wr/webrender/src/texture_cache.rs"
 mode         = "patch"
 content_file = "../bench-firefox/patches/firefox-cbindgen-visibility.patch"
 
+# Mozilla's upstream bindgen fix for gecko-profiler (Bug 2038918). With
+# libclang 21 or newer, bindgen emits a `std::vector::_Scary_val` alias that
+# names `_Val_types`, which does not exist, and the build stops with E0425.
+# Not in FIREFOX_151_0_RELEASE; the pull scenario's ref already has it (#1017).
+[[file]]
+path         = "tools/profiler/rust-api/build.rs"
+mode         = "patch"
+content_file = "../bench-firefox/patches/firefox-gecko-profiler-bindgen.patch"
+
 # v1 gates. min_key_stability_pct is relaxed (cross-path convergence on Windows
 # is unsolved); max_passthrough_pct + max_errors are the meaningful gates that
 # catch an unclassified clang-cl flag falling through to passthrough (#438).

--- a/scenarios/bench-firefox/patches/firefox-gecko-profiler-bindgen.patch
+++ b/scenarios/bench-firefox/patches/firefox-gecko-profiler-bindgen.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/profiler/rust-api/build.rs b/tools/profiler/rust-api/build.rs
+index 84298ed..7f9e270 100644
+--- a/tools/profiler/rust-api/build.rs
++++ b/tools/profiler/rust-api/build.rs
+@@ -98,7 +98,7 @@ fn generate_bindings() {
+         // std::vector needs to be converted to an opaque type because, if it's
+         // not an opaque type, bindgen can't find its size properly and
+         // MarkerSchema's total size reduces. That causes a heap buffer overflow.
+-        .opaque_type("std::vector")
++        .opaque_type("std::vector.*")
+         .raw_line("pub use self::root::*;")
+         // Tell cargo to invalidate the built crate whenever any of the
+         // included header files changed.


### PR DESCRIPTION
Bench Firefox (Windows) has failed every nightly since 2026-08-22 on a Firefox 151 bug, not a kache one (#1017).

With libclang 21 or newer, bindgen emits `pub type vector__Scary_val = root::std::_Vector_val<_Val_types>;` for gecko-profiler, and `_Val_types` does not exist, so the build stops with E0425. Mozilla fixed this upstream in https://github.com/mozilla-firefox/firefox/commit/c15572e302a9371e4ad5b186a252371240c655e5 (Bug 2038918) by changing `.opaque_type("std::vector")` to `.opaque_type("std::vector.*")` in `tools/profiler/rust-api/build.rs`. That commit is not in `FIREFOX_151_0_RELEASE`, which this scenario builds; the pull scenario's ref has it, and that job passes on the same runners.

This adds the same one-line change as a scenario patch, next to the existing cbindgen patch for 151. The patch was generated against the 151 file (blob 84298ed) and passes `git apply --check`, which is what the engine runs before applying it.

A dispatch of the scenario on this branch will confirm the build gets past gecko-profiler before this merges.
