### PR TITLE
bench: remove order bias from the perf gate and gate on warm misses

### DIFF
--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -236,8 +236,8 @@ jobs:
           reshim: false
 
       # Disk-full mid-build is the worst failure mode on the emptyDir-backed
-      # work volume. Each side needs two debug objdirs plus a store; the base
-      # side's scratch is deleted before the head side starts (see below), so
+      # work volume. Each side needs two debug objdirs plus a store; the first
+      # side's scratch is deleted before the second side starts (see below), so
       # the floor covers one side plus kache's own target tree with headroom.
       - name: Free-disk precheck
         run: |
@@ -318,6 +318,7 @@ jobs:
           cp target/release/kache-scenario "$RUNNER_TEMP/instrument/kache-scenario"
           cp -R scenarios "$RUNNER_TEMP/instrument/scenarios"
           cp scripts/perf-gate-compare.sh "$RUNNER_TEMP/instrument/perf-gate-compare.sh"
+          cp scripts/perf-gate-side.sh "$RUNNER_TEMP/instrument/perf-gate-side.sh"
 
       - name: Build kache from the merge base
         env:
@@ -341,34 +342,6 @@ jobs:
           "$RUNNER_TEMP/kache-base" --version
           "$RUNNER_TEMP/kache-head" --version
 
-      # The merge base runs FIRST and its scratch is deleted before the head
-      # side starts, so peak disk is one side, not two. Ordering is fixed rather
-      # than randomised: with a fixed order any thermal or cache-warmth drift
-      # biases every PR the same way, which is easier to reason about than a
-      # bias that changes run to run.
-      - name: Benchmark the merge base
-        timeout-minutes: 40
-        env:
-          RUSTC_WRAPPER: ""
-          # The subject pins its own toolchain via the rust-toolchain.toml the
-          # scenario injects; a forced RUSTUP_TOOLCHAIN would override it.
-          RUSTUP_TOOLCHAIN: ""
-        run: |
-          set -euo pipefail
-          "$RUNNER_TEMP/instrument/kache-scenario" \
-            --kache "$RUNNER_TEMP/kache-base" \
-            --scenarios "$RUNNER_TEMP/instrument/scenarios" \
-            --select suite:bench --select backend:kache \
-            --profile "$BENCH_PROFILE" \
-            --warm-same-tree \
-            --work-dir "tmp/perf-gate/base"
-          cp "tmp/perf-gate/base/$BENCH_SCENARIO.json" "$RUNNER_TEMP/base.json"
-          mkdir -p "$RUNNER_TEMP/logs/base"
-          cp tmp/perf-gate/base/*.log "$RUNNER_TEMP/logs/base/" || true
-          # Free the objdirs, worktrees and store before the head side runs.
-          # `clone-ref` is a SIBLING of the work dir, so it needs its own rm.
-          rm -rf tmp/perf-gate/base tmp/perf-gate/base-clone-ref
-
       # The harness clones third-party subjects over https. Anonymous
       # requests share this cluster's egress quota, and when it is exhausted
       # GitHub answers 401, which git reports as "could not read Username"
@@ -384,23 +357,56 @@ jobs:
           git config --global --replace-all \
             "http.https://github.com/.extraheader" "AUTHORIZATION: basic $header"
 
-      - name: Benchmark the PR head
-        timeout-minutes: 40
+      # Which side runs first alternates with the run number. The first side
+      # on a fresh pod pays for a cold page cache and any runner warm-up, and a
+      # fixed order handed that cost to the merge base on every pull request,
+      # so the head always read a little faster. The scenario's untimed
+      # `prepare` step keeps crate downloads and the toolchain install out of
+      # both sides' timings; alternating spreads what remains across runs
+      # instead of tilting every run the same way. A re-run keeps its run
+      # number, so it keeps its order.
+      - name: Choose which side runs first
+        id: order
         env:
-          RUSTC_WRAPPER: ""
-          RUSTUP_TOOLCHAIN: ""
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
           set -euo pipefail
-          "$RUNNER_TEMP/instrument/kache-scenario" \
-            --kache "$RUNNER_TEMP/kache-head" \
-            --scenarios "$RUNNER_TEMP/instrument/scenarios" \
-            --select suite:bench --select backend:kache \
-            --profile "$BENCH_PROFILE" \
-            --warm-same-tree \
-            --work-dir "tmp/perf-gate/head"
-          cp "tmp/perf-gate/head/$BENCH_SCENARIO.json" "$RUNNER_TEMP/head.json"
-          mkdir -p "$RUNNER_TEMP/logs/head"
-          cp tmp/perf-gate/head/*.log "$RUNNER_TEMP/logs/head/" || true
+          if [ $((RUN_NUMBER % 2)) -eq 0 ]; then
+            first="base"
+            second="head"
+          else
+            first="head"
+            second="base"
+          fi
+          echo "Side order for run $RUN_NUMBER: $first first, then $second"
+          {
+            echo "first=$first"
+            echo "second=$second"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "Perf gate side order for run $RUN_NUMBER: \`$first\` first, then \`$second\`."
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Each side deletes its scratch when it finishes, so peak disk is one
+      # side, not two.
+      - name: Benchmark the first side (${{ steps.order.outputs.first }})
+        timeout-minutes: 40
+        env:
+          SIDE: ${{ steps.order.outputs.first }}
+          RUSTC_WRAPPER: ""
+          # The subject pins its own toolchain via the rust-toolchain.toml the
+          # scenario injects; a forced RUSTUP_TOOLCHAIN would override it.
+          RUSTUP_TOOLCHAIN: ""
+        run: '"$RUNNER_TEMP/instrument/perf-gate-side.sh" "$SIDE"'
+
+      - name: Benchmark the second side (${{ steps.order.outputs.second }})
+        timeout-minutes: 40
+        env:
+          SIDE: ${{ steps.order.outputs.second }}
+          RUSTC_WRAPPER: ""
+          RUSTUP_TOOLCHAIN: ""
+        run: '"$RUNNER_TEMP/instrument/perf-gate-side.sh" "$SIDE"'
 
       # The threshold and the validity gates live in the script, so `just`
       # users and CI apply exactly the same rules. Non-zero exit = regression or

--- a/crates/kache-e2e/src/bench_profile.rs
+++ b/crates/kache-e2e/src/bench_profile.rs
@@ -81,6 +81,16 @@ pub struct BenchProfile {
     #[serde(default)]
     pub setup_marker: Option<String>,
 
+    /// Untimed preparation, run via `sh -c` in each checkout after the file
+    /// injections and before the first phase that builds there (e.g.
+    /// `cargo fetch --locked`). Without it the first timed build pays for
+    /// dependency downloads and toolchain installs that every later build,
+    /// and every later run on the same machine, gets for free. Runs with
+    /// the scenario `[env]` but without the cache wrapper, so it cannot seed
+    /// or observe the cache; it must fetch, not compile.
+    #[serde(default)]
+    pub prepare: Option<String>,
+
     /// Build command, run via `sh -c` in the checkout with the kache env
     /// injected. Wall-clock of this command is the measured build time.
     pub build: String,
@@ -292,6 +302,11 @@ impl BenchProfile {
     /// Interpolated build command.
     pub fn build_command(&self, kache: &Path) -> String {
         self.interpolate(&self.build, kache)
+    }
+
+    /// Interpolated preparation command, if the scenario declares one.
+    pub fn prepare_command(&self, kache: &Path) -> Option<String> {
+        self.prepare.as_deref().map(|c| self.interpolate(c, kache))
     }
 
     /// Whether setup should be skipped because its marker already exists
@@ -631,12 +646,19 @@ content = "value"
         let profiles = BenchProfile::discover(&root, &selectors).unwrap();
 
         for profile in profiles {
-            let commands = std::iter::once(("build", profile.build.as_str())).chain(
-                profile
-                    .setup
-                    .iter()
-                    .map(|command| ("setup", command.as_str())),
-            );
+            let commands = std::iter::once(("build", profile.build.as_str()))
+                .chain(
+                    profile
+                        .setup
+                        .iter()
+                        .map(|command| ("setup", command.as_str())),
+                )
+                .chain(
+                    profile
+                        .prepare
+                        .as_deref()
+                        .map(|command| ("prepare", command)),
+                );
             for (kind, command) in commands {
                 let output = std::process::Command::new("sh")
                     .args(["-n", "-c", command])
@@ -698,6 +720,54 @@ CC = "{kache} cc"
         assert_eq!(
             p.build_env(kache),
             vec![("CC".to_string(), "/usr/local/bin/kache cc".to_string())]
+        );
+    }
+
+    #[test]
+    fn prepare_is_optional_and_interpolated() {
+        let dir = tempfile::tempdir().unwrap();
+        let without = write_profile(
+            dir.path(),
+            "plain",
+            r#"
+name = "plain"
+repo = "r"
+ref  = "v1"
+objdir = "target"
+build = "b"
+"#,
+        );
+        let p = BenchProfile::load(&without).unwrap();
+        assert_eq!(p.prepare_command(Path::new("/k")), None);
+
+        let with = write_profile(
+            dir.path(),
+            "prepared",
+            r#"
+name = "prepared"
+repo = "r"
+ref  = "v1"
+objdir = "obj"
+build = "b"
+prepare = "{kache} fetch --into {objdir}"
+"#,
+        );
+        let p = BenchProfile::load(&with).unwrap();
+        assert_eq!(
+            p.prepare_command(Path::new("/k")).as_deref(),
+            Some("/k fetch --into obj")
+        );
+    }
+
+    /// The perf gate's subject must fetch before its first timed build, or
+    /// whichever side runs first pays for the downloads and the other does
+    /// not.
+    #[test]
+    fn shipped_pr_cargo_profile_fetches_before_timing() {
+        let p = BenchProfile::load(&repo_profile("pr-cargo")).expect("pr-cargo loads");
+        assert_eq!(
+            p.prepare_command(Path::new("/k")).as_deref(),
+            Some("cargo fetch --locked")
         );
     }
 

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -343,6 +343,26 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         profile.apply_files(clone, &kache)?;
     }
 
+    // Untimed preparation, one per clone, before either is built. clone-a is
+    // first built by cold, clone-b by the cross-clone warm phase; each phase
+    // records the step that ran for its clone.
+    let cold_prepare = prepare_clone(
+        &profile,
+        &clone_a,
+        Phase::Cold.name(),
+        &kache,
+        &work_dir,
+        &sh,
+    )?;
+    let warm_prepare = prepare_clone(
+        &profile,
+        &clone_b,
+        Phase::Warm.name(),
+        &kache,
+        &work_dir,
+        &sh,
+    )?;
+
     // Snapshot the volume's free space before any build runs, so the real
     // footprint of the cold+warm builds can be measured (free-space delta) and
     // used to VERIFY the sharing-corrected disk-layout estimate. Clones already
@@ -398,7 +418,7 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     // cold: either run it fresh (full run) or restore the snapshot saved
     // by a prior full run (`--retry`) and reuse cold's metrics. Either
     // way we emerge with `cold_metrics` + `cold_raw`.
-    let (cold_metrics, cold_raw) = if config.retry {
+    let (mut cold_metrics, cold_raw) = if config.retry {
         retry_load_cold(&profile.name, &kache, &cache_dir, &work_dir)?
     } else {
         run_cold_phase(
@@ -413,6 +433,7 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
             &sh,
         )?
     };
+    cold_metrics.prepare = cold_prepare;
 
     // warm-same-tree (opt-in): rebuild clone-a — the tree cold just built — with
     // its objdir wiped and the store left warm. Same absolute path, so the
@@ -529,8 +550,9 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     // clones. A path leak in the key shows up here as a near-zero rate.
     let stability = key_stability(&cold_raw, &warm_raw);
 
-    let warm_metrics =
+    let mut warm_metrics =
         PhaseMetrics::from_report(&warm, &warm_raw, warm_ms, warm_events, warm_leaks);
+    warm_metrics.prepare = warm_prepare;
     let verdict = Verdict::evaluate(
         &stability,
         &warm_metrics,
@@ -866,6 +888,7 @@ fn is_run_artifact(name: &str) -> bool {
         || name.starts_with("build-")
         || name.starts_with("wrapper-")
         || name.starts_with("trace-")
+        || name.starts_with("prepare-")
         || name.starts_with("key-diff.")
         || (name.starts_with("bench-") && name.ends_with(".json"))
         || name == crate::bench_otlp::METRICS_FILE
@@ -1186,6 +1209,59 @@ fn run_setup(
         run(Command::new(sh).arg("-c").arg(step).current_dir(clone))?;
     }
     Ok(())
+}
+
+/// Run the scenario's `prepare` command in `clone`, untimed as far as the
+/// phases are concerned, and return what ran and how long it took. `None`
+/// when the scenario declares no `prepare`.
+///
+/// Called once per clone, after the file injections (a pinned
+/// `rust-toolchain.toml` must already be in place for the toolchain install to
+/// happen here) and before `phase`, the first phase that builds in that clone.
+/// The scenario `[env]` is applied so the command resolves the same toolchain
+/// as the build. The cache wrapper is removed: a fetch has nothing to cache,
+/// and a stray wrapper call would land in the next phase's event log.
+fn prepare_clone(
+    profile: &BenchProfile,
+    clone: &Path,
+    phase: &str,
+    kache: &Path,
+    work_dir: &Path,
+    sh: &Path,
+) -> Result<Option<PrepareMetrics>> {
+    let Some(command) = profile.prepare_command(kache) else {
+        return Ok(None);
+    };
+    let log_path = work_dir.join(format!("prepare-{phase}.log"));
+    let log =
+        File::create(&log_path).with_context(|| format!("creating {}", log_path.display()))?;
+    eprintln!(
+        "\n[bench] [{phase}] preparing {} (`{command}`; untimed; output -> prepare-{phase}.log)",
+        clone.display()
+    );
+    let started = Instant::now();
+    let status = Command::new(sh)
+        .arg("-c")
+        .arg(&command)
+        .current_dir(clone)
+        .envs(profile.build_env(kache))
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .stdout(Stdio::from(
+            log.try_clone().context("cloning prepare-log handle")?,
+        ))
+        .stderr(Stdio::from(log))
+        .status()
+        .with_context(|| format!("spawning prepare command in {}", clone.display()))?;
+    if !status.success() {
+        bail!(
+            "[{phase}] prepare failed ({status}); see {}",
+            log_path.display()
+        );
+    }
+    let wall_ms = elapsed_ms(started.elapsed());
+    eprintln!("[bench] [{phase}] prepared in {}", fmt_wall_clock(wall_ms));
+    Ok(Some(PrepareMetrics { command, wall_ms }))
 }
 
 /// Build the project in `clone` with kache wired in; return the build's wall
@@ -1522,9 +1598,10 @@ fn run_pull_bench(
     )?;
     run_setup(profile, clone_a, kache, force_setup, sh)?;
     profile.apply_files(clone_a, kache)?;
+    let cold_prepare = prepare_clone(profile, clone_a, Phase::Cold.name(), kache, work_dir, sh)?;
 
     // cold: empty cache, build ref A in clone-a -> populate.
-    let (cold_metrics, _cold_raw) = run_cold_phase(
+    let (mut cold_metrics, _cold_raw) = run_cold_phase(
         profile,
         kache,
         cache_dir,
@@ -1535,6 +1612,7 @@ fn run_pull_bench(
         trace_keys,
         sh,
     )?;
+    cold_metrics.prepare = cold_prepare;
 
     // Reset the event log so the pull report covers only the pull build.
     if event_log.exists() {
@@ -1550,6 +1628,8 @@ fn run_pull_bench(
         .arg(clone_a)
         .args(["checkout", "--detach", ref_next]))?;
     profile.apply_files(clone_a, kache)?;
+    // ref_next can lock different dependencies, so it is prepared again.
+    let pull_prepare = prepare_clone(profile, clone_a, Phase::Pull.name(), kache, work_dir, sh)?;
 
     // pull: same cache, same path, new source. `build()` wipes the objdir at
     // the start of every phase (unconditionally), so this is a from-scratch
@@ -1581,8 +1661,9 @@ fn run_pull_bench(
     let pull_events = read_event_log(event_log);
     let (pull_leaks, _pull_leak_samples) =
         scan_leak_warnings(&work_dir.join(format!("wrapper-{}.log", Phase::Pull.name())));
-    let pull_metrics =
+    let mut pull_metrics =
         PhaseMetrics::from_report(&pull, &pull_raw, pull_ms, pull_events, pull_leaks);
+    pull_metrics.prepare = pull_prepare;
 
     // No cross-clone comparison: an empty KeyStability (compared == 0) makes
     // Verdict skip the key-stability check; the pull scenarios also set no
@@ -3801,6 +3882,20 @@ struct PhaseMetrics {
     /// The wall-clock above says a build got slower; this says which part of
     /// the wrapper did it.
     phases: PhaseTimes,
+    /// The scenario's untimed `prepare` step, when it ran in this phase's
+    /// clone before this phase's build. Its time is not part of `wall_ms`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    prepare: Option<PrepareMetrics>,
+}
+
+/// One run of a scenario's `prepare` command.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PrepareMetrics {
+    /// The interpolated command that ran.
+    command: String,
+    /// How long it took. Reported so a slow fetch is visible, never added to
+    /// a phase's wall clock.
+    wall_ms: u64,
 }
 
 /// Wrapper time by phase, in wrapper order, summed over every cacheable crate
@@ -3925,6 +4020,7 @@ impl PhaseMetrics {
             leak_warnings,
             storage: StorageInfo::from_raw(raw),
             phases: PhaseTimes::from_raw(raw),
+            prepare: None,
         }
     }
 }
@@ -4938,6 +5034,7 @@ mod tests {
                 dedup_saved_bytes: 0,
             },
             phases: PhaseTimes::default(),
+            prepare: None,
         }
     }
 
@@ -6034,6 +6131,132 @@ build = "sleep 0.2"
         assert!(!stale.exists(), "the objdir is wiped before the build");
         assert!(work_dir.join("build-cold.log").exists());
         assert!(work_dir.join("wrapper-cold.log").exists());
+    }
+
+    fn prepare_fixture(dir: &Path, prepare: Option<&str>) -> BenchProfile {
+        let path = dir.join("prep.toml");
+        let prepare = prepare
+            .map(|c| format!("prepare = {}\n", toml::Value::String(c.to_string())))
+            .unwrap_or_default();
+        std::fs::write(
+            &path,
+            format!(
+                r#"
+name = "prep"
+repo = "https://example.com/prep.git"
+ref = "v1"
+objdir = "target"
+build = "true"
+{prepare}
+[env]
+PREP_MARKER = "{{kache}}"
+"#
+            ),
+        )
+        .unwrap();
+        BenchProfile::load(&path).unwrap()
+    }
+
+    /// `prepare` runs in the clone with the scenario env, without the cache
+    /// wrapper (whatever the ambient environment sets), and reports its own
+    /// time so it never has to hide inside a phase's wall clock.
+    #[cfg(unix)]
+    #[test]
+    fn prepare_runs_in_the_clone_with_the_scenario_env_and_no_wrapper() {
+        let dir = tempfile::tempdir().unwrap();
+        let command = r#"sleep 0.2; echo "$PREP_MARKER ${RUSTC_WRAPPER:-unset} ${RUSTC_WORKSPACE_WRAPPER:-unset}" > prepared.txt"#;
+        let profile = prepare_fixture(dir.path(), Some(command));
+        let clone = dir.path().join("clone");
+        let work_dir = dir.path().join("work");
+        std::fs::create_dir_all(&clone).unwrap();
+        std::fs::create_dir_all(&work_dir).unwrap();
+
+        let got = prepare_clone(
+            &profile,
+            &clone,
+            "cold",
+            Path::new("/k"),
+            &work_dir,
+            &posix_sh().unwrap(),
+        )
+        .unwrap()
+        .expect("a declared prepare runs");
+
+        assert_eq!(got.command, command);
+        assert!(
+            (200..60_000).contains(&got.wall_ms),
+            "a 200ms sleep must time as at least 200ms, got {}ms",
+            got.wall_ms
+        );
+        assert_eq!(
+            std::fs::read_to_string(clone.join("prepared.txt")).unwrap(),
+            "/k unset unset\n"
+        );
+        assert!(work_dir.join("prepare-cold.log").exists());
+    }
+
+    #[test]
+    fn prepare_is_a_no_op_when_the_scenario_declares_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = prepare_fixture(dir.path(), None);
+        let got = prepare_clone(
+            &profile,
+            dir.path(),
+            "cold",
+            Path::new("/k"),
+            dir.path(),
+            &posix_sh().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(got, None);
+        assert!(!dir.path().join("prepare-cold.log").exists());
+    }
+
+    #[test]
+    fn a_failed_prepare_fails_the_run_and_names_its_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = prepare_fixture(dir.path(), Some("exit 3"));
+        let err = prepare_clone(
+            &profile,
+            dir.path(),
+            "warm",
+            Path::new("/k"),
+            dir.path(),
+            &posix_sh().unwrap(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("[warm] prepare failed"), "{err}");
+        assert!(err.contains("prepare-warm.log"), "{err}");
+    }
+
+    #[test]
+    fn prepare_logs_are_archived_with_the_run() {
+        assert!(is_run_artifact("prepare-cold.log"));
+        assert!(is_run_artifact("prepare-warm.log"));
+        assert!(is_run_artifact("key-diff.json"));
+        assert!(!is_run_artifact("prepared.txt"));
+    }
+
+    /// A phase that ran no prepare step serializes exactly as before, and a
+    /// saved phase from before the field existed still loads.
+    #[test]
+    fn phase_prepare_is_omitted_when_absent_and_recorded_when_present() {
+        let plain = serde_json::to_value(PhaseMetrics::default()).unwrap();
+        assert!(plain.get("prepare").is_none(), "{plain}");
+        let loaded: PhaseMetrics = serde_json::from_value(plain).unwrap();
+        assert_eq!(loaded.prepare, None);
+
+        let prepared = PhaseMetrics {
+            prepare: Some(PrepareMetrics {
+                command: "cargo fetch --locked".to_string(),
+                wall_ms: 41_200,
+            }),
+            ..Default::default()
+        };
+        let j = serde_json::to_value(&prepared).unwrap();
+        assert_eq!(j["prepare"]["command"], "cargo fetch --locked");
+        assert_eq!(j["prepare"]["wall_ms"], 41_200);
     }
 
     /// The two refusal categories must reach the payload as two numbers, from

--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -124,6 +124,17 @@ Perfetto/Chrome trace format; sccache benchmark runs write
 stats commands. `--trace-keys` is kache-only and adds `key-diff.{json,md}` for
 cache-key divergence analysis.
 
+### Untimed preparation
+
+`prepare = "cargo fetch --locked"` runs once in each clone after the file
+injections and before the first phase that builds there, outside the timer.
+Use it for work the first timed build would otherwise absorb: dependency
+downloads and toolchain installs. It sees the scenario `[env]` but not the
+cache wrapper, so it must fetch, not compile. Its output goes to
+`prepare-<phase>.log`, and the result JSON records the command and its
+`wall_ms` under that phase's `prepare` key, separate from the phase's own
+wall clock.
+
 Backend-specific benchmark scenarios should keep their source patches under the
 scenario's own `patches/` directory so kache and sccache requirements remain
 auditable if they diverge.

--- a/scenarios/bench-pr-cargo/scenario.toml
+++ b/scenarios/bench-pr-cargo/scenario.toml
@@ -46,6 +46,12 @@ setup = [
   "echo '[bench] bench-pr-cargo needs: a C compiler, pkg-config, and OpenSSL headers (libgit2-sys/curl-sys). Debian: apt install build-essential pkg-config libssl-dev. macOS: xcode-select --install && brew install openssl@3 pkg-config.'",
 ]
 
+# Downloads the locked crates and, through the injected rust-toolchain.toml,
+# installs the pinned toolchain before any timed build. The gate runs both
+# sides on one runner with a shared ~/.cargo, so without this the first side's
+# cold build pays for every download and the second side's does not.
+prepare = "cargo fetch --locked"
+
 # Build the `cargo` binary at the DEV profile, not release. Two reasons:
 #   * Time. The gate runs the subject three times per side and twice per PR
 #     (head + merge base) on one machine. A release build of this graph is the

--- a/scripts/perf-gate-compare.sh
+++ b/scripts/perf-gate-compare.sh
@@ -16,6 +16,11 @@
 # compares, and `wall_s`, the whole-second view the nightly reports and their
 # telemetry carry.
 #
+# Beside the wall clocks, the warm build's deterministic counts (hits, misses,
+# passthroughs, dep-info pre-pass runs) are compared when both results carry
+# them. More warm misses or passthroughs than the merge base fails the gate
+# on its own: a count does not move with the runner.
+#
 # Writes a markdown report to <markdown-out> for the step summary and the PR
 # comment, prints the same table to stdout, and exits non-zero when the gate
 # fails.
@@ -184,6 +189,61 @@ runner_drift="$(awk -v bc="$base_cold" -v hc="$head_cold" -v bw="$base_warm" -v 
         print (warm_pct > lim + 0 && cold_pct > lim + 0 && warm_pct <= cold_pct) ? "yes" : "no"
     }')"
 
+# ── Deterministic counts ─────────────────────────────────────────────────────
+# Wall clocks move with the runner; counts do not. Both sides build the same
+# subject at the same commit into an empty store, so the warm build's counts
+# depend on kache alone. A warm miss the merge base did not have is a compile
+# the head no longer serves from the cache, and a new passthrough is one it no
+# longer tries to cache. Either fails the gate whatever the wall clock says,
+# and the runner-drift pardon above does not apply to it. Fewer is never a
+# failure. The other rows are context for the reviewer.
+#
+# A row appears only when both result JSONs carry the field, so a result from
+# an older engine is compared on what it has rather than rejected. The table
+# itself appears only when at least one blocking count could be compared;
+# hits alone say nothing the validity gates above have not already checked.
+count_rows=()
+count_failures=()
+blocking_counts=0
+
+count_row() {
+    local label="$1" path="$2" blocking="$3"
+    local b h delta
+    b="$(field "$base_json" "$path")"
+    h="$(field "$head_json" "$path")"
+    if [ -z "$b" ] || [ -z "$h" ]; then
+        return 0
+    fi
+    delta=$((h - b))
+    if [ "$delta" -gt 0 ]; then
+        delta="+$delta"
+    fi
+    count_rows+=("| $label | $b | $h | $delta |")
+    if [ "$blocking" = "blocking" ]; then
+        blocking_counts=$((blocking_counts + 1))
+        if [ "$h" -gt "$b" ]; then
+            count_failures+=("$label rose from $b to $h")
+        fi
+    fi
+}
+
+count_row "hits" .warm_same_tree.hits reported
+count_row "misses" .warm_same_tree.misses blocking
+count_row "passthroughs" .warm_same_tree.event_log.passed_through blocking
+count_row "dep-info pre-pass runs" .warm_same_tree.phases.dep_info_runs reported
+
+count_table() {
+    [ "$blocking_counts" -gt 0 ] || return 0
+    echo "| warm build count | merge base | PR head | delta |"
+    echo "| --- | ---: | ---: | ---: |"
+    printf '%s\n' "${count_rows[@]}"
+    echo
+    echo "Counts do not move with the runner. More misses or passthroughs than the"
+    echo "merge base fails the gate whatever the wall clock says; the other rows are"
+    echo "reported only."
+    echo
+}
+
 # ── Where the warm build's time went ─────────────────────────────────────────
 # The wall-clock rows above say a build got slower. This says which part of the
 # wrapper did it, from the same phase totals the Perfetto trace draws per crate.
@@ -243,7 +303,11 @@ phase_table() {
 
 # The workflow's report step parses this first line into the commit status:
 # it strips the leading `## Perf gate: ` and keeps the rest. Keep the grammar.
-if [ "$regressed" = "yes" ] && [ "$runner_drift" = "yes" ]; then
+# A count failure leads: it is the one verdict the runner cannot explain.
+if [ "${#count_failures[@]}" -gt 0 ]; then
+    count_summary="$(printf '%s; ' "${count_failures[@]}")"
+    headline="## Perf gate: FAIL — warm build ${count_summary%; } (wall-clock ${warm_pct}%)"
+elif [ "$regressed" = "yes" ] && [ "$runner_drift" = "yes" ]; then
     headline="## Perf gate: pass — warm build ${warm_pct}% (limit +${WARM_REGRESSION_LIMIT_PCT}%; cold ${cold_pct}% on the same runner)"
 elif [ "$regressed" = "yes" ]; then
     headline="## Perf gate: FAIL — warm build ${warm_pct}% (limit +${WARM_REGRESSION_LIMIT_PCT}%)"
@@ -268,10 +332,19 @@ fi
     echo
     echo "Milliseconds (merge base / PR head): cold ${base_cold} / ${head_cold}, warm ${base_warm} / ${head_warm}, cross-worktree ${base_cross} / ${head_cross}."
     echo
+    count_table
     phase_table
 } | tee "$md_out"
 
+gate_status=0
+if [ "${#count_failures[@]}" -gt 0 ]; then
+    for f in "${count_failures[@]}"; do
+        echo "::error::perf gate: warm build $f; counts do not move with the runner, so this is the cache"
+    done
+    gate_status=1
+fi
 if [ "$regressed" = "yes" ] && [ "$runner_drift" != "yes" ]; then
     echo "::error::perf gate: warm wall-clock regressed ${warm_pct}% (merge base ${base_warm} ms, PR head ${head_warm} ms; limit +${WARM_REGRESSION_LIMIT_PCT}%)"
-    exit 1
+    gate_status=1
 fi
+exit "$gate_status"

--- a/scripts/perf-gate-side.sh
+++ b/scripts/perf-gate-side.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Measure one side of the per-PR perf gate: run the benchmark engine with that
+# side's kache binary, keep its result JSON and logs, then free its scratch so
+# the other side starts on the same disk budget.
+#
+# Usage: perf-gate-side.sh <base|head>
+#
+# Expects the layout .github/workflows/perf-gate.yml stages under
+# $RUNNER_TEMP: the instrument in instrument/ and the binaries under test as
+# kache-base and kache-head. BENCH_PROFILE and BENCH_SCENARIO come from the
+# workflow env. Writes $RUNNER_TEMP/<side>.json and $RUNNER_TEMP/logs/<side>/.
+set -euo pipefail
+
+side="${1:?usage: perf-gate-side.sh <base|head>}"
+case "$side" in
+    base | head) ;;
+    *)
+        echo "::error::perf gate: unknown side '$side' (want base or head)"
+        exit 1
+        ;;
+esac
+: "${RUNNER_TEMP:?}" "${BENCH_PROFILE:?}" "${BENCH_SCENARIO:?}"
+
+work="tmp/perf-gate/$side"
+"$RUNNER_TEMP/instrument/kache-scenario" \
+    --kache "$RUNNER_TEMP/kache-$side" \
+    --scenarios "$RUNNER_TEMP/instrument/scenarios" \
+    --select suite:bench --select backend:kache \
+    --profile "$BENCH_PROFILE" \
+    --warm-same-tree \
+    --work-dir "$work"
+cp "$work/$BENCH_SCENARIO.json" "$RUNNER_TEMP/$side.json"
+mkdir -p "$RUNNER_TEMP/logs/$side"
+cp "$work"/*.log "$RUNNER_TEMP/logs/$side/" || true
+# Free the objdirs, worktrees and store before the other side runs.
+# `clone-ref` is a SIBLING of the work dir, so it needs its own rm.
+rm -rf "$work" "$work-clone-ref"

--- a/scripts/test-perf-gate-compare.sh
+++ b/scripts/test-perf-gate-compare.sh
@@ -204,6 +204,105 @@ run_gate "$work/base.json" "$work/nullphase.json"
 expect_status "a null same-tree phase is rejected" 1
 expect_line "a null phase is reported as missing, not as lacking wall_ms" "PR head: no warm-same-tree phase in the result JSON"
 
+# --- deterministic counts -----------------------------------------------------
+#
+# The warm build's counts, added to a result the way the engine writes them.
+#   counts <path> <misses> <passthroughs>
+counts() {
+    jq --argjson m "$2" --argjson p "$3" \
+        '.warm_same_tree.misses = $m
+         | .warm_same_tree.event_log.passed_through = $p
+         | .warm_same_tree.phases.dep_info_runs = 315' \
+        "$1" >"$1.tmp" && mv "$1.tmp" "$1"
+}
+
+expect_no_line() {
+    local name="$1" substr="$2"
+    if [[ "$out" != *"$substr"* ]]; then ok "$name"; else no "$name" "output had '$substr': $out"; fi
+}
+
+# The results above carry hits but no miss or passthrough counts, so their
+# output is exactly what it was before counts were compared.
+result "$work/base.json" 112400 14600 17000
+result "$work/head.json" 108100 15100 16200
+run_gate "$work/base.json" "$work/head.json"
+expect_no_line "no count table without a blocking count on both sides" "| warm build count |"
+
+# Misses on one side only: nothing to compare, so nothing blocks.
+counts "$work/head.json" 9 99
+run_gate "$work/base.json" "$work/head.json"
+expect_status "counts on one side only do not fail" 0
+expect_no_line "counts on one side only print no table" "| warm build count |"
+
+counts "$work/base.json" 2 12
+counts "$work/head.json" 2 12
+run_gate "$work/base.json" "$work/head.json"
+expect_status "equal counts pass" 0
+expect_headline "equal counts keep the wall-clock headline" \
+    "## Perf gate: pass — warm build +3.4% (limit +5.0%)"
+expect_line "the count table has a header" "| warm build count | merge base | PR head | delta |"
+expect_line "hits are reported" "| hits | 783 | 783 | 0 |"
+expect_line "misses are reported" "| misses | 2 | 2 | 0 |"
+expect_line "passthroughs are reported" "| passthroughs | 12 | 12 | 0 |"
+expect_line "dep-info runs are reported" "| dep-info pre-pass runs | 315 | 315 | 0 |"
+
+# One more warm miss fails even though the wall clock is inside the limit.
+counts "$work/head.json" 3 12
+run_gate "$work/base.json" "$work/head.json"
+expect_status "one extra warm miss fails" 1
+expect_headline "the count failure leads the headline" \
+    "## Perf gate: FAIL — warm build misses rose from 2 to 3 (wall-clock +3.4%)"
+expect_line "the extra miss shows as a positive delta" "| misses | 2 | 3 | +1 |"
+expect_line "the extra miss is annotated" \
+    "::error::perf gate: warm build misses rose from 2 to 3; counts do not move with the runner, so this is the cache"
+
+counts "$work/head.json" 1 12
+run_gate "$work/base.json" "$work/head.json"
+expect_status "one fewer warm miss passes" 0
+expect_line "the saved miss shows as a negative delta" "| misses | 2 | 1 | -1 |"
+
+counts "$work/head.json" 2 13
+run_gate "$work/base.json" "$work/head.json"
+expect_status "one extra passthrough fails" 1
+expect_headline "the passthrough failure leads the headline" \
+    "## Perf gate: FAIL — warm build passthroughs rose from 12 to 13 (wall-clock +3.4%)"
+
+counts "$work/head.json" 2 11
+run_gate "$work/base.json" "$work/head.json"
+expect_status "one fewer passthrough passes" 0
+
+# Hits and dep-info runs are context, not verdicts.
+counts "$work/head.json" 2 12
+jq '.warm_same_tree.hits = 700 | .warm_same_tree.phases.dep_info_runs = 400' \
+    "$work/head.json" >"$work/moved.json"
+run_gate "$work/base.json" "$work/moved.json"
+expect_status "fewer hits and more dep-info runs alone do not fail" 0
+expect_line "a hit drop shows as a negative delta" "| hits | 783 | 700 | -83 |"
+
+# The runner-drift pardon covers the wall clock, never a count.
+result "$work/base.json" 106500 14800 17000
+result "$work/head.json" 117500 15837 18000
+counts "$work/base.json" 2 12
+counts "$work/head.json" 3 12
+run_gate "$work/base.json" "$work/head.json"
+expect_status "an extra miss fails even when the runner drifted" 1
+expect_headline "a pardoned wall move does not hide the count failure" \
+    "## Perf gate: FAIL — warm build misses rose from 2 to 3 (wall-clock +7.0%)"
+
+counts "$work/head.json" 3 14
+run_gate "$work/base.json" "$work/head.json"
+expect_headline "two count failures are joined in the headline" \
+    "## Perf gate: FAIL — warm build misses rose from 2 to 3; passthroughs rose from 12 to 14 (wall-clock +7.0%)"
+
+# A wall regression and a count regression both annotate.
+result "$work/base.json" 112400 14600 17000
+result "$work/head.json" 108100 16000 16200
+counts "$work/base.json" 2 12
+counts "$work/head.json" 3 12
+run_gate "$work/base.json" "$work/head.json"
+expect_status "a wall and a count regression fail together" 1
+expect_line "the wall regression is still annotated" "::error::perf gate: warm wall-clock regressed +9.6%"
+
 run_gate "$work/base.json" "$work/does-not-exist.json"
 expect_status "a missing input is an error" 1
 expect_line "the missing input is named" "missing benchmark result"


### PR DESCRIPTION
The merge base always ran first and shared `~/.cargo` with the head. Its timed cold build paid for crate downloads and the pinned toolchain install, and the head got both for free. The head's cold build read faster, `cold_pct` went negative, and the runner-drift pardon almost never applied. Over the last 10 gate runs the warm delta ranged from -12.6% to +6.4% against a 5% limit.

## What changes

- Scenarios can declare `prepare`, which runs in each clone before its first build, outside the timer and without the cache wrapper. bench-pr-cargo uses `cargo fetch --locked`. The result JSON records the command and its `wall_ms` per phase; nightly JSON is unchanged when a scenario declares none.
- The first side alternates between base and head by run number, through `scripts/perf-gate-side.sh`. The job summary and log show the order. The git auth step now runs before both sides; before, it ran between them, so the base side cloned without auth.
- The compare script prints a warm-build counts table (hits, misses, passthroughs, dep-info pre-pass runs). More warm misses or passthroughs than the merge base fails the gate on its own, because a count does not move with the runner.

## Why the count rule is safe to add

The last six gate runs reported identical warm counts on both sides every time: 0 misses, 17 passthroughs, 783 hits. A rise is a real change in what the cache serves, not noise.

## Validation

- `mise exec -- just check` passes.
- `scripts/test-perf-gate-compare.sh`: 62 cases, 13 new (equal counts pass, one extra miss fails, one fewer passes, the same for passthroughs, counts on one side only, a miss failure under runner drift).
- Workflow policy tests pass; actionlint and shellcheck are clean on the changed files.

## What this PR's own gate run does not show

The perf gate runs from the default branch through `workflow_run` and builds its instrument (engine, scenario, scripts) from there, by design. Its run on this PR used the old flow, so the green status says nothing about these changes. The first real run of the new flow is the first pull request after this merges; if it breaks, the gate reports "could not run", and it is not a required check.

One more data point for why this matters: on #1016, which changes no kache code, the gate failed at +8.4% warm and then passed at +0.3% on a rerun of the same commits.

Out of scope, for a follow-up: repeated warm runs with a median, and a noise-floor A/A run.

