### PR TITLE
fix(native): admit DWARF-bearing Mach-O members to the structural archive hash

### DIFF
--- a/fuzz/fuzz_targets/native_archive.rs
+++ b/fuzz/fuzz_targets/native_archive.rs
@@ -15,14 +15,15 @@ fuzz_target!(|data: &[u8]| {
         return;
     }
 
-    let first = native_archive::portable_static_archive_hash(data);
-    let second = native_archive::portable_static_archive_hash(data);
+    let first = native_archive::portable_static_archive_identity(data);
+    let second = native_archive::portable_static_archive_identity(data);
     assert_eq!(
         first, second,
         "native archive hashing must be deterministic"
     );
 
-    if let Some(hash) = first {
+    if let Some(identity) = first {
+        let hash = identity.digest;
         let digest = hash
             .strip_prefix("gnu-ar-v2:")
             .or_else(|| hash.strip_prefix("bsd-ar-v2:"))

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -1611,7 +1611,9 @@ pub fn compute_cache_key(
     // text by the generic codegen fold, so that identity refuses them rather
     // than let a rebuilt file under the same name restore a stale executable.
     // Libraries inherited only through rlib metadata are not exposed in this
-    // argv and are outside that direct-input identity.
+    // argv and are outside that direct-input identity. An invocation that
+    // links a `static=` archive itself keeps a DWARF-bearing Mach-O archive
+    // path-bound; see [`StaticLibUse`].
     // Linker order/section-order/map files and opaque response files require
     // side-input/output handling beyond the archive key. Fail closed instead
     // of caching an invocation whose auxiliary behavior cannot be reproduced.
@@ -1625,7 +1627,7 @@ pub fn compute_cache_key(
         tracing::trace!("[key:{}] link_lib:{}", crate_name, lib);
 
         if let Some((path, content_hash)) =
-            resolve_native_static_lib(lib, &native_search_dirs, file_hasher)?
+            resolve_native_static_lib(lib, &native_search_dirs, file_hasher, static_lib_use(args))?
         {
             hasher.update(b"link_lib_content:");
             hasher.update(content_hash.as_bytes());
@@ -2078,6 +2080,7 @@ fn resolve_native_static_lib(
     spec: &str,
     search_dirs: &[PathBuf],
     file_hasher: &FileHasher<'_>,
+    usage: StaticLibUse,
 ) -> Result<Option<(PathBuf, String)>> {
     let Some(name) = clean_static_lib_name(spec) else {
         return Ok(None);
@@ -2109,8 +2112,43 @@ fn resolve_native_static_lib(
     };
     // Every parse/read failure is uncacheable, never name-only: this archive is
     // bundled into the output, so omitting an existing file would be a false hit.
-    let hash = file_hasher.hash_static_lib(&path)?;
+    let hash = file_hasher.hash_static_lib_for(&path, usage)?;
     Ok(Some((path, hash)))
+}
+
+/// How an invocation uses a `static=` archive. It decides whether an archive
+/// with DWARF-bearing Mach-O members may share its structural digest across
+/// checkouts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StaticLibUse {
+    /// The invocation does not link the archive: rustc bundles it into its
+    /// rlib (or staticlib) output. A later cached debug link names rlib
+    /// members `<rlib>(member)` under `--out-dir`, which the `-oso_prefix`
+    /// kache injects there makes relative.
+    Bundled,
+    /// The invocation links the archive itself (bin, test, dylib, cdylib,
+    /// proc-macro). ld64 writes the archive's absolute path into the `N_OSO`
+    /// entry of every DWARF-bearing member.
+    Linked,
+}
+
+impl StaticLibUse {
+    /// Memo namespace. The two uses can hash one file differently, so they
+    /// never share a row.
+    fn memo_namespace(self) -> &'static str {
+        match self {
+            Self::Bundled => "static-ar-v6-bundled",
+            Self::Linked => "static-ar-v6",
+        }
+    }
+}
+
+fn static_lib_use(args: &RustcArgs) -> StaticLibUse {
+    if args.is_executable_output() {
+        StaticLibUse::Linked
+    } else {
+        StaticLibUse::Bundled
+    }
 }
 
 /// Auxiliary linker files are not yet captured/restored as cache artifacts.
@@ -2671,11 +2709,13 @@ fn is_ident_continue(byte: u8) -> bool {
 // the `path_normalizer` module docs for the full story.
 
 /// Compute a linked `static=` archive's cache-key digest. A proven GNU/BSD
-/// archive gets the structural member-identity hash; every other non-thin
-/// archive gets a digest of both its bytes and lexical absolute path because
-/// linkers can expose `archive-path(member)`. Thin archives are uncacheable:
-/// rustc reads external members whose bytes are absent from the container.
-fn compute_static_lib_hash(path: &Path) -> Result<String> {
+/// archive gets the structural member-identity hash, unless the invocation
+/// links an archive with DWARF-bearing Mach-O members itself. Every other
+/// non-thin archive gets a digest of both its bytes and lexical absolute path
+/// because linkers can expose `archive-path(member)`. Thin archives are
+/// uncacheable: rustc reads external members whose bytes are absent from the
+/// container.
+fn compute_static_lib_hash(path: &Path, usage: StaticLibUse) -> Result<String> {
     let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
     if bytes.starts_with(b"!<thin>\n") {
         anyhow::bail!(
@@ -2683,8 +2723,10 @@ fn compute_static_lib_hash(path: &Path) -> Result<String> {
             path.display()
         );
     }
-    if let Some(portable) = crate::native_archive::portable_static_archive_hash(&bytes) {
-        return Ok(portable);
+    if let Some(identity) = crate::native_archive::portable_static_archive_identity(&bytes)
+        && !(usage == StaticLibUse::Linked && identity.macho_dwarf_members)
+    {
+        return Ok(identity.digest);
     }
 
     let absolute = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
@@ -3771,14 +3813,21 @@ impl<'db> FileHasher<'db> {
     /// applied either way, and every scheme is domain-tagged.
     /// Scoped to `static=` (this method) on purpose — `.rlib`s are also `ar`
     /// archives but are hashed whole via [`Self::hash`].
+    /// This is the strict [`StaticLibUse::Linked`] reading; rlib bundling
+    /// goes through [`Self::hash_static_lib_for`].
     pub fn hash_static_lib(&self, path: &Path) -> Result<String> {
+        self.hash_static_lib_for(path, StaticLibUse::Linked)
+    }
+
+    /// [`Self::hash_static_lib`] for a known [`StaticLibUse`].
+    pub fn hash_static_lib_for(&self, path: &Path, usage: StaticLibUse) -> Result<String> {
         // Without a persistent cache (daemonless / tests), compute directly —
         // still honoring the too-new guard.
         let Some(cache) = &self.cache else {
             if let Ok(fingerprint) = FileFingerprint::from_path(path) {
                 self.note_too_new(&fingerprint);
             }
-            return compute_static_lib_hash(path);
+            return compute_static_lib_hash(path, usage);
         };
         let fingerprint = match FileFingerprint::from_path(path) {
             Ok(fp) => fp,
@@ -3787,7 +3836,7 @@ impl<'db> FileHasher<'db> {
                     "static-lib hash metadata lookup failed for {}: {e}",
                     path.display()
                 );
-                return compute_static_lib_hash(path);
+                return compute_static_lib_hash(path, usage);
             }
         };
         self.note_too_new(&fingerprint);
@@ -3796,7 +3845,7 @@ impl<'db> FileHasher<'db> {
         // archive read is cheap and not worth a row.
         let size = fingerprint.size;
         if size < MIN_PERSISTED_HASH_BYTES {
-            let hash = compute_static_lib_hash(path)?;
+            let hash = compute_static_lib_hash(path, usage)?;
             self.record_miss(size);
             return Ok(hash);
         }
@@ -3811,9 +3860,10 @@ impl<'db> FileHasher<'db> {
         // predates the GCC Mach-O LTO gate, and v5 predates admitting
         // DWARF-bearing Mach-O members (a v5 row would keep serving the
         // path-bound digest of an unchanged archive). None may be served
-        // after the final archive hardening.
+        // after the final archive hardening. Bundled and linked uses get
+        // separate rows because a DWARF archive hashes differently for each.
         let key = FileFingerprint {
-            path: format!("static-ar-v6\0{}", fingerprint.path),
+            path: format!("{}\0{}", usage.memo_namespace(), fingerprint.path),
             size: fingerprint.size,
             mtime_ns: fingerprint.mtime_ns,
             ctime_ns: fingerprint.ctime_ns,
@@ -3827,7 +3877,7 @@ impl<'db> FileHasher<'db> {
             Ok(None) => {}
             Err(e) => tracing::debug!("static-lib hash cache lookup failed: {e}"),
         }
-        let hash = compute_static_lib_hash(path)?;
+        let hash = compute_static_lib_hash(path, usage)?;
         self.record_miss(size);
         if let Err(e) = cache.put(&key, &hash) {
             tracing::debug!("static-lib hash cache update failed: {e}");
@@ -7264,7 +7314,7 @@ mod tests {
         let dirs = vec![dir.path().to_path_buf()];
 
         // A `static=` lib present in a search dir resolves and content-hashes.
-        let (path, h1) = resolve_native_static_lib("static=foo", &dirs, &fh)
+        let (path, h1) = resolve_native_static_lib("static=foo", &dirs, &fh, StaticLibUse::Bundled)
             .unwrap()
             .expect("static lib in a search dir must resolve");
         assert_eq!(path, lib);
@@ -7272,14 +7322,15 @@ mod tests {
         // `cc` emits the same OUT_DIR once per compiled archive. Repeating an
         // identical `-L native=...` must still resolve the one physical file.
         let duplicate_dirs = vec![dir.path().to_path_buf(), dir.path().to_path_buf()];
-        let (duplicate_path, _) = resolve_native_static_lib("static=foo", &duplicate_dirs, &fh)
-            .unwrap()
-            .expect("duplicate search dirs must not make one archive ambiguous");
+        let (duplicate_path, _) =
+            resolve_native_static_lib("static=foo", &duplicate_dirs, &fh, StaticLibUse::Bundled)
+                .unwrap()
+                .expect("duplicate search dirs must not make one archive ambiguous");
         assert_eq!(duplicate_path, lib);
 
         // Changed bytes → different hash (this is the false hit we close).
         std::fs::write(&lib, b"v2 different bytes").unwrap();
-        let (_, h2) = resolve_native_static_lib("static=foo", &dirs, &fh)
+        let (_, h2) = resolve_native_static_lib("static=foo", &dirs, &fh, StaticLibUse::Bundled)
             .unwrap()
             .unwrap();
         assert_ne!(h1, h2, "content change must change the resolved hash");
@@ -7287,22 +7338,22 @@ mod tests {
         // `dylib=`/bare are referenced not bundled → never content-hashed; a
         // missing lib and a modifier/rename spec also do not resolve.
         assert!(
-            resolve_native_static_lib("dylib=foo", &dirs, &fh)
+            resolve_native_static_lib("dylib=foo", &dirs, &fh, StaticLibUse::Bundled)
                 .unwrap()
                 .is_none()
         );
         assert!(
-            resolve_native_static_lib("foo", &dirs, &fh)
+            resolve_native_static_lib("foo", &dirs, &fh, StaticLibUse::Bundled)
                 .unwrap()
                 .is_none()
         );
         assert!(
-            resolve_native_static_lib("static:+verbatim=foo", &dirs, &fh)
+            resolve_native_static_lib("static:+verbatim=foo", &dirs, &fh, StaticLibUse::Bundled)
                 .unwrap()
                 .is_none()
         );
         assert!(
-            resolve_native_static_lib("static=absent", &dirs, &fh)
+            resolve_native_static_lib("static=absent", &dirs, &fh, StaticLibUse::Bundled)
                 .unwrap()
                 .is_none()
         );
@@ -7316,6 +7367,7 @@ mod tests {
                 "static=foo",
                 &[dir.path().to_path_buf(), other_dir.path().to_path_buf()],
                 &fh,
+                StaticLibUse::Bundled,
             )
             .is_err(),
             "distinct search-dir matches must fail closed"
@@ -7325,7 +7377,7 @@ mod tests {
         // ambiguous.
         std::fs::write(dir.path().join("foo.lib"), b"msvc import lib").unwrap();
         assert!(
-            resolve_native_static_lib("static=foo", &dirs, &fh).is_err(),
+            resolve_native_static_lib("static=foo", &dirs, &fh, StaticLibUse::Bundled).is_err(),
             "ambiguous .a/.lib match must fail closed"
         );
     }
@@ -7708,6 +7760,101 @@ mod tests {
         assert!(first_hash.starts_with("path-ar-v1:"));
         assert!(second_hash.starts_with("path-ar-v1:"));
         assert_ne!(first_hash, second_hash);
+    }
+
+    #[test]
+    fn static_lib_use_follows_executable_output() {
+        let use_of = |crate_type: &str, test: bool| {
+            let mut argv = vec![
+                "rustc".to_string(),
+                "src/lib.rs".to_string(),
+                "--crate-type".to_string(),
+                crate_type.to_string(),
+            ];
+            if test {
+                argv.push("--test".to_string());
+            }
+            static_lib_use(&RustcArgs::parse(&argv).unwrap())
+        };
+        assert_eq!(use_of("lib", false), StaticLibUse::Bundled);
+        assert_eq!(use_of("rlib", false), StaticLibUse::Bundled);
+        assert_eq!(use_of("bin", false), StaticLibUse::Linked);
+        assert_eq!(use_of("cdylib", false), StaticLibUse::Linked);
+        assert_eq!(use_of("proc-macro", false), StaticLibUse::Linked);
+        assert_eq!(use_of("lib", true), StaticLibUse::Linked);
+    }
+
+    /// A DWARF-bearing Mach-O archive shares its structural digest across
+    /// checkouts only when rustc bundles it into an rlib. An invocation that
+    /// links it itself writes the archive's absolute path into `N_OSO`, so
+    /// the digest stays path-bound there.
+    #[test]
+    fn linked_dwarf_archive_stays_path_bound() {
+        let dir = tempfile::tempdir().unwrap();
+        let fh = FileHasher::new();
+        let hash_in = |name: &str, bytes: &[u8], usage: StaticLibUse| {
+            let lib_dir = dir.path().join(name);
+            std::fs::create_dir_all(&lib_dir).unwrap();
+            let lib = lib_dir.join("libprobe.a");
+            std::fs::write(&lib, bytes).unwrap();
+            fh.hash_static_lib_for(&lib, usage).unwrap()
+        };
+
+        let dwarf = crate::native_archive::dwarf_bsd_archive_for_tests(b"debug");
+        let bundled = hash_in("a", &dwarf, StaticLibUse::Bundled);
+        assert!(bundled.starts_with("bsd-ar-v2:"));
+        assert_eq!(bundled, hash_in("b", &dwarf, StaticLibUse::Bundled));
+
+        let linked = hash_in("a", &dwarf, StaticLibUse::Linked);
+        assert!(linked.starts_with("path-ar-v1:"));
+        assert_ne!(linked, hash_in("b", &dwarf, StaticLibUse::Linked));
+        // The unqualified method is the linked reading.
+        assert_eq!(
+            fh.hash_static_lib(&dir.path().join("a/libprobe.a"))
+                .unwrap(),
+            linked
+        );
+
+        // Without DWARF, a linked archive keeps the structural digest.
+        let plain = gnu_ar_one_object(b"object");
+        let linked_plain = hash_in("c", &plain, StaticLibUse::Linked);
+        assert!(linked_plain.starts_with("gnu-ar-v2:"));
+        assert_eq!(linked_plain, hash_in("d", &plain, StaticLibUse::Linked));
+    }
+
+    #[test]
+    fn hash_static_lib_memo_rows_are_per_use() {
+        let dir = tempfile::tempdir().unwrap();
+        let fh = FileHasher::persistent(&dir.path().join("index.db"));
+        let lib = dir.path().join("libbig.a");
+        // Large enough for the persistent memo.
+        std::fs::write(
+            &lib,
+            crate::native_archive::dwarf_bsd_archive_for_tests(&vec![0x41_u8; 70_000]),
+        )
+        .unwrap();
+
+        let bundled = fh.hash_static_lib_for(&lib, StaticLibUse::Bundled).unwrap();
+        let linked = fh.hash_static_lib_for(&lib, StaticLibUse::Linked).unwrap();
+        assert!(bundled.starts_with("bsd-ar-v2:"));
+        assert!(linked.starts_with("path-ar-v1:"));
+        assert_eq!(
+            fh.hash_static_lib_for(&lib, StaticLibUse::Bundled).unwrap(),
+            bundled
+        );
+
+        let fingerprint = FileFingerprint::from_path(&lib).unwrap();
+        let cache = fh.cache.as_ref().expect("persistent cache opens");
+        for (namespace, expected) in [
+            ("static-ar-v6-bundled", &bundled),
+            ("static-ar-v6", &linked),
+        ] {
+            let key = FileFingerprint {
+                path: format!("{namespace}\0{}", fingerprint.path),
+                ..fingerprint.clone()
+            };
+            assert_eq!(cache.get(&key).unwrap().as_ref(), Some(expected));
+        }
     }
 
     #[test]

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -7857,6 +7857,31 @@ mod tests {
         }
     }
 
+    /// Archives under `MIN_PERSISTED_HASH_BYTES` are hashed without a memo
+    /// row; one of exactly that size gets a row.
+    #[test]
+    fn hash_static_lib_memo_threshold_is_exclusive() {
+        let dir = tempfile::tempdir().unwrap();
+        let fh = FileHasher::persistent(&dir.path().join("index.db"));
+        let cache = fh.cache.as_ref().expect("persistent cache opens");
+        let threshold = usize::try_from(MIN_PERSISTED_HASH_BYTES).unwrap();
+        for (name, len, memoized) in [
+            ("libsmall.a", threshold - 1, false),
+            ("libexact.a", threshold, true),
+        ] {
+            let lib = dir.path().join(name);
+            std::fs::write(&lib, vec![b'x'; len]).unwrap();
+            let hash = fh.hash_static_lib(&lib).unwrap();
+            let fingerprint = FileFingerprint::from_path(&lib).unwrap();
+            let key = FileFingerprint {
+                path: format!("static-ar-v6\0{}", fingerprint.path),
+                ..fingerprint
+            };
+            let expected = memoized.then_some(hash);
+            assert_eq!(cache.get(&key).unwrap(), expected, "{name}");
+        }
+    }
+
     #[test]
     fn thin_static_archive_is_uncacheable() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/cache_key.rs
+++ b/src/cache_key.rs
@@ -3806,12 +3806,14 @@ impl<'db> FileHasher<'db> {
         // things — `hash` stores plain blake3, this stores a structural or
         // path-bound archive digest). This restores the warm-build fast path the whole-file
         // hasher had: an unchanged large `static=` archive (e.g. rocksdb) is not
-        // re-read on every incremental build. `v5`: v1/v2 rows used older
-        // identity definitions, v3 predates the fail-closed ELF gate, and v4
-        // predates the GCC Mach-O LTO gate. None may be served after the final
-        // archive hardening.
+        // re-read on every incremental build. `v6`: v1/v2 rows used older
+        // identity definitions, v3 predates the fail-closed ELF gate, v4
+        // predates the GCC Mach-O LTO gate, and v5 predates admitting
+        // DWARF-bearing Mach-O members (a v5 row would keep serving the
+        // path-bound digest of an unchanged archive). None may be served
+        // after the final archive hardening.
         let key = FileFingerprint {
-            path: format!("static-ar-v5\0{}", fingerprint.path),
+            path: format!("static-ar-v6\0{}", fingerprint.path),
             size: fingerprint.size,
             mtime_ns: fingerprint.mtime_ns,
             ctime_ns: fingerprint.ctime_ns,
@@ -7632,8 +7634,12 @@ mod tests {
             path: format!("static-ar-v4\0{}", fingerprint.path),
             ..fingerprint.clone()
         };
-        let current_key = FileFingerprint {
+        let legacy_v5_key = FileFingerprint {
             path: format!("static-ar-v5\0{}", fingerprint.path),
+            ..fingerprint.clone()
+        };
+        let current_key = FileFingerprint {
+            path: format!("static-ar-v6\0{}", fingerprint.path),
             ..fingerprint
         };
         let cache = fh.cache.as_ref().expect("persistent cache opens");
@@ -7647,6 +7653,9 @@ mod tests {
         cache
             .put(&legacy_v4_key, "legacy-unguarded-macho-sentinel")
             .unwrap();
+        cache
+            .put(&legacy_v5_key, "legacy-path-bound-dwarf-sentinel")
+            .unwrap();
 
         let computed = fh.hash_static_lib(&lib).unwrap();
         assert!(computed.starts_with("gnu-ar-v2:"));
@@ -7654,6 +7663,7 @@ mod tests {
         assert_ne!(computed, "legacy-member-sentinel");
         assert_ne!(computed, "legacy-unguarded-object-sentinel");
         assert_ne!(computed, "legacy-unguarded-macho-sentinel");
+        assert_ne!(computed, "legacy-path-bound-dwarf-sentinel");
         assert_eq!(cache.get(&current_key).unwrap(), Some(computed.clone()));
         assert_eq!(fh.hash_static_lib(&lib).unwrap(), computed);
     }

--- a/src/native_archive.rs
+++ b/src/native_archive.rs
@@ -49,12 +49,19 @@
 //! header size INCLUDES those bytes. The path-derived `cc` name therefore
 //! lives inside the member data itself. The exact stored name bytes (including
 //! encoding/padding), parsed timestamp, and object DATA are all hashed.
-//! - only structurally valid, known Mach-O `MH_OBJECT` files
-//!   without debug sections, STABS, or embedded compiler bitcode/LTO. Darwin's
-//!   linker
-//!   records `archive(member)` (and archive-member time) in `N_OSO` debug-map
-//!   entries. Unsupported, malformed, debug-bearing, bitcode, and ARM64_32
-//!   objects therefore use the path-bound fallback;
+//! - only structurally valid, known Mach-O `MH_OBJECT` files without STABS
+//!   or embedded compiler bitcode/LTO. DWARF (`__DWARF,__debug_*` /
+//!   `__apple_*`, S_ATTR_DEBUG) is hashed like any other member bytes, so a
+//!   path a compiler left in `DW_AT_comp_dir` is identity-bearing, never a
+//!   false hit. Darwin's linker records `archive(member)` (and archive-member
+//!   time) in `N_OSO` debug-map entries for such members, but every cached
+//!   macOS debug link already makes those records checkout-independent —
+//!   ld64 `-oso_prefix` relative to `--out-dir` (`compiler/rustc.rs`) plus
+//!   the store-time `.dSYM` (#319) — exactly as for the debug-bearing Rust
+//!   objects every dev-profile rlib bundles; a `cc`-built archive is no
+//!   different once rustc has bundled its members into the rlib. Unsupported,
+//!   malformed, STABS, bitcode, and ARM64_32 objects therefore use the
+//!   path-bound fallback;
 //! - the ranlib member (`__.SYMDEF[ SORTED]` / `__.SYMDEF_64[ SORTED]`) DATA
 //!   **as-is**, tagged with its trimmed name: `_64` reads the same bytes with
 //!   a different word width and ` SORTED` changes the lookup contract, so the
@@ -71,7 +78,7 @@
 //!
 //! ## Out of scope -> path-bound fallback (`None`)
 //! Thin archives (`!<thin>`), Windows COFF `.lib`, GNU/BSD mixed layouts,
-//! debug-bearing Mach-O, compiler bitcode/LTO, ARM64_32, unknown object formats,
+//! STABS-bearing Mach-O, compiler bitcode/LTO, ARM64_32, unknown object formats,
 //! and anything malformed. Thin archives are made uncacheable because their
 //! external member bytes are absent from the container. Other fallbacks bind
 //! both the archive bytes and lexical absolute archive path.
@@ -206,7 +213,7 @@ fn gnu_archive_hash(bytes: &[u8]) -> Option<String> {
                 // bitcode uses archive-path-derived LTO identifiers, and an
                 // unknown format may have equally path-sensitive semantics.
                 let known_object = if has_macho_magic(data) {
-                    is_known_no_debug_macho_object(data)
+                    is_known_portable_macho_object(data)
                 } else {
                     is_known_elf_relocatable_object(data)
                 };
@@ -326,10 +333,14 @@ fn bsd_archive_hash(bytes: &[u8]) -> Option<String> {
         } else {
             // ld64 writes an N_OSO debug-map entry containing
             // `archive(member)` (and the member timestamp) for debug-bearing
-            // Mach-O objects. Dropping the name/header is therefore safe only
-            // after a bounded, fail-closed Mach-O inspection proves this is a
-            // known MH_OBJECT without debug sections, STABS, or bitcode.
-            if !is_known_no_debug_macho_object(content) {
+            // Mach-O objects. The exact stored name and timestamp are
+            // committed above, and the record's path half is already
+            // checkout-independent for every cached debug link (`-oso_prefix`,
+            // store-time `.dSYM` — see the module docs), so DWARF binds nothing
+            // further. Hashing the content is safe only after a bounded,
+            // fail-closed Mach-O inspection proves this is a known MH_OBJECT
+            // without STABS or bitcode.
+            if !is_known_portable_macho_object(content) {
                 return None;
             }
             // The exact stored name was committed above; frame the object
@@ -430,10 +441,12 @@ struct MachSymtab {
 
 /// Prove that `bytes` is a supported Mach-O relocatable object whose behavior
 /// is independent of the containing archive path after name/time are hashed.
-/// All arithmetic and table walks are bounded by the input slice. Any doubt
-/// returns `false`, selecting the caller's path-bound fallback.
-fn is_known_no_debug_macho_object(bytes: &[u8]) -> bool {
-    parse_known_no_debug_macho_object(bytes).is_some()
+/// DWARF is admitted (see the module docs); STABS, bitcode/LTO carriers, and
+/// unknown shapes are not. All arithmetic and table walks are bounded by the
+/// input slice. Any doubt returns `false`, selecting the caller's path-bound
+/// fallback.
+fn is_known_portable_macho_object(bytes: &[u8]) -> bool {
+    parse_known_portable_macho_object(bytes).is_some()
 }
 
 fn has_macho_magic(bytes: &[u8]) -> bool {
@@ -600,7 +613,7 @@ fn parse_known_elf_relocatable_object(bytes: &[u8]) -> Option<()> {
     Some(())
 }
 
-fn parse_known_no_debug_macho_object(bytes: &[u8]) -> Option<()> {
+fn parse_known_portable_macho_object(bytes: &[u8]) -> Option<()> {
     let magic = bytes.get(..4)?;
     let (endian, is_64) = match magic {
         b"\xce\xfa\xed\xfe" => (MachEndian::Little, false),
@@ -841,7 +854,18 @@ fn validate_macho_segment(
 }
 
 fn macho_segment_is_portable(name: &[u8]) -> bool {
-    name != b"__DWARF" && !is_macho_lto_segment(name)
+    !is_macho_lto_segment(name)
+}
+
+/// DWARF exactly as clang emits it: a `__debug_*` or `__apple_*` section in
+/// the `__DWARF` segment, flagged S_ATTR_DEBUG. ld64 reads these only to
+/// write the debug map (see the module docs); the bytes are hashed like any
+/// other member content. Any other spelling — a debug section in a code
+/// segment, a `__DWARF` section without the flag — stays fail-closed.
+fn macho_section_is_dwarf(section_segment: &[u8], section_name: &[u8], flags: u32) -> bool {
+    section_segment == b"__DWARF"
+        && flags & S_ATTR_DEBUG != 0
+        && (section_name.starts_with(b"__debug_") || section_name.starts_with(b"__apple_"))
 }
 
 fn macho_section_is_portable(section_segment: &[u8], section_name: &[u8], flags: u32) -> bool {
@@ -850,13 +874,14 @@ fn macho_section_is_portable(section_segment: &[u8], section_name: &[u8], flags:
     // is not source-level debug data and does not cause an N_OSO entry; a
     // no-debug C/C++ object commonly contains it.
     let compact_unwind = section_segment == b"__LD" && section_name == b"__compact_unwind";
-    (flags & S_ATTR_DEBUG == 0 || compact_unwind)
-        && section_segment != b"__DWARF"
-        && !section_name.starts_with(b"__debug_")
-        && !section_name.starts_with(b"__zdebug_")
-        && !is_macho_lto_segment(section_segment)
-        && section_name != b"__bitcode"
-        && section_name != b"__bundle"
+    macho_section_is_dwarf(section_segment, section_name, flags)
+        || ((flags & S_ATTR_DEBUG == 0 || compact_unwind)
+            && section_segment != b"__DWARF"
+            && !section_name.starts_with(b"__debug_")
+            && !section_name.starts_with(b"__zdebug_")
+            && !is_macho_lto_segment(section_segment)
+            && section_name != b"__bitcode"
+            && section_name != b"__bundle")
 }
 
 fn is_macho_zerofill(flags: u32) -> bool {
@@ -1813,6 +1838,19 @@ mod tests {
         )
     }
 
+    /// DWARF as clang emits it for a `-g` translation unit.
+    fn dwarf_macho(payload: &[u8]) -> Vec<u8> {
+        macho_object(
+            MachEndian::Little,
+            true,
+            "__DWARF",
+            "__debug_info",
+            S_ATTR_DEBUG,
+            N_SECT,
+            payload,
+        )
+    }
+
     fn read_le_u32(bytes: &[u8], offset: usize) -> u32 {
         u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap())
     }
@@ -1916,7 +1954,7 @@ mod tests {
         for command in commands {
             let object = macho_with_extra_command(base.clone(), &command);
             assert!(
-                parse_known_no_debug_macho_object(&object).is_some(),
+                parse_known_portable_macho_object(&object).is_some(),
                 "supported load command {} must parse",
                 read_le_u32(&command, 0)
             );
@@ -1928,7 +1966,7 @@ mod tests {
         let base = no_debug_macho(b"command payload");
         let mut wrong_file_type = base.clone();
         write_le_u32(&mut wrong_file_type, 12, 2);
-        assert!(parse_known_no_debug_macho_object(&wrong_file_type).is_none());
+        assert!(parse_known_portable_macho_object(&wrong_file_type).is_none());
 
         let symtab_offset = 32 + usize::try_from(read_le_u32(&base, 36)).unwrap();
         let mut duplicate_symtab_command = base[symtab_offset..symtab_offset + 24].to_vec();
@@ -1937,12 +1975,12 @@ mod tests {
             write_le_u32(&mut duplicate_symtab_command, offset, shifted);
         }
         let duplicate_symtab = macho_with_extra_command(base.clone(), &duplicate_symtab_command);
-        assert!(parse_known_no_debug_macho_object(&duplicate_symtab).is_none());
+        assert!(parse_known_portable_macho_object(&duplicate_symtab).is_none());
 
         let with_dysymtab = macho_with_extra_command(base.clone(), &macho_command(LC_DYSYMTAB, 80));
         let duplicate_dysymtab =
             macho_with_extra_command(with_dysymtab, &macho_command(LC_DYSYMTAB, 80));
-        assert!(parse_known_no_debug_macho_object(&duplicate_dysymtab).is_none());
+        assert!(parse_known_portable_macho_object(&duplicate_dysymtab).is_none());
 
         for command in [
             macho_command(LC_SYMTAB, 16),
@@ -1952,7 +1990,7 @@ mod tests {
             macho_command(LC_UUID, 16),
         ] {
             let object = macho_with_extra_command(base.clone(), &command);
-            assert!(parse_known_no_debug_macho_object(&object).is_none());
+            assert!(parse_known_portable_macho_object(&object).is_none());
         }
     }
 
@@ -1968,14 +2006,30 @@ mod tests {
     #[test]
     fn macho_section_policy_checks_each_marker_independently() {
         assert!(macho_segment_is_portable(b"__TEXT"));
-        for segment in [
-            &b"__DWARF"[..],
-            &b"__LLVM"[..],
-            &b"__GNU_LTO"[..],
-            &b"__GNU_OFFLD_LTO"[..],
-        ] {
+        assert!(macho_segment_is_portable(b"__DWARF"));
+        for segment in [&b"__LLVM"[..], &b"__GNU_LTO"[..], &b"__GNU_OFFLD_LTO"[..]] {
             assert!(!macho_segment_is_portable(segment));
         }
+
+        // Segment, S_ATTR_DEBUG, and a DWARF section name are each required
+        // for a section to count as clang's DWARF.
+        assert!(macho_section_is_dwarf(
+            b"__DWARF",
+            b"__debug_line",
+            S_ATTR_DEBUG
+        ));
+        assert!(macho_section_is_dwarf(
+            b"__DWARF",
+            b"__apple_types",
+            S_ATTR_DEBUG
+        ));
+        assert!(!macho_section_is_dwarf(b"__DWARF", b"__debug_line", 0));
+        assert!(!macho_section_is_dwarf(
+            b"__TEXT",
+            b"__debug_line",
+            S_ATTR_DEBUG
+        ));
+        assert!(!macho_section_is_dwarf(b"__DWARF", b"__text", S_ATTR_DEBUG));
 
         for (segment, section, flags, expected) in [
             (&b"__TEXT"[..], &b"__text"[..], 0, true),
@@ -1988,7 +2042,14 @@ mod tests {
             ),
             (&b"__LD"[..], &b"__text"[..], S_ATTR_DEBUG, false),
             (&b"__TEXT"[..], &b"__text"[..], S_ATTR_DEBUG, false),
+            (&b"__DWARF"[..], &b"__debug_info"[..], S_ATTR_DEBUG, true),
+            (&b"__DWARF"[..], &b"__debug_str"[..], S_ATTR_DEBUG, true),
+            (&b"__DWARF"[..], &b"__apple_names"[..], S_ATTR_DEBUG, true),
+            (&b"__DWARF"[..], &b"__debug_info"[..], 0, false),
+            (&b"__DWARF"[..], &b"__text"[..], S_ATTR_DEBUG, false),
             (&b"__DWARF"[..], &b"__text"[..], 0, false),
+            (&b"__DWARF"[..], &b"__zdebug_info"[..], S_ATTR_DEBUG, false),
+            (&b"__TEXT"[..], &b"__debug_info"[..], S_ATTR_DEBUG, false),
             (&b"__TEXT"[..], &b"__debug_info"[..], 0, false),
             (&b"__TEXT"[..], &b"__zdebug_info"[..], 0, false),
             (&b"__LLVM"[..], &b"__text"[..], 0, false),
@@ -2032,7 +2093,7 @@ mod tests {
             SEGMENT_FILEOFF,
             u64::from(data_offset + 1),
         );
-        assert!(parse_known_no_debug_macho_object(&starts_before_segment).is_none());
+        assert!(parse_known_portable_macho_object(&starts_before_segment).is_none());
 
         let mut ends_after_segment = base.clone();
         write_le_u64(
@@ -2041,15 +2102,15 @@ mod tests {
             u64::from(data_offset - 1),
         );
         write_le_u64(&mut ends_after_segment, SEGMENT_FILESIZE, 4);
-        assert!(parse_known_no_debug_macho_object(&ends_after_segment).is_none());
+        assert!(parse_known_portable_macho_object(&ends_after_segment).is_none());
 
         let mut ordinary_out_of_bounds = base.clone();
         write_le_u32(&mut ordinary_out_of_bounds, SECTION_OFFSET, u32::MAX);
-        assert!(parse_known_no_debug_macho_object(&ordinary_out_of_bounds).is_none());
+        assert!(parse_known_portable_macho_object(&ordinary_out_of_bounds).is_none());
 
         let mut zero_sized = ordinary_out_of_bounds.clone();
         write_le_u64(&mut zero_sized, SECTION_SIZE, 0);
-        assert!(parse_known_no_debug_macho_object(&zero_sized).is_some());
+        assert!(parse_known_portable_macho_object(&zero_sized).is_some());
 
         let mut zerofill = macho_object(
             MachEndian::Little,
@@ -2061,30 +2122,30 @@ mod tests {
             b"code",
         );
         write_le_u32(&mut zerofill, SECTION_OFFSET, u32::MAX);
-        assert!(parse_known_no_debug_macho_object(&zerofill).is_some());
+        assert!(parse_known_portable_macho_object(&zerofill).is_some());
 
         let mut bad_relocation = base;
         write_le_u32(&mut bad_relocation, SECTION_RELOFF, u32::MAX);
         write_le_u32(&mut bad_relocation, SECTION_NRELOC, 1);
-        assert!(parse_known_no_debug_macho_object(&bad_relocation).is_none());
+        assert!(parse_known_portable_macho_object(&bad_relocation).is_none());
     }
 
     #[test]
     fn data_in_code_alignment_applies_only_to_that_command() {
         assert!(
-            parse_known_no_debug_macho_object(&macho_with_linkedit_command(LC_DATA_IN_CODE, 0))
+            parse_known_portable_macho_object(&macho_with_linkedit_command(LC_DATA_IN_CODE, 0))
                 .is_some()
         );
         assert!(
-            parse_known_no_debug_macho_object(&macho_with_linkedit_command(LC_DATA_IN_CODE, 8))
+            parse_known_portable_macho_object(&macho_with_linkedit_command(LC_DATA_IN_CODE, 8))
                 .is_some()
         );
         assert!(
-            parse_known_no_debug_macho_object(&macho_with_linkedit_command(LC_DATA_IN_CODE, 7))
+            parse_known_portable_macho_object(&macho_with_linkedit_command(LC_DATA_IN_CODE, 7))
                 .is_none()
         );
         assert!(
-            parse_known_no_debug_macho_object(&macho_with_linkedit_command(
+            parse_known_portable_macho_object(&macho_with_linkedit_command(
                 LC_LINKER_OPTIMIZATION_HINT,
                 7,
             ))
@@ -2393,7 +2454,7 @@ mod tests {
             for is_64 in [false, true] {
                 let object = macho_object(endian, is_64, "__TEXT", "__text", 0, N_SECT, b"code");
                 assert!(
-                    is_known_no_debug_macho_object(&object),
+                    is_known_portable_macho_object(&object),
                     "supported MH_OBJECT must pass its endian/width gate"
                 );
             }
@@ -2408,7 +2469,7 @@ mod tests {
             N_SECT,
             b"unwind",
         );
-        assert!(is_known_no_debug_macho_object(&compact_unwind));
+        assert!(is_known_portable_macho_object(&compact_unwind));
     }
 
     #[test]
@@ -2423,41 +2484,107 @@ mod tests {
             b"code",
         );
         object[4..8].copy_from_slice(&0x0200_000c_u32.to_le_bytes());
-        assert!(!is_known_no_debug_macho_object(&object));
+        assert!(!is_known_portable_macho_object(&object));
 
         let archive = bsd_archive(&[("PerfUtils.o", 16, &object)]);
         assert!(portable_static_archive_hash(&archive).is_none());
     }
 
     #[test]
-    fn bsd_debug_sections_and_stabs_fall_back() {
-        let debug_section = macho_object(
-            MachEndian::Little,
-            true,
-            "__DWARF",
-            "__debug_info",
-            S_ATTR_DEBUG,
-            N_SECT,
-            b"debug",
+    fn bsd_dwarf_hashes_structurally_and_stabs_fall_back() {
+        // A `cc`-built dev-profile object carries DWARF. It gets the
+        // structural hash — path-independent, bound to name, time, and the
+        // DWARF bytes themselves — instead of the path-bound fallback that
+        // re-keyed every such archive per checkout.
+        let dwarf = dwarf_macho(b"debug");
+        let bsd = bsd_archive(&[
+            ("__.SYMDEF SORTED", 20, BSD_SYMDEF),
+            ("cafca65b3467684e-a.o", 20, &dwarf),
+        ]);
+        let hash = portable_static_archive_hash(&bsd).expect("DWARF member parses");
+        assert!(hash.starts_with("bsd-ar-v2:"));
+        let edited = bsd_archive(&[
+            ("__.SYMDEF SORTED", 20, BSD_SYMDEF),
+            ("cafca65b3467684e-a.o", 20, &dwarf_macho(b"debuG")),
+        ]);
+        assert_ne!(
+            portable_static_archive_hash(&edited).unwrap(),
+            hash,
+            "DWARF bytes are identity-bearing"
         );
-        let stab = macho_object(
-            MachEndian::Little,
-            true,
-            "__TEXT",
-            "__text",
-            0,
-            0x64, // N_SO: any N_STAB entry is name/time-sensitive in ld64
-            b"code",
-        );
-        for object in [&debug_section, &stab] {
-            let archive = bsd_archive(&[("derived-name.o", 16, object)]);
-            assert!(portable_static_archive_hash(&archive).is_none());
-        }
 
-        // A GNU-layout archive can carry Mach-O too; its `//` names are just as
-        // capable of entering ld64's N_OSO entry and must use the same guard.
-        let gnu_debug = archive(&[("debug.o/", &debug_section)]);
-        assert!(portable_static_archive_hash(&gnu_debug).is_none());
+        // A GNU-layout archive can carry Mach-O too; the shared gate admits
+        // the same object there.
+        let gnu = archive(&[("debug.o/", &dwarf)]);
+        assert!(
+            portable_static_archive_hash(&gnu)
+                .unwrap()
+                .starts_with("gnu-ar-v2:")
+        );
+
+        // STABS entries stay name/time-sensitive in ld64 and fall back, with
+        // or without DWARF alongside, under both layouts.
+        for (segment, section, flags) in [
+            ("__TEXT", "__text", 0),
+            ("__DWARF", "__debug_info", S_ATTR_DEBUG),
+        ] {
+            let stab = macho_object(
+                MachEndian::Little,
+                true,
+                segment,
+                section,
+                flags,
+                0x64, // N_SO: any N_STAB entry is name/time-sensitive in ld64
+                b"code",
+            );
+            assert!(!is_known_portable_macho_object(&stab));
+            assert!(
+                portable_static_archive_hash(&bsd_archive(&[("derived-name.o", 16, &stab)]))
+                    .is_none()
+            );
+            assert!(portable_static_archive_hash(&archive(&[("stab.o/", &stab)])).is_none());
+        }
+    }
+
+    #[test]
+    fn only_clang_shaped_dwarf_is_admitted() {
+        // Segment, S_ATTR_DEBUG, and a DWARF section name are each required;
+        // any other spelling of a debug section keeps the path-bound fallback.
+        for (segment, section, flags) in [
+            ("__DWARF", "__debug_info", 0),
+            ("__DWARF", "__text", S_ATTR_DEBUG),
+            ("__DWARF", "__text", 0),
+            ("__DWARF", "__zdebug_info", S_ATTR_DEBUG),
+            ("__TEXT", "__debug_info", S_ATTR_DEBUG),
+            ("__TEXT", "__debug_info", 0),
+        ] {
+            let object = macho_object(
+                MachEndian::Little,
+                true,
+                segment,
+                section,
+                flags,
+                N_SECT,
+                b"x",
+            );
+            assert!(
+                !is_known_portable_macho_object(&object),
+                "{segment},{section} flags={flags:#x} must fail closed"
+            );
+            assert!(portable_static_archive_hash(&bsd_archive(&[("x.o", 4, &object)])).is_none());
+        }
+        for section in ["__debug_line", "__apple_names"] {
+            let object = macho_object(
+                MachEndian::Little,
+                true,
+                "__DWARF",
+                section,
+                S_ATTR_DEBUG,
+                N_SECT,
+                b"x",
+            );
+            assert!(is_known_portable_macho_object(&object), "{section}");
+        }
     }
 
     #[test]
@@ -2650,7 +2777,7 @@ mod tests {
             .status()
             .expect("system C compiler runs");
         assert!(status.success(), "cc -c -g0 failed");
-        assert!(is_known_no_debug_macho_object(
+        assert!(is_known_portable_macho_object(
             &std::fs::read(&seed_object).unwrap()
         ));
 
@@ -2691,12 +2818,14 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "macos")]
-    fn real_darwin_debug_object_falls_back() {
+    fn real_darwin_debug_object_hashes_structurally() {
         use std::process::Command;
+        // A real `cc -c -g` object carries DWARF (`__DWARF,__debug_*` flagged
+        // S_ATTR_DEBUG). It must pass the gate, and an archive of it must get
+        // the structural BSD hash — the same one from any directory.
         let dir = tempfile::tempdir().unwrap();
         let source = dir.path().join("probe.c");
         let object = dir.path().join("cafca65b3467684e-debug.o");
-        let archive = dir.path().join("libprobe.a");
         std::fs::write(
             &source,
             b"int kache_archive_debug_probe(void) { return 701; }\n",
@@ -2713,21 +2842,36 @@ mod tests {
             .expect("system C compiler runs");
         assert!(status.success(), "cc -c -g failed");
         assert!(
-            !is_known_no_debug_macho_object(&std::fs::read(&object).unwrap()),
-            "debug-bearing Mach-O must fail the name-normalization gate"
+            is_known_portable_macho_object(&std::fs::read(&object).unwrap()),
+            "debug-bearing Mach-O passes the gate"
         );
 
-        let status = Command::new("ar")
-            .arg("crs")
-            .arg(&archive)
-            .arg(&object)
-            .env("ZERO_AR_DATE", "1")
-            .status()
-            .expect("system ar runs");
-        assert!(status.success(), "ar crs failed");
-        let bytes = std::fs::read(&archive).unwrap();
-        assert!(bsd_archive_hash(&bytes).is_none());
-        assert!(portable_static_archive_hash(&bytes).is_none());
+        let mut digests = Vec::new();
+        for name in ["PerfUtils", "OtherName"] {
+            let archive_dir = dir.path().join(name);
+            std::fs::create_dir_all(&archive_dir).unwrap();
+            let archive = archive_dir.join("libprobe.a");
+            let status = Command::new("ar")
+                .arg("crs")
+                .arg(&archive)
+                .arg(&object)
+                .env("ZERO_AR_DATE", "1")
+                .status()
+                .expect("system ar runs");
+            assert!(status.success(), "ar crs failed");
+            let bytes = std::fs::read(&archive).unwrap();
+            let hash = bsd_archive_hash(&bytes).expect("BSD arm claims a DWARF-bearing archive");
+            assert_portable_hash_shape(&hash);
+            assert_eq!(
+                portable_static_archive_hash(&bytes).as_deref(),
+                Some(hash.as_str())
+            );
+            digests.push(hash);
+        }
+        assert_eq!(
+            digests[0], digests[1],
+            "a DWARF-bearing archive hashes the same from any directory"
+        );
     }
 
     fn assert_portable_hash_shape(hash: &str) {

--- a/src/native_archive.rs
+++ b/src/native_archive.rs
@@ -11,7 +11,7 @@
 //! machines even when the linked content is identical (kunobi-ninja/kache#471),
 //! cross-clone-missing the lib and everything downstream of it.
 //!
-//! [`portable_static_archive_hash`] hashes the archive's link-relevant content
+//! [`portable_static_archive_identity`] hashes the archive's link-relevant content
 //! for the two `ar` flavors rustc links on kache's Unix targets: GNU / SysV
 //! (Linux) and BSD / Darwin (macOS, #691). It deliberately retains every
 //! effective member name. Linkers can observe `archive(member)` through order
@@ -54,14 +54,16 @@
 //!   `__apple_*`, S_ATTR_DEBUG) is hashed like any other member bytes, so a
 //!   path a compiler left in `DW_AT_comp_dir` is identity-bearing, never a
 //!   false hit. Darwin's linker records `archive(member)` (and archive-member
-//!   time) in `N_OSO` debug-map entries for such members, but every cached
-//!   macOS debug link already makes those records checkout-independent —
-//!   ld64 `-oso_prefix` relative to `--out-dir` (`compiler/rustc.rs`) plus
-//!   the store-time `.dSYM` (#319) — exactly as for the debug-bearing Rust
-//!   objects every dev-profile rlib bundles; a `cc`-built archive is no
-//!   different once rustc has bundled its members into the rlib. Unsupported,
-//!   malformed, STABS, bitcode, and ARM64_32 objects therefore use the
-//!   path-bound fallback;
+//!   time) in `N_OSO` debug-map entries for such members. Once rustc bundles
+//!   the archive into an rlib, a later cached debug link names
+//!   `<rlib>(member)` under `--out-dir`, which the ld64 `-oso_prefix` kache
+//!   injects there (`compiler/rustc.rs`) makes relative, as for the
+//!   debug-bearing Rust objects every dev-profile rlib carries. An
+//!   invocation that links the archive directly records the archive's own
+//!   absolute path, which that `--out-dir` prefix does not strip, so
+//!   [`ArchiveIdentity::macho_dwarf_members`] lets the caller keep the
+//!   path-bound fallback there. Unsupported, malformed, STABS, bitcode, and
+//!   ARM64_32 objects always use the path-bound fallback;
 //! - the ranlib member (`__.SYMDEF[ SORTED]` / `__.SYMDEF_64[ SORTED]`) DATA
 //!   **as-is**, tagged with its trimmed name: `_64` reads the same bytes with
 //!   a different word width and ` SORTED` changes the lookup contract, so the
@@ -104,12 +106,39 @@ const BSD_DOMAIN: &[u8] = b"kache.native-ar.bsd.member-identity.v2\0";
 /// member contents: rustc bundles the archive BYTES into its output, so the
 /// format difference IS an output difference — and the two arms frame
 /// different symbol-table semantics.
+pub fn portable_static_archive_identity(bytes: &[u8]) -> Option<ArchiveIdentity> {
+    gnu_archive_identity(bytes).or_else(|| bsd_archive_identity(bytes))
+}
+
+/// A structural archive digest, plus whether any member makes that digest
+/// unsafe to share when the caller links the archive itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArchiveIdentity {
+    /// Domain-tagged digest (`gnu-ar-v2:` / `bsd-ar-v2:`).
+    pub digest: String,
+    /// Some Mach-O member carries DWARF. ld64 names such a member
+    /// `archive-path(member)` in the `N_OSO` debug map of a binary that links
+    /// the archive directly (see the module docs).
+    pub macho_dwarf_members: bool,
+}
+
+#[cfg(test)]
 pub fn portable_static_archive_hash(bytes: &[u8]) -> Option<String> {
-    gnu_archive_hash(bytes).or_else(|| bsd_archive_hash(bytes))
+    portable_static_archive_identity(bytes).map(|identity| identity.digest)
+}
+
+#[cfg(test)]
+fn gnu_archive_hash(bytes: &[u8]) -> Option<String> {
+    gnu_archive_identity(bytes).map(|identity| identity.digest)
+}
+
+#[cfg(test)]
+fn bsd_archive_hash(bytes: &[u8]) -> Option<String> {
+    bsd_archive_identity(bytes).map(|identity| identity.digest)
 }
 
 /// The GNU / SysV arm. See "What is hashed (GNU archives)" in the module docs.
-fn gnu_archive_hash(bytes: &[u8]) -> Option<String> {
+fn gnu_archive_identity(bytes: &[u8]) -> Option<ArchiveIdentity> {
     // `!<thin>\n` and non-archives fail this check -> fallback.
     if bytes.len() < AR_MAGIC.len() || &bytes[..AR_MAGIC.len()] != AR_MAGIC {
         return None;
@@ -122,6 +151,7 @@ fn gnu_archive_hash(bytes: &[u8]) -> Option<String> {
     let mut seen_symtab = false;
     let mut longnames: Option<&[u8]> = None;
     let mut object_members: u64 = 0;
+    let mut macho_dwarf_members = false;
 
     while pos < bytes.len() {
         let header = bytes.get(pos..pos.checked_add(AR_HEADER_LEN)?)?;
@@ -212,13 +242,15 @@ fn gnu_archive_hash(bytes: &[u8]) -> Option<String> {
                 // member has passed a bounded object-format gate: raw/wrapped
                 // bitcode uses archive-path-derived LTO identifiers, and an
                 // unknown format may have equally path-sensitive semantics.
-                let known_object = if has_macho_magic(data) {
-                    is_known_no_debug_macho_object(data)
+                let dwarf = if has_macho_magic(data) {
+                    parse_known_no_debug_macho_object(data)?
+                } else if is_known_elf_relocatable_object(data) {
+                    false
                 } else {
-                    is_known_elf_relocatable_object(data)
-                };
-                if !known_object {
                     return None;
+                };
+                if dwarf {
+                    macho_dwarf_members = true;
                 }
                 hasher.update(b"member\0");
                 hasher.update(&(name.len() as u64).to_le_bytes());
@@ -244,15 +276,18 @@ fn gnu_archive_hash(bytes: &[u8]) -> Option<String> {
     }
     // Tagged so a portable digest can never even textually collide with the
     // plain-hex whole-file fallback (no reliance on blake3 collision resistance).
-    Some(format!("gnu-ar-v2:{}", hasher.finalize().to_hex()))
+    Some(ArchiveIdentity {
+        digest: format!("gnu-ar-v2:{}", hasher.finalize().to_hex()),
+        macho_dwarf_members,
+    })
 }
 
 /// The BSD / Darwin arm (#691). See "What is hashed (BSD / Darwin archives)"
-/// in the module docs. Strictness mirrors [`gnu_archive_hash`]: any GNU
+/// in the module docs. Strictness mirrors [`gnu_archive_identity`]: any GNU
 /// reserved name shape means a mixed/foreign layout -> `None`, never a guess;
 /// the ranlib member may only be the first member and appear at most once
 /// (where Darwin `ranlib` always writes it).
-fn bsd_archive_hash(bytes: &[u8]) -> Option<String> {
+fn bsd_archive_identity(bytes: &[u8]) -> Option<ArchiveIdentity> {
     if !bytes.starts_with(AR_MAGIC) {
         return None;
     }
@@ -263,6 +298,7 @@ fn bsd_archive_hash(bytes: &[u8]) -> Option<String> {
     let mut member_index: usize = 0;
     let mut seen_symdef = false;
     let mut object_members: u64 = 0;
+    let mut macho_dwarf_members = false;
 
     while pos < bytes.len() {
         let header = bytes.get(pos..pos.checked_add(AR_HEADER_LEN)?)?;
@@ -334,14 +370,15 @@ fn bsd_archive_hash(bytes: &[u8]) -> Option<String> {
             // ld64 writes an N_OSO debug-map entry containing
             // `archive(member)` (and the member timestamp) for debug-bearing
             // Mach-O objects. The exact stored name and timestamp are
-            // committed above, and the record's path half is already
-            // checkout-independent for every cached debug link (`-oso_prefix`,
-            // store-time `.dSYM` — see the module docs), so DWARF binds nothing
-            // further. Hashing the content is safe only after a bounded,
+            // committed above. The record's path half is checkout-independent
+            // only once rustc bundles the archive into an rlib, so DWARF
+            // members are reported and the caller keeps the path-bound digest
+            // for an invocation that links the archive itself (see the module
+            // docs). Hashing the content is safe only after a bounded,
             // fail-closed Mach-O inspection proves this is a known MH_OBJECT
             // without STABS or bitcode.
-            if !is_known_no_debug_macho_object(content) {
-                return None;
+            if parse_known_no_debug_macho_object(content)? {
+                macho_dwarf_members = true;
             }
             // The exact stored name was committed above; frame the object
             // content separately so no concatenation ambiguity is possible.
@@ -367,7 +404,10 @@ fn bsd_archive_hash(bytes: &[u8]) -> Option<String> {
     }
     // Tagged so a portable digest can never even textually collide with the
     // whole-file fallback or the GNU scheme.
-    Some(format!("bsd-ar-v2:{}", hasher.finalize().to_hex()))
+    Some(ArchiveIdentity {
+        digest: format!("bsd-ar-v2:{}", hasher.finalize().to_hex()),
+        macho_dwarf_members,
+    })
 }
 
 // Mach-O constants used by the deliberately small, fail-closed object gate.
@@ -445,6 +485,7 @@ struct MachSymtab {
 /// STABS, bitcode/LTO carriers, and unknown shapes are not. All arithmetic
 /// and table walks are bounded by the input slice. Any doubt returns `false`,
 /// selecting the caller's path-bound fallback.
+#[cfg(test)]
 fn is_known_no_debug_macho_object(bytes: &[u8]) -> bool {
     parse_known_no_debug_macho_object(bytes).is_some()
 }
@@ -613,7 +654,9 @@ fn parse_known_elf_relocatable_object(bytes: &[u8]) -> Option<()> {
     Some(())
 }
 
-fn parse_known_no_debug_macho_object(bytes: &[u8]) -> Option<()> {
+/// `Some(has_dwarf)` for an admitted object, where `has_dwarf` means some
+/// section is clang DWARF ([`macho_section_is_dwarf`]).
+fn parse_known_no_debug_macho_object(bytes: &[u8]) -> Option<bool> {
     let magic = bytes.get(..4)?;
     let (endian, is_64) = match magic {
         b"\xce\xfa\xed\xfe" => (MachEndian::Little, false),
@@ -650,6 +693,7 @@ fn parse_known_no_debug_macho_object(bytes: &[u8]) -> Option<()> {
     let mut command_offset = header_len;
     let mut section_count = 0_u32;
     let mut saw_segment = false;
+    let mut has_dwarf = false;
     let mut symtab: Option<MachSymtab> = None;
     let mut dysymtab: Option<[u32; 18]> = None;
 
@@ -668,13 +712,12 @@ fn parse_known_no_debug_macho_object(bytes: &[u8]) -> Option<()> {
         match cmd {
             LC_SEGMENT | LC_SEGMENT_64 => {
                 let segment_is_64 = macho_segment_width(cmd, is_64)?;
-                section_count = section_count.checked_add(validate_macho_segment(
-                    bytes,
-                    command,
-                    endian,
-                    segment_is_64,
-                    commands_end,
-                )?)?;
+                let (nsects, dwarf) =
+                    validate_macho_segment(bytes, command, endian, segment_is_64, commands_end)?;
+                section_count = section_count.checked_add(nsects)?;
+                if dwarf {
+                    has_dwarf = true;
+                }
                 saw_segment = true;
             }
             LC_SYMTAB => {
@@ -734,7 +777,7 @@ fn parse_known_no_debug_macho_object(bytes: &[u8]) -> Option<()> {
     if let Some(fields) = dysymtab {
         validate_macho_dysymtab(bytes, is_64, commands_end, symtab.nsyms, &fields)?;
     }
-    Some(())
+    Some(has_dwarf)
 }
 
 fn macho_command_table_is_plausible(ncmds: usize, sizeofcmds: usize) -> bool {
@@ -770,7 +813,7 @@ fn validate_macho_segment(
     endian: MachEndian,
     is_64: bool,
     commands_end: usize,
-) -> Option<u32> {
+) -> Option<(u32, bool)> {
     let (base_size, section_size, fileoff, filesize, nsects) = if is_64 {
         (
             72_usize,
@@ -803,6 +846,7 @@ fn validate_macho_segment(
         Some(checked_file_region(bytes.len(), fileoff, filesize, 0)?)
     };
 
+    let mut has_dwarf = false;
     for index in 0..usize::try_from(nsects).ok()? {
         let start = base_size.checked_add(index.checked_mul(section_size)?)?;
         let section = command.get(start..start.checked_add(section_size)?)?;
@@ -829,6 +873,9 @@ fn validate_macho_segment(
         if !macho_section_is_portable(section_segment, section_name, flags) {
             return None;
         }
+        if macho_section_is_dwarf(section_segment, section_name, flags) {
+            has_dwarf = true;
+        }
 
         let is_zerofill = is_macho_zerofill(flags);
         if !is_zerofill && size != 0 {
@@ -850,7 +897,7 @@ fn validate_macho_segment(
             )?;
         }
     }
-    Some(nsects)
+    Some((nsects, has_dwarf))
 }
 
 fn macho_segment_is_portable(name: &[u8]) -> bool {
@@ -1109,6 +1156,15 @@ fn parse_ar_decimal(field: &[u8]) -> Option<usize> {
         return None;
     }
     s.parse::<usize>().ok()
+}
+
+/// A BSD archive with one DWARF-bearing Mach-O member, for `cache_key` tests.
+#[cfg(test)]
+pub(crate) fn dwarf_bsd_archive_for_tests(payload: &[u8]) -> Vec<u8> {
+    tests::bsd_archive(&[
+        ("__.SYMDEF SORTED", 20, tests::BSD_SYMDEF),
+        ("cafca65b3467684e-a.o", 20, &tests::dwarf_macho(payload)),
+    ])
 }
 
 #[cfg(test)]
@@ -1676,7 +1732,7 @@ mod tests {
         h
     }
 
-    fn bsd_archive(members: &[(&str, usize, &[u8])]) -> Vec<u8> {
+    pub(super) fn bsd_archive(members: &[(&str, usize, &[u8])]) -> Vec<u8> {
         let mut a = AR_MAGIC.to_vec();
         for (n, pad, d) in members {
             a.extend_from_slice(&bsd_member(n, *pad, d));
@@ -1841,7 +1897,7 @@ mod tests {
     }
 
     /// DWARF as clang emits it for a `-g` translation unit.
-    fn dwarf_macho(payload: &[u8]) -> Vec<u8> {
+    pub(super) fn dwarf_macho(payload: &[u8]) -> Vec<u8> {
         macho_object(
             MachEndian::Little,
             true,
@@ -2003,6 +2059,43 @@ mod tests {
         write_le_u32(&mut command, 8, u32::try_from(final_commands_end).unwrap());
         write_le_u32(&mut command, 12, data_size);
         macho_with_extra_command(base, &command)
+    }
+
+    #[test]
+    fn identity_reports_macho_dwarf_members() {
+        let plain = macho_object(
+            MachEndian::Little,
+            true,
+            "__TEXT",
+            "__text",
+            0,
+            N_SECT,
+            b"code",
+        );
+        let dwarf = dwarf_macho(b"debug");
+        assert_eq!(parse_known_no_debug_macho_object(&plain), Some(false));
+        assert_eq!(parse_known_no_debug_macho_object(&dwarf), Some(true));
+
+        let dwarf_of = |bytes: &[u8]| {
+            portable_static_archive_identity(bytes)
+                .expect("archive parses")
+                .macho_dwarf_members
+        };
+        // One DWARF member marks the whole archive, in either position.
+        assert!(!dwarf_of(&bsd_archive(&[("plain.o", 8, &plain)])));
+        assert!(dwarf_of(&bsd_archive(&[("dwarf.o", 8, &dwarf)])));
+        assert!(dwarf_of(&bsd_archive(&[
+            ("dwarf.o", 8, &dwarf),
+            ("plain.o", 8, &plain)
+        ])));
+        assert!(!dwarf_of(&archive(&[("plain.o/", &plain)])));
+        assert!(dwarf_of(&archive(&[("dwarf.o/", &dwarf)])));
+        assert!(dwarf_of(&archive(&[
+            ("plain.o/", &plain),
+            ("dwarf.o/", &dwarf)
+        ])));
+        // ELF members never set it: no N_OSO debug map there.
+        assert!(!dwarf_of(&archive(&[("elf.o/", &elf_object(b"code"))])));
     }
 
     #[test]
@@ -2325,7 +2418,7 @@ mod tests {
     // A realistic Darwin ranlib payload shape (its exact bytes don't matter to
     // the parser; only that it is stable across clones, which it is when the
     // inline-name lengths — and thus its stored offsets — are equal).
-    const BSD_SYMDEF: &[u8] =
+    pub(super) const BSD_SYMDEF: &[u8] =
         b"\x10\x00\x00\x00\x00\x00\x00\x00\x88\x00\x00\x00\x08\x00\x00\x00foo\0bar\0";
 
     #[test]

--- a/src/native_archive.rs
+++ b/src/native_archive.rs
@@ -213,7 +213,7 @@ fn gnu_archive_hash(bytes: &[u8]) -> Option<String> {
                 // bitcode uses archive-path-derived LTO identifiers, and an
                 // unknown format may have equally path-sensitive semantics.
                 let known_object = if has_macho_magic(data) {
-                    is_known_portable_macho_object(data)
+                    is_known_no_debug_macho_object(data)
                 } else {
                     is_known_elf_relocatable_object(data)
                 };
@@ -340,7 +340,7 @@ fn bsd_archive_hash(bytes: &[u8]) -> Option<String> {
             // further. Hashing the content is safe only after a bounded,
             // fail-closed Mach-O inspection proves this is a known MH_OBJECT
             // without STABS or bitcode.
-            if !is_known_portable_macho_object(content) {
+            if !is_known_no_debug_macho_object(content) {
                 return None;
             }
             // The exact stored name was committed above; frame the object
@@ -441,12 +441,12 @@ struct MachSymtab {
 
 /// Prove that `bytes` is a supported Mach-O relocatable object whose behavior
 /// is independent of the containing archive path after name/time are hashed.
-/// DWARF is admitted (see the module docs); STABS, bitcode/LTO carriers, and
-/// unknown shapes are not. All arithmetic and table walks are bounded by the
-/// input slice. Any doubt returns `false`, selecting the caller's path-bound
-/// fallback.
-fn is_known_portable_macho_object(bytes: &[u8]) -> bool {
-    parse_known_portable_macho_object(bytes).is_some()
+/// "no debug" is about STABS: DWARF is admitted (see the module docs), while
+/// STABS, bitcode/LTO carriers, and unknown shapes are not. All arithmetic
+/// and table walks are bounded by the input slice. Any doubt returns `false`,
+/// selecting the caller's path-bound fallback.
+fn is_known_no_debug_macho_object(bytes: &[u8]) -> bool {
+    parse_known_no_debug_macho_object(bytes).is_some()
 }
 
 fn has_macho_magic(bytes: &[u8]) -> bool {
@@ -613,7 +613,7 @@ fn parse_known_elf_relocatable_object(bytes: &[u8]) -> Option<()> {
     Some(())
 }
 
-fn parse_known_portable_macho_object(bytes: &[u8]) -> Option<()> {
+fn parse_known_no_debug_macho_object(bytes: &[u8]) -> Option<()> {
     let magic = bytes.get(..4)?;
     let (endian, is_64) = match magic {
         b"\xce\xfa\xed\xfe" => (MachEndian::Little, false),
@@ -869,19 +869,21 @@ fn macho_section_is_dwarf(section_segment: &[u8], section_name: &[u8], flags: u3
 }
 
 fn macho_section_is_portable(section_segment: &[u8], section_name: &[u8], flags: u32) -> bool {
+    if macho_section_is_dwarf(section_segment, section_name, flags) {
+        return true;
+    }
     // clang marks `__LD,__compact_unwind` with S_ATTR_DEBUG so ld64 strips
     // the intermediate records after producing runtime unwind metadata. It
     // is not source-level debug data and does not cause an N_OSO entry; a
     // no-debug C/C++ object commonly contains it.
     let compact_unwind = section_segment == b"__LD" && section_name == b"__compact_unwind";
-    macho_section_is_dwarf(section_segment, section_name, flags)
-        || ((flags & S_ATTR_DEBUG == 0 || compact_unwind)
-            && section_segment != b"__DWARF"
-            && !section_name.starts_with(b"__debug_")
-            && !section_name.starts_with(b"__zdebug_")
-            && !is_macho_lto_segment(section_segment)
-            && section_name != b"__bitcode"
-            && section_name != b"__bundle")
+    (flags & S_ATTR_DEBUG == 0 || compact_unwind)
+        && section_segment != b"__DWARF"
+        && !section_name.starts_with(b"__debug_")
+        && !section_name.starts_with(b"__zdebug_")
+        && !is_macho_lto_segment(section_segment)
+        && section_name != b"__bitcode"
+        && section_name != b"__bundle"
 }
 
 fn is_macho_zerofill(flags: u32) -> bool {
@@ -1954,7 +1956,7 @@ mod tests {
         for command in commands {
             let object = macho_with_extra_command(base.clone(), &command);
             assert!(
-                parse_known_portable_macho_object(&object).is_some(),
+                parse_known_no_debug_macho_object(&object).is_some(),
                 "supported load command {} must parse",
                 read_le_u32(&command, 0)
             );
@@ -1966,7 +1968,7 @@ mod tests {
         let base = no_debug_macho(b"command payload");
         let mut wrong_file_type = base.clone();
         write_le_u32(&mut wrong_file_type, 12, 2);
-        assert!(parse_known_portable_macho_object(&wrong_file_type).is_none());
+        assert!(parse_known_no_debug_macho_object(&wrong_file_type).is_none());
 
         let symtab_offset = 32 + usize::try_from(read_le_u32(&base, 36)).unwrap();
         let mut duplicate_symtab_command = base[symtab_offset..symtab_offset + 24].to_vec();
@@ -1975,12 +1977,12 @@ mod tests {
             write_le_u32(&mut duplicate_symtab_command, offset, shifted);
         }
         let duplicate_symtab = macho_with_extra_command(base.clone(), &duplicate_symtab_command);
-        assert!(parse_known_portable_macho_object(&duplicate_symtab).is_none());
+        assert!(parse_known_no_debug_macho_object(&duplicate_symtab).is_none());
 
         let with_dysymtab = macho_with_extra_command(base.clone(), &macho_command(LC_DYSYMTAB, 80));
         let duplicate_dysymtab =
             macho_with_extra_command(with_dysymtab, &macho_command(LC_DYSYMTAB, 80));
-        assert!(parse_known_portable_macho_object(&duplicate_dysymtab).is_none());
+        assert!(parse_known_no_debug_macho_object(&duplicate_dysymtab).is_none());
 
         for command in [
             macho_command(LC_SYMTAB, 16),
@@ -1990,7 +1992,7 @@ mod tests {
             macho_command(LC_UUID, 16),
         ] {
             let object = macho_with_extra_command(base.clone(), &command);
-            assert!(parse_known_portable_macho_object(&object).is_none());
+            assert!(parse_known_no_debug_macho_object(&object).is_none());
         }
     }
 
@@ -2093,7 +2095,7 @@ mod tests {
             SEGMENT_FILEOFF,
             u64::from(data_offset + 1),
         );
-        assert!(parse_known_portable_macho_object(&starts_before_segment).is_none());
+        assert!(parse_known_no_debug_macho_object(&starts_before_segment).is_none());
 
         let mut ends_after_segment = base.clone();
         write_le_u64(
@@ -2102,15 +2104,15 @@ mod tests {
             u64::from(data_offset - 1),
         );
         write_le_u64(&mut ends_after_segment, SEGMENT_FILESIZE, 4);
-        assert!(parse_known_portable_macho_object(&ends_after_segment).is_none());
+        assert!(parse_known_no_debug_macho_object(&ends_after_segment).is_none());
 
         let mut ordinary_out_of_bounds = base.clone();
         write_le_u32(&mut ordinary_out_of_bounds, SECTION_OFFSET, u32::MAX);
-        assert!(parse_known_portable_macho_object(&ordinary_out_of_bounds).is_none());
+        assert!(parse_known_no_debug_macho_object(&ordinary_out_of_bounds).is_none());
 
         let mut zero_sized = ordinary_out_of_bounds.clone();
         write_le_u64(&mut zero_sized, SECTION_SIZE, 0);
-        assert!(parse_known_portable_macho_object(&zero_sized).is_some());
+        assert!(parse_known_no_debug_macho_object(&zero_sized).is_some());
 
         let mut zerofill = macho_object(
             MachEndian::Little,
@@ -2122,30 +2124,30 @@ mod tests {
             b"code",
         );
         write_le_u32(&mut zerofill, SECTION_OFFSET, u32::MAX);
-        assert!(parse_known_portable_macho_object(&zerofill).is_some());
+        assert!(parse_known_no_debug_macho_object(&zerofill).is_some());
 
         let mut bad_relocation = base;
         write_le_u32(&mut bad_relocation, SECTION_RELOFF, u32::MAX);
         write_le_u32(&mut bad_relocation, SECTION_NRELOC, 1);
-        assert!(parse_known_portable_macho_object(&bad_relocation).is_none());
+        assert!(parse_known_no_debug_macho_object(&bad_relocation).is_none());
     }
 
     #[test]
     fn data_in_code_alignment_applies_only_to_that_command() {
         assert!(
-            parse_known_portable_macho_object(&macho_with_linkedit_command(LC_DATA_IN_CODE, 0))
+            parse_known_no_debug_macho_object(&macho_with_linkedit_command(LC_DATA_IN_CODE, 0))
                 .is_some()
         );
         assert!(
-            parse_known_portable_macho_object(&macho_with_linkedit_command(LC_DATA_IN_CODE, 8))
+            parse_known_no_debug_macho_object(&macho_with_linkedit_command(LC_DATA_IN_CODE, 8))
                 .is_some()
         );
         assert!(
-            parse_known_portable_macho_object(&macho_with_linkedit_command(LC_DATA_IN_CODE, 7))
+            parse_known_no_debug_macho_object(&macho_with_linkedit_command(LC_DATA_IN_CODE, 7))
                 .is_none()
         );
         assert!(
-            parse_known_portable_macho_object(&macho_with_linkedit_command(
+            parse_known_no_debug_macho_object(&macho_with_linkedit_command(
                 LC_LINKER_OPTIMIZATION_HINT,
                 7,
             ))
@@ -2454,7 +2456,7 @@ mod tests {
             for is_64 in [false, true] {
                 let object = macho_object(endian, is_64, "__TEXT", "__text", 0, N_SECT, b"code");
                 assert!(
-                    is_known_portable_macho_object(&object),
+                    is_known_no_debug_macho_object(&object),
                     "supported MH_OBJECT must pass its endian/width gate"
                 );
             }
@@ -2469,7 +2471,7 @@ mod tests {
             N_SECT,
             b"unwind",
         );
-        assert!(is_known_portable_macho_object(&compact_unwind));
+        assert!(is_known_no_debug_macho_object(&compact_unwind));
     }
 
     #[test]
@@ -2484,7 +2486,7 @@ mod tests {
             b"code",
         );
         object[4..8].copy_from_slice(&0x0200_000c_u32.to_le_bytes());
-        assert!(!is_known_portable_macho_object(&object));
+        assert!(!is_known_no_debug_macho_object(&object));
 
         let archive = bsd_archive(&[("PerfUtils.o", 16, &object)]);
         assert!(portable_static_archive_hash(&archive).is_none());
@@ -2537,7 +2539,7 @@ mod tests {
                 0x64, // N_SO: any N_STAB entry is name/time-sensitive in ld64
                 b"code",
             );
-            assert!(!is_known_portable_macho_object(&stab));
+            assert!(!is_known_no_debug_macho_object(&stab));
             assert!(
                 portable_static_archive_hash(&bsd_archive(&[("derived-name.o", 16, &stab)]))
                     .is_none()
@@ -2568,7 +2570,7 @@ mod tests {
                 b"x",
             );
             assert!(
-                !is_known_portable_macho_object(&object),
+                !is_known_no_debug_macho_object(&object),
                 "{segment},{section} flags={flags:#x} must fail closed"
             );
             assert!(portable_static_archive_hash(&bsd_archive(&[("x.o", 4, &object)])).is_none());
@@ -2583,7 +2585,7 @@ mod tests {
                 N_SECT,
                 b"x",
             );
-            assert!(is_known_portable_macho_object(&object), "{section}");
+            assert!(is_known_no_debug_macho_object(&object), "{section}");
         }
     }
 
@@ -2777,7 +2779,7 @@ mod tests {
             .status()
             .expect("system C compiler runs");
         assert!(status.success(), "cc -c -g0 failed");
-        assert!(is_known_portable_macho_object(
+        assert!(is_known_no_debug_macho_object(
             &std::fs::read(&seed_object).unwrap()
         ));
 
@@ -2842,7 +2844,7 @@ mod tests {
             .expect("system C compiler runs");
         assert!(status.success(), "cc -c -g failed");
         assert!(
-            is_known_portable_macho_object(&std::fs::read(&object).unwrap()),
+            is_known_no_debug_macho_object(&std::fs::read(&object).unwrap()),
             "debug-bearing Mach-O passes the gate"
         );
 


### PR DESCRIPTION
## Summary

This PR adopts [#999](https://github.com/kunobi-ninja/kache/pull/999) by @yanyaoer, pinned at head `76f3095`, which fixes [#998](https://github.com/kunobi-ninja/kache/issues/998). A maintainer opened it to finish the change requested in review. The original PR stays open until this one lands.

On macOS, a `cc`-built `static=` archive whose objects carry DWARF took the path-bound `path-ar-v1` digest. Its rlib then re-keyed per checkout even when the archives were byte-identical. `ring` is the common case, because it passes `-gfull` on Apple targets.

Imported from #999 with `cherry-pick -x` onto current main. Authorship is kept.

- `31bf6ef` (source `37c9c6b`): admit clang-shaped DWARF to the Mach-O gate in both archive arms.
- `fe54fd9` (source `76f3095`): move the static-lib memo namespace to `static-ar-v6`.

Maintainer commit:

- `9089701`: keep the path-bound digest when the invocation links the archive itself (bin, test, dylib, cdylib, proc-macro). There, ld64 writes the archive's absolute `OUT_DIR` path into `N_OSO`, and kache's `-oso_prefix` only strips `--out-dir`. The archive identity now reports whether any Mach-O member carries DWARF. `hash_static_lib_for` takes a `StaticLibUse`, and each use gets its own memo row. `hash_static_lib` keeps the strict linked reading for existing callers. rlibs, `ring` included, still converge.

## Test plan

- [x] `just check` on macOS: fmt, clippy `-D warnings`, 3338 workspace tests
- [x] New tests: `identity_reports_macho_dwarf_members`, `linked_dwarf_archive_stays_path_bound`, `hash_static_lib_memo_rows_are_per_use`, `static_lib_use_follows_executable_output`
- [x] The contributor's real `cc -g` archive test hashes the same from two directories
- [ ] Mutation shards (CI)
- [ ] The two-checkout end-to-end runs from #998 and the review of #999 were not repeated on this head

## Checklist

- [x] `just check` passes locally (mutants left to CI per AGENTS.md)
- [x] New behaviour is covered by tests where it makes sense
- [x] Commit messages follow conventional commits
- [x] User-visible changes are reflected in the docs: none, the module docs carry the design
