### PR TITLE
fix(cc): cache nightly passthrough flags that only needed a table row

### DIFF
--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -112,7 +112,7 @@ delete an entry once kache caches that case.
 [checks.measure.warm]
 known_passthrough = [
   "unsupported|rustc build-script probe",
-  "unsupported|cc unsupported flag(s): -mtune=skylake — not yet",
+  "unsupported|cc unsupported flag(s): -Ofast — not yet",
 ]
 ```
 

--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -112,7 +112,7 @@ delete an entry once kache caches that case.
 [checks.measure.warm]
 known_passthrough = [
   "unsupported|rustc build-script probe",
-  "unsupported|cc unsupported flag(s): -funroll-loops — not yet",
+  "unsupported|cc unsupported flag(s): -mtune=skylake — not yet",
 ]
 ```
 

--- a/scenarios/bench-firefox-pull-windows/scenario.toml
+++ b/scenarios/bench-firefox-pull-windows/scenario.toml
@@ -56,7 +56,6 @@ known_passthrough = [
   "unsupported|cc preprocessor mode -E to stdout",
   "uncacheable|determining native Windows MSVC link identity: selected Windows linker is neither",
   "uncacheable|determining native Windows MSVC link identity: explicit Windows linker input files",
-  "unsupported|cc unsupported flag(s): -- — not yet",
   "unsupported|cc link mode",
   "unsupported|cc unsupported flag(s): -Wall -Wno-parentheses -Wno-unused-function — not yet",
   "uncacheable|cc -E key probe exited 1",

--- a/scenarios/bench-firefox-pull/scenario.toml
+++ b/scenarios/bench-firefox-pull/scenario.toml
@@ -64,8 +64,6 @@ known_passthrough = [
   "uncacheable|cc include candidate <path> is unreadable",
   "unsupported|rustc build-script probe",
   "uncacheable|cc -E key probe exited 1",
-  "unsupported|cc unsupported flag(s): -mavxvnni — not yet",
   "uncacheable|cc: resolved invocation unavailable for probe-captured flags",
-  "unsupported|cc unsupported flag(s): -fno-stack-protector -fno-asynchronous-unwind-tables — not yet",
 ]
 min_hit_rate_pct = 50.0

--- a/scenarios/bench-firefox/scenario.toml
+++ b/scenarios/bench-firefox/scenario.toml
@@ -154,7 +154,5 @@ known_passthrough = [
   "uncacheable|cc include candidate <path> is unreadable",
   "unsupported|rustc build-script probe",
   "uncacheable|cc -E key probe exited 1",
-  "unsupported|cc unsupported flag(s): -mavxvnni — not yet",
   "uncacheable|cc: resolved invocation unavailable for probe-captured flags",
-  "unsupported|cc unsupported flag(s): -fno-stack-protector -fno-asynchronous-unwind-tables — not yet",
 ]

--- a/scenarios/bench-lance/scenario.toml
+++ b/scenarios/bench-lance/scenario.toml
@@ -97,5 +97,4 @@ max_errors = 0
 # Any other reason warns; delete an entry once it is fixed.
 known_passthrough = [
   "unsupported|rustc build-script probe",
-  "unsupported|cc unsupported flag(s): -funroll-loops — not yet",
 ]

--- a/scenarios/e2e-c-passthrough/scenario.toml
+++ b/scenarios/e2e-c-passthrough/scenario.toml
@@ -1,20 +1,16 @@
 # kache-e2e fixture: a build kache must NOT cache.
 #
-# The inverse of c-hello. The `-c` compile passes `-funroll-loops`, an
+# The inverse of c-hello. The `-c` compile passes `-mtune=skylake`, an
 # unmodeled codegen flag. kache's classifier refuses it (no row in
 # `CC_FLAGS` matches), the compile passes through to the real
 # compiler uncached, and every phase lands ZERO cache entries.
 #
 # Choice of flag: this fixture needs "an unmodeled codegen flag the
 # classifier will refuse". `-march=native` was the original pick;
-# #115 disproved its permanence (the probe captures host-resolved
-# cpu/features, so `-march=*` caches per-machine). `-ffast-math` was
-# the next pick, but the Firefox nightly bench showed it forcing real
-# media TUs through uncached, so it is now modeled as `CapturedByProbe`
-# (its codegen effect IS in the resolved `cc -###` tokens). The current
-# pick is `-funroll-loops` — a genuine codegen optimization still
-# unmodeled. If a future PR DOES model it, that PR should pick a new
-# unmodeled flag here.
+# #115 disproved its permanence. `-ffast-math` then `-funroll-loops`
+# followed; both are now `CapturedByProbe` after nightlies showed
+# them on real TUs. The current pick is `-mtune=skylake`. If a future
+# PR DOES model it, that PR should pick a new unmodeled flag here.
 #
 # This is the e2e cell for the unmodeled-codegen-flag passthrough
 # behavior. c-hello proves a clean compile caches; this proves an
@@ -44,7 +40,7 @@ clean = "make clean"
 run = "./build/main"
 expected_stdout_contains = ["c-passthrough ok"]
 
-# Cold: `-march=native` is unmodeled → the compile is refused →
+# Cold: `-mtune=skylake` is unmodeled → the compile is refused →
 # passthrough → no kache event → nothing in the cache.
 [assertions.cold]
 max_entries_after = 0

--- a/scenarios/e2e-c-passthrough/scenario.toml
+++ b/scenarios/e2e-c-passthrough/scenario.toml
@@ -1,16 +1,16 @@
 # kache-e2e fixture: a build kache must NOT cache.
 #
-# The inverse of c-hello. The `-c` compile passes `-mtune=skylake`, an
+# The inverse of c-hello. The `-c` compile passes `-Ofast`, an
 # unmodeled codegen flag. kache's classifier refuses it (no row in
 # `CC_FLAGS` matches), the compile passes through to the real
 # compiler uncached, and every phase lands ZERO cache entries.
 #
-# Choice of flag: this fixture needs "an unmodeled codegen flag the
-# classifier will refuse". `-march=native` was the original pick;
-# #115 disproved its permanence. `-ffast-math` then `-funroll-loops`
-# followed; both are now `CapturedByProbe` after nightlies showed
-# them on real TUs. The current pick is `-mtune=skylake`. If a future
-# PR DOES model it, that PR should pick a new unmodeled flag here.
+# Choice of flag: this fixture needs "an unmodeled codegen flag that
+# compiles on every CI OS". `-march=native`, `-ffast-math`, and
+# `-funroll-loops` were classified from nightlies. `-mtune=skylake`
+# compiles on Linux but Apple clang on arm64 rejects the CPU name.
+# The current pick is `-Ofast`. If a future PR DOES model it, that
+# PR should pick a new unmodeled flag here.
 #
 # This is the e2e cell for the unmodeled-codegen-flag passthrough
 # behavior. c-hello proves a clean compile caches; this proves an
@@ -40,7 +40,7 @@ clean = "make clean"
 run = "./build/main"
 expected_stdout_contains = ["c-passthrough ok"]
 
-# Cold: `-mtune=skylake` is unmodeled → the compile is refused →
+# Cold: `-Ofast` is unmodeled → the compile is refused →
 # passthrough → no kache event → nothing in the cache.
 [assertions.cold]
 max_entries_after = 0

--- a/scenarios/e2e-c-passthrough/source/Makefile
+++ b/scenarios/e2e-c-passthrough/source/Makefile
@@ -1,18 +1,18 @@
 # kache-e2e fixture: a C build kache must NOT cache.
 #
-# The `-c` compile passes `-mtune=skylake` — an unmodeled codegen flag
+# The `-c` compile passes `-Ofast` — an unmodeled codegen flag
 # that kache's classifier does not recognize. The compile passes
 # through to the real compiler, caching nothing.
 #
-# Choice of flag: this needs an "unmodeled codegen flag that won't
-# get classified later". `-march=native` was the original pick but
-# #115 added `Prefix("-march=")`. `-ffast-math` then `-funroll-loops`
-# followed; both are now `CapturedByProbe` after nightlies showed
-# them on real TUs. `-mtune=skylake` is the current pick; if a future
-# PR models it, that PR should pick a different fixture flag here.
+# Choice of flag: this needs an "unmodeled codegen flag that compiles
+# on every CI OS". `-march=native` then `-ffast-math` then
+# `-funroll-loops` were classified from nightlies. `-mtune=skylake`
+# compiles on Linux but Apple clang on arm64 rejects the CPU name.
+# `-Ofast` is the current pick; if a future PR models it, that PR
+# should pick a different fixture flag here.
 
 CC      ?= cc
-CFLAGS  ?= -O2 -mtune=skylake
+CFLAGS  ?= -Ofast
 SRC     := src/main.c
 BUILD   := build
 OBJ     := $(BUILD)/main.o

--- a/scenarios/e2e-c-passthrough/source/Makefile
+++ b/scenarios/e2e-c-passthrough/source/Makefile
@@ -1,21 +1,18 @@
 # kache-e2e fixture: a C build kache must NOT cache.
 #
-# The `-c` compile passes `-funroll-loops` — an unmodeled codegen flag
+# The `-c` compile passes `-mtune=skylake` — an unmodeled codegen flag
 # that kache's classifier does not recognize. The compile passes
 # through to the real compiler, caching nothing.
 #
 # Choice of flag: this needs an "unmodeled codegen flag that won't
 # get classified later". `-march=native` was the original pick but
-# #115 added `Prefix("-march=")` (the resolved `cc -###` tokens
-# differentiate the per-host target-cpu/feature set). `-ffast-math`
-# was the next pick, but the Firefox nightly bench showed it forcing
-# real TUs through uncached, so it is now `CapturedByProbe` too.
-# `-funroll-loops` is the current pick — a genuine codegen
-# optimization the classifier still refuses; if a future PR models it,
-# that PR should pick a different fixture flag here.
+# #115 added `Prefix("-march=")`. `-ffast-math` then `-funroll-loops`
+# followed; both are now `CapturedByProbe` after nightlies showed
+# them on real TUs. `-mtune=skylake` is the current pick; if a future
+# PR models it, that PR should pick a different fixture flag here.
 
 CC      ?= cc
-CFLAGS  ?= -O2 -funroll-loops
+CFLAGS  ?= -O2 -mtune=skylake
 SRC     := src/main.c
 BUILD   := build
 OBJ     := $(BUILD)/main.o

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -694,8 +694,8 @@ impl CcArgs {
     ///   kache explicitly models (`FlagClass::ModeledInKey`) plus the
     ///   resolved `cc -###` tokens (`FlagClass::CapturedByProbe`). A
     ///   flag whose object-file effect is in none of those — an
-    ///   unmodeled codegen flag (`-Ofast`, `-funroll-loops`,
-    ///   `-fsanitize=address`), profiling (`-pg`), or a flag kache has
+    ///   unmodeled codegen flag (`-Ofast`, `-fsanitize=address`),
+    ///   profiling (`-pg`), or a flag kache has
     ///   never seen — would miscache. The table is the source of truth;
     ///   anything it does not classify is refused with the offending
     ///   flags named in the reason.
@@ -2317,6 +2317,14 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         dialect: None,
     },
     FlagSpec {
+        // End-of-options marker. Does not change object bytes; Firefox's
+        // Windows clang-cl nightly still refused it as an unclassified flag.
+        matcher: Matcher::Exact("--"),
+        class: FlagClass::NoObjectEffect,
+        source: "Firefox Windows 0.20 nightly — end-of-options marker.",
+        dialect: None,
+    },
+    FlagSpec {
         // MSVC `/c` slash spelling of the compile-mode marker (cl only).
         // The parser already routes `/c` to CompileMode::Compile via
         // CC_ARG_SPECS; this row tells the unsupported-flag classifier the
@@ -2423,15 +2431,15 @@ pub static CC_FLAGS: &[FlagSpec] = &[
     FlagSpec {
         matcher: Matcher::Regex(concat!(
             r"-f(?:no-)?(?:",
-            "associative-math|data-sections|fast-math|finite-math-only|",
-            "function-sections|math-errno|merge-all-constants|omit-frame-pointer|",
-            "reciprocal-math|rounding-math|semantic-interposition|signaling-nans|",
-            "signed-zeros|strict-aliasing|trapping-math|unsafe-math-optimizations|",
-            "unwind-tables|wrapv",
+            "associative-math|asynchronous-unwind-tables|data-sections|fast-math|",
+            "finite-math-only|function-sections|math-errno|merge-all-constants|",
+            "omit-frame-pointer|reciprocal-math|rounding-math|semantic-interposition|",
+            "signaling-nans|signed-zeros|strict-aliasing|trapping-math|",
+            "unsafe-math-optimizations|unroll-loops|unwind-tables|wrapv",
             ")",
         )),
         class: FlagClass::CapturedByProbe,
-        source: "#114/#245/#418/#422/#426/#580/#856 — codegen knobs, both polarities, resolved into -cc1 tokens. One sorted stem per knob covers -f<stem> AND -fno-<stem> (prevents the missed-polarity passthrough class).",
+        source: "#114/#245/#418/#422/#426/#580/#856 + 0.20 nightly — codegen knobs, both polarities, resolved into -cc1 tokens. One sorted stem per knob covers -f<stem> AND -fno-<stem> (prevents the missed-polarity passthrough class). unroll-loops / asynchronous-unwind-tables from lance/Firefox passthroughs.",
         dialect: None,
     },
     FlagSpec {
@@ -2466,9 +2474,13 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         dialect: None,
     },
     FlagSpec {
-        matcher: Matcher::Exact("-fstack-protector-strong"),
+        // Firefox nightly still passed `-fno-stack-protector` through because
+        // only `-fstack-protector-strong` was listed. Cover the family
+        // (bare / -strong / -all, both polarities); clang forwards the
+        // resulting -stack-protector* token to -cc1.
+        matcher: Matcher::Regex(r"-f(?:no-)?stack-protector(?:-strong|-all)?"),
         class: FlagClass::CapturedByProbe,
-        source: "Issue #114 — stack-protector codegen mode.",
+        source: "Issue #114 + Firefox 0.20 nightly — stack-protector family, both polarities.",
         dialect: None,
     },
     FlagSpec {
@@ -2872,7 +2884,7 @@ pub static CC_FLAGS: &[FlagSpec] = &[
         // (`-mtune=`, `-mcpu=`, `-mcmodel=`) and unmodeled `-m` flags still
         // refuse. `-mabi=` is modeled separately above.
         matcher: Matcher::Regex(
-            r"^-m(?:no-)?(?:32|64|mmx|sse|sse2|sse3|ssse3|sse4|sse4\.1|sse4\.2|sse4a|avx|avx2|avx512[a-z0-9]+|fma|fma4|f16c|bmi|bmi2|abm|popcnt|lzcnt|aes|vaes|pclmul|vpclmulqdq|gfni|sha|movbe|rdrnd|rdseed|adx|fsgsbase|xsave|xsaveopt|xsavec|xsaves|prfchw|clflushopt|clwb|cldemote|fxsr)$",
+            r"^-m(?:no-)?(?:32|64|mmx|sse|sse2|sse3|ssse3|sse4|sse4\.1|sse4\.2|sse4a|avx|avx2|avxvnni|avx512[a-z0-9]+|fma|fma4|f16c|bmi|bmi2|abm|popcnt|lzcnt|aes|vaes|pclmul|vpclmulqdq|gfni|sha|movbe|rdrnd|rdseed|adx|fsgsbase|xsave|xsaveopt|xsavec|xsaves|prfchw|clflushopt|clwb|cldemote|fxsr)$",
         ),
         class: FlagClass::CapturedByProbe,
         source: "Issue #375 (extended, Firefox nightly bench) — x86 width + SIMD/ISA codec feature flags; resolved into target-cpu/target-feature tokens.",
@@ -7696,7 +7708,6 @@ mod tests {
             // / -mrecip= are now CapturedByProbe — modeled from the Firefox bench — so
             // they are deliberately NOT here; these remain genuinely unmodeled.)
             "-fsanitize=address",
-            "-funroll-loops",
             "-fno-pic",
             "-mtune=skylake",
             // unmodeled optimization / debug variants
@@ -7768,10 +7779,20 @@ mod tests {
             "-mssse3",
             "-mfma",
             "-mavx512f",
+            "-mavxvnni",
             "-mno-sse3",
             // zstd-sys merge-all-constants knob (#856)
             "-fmerge-all-constants",
             "-fno-merge-all-constants",
+            // Firefox / lance 0.20 nightly passthroughs
+            "-funroll-loops",
+            "-fno-unroll-loops",
+            "-fno-stack-protector",
+            "-fstack-protector",
+            "-fstack-protector-strong",
+            "-fno-asynchronous-unwind-tables",
+            "-fasynchronous-unwind-tables",
+            "--",
         ] {
             let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
             assert!(
@@ -7838,6 +7859,8 @@ mod tests {
             "function-sections",
             "data-sections",
             "unwind-tables",
+            "asynchronous-unwind-tables",
+            "unroll-loops",
             "fast-math",
             "finite-math-only",
         ] {
@@ -9017,7 +9040,7 @@ mod tests {
             "foo.c",
             "-o",
             "foo.o",
-            "-funroll-loops",
+            "-mtune=skylake",
             "-fsanitize=address",
         ]);
         let detail = descs
@@ -9025,7 +9048,7 @@ mod tests {
             .find(|d| d.contains("unsupported flag"))
             .expect("expected an unsupported-flag refuse reason");
         assert!(
-            detail.contains("-funroll-loops"),
+            detail.contains("-mtune=skylake"),
             "reason should name the flag: {detail}"
         );
         assert!(

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -8175,13 +8175,6 @@ mod tests {
     #[test]
     fn classifier_does_not_overreach_gecko_darwin_family() {
         for flag in &[
-            // (The inverse forms #114 once left out — -fmath-errno,
-            // -fstrict-aliasing, -fno-unwind-tables, -fomit-frame-pointer — are
-            // now modeled via the sorted codegen-knob stem list, both polarities.
-            // The deliberately-refused boundary below is the NON-knob lookalikes.)
-            // Adjacent stack-protector variants not on the list
-            "-fstack-protector",
-            "-fstack-protector-all",
             // Lookalike that isn't the macOS deployment-target flag
             "-mmacosx-min-version=10.15",
         ] {
@@ -8189,6 +8182,19 @@ mod tests {
             assert!(
                 descs.iter().any(|d| d.contains("unsupported flag")),
                 "{flag} is NOT on the #114 list and must still refuse, got: {descs:?}"
+            );
+        }
+        // The stack-protector family is now classified (Firefox nightly
+        // passed `-fno-stack-protector` through while only `-strong` was listed).
+        for flag in &[
+            "-fstack-protector",
+            "-fstack-protector-all",
+            "-fno-stack-protector",
+        ] {
+            let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
+            assert!(
+                !descs.iter().any(|d| d.contains("unsupported flag")),
+                "{flag} is the stack-protector family and must classify, got: {descs:?}"
             );
         }
     }

--- a/src/compiler/cc.rs
+++ b/src/compiler/cc.rs
@@ -8174,16 +8174,19 @@ mod tests {
     /// as wildcards.
     #[test]
     fn classifier_does_not_overreach_gecko_darwin_family() {
-        for flag in &[
-            // Lookalike that isn't the macOS deployment-target flag
+        // Lookalike that isn't the macOS deployment-target flag
+        let descs = refuse_descriptions(&[
+            "cc",
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o",
             "-mmacosx-min-version=10.15",
-        ] {
-            let descs = refuse_descriptions(&["cc", "-c", "foo.c", "-o", "foo.o", flag]);
-            assert!(
-                descs.iter().any(|d| d.contains("unsupported flag")),
-                "{flag} is NOT on the #114 list and must still refuse, got: {descs:?}"
-            );
-        }
+        ]);
+        assert!(
+            descs.iter().any(|d| d.contains("unsupported flag")),
+            "-mmacosx-min-version=10.15 is NOT on the #114 list and must still refuse, got: {descs:?}"
+        );
         // The stack-protector family is now classified (Firefox nightly
         // passed `-fno-stack-protector` through while only `-strong` was listed).
         for flag in &[


### PR DESCRIPTION
SigNoz nightly (kache 0.19.0) still passes through real compiles for flags that belong in `CC_FLAGS`. The expensive leftovers are Firefox (394–934 unsupported) and a handful on lance.

This PR classifies the small ones:

- \`-mavxvnni\` (ISA regex, next to \`-mavx2\`)
- \`-f[no-]stack-protector{,-strong,-all}\` (only \`-fstack-protector-strong\` was listed)
- \`-f[no-]asynchronous-unwind-tables\` and \`-f[no-]unroll-loops\` (codegen stems)
- \`--\` end-of-options

Not in this PR (not a table row): cc link mode, \`-E\` to stdout, unreadable include candidates, \`-E\` probe failures, MSVC linker identity, \`-Zl\`. Substrate's 72.8% key stability is a key leak, not a flag miss; 0.19.0 nightlies also predate #1012/#1021/#1022.

Should land before tagging 0.20.0 ([#1027](https://github.com/kunobi-ninja/kache/pull/1027)).