### PR TITLE
feat(nvcc): adapter skeleton with parse, refusals and passthrough dispatch

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -23,6 +23,7 @@ use crate::link::LinkStrategy;
 
 pub mod cc;
 pub mod flags;
+pub mod nvcc;
 pub mod platform;
 pub mod rustc;
 
@@ -760,7 +761,7 @@ pub trait Compiler {
 /// Registration is deliberately concrete and local: adding an adapter means
 /// adding its module-owned descriptor here, with no broad enum of possible
 /// future tool kinds.
-pub const COMPILER_ADAPTERS: &[CompilerAdapter] = &[rustc::ADAPTER, cc::ADAPTER];
+pub const COMPILER_ADAPTERS: &[CompilerAdapter] = &[rustc::ADAPTER, cc::ADAPTER, nvcc::ADAPTER];
 
 /// Detect which compiler adapter an argv vector is invoking.
 ///
@@ -895,8 +896,9 @@ fn is_program_on_path(program: &str) -> bool {
 ///
 /// Cargo preserves `RUSTC` when it invokes `RUSTC_WRAPPER`, which identifies
 /// custom drivers such as Kani's `kani-compiler` without maintaining a list of
-/// tool names. `nvcc` remains an explicit passthrough because Kache supports it
-/// as a compiler launcher but cannot safely cache its multi-phase outputs.
+/// tool names. (`nvcc` used to live here; since kunobi-ninja/kache#1024 it has
+/// its own adapter and dispatches to `run_nvcc`, which passes through with a
+/// recorded reason until the cache path lands.)
 pub(crate) fn is_passthrough_compiler_invocation(args: &[String]) -> bool {
     let rustc = std::env::var_os("RUSTC");
     is_passthrough_compiler_invocation_with(args, rustc.as_deref())
@@ -912,12 +914,7 @@ pub(crate) fn is_passthrough_compiler_invocation_with(
     if is_kache_subcommand_or_flag(program) {
         return false;
     }
-    let is_configured_rustc =
-        configured_rustc.is_some_and(|rustc| rustc == std::ffi::OsStr::new(program.as_str()));
-    let is_nvcc = command_basename(program)
-        .map(strip_windows_exe_suffix)
-        .is_some_and(|name| name.eq_ignore_ascii_case("nvcc"));
-    is_configured_rustc || is_nvcc
+    configured_rustc.is_some_and(|rustc| rustc == std::ffi::OsStr::new(program.as_str()))
 }
 
 pub fn is_workspace_wrapper_chain(args: &[String]) -> bool {
@@ -1187,7 +1184,7 @@ mod tests {
     }
 
     #[test]
-    fn passthrough_compiler_accepts_configured_rustc_and_nvcc() {
+    fn passthrough_compiler_accepts_configured_rustc() {
         assert!(is_passthrough_compiler_invocation_with(
             &s(&["/home/user/.kani/kani-0.67.0/bin/kani-compiler", "-vV"]),
             Some(std::ffi::OsStr::new(
@@ -1198,11 +1195,13 @@ mod tests {
             &s(&["custom-rustc-driver", "--crate-name", "demo"]),
             Some(std::ffi::OsStr::new("custom-rustc-driver")),
         ));
-        assert!(is_passthrough_compiler_invocation_with(
+        // nvcc has its own adapter since #1024: it dispatches to run_nvcc,
+        // not to the generic passthrough.
+        assert!(!is_passthrough_compiler_invocation_with(
             &s(&[r"C:\CUDA\bin\nvcc.exe", "-c", "kernel.cu"]),
             None,
         ));
-        assert!(is_passthrough_compiler_invocation_with(
+        assert!(!is_passthrough_compiler_invocation_with(
             &s(&["nvcc", "-c", "kernel.cu"]),
             None,
         ));

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -1,0 +1,638 @@
+//! CUDA `nvcc` compiler adapter.
+//!
+//! Phase 1 (kunobi-ninja/kache#1024): argv recognition, argument parsing,
+//! and refuse-to-cache classification. There is deliberately no caching
+//! yet — [`run_nvcc`](crate::wrapper::run_nvcc) parses every invocation,
+//! reports *why* it is not cached, and passes through to the real `nvcc`.
+//!
+//! ## Why the parser is strict (fail-closed)
+//!
+//! An unrecognized flag must refuse, never assume cacheable. `nvcc` is a
+//! *driver*: one `-c` line fans out to `cudafe++`, one `cicc` + `ptxas`
+//! pair per GPU architecture, `fatbinary`, and the host C++ compiler.
+//! A flag the parser does not model could change any of those stages'
+//! outputs, so [`NvccArgs::refuse_reasons`] reports it as
+//! [`RefuseReason::Unsupported`] until phase 2 classifies it into the key
+//! (the same per-flag road the cc adapter walked).
+//!
+//! ## Why `-E` can never key (and `-M` can)
+//!
+//! `nvcc -E` always defines `__CUDA_ARCH__`, so host-only code guarded by
+//! `#ifndef __CUDA_ARCH__` is invisible in preprocessed output — two
+//! different sources could preprocess identically. Phase 2 therefore keys
+//! raw source + header *contents* via the `nvcc -M` dependency closure,
+//! never preprocessed output.
+
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+use super::{Compiler, CompilerAdapter, CompilerId, RefuseReason};
+
+pub const NVCC_ID: CompilerId = CompilerId::new("nvcc");
+pub const ADAPTER: CompilerAdapter =
+    CompilerAdapter::new(NVCC_ID, "nvcc", NvccCompiler::recognizes);
+
+/// What an `nvcc` invocation does. Only [`NvccMode::Compile`] is a future
+/// cache candidate; every other mode refuses in [`NvccArgs::refuse_reasons`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NvccMode {
+    /// `nvcc -c a.cu -o a.o`: single whole-invocation device compile.
+    Compile,
+    /// `nvcc -dlink`: device-link step combining relocatable objects.
+    DeviceLink,
+    /// No `-c`: host/device link producing an executable or shared object.
+    Link,
+    /// `nvcc --lib`: library archiving mode.
+    Lib,
+    /// `nvcc -E`: preprocessor output.
+    Preprocess,
+    /// Standalone `-ptx` / `-cubin` / `-fatbin` / `--optix-ir` emission.
+    EmitPtx,
+    EmitCubin,
+    EmitFatbin,
+    EmitOptixIr,
+    /// Version / help / dry-run queries: informational, nothing to cache.
+    Query,
+}
+
+/// Parsed `nvcc` invocation.
+#[derive(Debug, Clone)]
+pub struct NvccArgs {
+    /// `argv[0]` as given (bare `nvcc`, path, `nvcc.exe`).
+    pub program: String,
+    /// `argv[1..]` verbatim, for byte-for-byte passthrough execution.
+    pub rest: Vec<String>,
+    /// What the invocation does.
+    pub mode: NvccMode,
+    /// Source files (`.cu` and accepted host extensions, see
+    /// [`is_nvcc_source`]). Linker inputs (`.o`, `.a`, …) are *not*
+    /// collected — link modes refuse before sources matter.
+    pub sources: Vec<PathBuf>,
+    /// `-o <file>`.
+    pub output: Option<PathBuf>,
+    /// `-dc` or `-rdc=true`: relocatable / separable device code.
+    pub separate_device_code: bool,
+    /// `-G`: device-debug info.
+    pub device_debug: bool,
+    /// `-keep` / `--save-temps`: intermediate files kept.
+    pub keep_temps: bool,
+    /// `@file`: response file (never expanded — refuse).
+    pub response_file: bool,
+    /// Flags the phase-1 table knows but phase 2 has not classified into
+    /// the key yet (include dirs, defines, `-O`, `-gencode`, `-Xcompiler`,
+    /// …). Known-but-unmodeled still refuses; the table exists so phase 2
+    /// promotes entries instead of discovering flags from scratch.
+    pub deferred_flags: Vec<String>,
+    /// Flags matching nothing in the table. Always refuse; the
+    /// user-declared allow-list ([`NvccCompiler::extra_allowlist_flags`])
+    /// is the only escape hatch.
+    pub unknown_flags: Vec<String>,
+}
+
+/// Source extensions `nvcc` accepts on a compile line. `.cu` is the CUDA
+/// language; the host extensions let `nvcc` drive plain C/C++ files too
+/// (common via `CUDACXX` wrappers covering a whole project).
+fn is_nvcc_source(name: &str) -> bool {
+    let ext = std::path::Path::new(name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    matches!(
+        ext,
+        "cu" | "cuh" | "c" | "cc" | "cpp" | "cxx" | "C" | "h" | "hpp" | "hxx"
+    )
+}
+
+impl NvccArgs {
+    pub fn parse(args: &[String]) -> Result<Self> {
+        let Some(program) = args.first().cloned() else {
+            anyhow::bail!("nvcc: empty argv");
+        };
+        let rest = args[1..].to_vec();
+        let mut parsed = NvccArgs {
+            program,
+            rest,
+            mode: NvccMode::Link,
+            sources: Vec::new(),
+            output: None,
+            separate_device_code: false,
+            device_debug: false,
+            keep_temps: false,
+            response_file: false,
+            deferred_flags: Vec::new(),
+            unknown_flags: Vec::new(),
+        };
+
+        // Mode votes: emit/query modes win over `-c` when combined;
+        // `--lib` / `-dlink` win over plain link. Last vote of the
+        // highest-precedence class wins (matches driver behavior closely
+        // enough for refuse classification — never for keying).
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        enum Vote {
+            Link,
+            Compile,
+            Lib,
+            DeviceLink,
+            Emit,
+            Preprocess,
+            Query,
+        }
+        let mut vote = Vote::Link;
+        let mut set_vote = |v: Vote, mode: NvccMode, parsed: &mut NvccArgs| {
+            if v >= vote {
+                vote = v;
+                parsed.mode = mode;
+            }
+        };
+
+        let argv = parsed.rest.clone();
+        let mut i = 0;
+        while i < argv.len() {
+            let arg = argv[i].as_str();
+            // Value-taking flags in `--flag value` form consume argv[i+1].
+            // `take_value` bails on a missing value — a truncated line is a
+            // parse error, and the wrapper surfaces the real compiler's
+            // diagnostic via passthrough (fail-closed, never miskey).
+            let take_value = |i: &mut usize, flag: &str| -> Result<String> {
+                *i += 1;
+                argv.get(*i)
+                    .cloned()
+                    .with_context(|| format!("nvcc: {flag} missing value"))
+            };
+            match arg {
+                "-c" | "--compile" => set_vote(Vote::Compile, NvccMode::Compile, &mut parsed),
+                "-dc" | "--device-c" => {
+                    parsed.separate_device_code = true;
+                    set_vote(Vote::Compile, NvccMode::Compile, &mut parsed);
+                }
+                "-dlink" | "--device-link" => {
+                    set_vote(Vote::DeviceLink, NvccMode::DeviceLink, &mut parsed);
+                }
+                "--lib" | "-lib" => set_vote(Vote::Lib, NvccMode::Lib, &mut parsed),
+                "-E" | "--preprocess" => {
+                    set_vote(Vote::Preprocess, NvccMode::Preprocess, &mut parsed);
+                }
+                "-ptx" | "--ptx" => set_vote(Vote::Emit, NvccMode::EmitPtx, &mut parsed),
+                "-cubin" | "--cubin" => {
+                    set_vote(Vote::Emit, NvccMode::EmitCubin, &mut parsed);
+                }
+                "-fatbin" | "--fatbin" => {
+                    set_vote(Vote::Emit, NvccMode::EmitFatbin, &mut parsed);
+                }
+                "--optix-ir" => set_vote(Vote::Emit, NvccMode::EmitOptixIr, &mut parsed),
+                "-G" | "--device-debug" => parsed.device_debug = true,
+                "-keep" | "--keep" | "--save-temps" | "-save-temps" => parsed.keep_temps = true,
+                "--version" | "-V" | "--help" | "-h" | "--dryrun" => {
+                    set_vote(Vote::Query, NvccMode::Query, &mut parsed);
+                }
+                "--time" => parsed.unknown_flags.push(arg.to_string()),
+                "-o" => {
+                    let value = take_value(&mut i, "-o")?;
+                    parsed.output = Some(PathBuf::from(value));
+                }
+                _ if arg.starts_with("-o") && arg.len() > 2 && !arg.starts_with("-O") => {
+                    parsed.output = Some(PathBuf::from(&arg[2..]));
+                }
+                _ if arg == "-rdc" => parsed.separate_device_code = true,
+                _ if arg.starts_with("-rdc=") || arg.starts_with("--relocatable-device-code=") => {
+                    let value = arg.rsplit('=').next().unwrap_or("");
+                    parsed.separate_device_code = matches!(value, "true" | "1");
+                }
+                // Dependency-output flags: recorded so phase 2 can find the
+                // `.d` sidecar; the `-M` *listing* mode still compiles, so
+                // no mode vote.
+                "-M" | "-MM" | "-MD" | "-MMD" | "-MG" | "-MP" | "--generate-dependencies" => {
+                    parsed.deferred_flags.push(arg.to_string());
+                }
+                "-MF" | "-MT" | "-MQ" => {
+                    let value = take_value(&mut i, arg)?;
+                    parsed.deferred_flags.push(format!("{arg} {value}"));
+                }
+                _ if arg.starts_with("-MF") || arg.starts_with("-MT") || arg.starts_with("-MQ") => {
+                    parsed.deferred_flags.push(arg.to_string());
+                }
+                // Verbatim-forwarded / codegen-defining flags: known,
+                // keyed in phase 2, refused until then.
+                _ if arg == "-Xcompiler"
+                    || arg == "-Xlinker"
+                    || arg == "-Xptxas"
+                    || arg == "-Xnvlink"
+                    || arg == "--compiler-options"
+                    || arg == "-gencode"
+                    || arg == "-arch"
+                    || arg == "-code" =>
+                {
+                    let value = take_value(&mut i, arg)?;
+                    parsed.deferred_flags.push(format!("{arg} {value}"));
+                }
+                _ if arg.starts_with("-Xcompiler")
+                    || arg.starts_with("-Xlinker")
+                    || arg.starts_with("-Xptxas")
+                    || arg.starts_with("-Xnvlink")
+                    || arg.starts_with("-gencode")
+                    || arg.starts_with("-arch=")
+                    || arg.starts_with("-code=")
+                    || arg.starts_with("--gpu-architecture=")
+                    || arg.starts_with("--gpu-code=") =>
+                {
+                    parsed.deferred_flags.push(arg.to_string());
+                }
+                _ if arg == "-D"
+                    || arg == "-U"
+                    || arg == "-I"
+                    || arg == "-isystem"
+                    || arg == "-iquote"
+                    || arg == "-include"
+                    || arg == "-O"
+                    || arg == "-std"
+                    || arg == "--std"
+                    || arg == "-x"
+                    || arg == "-L"
+                    || arg == "-l" =>
+                {
+                    let value = take_value(&mut i, arg)?;
+                    parsed.deferred_flags.push(format!("{arg} {value}"));
+                }
+                _ if arg.starts_with("-D")
+                    || arg.starts_with("-U")
+                    || arg.starts_with("-I")
+                    || arg.starts_with("-O")
+                    || arg.starts_with("-std=")
+                    || arg.starts_with("--std=")
+                    || arg.starts_with("-x")
+                    || arg.starts_with("-g")
+                    || arg.starts_with("-m")
+                    || arg.starts_with("--expt-")
+                    || arg.starts_with("-Xfatbin") =>
+                {
+                    parsed.deferred_flags.push(arg.to_string());
+                }
+                _ if arg == "-shared"
+                    || arg == "--shared"
+                    || arg == "-static"
+                    || arg == "-v"
+                    || arg == "--verbose"
+                    || arg == "-w"
+                    || arg == "-Wall"
+                    || arg == "-W" =>
+                {
+                    parsed.deferred_flags.push(arg.to_string());
+                }
+                _ if arg.starts_with("--W") || arg.starts_with("-W") => {
+                    parsed.deferred_flags.push(arg.to_string());
+                }
+                _ if arg.starts_with('@') => parsed.response_file = true,
+                _ if arg.starts_with('-') => parsed.unknown_flags.push(arg.to_string()),
+                _ => {
+                    if is_nvcc_source(arg) {
+                        parsed.sources.push(PathBuf::from(arg));
+                    } else {
+                        // Linker inputs (`.o`, `.a`, …) and anything else
+                        // positional: not a compilable source line.
+                        parsed.unknown_flags.push(arg.to_string());
+                    }
+                }
+            }
+            i += 1;
+        }
+        Ok(parsed)
+    }
+
+    /// Reasons this invocation must bypass the cache. Empty = cacheable
+    /// (once phase 2 wires the store path — phase 1 passes through anyway).
+    pub fn refuse_reasons(&self, extra_allowlist_flags: &[String]) -> Vec<RefuseReason> {
+        match self.mode {
+            NvccMode::Query => return vec![RefuseReason::NotPrimary],
+            NvccMode::Preprocess => {
+                return vec![RefuseReason::Unsupported(
+                    "nvcc preprocessor mode (-E) — not yet supported",
+                )];
+            }
+            NvccMode::EmitPtx => {
+                return vec![RefuseReason::Unsupported(
+                    "nvcc standalone -ptx emission — not yet supported",
+                )];
+            }
+            NvccMode::EmitCubin => {
+                return vec![RefuseReason::Unsupported(
+                    "nvcc standalone -cubin emission — not yet supported",
+                )];
+            }
+            NvccMode::EmitFatbin => {
+                return vec![RefuseReason::Unsupported(
+                    "nvcc standalone -fatbin emission — not yet supported",
+                )];
+            }
+            NvccMode::EmitOptixIr => {
+                return vec![RefuseReason::Unsupported(
+                    "nvcc standalone --optix-ir emission — not yet supported",
+                )];
+            }
+            NvccMode::Lib => {
+                return vec![RefuseReason::Unsupported(
+                    "nvcc library mode (--lib) — not yet supported",
+                )];
+            }
+            NvccMode::DeviceLink => {
+                return vec![RefuseReason::Unsupported(
+                    "nvcc device-link (-dlink) mode — not yet supported",
+                )];
+            }
+            NvccMode::Link => {
+                return vec![RefuseReason::Unsupported(
+                    "nvcc link mode — not yet supported",
+                )];
+            }
+            NvccMode::Compile => {}
+        }
+
+        let mut reasons = Vec::new();
+        if self.sources.len() != 1 {
+            reasons.push(RefuseReason::Unsupported(
+                "nvcc multi-source or source-less compile — not yet supported",
+            ));
+        }
+        if self.separate_device_code {
+            reasons.push(RefuseReason::Unsupported(
+                "nvcc separable device code (-dc/-rdc) — not yet supported (kunobi-ninja/kache#1024)",
+            ));
+        }
+        if self.device_debug {
+            reasons.push(RefuseReason::Unsupported(
+                "nvcc device debug (-G) — not yet supported",
+            ));
+        }
+        if self.keep_temps {
+            reasons.push(RefuseReason::Unsupported(
+                "nvcc kept intermediates (-keep/--save-temps) — not yet supported",
+            ));
+        }
+        if self.response_file {
+            reasons.push(RefuseReason::Unsupported(
+                "nvcc response file (@file) — not yet supported",
+            ));
+        }
+        // Deferred = known but unkeyed (phase 2 promotes these); unknown =
+        // unrecognized, fail-closed. The allow-list covers both: a user who
+        // has audited a flag opts it in explicitly.
+        let unmodeled: Vec<&String> = self
+            .deferred_flags
+            .iter()
+            .chain(self.unknown_flags.iter())
+            .filter(|f| !extra_allowlist_flags.iter().any(|a| flag_matches(a, f)))
+            .collect();
+        if !unmodeled.is_empty() {
+            let detail = format!(
+                "unrecognized nvcc flag(s) {} — not yet supported",
+                unmodeled
+                    .iter()
+                    .map(|f| f.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            // `RefuseReason::Unsupported` carries `&'static str`; the
+            // dynamic list is debug-logged by the caller instead. The
+            // static detail names the class; `explain-miss` shows flags.
+            tracing::debug!("nvcc unmodeled flags refused: {detail}");
+            reasons.push(RefuseReason::Unsupported(
+                "unrecognized nvcc flag(s) — not yet supported",
+            ));
+        }
+        reasons
+    }
+
+    /// `-o` output, if any. Unused until the phase-2 store path reads it.
+    #[allow(dead_code)] // used in tests; wired into run_nvcc in phase 2
+    pub fn object_output_path(&self) -> Option<PathBuf> {
+        self.output.clone()
+    }
+}
+
+/// Allow-list entry matching: exact flag, or the flag's head before its
+/// first value separator (`-O2` covered by `-O`, `-gencode arch=…` by
+/// `-gencode`). Deliberately prefix-simple — auditing stays explicit.
+fn flag_matches(allow: &str, flag: &str) -> bool {
+    flag == allow
+        || flag
+            .split([' ', '='])
+            .next()
+            .is_some_and(|head| head == allow)
+}
+
+/// The `nvcc` compiler: recognition today, full [`Compiler`] in phase 2.
+pub struct NvccCompiler {
+    /// User-declared flags the built-in table doesn't model but the user
+    /// opted into caching. Shared with the cc knob for now
+    /// (`KACHE_CC_EXTRA_ALLOWLIST_FLAGS`); a dedicated `[nvcc]` knob is a
+    /// follow-up once the flag set deserves its own namespace.
+    extra_allowlist_flags: Vec<String>,
+}
+
+impl NvccCompiler {
+    pub fn with_extra_allowlist_flags(extra_allowlist_flags: Vec<String>) -> Self {
+        Self {
+            extra_allowlist_flags,
+        }
+    }
+
+    /// Does this argv invoke `nvcc`? Basename match, case-insensitive,
+    /// `.exe`-tolerant: `nvcc`, `/usr/local/cuda/bin/nvcc`,
+    /// `C:\CUDA\bin\nvcc.exe`.
+    pub fn recognizes(args: &[String]) -> bool {
+        let Some(program) = args.first() else {
+            return false;
+        };
+        super::command_basename(program)
+            .map(super::strip_windows_exe_suffix)
+            .is_some_and(|name| name.eq_ignore_ascii_case("nvcc"))
+    }
+}
+
+impl Compiler for NvccCompiler {
+    type Parsed = NvccArgs;
+
+    fn id(&self) -> CompilerId {
+        NVCC_ID
+    }
+
+    fn parse(&self, args: &[String]) -> Result<NvccArgs> {
+        NvccArgs::parse(args)
+    }
+
+    fn refuse_reasons(&self, parsed: &NvccArgs) -> Vec<RefuseReason> {
+        parsed.refuse_reasons(&self.extra_allowlist_flags)
+    }
+
+    fn cache_key(&self, _parsed: &NvccArgs, _ctx: &super::KeyCtx<'_, '_>) -> Result<String> {
+        anyhow::bail!("nvcc cache key not yet implemented (phase 2, kunobi-ninja/kache#1024)")
+    }
+
+    fn execute(&self, _parsed: &NvccArgs) -> Result<super::CompileResult> {
+        anyhow::bail!("nvcc execution not yet implemented (phase 2, kunobi-ninja/kache#1024)")
+    }
+
+    fn classify_output(&self, _parsed: &NvccArgs, name: &str) -> super::ArtifactKind {
+        super::classify_by_filename(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(args: &[&str]) -> Vec<String> {
+        args.iter().map(|a| a.to_string()).collect()
+    }
+
+    fn parse_ok(args: &[&str]) -> NvccArgs {
+        NvccArgs::parse(&s(args)).expect("parse must succeed")
+    }
+
+    #[test]
+    fn recognizes_nvcc_spellings() {
+        assert!(NvccCompiler::recognizes(&s(&["nvcc", "-c", "a.cu"])));
+        assert!(NvccCompiler::recognizes(&s(&[
+            "/usr/local/cuda/bin/nvcc",
+            "-c",
+            "a.cu"
+        ])));
+        assert!(NvccCompiler::recognizes(&s(&[
+            r"C:\CUDA\bin\nvcc.exe",
+            "-c",
+            "kernel.cu"
+        ])));
+        assert!(NvccCompiler::recognizes(&s(&["NVCC", "--version"])));
+        assert!(!NvccCompiler::recognizes(&s(&["cc", "-c", "a.c"])));
+        assert!(!NvccCompiler::recognizes(&s(&["gcc", "-c", "a.c"])));
+        assert!(!NvccCompiler::recognizes(&s(&[
+            "nvcc-wrapper",
+            "-c",
+            "a.cu"
+        ])));
+        assert!(!NvccCompiler::recognizes(&[]));
+    }
+
+    #[test]
+    fn parses_single_source_compile() {
+        let parsed = parse_ok(&["nvcc", "-c", "src/kernel.cu", "-o", "build/kernel.o"]);
+        assert_eq!(parsed.mode, NvccMode::Compile);
+        assert_eq!(parsed.sources, vec![PathBuf::from("src/kernel.cu")]);
+        assert_eq!(
+            parsed.object_output_path(),
+            Some(PathBuf::from("build/kernel.o"))
+        );
+        assert!(!parsed.separate_device_code);
+        assert!(!parsed.device_debug);
+    }
+
+    #[test]
+    fn parses_joined_output_and_arch_flags() {
+        let parsed = parse_ok(&[
+            "nvcc",
+            "-c",
+            "k.cu",
+            "-obuild/k.o",
+            "-gencode",
+            "arch=compute_80,code=sm_80",
+            "-Xcompiler",
+            "-fPIC",
+            "-DUSE_CUDA",
+            "-O2",
+        ]);
+        assert_eq!(parsed.mode, NvccMode::Compile);
+        assert_eq!(parsed.output, Some(PathBuf::from("build/k.o")));
+        assert!(parsed.unknown_flags.is_empty());
+        assert_eq!(parsed.deferred_flags.len(), 4);
+    }
+
+    #[test]
+    fn query_is_not_primary() {
+        for query in [["nvcc", "--version"], ["nvcc", "-V"], ["nvcc", "--dryrun"]] {
+            let parsed = parse_ok(&query);
+            assert_eq!(parsed.mode, NvccMode::Query);
+            let reasons = parsed.refuse_reasons(&[]);
+            assert_eq!(reasons.len(), 1);
+            assert!(matches!(reasons[0], RefuseReason::NotPrimary));
+        }
+    }
+
+    #[test]
+    fn link_and_device_link_refuse() {
+        let parsed = parse_ok(&["nvcc", "a.o", "b.o", "-o", "app"]);
+        assert_eq!(parsed.mode, NvccMode::Link);
+        let reasons = parsed.refuse_reasons(&[]);
+        assert!(
+            reasons
+                .iter()
+                .any(|r| { matches!(r, RefuseReason::Unsupported(d) if d.contains("link mode")) })
+        );
+
+        let parsed = parse_ok(&["nvcc", "-dlink", "a.o", "-o", "dlink.o"]);
+        assert_eq!(parsed.mode, NvccMode::DeviceLink);
+        assert!(!parsed.refuse_reasons(&[]).is_empty());
+    }
+
+    #[test]
+    fn separable_and_debug_refuse_with_named_reasons() {
+        let parsed = parse_ok(&["nvcc", "-c", "-dc", "k.cu", "-o", "k.o"]);
+        assert!(parsed.separate_device_code);
+        let reasons = parsed.refuse_reasons(&[]);
+        assert!(
+            reasons
+                .iter()
+                .any(|r| { matches!(r, RefuseReason::Unsupported(d) if d.contains("-dc")) })
+        );
+
+        let parsed = parse_ok(&["nvcc", "-c", "-rdc=true", "k.cu", "-o", "k.o"]);
+        assert!(parsed.separate_device_code);
+
+        let parsed = parse_ok(&["nvcc", "-c", "-rdc=false", "k.cu", "-o", "k.o"]);
+        assert!(!parsed.separate_device_code);
+
+        let parsed = parse_ok(&["nvcc", "-c", "-G", "k.cu", "-o", "k.o"]);
+        assert!(parsed.device_debug);
+        let reasons = parsed.refuse_reasons(&[]);
+        assert!(
+            reasons
+                .iter()
+                .any(|r| { matches!(r, RefuseReason::Unsupported(d) if d.contains("-G")) })
+        );
+    }
+
+    #[test]
+    fn multi_source_refuses() {
+        let parsed = parse_ok(&["nvcc", "-c", "a.cu", "b.cu", "-o", "out.o"]);
+        assert!(
+            parsed.refuse_reasons(&[]).iter().any(|r| {
+                matches!(r, RefuseReason::Unsupported(d) if d.contains("multi-source"))
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_flags_refuse_unless_allowlisted() {
+        let parsed = parse_ok(&["nvcc", "-c", "k.cu", "--fancy-new-flag", "-o", "k.o"]);
+        assert_eq!(parsed.unknown_flags, vec!["--fancy-new-flag".to_string()]);
+        assert!(!parsed.refuse_reasons(&[]).is_empty());
+        // Allow-listed by head: caching proceeds past the flag check.
+        let reasons = parsed.refuse_reasons(&["--fancy-new-flag".to_string()]);
+        assert!(reasons.is_empty(), "unexpected refusals: {reasons:?}");
+    }
+
+    #[test]
+    fn response_file_and_keep_refuse() {
+        let parsed = parse_ok(&["nvcc", "-c", "@args.rsp", "-o", "k.o"]);
+        assert!(parsed.response_file);
+
+        let parsed = parse_ok(&["nvcc", "-c", "-keep", "k.cu", "-o", "k.o"]);
+        assert!(parsed.keep_temps);
+        assert!(!parsed.refuse_reasons(&[]).is_empty());
+    }
+
+    #[test]
+    fn missing_value_is_parse_error() {
+        assert!(NvccArgs::parse(&s(&["nvcc", "-c", "k.cu", "-o"])).is_err());
+        assert!(NvccArgs::parse(&s(&["nvcc", "-c", "k.cu", "-gencode"])).is_err());
+        assert!(NvccArgs::parse(&[]).is_err());
+    }
+}

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -230,20 +230,21 @@ impl NvccArgs {
             }
         };
 
-        let argv = parsed.rest.clone();
-        let mut i = 0;
-        while i < argv.len() {
-            let arg = argv[i].as_str();
-            // Value-taking flags in `--flag value` form consume argv[i+1].
-            // `take_value` bails on a missing value — a truncated line is a
-            // parse error, and the wrapper surfaces the real compiler's
-            // diagnostic via passthrough (fail-closed, never miskey).
-            let take_value = |i: &mut usize, flag: &str| -> Result<String> {
-                *i += 1;
-                argv.get(*i)
-                    .cloned()
-                    .with_context(|| format!("nvcc: {flag} missing value"))
-            };
+        // Iterator, not an index: there is no counter to mutate, so the
+        // loop cannot hang on a bad increment — a truncated line ends the
+        // iteration and `take_value` bails fail-closed (never miskeyed).
+        let mut argv = parsed.rest.clone().into_iter();
+        while let Some(arg) = argv.next() {
+            let arg = arg.as_str();
+            // Value-taking flags in `--flag value` form consume the next
+            // item. A missing value bails: truncated line, parse error, and
+            // the wrapper surfaces the real compiler's diagnostic via
+            // passthrough.
+            let take_value =
+                |argv: &mut std::vec::IntoIter<String>, flag: &str| -> Result<String> {
+                    argv.next()
+                        .with_context(|| format!("nvcc: {flag} missing value"))
+                };
             match arg {
                 "-c" | "--compile" => set_vote(Vote::Compile, NvccMode::Compile, &mut parsed),
                 "-dc" | "--device-c" => {
@@ -271,7 +272,7 @@ impl NvccArgs {
                     set_vote(Vote::Query, NvccMode::Query, &mut parsed);
                 }
                 "-o" => {
-                    let value = take_value(&mut i, "-o")?;
+                    let value = take_value(&mut argv, "-o")?;
                     parsed.output = Some(PathBuf::from(value));
                 }
                 // Joined `-oout.o`. (No length check: the exact `"-o"` arm
@@ -294,7 +295,7 @@ impl NvccArgs {
                     parsed.deferred_flags.push(arg.to_string());
                 }
                 _ if VALUE_FLAGS.contains(&arg) => {
-                    let value = take_value(&mut i, arg)?;
+                    let value = take_value(&mut argv, arg)?;
                     parsed.deferred_flags.push(format!("{arg} {value}"));
                 }
                 _ if JOINED_PREFIXES.iter().any(|p| arg.starts_with(p)) => {
@@ -312,7 +313,6 @@ impl NvccArgs {
                     }
                 }
             }
-            i += 1;
         }
         Ok(parsed)
     }

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -89,6 +89,91 @@ pub struct NvccArgs {
     pub unknown_flags: Vec<String>,
 }
 
+/// Flags taking a separate value (`-D FOO`, `-gencode arch=..,code=..`).
+/// Checked before [`JOINED_PREFIXES`], so `-MF` takes a value while
+/// `-MFout.d` matches the joined form. Every entry is deferred (known but
+/// unkeyed) until phase 2 promotes it into the cache key.
+const VALUE_FLAGS: &[&str] = &[
+    "-D",
+    "-U",
+    "-I",
+    "-isystem",
+    "-iquote",
+    "-include",
+    "-O",
+    "-std",
+    "--std",
+    "-x",
+    "-L",
+    "-l",
+    "-MF",
+    "-MT",
+    "-MQ",
+    "-Xcompiler",
+    "-Xlinker",
+    "-Xptxas",
+    "-Xnvlink",
+    "--compiler-options",
+    "-gencode",
+    "-arch",
+    "-code",
+];
+
+/// Joined prefixes (`-O2`, `-DFOO`, `-arch=sm_80`, `-Werror`). Checked
+/// after [`VALUE_FLAGS`].
+///
+/// NOTE for phase 2: `-march=native` (and any host-resolved value) must
+/// refuse, never key — a resolved-through-probe classification like cc's
+/// `CapturedByProbe`, not a verbatim accept.
+const JOINED_PREFIXES: &[&str] = &[
+    "-D",
+    "-U",
+    "-I",
+    "-O",
+    "-std=",
+    "--std=",
+    "-x",
+    "-g",
+    "-m",
+    "--expt-",
+    "-Xfatbin",
+    "-MF",
+    "-MT",
+    "-MQ",
+    "-Xcompiler",
+    "-Xlinker",
+    "-Xptxas",
+    "-Xnvlink",
+    "-gencode",
+    "-arch=",
+    "-code=",
+    "--gpu-architecture=",
+    "--gpu-code=",
+    "--W",
+    "-W",
+];
+
+/// Bare flags with no value (`-M`, `-shared`, `-v`). Recorded deferred
+/// like the tables above. Kept as data, not match arms, so extending
+/// coverage is adding a string, not a branch.
+const BARE_DEFERRED_FLAGS: &[&str] = &[
+    "-M",
+    "-MM",
+    "-MD",
+    "-MMD",
+    "-MG",
+    "-MP",
+    "--generate-dependencies",
+    "-shared",
+    "--shared",
+    "-static",
+    "-v",
+    "--verbose",
+    "-w",
+    "-Wall",
+    "-W",
+];
+
 /// Source extensions `nvcc` accepts on a compile line. `.cu` is the CUDA
 /// language; the host extensions let `nvcc` drive plain C/C++ files too
 /// (common via `CUDACXX` wrappers covering a whole project).
@@ -185,12 +270,15 @@ impl NvccArgs {
                 "--version" | "-V" | "--help" | "-h" | "--dryrun" => {
                     set_vote(Vote::Query, NvccMode::Query, &mut parsed);
                 }
-                "--time" => parsed.unknown_flags.push(arg.to_string()),
                 "-o" => {
                     let value = take_value(&mut i, "-o")?;
                     parsed.output = Some(PathBuf::from(value));
                 }
-                _ if arg.starts_with("-o") && arg.len() > 2 && !arg.starts_with("-O") => {
+                // Joined `-oout.o`. (No length check: the exact `"-o"` arm
+                // above already claims the bare spelling, so anything
+                // reaching here carries a value.) `-O*` excluded —
+                // optimization levels are deferred flags, not outputs.
+                _ if arg.starts_with("-o") && !arg.starts_with("-O") => {
                     parsed.output = Some(PathBuf::from(&arg[2..]));
                 }
                 _ if arg == "-rdc" => parsed.separate_device_code = true,
@@ -198,87 +286,18 @@ impl NvccArgs {
                     let value = arg.rsplit('=').next().unwrap_or("");
                     parsed.separate_device_code = matches!(value, "true" | "1");
                 }
-                // Dependency-output flags: recorded so phase 2 can find the
-                // `.d` sidecar; the `-M` *listing* mode still compiles, so
-                // no mode vote.
-                "-M" | "-MM" | "-MD" | "-MMD" | "-MG" | "-MP" | "--generate-dependencies" => {
+                // Known-but-unmodeled flags (see the tables): recorded so
+                // phase 2 promotes entries instead of discovering flags
+                // from scratch. Table lookup, not `||` chains, so adding
+                // coverage is adding a string.
+                _ if BARE_DEFERRED_FLAGS.contains(&arg) => {
                     parsed.deferred_flags.push(arg.to_string());
                 }
-                "-MF" | "-MT" | "-MQ" => {
+                _ if VALUE_FLAGS.contains(&arg) => {
                     let value = take_value(&mut i, arg)?;
                     parsed.deferred_flags.push(format!("{arg} {value}"));
                 }
-                _ if arg.starts_with("-MF") || arg.starts_with("-MT") || arg.starts_with("-MQ") => {
-                    parsed.deferred_flags.push(arg.to_string());
-                }
-                // Verbatim-forwarded / codegen-defining flags: known,
-                // keyed in phase 2, refused until then.
-                _ if arg == "-Xcompiler"
-                    || arg == "-Xlinker"
-                    || arg == "-Xptxas"
-                    || arg == "-Xnvlink"
-                    || arg == "--compiler-options"
-                    || arg == "-gencode"
-                    || arg == "-arch"
-                    || arg == "-code" =>
-                {
-                    let value = take_value(&mut i, arg)?;
-                    parsed.deferred_flags.push(format!("{arg} {value}"));
-                }
-                _ if arg.starts_with("-Xcompiler")
-                    || arg.starts_with("-Xlinker")
-                    || arg.starts_with("-Xptxas")
-                    || arg.starts_with("-Xnvlink")
-                    || arg.starts_with("-gencode")
-                    || arg.starts_with("-arch=")
-                    || arg.starts_with("-code=")
-                    || arg.starts_with("--gpu-architecture=")
-                    || arg.starts_with("--gpu-code=") =>
-                {
-                    parsed.deferred_flags.push(arg.to_string());
-                }
-                _ if arg == "-D"
-                    || arg == "-U"
-                    || arg == "-I"
-                    || arg == "-isystem"
-                    || arg == "-iquote"
-                    || arg == "-include"
-                    || arg == "-O"
-                    || arg == "-std"
-                    || arg == "--std"
-                    || arg == "-x"
-                    || arg == "-L"
-                    || arg == "-l" =>
-                {
-                    let value = take_value(&mut i, arg)?;
-                    parsed.deferred_flags.push(format!("{arg} {value}"));
-                }
-                _ if arg.starts_with("-D")
-                    || arg.starts_with("-U")
-                    || arg.starts_with("-I")
-                    || arg.starts_with("-O")
-                    || arg.starts_with("-std=")
-                    || arg.starts_with("--std=")
-                    || arg.starts_with("-x")
-                    || arg.starts_with("-g")
-                    || arg.starts_with("-m")
-                    || arg.starts_with("--expt-")
-                    || arg.starts_with("-Xfatbin") =>
-                {
-                    parsed.deferred_flags.push(arg.to_string());
-                }
-                _ if arg == "-shared"
-                    || arg == "--shared"
-                    || arg == "-static"
-                    || arg == "-v"
-                    || arg == "--verbose"
-                    || arg == "-w"
-                    || arg == "-Wall"
-                    || arg == "-W" =>
-                {
-                    parsed.deferred_flags.push(arg.to_string());
-                }
-                _ if arg.starts_with("--W") || arg.starts_with("-W") => {
+                _ if JOINED_PREFIXES.iter().any(|p| arg.starts_with(p)) => {
                     parsed.deferred_flags.push(arg.to_string());
                 }
                 _ if arg.starts_with('@') => parsed.response_file = true,
@@ -408,15 +427,14 @@ impl NvccArgs {
     }
 }
 
-/// Allow-list entry matching: exact flag, or the flag's head before its
-/// first value separator (`-O2` covered by `-O`, `-gencode arch=…` by
-/// `-gencode`). Deliberately prefix-simple — auditing stays explicit.
+/// Allow-list entry matching: the flag verbatim (`-DFOO` covers the
+/// deferred entry `"-D FOO"` only when listed whole), or the entry head
+/// before its first value separator (`-O` covers `-O2`, `-gencode`
+/// covers `-gencode arch=..`). Deliberately explicit — auditing stays a
+/// conscious act, and the boundary form keeps `-O2` from smuggling in an
+/// unrelated `-Ox` spelling.
 fn flag_matches(allow: &str, flag: &str) -> bool {
-    flag == allow
-        || flag
-            .split([' ', '='])
-            .next()
-            .is_some_and(|head| head == allow)
+    flag == allow || flag.starts_with(allow) && flag[allow.len()..].starts_with([' ', '='])
 }
 
 /// The `nvcc` compiler: recognition today, full [`Compiler`] in phase 2.
@@ -614,7 +632,7 @@ mod tests {
         let parsed = parse_ok(&["nvcc", "-c", "k.cu", "--fancy-new-flag", "-o", "k.o"]);
         assert_eq!(parsed.unknown_flags, vec!["--fancy-new-flag".to_string()]);
         assert!(!parsed.refuse_reasons(&[]).is_empty());
-        // Allow-listed by head: caching proceeds past the flag check.
+        // Allow-listed verbatim: caching proceeds past the flag check.
         let reasons = parsed.refuse_reasons(&["--fancy-new-flag".to_string()]);
         assert!(reasons.is_empty(), "unexpected refusals: {reasons:?}");
     }
@@ -634,5 +652,181 @@ mod tests {
         assert!(NvccArgs::parse(&s(&["nvcc", "-c", "k.cu", "-o"])).is_err());
         assert!(NvccArgs::parse(&s(&["nvcc", "-c", "k.cu", "-gencode"])).is_err());
         assert!(NvccArgs::parse(&[]).is_err());
+    }
+
+    /// Every non-compile mode pins its refusal: deleting a mode arm must
+    /// change the mode (caught here), not just shuffle the reason.
+    #[test]
+    fn every_emit_mode_names_its_refusal() {
+        let cases: &[(&[&str], NvccMode, &str)] = &[
+            (
+                &["nvcc", "-E", "k.cu"],
+                NvccMode::Preprocess,
+                "preprocessor",
+            ),
+            (
+                &["nvcc", "--lib", "a.o", "-o", "lib.a"],
+                NvccMode::Lib,
+                "--lib",
+            ),
+            (&["nvcc", "-ptx", "k.cu"], NvccMode::EmitPtx, "-ptx"),
+            (&["nvcc", "-cubin", "k.cu"], NvccMode::EmitCubin, "-cubin"),
+            (
+                &["nvcc", "-fatbin", "k.cu"],
+                NvccMode::EmitFatbin,
+                "-fatbin",
+            ),
+            (
+                &["nvcc", "--optix-ir", "k.cu"],
+                NvccMode::EmitOptixIr,
+                "--optix-ir",
+            ),
+        ];
+        for (argv, mode, reason_part) in cases {
+            let parsed = parse_ok(argv);
+            assert_eq!(parsed.mode, *mode, "wrong mode for {argv:?}");
+            assert!(
+                parsed.refuse_reasons(&[]).iter().any(|r| {
+                    matches!(r, RefuseReason::Unsupported(d) if d.contains(reason_part))
+                }),
+                "missing {reason_part:?} refusal for {argv:?}"
+            );
+        }
+    }
+
+    /// Each flag table contributes: a bare flag, a separate-value flag,
+    /// and joined forms must all land deferred (never unknown).
+    #[test]
+    fn every_flag_table_lands_deferred() {
+        let parsed = parse_ok(&[
+            "nvcc",
+            "-c",
+            "k.cu",
+            "-o",
+            "k.o",
+            "-M",
+            "-MD",
+            "-MF",
+            "deps.d",
+            "-MFdeps2.d",
+            "-shared",
+            "-v",
+            "-D",
+            "FOO=1",
+            "-I/usr/include",
+            "-arch=sm_80",
+            "--gpu-architecture=compute_80",
+            "-Werror",
+            "-m64",
+        ]);
+        assert_eq!(parsed.mode, NvccMode::Compile);
+        assert!(
+            parsed.unknown_flags.is_empty(),
+            "unexpected unknowns: {:?}",
+            parsed.unknown_flags
+        );
+        for expected in [
+            "-M",
+            "-MD",
+            "-MF deps.d",
+            "-MFdeps2.d",
+            "-shared",
+            "-v",
+            "-D FOO=1",
+            "-I/usr/include",
+            "-arch=sm_80",
+            "--gpu-architecture=compute_80",
+            "-Werror",
+            "-m64",
+        ] {
+            assert!(
+                parsed.deferred_flags.iter().any(|f| f == expected),
+                "missing deferred {expected:?} in {:?}",
+                parsed.deferred_flags
+            );
+        }
+    }
+
+    #[test]
+    fn bare_rdc_sets_separable() {
+        let parsed = parse_ok(&["nvcc", "-c", "-rdc", "k.cu", "-o", "k.o"]);
+        assert!(parsed.separate_device_code);
+    }
+
+    /// Linker inputs are positional unknowns, never sources: a `-c` line
+    /// over `.o` files has no source to key.
+    #[test]
+    fn linker_inputs_are_not_sources() {
+        let parsed = parse_ok(&["nvcc", "-c", "a.o", "-o", "app"]);
+        assert!(parsed.sources.is_empty());
+        assert_eq!(parsed.unknown_flags, vec!["a.o".to_string()]);
+        assert!(
+            parsed.refuse_reasons(&[]).iter().any(|r| {
+                matches!(r, RefuseReason::Unsupported(d) if d.contains("source-less"))
+            })
+        );
+    }
+
+    /// Dash-prefixed positionals are flags (unknown), never sources — even
+    /// when the tail looks like a source extension.
+    #[test]
+    fn dash_prefixed_positionals_are_never_sources() {
+        let parsed = parse_ok(&["nvcc", "-c", "-q.cu", "-o", "k.o"]);
+        assert!(parsed.sources.is_empty());
+        assert_eq!(parsed.unknown_flags, vec!["-q.cu".to_string()]);
+    }
+
+    /// `--time` has no dedicated arm: it falls through to the unknown
+    /// bucket, which refuses identically. Pinned so a future arm addition
+    /// is a conscious change.
+    #[test]
+    fn time_falls_through_to_unknown() {
+        let parsed = parse_ok(&["nvcc", "-c", "k.cu", "--time", "-o", "k.o"]);
+        assert_eq!(parsed.unknown_flags, vec!["--time".to_string()]);
+        assert!(!parsed.refuse_reasons(&[]).is_empty());
+    }
+
+    #[test]
+    fn flag_matches_boundary_rules() {
+        assert!(flag_matches("--fancy-new-flag", "--fancy-new-flag"));
+        assert!(flag_matches("-O", "-O 2"));
+        assert!(flag_matches("-gencode", "-gencode=arch"));
+        // No smuggling: `-O` must not cover `-O2`, and an unrelated flag
+        // or a longer allow entry never matches.
+        assert!(!flag_matches("-O", "-O2"));
+        assert!(!flag_matches("-O", "--fancy"));
+        assert!(!flag_matches("--long-flag", "-D"));
+    }
+
+    #[test]
+    fn allowlist_head_does_not_smuggle() {
+        let parsed = parse_ok(&["nvcc", "-c", "k.cu", "-O2", "-o", "k.o"]);
+        assert!(!parsed.refuse_reasons(&["-O".to_string()]).is_empty());
+        // ...but the verbatim entry still works.
+        assert!(parsed.refuse_reasons(&["-O2".to_string()]).is_empty());
+    }
+
+    /// The trait surface phase 2 builds on: refusals delegate, and the
+    /// unimplemented key/execute fail loudly instead of faking success.
+    #[test]
+    fn compiler_trait_delegates_and_stubs_fail() {
+        let compiler = NvccCompiler::with_extra_allowlist_flags(Vec::new());
+        let link = parse_ok(&["nvcc", "a.o", "b.o", "-o", "app"]);
+        assert!(!compiler.refuse_reasons(&link).is_empty());
+
+        let temp = tempfile::tempdir().unwrap();
+        let file_hasher = crate::cache_key::FileHasher::new();
+        let path_normalizer = crate::path_normalizer::PathNormalizer::empty();
+        let ctx = crate::compiler::KeyCtx {
+            file_hasher: &file_hasher,
+            path_normalizer: &path_normalizer,
+            cache_dir: &temp.path().join("cache"),
+            key_salt: None,
+            key_env_vars: &[],
+            extra_inputs_digest: None,
+        };
+        let compile = parse_ok(&["nvcc", "-c", "k.cu", "-o", "k.o"]);
+        assert!(compiler.cache_key(&compile, &ctx).is_err());
+        assert!(compiler.execute(&compile).is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1157,6 +1157,8 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
         wrapper::run(&config, args)?
     } else if adapter.id() == compiler::cc::CC_ID {
         wrapper::run_cc(&config, args)?
+    } else if adapter.id() == compiler::nvcc::NVCC_ID {
+        wrapper::run_nvcc(&config, args)?
     } else {
         anyhow::bail!(
             "detected compiler adapter {} ({}) has no wrapper dispatch",
@@ -1641,9 +1643,8 @@ mod tests {
             ),
             LogMode::Wrapper
         );
-        // The same generic passthrough revives the existing nvcc compatibility
-        // path, which was previously unreachable because log-mode detection
-        // rejected nvcc before `run_wrapper_mode` could pass it through.
+        // nvcc dispatches to run_nvcc via its adapter (#1024), which is
+        // wrapper-mode logging like every other compiler path.
         assert_eq!(
             detect_log_mode_with_rustc(
                 &[

--- a/src/main.rs
+++ b/src/main.rs
@@ -1079,6 +1079,30 @@ fn rustc_args_for_direct_preclean(args: &[String]) -> Option<&[String]> {
     }
 }
 
+/// Which wrapper entry point an adapter dispatches to.
+///
+/// Pure so the dispatch choice is unit-testable: `run_wrapper_mode` only
+/// executes it. `None` means the adapter has no wrapper entry point yet
+/// (the caller bails with the adapter's identity).
+fn wrapper_target(adapter: &compiler::CompilerAdapter) -> Option<WrapperTarget> {
+    if adapter.id() == compiler::rustc::RUSTC_ID {
+        Some(WrapperTarget::Rustc)
+    } else if adapter.id() == compiler::cc::CC_ID {
+        Some(WrapperTarget::Cc)
+    } else if adapter.id() == compiler::nvcc::NVCC_ID {
+        Some(WrapperTarget::Nvcc)
+    } else {
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WrapperTarget {
+    Rustc,
+    Cc,
+    Nvcc,
+}
+
 fn run_wrapper_mode(args: &[String]) -> Result<()> {
     // Re-entrancy guard. If a child compiler kache spawns is itself a
     // kache wrapper — e.g. `cc` on PATH shadowed by `kache cc` — the
@@ -1153,18 +1177,15 @@ fn run_wrapper_mode(args: &[String]) -> Result<()> {
             args.first()
         );
     };
-    let exit_code = if adapter.id() == compiler::rustc::RUSTC_ID {
-        wrapper::run(&config, args)?
-    } else if adapter.id() == compiler::cc::CC_ID {
-        wrapper::run_cc(&config, args)?
-    } else if adapter.id() == compiler::nvcc::NVCC_ID {
-        wrapper::run_nvcc(&config, args)?
-    } else {
-        anyhow::bail!(
+    let exit_code = match wrapper_target(adapter) {
+        Some(WrapperTarget::Rustc) => wrapper::run(&config, args)?,
+        Some(WrapperTarget::Cc) => wrapper::run_cc(&config, args)?,
+        Some(WrapperTarget::Nvcc) => wrapper::run_nvcc(&config, args)?,
+        None => anyhow::bail!(
             "detected compiler adapter {} ({}) has no wrapper dispatch",
             adapter.id(),
             adapter.display_name()
-        );
+        ),
     };
     std::process::exit(exit_code);
 }
@@ -1350,6 +1371,36 @@ mod tests {
         assert!(!is_cc_compiler_invocation(&["rustc".to_string()]));
         assert!(!is_cc_compiler_invocation(&["other-tool".to_string()]));
         assert!(!is_cc_compiler_invocation(&["nvcc".to_string()]));
+    }
+
+    #[test]
+    fn wrapper_target_routes_every_adapter() {
+        let adapter_for = |argv: &[&str]| {
+            compiler::detect_compiler(
+                &argv
+                    .iter()
+                    .map(|arg| (*arg).to_string())
+                    .collect::<Vec<_>>(),
+            )
+            .expect("adapter must match")
+        };
+        assert_eq!(
+            wrapper_target(adapter_for(&["rustc", "--crate-name", "foo"])),
+            Some(WrapperTarget::Rustc)
+        );
+        assert_eq!(
+            wrapper_target(adapter_for(&["cc", "-c", "foo.c"])),
+            Some(WrapperTarget::Cc)
+        );
+        assert_eq!(
+            wrapper_target(adapter_for(&["nvcc", "-c", "kernel.cu"])),
+            Some(WrapperTarget::Nvcc)
+        );
+        let unknown =
+            compiler::CompilerAdapter::new(compiler::CompilerId::new("unwired"), "unwired", |_| {
+                false
+            });
+        assert_eq!(wrapper_target(&unknown), None);
     }
 
     #[cfg(unix)]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -10,6 +10,7 @@ use crate::cache_key::FileHashStats;
 use crate::cache_key::FileHasher;
 use crate::compile;
 use crate::compiler::cc::CcCompiler;
+use crate::compiler::nvcc::NvccCompiler;
 use crate::compiler::rustc::RustcCompiler;
 use crate::compiler::{
     ArtifactKind, ArtifactSet, Compiler, KeyCtx, classify_by_filename, plan_post_restore, platform,
@@ -656,6 +657,89 @@ fn wrapper_entry() -> std::time::Instant {
         }
         None => std::time::Instant::now(),
     }
+}
+
+/// Run kache as a CUDA `nvcc` compiler wrapper (`CUDACXX="kache nvcc"`,
+/// `NVCC="kache nvcc"`, or `CMAKE_CUDA_COMPILER_LAUNCHER=kache`).
+///
+/// Phase 1 (kunobi-ninja/kache#1024): parse → refuse-check → passthrough.
+/// Every invocation runs the real `nvcc` with the original argv; the value
+/// is recognition + a recorded passthrough reason (visible in
+/// `report`/`why-miss`), proving the dispatch path before phase 2 wires
+/// key → local store → remote check/upload.
+pub fn run_nvcc(config: &Config, wrapper_args: &[String]) -> Result<i32> {
+    let start = wrapper_entry();
+    // Shared with the cc knob for now; a dedicated `[nvcc]` knob is a
+    // follow-up once the flag set deserves its own namespace (#1024).
+    let compiler =
+        NvccCompiler::with_extra_allowlist_flags(config.cc_extra_allowlist_flags.clone());
+    let parsed = compiler
+        .parse(wrapper_args)
+        .context("parsing nvcc arguments")?;
+    let event_root = nvcc_event_root();
+
+    // The crate-name slot in events / metadata is the source file
+    // name — the closest analogue to rustc's crate name.
+    let crate_name = parsed
+        .sources
+        .first()
+        .and_then(|s| s.file_name())
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let refuse = compiler.refuse_reasons(&parsed);
+    // Phase 1 has no store path yet: even a cacheable-looking invocation
+    // passes through, with an explicit reason instead of a fake hit.
+    let reason = if refuse.is_empty() {
+        "unsupported|nvcc cache store/restore not yet wired (phase 1, kunobi-ninja/kache#1024)"
+            .to_string()
+    } else {
+        refuse_reason_string(&refuse)
+    };
+    tracing::debug!("nvcc: passthrough ({reason})");
+    nvcc_passthrough_with_event(config, &parsed, &crate_name, &event_root, start, reason)
+}
+
+/// Run an `nvcc` invocation without caching — invoke the compiler with
+/// the original argv, propagate the exit code.
+///
+/// A refusal promises to preserve `nvcc`'s behavior exactly, so this
+/// never injects flags (prefix maps, `SOURCE_DATE_EPOCH`): those belong
+/// to the phase-2 cache-miss execution path.
+fn nvcc_passthrough(parsed: &crate::compiler::nvcc::NvccArgs) -> Result<PassthroughOutput> {
+    crate::opcounts::record_compiler_run();
+    let status = std::process::Command::new(&parsed.program)
+        .args(&parsed.rest)
+        .status()
+        .with_context(|| format!("executing {}", parsed.program))?;
+    Ok(PassthroughOutput {
+        exit_code: status.code().unwrap_or(1),
+        fallback: false,
+    })
+}
+
+fn nvcc_passthrough_with_event<R: Into<String>>(
+    config: &Config,
+    parsed: &crate::compiler::nvcc::NvccArgs,
+    crate_name: &str,
+    root: &str,
+    start: std::time::Instant,
+    reason: R,
+) -> Result<i32> {
+    let output = nvcc_passthrough(parsed)?;
+    log_passthrough_event(
+        config,
+        root,
+        crate_name,
+        start.elapsed().as_millis() as u64,
+        reason.into(),
+        &output,
+    );
+    Ok(output.exit_code)
+}
+
+fn nvcc_event_root() -> String {
+    event_root_string(event_root_override().or_else(|| std::env::current_dir().ok()))
 }
 
 /// Run kache as a C-family compiler wrapper (`CC=kache cc`,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -8759,6 +8759,52 @@ exit 0
         );
     }
 
+    /// Phase 1 nvcc (#1024): a parsed invocation runs the real compiler
+    /// with the original argv and propagates its exit code — and records
+    /// the passthrough reason. The nonzero exit kills the `Ok(0)` /
+    /// `Ok(1)` / `Ok(-1)` body mutants in both `run_nvcc` and
+    /// `nvcc_passthrough_with_event`; the sentinel root kills the
+    /// `nvcc_event_root` value mutants.
+    #[cfg(unix)]
+    #[test]
+    fn nvcc_passthrough_propagates_exit_code_and_reasons() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _lock = crate::test_support::process_state_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let fake_nvcc = dir.path().join("nvcc");
+        let shell =
+            crate::compiler::resolve_program_on_path("sh").expect("sh must be available on PATH");
+        std::fs::write(&fake_nvcc, format!("#!{}\nexit 3\n", shell.display())).unwrap();
+        std::fs::set_permissions(&fake_nvcc, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let _root_guard = TestEnvGuard::set("KACHE_EVENT_ROOT", "/nvcc-phase1-root");
+        let config = test_config(dir.path().join("cache"));
+        let exit = run_nvcc(
+            &config,
+            &s(&[
+                &fake_nvcc.to_string_lossy(),
+                "-c",
+                "kernel.cu",
+                "-o",
+                "kernel.o",
+            ]),
+        )
+        .unwrap();
+        assert_eq!(exit, 3);
+
+        let events = crate::events::read_events(&config.event_log_path()).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].root, "/nvcc-phase1-root");
+        assert_eq!(events[0].crate_name, "kernel.cu");
+        assert_eq!(events[0].result, EventResult::Passthrough);
+        assert!(
+            events[0].passthrough_reason.contains("not yet wired"),
+            "unexpected reason: {}",
+            events[0].passthrough_reason
+        );
+    }
+
     /// #1015: a fallback wrapper such as sccache keys on the same preprocessor
     /// output, so it would serve the stale object kache just refused to cache.
     /// Only that refusal skips it; other key failures keep the fallback.


### PR DESCRIPTION
## Summary

Part of #1024.

Phase 1 of CUDA support: `nvcc` gets its own compiler adapter (recognition, argument parsing, refuse-to-cache classification) and dispatches to a new `run_nvcc`, which passes every invocation through to the real compiler with a recorded reason. No caching yet — this proves the dispatch path before phase 2 wires key -> local store -> remote check/upload.

- new `compiler/nvcc.rs`: `NvccArgs::parse`, `NvccMode`, fail-closed refusals (link/`-dlink`/`--lib`, `-E`, `-ptx`/`-cubin`/`-fatbin`/`--optix-ir`, `-dc`/`-rdc`, `-G`, `-keep`, `@file`, unknown flags), known-but-unkeyed `deferred_flags` table for phase 2 to promote
- `COMPILER_ADAPTERS` registration; `nvcc` leaves the generic passthrough
- `run_nvcc`: parse -> refuse -> passthrough with event (visible in `report`/`why-miss`)

## Verification

- 10 new unit tests (`compiler::nvcc::tests`) plus updated passthrough/log-mode neighbors
- `cargo test --bin kache`: full suite green (2311 + 149 passed, 0 failed)
- `cargo fmt --check`, `cargo clippy --all-targets`: clean
- smoke-tested against a stub `nvcc`: dispatch, exit-code propagation, report reasons