### PR TITLE
fix: identify macOS SDK when xcrun rejects a filesystem SDKROOT

### DIFF
--- a/.github/tests/workflow-policy.mjs
+++ b/.github/tests/workflow-policy.mjs
@@ -128,9 +128,9 @@ function resolveRunner(source, context) {
     : source;
 }
 for (const [name, expression] of routing) {
-  const os = /:(test-macos|macOS)$/.test(name)
+  const os = /:(cargo-macos|macOS)$/.test(name)
     ? "MACOS"
-    : /:(test-windows|Windows)$/.test(name)
+    : /:(cargo-windows|Windows)$/.test(name)
       ? "WINDOWS"
       : "LINUX";
   const platform = `CI_RUNNER_${os}`;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,9 @@ jobs:
     # the 6h GitHub default — the step-level timeouts below only guard their own
     # steps. (`just ci` itself is additionally capped at 30m.)
     timeout-minutes: 40
-    # `just ci` needs Linux (docker buildx, helm and tarpaulin). macOS has
-    # a dedicated, lighter test job below.
+    # `just ci` needs Linux (docker buildx, helm and tarpaulin). macOS cargo
+    # tests live in `cargo test (macOS)`; the Nix package build is
+    # `Nix package (macOS)`.
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # mise installs everything in mise.toml (just, helm, sccache,
@@ -648,20 +649,34 @@ jobs:
       - name: cargo deny check
         run: just audit
 
+  # Linux evaluates every system (catches #597-style eval breakage) and builds
+  # the Linux package. macOS actually *builds* the Darwin package: stdenv sets
+  # SDKROOT to the Apple SDK store path and puts xcbuild's xcrun on PATH, which
+  # `cargo test` on a hosted Mac never sees. That is how the SDK-identity
+  # checkPhase failure in nixpkgs#561411 stayed invisible here.
   nix-package:
-    name: Nix package
-    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
+    name: Nix package (${{ matrix.os }})
+    runs-on: ${{ matrix.runner }}
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
-    timeout-minutes: 25
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: Linux
+            runner: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
+          - os: macOS
+            runner: ${{ fromJSON(!github.event.repository.private && '"macos-latest"' || vars.CI_RUNNER_MACOS) }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       # `--all-systems` is the point: without it the check only evaluates the
       # runner's own system, which is how the x86_64-darwin breakage in #597
       # stayed invisible here. Evaluation is cross-system, so this costs
-      # seconds and needs no emulation.
+      # seconds and needs no emulation. One OS is enough.
       - name: Check flake evaluation
+        if: matrix.os == 'Linux'
         run: nix flake check --all-systems --no-build
       # Builds every check for THIS system, including `checks.package`, which
       # is `pkgs.kache` — so this covers the package build too. Deliberately
@@ -1029,15 +1044,16 @@ jobs:
           path: tmp/e2e/
           retention-days: 14
 
-  # --- macOS test suite ---
+  # --- macOS cargo test ---
   # The Linux `check` job runs the full `just ci` (coverage + docker + helm);
-  # replicating that on macOS isn't worth it. Instead this job runs a focused
-  # `cargo test` pass on a hosted macOS runner so OS-specific
-  # regressions — e.g. the daemon's Unix-socket EOF behaviour, which once hung
-  # the suite on macOS while passing on Linux — are caught before merge.
+  # replicating that on macOS isn't worth it. This is `cargo test` + clippy on
+  # a hosted Mac with Apple's toolchain, not the Nix package (that's
+  # `Nix package (macOS)`). Catches OS-specific regressions — e.g. the
+  # daemon's Unix-socket EOF behaviour, which once hung the suite on macOS
+  # while passing on Linux — before merge.
   # Blocking: macOS is a first-class supported platform.
-  test-macos:
-    name: Test (macOS)
+  cargo-macos:
+    name: cargo test (macOS)
     runs-on: ${{ fromJSON(!github.event.repository.private && '"macos-latest"' || vars.CI_RUNNER_MACOS) }}
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
@@ -1119,15 +1135,15 @@ jobs:
         env:
           RUSTC_WRAPPER: ""
 
-  # --- Windows test suite ---
-  # Mirrors `test-macos`: the Linux `check` job runs the full `just ci` and
-  # macOS has its own focused pass, but until now nothing ran `cargo test` (or
+  # --- Windows cargo test ---
+  # Mirrors `cargo test (macOS)`: the Linux `check` job runs the full `just ci`
+  # and macOS has its own cargo pass. Nothing used to run `cargo test` (or
   # clippy) on Windows — so Windows-only regressions slipped through every gate
   # (e.g. #348: the build-session marker write failing under a mandatory file
   # lock). Use the same hosted Windows image as the e2e job's Windows arm.
   # Blocking: Windows is a first-class supported platform.
-  test-windows:
-    name: Test (Windows)
+  cargo-windows:
+    name: cargo test (Windows)
     runs-on: ${{ fromJSON(!github.event.repository.private && '"windows-latest"' || vars.CI_RUNNER_WINDOWS) }}
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
@@ -1166,7 +1182,7 @@ jobs:
           [ -z "$missing" ] || exit 1
           echo "all build/fixture tools present"
       # Keep Rust + mise install/cache/state under the per-run temp dir. See the
-      # e2e and test-macos jobs for the full rationale.
+      # e2e and cargo-macos jobs for the full rationale.
       - name: Isolate tool state
         run: |
           mkdir -p \
@@ -1240,8 +1256,8 @@ jobs:
         cow-filesystem,
         nix-package,
         e2e,
-        test-macos,
-        test-windows,
+        cargo-macos,
+        cargo-windows,
         version-consistency,
       ]
     # IN-ORG MIRROR of zondax/_workflows@7f61511 (v11) — a byte-identical import.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1238,6 +1238,40 @@ jobs:
         env:
           RUSTC_WRAPPER: ""
 
+  # Branch protection still requires the pre-rename check names. These jobs
+  # report those contexts from the renamed jobs. Drop once protection lists
+  # Nix package (Linux), Nix package (macOS), cargo test (macOS), and
+  # cargo test (Windows).
+  nix-package-alias:
+    name: Nix package
+    needs: nix-package
+    if: always() && needs.nix-package.result != 'skipped'
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
+    timeout-minutes: 5
+    steps:
+      - name: Mirror nix-package
+        run: test "${{ needs.nix-package.result }}" = "success"
+
+  cargo-macos-alias:
+    name: Test (macOS)
+    needs: cargo-macos
+    if: always() && needs.cargo-macos.result != 'skipped'
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
+    timeout-minutes: 5
+    steps:
+      - name: Mirror cargo-macos
+        run: test "${{ needs.cargo-macos.result }}" = "success"
+
+  cargo-windows-alias:
+    name: Test (Windows)
+    needs: cargo-windows
+    if: always() && needs.cargo-windows.result != 'skipped'
+    runs-on: ${{ fromJSON(!github.event.repository.private && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX) }}
+    timeout-minutes: 5
+    steps:
+      - name: Mirror cargo-windows
+        run: test "${{ needs.cargo-windows.result }}" = "success"
+
   # --- Release (only on v* tags) ---
   release:
     # This `if:` and the `version-consistency` job's `if: github.ref_type ==

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -83,9 +83,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           ./scripts/require-ci-green.sh "$(git rev-parse HEAD)" \
-            "Check (Linux)" "Nix package" "CoW filesystem (btrfs)" \
+            "Check (Linux)" "Nix package (Linux)" "Nix package (macOS)" \
+            "CoW filesystem (btrfs)" \
             "E2E smoke (Linux)" "E2E smoke (macOS)" "E2E smoke (Windows)" \
-            "Test (macOS)" "Test (Windows)"
+            "cargo test (macOS)" "cargo test (Windows)"
 
       # Package set comes from scripts/crates-io.py (every publishable workspace
       # member, dependency order). Adding a crate does not require a workflow edit.

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -64,6 +64,10 @@ buildRustPackage {
     "--skip=store::tests::test_exclude_from_indexing_sets_tmutil_xattr"
   ];
 
+  # planner_client / remote_backend tests bind 127.0.0.1. Darwin's Nix sandbox
+  # denies that unless this is set.
+  __darwinAllowLocalNetworking = true;
+
   # The suite runs ~2000 tests at full parallelism; nix-daemon's default soft
   # descriptor limit (often 1024) is low enough for the parallel run to hit
   # EMFILE, which surfaced as spurious single-test failures in flake builds

--- a/src/native_link_key.rs
+++ b/src/native_link_key.rs
@@ -138,14 +138,66 @@ fn print_file_name(driver: &Path, name: &str) -> Option<PathBuf> {
 /// Line Tools vs Xcode spell the same SDK differently and would over-key.
 /// `SDKROOT`, when set, is the SDK that is queried — reporting the default
 /// SDK's version beside another SDK's root would describe an SDK no link used.
+///
+/// Apple's `xcrun` accepts a filesystem path as `--sdk`. xcbuild's `xcrun`
+/// only accepts a name such as `macosx`. When `xcrun` rejects a path that is
+/// still a real SDK directory, read the same version and build from
+/// `SystemVersion.plist` inside that root.
 #[cfg(target_os = "macos")]
 pub(crate) fn sdk_identity_for(root: Option<String>) -> Result<Option<String>> {
     let sdk = root.as_deref().unwrap_or("macosx");
-    let version = xcrun(&["--sdk", sdk, "--show-sdk-version"])
-        .ok_or_else(|| anyhow::anyhow!("xcrun --show-sdk-version failed"))?;
-    let build = xcrun(&["--sdk", sdk, "--show-sdk-build-version"])
-        .ok_or_else(|| anyhow::anyhow!("xcrun --show-sdk-build-version failed"))?;
-    Ok(Some(format!("{version} ({build})")))
+    if let Some(identity) = xcrun_identity(sdk) {
+        return Ok(Some(identity));
+    }
+    let path = Path::new(sdk);
+    if path.is_dir() {
+        return identity_from_sdk_root(path).map(Some);
+    }
+    bail!("xcrun --show-sdk-version failed");
+}
+
+#[cfg(target_os = "macos")]
+fn xcrun_identity(sdk: &str) -> Option<String> {
+    let version = xcrun(&["--sdk", sdk, "--show-sdk-version"])?;
+    let build = xcrun(&["--sdk", sdk, "--show-sdk-build-version"])?;
+    Some(format!("{version} ({build})"))
+}
+
+/// `ProductVersion` / `ProductBuildVersion` as `xcrun --show-sdk-version` and
+/// `--show-sdk-build-version` report them for this root.
+#[cfg(target_os = "macos")]
+fn identity_from_sdk_root(root: &Path) -> Result<String> {
+    let plist = root.join("System/Library/CoreServices/SystemVersion.plist");
+    let body = std::fs::read_to_string(&plist).with_context(|| {
+        format!(
+            "xcrun rejected --sdk {} and {} is unreadable",
+            root.display(),
+            plist.display()
+        )
+    })?;
+    let version = plist_string(&body, "ProductVersion").ok_or_else(|| {
+        anyhow::anyhow!(
+            "{} has no ProductVersion; not a usable macOS SDK",
+            plist.display()
+        )
+    })?;
+    let build = plist_string(&body, "ProductBuildVersion").ok_or_else(|| {
+        anyhow::anyhow!(
+            "{} has no ProductBuildVersion; not a usable macOS SDK",
+            plist.display()
+        )
+    })?;
+    Ok(format!("{version} ({build})"))
+}
+
+#[cfg(target_os = "macos")]
+fn plist_string(body: &str, key: &str) -> Option<String> {
+    let needle = format!("<key>{key}</key>");
+    let rest = body.split(&needle).nth(1)?;
+    let rest = rest.trim_start().strip_prefix("<string>")?;
+    let (value, _) = rest.split_once("</string>")?;
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -1670,6 +1722,43 @@ mod tests {
         assert!(
             overridden.is_err(),
             "an unusable SDKROOT must not report the default SDK: {overridden:?}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn sdk_identity_reads_a_filesystem_sdkroot_when_xcrun_rejects_the_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let plist_dir = root.join("System/Library/CoreServices");
+        std::fs::create_dir_all(&plist_dir).unwrap();
+        std::fs::write(
+            plist_dir.join("SystemVersion.plist"),
+            "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+	<key>ProductBuildVersion</key>
+	<string>23E208</string>
+	<key>ProductVersion</key>
+	<string>14.4</string>
+</dict>
+</plist>
+",
+        )
+        .unwrap();
+
+        let identity = sdk_identity_for(Some(root.display().to_string()))
+            .unwrap()
+            .expect("a real SDK directory must be identifiable without xcrun --sdk <path>");
+        assert_eq!(identity, "14.4 (23E208)");
+
+        let empty = tempfile::tempdir().unwrap();
+        assert!(
+            sdk_identity_for(Some(empty.path().display().to_string())).is_err(),
+            "a directory that is not an SDK must not report the default SDK"
         );
     }
 

--- a/src/native_link_key.rs
+++ b/src/native_link_key.rs
@@ -25,7 +25,7 @@
 //! `/MANIFESTFILE:` and `/PDBSTRIPPED:` are only text in the key, so a file
 //! rebuilt under an unchanged name would otherwise restore a stale executable.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -1937,10 +1937,12 @@ mod tests {
         environment
             .variables
             .insert("VSCMD_ARG_HOST_ARCH".into(), "mystery".into());
-        assert!(selected_architecture(&environment, "arm64")
-            .unwrap_err()
-            .to_string()
-            .contains("VSCMD_ARG_HOST_ARCH"));
+        assert!(
+            selected_architecture(&environment, "arm64")
+                .unwrap_err()
+                .to_string()
+                .contains("VSCMD_ARG_HOST_ARCH")
+        );
 
         environment.variables.insert("EMPTY".into(), "  ".into());
         assert_eq!(environment.var("EMPTY"), None);
@@ -2075,9 +2077,11 @@ mod tests {
             environment.command_environment(WindowsTool::Cl, &compiler),
             environment.compiler_command_env.as_slice()
         );
-        assert!(environment
-            .command_environment(WindowsTool::Cl, Path::new("other-cl.exe"))
-            .is_empty());
+        assert!(
+            environment
+                .command_environment(WindowsTool::Cl, Path::new("other-cl.exe"))
+                .is_empty()
+        );
     }
 
     #[test]
@@ -2231,16 +2235,18 @@ mod tests {
         );
 
         std::fs::write(second.join("vcruntimed.lib"), b"different").unwrap();
-        assert!(hash_windows_runtime_libraries(
-            &environment,
-            "x64",
-            "10.0.26100.0",
-            "10.0.26100.0",
-            std::slice::from_ref(&first),
-        )
-        .unwrap_err()
-        .to_string()
-        .contains("conflicting files"));
+        assert!(
+            hash_windows_runtime_libraries(
+                &environment,
+                "x64",
+                "10.0.26100.0",
+                "10.0.26100.0",
+                std::slice::from_ref(&first),
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("conflicting files")
+        );
 
         for (names, expected) in [
             (
@@ -2308,14 +2314,16 @@ mod tests {
         );
 
         let missing = root.path().join("missing");
-        assert!(windows_library_dirs(
-            &environment,
-            "x64",
-            "10.0.26100.0",
-            "10.0.26100.0",
-            &[missing],
-        )
-        .is_err());
+        assert!(
+            windows_library_dirs(
+                &environment,
+                "x64",
+                "10.0.26100.0",
+                "10.0.26100.0",
+                &[missing],
+            )
+            .is_err()
+        );
         let mut invalid_lib = environment.clone();
         invalid_lib.variables.insert(
             "LIB".into(),
@@ -2600,16 +2608,18 @@ mod tests {
         .unwrap();
         assert_eq!(identity.linker, LINK_BANNER);
 
-        assert!(probe_windows_msvc_identity_with(
-            Some(&directory.path().join("cl.exe")),
-            "x64",
-            &[],
-            &environment,
-            |_, _| unreachable!(),
-        )
-        .unwrap_err()
-        .to_string()
-        .contains("neither link.exe nor lld-link.exe"));
+        assert!(
+            probe_windows_msvc_identity_with(
+                Some(&directory.path().join("cl.exe")),
+                "x64",
+                &[],
+                &environment,
+                |_, _| unreachable!(),
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("neither link.exe nor lld-link.exe")
+        );
         for variable in ["LINK", "_LINK_"] {
             let mut with_options = environment.clone();
             with_options

--- a/src/native_link_key.rs
+++ b/src/native_link_key.rs
@@ -25,7 +25,7 @@
 //! `/MANIFESTFILE:` and `/PDBSTRIPPED:` are only text in the key, so a file
 //! rebuilt under an unchanged name would otherwise restore a stale executable.
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -165,7 +165,10 @@ fn xcrun_identity(sdk: &str) -> Option<String> {
 
 /// `ProductVersion` / `ProductBuildVersion` as `xcrun --show-sdk-version` and
 /// `--show-sdk-build-version` report them for this root.
-#[cfg(target_os = "macos")]
+///
+/// Compiled in tests on every OS so the Linux mutation lane can kill mutants
+/// in the plist fallback (`#[cfg(any(test, target_os = "macos"))]`).
+#[cfg(any(test, target_os = "macos"))]
 fn identity_from_sdk_root(root: &Path) -> Result<String> {
     let plist = root.join("System/Library/CoreServices/SystemVersion.plist");
     let body = std::fs::read_to_string(&plist).with_context(|| {
@@ -190,7 +193,7 @@ fn identity_from_sdk_root(root: &Path) -> Result<String> {
     Ok(format!("{version} ({build})"))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(test, target_os = "macos"))]
 fn plist_string(body: &str, key: &str) -> Option<String> {
     let needle = format!("<key>{key}</key>");
     let rest = body.split(&needle).nth(1)?;
@@ -1725,16 +1728,7 @@ mod tests {
         );
     }
 
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn sdk_identity_reads_a_filesystem_sdkroot_when_xcrun_rejects_the_path() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path();
-        let plist_dir = root.join("System/Library/CoreServices");
-        std::fs::create_dir_all(&plist_dir).unwrap();
-        std::fs::write(
-            plist_dir.join("SystemVersion.plist"),
-            "\
+    const SYSTEM_VERSION_PLIST: &str = "\
 <?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
 \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
@@ -1746,11 +1740,58 @@ mod tests {
 	<string>14.4</string>
 </dict>
 </plist>
-",
-        )
-        .unwrap();
+";
 
-        let identity = sdk_identity_for(Some(root.display().to_string()))
+    fn write_system_version_plist(root: &Path, body: &str) {
+        let plist_dir = root.join("System/Library/CoreServices");
+        std::fs::create_dir_all(&plist_dir).unwrap();
+        std::fs::write(plist_dir.join("SystemVersion.plist"), body).unwrap();
+    }
+
+    #[test]
+    fn plist_string_reads_xml_string_values_and_rejects_empty() {
+        assert_eq!(
+            plist_string(SYSTEM_VERSION_PLIST, "ProductVersion").as_deref(),
+            Some("14.4")
+        );
+        assert_eq!(
+            plist_string(SYSTEM_VERSION_PLIST, "ProductBuildVersion").as_deref(),
+            Some("23E208")
+        );
+        assert_eq!(plist_string(SYSTEM_VERSION_PLIST, "ProductName"), None);
+        assert_eq!(
+            plist_string(
+                "<key>ProductVersion</key>\n<string>   </string>",
+                "ProductVersion"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn identity_from_sdk_root_reads_system_version_plist() {
+        let dir = tempfile::tempdir().unwrap();
+        write_system_version_plist(dir.path(), SYSTEM_VERSION_PLIST);
+        assert_eq!(identity_from_sdk_root(dir.path()).unwrap(), "14.4 (23E208)");
+
+        let empty = tempfile::tempdir().unwrap();
+        assert!(identity_from_sdk_root(empty.path()).is_err());
+
+        let missing_version = tempfile::tempdir().unwrap();
+        write_system_version_plist(
+            missing_version.path(),
+            "<key>ProductBuildVersion</key><string>23E208</string>",
+        );
+        assert!(identity_from_sdk_root(missing_version.path()).is_err());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn sdk_identity_reads_a_filesystem_sdkroot_when_xcrun_rejects_the_path() {
+        let dir = tempfile::tempdir().unwrap();
+        write_system_version_plist(dir.path(), SYSTEM_VERSION_PLIST);
+
+        let identity = sdk_identity_for(Some(dir.path().display().to_string()))
             .unwrap()
             .expect("a real SDK directory must be identifiable without xcrun --sdk <path>");
         assert_eq!(identity, "14.4 (23E208)");
@@ -1896,12 +1937,10 @@ mod tests {
         environment
             .variables
             .insert("VSCMD_ARG_HOST_ARCH".into(), "mystery".into());
-        assert!(
-            selected_architecture(&environment, "arm64")
-                .unwrap_err()
-                .to_string()
-                .contains("VSCMD_ARG_HOST_ARCH")
-        );
+        assert!(selected_architecture(&environment, "arm64")
+            .unwrap_err()
+            .to_string()
+            .contains("VSCMD_ARG_HOST_ARCH"));
 
         environment.variables.insert("EMPTY".into(), "  ".into());
         assert_eq!(environment.var("EMPTY"), None);
@@ -2036,11 +2075,9 @@ mod tests {
             environment.command_environment(WindowsTool::Cl, &compiler),
             environment.compiler_command_env.as_slice()
         );
-        assert!(
-            environment
-                .command_environment(WindowsTool::Cl, Path::new("other-cl.exe"))
-                .is_empty()
-        );
+        assert!(environment
+            .command_environment(WindowsTool::Cl, Path::new("other-cl.exe"))
+            .is_empty());
     }
 
     #[test]
@@ -2194,18 +2231,16 @@ mod tests {
         );
 
         std::fs::write(second.join("vcruntimed.lib"), b"different").unwrap();
-        assert!(
-            hash_windows_runtime_libraries(
-                &environment,
-                "x64",
-                "10.0.26100.0",
-                "10.0.26100.0",
-                std::slice::from_ref(&first),
-            )
-            .unwrap_err()
-            .to_string()
-            .contains("conflicting files")
-        );
+        assert!(hash_windows_runtime_libraries(
+            &environment,
+            "x64",
+            "10.0.26100.0",
+            "10.0.26100.0",
+            std::slice::from_ref(&first),
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("conflicting files"));
 
         for (names, expected) in [
             (
@@ -2273,16 +2308,14 @@ mod tests {
         );
 
         let missing = root.path().join("missing");
-        assert!(
-            windows_library_dirs(
-                &environment,
-                "x64",
-                "10.0.26100.0",
-                "10.0.26100.0",
-                &[missing],
-            )
-            .is_err()
-        );
+        assert!(windows_library_dirs(
+            &environment,
+            "x64",
+            "10.0.26100.0",
+            "10.0.26100.0",
+            &[missing],
+        )
+        .is_err());
         let mut invalid_lib = environment.clone();
         invalid_lib.variables.insert(
             "LIB".into(),
@@ -2567,18 +2600,16 @@ mod tests {
         .unwrap();
         assert_eq!(identity.linker, LINK_BANNER);
 
-        assert!(
-            probe_windows_msvc_identity_with(
-                Some(&directory.path().join("cl.exe")),
-                "x64",
-                &[],
-                &environment,
-                |_, _| unreachable!(),
-            )
-            .unwrap_err()
-            .to_string()
-            .contains("neither link.exe nor lld-link.exe")
-        );
+        assert!(probe_windows_msvc_identity_with(
+            Some(&directory.path().join("cl.exe")),
+            "x64",
+            &[],
+            &environment,
+            |_, _| unreachable!(),
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("neither link.exe nor lld-link.exe"));
         for variable in ["LINK", "_LINK_"] {
             let mut with_options = environment.clone();
             with_options


### PR DESCRIPTION
Darwin nixpkgs builds set `SDKROOT` to the Apple SDK store path and put xcbuild's `xcrun` on `PATH`. That `xcrun` only accepts a named SDK (`macosx`), so `sdk_identity_for` failed closed with `xcrun --show-sdk-version failed`. Native bin/cdylib cache keys then cannot be computed, and the package checkPhase dies on the cache-key tests.

This is a kache bug, not a packaging skip. If `xcrun --sdk <path>` fails and the path is still an SDK directory, read `ProductVersion` / `ProductBuildVersion` from `SystemVersion.plist` (`14.4 (23E208)` matches `xcrun` for the same SDK). `/nonexistent.sdk` still fails closed.

### CI

`nix-package` was Ubuntu-only. `--all-systems --no-build` evaluates Darwin; the build never ran there. Hosted `cargo test` uses Apple's `xcrun`, which accepts a path as `--sdk`. That combination is why this stayed green.

This PR:

- Builds `nix flake check` on macOS as `Nix package (macOS)`.
- Renames `Test (macOS)` / `Test (Windows)` to `cargo test (macOS)` / `cargo test (Windows)` so they are not mistaken for the Nix jobs.
- Allows Darwin sandbox loopback for the mock HTTP tests.

**Branch protection** must be updated or merge will stick:

| Was | Now |
| --- | --- |
| Nix package | Nix package (Linux) **and** Nix package (macOS) |
| Test (macOS) | cargo test (macOS) |
| Test (Windows) | cargo test (Windows) |

Unblocks https://github.com/NixOS/nixpkgs/pull/561411 without patching the 0.19.0 tarball. Stefan can bump once this is tagged.