### PR TITLE
bench: keep millisecond precision, report unknowns, record the runner

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -289,6 +289,10 @@ exclude_re = [
     "replace print_sccache_summary with \\(\\)",
     "crates/kache-e2e/src/disk_usage.rs:.*other::",
     "crates/kache-e2e/src/bench_host.rs:.*(macos|other)::",
+    # Struct-field mutants inside the macOS readers: the `AttrList` shape above.
+    # Anchored on the enclosing function, because `HostInfo` and `LoadSample`
+    # are also built by the Linux readers, which stay in scope.
+    "expression in macos::(host_facts|load_sample)",
     "replace run_cold_phase .* with Ok",
     "src/cache_fs.rs:.*replace probe_windows",
     "src/cache_fs.rs:.*replace statfs_total_bytes_macos",

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -223,6 +223,12 @@ gitignore = true
 # `disk_usage::other` is the non-Unix fallback for inode identity and
 # allocated size. The ubuntu lane never compiles it; `disk_usage::unix` and
 # the measurement walk stay in scope.
+#
+# `bench_host::macos` and `bench_host::other` are the same shape: thin
+# wrappers around `sysctl` and `mount`, and a constant fallback, that the
+# ubuntu lane never compiles. Their parsers and the procfs readers are
+# platform-neutral and stay in scope; the macOS Test lane runs the real
+# wrappers through the host smoke test.
 exclude_globs = ["crates/kache-fs/src/apfs.rs"]
 exclude_re = [
     "crates/kache-fs/src/copy.rs:.*(native_reflink_macos|native_reflink_windows|native_reflink_unsupported|windows_cluster_size)",
@@ -282,6 +288,7 @@ exclude_re = [
     "replace print_pull_summary with \\(\\)",
     "replace print_sccache_summary with \\(\\)",
     "crates/kache-e2e/src/disk_usage.rs:.*other::",
+    "crates/kache-e2e/src/bench_host.rs:.*(macos|other)::",
     "replace run_cold_phase .* with Ok",
     "src/cache_fs.rs:.*replace probe_windows",
     "src/cache_fs.rs:.*replace statfs_total_bytes_macos",

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -289,10 +289,6 @@ exclude_re = [
     "replace print_sccache_summary with \\(\\)",
     "crates/kache-e2e/src/disk_usage.rs:.*other::",
     "crates/kache-e2e/src/bench_host.rs:.*(macos|other)::",
-    # Struct-field mutants inside the macOS readers: the `AttrList` shape above.
-    # Anchored on the enclosing function, because `HostInfo` and `LoadSample`
-    # are also built by the Linux readers, which stay in scope.
-    "expression in macos::(host_facts|load_sample)",
     "replace run_cold_phase .* with Ok",
     "src/cache_fs.rs:.*replace probe_windows",
     "src/cache_fs.rs:.*replace statfs_total_bytes_macos",

--- a/crates/kache-e2e/src/bench_host.rs
+++ b/crates/kache-e2e/src/bench_host.rs
@@ -1,0 +1,821 @@
+//! Which machine ran a bench, and how busy it was while it did.
+//!
+//! Two runs of one scenario at one commit can differ by more than the change
+//! under test when they land on different hardware or share a node with other
+//! jobs. The result JSON records the runner once per run and the load around
+//! each timed build, so a step in a series can be traced to the machine rather
+//! than to the code.
+//!
+//! Everything here is best effort. A value the host does not expose is `None`
+//! (JSON `null`), never zero or an empty string, and nothing here can fail a
+//! run. None of it reaches the OTLP attributes: a runner name is a series per
+//! machine, and the artifact is where that detail costs nothing.
+//!
+//! Linux sources are read through [`procfs`] against a root directory, so the
+//! tests feed it a fixture tree on any host. The macOS wrappers only call
+//! `sysctl` and `mount`; their parsers are platform-neutral and tested here.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// The machine a bench ran on.
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+pub struct HostInfo {
+    /// Logical CPUs the host has. Where the platform does not say, this falls
+    /// back to the parallelism the process is allowed, which already reflects
+    /// affinity and cgroup limits.
+    pub logical_cpus: Option<u64>,
+    /// `model name` from `/proc/cpuinfo`, or `machdep.cpu.brand_string` on
+    /// macOS. Absent on Linux hosts whose cpuinfo has no such line (most ARM).
+    pub cpu_model: Option<String>,
+    pub memory_bytes: Option<u64>,
+    /// `std::env::consts::OS`.
+    pub os: String,
+    pub kernel_release: Option<String>,
+    /// Filesystem type backing the bench work dir (`ext4`, `overlay`, `apfs`).
+    pub work_dir_fs: Option<String>,
+    /// The cgroup v2 `cpu.max` of this process, when the host has one.
+    pub cgroup_cpu_max: Option<CpuMax>,
+    #[serde(flatten)]
+    pub runner: RunnerEnv,
+}
+
+impl HostInfo {
+    /// Read the host once. Never fails; unknown values stay `None`.
+    pub fn collect(work_dir: &Path) -> Self {
+        Self::assemble(
+            platform::host_facts(work_dir),
+            std::thread::available_parallelism()
+                .ok()
+                .map(|n| n.get() as u64),
+            RunnerEnv::from_lookup(|name| std::env::var(name).ok()),
+        )
+    }
+
+    /// Fill in what every platform shares around the platform's own facts.
+    fn assemble(facts: HostInfo, parallelism: Option<u64>, runner: RunnerEnv) -> Self {
+        HostInfo {
+            logical_cpus: facts.logical_cpus.or(parallelism),
+            os: std::env::consts::OS.to_string(),
+            runner,
+            ..facts
+        }
+    }
+}
+
+/// CI and scheduler identity from the environment. Unset or blank is `None`.
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+pub struct RunnerEnv {
+    /// `RUNNER_NAME`: the GitHub Actions runner that took the job.
+    pub runner_name: Option<String>,
+    /// `NODE_NAME`, else `KUBE_NODE_NAME`: the Kubernetes node under an
+    /// ephemeral runner pod, when the pod spec exports it.
+    pub node_name: Option<String>,
+    pub github_run_id: Option<String>,
+    pub github_run_attempt: Option<String>,
+}
+
+impl RunnerEnv {
+    pub fn from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Self {
+        let get = |name: &str| lookup(name).filter(|value| !value.trim().is_empty());
+        RunnerEnv {
+            runner_name: get("RUNNER_NAME"),
+            node_name: get("NODE_NAME").or_else(|| get("KUBE_NODE_NAME")),
+            github_run_id: get("GITHUB_RUN_ID"),
+            github_run_attempt: get("GITHUB_RUN_ATTEMPT"),
+        }
+    }
+}
+
+/// A cgroup v2 `cpu.max`: the group may use `quota_us` of CPU time every
+/// `period_us`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct CpuMax {
+    /// `None` when the file says `max`, which means no limit. An unreadable
+    /// file makes the whole [`HostInfo::cgroup_cpu_max`] `None` instead.
+    pub quota_us: Option<u64>,
+    pub period_us: u64,
+}
+
+/// Parse a `cpu.max` line: `max 100000` or `200000 100000`.
+pub fn parse_cpu_max(text: &str) -> Option<CpuMax> {
+    let mut fields = text.split_whitespace();
+    let quota = fields.next()?;
+    let period_us = fields.next()?.parse().ok()?;
+    let quota_us = if quota == "max" {
+        None
+    } else {
+        Some(quota.parse().ok()?)
+    };
+    Some(CpuMax {
+        quota_us,
+        period_us,
+    })
+}
+
+/// A point-in-time reading of the host's load counters.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct LoadSample {
+    cpu_some_us: Option<u64>,
+    io_some_us: Option<u64>,
+    memory_some_us: Option<u64>,
+    loadavg: Option<[f64; 3]>,
+}
+
+impl LoadSample {
+    pub fn take() -> Self {
+        platform::load_sample()
+    }
+}
+
+/// How contended the host was across one timed build.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PhaseLoad {
+    /// Microseconds during the build in which some task waited for a CPU: the
+    /// growth of `some total=` in `/proc/pressure/cpu`. Linux with PSI only.
+    pub cpu_pressure_some_us: Option<u64>,
+    /// The same for `/proc/pressure/io`.
+    pub io_pressure_some_us: Option<u64>,
+    /// The same for `/proc/pressure/memory`.
+    pub memory_pressure_some_us: Option<u64>,
+    /// 1, 5 and 15 minute load averages when the build started.
+    pub loadavg_start: Option<[f64; 3]>,
+    /// The same when it finished.
+    pub loadavg_end: Option<[f64; 3]>,
+}
+
+impl PhaseLoad {
+    pub fn between(start: &LoadSample, end: &LoadSample) -> Self {
+        PhaseLoad {
+            cpu_pressure_some_us: counter_delta(start.cpu_some_us, end.cpu_some_us),
+            io_pressure_some_us: counter_delta(start.io_some_us, end.io_some_us),
+            memory_pressure_some_us: counter_delta(start.memory_some_us, end.memory_some_us),
+            loadavg_start: start.loadavg,
+            loadavg_end: end.loadavg,
+        }
+    }
+}
+
+/// Growth of a monotonic counter. `None` when either reading is missing, or
+/// when the counter went backwards, which is a reset rather than a value.
+fn counter_delta(start: Option<u64>, end: Option<u64>) -> Option<u64> {
+    end?.checked_sub(start?)
+}
+
+/// `some total=` from a `/proc/pressure/*` file, in microseconds.
+fn pressure_some_total_us(text: &str) -> Option<u64> {
+    text.lines()
+        .find(|line| line.starts_with("some "))?
+        .split_whitespace()
+        .find_map(|field| field.strip_prefix("total="))?
+        .parse()
+        .ok()
+}
+
+/// The three load averages from `/proc/loadavg` (`0.52 0.58 0.59 1/123 456`)
+/// or macOS `sysctl -n vm.loadavg` (`{ 1.93 2.05 2.14 }`).
+fn parse_loadavg(text: &str) -> Option<[f64; 3]> {
+    let mut values = text
+        .split_whitespace()
+        .map(|field| field.trim_matches(|c| c == '{' || c == '}'))
+        .filter(|field| !field.is_empty())
+        .map(|field| field.parse::<f64>().ok());
+    Some([values.next()??, values.next()??, values.next()??])
+}
+
+/// The filesystem type of the deepest mount point containing `path`. Among
+/// equal mount points the last listed wins, since a later mount hides an
+/// earlier one at the same place.
+fn fs_type_for(path: &Path, mounts: &[(PathBuf, String)]) -> Option<String> {
+    mounts
+        .iter()
+        .filter(|(mount_point, _)| path.starts_with(mount_point))
+        .max_by_key(|(mount_point, _)| mount_point.components().count())
+        .map(|(_, fs)| fs.clone())
+}
+
+/// `(mount point, fs type)` from BSD `mount` output:
+/// `/dev/disk3s5 on /System/Volumes/Data (apfs, local, journaled)`.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn bsd_mounts(text: &str) -> Vec<(PathBuf, String)> {
+    text.lines()
+        .filter_map(|line| {
+            let (_, rest) = line.split_once(" on ")?;
+            let (mount_point, options) = rest.rsplit_once(" (")?;
+            let fs = options.split([',', ')']).next()?.trim();
+            (!fs.is_empty()).then(|| (PathBuf::from(mount_point), fs.to_string()))
+        })
+        .collect()
+}
+
+fn read(path: &Path) -> Option<String> {
+    std::fs::read_to_string(path).ok()
+}
+
+/// A trimmed value, or `None` for a blank one.
+fn non_empty(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Linux sources, read under a root so tests can point them at a fixture.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+mod procfs {
+    use super::*;
+
+    pub(super) struct Roots<'a> {
+        /// `/proc`.
+        pub(super) proc: &'a Path,
+        /// `/sys/fs/cgroup`.
+        pub(super) cgroup: &'a Path,
+    }
+
+    pub(super) fn host_facts(roots: &Roots, work_dir: &Path) -> HostInfo {
+        let cpuinfo = read(&roots.proc.join("cpuinfo"));
+        let work_dir = canonical(work_dir);
+        HostInfo {
+            logical_cpus: cpuinfo.as_deref().and_then(cpuinfo_processors),
+            cpu_model: cpuinfo.as_deref().and_then(cpuinfo_model),
+            memory_bytes: read(&roots.proc.join("meminfo"))
+                .as_deref()
+                .and_then(meminfo_total_bytes),
+            kernel_release: read(&roots.proc.join("sys/kernel/osrelease")).and_then(non_empty),
+            work_dir_fs: read(&roots.proc.join("self/mounts"))
+                .and_then(|text| fs_type_for(&work_dir, &proc_mounts(&text))),
+            cgroup_cpu_max: cgroup_cpu_max(
+                roots.cgroup,
+                read(&roots.proc.join("self/cgroup")).as_deref(),
+            ),
+            ..HostInfo::default()
+        }
+    }
+
+    pub(super) fn load_sample(proc: &Path) -> LoadSample {
+        let psi = |name: &str| {
+            read(&proc.join("pressure").join(name))
+                .as_deref()
+                .and_then(pressure_some_total_us)
+        };
+        LoadSample {
+            cpu_some_us: psi("cpu"),
+            io_some_us: psi("io"),
+            memory_some_us: psi("memory"),
+            loadavg: read(&proc.join("loadavg"))
+                .as_deref()
+                .and_then(parse_loadavg),
+        }
+    }
+
+    /// One `processor : N` line per logical CPU.
+    pub(super) fn cpuinfo_processors(text: &str) -> Option<u64> {
+        let count = text
+            .lines()
+            .filter(|line| line.split(':').next().map(str::trim) == Some("processor"))
+            .count() as u64;
+        (count > 0).then_some(count)
+    }
+
+    pub(super) fn cpuinfo_model(text: &str) -> Option<String> {
+        text.lines()
+            .find_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                (key.trim() == "model name").then(|| value.to_string())
+            })
+            .and_then(non_empty)
+    }
+
+    /// `MemTotal:` in bytes. The kernel labels the figure `kB`; it is KiB.
+    pub(super) fn meminfo_total_bytes(text: &str) -> Option<u64> {
+        let value = text
+            .lines()
+            .find_map(|line| line.strip_prefix("MemTotal:"))?;
+        let kib: u64 = value.split_whitespace().next()?.parse().ok()?;
+        kib.checked_mul(1024)
+    }
+
+    /// `(mount point, fs type)` from `/proc/self/mounts`, whose fields are
+    /// device, mount point, type and options.
+    pub(super) fn proc_mounts(text: &str) -> Vec<(PathBuf, String)> {
+        text.lines()
+            .filter_map(|line| {
+                let mut fields = line.split_whitespace();
+                let _device = fields.next()?;
+                let mount_point = unescape_mount_field(fields.next()?);
+                let fs = fields.next()?;
+                Some((PathBuf::from(mount_point), fs.to_string()))
+            })
+            .collect()
+    }
+
+    /// The kernel writes space, tab, newline and backslash in a mount point as
+    /// octal escapes. The backslash goes last so a literal `\` followed by
+    /// digits is not decoded twice.
+    pub(super) fn unescape_mount_field(field: &str) -> String {
+        field
+            .replace("\\040", " ")
+            .replace("\\011", "\t")
+            .replace("\\012", "\n")
+            .replace("\\134", "\\")
+    }
+
+    /// This process's cgroup v2 path: the `0::` line of `/proc/self/cgroup`.
+    pub(super) fn cgroup_v2_path(proc_self_cgroup: &str) -> Option<&str> {
+        proc_self_cgroup
+            .lines()
+            .find_map(|line| line.strip_prefix("0::"))
+            .map(str::trim)
+    }
+
+    /// The process's own `cpu.max`, else the one at the cgroup root, which is
+    /// what a container with its own cgroup namespace sees.
+    pub(super) fn cgroup_cpu_max(
+        cgroup_root: &Path,
+        proc_self_cgroup: Option<&str>,
+    ) -> Option<CpuMax> {
+        let own = proc_self_cgroup.and_then(cgroup_v2_path).map(|rel| {
+            cgroup_root
+                .join(rel.trim_start_matches('/'))
+                .join("cpu.max")
+        });
+        own.into_iter()
+            .chain([cgroup_root.join("cpu.max")])
+            .find_map(|path| read(&path).as_deref().and_then(parse_cpu_max))
+    }
+}
+
+#[cfg(target_os = "linux")]
+use linux as platform;
+#[cfg(target_os = "macos")]
+use macos as platform;
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+use other as platform;
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::*;
+
+    pub(super) fn host_facts(work_dir: &Path) -> HostInfo {
+        procfs::host_facts(
+            &procfs::Roots {
+                proc: Path::new("/proc"),
+                cgroup: Path::new("/sys/fs/cgroup"),
+            },
+            work_dir,
+        )
+    }
+
+    pub(super) fn load_sample() -> LoadSample {
+        procfs::load_sample(Path::new("/proc"))
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use std::process::Command;
+
+    fn stdout_of(command: &mut Command) -> Option<String> {
+        let out = command.output().ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        non_empty(String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+
+    fn sysctl(name: &str) -> Option<String> {
+        stdout_of(Command::new("sysctl").args(["-n", name]))
+    }
+
+    pub(super) fn host_facts(work_dir: &Path) -> HostInfo {
+        let work_dir = canonical(work_dir);
+        HostInfo {
+            logical_cpus: sysctl("hw.logicalcpu").and_then(|v| v.parse().ok()),
+            cpu_model: sysctl("machdep.cpu.brand_string"),
+            memory_bytes: sysctl("hw.memsize").and_then(|v| v.parse().ok()),
+            kernel_release: sysctl("kern.osrelease"),
+            work_dir_fs: stdout_of(&mut Command::new("mount"))
+                .and_then(|text| fs_type_for(&work_dir, &bsd_mounts(&text))),
+            ..HostInfo::default()
+        }
+    }
+
+    pub(super) fn load_sample() -> LoadSample {
+        LoadSample {
+            loadavg: sysctl("vm.loadavg").as_deref().and_then(parse_loadavg),
+            ..LoadSample::default()
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod other {
+    use super::*;
+
+    pub(super) fn host_facts(_work_dir: &Path) -> HostInfo {
+        HostInfo::default()
+    }
+
+    pub(super) fn load_sample() -> LoadSample {
+        LoadSample::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::procfs::*;
+    use super::*;
+
+    const CPUINFO: &str = "processor\t: 0\nvendor_id\t: GenuineIntel\n\
+                           model name\t: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz\n\n\
+                           processor\t: 1\nmodel name\t: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz\n";
+
+    const MEMINFO: &str = "MemTotal:       16374584 kB\nMemFree:          905392 kB\n";
+
+    const PRESSURE: &str = "some avg10=0.00 avg60=0.12 avg300=0.05 total=123456\n\
+                            full avg10=0.00 avg60=0.00 avg300=0.00 total=654321\n";
+
+    fn write(root: &Path, rel: &str, text: &str) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, text).unwrap();
+    }
+
+    #[test]
+    fn cpu_max_reads_a_quota_or_no_limit() {
+        assert_eq!(
+            parse_cpu_max("200000 100000\n"),
+            Some(CpuMax {
+                quota_us: Some(200_000),
+                period_us: 100_000
+            })
+        );
+        assert_eq!(
+            parse_cpu_max("max 100000"),
+            Some(CpuMax {
+                quota_us: None,
+                period_us: 100_000
+            })
+        );
+        assert_eq!(parse_cpu_max(""), None);
+        assert_eq!(parse_cpu_max("max"), None);
+        assert_eq!(parse_cpu_max("lots 100000"), None);
+        assert_eq!(parse_cpu_max("200000 soon"), None);
+    }
+
+    #[test]
+    fn pressure_reads_the_some_line_only() {
+        assert_eq!(pressure_some_total_us(PRESSURE), Some(123_456));
+        // Line order does not matter; the `full` total must never be taken.
+        let reversed = "full avg10=0.00 total=9\nsome avg10=0.00 total=7\n";
+        assert_eq!(pressure_some_total_us(reversed), Some(7));
+        assert_eq!(pressure_some_total_us("full avg10=0.00 total=9\n"), None);
+        assert_eq!(pressure_some_total_us("some avg10=0.00\n"), None);
+        assert_eq!(pressure_some_total_us(""), None);
+    }
+
+    #[test]
+    fn loadavg_reads_both_platform_formats() {
+        assert_eq!(
+            parse_loadavg("0.52 0.58 0.59 1/1234 5678\n"),
+            Some([0.52, 0.58, 0.59])
+        );
+        assert_eq!(
+            parse_loadavg("{ 1.93 2.05 2.14 }\n"),
+            Some([1.93, 2.05, 2.14])
+        );
+        assert_eq!(parse_loadavg("0.1 0.2"), None);
+        assert_eq!(parse_loadavg("0.1 busy 0.3"), None);
+        assert_eq!(parse_loadavg(""), None);
+    }
+
+    #[test]
+    fn counter_delta_needs_both_readings_and_forward_motion() {
+        assert_eq!(counter_delta(Some(100), Some(250)), Some(150));
+        assert_eq!(counter_delta(Some(100), Some(100)), Some(0));
+        assert_eq!(counter_delta(None, Some(250)), None);
+        assert_eq!(counter_delta(Some(100), None), None);
+        assert_eq!(counter_delta(Some(250), Some(100)), None);
+    }
+
+    #[test]
+    fn phase_load_pairs_each_counter_with_its_own() {
+        let start = LoadSample {
+            cpu_some_us: Some(10),
+            io_some_us: Some(1_000),
+            memory_some_us: None,
+            loadavg: Some([1.0, 2.0, 3.0]),
+        };
+        let end = LoadSample {
+            cpu_some_us: Some(15),
+            io_some_us: Some(1_300),
+            memory_some_us: Some(4),
+            loadavg: Some([4.0, 5.0, 6.0]),
+        };
+        assert_eq!(
+            PhaseLoad::between(&start, &end),
+            PhaseLoad {
+                cpu_pressure_some_us: Some(5),
+                io_pressure_some_us: Some(300),
+                memory_pressure_some_us: None,
+                loadavg_start: Some([1.0, 2.0, 3.0]),
+                loadavg_end: Some([4.0, 5.0, 6.0]),
+            }
+        );
+    }
+
+    #[test]
+    fn cpuinfo_counts_processors_and_names_the_model() {
+        assert_eq!(cpuinfo_processors(CPUINFO), Some(2));
+        assert_eq!(cpuinfo_processors("vendor_id\t: x\n"), None);
+        // A key that merely starts with the word is not a processor line.
+        assert_eq!(cpuinfo_processors("processors\t: 4\n"), None);
+        assert_eq!(
+            cpuinfo_model(CPUINFO).as_deref(),
+            Some("Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz")
+        );
+        assert_eq!(cpuinfo_model("processor\t: 0\nBogoMIPS\t: 50.00\n"), None);
+        assert_eq!(cpuinfo_model("model name\t:   \n"), None);
+    }
+
+    #[test]
+    fn meminfo_total_is_kib_times_1024() {
+        assert_eq!(meminfo_total_bytes(MEMINFO), Some(16_374_584 * 1024));
+        assert_eq!(meminfo_total_bytes("MemFree: 1 kB\n"), None);
+        assert_eq!(meminfo_total_bytes("MemTotal: many kB\n"), None);
+    }
+
+    #[test]
+    fn proc_mounts_decode_escaped_mount_points() {
+        let text = "overlay / overlay rw 0 0\n\
+                    /dev/sda1 /mnt/my\\040disk ext4 rw 0 0\n\
+                    tmpfs /odd\\134040 tmpfs rw 0 0\n\
+                    broken\n";
+        assert_eq!(
+            proc_mounts(text),
+            vec![
+                (PathBuf::from("/"), "overlay".to_string()),
+                (PathBuf::from("/mnt/my disk"), "ext4".to_string()),
+                (PathBuf::from("/odd\\040"), "tmpfs".to_string()),
+            ]
+        );
+        assert_eq!(unescape_mount_field("a\\011b\\012c"), "a\tb\nc");
+    }
+
+    #[test]
+    fn bsd_mounts_take_the_first_option_as_the_type() {
+        let text = "/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)\n\
+                    /dev/disk3s5 on /System/Volumes/Data (apfs, local, journaled, nobrowse)\n\
+                    map auto_home on /System/Volumes/Data/home (autofs)\n\
+                    garbage line\n\
+                    x on /empty ()\n";
+        assert_eq!(
+            bsd_mounts(text),
+            vec![
+                (PathBuf::from("/"), "apfs".to_string()),
+                (PathBuf::from("/System/Volumes/Data"), "apfs".to_string()),
+                (
+                    PathBuf::from("/System/Volumes/Data/home"),
+                    "autofs".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn fs_type_is_the_deepest_containing_mount() {
+        let mounts = vec![
+            (PathBuf::from("/"), "ext4".to_string()),
+            (PathBuf::from("/home"), "xfs".to_string()),
+            (PathBuf::from("/home"), "overlay".to_string()),
+            (PathBuf::from("/home/u/deeper"), "tmpfs".to_string()),
+        ];
+        assert_eq!(
+            fs_type_for(Path::new("/home/u/work"), &mounts).as_deref(),
+            Some("overlay"),
+            "the later of two mounts at one place wins"
+        );
+        assert_eq!(
+            fs_type_for(Path::new("/homer/work"), &mounts).as_deref(),
+            Some("ext4"),
+            "a mount point matches by path component, not by prefix"
+        );
+        assert_eq!(fs_type_for(Path::new("/home/u/work"), &[]), None);
+    }
+
+    #[test]
+    fn cgroup_path_is_the_v2_line() {
+        assert_eq!(
+            cgroup_v2_path("12:cpu:/legacy\n0::/system.slice/runner.service\n"),
+            Some("/system.slice/runner.service")
+        );
+        assert_eq!(cgroup_v2_path("12:cpu:/legacy\n"), None);
+    }
+
+    #[test]
+    fn cgroup_cpu_max_prefers_the_process_group_then_the_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let own = "0::/job.slice/step\n";
+
+        assert_eq!(cgroup_cpu_max(root, Some(own)), None, "nothing to read");
+
+        write(root, "cpu.max", "max 100000\n");
+        assert_eq!(
+            cgroup_cpu_max(root, Some(own)),
+            Some(CpuMax {
+                quota_us: None,
+                period_us: 100_000
+            }),
+            "the root file is the fallback"
+        );
+        assert_eq!(
+            cgroup_cpu_max(root, None).map(|max| max.period_us),
+            Some(100_000)
+        );
+
+        write(root, "job.slice/step/cpu.max", "400000 100000\n");
+        assert_eq!(
+            cgroup_cpu_max(root, Some(own)),
+            Some(CpuMax {
+                quota_us: Some(400_000),
+                period_us: 100_000
+            }),
+            "the process's own group wins"
+        );
+    }
+
+    #[test]
+    fn runner_env_skips_blank_values_and_falls_back_for_the_node() {
+        let env = |pairs: &'static [(&'static str, &'static str)]| {
+            move |name: &str| {
+                pairs
+                    .iter()
+                    .find(|(key, _)| *key == name)
+                    .map(|(_, value)| value.to_string())
+            }
+        };
+        assert_eq!(
+            RunnerEnv::from_lookup(env(&[
+                ("RUNNER_NAME", "kunobi-runners-abc"),
+                ("NODE_NAME", "node-1"),
+                ("KUBE_NODE_NAME", "node-2"),
+                ("GITHUB_RUN_ID", "123"),
+                ("GITHUB_RUN_ATTEMPT", "2"),
+            ])),
+            RunnerEnv {
+                runner_name: Some("kunobi-runners-abc".into()),
+                node_name: Some("node-1".into()),
+                github_run_id: Some("123".into()),
+                github_run_attempt: Some("2".into()),
+            }
+        );
+        assert_eq!(
+            RunnerEnv::from_lookup(env(&[("RUNNER_NAME", " "), ("KUBE_NODE_NAME", "node-2")])),
+            RunnerEnv {
+                node_name: Some("node-2".into()),
+                ..RunnerEnv::default()
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_host_values_serialize_as_null() {
+        let json = serde_json::to_value(HostInfo::default()).unwrap();
+        for key in [
+            "logical_cpus",
+            "cpu_model",
+            "memory_bytes",
+            "kernel_release",
+            "work_dir_fs",
+            "cgroup_cpu_max",
+            "runner_name",
+            "node_name",
+            "github_run_id",
+            "github_run_attempt",
+        ] {
+            assert!(json[key].is_null(), "{key} must be null, got {}", json[key]);
+        }
+    }
+
+    #[test]
+    fn assemble_prefers_the_platform_cpu_count_and_sets_the_os() {
+        let runner = RunnerEnv {
+            github_run_id: Some("9".into()),
+            ..RunnerEnv::default()
+        };
+        let counted = HostInfo {
+            logical_cpus: Some(8),
+            kernel_release: Some("6.8.0".into()),
+            ..HostInfo::default()
+        };
+        let host = HostInfo::assemble(counted, Some(2), runner.clone());
+        assert_eq!(host.logical_cpus, Some(8));
+        assert_eq!(host.os, std::env::consts::OS);
+        assert_eq!(host.kernel_release.as_deref(), Some("6.8.0"));
+        assert_eq!(host.runner, runner);
+
+        let uncounted = HostInfo::assemble(HostInfo::default(), Some(2), RunnerEnv::default());
+        assert_eq!(uncounted.logical_cpus, Some(2));
+    }
+
+    #[test]
+    fn linux_facts_come_from_a_proc_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let proc = dir.path().join("proc");
+        let cgroup = dir.path().join("cgroup");
+        let work = dir.path().join("work");
+        std::fs::create_dir_all(&work).unwrap();
+        let work_mount = canonical(&work);
+        write(&proc, "cpuinfo", CPUINFO);
+        write(&proc, "meminfo", MEMINFO);
+        write(&proc, "sys/kernel/osrelease", "6.8.0-1021-azure\n");
+        write(
+            &proc,
+            "self/mounts",
+            &format!(
+                "overlay / overlay rw 0 0\ntmpfs {} tmpfs rw 0 0\n",
+                work_mount.display()
+            ),
+        );
+        write(&proc, "self/cgroup", "0::/\n");
+        write(&cgroup, "cpu.max", "200000 100000\n");
+
+        let facts = host_facts(
+            &Roots {
+                proc: &proc,
+                cgroup: &cgroup,
+            },
+            &work,
+        );
+
+        assert_eq!(
+            facts,
+            HostInfo {
+                logical_cpus: Some(2),
+                cpu_model: Some("Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz".into()),
+                memory_bytes: Some(16_374_584 * 1024),
+                kernel_release: Some("6.8.0-1021-azure".into()),
+                work_dir_fs: Some("tmpfs".into()),
+                cgroup_cpu_max: Some(CpuMax {
+                    quota_us: Some(200_000),
+                    period_us: 100_000
+                }),
+                ..HostInfo::default()
+            }
+        );
+
+        let empty = dir.path().join("empty");
+        let unknown = host_facts(
+            &Roots {
+                proc: &empty,
+                cgroup: &empty,
+            },
+            &work,
+        );
+        assert_eq!(unknown, HostInfo::default(), "nothing readable is all null");
+    }
+
+    #[test]
+    fn linux_load_comes_from_a_proc_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let proc = dir.path();
+        write(proc, "pressure/cpu", PRESSURE);
+        write(proc, "pressure/io", "some avg10=0.00 total=77\n");
+        write(proc, "pressure/memory", "some avg10=0.00 total=5\n");
+        write(proc, "loadavg", "0.52 0.58 0.59 1/1234 5678\n");
+
+        assert_eq!(
+            load_sample(proc),
+            LoadSample {
+                cpu_some_us: Some(123_456),
+                io_some_us: Some(77),
+                memory_some_us: Some(5),
+                loadavg: Some([0.52, 0.58, 0.59]),
+            }
+        );
+        assert_eq!(load_sample(&proc.join("missing")), LoadSample::default());
+    }
+
+    /// The real collectors on the host running the tests. Values vary by
+    /// machine, so this checks only what every supported host exposes.
+    #[test]
+    fn this_host_is_described() {
+        let dir = tempfile::tempdir().unwrap();
+        let host = HostInfo::collect(dir.path());
+        assert_eq!(host.os, std::env::consts::OS);
+        let parallelism = std::thread::available_parallelism().unwrap().get() as u64;
+        assert!(host.logical_cpus.unwrap() >= parallelism, "{host:?}");
+        if cfg!(any(target_os = "linux", target_os = "macos")) {
+            assert!(host.memory_bytes.unwrap() > 0, "{host:?}");
+            assert!(host.kernel_release.is_some(), "{host:?}");
+            assert!(host.work_dir_fs.is_some(), "{host:?}");
+        }
+        if cfg!(unix) {
+            assert!(LoadSample::take().loadavg.is_some());
+        }
+    }
+}

--- a/crates/kache-e2e/src/bench_host.rs
+++ b/crates/kache-e2e/src/bench_host.rs
@@ -208,6 +208,35 @@ fn bsd_mounts(text: &str) -> Vec<(PathBuf, String)> {
         .collect()
 }
 
+/// Host facts from BSD-style sources: a `sysctl -n <name>` lookup and the
+/// `mount` table. Platform-neutral so every host compiles and tests the field
+/// mapping; only the macOS module feeds it real commands.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn bsd_host_facts(
+    sysctl: impl Fn(&str) -> Option<String>,
+    mount_table: Option<String>,
+    work_dir: &Path,
+) -> HostInfo {
+    HostInfo {
+        logical_cpus: sysctl("hw.logicalcpu").and_then(|v| v.parse().ok()),
+        cpu_model: sysctl("machdep.cpu.brand_string"),
+        memory_bytes: sysctl("hw.memsize").and_then(|v| v.parse().ok()),
+        kernel_release: sysctl("kern.osrelease"),
+        work_dir_fs: mount_table.and_then(|text| fs_type_for(work_dir, &bsd_mounts(&text))),
+        ..HostInfo::default()
+    }
+}
+
+/// A load sample from a BSD `sysctl` lookup. BSD has no pressure-stall
+/// counters, so only the load average is filled in.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn bsd_load_sample(sysctl: impl Fn(&str) -> Option<String>) -> LoadSample {
+    LoadSample {
+        loadavg: sysctl("vm.loadavg").as_deref().and_then(parse_loadavg),
+        ..LoadSample::default()
+    }
+}
+
 fn read(path: &Path) -> Option<String> {
     std::fs::read_to_string(path).ok()
 }
@@ -391,23 +420,15 @@ mod macos {
     }
 
     pub(super) fn host_facts(work_dir: &Path) -> HostInfo {
-        let work_dir = canonical(work_dir);
-        HostInfo {
-            logical_cpus: sysctl("hw.logicalcpu").and_then(|v| v.parse().ok()),
-            cpu_model: sysctl("machdep.cpu.brand_string"),
-            memory_bytes: sysctl("hw.memsize").and_then(|v| v.parse().ok()),
-            kernel_release: sysctl("kern.osrelease"),
-            work_dir_fs: stdout_of(&mut Command::new("mount"))
-                .and_then(|text| fs_type_for(&work_dir, &bsd_mounts(&text))),
-            ..HostInfo::default()
-        }
+        bsd_host_facts(
+            sysctl,
+            stdout_of(&mut Command::new("mount")),
+            &canonical(work_dir),
+        )
     }
 
     pub(super) fn load_sample() -> LoadSample {
-        LoadSample {
-            loadavg: sysctl("vm.loadavg").as_deref().and_then(parse_loadavg),
-            ..LoadSample::default()
-        }
+        bsd_load_sample(sysctl)
     }
 }
 
@@ -583,6 +604,52 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn bsd_host_facts_map_each_sysctl_and_the_mount_table() {
+        let sysctl = |name: &str| {
+            match name {
+                "hw.logicalcpu" => Some("10"),
+                "machdep.cpu.brand_string" => Some("Apple M1 Pro"),
+                "hw.memsize" => Some("17179869184"),
+                "kern.osrelease" => Some("24.6.0"),
+                _ => None,
+            }
+            .map(str::to_string)
+        };
+        let mounts = "/dev/disk3s1s1 on / (apfs, local, read-only, journaled)\n\
+                      /dev/disk5s1 on /Volumes/Work (hfs, local, journaled)\n";
+        let facts = bsd_host_facts(
+            sysctl,
+            Some(mounts.to_string()),
+            Path::new("/Volumes/Work/kache"),
+        );
+        assert_eq!(facts.logical_cpus, Some(10));
+        assert_eq!(facts.cpu_model.as_deref(), Some("Apple M1 Pro"));
+        assert_eq!(facts.memory_bytes, Some(17_179_869_184));
+        assert_eq!(facts.kernel_release.as_deref(), Some("24.6.0"));
+        assert_eq!(facts.work_dir_fs.as_deref(), Some("hfs"));
+    }
+
+    #[test]
+    fn bsd_host_facts_leave_unreadable_values_unknown() {
+        let sysctl = |name: &str| (name == "hw.logicalcpu").then(|| "ten".to_string());
+        let facts = bsd_host_facts(sysctl, None, Path::new("/Volumes/Work"));
+        assert_eq!(facts.logical_cpus, None);
+        assert_eq!(facts.cpu_model, None);
+        assert_eq!(facts.memory_bytes, None);
+        assert_eq!(facts.kernel_release, None);
+        assert_eq!(facts.work_dir_fs, None);
+    }
+
+    #[test]
+    fn bsd_load_sample_reads_the_sysctl_load_average() {
+        let sample = bsd_load_sample(|name: &str| {
+            (name == "vm.loadavg").then(|| "{ 1.93 2.05 2.14 }\n".to_string())
+        });
+        assert_eq!(sample.loadavg, Some([1.93, 2.05, 2.14]));
+        assert_eq!(bsd_load_sample(|_: &str| None).loadavg, None);
     }
 
     #[test]

--- a/crates/kache-e2e/src/bench_otlp.rs
+++ b/crates/kache-e2e/src/bench_otlp.rs
@@ -55,7 +55,9 @@ pub struct OtlpRun {
 
 pub struct OtlpPhase {
     pub name: &'static str,
-    pub wall_s: u64,
+    /// Build wall clock. Exported in seconds with the milliseconds kept: a
+    /// whole second is 7% of a 13 s warm build.
+    pub wall_ms: u64,
     pub time_saved_s: Option<u64>,
     pub hits: u64,
     pub dups: Option<u64>,
@@ -78,7 +80,9 @@ pub struct OtlpPhase {
     /// Bounded by the caller rather than here, because the bound is a
     /// cardinality decision: one series per crate name per project, and crate
     /// names are chosen by the repository being benchmarked.
-    pub top_misses: Vec<(String, u64)>,
+    ///
+    /// `(crate, seconds)`, fractional: a sub-second miss is not a zero.
+    pub top_misses: Vec<(String, f64)>,
     /// Compiles kache looked at but never asked the cache about: probes,
     /// queries, and anything it declined.
     ///
@@ -127,6 +131,11 @@ impl OtlpRun {
     pub fn tool_version_or_unknown(cache_tool: &str, version: Option<&str>) -> String {
         version.map_or_else(|| format!("{cache_tool} unknown"), str::to_string)
     }
+}
+
+/// Milliseconds as fractional seconds, the unit every `s` gauge here carries.
+pub fn seconds(ms: u64) -> f64 {
+    ms as f64 / 1000.0
 }
 
 pub fn write_otlp(work_dir: &Path, run: &OtlpRun) -> Result<()> {
@@ -183,7 +192,7 @@ fn metrics_for(run: &OtlpRun) -> Vec<Value> {
     for phase in &run.phases {
         let phase_attrs = common_attrs(run, Some(phase.name));
         duration_points.push(as_double(
-            phase.wall_s as f64,
+            seconds(phase.wall_ms),
             &run.time_unix_nano,
             &phase_attrs,
         ));
@@ -191,11 +200,7 @@ fn metrics_for(run: &OtlpRun) -> Vec<Value> {
             saved_points.push(as_double(saved as f64, &run.time_unix_nano, &phase_attrs));
         }
         if let Some(unconsulted) = phase.unconsulted {
-            unconsulted_points.push(as_double(
-                unconsulted as f64,
-                &run.time_unix_nano,
-                &phase_attrs,
-            ));
+            unconsulted_points.push(as_int(unconsulted, &run.time_unix_nano, &phase_attrs));
         }
         // Deliberately not one series per crate. Every other attribute here is
         // a bounded vocabulary -- 18 projects, 3 tools, 3 phases -- and a crate
@@ -231,15 +236,15 @@ fn metrics_for(run: &OtlpRun) -> Vec<Value> {
         // number. Which crate it is stays in the bench artifact and the trace,
         // where a name costs nothing.
         if !phase.top_misses.is_empty() {
-            let costliest = phase.top_misses.iter().map(|(_, s)| *s).max().unwrap_or(0);
-            let summed: u64 = phase.top_misses.iter().map(|(_, s)| *s).sum();
+            let costliest = phase.top_misses.iter().map(|(_, s)| *s).fold(0.0, f64::max);
+            let summed: f64 = phase.top_misses.iter().map(|(_, s)| *s).sum();
             miss_cost_points.push(as_double(
-                costliest as f64,
+                costliest,
                 &run.time_unix_nano,
                 &unit_attrs(run, phase.name, "costliest"),
             ));
             miss_cost_points.push(as_double(
-                summed as f64,
+                summed,
                 &run.time_unix_nano,
                 &unit_attrs(run, phase.name, "top"),
             ));
@@ -452,7 +457,7 @@ mod tests {
             phases: vec![
                 OtlpPhase {
                     name: "cold",
-                    wall_s: 400,
+                    wall_ms: 400_000,
                     time_saved_s: Some(0),
                     hits: 0,
                     dups: Some(0),
@@ -470,7 +475,7 @@ mod tests {
                 },
                 OtlpPhase {
                     name: "warm",
-                    wall_s: 95,
+                    wall_ms: 95_400,
                     time_saved_s: Some(280),
                     hits: 480,
                     dups: Some(10),
@@ -481,7 +486,11 @@ mod tests {
                     weighted_hit_rate_pct: Some(97.5),
                     leak_warnings: Some(2),
                     objdir_bytes: 8_100_000_000,
-                    top_misses: vec![("gecko".into(), 97), ("style".into(), 42)],
+                    top_misses: vec![
+                        ("gecko".into(), 97.25),
+                        ("style".into(), 42.0),
+                        ("tiny".into(), 0.5),
+                    ],
                     unconsulted: Some(11),
                     passthrough: vec![("not-a-compile", 12), ("unsupported", 3)],
                     passthrough_reasons: vec![(
@@ -707,7 +716,7 @@ mod tests {
         run.key_stability_pct = None;
         run.phases = vec![OtlpPhase {
             name: "pull",
-            wall_s: 120,
+            wall_ms: 120_000,
             time_saved_s: Some(40),
             hits: 100,
             dups: Some(0),
@@ -746,7 +755,7 @@ mod tests {
             disk_footprint_bytes: 300,
             phases: vec![OtlpPhase {
                 name: "warm",
-                wall_s: 10,
+                wall_ms: 10_000,
                 time_saved_s: None,
                 hits: 4,
                 dups: None,
@@ -780,6 +789,43 @@ mod tests {
             .map(|p| attr_map(p)["kache.bench.result"].clone())
             .collect();
         assert_eq!(results, vec!["hit", "miss", "total"]);
+    }
+
+    #[test]
+    fn seconds_keeps_the_milliseconds() {
+        assert_eq!(seconds(95_400), 95.4);
+        assert_eq!(seconds(999), 0.999);
+        assert_eq!(seconds(0), 0.0);
+    }
+
+    /// The build duration carries the milliseconds the engine timed. Truncated
+    /// to whole seconds, a 13 s warm build moves by up to 7%.
+    #[test]
+    fn build_duration_is_fractional_seconds() {
+        let body = serialize_metrics(&kache_run());
+        let points = metric(&body, "kache.bench.build.duration")["gauge"]["dataPoints"]
+            .as_array()
+            .unwrap();
+        let warm = points
+            .iter()
+            .find(|p| attr_map(p)["kache.bench.phase"] == "warm")
+            .unwrap();
+        assert_eq!(warm["asDouble"], 95.4);
+        assert_eq!(metric(&body, "kache.bench.build.duration")["unit"], "s");
+    }
+
+    /// An unknown weighted rate opens no point for its phase. Emitting zero
+    /// would read as "every compile missed" rather than "nothing to weigh".
+    #[test]
+    fn an_unknown_weighted_rate_is_skipped_per_phase() {
+        let mut run = kache_run();
+        run.phases[0].weighted_hit_rate_pct = None;
+        let body = serialize_metrics(&run);
+        let points = metric(&body, "kache.bench.cache.weighted_hit_rate")["gauge"]["dataPoints"]
+            .as_array()
+            .unwrap();
+        assert_eq!(points.len(), 1);
+        assert_eq!(attr_map(&points[0])["kache.bench.phase"], "warm");
     }
 
     #[test]
@@ -854,11 +900,12 @@ mod costliest_misses {
         let body = super::tests::payload_for_kache_run();
         assert_eq!(
             pick(&body, "kache.bench.miss.cost", "warm", "costliest")["asDouble"],
-            97.0
+            97.25
         );
+        // The half-second miss counts: in whole seconds it would be zero.
         assert_eq!(
             pick(&body, "kache.bench.miss.cost", "warm", "top")["asDouble"],
-            139.0
+            139.75
         );
     }
 
@@ -899,7 +946,9 @@ mod costliest_misses {
             .iter()
             .find(|p| attr(p, "kache.bench.phase") == Some("warm"))
             .unwrap();
-        assert_eq!(warm["asDouble"], 11.0);
+        // A count, like every other count in the payload.
+        assert_eq!(warm["asInt"], "11");
+        assert!(warm.get("asDouble").is_none());
     }
 }
 

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -447,8 +447,8 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     // cache already works in and is noted in the summary.
     let warm_same_tree_metrics = if config.warm_same_tree {
         reset_event_log(&event_log)?;
-        daemon::start(&kache, &cache_dir, &kache_config);
-        let wall_ms = build(
+        let daemon_started = daemon::start(&kache, &cache_dir, &kache_config);
+        let same_tree_run = build(
             &profile,
             &clone_a,
             Phase::WarmSameTree.name(),
@@ -480,9 +480,10 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         let (leaks, _) = scan_leak_warnings(
             &work_dir.join(format!("wrapper-{}.log", Phase::WarmSameTree.name())),
         );
-        Some(PhaseMetrics::from_report(
-            &report, &raw, wall_ms, events, leaks,
-        ))
+        Some(
+            PhaseMetrics::from_report(&report, &raw, same_tree_run.wall_ms, events, leaks)
+                .with_build_context(same_tree_run.load, daemon_started),
+        )
     } else {
         None
     };
@@ -496,8 +497,8 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     // what cold populated. Bring the daemon up first so the restore uses the
     // async file-hash prefetch path instead of hashing every input inline
     // (cold's daemon was stopped before its report capture).
-    daemon::start(&kache, &cache_dir, &kache_config);
-    let warm_ms = build(
+    let warm_daemon_started = daemon::start(&kache, &cache_dir, &kache_config);
+    let warm_run = build(
         &profile,
         &clone_b,
         Phase::Warm.name(),
@@ -530,20 +531,14 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     // measurement.
     let disk_measured_bytes = disk_delta(disk_free_before, available_bytes(&work_dir));
 
-    // Speedups stay on whole seconds: the nightly JSON and the kartero payload
-    // carry them, and the perf gate reads `wall_ms` directly instead.
-    let warm_s = whole_seconds(warm_ms);
-    let speedup = if warm_s > 0 {
-        cold_metrics.wall_s as f64 / warm_s as f64
-    } else {
-        0.0
-    };
+    // Taken on milliseconds; see `phase_speedup`.
+    let speedup = phase_speedup(cold_metrics.wall_ms, warm_run.wall_ms);
     // Same-tree speedup against the SAME run's cold build — the "did the warm
     // build actually beat the cold one that seeded it" number a timing gate
     // needs before it trusts a wall-clock delta. Present only when the phase ran.
     let warm_same_tree_speedup = warm_same_tree_metrics
         .as_ref()
-        .map(|m| phase_speedup(cold_metrics.wall_s, m.wall_s));
+        .map(|m| phase_speedup(cold_metrics.wall_ms, m.wall_ms));
 
     // Cross-clone cache-key stability: for the deterministic correctness
     // signal, see how many crates produced an identical key in both
@@ -551,7 +546,8 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     let stability = key_stability(&cold_raw, &warm_raw);
 
     let mut warm_metrics =
-        PhaseMetrics::from_report(&warm, &warm_raw, warm_ms, warm_events, warm_leaks);
+        PhaseMetrics::from_report(&warm, &warm_raw, warm_run.wall_ms, warm_events, warm_leaks)
+            .with_build_context(warm_run.load, warm_daemon_started);
     warm_metrics.prepare = warm_prepare;
     let verdict = Verdict::evaluate(
         &stability,
@@ -563,8 +559,9 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
     // than folded into it: `verdict` is the shape the nightly telemetry and the
     // report JSON already publish, and both phases name the same checks. Key
     // stability is cross-clone by definition, so it is passed as "nothing
-    // compared" — `Verdict::evaluate` skips that check when the denominator is
-    // zero. Both verdicts drive the exit code (see the end of this function).
+    // compared", whose percentage is unknown, and `Verdict::evaluate` skips
+    // that check. Both verdicts drive the exit code (see the end of this
+    // function).
     let warm_same_tree_verdict = warm_same_tree_metrics.as_ref().map(|metrics| {
         Verdict::evaluate(
             &KeyStability::default(),
@@ -643,10 +640,11 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
         run_id: run_id.clone(),
         artifact_dir: run_archive_dir.display().to_string(),
         cache_tool_version: cache_tool_version.clone(),
+        host: crate::bench_host::HostInfo::collect(&work_dir),
         cold: cold_metrics,
         warm_same_tree: warm_same_tree_metrics,
         warm: warm_metrics,
-        speedup: round2(speedup),
+        speedup,
         warm_same_tree_speedup,
         cache_size_mb: bytes_to_mib(disk.cache_bytes),
         cold_objdir_bytes,
@@ -679,7 +677,7 @@ pub fn run_bench(config: BenchRunConfig) -> Result<()> {
             verdict_ok: result.verdict.ok,
             speedup: Some(result.speedup),
             cache_size_bytes: crate::bench_otlp::OtlpRun::bytes_from_mib(result.cache_size_mb),
-            key_stability_pct: Some(result.key_stability.stable_pct),
+            key_stability_pct: result.key_stability.stable_pct,
             disk_measured_bytes: result.disk_measured_bytes,
             disk_footprint_bytes: result.disk_footprint_bytes,
             phases: otlp_phases(
@@ -758,14 +756,6 @@ fn footprint_warning(
     })
 }
 
-/// Speedup of a warm phase against the cold build that seeded it, rounded for
-/// the report.
-///
-/// Taken on the whole-second `wall_s`, the value the nightly JSON and its
-/// telemetry have always carried; the perf gate does not read speedups, it
-/// compares `wall_ms` directly. Zero when the phase rounded down to zero
-/// seconds: dividing by zero yields an infinity that is not a number any
-/// report should carry.
 /// Space the run consumed: free space before minus free space after, when
 /// both readings exist. `None` when either is missing, and when the tree
 /// grew back (other activity freed more than the builds wrote), which is not
@@ -782,9 +772,16 @@ fn bytes_to_mib(bytes: u64) -> f64 {
     round1(bytes as f64 / (1024.0 * 1024.0))
 }
 
-fn phase_speedup(cold_wall_s: u64, phase_wall_s: u64) -> f64 {
-    if phase_wall_s > 0 {
-        round2(cold_wall_s as f64 / phase_wall_s as f64)
+/// Speedup of a warm phase against the cold build that seeded it, rounded for
+/// the report.
+///
+/// Taken on milliseconds. The whole-second `wall_s` truncates up to a second
+/// off each side, which moves the ratio for a 13 s warm build by as much as
+/// 7%. Zero when the phase took no measurable time: dividing by zero yields an
+/// infinity that is not a number any report should carry.
+fn phase_speedup(cold_wall_ms: u64, phase_wall_ms: u64) -> f64 {
+    if phase_wall_ms > 0 {
+        round2(cold_wall_ms as f64 / phase_wall_ms as f64)
     } else {
         0.0
     }
@@ -819,18 +816,32 @@ fn fmt_wall_clock(wall_ms: u64) -> String {
 /// engine that timed whole seconds only has no milliseconds for cold, so they
 /// are backfilled from the seconds here; a serde default cannot read a sibling
 /// field. The backfilled value is a floor (a recorded 14s was anything up to
-/// 14.999s), which is what a whole-second record can give.
+/// 14.999s), which is what a whole-second record can give. The costliest
+/// misses get the same treatment for `compile_time_ms`.
 fn load_saved_phase<T: serde::de::DeserializeOwned>(mut saved: serde_json::Value) -> Result<T> {
-    if let Some(phase) = saved.as_object_mut()
-        && !phase.contains_key("wall_ms")
-        && let Some(wall_s) = phase.get("wall_s").and_then(serde_json::Value::as_u64)
+    backfill_ms(&mut saved, "wall_s", "wall_ms");
+    if let Some(misses) = saved
+        .get_mut("top_misses")
+        .and_then(serde_json::Value::as_array_mut)
     {
-        phase.insert(
-            "wall_ms".to_string(),
-            serde_json::Value::from(wall_s.saturating_mul(1000)),
-        );
+        for miss in misses {
+            backfill_ms(miss, "compile_time_s", "compile_time_ms");
+        }
     }
     Ok(serde_json::from_value(saved)?)
+}
+
+/// Give `record` its `ms_key` from `seconds_key` when it has only the seconds.
+fn backfill_ms(record: &mut serde_json::Value, seconds_key: &str, ms_key: &str) {
+    if let Some(fields) = record.as_object_mut()
+        && !fields.contains_key(ms_key)
+        && let Some(seconds) = fields.get(seconds_key).and_then(serde_json::Value::as_u64)
+    {
+        fields.insert(
+            ms_key.to_string(),
+            serde_json::Value::from(seconds.saturating_mul(1000)),
+        );
+    }
 }
 
 /// Did any configured assertion say this run is not a valid measurement?
@@ -1036,7 +1047,7 @@ fn otlp_phase(
 ) -> crate::bench_otlp::OtlpPhase {
     crate::bench_otlp::OtlpPhase {
         name,
-        wall_s: metrics.wall_s,
+        wall_ms: metrics.wall_ms,
         time_saved_s: Some(metrics.time_saved_s),
         hits: metrics.hits,
         dups: Some(metrics.dups),
@@ -1044,7 +1055,7 @@ fn otlp_phase(
         errors: Some(metrics.errors),
         total: Some(metrics.total_crates),
         hit_rate_pct: metrics.hit_rate_pct,
-        weighted_hit_rate_pct: Some(metrics.weighted_hit_rate_pct),
+        weighted_hit_rate_pct: metrics.weighted_hit_rate_pct,
         leak_warnings: Some(metrics.leak_warnings),
         objdir_bytes,
         // The two categories kache's own RefuseReason draws: a probe that was
@@ -1065,7 +1076,12 @@ fn otlp_phase(
             .top_misses
             .iter()
             .take(TOP_MISSES_EMITTED)
-            .map(|m| (m.crate_name.clone(), m.compile_time_s))
+            .map(|m| {
+                (
+                    m.crate_name.clone(),
+                    crate::bench_otlp::seconds(m.compile_time_ms),
+                )
+            })
             .collect(),
         // What kache looked at and never asked the cache about: probes,
         // queries, and compiles it declined. The hit rate divides by what was
@@ -1087,7 +1103,7 @@ fn otlp_sccache_phase(
 ) -> crate::bench_otlp::OtlpPhase {
     crate::bench_otlp::OtlpPhase {
         name,
-        wall_s: metrics.wall_s,
+        wall_ms: metrics.wall_ms,
         time_saved_s: None,
         hits: metrics.cache_hits,
         dups: None,
@@ -1404,7 +1420,7 @@ fn build(
     cache_backend: CacheBackend,
     trace_keys: bool,
     sh: &Path,
-) -> Result<u64> {
+) -> Result<BuildRun> {
     let log_path = work_dir.join(format!("build-{phase}.log"));
     let wrapper_log_path = work_dir.join(format!("wrapper-{phase}.log"));
     let mut log =
@@ -1429,6 +1445,7 @@ fn build(
         std::fs::remove_dir_all(&objdir)
             .with_context(|| format!("wiping objdir {}", objdir.display()))?;
     }
+    let load_before = crate::bench_host::LoadSample::take();
     let started = Instant::now();
     let mut cmd = Command::new(sh);
     cmd.arg("-c")
@@ -1512,13 +1529,22 @@ fn build(
         }
     }
     let status = child.wait().context("waiting for build command")?;
+    let wall_ms = elapsed_ms(started.elapsed());
+    let load =
+        crate::bench_host::PhaseLoad::between(&load_before, &crate::bench_host::LoadSample::take());
     if !status.success() {
         bail!(
             "[{phase}] build failed ({status}) — see {}",
             log_path.display()
         );
     }
-    Ok(elapsed_ms(started.elapsed()))
+    Ok(BuildRun { wall_ms, load })
+}
+
+/// One timed build: its wall clock and how busy the host was meanwhile.
+struct BuildRun {
+    wall_ms: u64,
+    load: crate::bench_host::PhaseLoad,
 }
 
 /// Capture kache's report for the phase that just finished: write the
@@ -1591,8 +1617,8 @@ fn run_cold_phase(
         std::fs::remove_dir_all(cache_dir).context("clearing cache dir")?;
     }
     std::fs::create_dir_all(cache_dir)?;
-    daemon::start(kache, cache_dir, kache_config);
-    let cold_ms = build(
+    let daemon_started = daemon::start(kache, cache_dir, kache_config);
+    let cold_run = build(
         profile,
         clone_a,
         Phase::Cold.name(),
@@ -1626,7 +1652,8 @@ fn run_cold_phase(
     source::snapshot_dir(cache_dir, &work_dir.join("cache-after-cold"))?;
 
     Ok((
-        PhaseMetrics::from_report(&cold, &cold_raw, cold_ms, cold_events, cold_leaks),
+        PhaseMetrics::from_report(&cold, &cold_raw, cold_run.wall_ms, cold_events, cold_leaks)
+            .with_build_context(cold_run.load, daemon_started),
         cold_raw,
     ))
 }
@@ -1742,8 +1769,8 @@ fn run_pull_bench(
     // pull: same cache, same path, new source. `build()` wipes the objdir at
     // the start of every phase (unconditionally), so this is a from-scratch
     // rebuild at ref_next and kache is asked about every TU.
-    daemon::start(kache, cache_dir, kache_config);
-    let pull_ms = build(
+    let daemon_started = daemon::start(kache, cache_dir, kache_config);
+    let pull_run = build(
         profile,
         clone_a,
         Phase::Pull.name(),
@@ -1770,17 +1797,14 @@ fn run_pull_bench(
     let (pull_leaks, _pull_leak_samples) =
         scan_leak_warnings(&work_dir.join(format!("wrapper-{}.log", Phase::Pull.name())));
     let mut pull_metrics =
-        PhaseMetrics::from_report(&pull, &pull_raw, pull_ms, pull_events, pull_leaks);
+        PhaseMetrics::from_report(&pull, &pull_raw, pull_run.wall_ms, pull_events, pull_leaks)
+            .with_build_context(pull_run.load, daemon_started);
     pull_metrics.prepare = pull_prepare;
 
-    // No cross-clone comparison: an empty KeyStability (compared == 0) makes
-    // Verdict skip the key-stability check; the pull scenarios also set no
+    // No cross-clone comparison: an empty KeyStability has no percentage, so
+    // Verdict skips the key-stability check; the pull scenarios also set no
     // min_key_stability_pct.
-    let no_stability = KeyStability {
-        stable_pct: 0.0,
-        stable: 0,
-        compared: 0,
-    };
+    let no_stability = KeyStability::default();
     let verdict = Verdict::evaluate(
         &no_stability,
         &pull_metrics,
@@ -1806,6 +1830,7 @@ fn run_pull_bench(
         run_id: run_id.to_string(),
         artifact_dir: run_archive_dir.display().to_string(),
         cache_tool_version: cache_tool_version.map(String::from),
+        host: crate::bench_host::HostInfo::collect(work_dir),
         cold: cold_metrics,
         pull: pull_metrics,
         cache_size_mb: bytes_to_mib(disk.cache_bytes),
@@ -1901,7 +1926,8 @@ fn run_sccache_bench(
         CacheBackend::Sccache,
         false,
         sh,
-    )?;
+    )?
+    .wall_ms;
     let warm_metrics = capture_sccache_report(
         sccache,
         cache_dir,
@@ -1915,13 +1941,8 @@ fn run_sccache_bench(
     ensure_sccache_base_dirs(&warm_metrics, clone_b, Phase::Warm.name())?;
 
     let disk_measured_bytes = disk_delta(disk_free_before, available_bytes(work_dir));
-    // Whole seconds, as for the kache path: the speedup is a nightly value.
-    let warm_s = whole_seconds(warm_ms);
-    let speedup = if warm_s > 0 {
-        cold_metrics.wall_s as f64 / warm_s as f64
-    } else {
-        0.0
-    };
+    // Milliseconds, as for the kache path; see `phase_speedup`.
+    let speedup = phase_speedup(cold_metrics.wall_ms, warm_ms);
     let measure_warnings = sccache_measure_warnings(
         &warm_metrics,
         speedup,
@@ -1953,7 +1974,7 @@ fn run_sccache_bench(
             .or_else(|| cold_metrics.cache_location.clone()),
         cold: cold_metrics,
         warm: warm_metrics,
-        speedup: round2(speedup),
+        speedup,
         cache_size_mb: round1(cache_dir_bytes as f64 / 1024.0 / 1024.0),
         cache_dir_bytes,
         cold_objdir_bytes,
@@ -2035,7 +2056,8 @@ fn run_sccache_cold_phase(
         CacheBackend::Sccache,
         false,
         sh,
-    )?;
+    )?
+    .wall_ms;
     let cold_metrics = capture_sccache_report(
         sccache,
         cache_dir,
@@ -2241,6 +2263,17 @@ fn read_event_log(path: &Path) -> EventLogStats {
     for item in stream {
         let Ok(ev) = item else { continue };
         stats.total += 1;
+        // Annotations the wrapper adds to an event whose outcome alone does
+        // not say it went wrong. They feed the phase's invalid reasons.
+        if has_text(&ev["store_error"]) {
+            stats.store_errors += 1;
+        }
+        if has_text(&ev["lookup_rejection"]) {
+            stats.lookup_rejections += 1;
+        }
+        if ev["fallback"].as_bool().unwrap_or(false) {
+            stats.fallbacks += 1;
+        }
         // Each event has a `size` field (bytes) for the cache entry's
         // artifact payload. Sum it across hit / miss buckets so the
         // summary can express coverage by bytes, not just by count.
@@ -2298,6 +2331,12 @@ fn read_event_log(path: &Path) -> EventLogStats {
     stats.top_passthrough = all.iter().take(8).cloned().collect();
     stats.passthrough_reasons = all;
     stats
+}
+
+/// A non-empty string field. The wrapper omits these when they are empty, and
+/// an older log may carry them as `""`.
+fn has_text(field: &serde_json::Value) -> bool {
+    field.as_str().is_some_and(|text| !text.is_empty())
 }
 
 /// Scan kache's wrapper-mode log file for `PathNormalizer` leak detector
@@ -2707,13 +2746,8 @@ fn key_stability(cold_raw: &serde_json::Value, warm_raw: &serde_json::Value) -> 
             }
         }
     }
-    let pct = if compared == 0 {
-        0.0
-    } else {
-        stable as f64 / compared as f64 * 100.0
-    };
     KeyStability {
-        stable_pct: round1(pct),
+        stable_pct: (compared > 0).then(|| round1(stable as f64 / compared as f64 * 100.0)),
         stable,
         compared,
     }
@@ -2952,7 +2986,7 @@ fn otlp_mbx_phase(
 ) -> crate::bench_otlp::OtlpPhase {
     crate::bench_otlp::OtlpPhase {
         name,
-        wall_s: metrics.wall_s,
+        wall_ms: metrics.wall_ms,
         time_saved_s: Some(metrics.time_saved_s),
         hits: metrics.hits,
         dups: None,
@@ -3035,7 +3069,8 @@ fn run_mbx_cold_phase(
         CacheBackend::Mbx,
         false,
         sh,
-    )?;
+    )?
+    .wall_ms;
     let cold_metrics = capture_mbx_report(work_dir, Phase::Cold.name(), cold_ms)?;
     source::snapshot_dir(cache_dir, &work_dir.join("cache-after-cold"))?;
     Ok(cold_metrics)
@@ -3108,11 +3143,12 @@ fn run_mbx_bench(
         CacheBackend::Mbx,
         false,
         sh,
-    )?;
+    )?
+    .wall_ms;
     let warm_metrics = capture_mbx_report(work_dir, Phase::Warm.name(), warm_ms)?;
 
     let disk_measured_bytes = disk_delta(disk_free_before, available_bytes(work_dir));
-    let speedup = phase_speedup(cold_metrics.wall_s, warm_metrics.wall_s);
+    let speedup = phase_speedup(cold_metrics.wall_ms, warm_metrics.wall_ms);
     let measure_warnings = external_measure_warnings(
         warm_metrics.wall_s,
         warm_metrics.hit_rate_pct,
@@ -3566,8 +3602,12 @@ fn write_summary(
     writeln!(out, "  speedup    : {:.2}x", r.speedup)?;
     writeln!(
         out,
-        "  warm cache : {} hits / {} dups / {} misses   {:.1}% hit rate ({:.1}% weighted)",
-        r.warm.hits, r.warm.dups, r.warm.misses, r.warm.hit_rate_pct, r.warm.weighted_hit_rate_pct
+        "  warm cache : {} hits / {} dups / {} misses   {:.1}% hit rate ({} weighted)",
+        r.warm.hits,
+        r.warm.dups,
+        r.warm.misses,
+        r.warm.hit_rate_pct,
+        fmt_pct(r.warm.weighted_hit_rate_pct)
     )?;
     let el = &r.warm.event_log;
     let cacheable = el.hit_bytes.saturating_add(el.miss_bytes);
@@ -3699,8 +3739,10 @@ fn write_summary(
     // ── diagnostics: did the run actually exercise kache? ──
     writeln!(
         out,
-        "  key stability : {:.1}%   ({} of {} crates kept an identical key across clones)",
-        r.key_stability.stable_pct, r.key_stability.stable, r.key_stability.compared
+        "  key stability : {}   ({} of {} crates kept an identical key across clones)",
+        fmt_pct(r.key_stability.stable_pct),
+        r.key_stability.stable,
+        r.key_stability.compared
     )?;
     if let Some(top) = &r.key_diff_top {
         writeln!(
@@ -3715,6 +3757,13 @@ fn write_summary(
         el.total, el.cached, el.passed_through, el.errored
     )?;
     if let Some(line) = prediction_summary_line(&r.warm.phases, r.cold.phases.dep_info_runs) {
+        writeln!(out, "{line}")?;
+    }
+    for line in invalid_reason_lines(&[
+        (Phase::Cold.name(), Some(&r.cold)),
+        (Phase::WarmSameTree.name(), r.warm_same_tree.as_ref()),
+        (Phase::Warm.name(), Some(&r.warm)),
+    ]) {
         writeln!(out, "{line}")?;
     }
     if !el.top_passthrough.is_empty() {
@@ -3762,10 +3811,13 @@ fn write_summary(
             out,
             "  costliest warm misses (recompiled despite the cache):"
         )?;
-        // Whole seconds: kache's report carries a miss's compile time as such.
-        let fmt = |s: u64| format!("{}m {:02}s", s / 60, s % 60);
         for m in r.warm.top_misses.iter().take(5) {
-            writeln!(out, "    {:>8}  {}", fmt(m.compile_time_s), m.crate_name)?;
+            writeln!(
+                out,
+                "    {:>9}  {}",
+                fmt_wall_clock(m.compile_time_ms),
+                m.crate_name
+            )?;
         }
     }
 
@@ -3815,6 +3867,28 @@ fn write_summary(
     Ok(())
 }
 
+/// A percentage for a summary line, or `n/a` when there is none to show.
+fn fmt_pct(pct: Option<f64>) -> String {
+    pct.map_or_else(|| "n/a".to_string(), |pct| format!("{pct:.1}%"))
+}
+
+/// One summary line per phase that recorded an invalid reason. They are
+/// reported, not blocking: the verdict does not read them yet.
+fn invalid_reason_lines(phases: &[(&str, Option<&PhaseMetrics>)]) -> Vec<String> {
+    phases
+        .iter()
+        .filter_map(|&(name, metrics)| {
+            let reasons = &metrics?.invalid_reasons;
+            (!reasons.is_empty()).then(|| {
+                format!(
+                    "  invalid ({name}) : {}   (reported, not blocking)",
+                    reasons.join(", ")
+                )
+            })
+        })
+        .collect()
+}
+
 fn print_pull_summary(r: &PullBenchResult, archive_dir: &Path) {
     eprintln!("\n===== {} (daily pull) =====", r.project);
     eprintln!("platform    : {}", r.platform);
@@ -3825,13 +3899,19 @@ fn print_pull_summary(r: &PullBenchResult, archive_dir: &Path) {
         r.cold.total_crates, r.cold.hit_rate_pct, r.cold.wall_s
     );
     eprintln!(
-        "pull        : {} crates, {:.1}% hit ({:.1}% weighted), {}s wall, {} passthrough",
+        "pull        : {} crates, {:.1}% hit ({} weighted), {}s wall, {} passthrough",
         r.pull.total_crates,
         r.pull.hit_rate_pct,
-        r.pull.weighted_hit_rate_pct,
+        fmt_pct(r.pull.weighted_hit_rate_pct),
         r.pull.wall_s,
         r.pull.event_log.passed_through,
     );
+    for line in invalid_reason_lines(&[
+        (Phase::Cold.name(), Some(&r.cold)),
+        (Phase::Pull.name(), Some(&r.pull)),
+    ]) {
+        eprintln!("{line}");
+    }
     eprintln!("cache size  : {:.1} MiB", r.cache_size_mb);
     eprintln!(
         "footprint   : {}   cache + objdir on disk, each inode once",
@@ -3868,6 +3948,8 @@ struct BenchResult {
     /// Output of `<cache-tool> --version`.
     #[serde(skip_serializing_if = "Option::is_none")]
     cache_tool_version: Option<String>,
+    /// The machine that ran the bench. Kept out of the OTLP attributes.
+    host: crate::bench_host::HostInfo,
     cold: PhaseMetrics,
     /// The same-worktree warm rebuild, present only under `--warm-same-tree`.
     /// Absent from every nightly scenario's JSON, so downstream readers must
@@ -3938,6 +4020,7 @@ struct PullBenchResult {
     artifact_dir: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     cache_tool_version: Option<String>,
+    host: crate::bench_host::HostInfo,
     cold: PhaseMetrics,
     pull: PhaseMetrics,
     cache_size_mb: f64,
@@ -3978,8 +4061,9 @@ struct PhaseMetrics {
     errors: u64,
     /// Hit rate by count.
     hit_rate_pct: f64,
-    /// Hit rate weighted by compile cost — tracks real time saved.
-    weighted_hit_rate_pct: f64,
+    /// Hit rate weighted by compile cost, which tracks real time saved.
+    /// `None` when the report had no compile times to weigh by.
+    weighted_hit_rate_pct: Option<f64>,
     /// Compile time avoided by cache hits, in seconds.
     time_saved_s: u64,
     /// Costliest cache misses this phase (kache's `top_misses`).
@@ -4000,6 +4084,14 @@ struct PhaseMetrics {
     /// clone before this phase's build. Its time is not part of `wall_ms`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     prepare: Option<PrepareMetrics>,
+    /// Why this phase's numbers may not mean what they appear to, such as
+    /// `store_errors:3` or `daemon_not_running`. Reported in the summary; the
+    /// verdict does not read them yet. See [`invalid_reasons`].
+    #[serde(default)]
+    invalid_reasons: Vec<String>,
+    /// How contended the host was across the timed build.
+    #[serde(default)]
+    load: crate::bench_host::PhaseLoad,
 }
 
 /// One run of a scenario's `prepare` command.
@@ -4110,9 +4202,11 @@ impl PhaseMetrics {
             .map(|arr| {
                 arr.iter()
                     .filter_map(|m| {
+                        let compile_time_ms = m["compile_time_ms"].as_u64().unwrap_or(0);
                         Some(MissEntry {
                             crate_name: m["crate_name"].as_str()?.to_string(),
-                            compile_time_s: m["compile_time_ms"].as_u64().unwrap_or(0) / 1000,
+                            compile_time_s: whole_seconds(compile_time_ms),
+                            compile_time_ms,
                         })
                     })
                     .collect()
@@ -4127,7 +4221,7 @@ impl PhaseMetrics {
             misses: s.misses,
             errors: sum["errors"].as_u64().unwrap_or(0),
             hit_rate_pct: round1(s.hit_rate_pct),
-            weighted_hit_rate_pct: round1(sum["weighted_hit_rate_pct"].as_f64().unwrap_or(0.0)),
+            weighted_hit_rate_pct: sum["weighted_hit_rate_pct"].as_f64().map(round1),
             time_saved_s: sum["time_saved_ms"].as_u64().unwrap_or(0) / 1000,
             top_misses,
             event_log,
@@ -4135,15 +4229,58 @@ impl PhaseMetrics {
             storage: StorageInfo::from_raw(raw),
             phases: PhaseTimes::from_raw(raw),
             prepare: None,
+            invalid_reasons: Vec::new(),
+            load: crate::bench_host::PhaseLoad::default(),
         }
     }
+
+    /// Attach what the engine saw around the timed build: how loaded the host
+    /// was, and whether the daemon the phase started came up.
+    fn with_build_context(
+        mut self,
+        load: crate::bench_host::PhaseLoad,
+        daemon_started: bool,
+    ) -> Self {
+        self.invalid_reasons = invalid_reasons(&self.event_log, daemon_started);
+        self.load = load;
+        self
+    }
+}
+
+/// Why a phase's numbers may not mean what they appear to.
+///
+/// `store_errors:N` are misses whose store failed, so they will miss again on
+/// every build. `lookup_rejections:N` found an entry and could not use it.
+/// `fallback_passthroughs:N` went to a configured fallback wrapper, whose
+/// cache is not the one being measured. `daemon_not_running` means the
+/// engine's `kache daemon start` for the phase did not succeed, so the build
+/// ran without the prefetch and hashing paths a daemon provides.
+fn invalid_reasons(event_log: &EventLogStats, daemon_started: bool) -> Vec<String> {
+    let mut reasons: Vec<String> = [
+        ("store_errors", event_log.store_errors),
+        ("lookup_rejections", event_log.lookup_rejections),
+        ("fallback_passthroughs", event_log.fallbacks),
+    ]
+    .into_iter()
+    .filter(|&(_, count)| count > 0)
+    .map(|(name, count)| format!("{name}:{count}"))
+    .collect();
+    if !daemon_started {
+        reasons.push("daemon_not_running".to_string());
+    }
+    reasons
 }
 
 /// One expensive cache miss, surfaced from kache's `top_misses`.
 #[derive(Debug, Serialize, Deserialize)]
 struct MissEntry {
     crate_name: String,
+    /// Whole seconds, truncated from `compile_time_ms`. Kept for readers of
+    /// older results.
     compile_time_s: u64,
+    /// The compile time kache's report records for the miss.
+    #[serde(default)]
+    compile_time_ms: u64,
 }
 
 /// kache's storage-savings breakdown for one phase — surfaced from the
@@ -4237,6 +4374,29 @@ struct EventLogStats {
     /// together they form the cacheable-bytes denominator that lets
     /// the summary report a bytes-version of the weighted hit rate.
     miss_bytes: u64,
+    /// Events whose store failed after the compiler ran (`store_error`).
+    #[serde(default)]
+    store_errors: u64,
+    /// Events whose existing entry was rejected before the compiler ran
+    /// (`lookup_rejection`).
+    #[serde(default)]
+    lookup_rejections: u64,
+    /// Events kache handed to a configured fallback wrapper (`fallback`).
+    #[serde(default)]
+    fallbacks: u64,
+}
+
+/// Events that were real compiles: everything but probes and queries.
+fn compile_count(event_log: &EventLogStats) -> u64 {
+    event_log.total.saturating_sub(event_log.probed)
+}
+
+/// Share of real compiles kache declined to cache, in percent. A probe is not
+/// a compile, so it leaves the denominator as well as the numerator. `None`
+/// when nothing but probes ran.
+fn passthrough_pct(event_log: &EventLogStats) -> Option<f64> {
+    let compiles = compile_count(event_log);
+    (compiles > 0).then(|| event_log.passed_through as f64 / compiles as f64 * 100.0)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -4259,7 +4419,8 @@ struct ReasonCount {
 #[derive(Debug, Serialize, Default)]
 struct KeyStability {
     /// Percentage of compared crates that produced an identical key set.
-    stable_pct: f64,
+    /// `None` when no crate was cached in both clones: there is no ratio.
+    stable_pct: Option<f64>,
     /// Crates whose key was identical across the two clones.
     stable: u64,
     /// Crates kache cached in both clones (the comparison denominator).
@@ -4330,8 +4491,8 @@ impl Verdict {
     /// Applied to one phase's metrics at a time: the cross-clone `warm` phase
     /// against `[checks.assert.warm]`, and — when `--warm-same-tree` ran — the
     /// same-tree phase against `[checks.assert.warm-same-tree]`. Pass a default
-    /// [`KeyStability`] for the latter; a zero denominator skips the
-    /// cross-clone-only stability check.
+    /// [`KeyStability`] for the latter; with no percentage to compare, the
+    /// cross-clone-only stability check is skipped.
     ///
     /// `max_errors` is intentionally NOT a degradation trigger. kache's
     /// `EventResult::Error` counts only wrapped-compiler non-zero exits — never
@@ -4360,25 +4521,24 @@ impl Verdict {
         };
 
         if let Some(min_key_stability_pct) = spec.min_key_stability_pct
-            && stability.compared > 0
+            && let Some(stable_pct) = stability.stable_pct
         {
-            if stability.stable_pct < min_key_stability_pct {
+            if stable_pct < min_key_stability_pct {
                 checks.push(AssertionCheck {
                     name: "min_key_stability_pct",
                     expected: format!(">= {min_key_stability_pct:.1}"),
-                    actual: format!("{:.1}", stability.stable_pct),
+                    actual: format!("{stable_pct:.1}"),
                     passed: false,
                 });
                 issues.push(format!(
-                    "cross-clone key stability {:.1}% — the cache key is not \
-                     path-portable; the warm phase did not validly measure caching",
-                    stability.stable_pct
+                    "cross-clone key stability {stable_pct:.1}% — the cache key is not \
+                     path-portable; the warm phase did not validly measure caching"
                 ));
             } else {
                 checks.push(AssertionCheck {
                     name: "min_key_stability_pct",
                     expected: format!(">= {min_key_stability_pct:.1}"),
-                    actual: format!("{:.1}", stability.stable_pct),
+                    actual: format!("{stable_pct:.1}"),
                     passed: true,
                 });
             }
@@ -4426,9 +4586,8 @@ impl Verdict {
 
         let el = &warm.event_log;
         if let Some(max_passthrough_pct) = spec.max_passthrough_pct
-            && el.total > 0
+            && let Some(pt_pct) = passthrough_pct(el)
         {
-            let pt_pct = el.passed_through as f64 / el.total as f64 * 100.0;
             if pt_pct > max_passthrough_pct {
                 checks.push(AssertionCheck {
                     name: "max_passthrough_pct",
@@ -4439,7 +4598,9 @@ impl Verdict {
                 issues.push(format!(
                     "{:.0}% of compiles ({} of {}) passed through uncached — \
                      kache barely exercised",
-                    pt_pct, el.passed_through, el.total
+                    pt_pct,
+                    el.passed_through,
+                    compile_count(el)
                 ));
             } else {
                 checks.push(AssertionCheck {
@@ -4770,7 +4931,7 @@ mod tests {
     #[test]
     fn wrapped_compile_failures_do_not_degrade_the_run() {
         let stability = KeyStability {
-            stable_pct: 96.9,
+            stable_pct: Some(96.9),
             stable: 560,
             compared: 578,
         };
@@ -5139,7 +5300,7 @@ mod tests {
             misses: 4,
             errors,
             hit_rate_pct: 60.0,
-            weighted_hit_rate_pct: 60.0,
+            weighted_hit_rate_pct: Some(60.0),
             time_saved_s: 0,
             top_misses: Vec::new(),
             event_log: EventLogStats {
@@ -5152,6 +5313,9 @@ mod tests {
                 passthrough_reasons: Vec::new(),
                 hit_bytes: 0,
                 miss_bytes: 0,
+                store_errors: 0,
+                lookup_rejections: 0,
+                fallbacks: 0,
             },
             leak_warnings: 0,
             storage: StorageInfo {
@@ -5170,13 +5334,43 @@ mod tests {
             },
             phases: PhaseTimes::default(),
             prepare: None,
+            invalid_reasons: Vec::new(),
+            load: crate::bench_host::PhaseLoad::default(),
         }
+    }
+
+    /// Stability exactly at the floor passes, just under it fails, and an
+    /// unknown percentage is not checked at all.
+    #[test]
+    fn key_stability_check_passes_at_the_floor_and_skips_the_unknown() {
+        let spec = ScenarioAssertSpec {
+            min_key_stability_pct: Some(80.0),
+            ..Default::default()
+        };
+        let warm = PhaseMetrics::default();
+        let stability = |stable_pct| KeyStability {
+            stable_pct,
+            stable: 0,
+            compared: 0,
+        };
+
+        let at_floor = Verdict::evaluate(&stability(Some(80.0)), &warm, Some(&spec));
+        assert!(at_floor.ok, "{:?}", at_floor.issues);
+        assert_eq!(at_floor.checks[0].actual, "80.0");
+
+        let under = Verdict::evaluate(&stability(Some(79.9)), &warm, Some(&spec));
+        assert!(!under.ok);
+        assert!(under.issues[0].contains("79.9%"), "{:?}", under.issues);
+
+        let unknown = Verdict::evaluate(&stability(None), &warm, Some(&spec));
+        assert!(unknown.ok);
+        assert!(unknown.checks.is_empty());
     }
 
     #[test]
     fn verdict_has_no_hidden_assertions_without_configured_checks() {
         let stability = KeyStability {
-            stable_pct: 0.0,
+            stable_pct: Some(0.0),
             stable: 0,
             compared: 4,
         };
@@ -5192,7 +5386,7 @@ mod tests {
     #[test]
     fn verdict_uses_only_configured_assert_thresholds() {
         let stability = KeyStability {
-            stable_pct: 0.0,
+            stable_pct: Some(0.0),
             stable: 0,
             compared: 4,
         };
@@ -5218,7 +5412,7 @@ mod tests {
     #[test]
     fn verdict_uses_configured_assert_thresholds() {
         let stability = KeyStability {
-            stable_pct: 75.0,
+            stable_pct: Some(75.0),
             stable: 3,
             compared: 4,
         };
@@ -5504,18 +5698,21 @@ mod tests {
         assert!(!measures_disk_footprint(true, true));
     }
 
-    /// The warm-vs-cold speedup, including the zero-second boundary the
-    /// engine's whole-second timing can actually produce on a small subject.
+    /// The warm-vs-cold speedup, taken on milliseconds, including the zero
+    /// boundary.
     #[test]
     fn phase_speedup_divides_cold_by_the_phase_and_guards_zero() {
         // A three-times-faster warm build.
-        assert_eq!(phase_speedup(300, 100), 3.0);
+        assert_eq!(phase_speedup(300_000, 100_000), 3.0);
         // Not a ratio a multiply or a remainder would produce.
-        assert_eq!(phase_speedup(90, 60), 1.5);
+        assert_eq!(phase_speedup(90_000, 60_000), 1.5);
         // Slower than cold is reported as-is; it is the validity gates' job to
         // reject that, not this helper's to hide it.
-        assert_eq!(phase_speedup(60, 120), 0.5);
-        // Exactly one second is the smallest measurable phase and must still
+        assert_eq!(phase_speedup(60_000, 120_000), 0.5);
+        // The milliseconds matter: 100 s over 13.9 s is 7.19x. Truncated to
+        // whole seconds the same builds would read 100 / 13 = 7.69x.
+        assert_eq!(phase_speedup(100_000, 13_900), 7.19);
+        // One millisecond is the smallest measurable phase and must still
         // divide rather than fall into the zero guard.
         assert_eq!(phase_speedup(42, 1), 42.0);
         // Zero: dividing would yield infinity, which no report should carry.
@@ -5604,6 +5801,7 @@ mod tests {
             run_id: "20260901T000000Z-kache-1".to_string(),
             artifact_dir: "tmp/perf-gate/head/runs/x".to_string(),
             cache_tool_version: Some("kache 0.16.1".to_string()),
+            host: crate::bench_host::HostInfo::default(),
             cold: phase(300_000, 0),
             warm_same_tree: Some(phase(100_400, 412)),
             warm: phase(120_900, 400),
@@ -5757,14 +5955,15 @@ mod tests {
         noisy.warm.top_misses = vec![MissEntry {
             crate_name: "libgit2-sys".to_string(),
             compile_time_s: 125,
+            compile_time_ms: 125_400,
         }];
         noisy.measure_warnings = vec!["warm hit rate 12.0% below threshold 50.0%".to_string()];
         let text = summary_text(&noisy);
         assert!(text.contains("costliest warm misses"), "{text}");
-        // A miss's compile time is whole seconds from kache's report, shown as
-        // minutes and zero-padded seconds. 125 rather than 71 because
+        // A miss's compile time is shown from its milliseconds, as minutes and
+        // zero-padded seconds with tenths. 125 s rather than 71 s because
         // 71 - 60 == 71 % 60, which would let a wrong operator print the same.
-        assert!(text.contains("2m 05s  libgit2-sys"), "{text}");
+        assert!(text.contains("2m 05.4s  libgit2-sys"), "{text}");
         assert!(text.contains("MEASURE WARNINGS"), "{text}");
         assert!(text.contains("warm hit rate 12.0%"), "{text}");
     }
@@ -5785,6 +5984,7 @@ mod tests {
             run_id: "run-1".into(),
             artifact_dir: "/tmp/run-1".into(),
             cache_tool_version: Some("kache 0.8.0".into()),
+            host: crate::bench_host::HostInfo::default(),
             cold: PhaseMetrics::default(),
             pull: PhaseMetrics::default(),
             cache_size_mb: 1.0,
@@ -6026,8 +6226,8 @@ mod tests {
         );
         let phase = otlp_mbx_phase("warm", &m, 77);
         assert_eq!(
-            (phase.name, phase.wall_s, phase.objdir_bytes),
-            ("warm", 4, 77)
+            (phase.name, phase.wall_ms, phase.objdir_bytes),
+            ("warm", 4_000, 77)
         );
         assert_eq!((phase.hits, phase.misses, phase.total), (8, 2, Some(10)));
         assert_eq!(phase.time_saved_s, Some(3));
@@ -6246,7 +6446,7 @@ build = "sleep 0.2"
         std::fs::create_dir_all(&work_dir).unwrap();
         let sh = posix_sh().unwrap();
 
-        let wall_ms = build(
+        let run = build(
             &profile,
             &clone,
             "cold",
@@ -6259,6 +6459,7 @@ build = "sleep 0.2"
             &sh,
         )
         .unwrap();
+        let wall_ms = run.wall_ms;
 
         assert!(
             (200..60_000).contains(&wall_ms),
@@ -6267,6 +6468,13 @@ build = "sleep 0.2"
         assert!(!stale.exists(), "the objdir is wiped before the build");
         assert!(work_dir.join("build-cold.log").exists());
         assert!(work_dir.join("wrapper-cold.log").exists());
+        // Both supported unix hosts expose load averages; the build samples
+        // them on each side of the timer.
+        assert!(
+            run.load.loadavg_start.is_some() && run.load.loadavg_end.is_some(),
+            "{:?}",
+            run.load
+        );
     }
 
     fn prepare_fixture(dir: &Path, prepare: Option<&str>) -> BenchProfile {
@@ -6603,34 +6811,399 @@ PREP_MARKER = "{{kache}}"
     /// clone's objdir.
     #[test]
     fn otlp_phases_carry_the_same_tree_warm_only_when_it_ran() {
-        let cold = PhaseMetrics {
-            wall_s: 100,
+        let phase = |wall_ms| PhaseMetrics {
+            wall_ms,
             ..Default::default()
         };
-        let same_tree = PhaseMetrics {
-            wall_s: 20,
-            ..Default::default()
-        };
-        let warm = PhaseMetrics {
-            wall_s: 30,
-            ..Default::default()
-        };
+        let (cold, same_tree, warm) = (phase(100_400), phase(20_000), phase(30_900));
 
         let without = otlp_phases(&cold, None, &warm, 7, 9);
         assert_eq!(
             without
                 .iter()
-                .map(|phase| (phase.name, phase.wall_s, phase.objdir_bytes))
+                .map(|phase| (phase.name, phase.wall_ms, phase.objdir_bytes))
                 .collect::<Vec<_>>(),
-            vec![("cold", 100, 7), ("warm", 30, 9)]
+            vec![("cold", 100_400, 7), ("warm", 30_900, 9)]
         );
 
         let with = otlp_phases(&cold, Some(&same_tree), &warm, 7, 9);
         assert_eq!(
             with.iter()
-                .map(|phase| (phase.name, phase.wall_s, phase.objdir_bytes))
+                .map(|phase| (phase.name, phase.wall_ms, phase.objdir_bytes))
                 .collect::<Vec<_>>(),
-            vec![("cold", 100, 7), ("warm-same-tree", 20, 7), ("warm", 30, 9)]
+            vec![
+                ("cold", 100_400, 7),
+                ("warm-same-tree", 20_000, 7),
+                ("warm", 30_900, 9)
+            ]
         );
+    }
+
+    /// An unknown weighted rate stays unknown on its way to the payload, and a
+    /// sub-second miss keeps its milliseconds instead of truncating to zero.
+    #[test]
+    fn from_report_keeps_unknown_rates_and_sub_second_misses() {
+        let raw = serde_json::json!({
+            "schema_version": 1,
+            "summary": {
+                "hit_rate_pct": 50.0,
+                "total_crates": 2,
+                "local_hits": 1,
+                "prefetch_hits": 0,
+                "remote_hits": 0,
+                "dups": 0,
+                "misses": 1,
+                "errors": 0,
+                "weighted_hit_rate_pct": null,
+                "time_saved_ms": 0
+            },
+            "top_misses": [
+                { "crate_name": "tiny", "compile_time_ms": 400 },
+                { "crate_name": "big", "compile_time_ms": 97_250 }
+            ]
+        });
+        let report: report::KacheReport =
+            serde_json::from_value(raw.clone()).expect("a minimal report parses");
+
+        let metrics = PhaseMetrics::from_report(&report, &raw, 1, EventLogStats::default(), 0);
+
+        assert_eq!(metrics.weighted_hit_rate_pct, None);
+        assert_eq!(
+            metrics
+                .top_misses
+                .iter()
+                .map(|m| (m.crate_name.as_str(), m.compile_time_s, m.compile_time_ms))
+                .collect::<Vec<_>>(),
+            vec![("tiny", 0, 400), ("big", 97, 97_250)]
+        );
+        let otlp = otlp_phase("warm", &metrics, 0);
+        assert_eq!(otlp.weighted_hit_rate_pct, None);
+        assert_eq!(
+            otlp.top_misses,
+            vec![("tiny".to_string(), 0.4), ("big".to_string(), 97.25)]
+        );
+    }
+
+    #[test]
+    fn a_known_weighted_rate_is_rounded_and_carried() {
+        let raw = serde_json::json!({
+            "schema_version": 1,
+            "summary": {
+                "hit_rate_pct": 50.0, "total_crates": 2, "local_hits": 1,
+                "prefetch_hits": 0, "remote_hits": 0, "misses": 1,
+                "weighted_hit_rate_pct": 97.46
+            }
+        });
+        let report: report::KacheReport = serde_json::from_value(raw.clone()).unwrap();
+        let metrics = PhaseMetrics::from_report(&report, &raw, 1, EventLogStats::default(), 0);
+        assert_eq!(metrics.weighted_hit_rate_pct, Some(97.5));
+        assert_eq!(
+            otlp_phase("warm", &metrics, 0).weighted_hit_rate_pct,
+            Some(97.5)
+        );
+    }
+
+    /// `--retry` against an older result: a miss recorded in whole seconds is
+    /// backfilled as a floor, one that has milliseconds keeps them, and fields
+    /// added since then default instead of failing the load.
+    #[test]
+    fn a_saved_miss_without_milliseconds_is_backfilled_from_its_seconds() {
+        let mut saved = serde_json::to_value(PhaseMetrics {
+            top_misses: vec![
+                MissEntry {
+                    crate_name: "old".into(),
+                    compile_time_s: 97,
+                    compile_time_ms: 97_250,
+                },
+                MissEntry {
+                    crate_name: "new".into(),
+                    compile_time_s: 0,
+                    compile_time_ms: 400,
+                },
+            ],
+            ..Default::default()
+        })
+        .unwrap();
+        saved["top_misses"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("compile_time_ms");
+        for key in ["invalid_reasons", "load"] {
+            saved.as_object_mut().unwrap().remove(key);
+        }
+        for key in ["store_errors", "lookup_rejections", "fallbacks"] {
+            saved["event_log"].as_object_mut().unwrap().remove(key);
+        }
+
+        let loaded: PhaseMetrics = load_saved_phase(saved).unwrap();
+
+        assert_eq!(loaded.top_misses[0].compile_time_ms, 97_000);
+        assert_eq!(loaded.top_misses[1].compile_time_ms, 400);
+        assert!(loaded.invalid_reasons.is_empty());
+        assert_eq!(loaded.event_log.store_errors, 0);
+    }
+
+    /// With nothing compared there is no ratio. Reporting 0% would read as
+    /// "every key leaked", the opposite of "nothing to compare".
+    #[test]
+    fn key_stability_is_unknown_until_a_crate_was_cached_in_both_clones() {
+        let events = |pairs: &[(&str, &str)]| {
+            serde_json::json!({
+                "all_events": pairs
+                    .iter()
+                    .map(|(name, key)| serde_json::json!({ "crate_name": name, "cache_key": key }))
+                    .collect::<Vec<_>>()
+            })
+        };
+
+        let disjoint = key_stability(&events(&[("a", "k1")]), &events(&[("b", "k2")]));
+        assert_eq!((disjoint.stable_pct, disjoint.compared), (None, 0));
+
+        let one = key_stability(&events(&[("a", "k1")]), &events(&[("a", "k1")]));
+        assert_eq!(
+            (one.stable_pct, one.stable, one.compared),
+            (Some(100.0), 1, 1)
+        );
+
+        let half = key_stability(
+            &events(&[("a", "k1"), ("b", "k2"), ("c", "k3")]),
+            &events(&[("a", "k1"), ("b", "moved"), ("d", "k4")]),
+        );
+        assert_eq!(
+            (half.stable_pct, half.stable, half.compared),
+            (Some(50.0), 1, 2)
+        );
+    }
+
+    /// The wrapper marks a failed store, a rejected lookup and a fallback on
+    /// the event itself; each is counted once per event that carries it, and
+    /// an empty annotation is not one.
+    #[test]
+    fn the_event_log_counts_the_annotations_that_invalidate_a_phase() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("events.jsonl");
+        std::fs::write(
+            &log,
+            concat!(
+                r#"{"result":"miss","store_error":"disk full"}"#,
+                "\n",
+                r#"{"result":"miss","store_error":""}"#,
+                "\n",
+                r#"{"result":"local_hit"}"#,
+                "\n",
+                r#"{"result":"miss","lookup_rejection":"artifact set incomplete"}"#,
+                "\n",
+                r#"{"result":"passthrough","passthrough_reason":"unsupported|x","fallback":true}"#,
+                "\n",
+                r#"{"result":"passthrough","passthrough_reason":"unsupported|y","fallback":false}"#,
+                "\n",
+                r#"{"result":"miss","store_error":"read-only","lookup_rejection":"stale"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let stats = read_event_log(&log);
+
+        assert_eq!(stats.total, 7);
+        assert_eq!(
+            (stats.store_errors, stats.lookup_rejections, stats.fallbacks),
+            (2, 2, 1)
+        );
+    }
+
+    #[test]
+    fn invalid_reasons_name_each_nonzero_count_and_a_missing_daemon() {
+        let clean = EventLogStats::default();
+        assert!(invalid_reasons(&clean, true).is_empty());
+        assert_eq!(invalid_reasons(&clean, false), vec!["daemon_not_running"]);
+
+        let noisy = EventLogStats {
+            store_errors: 3,
+            lookup_rejections: 1,
+            fallbacks: 2,
+            ..Default::default()
+        };
+        assert_eq!(
+            invalid_reasons(&noisy, true),
+            vec![
+                "store_errors:3",
+                "lookup_rejections:1",
+                "fallback_passthroughs:2"
+            ]
+        );
+
+        let one = EventLogStats {
+            fallbacks: 1,
+            ..Default::default()
+        };
+        assert_eq!(
+            invalid_reasons(&one, false),
+            vec!["fallback_passthroughs:1", "daemon_not_running"]
+        );
+    }
+
+    #[test]
+    fn build_context_sets_the_load_and_the_invalid_reasons() {
+        let load = crate::bench_host::PhaseLoad {
+            cpu_pressure_some_us: Some(42),
+            ..Default::default()
+        };
+        let metrics = PhaseMetrics {
+            event_log: EventLogStats {
+                store_errors: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .with_build_context(load.clone(), false);
+
+        assert_eq!(metrics.load, load);
+        assert_eq!(
+            metrics.invalid_reasons,
+            vec!["store_errors:1", "daemon_not_running"]
+        );
+    }
+
+    /// Probes are not compiles. Counting them in the denominator made a run
+    /// that declined a quarter of its real compiles look like it declined a
+    /// tenth, and pass a ceiling it should have failed.
+    #[test]
+    fn the_passthrough_rate_divides_by_real_compiles_only() {
+        let el = EventLogStats {
+            total: 100,
+            probed: 60,
+            passed_through: 10,
+            ..Default::default()
+        };
+        assert_eq!(compile_count(&el), 40);
+        assert_eq!(passthrough_pct(&el), Some(25.0));
+
+        let probes_only = EventLogStats {
+            total: 5,
+            probed: 5,
+            ..Default::default()
+        };
+        assert_eq!(passthrough_pct(&probes_only), None);
+
+        let single = EventLogStats {
+            total: 1,
+            passed_through: 1,
+            ..Default::default()
+        };
+        assert_eq!(passthrough_pct(&single), Some(100.0));
+
+        let warm = PhaseMetrics {
+            event_log: el,
+            ..Default::default()
+        };
+        let spec = ScenarioAssertSpec {
+            max_passthrough_pct: Some(20.0),
+            ..Default::default()
+        };
+        let verdict = Verdict::evaluate(&KeyStability::default(), &warm, Some(&spec));
+        assert!(!verdict.ok);
+        assert_eq!(verdict.checks[0].actual, "25.0");
+        assert!(
+            verdict.issues[0].contains("(10 of 40)"),
+            "{:?}",
+            verdict.issues
+        );
+    }
+
+    #[test]
+    fn fmt_pct_shows_one_decimal_or_not_available() {
+        assert_eq!(fmt_pct(Some(96.94)), "96.9%");
+        assert_eq!(fmt_pct(None), "n/a");
+    }
+
+    #[test]
+    fn invalid_reason_lines_skip_absent_and_clean_phases() {
+        let flagged = PhaseMetrics {
+            invalid_reasons: vec![
+                "fallback_passthroughs:4".into(),
+                "daemon_not_running".into(),
+            ],
+            ..Default::default()
+        };
+        let clean = PhaseMetrics::default();
+        assert_eq!(
+            invalid_reason_lines(&[
+                ("cold", Some(&clean)),
+                ("warm-same-tree", None),
+                ("pull", Some(&flagged)),
+            ]),
+            vec![
+                "  invalid (pull) : fallback_passthroughs:4, daemon_not_running   (reported, not blocking)"
+            ]
+        );
+    }
+
+    #[test]
+    fn summary_marks_unknown_rates_and_lists_invalid_reasons() {
+        let mut result = bench_result_fixture();
+        let text = summary_text(&result);
+        assert!(text.contains("hit rate (n/a weighted)"), "{text}");
+        assert!(
+            text.contains("key stability : n/a   (0 of 0 crates"),
+            "{text}"
+        );
+        assert!(!text.contains("invalid ("), "{text}");
+
+        result.warm.weighted_hit_rate_pct = Some(97.46);
+        result.key_stability = KeyStability {
+            stable_pct: Some(96.9),
+            stable: 560,
+            compared: 578,
+        };
+        result.warm.invalid_reasons = vec!["store_errors:2".into()];
+        let text = summary_text(&result);
+        assert!(text.contains("hit rate (97.5% weighted)"), "{text}");
+        assert!(
+            text.contains("key stability : 96.9%   (560 of 578 crates"),
+            "{text}"
+        );
+        assert!(
+            text.contains("invalid (warm) : store_errors:2   (reported, not blocking)"),
+            "{text}"
+        );
+        assert!(!text.contains("invalid (cold)"), "{text}");
+    }
+
+    /// Run the stand-in until it actually executed; see
+    /// `write_otlp_until_spawned` for why a spawn can transiently fail.
+    fn daemon_start_until_spawned(kache: &Path, dir: &Path, marker: &Path) -> bool {
+        let mut started = false;
+        for _ in 0..50 {
+            started = daemon::start(kache, dir, &dir.join("kache.toml"));
+            if marker.is_file() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        started
+    }
+
+    /// `daemon_not_running` rests on this result, so both answers matter.
+    #[test]
+    fn daemon_start_reports_whether_the_start_succeeded() {
+        let up = tempfile::tempdir().unwrap();
+        let marker = up.path().join("ran");
+        let kache = fake_kache_that_records(up.path(), &marker, 0);
+        assert!(daemon_start_until_spawned(&kache, up.path(), &marker));
+        let args = std::fs::read_to_string(&marker).unwrap();
+        assert!(args.contains("daemon") && args.contains("start"), "{args}");
+
+        let down = tempfile::tempdir().unwrap();
+        let marker = down.path().join("ran");
+        let kache = fake_kache_that_records(down.path(), &marker, 1);
+        assert!(!daemon_start_until_spawned(&kache, down.path(), &marker));
+        assert!(marker.is_file(), "the failing stand-in must have run");
+
+        assert!(!daemon::start(
+            &down.path().join("no-such-kache"),
+            down.path(),
+            &down.path().join("kache.toml")
+        ));
     }
 }

--- a/crates/kache-e2e/src/bench_runner.rs
+++ b/crates/kache-e2e/src/bench_runner.rs
@@ -5436,6 +5436,34 @@ mod tests {
         assert_eq!(failed, vec!["min_key_stability_pct", "max_passthrough_pct"]);
     }
 
+    /// The passthrough gate reads "at most `max_passthrough_pct`", so a rate
+    /// exactly at the limit passes. 2 of 8 is 25% with no rounding, unlike the
+    /// shared fixture's 3 of 10, whose `f64` rate lands just above 30.
+    #[test]
+    fn verdict_passthrough_exactly_at_the_limit_passes() {
+        let stability = KeyStability {
+            stable_pct: Some(100.0),
+            stable: 4,
+            compared: 4,
+        };
+        let mut warm = phase_metrics_for_verdict(0);
+        warm.event_log.total = 8;
+        warm.event_log.passed_through = 2;
+        let spec = ScenarioAssertSpec {
+            max_passthrough_pct: Some(25.0),
+            ..Default::default()
+        };
+
+        let verdict = Verdict::evaluate(&stability, &warm, Some(&spec));
+
+        let check = verdict
+            .checks
+            .iter()
+            .find(|check| check.name == "max_passthrough_pct")
+            .expect("passthrough check is configured");
+        assert!(check.passed, "25% at a 25% limit, got {}", check.actual);
+    }
+
     /// The PR perf gate's core safety property: a phase that recompiled the
     /// world must be rejected, not reported as a fast build. Zero hits and zero
     /// restored bytes are the two ways "this measured nothing" shows up.

--- a/crates/kache-e2e/src/daemon.rs
+++ b/crates/kache-e2e/src/daemon.rs
@@ -21,8 +21,9 @@ pub fn stop(kache_path: &Path, cache_dir: &Path) {
 /// Best-effort: start a kache daemon bound to `cache_dir`.
 ///
 /// The wrapper falls back to no-daemon mode if this fails, so callers should
-/// warn but not fail the scenario.
-pub fn start(kache_path: &Path, cache_dir: &Path, kache_config: &Path) {
+/// warn but not fail the scenario. Returns whether `kache daemon start`
+/// succeeded, so a bench can record that its phase ran without one.
+pub fn start(kache_path: &Path, cache_dir: &Path, kache_config: &Path) -> bool {
     match Command::new(kache_path)
         .args(["daemon", "start"])
         .env("KACHE_CACHE_DIR", cache_dir)
@@ -31,8 +32,17 @@ pub fn start(kache_path: &Path, cache_dir: &Path, kache_config: &Path) {
         .stderr(Stdio::null())
         .status()
     {
-        Ok(s) if s.success() => eprintln!("[bench] daemon started"),
-        Ok(s) => eprintln!("[bench] WARN: daemon start exited {s} (running w/o daemon)"),
-        Err(e) => eprintln!("[bench] WARN: daemon start failed ({e}) (running w/o daemon)"),
+        Ok(s) if s.success() => {
+            eprintln!("[bench] daemon started");
+            true
+        }
+        Ok(s) => {
+            eprintln!("[bench] WARN: daemon start exited {s} (running w/o daemon)");
+            false
+        }
+        Err(e) => {
+            eprintln!("[bench] WARN: daemon start failed ({e}) (running w/o daemon)");
+            false
+        }
     }
 }

--- a/crates/kache-e2e/src/lib.rs
+++ b/crates/kache-e2e/src/lib.rs
@@ -12,6 +12,7 @@
 //! owns the lifecycle; the TOML owns what the fixture is and what it expects.
 
 pub mod assertions;
+mod bench_host;
 mod bench_otlp;
 pub mod bench_profile;
 pub mod bench_runner;

--- a/docs/benchmarks.mdx
+++ b/docs/benchmarks.mdx
@@ -36,7 +36,7 @@ It measures one mid-size subject — `bench-pr-cargo`, the `rust-lang/cargo` tre
 
 The pull request head and its merge base are both measured, back to back on the same runner, so the report is a delta rather than a comparison against a stored figure from another machine. A warm build more than 5% slower than the merge base fails the gate. Cold and cross-worktree deltas are reported without failing while their noise floor is still being established. The numbers land as a comment on the pull request.
 
-The engine times every phase in milliseconds (`wall_ms` in the result JSON) and the gate takes its delta on that field. The subject's warm build runs about 15 seconds on the gate's runner, where a whole-second tick would already be 7% of the build, more than the threshold. The whole-second `wall_s` next to it is derived from `wall_ms` and keeps its role in the nightly reports and their telemetry.
+The engine times every phase in milliseconds (`wall_ms` in the result JSON) and the gate takes its delta on that field. The subject's warm build runs about 15 seconds on the gate's runner, where a whole-second tick would already be 7% of the build, more than the threshold. The whole-second `wall_s` next to it is derived from `wall_ms` and stays in the result JSON for older readers. Speedups and the nightly telemetry are computed from `wall_ms`.
 
 The gate refuses to compare a warm build shorter than 5 seconds. Below that, 5% of the build is within the fixed cost of spawning the shell, cargo, and its dependency resolution on a shared runner, so a delta would measure the runner rather than kache. The refusal is reported as `INVALID MEASUREMENT`, distinct from a failing delta.
 

--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -97,7 +97,9 @@ fields are not evaluated. The fields are `min_key_stability_pct`,
 `max_passthrough_pct`, `max_errors`, `min_hits`, and `min_restored_bytes`. The
 last two are validity floors: a phase that recompiled everything reports no hits
 and restores no bytes, and without them its wall-clock reads as a flatteringly
-fast build. `checks.measure` warnings are advisory only.
+fast build. `max_passthrough_pct` divides by real compiles: probes and
+queries such as `rustc -vV` are left out of both sides of the ratio.
+`checks.measure` warnings are advisory only.
 
 `checks.measure.<phase>` can also list `known_passthrough`: the reasons the
 scenario still passes real compiles through for, as prefixes of the label the


### PR DESCRIPTION
Nightly numbers were misleading in small ways that add up. A 13 s warm build's speedup moved by up to 7% because it was computed from whole seconds. Sub-second misses showed as zero cost. A missing weighted hit rate or an empty key-stability comparison was exported as 0%, which reads as total failure. And nothing recorded which machine produced a number: the same hk cold build took 89 s on one pod and 110 to 115 s on others in one week.

## What changes

- Speedups, the OTLP build duration and miss cost come from `wall_ms` and `compile_time_ms`. `wall_s` and `compile_time_s` stay in the JSON for older readers.
- `weighted_hit_rate_pct` and `key_stability.stable_pct` are `null` when there is nothing to measure, and their OTLP points are skipped. `unconsulted` is exported as an integer.
- Each phase lists `invalid_reasons`: store errors, lookup rejections, fallback passthroughs, and a failed daemon start. The summary prints them. They do not fail the run yet.
- The passthrough rate divides by real compiles; probes such as `rustc -vV` are left out of both sides.
- The result JSON gains a `host` object (CPU count and model, memory, OS and kernel, work-dir filesystem, cgroup `cpu.max`, runner and node name, run id and attempt) and per-phase pressure-stall deltas and loadavg. None of this becomes an OTLP attribute; the ban on platform and `cicd.*` attributes is unchanged.

## Notes

- JSON readers of the bench results must accept `null` for the two rates. The perf gate script does not read them, and the telemetry collector reads OTLP metric names, not these JSON fields.
- `.cargo/mutants.toml` excludes the macOS and other-platform host readers, following the existing `disk_usage::other` exclusion: the Linux mutation lane never compiles them.
- This touches `bench_runner.rs` alongside #1019; whichever merges second gets a rebase.

## A real run

The perf gate builds its instrument from the default branch, so it does not exercise this change. A dispatch of the hk arm on this branch did: https://github.com/kunobi-ninja/kache/actions/runs/34680815701 (success).

- `host`: AMD EPYC 7343, 16 logical CPUs, 64 GB, kernel 6.1, ext4 work dir, runner name recorded. `cgroup_cpu_max` is 600000/100000, so the pod may use 6 of the 16 CPUs it can see. `node_name` is null: the ARC pod does not expose `NODE_NAME` yet.
- Per-phase `load` is populated (CPU and IO pressure-stall deltas, loadavg at start and end). `invalid_reasons` is empty on all three phases of this clean run.
- Speedups keep their precision: 4.71 cross-clone and 6.4 same-tree.
- Key stability 99.8% (827 of 829 compared).

## Validation

`mise exec -- just check` passes. `cargo test -p kache-e2e --lib`: 221 passed. clippy with `-D warnings` passes for the host, Linux and Windows targets. The Linux procfs, cgroup and pressure readers are tested against fixture trees; their first real-host run is this PR's CI.

